### PR TITLE
refactor(frontend): extract shared TierMarkerOverlay for habit tile + goal modal

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } from 'react-native';
 
-import { TierStar } from '../../components/TierStar';
 import { colors, STAGE_COLORS, spacing, surface } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE, MS_PER_DAY } from '../../utils/dateUtils';
 
 import ConfirmDialog from './components/ConfirmDialog';
-import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
+import { TIER_LABELS, type TierType } from './goalMarker';
 import type { HabitTileProps, Goal, Habit } from './Habits.types';
 import {
   getProgressPercentage,
@@ -15,11 +14,15 @@ import {
   getGoalTier,
   getMarkerPositions,
   getProgressBarColor,
-  getTierColor,
   isGoalAchieved,
   isEarlyUnlocked,
   calculateTodaysProgress,
 } from './HabitUtils';
+import {
+  TierMarkerOverlay,
+  type MarkerInteraction,
+  type TierMarkerSpec,
+} from './TierMarkerOverlay';
 
 /** Marker star size: a touch larger than the bar so it reads as a sitting marker. */
 const markerStarSize = (scale: number): number => spacing(2, scale);
@@ -28,85 +31,6 @@ const formatGoalTooltip = (goal: Goal, habit: Habit, tz: string): string => {
   const label = TIER_LABELS[goal.tier];
   const progress = calculateTodaysProgress(habit, tz);
   return `${label}: ${progress}/${goal.target} ${goal.target_unit}`;
-};
-
-interface GoalTooltipProps {
-  goal: Goal;
-  habit: Habit;
-  tier: TierType;
-  scale: number;
-  tz: string;
-}
-
-const GoalTooltipContent = ({ goal, habit, tier, scale, tz }: GoalTooltipProps) => (
-  <View testID={`tooltip-${tier}`} style={tooltipBoxStyle(getTierColor(tier))}>
-    <Text
-      style={{
-        fontSize: spacing(1.5, scale),
-        color: '#333',
-        fontFamily: 'serif',
-        fontStyle: 'italic',
-        letterSpacing: 0.5,
-      }}
-    >
-      {formatGoalTooltip(goal, habit, tz)}
-    </Text>
-  </View>
-);
-
-interface GoalMarkerProps {
-  goal: Goal;
-  habit: Habit;
-  tier: TierType;
-  markerPosition: number;
-  barHeight: number;
-  zIndex: number;
-  scale: number;
-  tooltip: TierType | null;
-  setTooltip: (_v: TierType | null) => void;
-  tz: string;
-}
-
-const GoalMarker = ({
-  goal,
-  habit,
-  tier,
-  markerPosition,
-  barHeight,
-  zIndex,
-  scale,
-  tooltip,
-  setTooltip,
-  tz,
-}: GoalMarkerProps) => {
-  const clamped = clampPercentage(markerPosition);
-  const starSize = markerStarSize(scale);
-  const met = isGoalAchieved(goal, habit, tz);
-  return (
-    <View
-      style={{
-        position: 'absolute',
-        left: `${clamped}%`,
-        top: (barHeight - starSize) / 2,
-        transform: [{ translateX: centeredTranslateX(clamped, starSize) }],
-        zIndex,
-        alignItems: 'center',
-      }}
-    >
-      {tooltip === tier && (
-        <GoalTooltipContent goal={goal} habit={habit} tier={tier} scale={scale} tz={tz} />
-      )}
-      <TouchableOpacity
-        testID={`marker-${tier}`}
-        onPressIn={() => setTooltip(tier)}
-        onPressOut={() => setTooltip(null)}
-        onMouseEnter={() => setTooltip(tier)}
-        onMouseLeave={() => setTooltip(null)}
-      >
-        <TierStar tier={tier} met={met} size={starSize} />
-      </TouchableOpacity>
-    </View>
-  );
 };
 
 interface HabitHeaderProps {
@@ -242,65 +166,59 @@ export const useTileLayout = () => {
   return { columns, scale, gridGutter, tileMinHeight, iconInline };
 };
 
-interface GoalMarkerEntry {
+/** A tile marker spec carries its resolved `Goal` for tooltip formatting. */
+interface TileMarkerSpec extends TierMarkerSpec {
   goal: Goal;
-  tier: TierType;
-  markerPosition: number;
-  zIndex: number;
-  visible: boolean;
 }
+
+/** Tile tooltip body: the tier progress line, sized to scale with the tile. */
+const TileTooltipText = ({
+  goal,
+  habit,
+  tz,
+  scale,
+}: {
+  goal: Goal;
+  habit: Habit;
+  tz: string;
+  scale: number;
+}) => (
+  <Text
+    style={{
+      fontSize: spacing(1.5, scale),
+      color: '#333',
+      fontFamily: 'serif',
+      fontStyle: 'italic',
+      letterSpacing: 0.5,
+    }}
+  >
+    {formatGoalTooltip(goal, habit, tz)}
+  </Text>
+);
+
+/** Every tile marker is a press-to-reveal-tooltip touch target (no drag on the tile). */
+const tileMarkerInteraction = (
+  tier: TierType,
+  setTooltip: (_v: TierType | null) => void,
+): MarkerInteraction => ({
+  Wrapper: TouchableOpacity,
+  interactionProps: {
+    onPressIn: () => setTooltip(tier),
+    onPressOut: () => setTooltip(null),
+  },
+});
 
 interface ProgressBarProps {
   habit: Habit;
   barHeight: number;
   progressPercentage: number;
   progressBarColor: string;
-  markers: GoalMarkerEntry[];
+  markers: TileMarkerSpec[];
   scale: number;
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
   tz: string;
 }
-
-interface MarkerListProps {
-  markers: GoalMarkerEntry[];
-  habit: Habit;
-  barHeight: number;
-  scale: number;
-  tooltip: TierType | null;
-  setTooltip: (_v: TierType | null) => void;
-  tz: string;
-}
-
-const MarkerList = ({
-  markers,
-  habit,
-  barHeight,
-  scale,
-  tooltip,
-  setTooltip,
-  tz,
-}: MarkerListProps) => (
-  <>
-    {markers
-      .filter((m) => m.visible)
-      .map((m) => (
-        <GoalMarker
-          key={m.tier}
-          goal={m.goal}
-          habit={habit}
-          tier={m.tier}
-          markerPosition={m.markerPosition}
-          barHeight={barHeight}
-          zIndex={m.zIndex}
-          scale={scale}
-          tooltip={tooltip}
-          setTooltip={setTooltip}
-          tz={tz}
-        />
-      ))}
-  </>
-);
 
 const COLOR_TRANSITION_MS = 400;
 
@@ -392,14 +310,18 @@ const ProgressBar = ({
             borderRadius={borderR}
           />
         </View>
-        <MarkerList
+        <TierMarkerOverlay<TileMarkerSpec>
           markers={markers}
-          habit={habit}
           barHeight={barHeight}
-          scale={scale}
+          starSize={markerStarSize(scale)}
           tooltip={tooltip}
           setTooltip={setTooltip}
-          tz={tz}
+          markerTestIDPrefix="marker"
+          tooltipTestIDPrefix="tooltip"
+          renderTooltip={(m) => (
+            <TileTooltipText goal={m.goal} habit={habit} tz={tz} scale={scale} />
+          )}
+          resolveInteraction={(m) => tileMarkerInteraction(m.tier, setTooltip)}
         />
       </View>
     </View>
@@ -423,27 +345,31 @@ const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
   } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
 
   // SG is unconditionally visible (the prior ``hasCleared`` gate caused user-reported confusion).
-  const markers: GoalMarkerEntry[] = [
+  // ``met`` is only computed when the goal exists — an absent tier has no goal to achieve.
+  const markers: TileMarkerSpec[] = [
     {
       goal: lowGoal!,
       tier: 'low',
-      markerPosition: lowMarker,
+      position: lowMarker,
       zIndex: 1,
       visible: !!lowGoal,
+      met: lowGoal ? isGoalAchieved(lowGoal, habit, tz) : false,
     },
     {
       goal: clearGoal!,
       tier: 'clear',
-      markerPosition: clearMarker,
+      position: clearMarker,
       zIndex: 2,
       visible: !!clearGoal,
+      met: clearGoal ? isGoalAchieved(clearGoal, habit, tz) : false,
     },
     {
       goal: stretchGoal!,
       tier: 'stretch',
-      markerPosition: stretchMarker,
+      position: stretchMarker,
       zIndex: 3,
       visible: !!stretchGoal,
+      met: stretchGoal ? isGoalAchieved(stretchGoal, habit, tz) : false,
     },
   ];
 

--- a/frontend/src/features/Habits/TierMarkerOverlay.tsx
+++ b/frontend/src/features/Habits/TierMarkerOverlay.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { View, type DimensionValue, type ViewStyle } from 'react-native';
+
+import { TierStar } from '../../components/TierStar';
+
+import { centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
+import { clampPercentage, getTierColor } from './HabitUtils';
+
+/**
+ * One tier marker's render spec: which tier, where it sits on the bar
+ * (`position` as a 0–100 percent), its stacking `zIndex`, whether the goal is
+ * `met` (drives the star fill), and whether it is `visible` at all.
+ */
+export interface TierMarkerSpec {
+  tier: TierType;
+  position: number;
+  zIndex: number;
+  met: boolean;
+  visible: boolean;
+}
+
+/**
+ * How a marker wraps and wires its press/pan interaction. `Wrapper` is the
+ * element type (e.g. `TouchableOpacity` for tap tooltips, `View` for pan
+ * drag), and `interactionProps` are spread onto it. The overlay layers its
+ * own hover handlers on top, so mouse enter/leave always win.
+ */
+export interface MarkerInteraction {
+  Wrapper: React.ComponentType<Record<string, unknown>>;
+  interactionProps: Record<string, unknown>;
+}
+
+/** Center a tier star on its bar position and vertically on the bar height. */
+const markerContainerStyle = (
+  position: number,
+  zIndex: number,
+  starSize: number,
+  barHeight: number,
+): ViewStyle => {
+  const clamped = clampPercentage(position);
+  return {
+    position: 'absolute',
+    left: `${clamped}%` as DimensionValue,
+    top: (barHeight - starSize) / 2,
+    transform: [{ translateX: centeredTranslateX(clamped, starSize) }],
+    zIndex,
+    alignItems: 'center',
+  };
+};
+
+interface TierMarkerOverlayProps<T extends TierMarkerSpec> {
+  markers: T[];
+  barHeight: number;
+  starSize: number;
+  tooltip: TierType | null;
+  setTooltip: (_v: TierType | null) => void;
+  markerTestIDPrefix: string;
+  tooltipTestIDPrefix: string;
+  renderTooltip: (_m: T) => React.ReactNode;
+  resolveInteraction: (_m: T) => MarkerInteraction;
+}
+
+/**
+ * The shared three-tier goal-marker overlay: renders a tier star per visible
+ * marker, positioned along a progress bar, each with a hover/press tooltip.
+ * Callers supply the marker specs, the tooltip body, and the interaction
+ * wrapper so the habit tile and the goal modal can share one implementation
+ * while keeping their own sizing, wrappers, and tooltip typography.
+ */
+export function TierMarkerOverlay<T extends TierMarkerSpec>({
+  markers,
+  barHeight,
+  starSize,
+  tooltip,
+  setTooltip,
+  markerTestIDPrefix,
+  tooltipTestIDPrefix,
+  renderTooltip,
+  resolveInteraction,
+}: TierMarkerOverlayProps<T>): React.JSX.Element {
+  return (
+    <>
+      {markers
+        .filter((m) => m.visible)
+        .map((m) => {
+          const { Wrapper, interactionProps } = resolveInteraction(m);
+          return (
+            <Wrapper
+              key={m.tier}
+              testID={`${markerTestIDPrefix}-${m.tier}`}
+              {...interactionProps}
+              onMouseEnter={() => setTooltip(m.tier)}
+              onMouseLeave={() => setTooltip(null)}
+              style={markerContainerStyle(m.position, m.zIndex, starSize, barHeight)}
+            >
+              {tooltip === m.tier && (
+                <View
+                  testID={`${tooltipTestIDPrefix}-${m.tier}`}
+                  style={tooltipBoxStyle(getTierColor(m.tier))}
+                >
+                  {renderTooltip(m)}
+                </View>
+              )}
+              <TierStar tier={m.tier} met={m.met} size={starSize} />
+            </Wrapper>
+          );
+        })}
+    </>
+  );
+}

--- a/frontend/src/features/Habits/__tests__/TierMarkerOverlay.test.tsx
+++ b/frontend/src/features/Habits/__tests__/TierMarkerOverlay.test.tsx
@@ -1,0 +1,221 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import { TierStar } from '../../../components/TierStar';
+import { TierMarkerOverlay } from '../TierMarkerOverlay';
+import type { MarkerInteraction, TierMarkerSpec } from '../TierMarkerOverlay';
+
+interface TestMarkerSpec extends TierMarkerSpec {
+  label: string;
+}
+
+const PAN_PROP_KEY = 'data-pan';
+const PAN_PROP_VALUE = 'yes';
+const DEFAULT_BAR_HEIGHT = 24;
+const DEFAULT_STAR_SIZE = 14;
+const OVER_MAX_POSITION = 150;
+
+const baseMarkers: Record<TierMarkerSpec['tier'], TestMarkerSpec> = {
+  low: { tier: 'low', position: 10, zIndex: 1, met: false, visible: true, label: 'Low' },
+  clear: { tier: 'clear', position: 50, zIndex: 2, met: false, visible: true, label: 'Clear' },
+  stretch: { tier: 'stretch', position: 90, zIndex: 3, met: true, visible: true, label: 'Stretch' },
+};
+
+const buildMarkers = (
+  overrides: Partial<Record<TierMarkerSpec['tier'], Partial<TestMarkerSpec>>> = {},
+): TestMarkerSpec[] =>
+  (['low', 'clear', 'stretch'] as const).map((tier) => ({
+    ...baseMarkers[tier],
+    ...overrides[tier],
+  }));
+
+const defaultRenderTooltip = (m: TestMarkerSpec): React.ReactNode => <Text>{m.label}</Text>;
+
+interface HarnessProps {
+  markers: TestMarkerSpec[];
+  markerTestIDPrefix?: string;
+  tooltipTestIDPrefix?: string;
+  renderTooltip?: (m: TestMarkerSpec) => React.ReactNode;
+}
+
+// Wraps TierMarkerOverlay with real useState so setTooltip round-trips
+// through a re-render, exercising the hover/press wiring end-to-end.
+const Harness = ({
+  markers,
+  markerTestIDPrefix = 'marker',
+  tooltipTestIDPrefix = 'tooltip',
+  renderTooltip = defaultRenderTooltip,
+}: HarnessProps) => {
+  const [tooltip, setTooltip] = useState<TierMarkerSpec['tier'] | null>(null);
+
+  const resolveInteraction = (m: TestMarkerSpec): MarkerInteraction => {
+    if (m.tier === 'stretch') {
+      return {
+        Wrapper: TouchableOpacity,
+        interactionProps: {
+          onPressIn: () => setTooltip(m.tier),
+          onPressOut: () => setTooltip(null),
+        },
+      };
+    }
+    return { Wrapper: View, interactionProps: { [PAN_PROP_KEY]: PAN_PROP_VALUE } };
+  };
+
+  return (
+    <TierMarkerOverlay
+      markers={markers}
+      barHeight={DEFAULT_BAR_HEIGHT}
+      starSize={DEFAULT_STAR_SIZE}
+      tooltip={tooltip}
+      setTooltip={setTooltip}
+      markerTestIDPrefix={markerTestIDPrefix}
+      tooltipTestIDPrefix={tooltipTestIDPrefix}
+      renderTooltip={renderTooltip}
+      resolveInteraction={resolveInteraction}
+    />
+  );
+};
+
+describe('TierMarkerOverlay visibility', () => {
+  it('renders only markers whose visible flag is true', () => {
+    const markers = buildMarkers({ clear: { visible: false } });
+    const component = renderer.create(<Harness markers={markers} />);
+
+    expect(component.root.findByProps({ testID: 'marker-low' })).toBeTruthy();
+    expect(component.root.findByProps({ testID: 'marker-stretch' })).toBeTruthy();
+    expect(() => component.root.findByProps({ testID: 'marker-clear' })).toThrow();
+  });
+});
+
+describe('TierMarkerOverlay resolveInteraction wiring', () => {
+  it('spreads interactionProps from resolveInteraction onto the Wrapper', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-low' });
+    expect(marker.props[PAN_PROP_KEY]).toBe(PAN_PROP_VALUE);
+  });
+
+  it('honors a resolveInteraction Wrapper whose onPressIn/onPressOut drive the tooltip', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-stretch' });
+    expect(typeof marker.props.onPressIn).toBe('function');
+    expect(() => component.root.findByProps({ testID: 'tooltip-stretch' })).toThrow();
+
+    renderer.act(() => {
+      marker.props.onPressIn();
+    });
+    expect(component.root.findByProps({ testID: 'tooltip-stretch' })).toBeTruthy();
+
+    renderer.act(() => {
+      marker.props.onPressOut();
+    });
+    expect(() => component.root.findByProps({ testID: 'tooltip-stretch' })).toThrow();
+  });
+});
+
+describe('TierMarkerOverlay hover', () => {
+  it('shows the tooltip on mouse enter and hides it on mouse leave', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-low' });
+    expect(() => component.root.findByProps({ testID: 'tooltip-low' })).toThrow();
+
+    renderer.act(() => {
+      marker.props.onMouseEnter();
+    });
+    expect(component.root.findByProps({ testID: 'tooltip-low' })).toBeTruthy();
+    expect(() => component.root.findByProps({ testID: 'tooltip-clear' })).toThrow();
+
+    renderer.act(() => {
+      marker.props.onMouseLeave();
+    });
+    expect(() => component.root.findByProps({ testID: 'tooltip-low' })).toThrow();
+  });
+});
+
+describe('TierMarkerOverlay renderTooltip', () => {
+  it('renders the renderTooltip output inside the tooltip box', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(
+      <Harness markers={markers} renderTooltip={(m) => <Text>{`known-${m.tier}`}</Text>} />,
+    );
+
+    const marker = component.root.findByProps({ testID: 'marker-clear' });
+    renderer.act(() => {
+      marker.props.onMouseEnter();
+    });
+
+    const box = component.root.findByProps({ testID: 'tooltip-clear' });
+    const text = box.findByType(Text);
+    expect(text.props.children).toBe('known-clear');
+  });
+});
+
+describe('TierMarkerOverlay position style', () => {
+  it('places a marker at left = position% with a translateX transform', () => {
+    const markers = buildMarkers({ clear: { position: 50 } });
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-clear' });
+    expect(marker.props.style.position).toBe('absolute');
+    expect(marker.props.style.left).toBe('50%');
+    expect(marker.props.style.zIndex).toBe(2);
+    expect(marker.props.style.alignItems).toBe('center');
+    expect(Array.isArray(marker.props.style.transform)).toBe(true);
+  });
+
+  it('clamps an out-of-range position to 100%', () => {
+    const markers = buildMarkers({ stretch: { position: OVER_MAX_POSITION } });
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-stretch' });
+    expect(marker.props.style.left).toBe('100%');
+  });
+});
+
+describe('TierMarkerOverlay testID prefixes', () => {
+  it('honors a custom markerTestIDPrefix/tooltipTestIDPrefix pair', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(
+      <Harness
+        markers={markers}
+        markerTestIDPrefix="modal-marker"
+        tooltipTestIDPrefix="modal-tooltip"
+      />,
+    );
+
+    const marker = component.root.findByProps({ testID: 'modal-marker-low' });
+    renderer.act(() => {
+      marker.props.onMouseEnter();
+    });
+    expect(component.root.findByProps({ testID: 'modal-tooltip-low' })).toBeTruthy();
+  });
+
+  it('honors the default markerTestIDPrefix/tooltipTestIDPrefix pair', () => {
+    const markers = buildMarkers();
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const marker = component.root.findByProps({ testID: 'marker-low' });
+    renderer.act(() => {
+      marker.props.onMouseEnter();
+    });
+    expect(component.root.findByProps({ testID: 'tooltip-low' })).toBeTruthy();
+  });
+});
+
+describe('TierMarkerOverlay star rendering', () => {
+  it('renders one image-role TierStar per visible marker', () => {
+    const markers = buildMarkers({ clear: { visible: false } });
+    const component = renderer.create(<Harness markers={markers} />);
+
+    const stars = component.root.findAllByType(TierStar);
+    expect(stars).toHaveLength(2);
+  });
+});

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -11,18 +11,11 @@ import {
   PanResponder,
   StyleSheet,
 } from 'react-native';
-import type {
-  DimensionValue,
-  GestureResponderHandlers,
-  LayoutChangeEvent,
-  ViewStyle,
-  TextStyle,
-} from 'react-native';
+import type { GestureResponderHandlers, LayoutChangeEvent, TextStyle } from 'react-native';
 import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
 import { Button } from '../../../components/Button';
-import { TierStar } from '../../../components/TierStar';
 import { useAuth } from '../../../context/AuthContext';
 import {
   colors,
@@ -35,7 +28,7 @@ import {
 import useResponsive from '../../../design/useResponsive';
 import { addDaysInTZ, dayKeyInTZ, todayInUserTZ } from '../../../utils/dateUtils';
 import { TARGET_UNITS, FREQUENCY_UNITS } from '../constants';
-import { TIER_LABELS, centeredTranslateX, tooltipBoxStyle } from '../goalMarker';
+import { TIER_LABELS, type TierType } from '../goalMarker';
 import styles from '../Habits.styles';
 import type { GoalModalProps, Goal } from '../Habits.types';
 import {
@@ -47,24 +40,16 @@ import {
   getGoalTarget,
   isGoalAchieved,
 } from '../HabitUtils';
+import {
+  TierMarkerOverlay,
+  type MarkerInteraction,
+  type TierMarkerSpec,
+} from '../TierMarkerOverlay';
 
 import ConfirmDialog from './ConfirmDialog';
 
 /** Height of the goal progress bar; tier star markers are centered on it. */
 const MODAL_BAR_HEIGHT = 12;
-
-/** Position a tier star marker on the bar: centered on its threshold and on the bar height. */
-const markerContainerStyle = (leftPct: number, z: number, starSize: number): ViewStyle => {
-  const clamped = clampPercentage(leftPct);
-  return {
-    position: 'absolute',
-    left: `${clamped}%` as DimensionValue,
-    top: (MODAL_BAR_HEIGHT - starSize) / 2,
-    transform: [{ translateX: centeredTranslateX(clamped, starSize) }],
-    zIndex: z,
-    alignItems: 'center',
-  };
-};
 
 const tooltipTextStyle: TextStyle = {
   fontSize: 10,
@@ -80,70 +65,18 @@ const formatGoalTooltip = (g: Goal | undefined): string => {
   return `${label}: ${g.target} ${g.target_unit} per ${g.frequency_unit.replace('_', ' ')}`;
 };
 
-interface GoalMarkerItemProps {
-  goal: Goal;
-  tier: 'low' | 'clear' | 'stretch';
-  position: number;
-  zIndex: number;
-  met: boolean;
-  tooltip: 'low' | 'clear' | 'stretch' | null;
-  setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
+/** A modal marker spec carries its resolved `Goal` and (for draggable tiers) pan handlers. */
+interface ModalMarkerSpec extends TierMarkerSpec {
+  goal: Goal | undefined;
   panHandlers?: GestureResponderHandlers;
 }
-
-const GoalMarkerItem = ({
-  goal,
-  tier,
-  position,
-  zIndex,
-  met,
-  tooltip,
-  setTooltip,
-  panHandlers,
-}: GoalMarkerItemProps) => {
-  const { scale } = useResponsive();
-  // Match HabitTile's marker sizing so the two surfaces stay visually consistent.
-  const starSize = spacing(2, scale);
-  const Wrapper = tier === 'stretch' ? TouchableOpacity : View;
-  const interactionProps =
-    tier === 'stretch'
-      ? { onPressIn: () => setTooltip(tier), onPressOut: () => setTooltip(null) }
-      : panHandlers ?? {};
-
-  return (
-    <Wrapper
-      testID={`modal-marker-${tier}`}
-      {...interactionProps}
-      onMouseEnter={() => setTooltip(tier)}
-      onMouseLeave={() => setTooltip(null)}
-      style={markerContainerStyle(position, zIndex, starSize)}
-    >
-      {tooltip === tier && (
-        <View testID={`modal-tooltip-${tier}`} style={tooltipBoxStyle(getTierColor(tier))}>
-          <Text style={tooltipTextStyle}>{formatGoalTooltip(goal)}</Text>
-        </View>
-      )}
-      <TierStar tier={tier} met={met} size={starSize} />
-    </Wrapper>
-  );
-};
 
 interface GoalProgressBarProps {
   progressPercentage: number;
   progressBarColor: string;
-  lowGoal: Goal | undefined;
-  clearGoal: Goal | undefined;
-  stretchGoal: Goal | undefined;
-  lowMarker: number;
-  clearMarker: number;
-  stretchMarker: number;
-  lowMet: boolean;
-  clearMet: boolean;
-  stretchMet: boolean;
-  tooltip: 'low' | 'clear' | 'stretch' | null;
-  setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
-  lowPanHandlers: GestureResponderHandlers;
-  clearPanHandlers: GestureResponderHandlers;
+  markers: ModalMarkerSpec[];
+  tooltip: TierType | null;
+  setTooltip: (_v: TierType | null) => void;
   onLayout: (_e: LayoutChangeEvent) => void;
 }
 
@@ -166,113 +99,49 @@ const ProgressFill = ({ progressPercentage, progressBarColor }: ProgressFillProp
   </View>
 );
 
-interface GoalMarkersRowProps {
-  lowGoal: Goal | undefined;
-  clearGoal: Goal | undefined;
-  stretchGoal: Goal | undefined;
-  lowMarker: number;
-  clearMarker: number;
-  stretchMarker: number;
-  lowMet: boolean;
-  clearMet: boolean;
-  stretchMet: boolean;
-  tooltip: 'low' | 'clear' | 'stretch' | null;
-  setTooltip: (_v: 'low' | 'clear' | 'stretch' | null) => void;
-  lowPanHandlers: GestureResponderHandlers;
-  clearPanHandlers: GestureResponderHandlers;
-}
-
-interface MarkerEntry {
-  tier: 'low' | 'clear' | 'stretch';
-  goal: Goal | undefined;
-  position: number;
-  zIndex: number;
-  met: boolean;
-  panHandlers?: GestureResponderHandlers;
-}
-
-const buildMarkerEntries = (p: GoalMarkersRowProps): MarkerEntry[] => [
-  {
-    tier: 'low',
-    goal: p.lowGoal,
-    position: p.lowMarker,
-    zIndex: 1,
-    met: p.lowMet,
-    panHandlers: p.lowPanHandlers,
-  },
-  {
-    tier: 'clear',
-    goal: p.clearGoal,
-    position: p.clearMarker,
-    zIndex: 2,
-    met: p.clearMet,
-    panHandlers: p.clearPanHandlers,
-  },
-  { tier: 'stretch', goal: p.stretchGoal, position: p.stretchMarker, zIndex: 3, met: p.stretchMet },
-];
-
-const GoalMarkersRow = (props: GoalMarkersRowProps) => {
-  const { tooltip, setTooltip } = props;
-  return (
-    <>
-      {buildMarkerEntries(props).map((it) =>
-        it.goal ? (
-          <GoalMarkerItem
-            key={it.tier}
-            goal={it.goal}
-            tier={it.tier}
-            position={it.position}
-            zIndex={it.zIndex}
-            met={it.met}
-            tooltip={tooltip}
-            setTooltip={setTooltip}
-            panHandlers={it.panHandlers}
-          />
-        ) : null,
-      )}
-    </>
-  );
-};
-
 const GoalProgressBar = ({
   progressPercentage,
   progressBarColor,
-  lowGoal,
-  clearGoal,
-  stretchGoal,
-  lowMarker,
-  clearMarker,
-  stretchMarker,
-  lowMet,
-  clearMet,
-  stretchMet,
+  markers,
   tooltip,
   setTooltip,
-  lowPanHandlers,
-  clearPanHandlers,
   onLayout,
-}: GoalProgressBarProps) => (
-  <View style={{ marginVertical: 16 }} onLayout={onLayout}>
-    <View style={{ height: MODAL_BAR_HEIGHT, position: 'relative' }}>
-      <ProgressFill progressPercentage={progressPercentage} progressBarColor={progressBarColor} />
-      <GoalMarkersRow
-        lowGoal={lowGoal}
-        clearGoal={clearGoal}
-        stretchGoal={stretchGoal}
-        lowMarker={lowMarker}
-        clearMarker={clearMarker}
-        stretchMarker={stretchMarker}
-        lowMet={lowMet}
-        clearMet={clearMet}
-        stretchMet={stretchMet}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-        lowPanHandlers={lowPanHandlers}
-        clearPanHandlers={clearPanHandlers}
-      />
+}: GoalProgressBarProps) => {
+  const { scale } = useResponsive();
+  const starSize = spacing(2, scale);
+
+  // Stretch markers open their tooltip on tap; low/clear are draggable, so they
+  // wrap a plain View and forward their pan handlers instead.
+  const resolveModalInteraction = (m: ModalMarkerSpec): MarkerInteraction =>
+    m.tier === 'stretch'
+      ? {
+          Wrapper: TouchableOpacity,
+          interactionProps: {
+            onPressIn: () => setTooltip('stretch'),
+            onPressOut: () => setTooltip(null),
+          },
+        }
+      : { Wrapper: View, interactionProps: { ...m.panHandlers } };
+
+  return (
+    <View style={{ marginVertical: 16 }} onLayout={onLayout}>
+      <View style={{ height: MODAL_BAR_HEIGHT, position: 'relative' }}>
+        <ProgressFill progressPercentage={progressPercentage} progressBarColor={progressBarColor} />
+        <TierMarkerOverlay<ModalMarkerSpec>
+          markers={markers}
+          barHeight={MODAL_BAR_HEIGHT}
+          starSize={starSize}
+          tooltip={tooltip}
+          setTooltip={setTooltip}
+          markerTestIDPrefix="modal-marker"
+          tooltipTestIDPrefix="modal-tooltip"
+          renderTooltip={(m) => <Text style={tooltipTextStyle}>{formatGoalTooltip(m.goal)}</Text>}
+          resolveInteraction={resolveModalInteraction}
+        />
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 // Layout constants for the log-date stepper.
 const LOG_DATE_NOON_HOUR = 12;
@@ -1177,24 +1046,46 @@ const buildProgressBarProps = (
   habit: NonNullable<GoalModalProps['habit']>,
   m: ReturnType<typeof useGoalMarkers>,
   tz: string,
-) => ({
-  progressPercentage: modalProgressPercentage(habit, m, tz),
-  progressBarColor: getProgressBarColor(habit, tz),
-  lowGoal: m.lowGoal,
-  clearGoal: m.clearGoal,
-  stretchGoal: m.stretchGoal,
-  lowMarker: m.lowMarker,
-  clearMarker: m.clearMarker,
-  stretchMarker: m.stretchMarker,
-  lowMet: m.lowGoal ? isGoalAchieved(m.lowGoal, habit, tz) : false,
-  clearMet: m.clearGoal ? isGoalAchieved(m.clearGoal, habit, tz) : false,
-  stretchMet: m.stretchGoal ? isGoalAchieved(m.stretchGoal, habit, tz) : false,
-  tooltip: m.tooltip,
-  setTooltip: m.setTooltip,
-  lowPanHandlers: m.lowPan.panHandlers,
-  clearPanHandlers: m.clearPan.panHandlers,
-  onLayout: m.handleBarLayout,
-});
+): GoalProgressBarProps => {
+  // ``met`` is only computed when the goal exists — an absent tier has nothing to achieve.
+  const markers: ModalMarkerSpec[] = [
+    {
+      tier: 'low',
+      goal: m.lowGoal,
+      position: m.lowMarker,
+      zIndex: 1,
+      met: m.lowGoal ? isGoalAchieved(m.lowGoal, habit, tz) : false,
+      visible: !!m.lowGoal,
+      panHandlers: m.lowPan.panHandlers,
+    },
+    {
+      tier: 'clear',
+      goal: m.clearGoal,
+      position: m.clearMarker,
+      zIndex: 2,
+      met: m.clearGoal ? isGoalAchieved(m.clearGoal, habit, tz) : false,
+      visible: !!m.clearGoal,
+      panHandlers: m.clearPan.panHandlers,
+    },
+    {
+      tier: 'stretch',
+      goal: m.stretchGoal,
+      position: m.stretchMarker,
+      zIndex: 3,
+      met: m.stretchGoal ? isGoalAchieved(m.stretchGoal, habit, tz) : false,
+      visible: !!m.stretchGoal,
+    },
+  ];
+
+  return {
+    progressPercentage: modalProgressPercentage(habit, m, tz),
+    progressBarColor: getProgressBarColor(habit, tz),
+    markers,
+    tooltip: m.tooltip,
+    setTooltip: m.setTooltip,
+    onLayout: m.handleBarLayout,
+  };
+};
 
 /** Amount + date draft state for the Log Units control. */
 const useLogState = (


### PR DESCRIPTION
## Summary

The 3-tier (`low`/`clear`/`stretch`) goal-marker overlay drawn on a habit's
progress bar was implemented **twice**, independently — once in `HabitTile` and
once in `GoalModal` — kept visually consistent by a `// Match HabitTile's marker
sizing…` manual-sync comment, and already drifting (divergent visibility gates,
tooltip font handling, and wrapper elements).

This consolidates both into a single generic `<TierMarkerOverlay>`
(`frontend/src/features/Habits/TierMarkerOverlay.tsx`) and deletes the bespoke
marker renderers from both surfaces plus the manual-sync comment:

- **HabitTile** — removed `GoalMarker`, `MarkerList`, `GoalTooltipContent`,
  `GoalMarkerEntry`; `useHabitTileData` now emits marker specs and `ProgressBar`
  renders the shared overlay via small `TileTooltipText` / `tileMarkerInteraction`
  helpers.
- **GoalModal** — removed `GoalMarkerItem`, `GoalMarkersRow`, `buildMarkerEntries`,
  `MarkerEntry`, the local `markerContainerStyle`, and the manual-sync comment;
  `GoalProgressBar` renders the shared overlay via `resolveModalInteraction`.

The two genuinely-different axes are preserved as explicit props (not flattened):
1. **Tooltip typography** — the tile scales its tooltip font with the tile
   (`spacing(1.5, scale)`); the modal pins `fontSize: 10`. Passed via a
   `renderTooltip` prop.
2. **Drag support** — the modal's `low`/`clear` markers keep their drag
   pan-handlers (wrapped in a `View`) while `stretch` keeps press-to-reveal
   (wrapped in `TouchableOpacity`). Passed via a `resolveInteraction` prop.

### Intentional convergence (behavior note)
The tile's `marker-*` testID + press/mouse handlers moved from an inner
star-only `TouchableOpacity` (tooltip a sibling) onto the single positioned
wrapper (tooltip + star inside), matching the modal's shape. This is layout- and
interaction-equivalent because the tooltip is `position: absolute` (out of flow,
so the touch/hit area stays star-sized). On web this converges the tile onto the
modal's (slightly better) hover semantics; no pinned test observes a difference.

## Test plan
- New focused unit test `TierMarkerOverlay.test.tsx` covers the `visible` filter,
  both interaction branches (press wrapper + pan/`View` wrapper), hover
  show/hide, tooltip-body rendering, position/clamp math, and testID-prefix
  parity — satisfying the "both surfaces derive marker rendering from the shared
  code" acceptance criterion.
- Existing `HabitTileTooltip.test.tsx` and `GoalModal.test.tsx` are unchanged and
  remain green — they are the behavior-identical proof.
- `npx tsc --noEmit` exit 0; ESLint `--max-warnings=0` clean; full Jest suite
  **2795/2795** pass; `./scripts/frontend/check-all.sh` **4/4** pass.

Closes #1081