### PR TITLE
feat(frontend): rich torus/spiral visual for the Wavelength explainer

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -274,6 +274,10 @@ const styles = StyleSheet.create({
   explainerScroll: {
     paddingBottom: spacing(2),
   },
+  // Decorative torus/spiral illustration sitting under the title, above the copy.
+  explainerVisual: {
+    marginBottom: spacing(1.5),
+  },
   explainerTitle: {
     ...editorialType.title,
     fontSize: 22,

--- a/frontend/src/features/Map/TorusSpiralVisual.tsx
+++ b/frontend/src/features/Map/TorusSpiralVisual.tsx
@@ -1,0 +1,84 @@
+// frontend/features/Map/TorusSpiralVisual.tsx
+
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+import { accent, ink } from '../../design/tokens';
+
+import styles from './Map.styles';
+import { spiralPath, torusRings } from './torusGeometry';
+
+/**
+ * Static torus/spiral illustration for the "How the Wavelength works" explainer.
+ *
+ * It draws the model warmly rather than measuring anything: a stack of nested,
+ * tilted ellipse rings for the torus (the auric field) with the growing spiral
+ * winding up through them. The art is intentionally still — no animation — so it
+ * respects "Reduce Motion" by construction and adds nothing to the Map screen's
+ * render budget (it mounts only while the explainer sheet is open).
+ *
+ * It carries an ``image`` role and a describing label because it depicts the
+ * model, and is ``pointerEvents="none"`` so it never intercepts the sheet's
+ * scroll.
+ */
+
+/** Logical drawing width the geometry is computed against (the SVG viewBox). */
+const VIEW_WIDTH = 320;
+
+/** Logical drawing height the geometry is computed against (the SVG viewBox). */
+const VIEW_HEIGHT = 200;
+
+/** Rendered height of the illustration, in dp; the width fills its container. */
+const RENDER_HEIGHT = 160;
+
+/** Stroke thickness of each faint torus ring, in logical units. */
+const RING_STROKE_WIDTH = 1.5;
+
+/** Softening opacity of the torus rings so the spiral reads as the foreground. */
+const RING_OPACITY = 0.5;
+
+/** Stroke thickness of the foreground spiral, in logical units. */
+const SPIRAL_STROKE_WIDTH = 2.5;
+
+/** Screen-reader description of the illustration's meaning. */
+const ACCESSIBILITY_LABEL =
+  'An illustration of the torus: a spiral rising and widening through the octaves.';
+
+// Geometry is static, so it is computed once at module load rather than per render.
+const RINGS = torusRings(VIEW_WIDTH, VIEW_HEIGHT);
+const SPIRAL = spiralPath(VIEW_WIDTH, VIEW_HEIGHT);
+
+/** The explainer's decorative-but-labeled torus/spiral artwork. */
+export default function TorusSpiralVisual(): React.JSX.Element {
+  return (
+    <Svg
+      testID="torus-spiral-visual"
+      width="100%"
+      height={RENDER_HEIGHT}
+      viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      style={styles.explainerVisual}
+      pointerEvents="none"
+      accessibilityRole="image"
+      accessibilityLabel={ACCESSIBILITY_LABEL}
+    >
+      {RINGS.map((ring) => (
+        <Path
+          key={ring.d}
+          d={ring.d}
+          stroke={ink.soft}
+          strokeOpacity={RING_OPACITY}
+          strokeWidth={RING_STROKE_WIDTH}
+          fill="none"
+        />
+      ))}
+      <Path
+        d={SPIRAL}
+        stroke={accent.primary}
+        strokeWidth={SPIRAL_STROKE_WIDTH}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </Svg>
+  );
+}

--- a/frontend/src/features/Map/WavelengthExplainer.tsx
+++ b/frontend/src/features/Map/WavelengthExplainer.tsx
@@ -5,6 +5,7 @@ import Markdown from 'react-native-markdown-display';
 import { markdownStyles } from '../Course/Course.styles';
 
 import styles from './Map.styles';
+import TorusSpiralVisual from './TorusSpiralVisual';
 import { WAVELENGTH_EXPLAINER } from './wavelengthExplainerContent';
 
 interface WavelengthExplainerProps {
@@ -30,6 +31,7 @@ const ExplainerSheet = ({ onClose }: { onClose: () => void }): React.JSX.Element
       showsVerticalScrollIndicator={false}
     >
       <Text style={styles.explainerTitle}>{WAVELENGTH_EXPLAINER.title}</Text>
+      <TorusSpiralVisual />
       <Markdown style={markdownStyles}>{WAVELENGTH_EXPLAINER.markdown}</Markdown>
     </ScrollView>
   </Pressable>

--- a/frontend/src/features/Map/__tests__/TorusSpiralVisual.test.tsx
+++ b/frontend/src/features/Map/__tests__/TorusSpiralVisual.test.tsx
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import TorusSpiralVisual from '../TorusSpiralVisual';
+
+describe('TorusSpiralVisual', () => {
+  it('renders the illustration container', () => {
+    const { getByTestId } = render(<TorusSpiralVisual />);
+    expect(getByTestId('torus-spiral-visual')).toBeTruthy();
+  });
+
+  it('exposes an image role for screen readers', () => {
+    const { getByTestId } = render(<TorusSpiralVisual />);
+    expect(getByTestId('torus-spiral-visual').props.accessibilityRole).toBe('image');
+  });
+
+  it('carries a non-empty accessibility label', () => {
+    const { getByTestId } = render(<TorusSpiralVisual />);
+    expect(getByTestId('torus-spiral-visual').props.accessibilityLabel.length).toBeGreaterThan(0);
+  });
+
+  it('is non-interactive so it never blocks the sheet scroll', () => {
+    const { getByTestId } = render(<TorusSpiralVisual />);
+    expect(getByTestId('torus-spiral-visual').props.pointerEvents).toBe('none');
+  });
+});

--- a/frontend/src/features/Map/__tests__/WavelengthExplainer.test.tsx
+++ b/frontend/src/features/Map/__tests__/WavelengthExplainer.test.tsx
@@ -31,6 +31,11 @@ describe('WavelengthExplainer', () => {
     expect(getByTestId('wavelength-explainer')).toBeTruthy();
   });
 
+  it('renders the torus/spiral illustration inside the visible sheet', () => {
+    const { getByTestId } = render(<WavelengthExplainer visible onClose={() => {}} />);
+    expect(getByTestId('torus-spiral-visual')).toBeTruthy();
+  });
+
   it('renders the torus/auric-field concept', () => {
     const { getAllByText } = render(<WavelengthExplainer visible onClose={() => {}} />);
     expect(getAllByText(/torus/i).length).toBeGreaterThan(0);

--- a/frontend/src/features/Map/__tests__/torusGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/torusGeometry.test.ts
@@ -1,0 +1,100 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { SPIRAL_SAMPLE_COUNT, TORUS_RING_COUNT, spiralPath, torusRings } from '../torusGeometry';
+
+const SMALL_WIDTH = 100;
+const SMALL_HEIGHT = 200;
+const LARGE_WIDTH = 200;
+const LARGE_HEIGHT = 400;
+const MAX_DECIMALS = 3;
+const COORDS_PER_POINT = 2;
+const Y_OFFSET = 1;
+
+/** Every numeric token in an SVG path string, in order, ignoring the letters. */
+const numbersIn = (path: string): number[] =>
+  path
+    .split(/[\s,]+/)
+    .map(Number)
+    .filter((value) => !Number.isNaN(value));
+
+/** Whether a number carries no more than MAX_DECIMALS fractional digits. */
+const hasBoundedPrecision = (value: number): boolean => {
+  const fraction = String(value).split('.')[1] ?? '';
+  return fraction.length <= MAX_DECIMALS;
+};
+
+describe('torusRings', () => {
+  it('returns exactly TORUS_RING_COUNT rings', () => {
+    expect(torusRings(SMALL_WIDTH, SMALL_HEIGHT)).toHaveLength(TORUS_RING_COUNT);
+  });
+
+  it('emits a non-empty arc path beginning with a move command for every ring', () => {
+    for (const ring of torusRings(SMALL_WIDTH, SMALL_HEIGHT)) {
+      expect(ring.d.length).toBeGreaterThan(0);
+      expect(ring.d.startsWith('M')).toBe(true);
+    }
+  });
+
+  it('keeps every emitted number finite and within three decimals', () => {
+    for (const ring of torusRings(SMALL_WIDTH, SMALL_HEIGHT)) {
+      for (const value of numbersIn(ring.d)) {
+        expect(Number.isFinite(value)).toBe(true);
+        expect(hasBoundedPrecision(value)).toBe(true);
+      }
+    }
+  });
+
+  it('keeps every ring number non-negative and within the layout extent', () => {
+    const bound = Math.max(SMALL_WIDTH, SMALL_HEIGHT);
+    for (const ring of torusRings(SMALL_WIDTH, SMALL_HEIGHT)) {
+      for (const value of numbersIn(ring.d)) {
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(bound);
+      }
+    }
+  });
+
+  it('scales the ring coordinates with width and height', () => {
+    const small = torusRings(SMALL_WIDTH, SMALL_HEIGHT);
+    const large = torusRings(LARGE_WIDTH, LARGE_HEIGHT);
+    for (let index = 0; index < small.length; index += 1) {
+      expect(large[index]?.d).not.toBe(small[index]?.d);
+    }
+  });
+});
+
+describe('spiralPath', () => {
+  it('emits a non-empty polyline beginning with a move command', () => {
+    const path = spiralPath(SMALL_WIDTH, SMALL_HEIGHT);
+    expect(path.length).toBeGreaterThan(0);
+    expect(path.startsWith('M')).toBe(true);
+  });
+
+  it('samples SPIRAL_SAMPLE_COUNT points', () => {
+    const numbers = numbersIn(spiralPath(SMALL_WIDTH, SMALL_HEIGHT));
+    expect(numbers).toHaveLength(SPIRAL_SAMPLE_COUNT * COORDS_PER_POINT);
+  });
+
+  it('rises: the first sampled point sits below the last (larger y to smaller y)', () => {
+    const numbers = numbersIn(spiralPath(SMALL_WIDTH, SMALL_HEIGHT));
+    const firstY = numbers[Y_OFFSET] ?? 0;
+    const lastY = numbers[numbers.length - 1] ?? 0;
+    expect(firstY).toBeGreaterThan(lastY);
+  });
+
+  it('keeps every sampled point inside the layout bounds', () => {
+    const numbers = numbersIn(spiralPath(SMALL_WIDTH, SMALL_HEIGHT));
+    for (let index = 0; index < numbers.length; index += COORDS_PER_POINT) {
+      const x = numbers[index] ?? 0;
+      const y = numbers[index + Y_OFFSET] ?? 0;
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(SMALL_WIDTH);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(SMALL_HEIGHT);
+    }
+  });
+
+  it('scales the spiral coordinates with width and height', () => {
+    expect(spiralPath(LARGE_WIDTH, LARGE_HEIGHT)).not.toBe(spiralPath(SMALL_WIDTH, SMALL_HEIGHT));
+  });
+});

--- a/frontend/src/features/Map/torusGeometry.ts
+++ b/frontend/src/features/Map/torusGeometry.ts
@@ -1,0 +1,128 @@
+// frontend/features/Map/torusGeometry.ts
+
+/**
+ * Pure geometry for the Wavelength explainer's torus/spiral illustration.
+ *
+ * The picture holds two motifs from the model: the torus (the auric field) as a
+ * stack of nested, tilted ellipse rings, and the growing spiral that widens and
+ * lifts through it. Every helper works in unit space [0,1] and scales that unit
+ * space into pixel space; none of them touch React, so the illustration's math
+ * is testable in isolation from rendering.
+ */
+
+/** Decimal places kept in emitted SVG coordinates (matches waveGeometry/TierStar). */
+const COORD_PRECISION = 3;
+
+/** Number of nested ellipse rings that suggest the torus / auric field. */
+export const TORUS_RING_COUNT = 4;
+
+/** Number of points sampled along the rising spiral path. */
+export const SPIRAL_SAMPLE_COUNT = 48;
+
+/** Horizontal centre of the illustration in unit space; every ring shares it. */
+const CENTER_X = 0.5;
+
+/** Vertical centre of the torus body in unit space. */
+const CENTER_Y = 0.5;
+
+/** Widest ring's horizontal radius in unit space (leaves a margin inside the box). */
+const TORUS_OUTER_RX = 0.42;
+
+/** Widest ring's vertical radius — flatter than rx so the torus reads as tilted. */
+const TORUS_OUTER_RY = 0.2;
+
+/** Fraction each inner ring shrinks relative to the widest ring's radii. */
+const RING_STEP = 0.18;
+
+/** Number of full turns the spiral winds as it climbs. */
+const SPIRAL_TURNS = 2.5;
+
+/** Spiral's maximum horizontal swing from centre, reached at the top of the climb. */
+const SPIRAL_MAX_RX = 0.4;
+
+/** Spiral's gentle vertical wobble, giving the climb a tilted, three-dimensional read. */
+const SPIRAL_MAX_RY = 0.06;
+
+/** Vertical position of the spiral's first (lowest) sample in unit space. */
+const SPIRAL_BOTTOM_Y = 0.92;
+
+/** Vertical position of the spiral's last (highest) sample in unit space. */
+const SPIRAL_TOP_Y = 0.08;
+
+/** A full revolution in radians; the spiral angle is a multiple of it. */
+const FULL_TURN = Math.PI * 2;
+
+/** Round a unit coordinate into a pixel coordinate string at fixed precision. */
+const toPixel = (unit: number, extent: number): string => (unit * extent).toFixed(COORD_PRECISION);
+
+/** A single nested ellipse ring of the torus, as an SVG path string. */
+export interface TorusRing {
+  /** SVG path data drawing one tilted ellipse in pixel space. */
+  d: string;
+}
+
+/**
+ * The horizontal and vertical radii, in unit space, of ring ``index`` (0 is the
+ * widest, outermost ring). Each successive ring shrinks by ``RING_STEP`` so the
+ * stack reads as a field of concentric halos around a common centre.
+ */
+const ringRadii = (index: number): { rx: number; ry: number } => {
+  const scale = 1 - RING_STEP * index;
+  return { rx: TORUS_OUTER_RX * scale, ry: TORUS_OUTER_RY * scale };
+};
+
+/**
+ * One tilted ellipse centred on the illustration, drawn with two SVG arc
+ * commands (left edge over the top to the right edge, then back under). All
+ * emitted coordinates stay within the given width/height because the widest
+ * radius keeps a margin inside unit space.
+ */
+const ellipsePath = (rx: number, ry: number, width: number, height: number): string => {
+  const left = toPixel(CENTER_X - rx, width);
+  const right = toPixel(CENTER_X + rx, width);
+  const midY = toPixel(CENTER_Y, height);
+  const rxPixel = toPixel(rx, width);
+  const ryPixel = toPixel(ry, height);
+  return `M ${left} ${midY} A ${rxPixel} ${ryPixel} 0 1 0 ${right} ${midY} A ${rxPixel} ${ryPixel} 0 1 0 ${left} ${midY}`;
+};
+
+/**
+ * The torus as ``TORUS_RING_COUNT`` nested tilted ellipses in pixel space,
+ * widest first. Coordinates scale with width and height, so a larger layout
+ * yields a larger torus.
+ */
+export const torusRings = (width: number, height: number): readonly TorusRing[] =>
+  Array.from({ length: TORUS_RING_COUNT }, (_unused, index) => {
+    const { rx, ry } = ringRadii(index);
+    return { d: ellipsePath(rx, ry, width, height) };
+  });
+
+/**
+ * The (x, y) unit-space position of the spiral at sample ``index`` of
+ * ``SPIRAL_SAMPLE_COUNT``. The climb runs from ``SPIRAL_BOTTOM_Y`` up to
+ * ``SPIRAL_TOP_Y`` (y decreases as the spiral rises), the horizontal swing
+ * grows from centre toward ``SPIRAL_MAX_RX`` as it lifts (the spiral widening
+ * the torus), and a small vertical wobble gives the turns a tilted read.
+ */
+const spiralPoint = (index: number): { x: number; y: number } => {
+  const t = index / (SPIRAL_SAMPLE_COUNT - 1);
+  const angle = t * SPIRAL_TURNS * FULL_TURN;
+  const baseY = SPIRAL_BOTTOM_Y + (SPIRAL_TOP_Y - SPIRAL_BOTTOM_Y) * t;
+  const x = CENTER_X + SPIRAL_MAX_RX * t * Math.cos(angle);
+  const y = baseY + SPIRAL_MAX_RY * t * Math.sin(angle);
+  return { x, y };
+};
+
+/**
+ * The rising spiral as one SVG polyline path in pixel space, sampled at
+ * ``SPIRAL_SAMPLE_COUNT`` points from the bottom of the box to the top.
+ * Coordinates scale with width and height.
+ */
+export const spiralPath = (width: number, height: number): string => {
+  const commands = Array.from({ length: SPIRAL_SAMPLE_COUNT }, (_unused, index) => {
+    const { x, y } = spiralPoint(index);
+    const verb = index === 0 ? 'M' : 'L';
+    return `${verb} ${toPixel(x, width)} ${toPixel(y, height)}`;
+  });
+  return commands.join(' ');
+};


### PR DESCRIPTION
## Summary

Adds a static, tasteful torus/spiral SVG illustration to the top of the
"How the Wavelength works" explainer sheet (Map screen). The original course
slides were visual ("It's a torus, ok?"); this lands the metaphor more vividly
than the warm prose alone while staying declinable and never gating.

- `torusGeometry.ts` — a pure, React-free geometry module (mirrors the existing
  `waveGeometry.ts` split): emits `TORUS_RING_COUNT` nested tilted ellipse rings
  for the auric-field torus, plus a rising, widening `spiralPath` polyline. All
  helpers scale by pixel `width`/`height` and emit SVG path strings at 3-decimal
  precision.
- `TorusSpiralVisual.tsx` — a decorative-but-labeled `react-native-svg`
  component rendering the geometry in Candle & Ink tokens (`accent.primary`
  spiral over faint `ink.soft` rings). It is `accessibilityRole="image"` with a
  describing label (it depicts the model, so it announces sensibly) and
  `pointerEvents="none"` so it never blocks the sheet scroll.
- Wired into `WavelengthExplainer.tsx` with one import + one element, under the
  title and above the markdown.

**Static SVG only — no animation.** That respects "Reduce Motion" by
construction, adds nothing to the Map screen's render budget (the visual mounts
only while the modal is open), and keeps a bounded element count (4 rings + one
48-point spiral), so no perf pass is required. The explainer copy
(`wavelengthExplainerContent.ts`) is untouched.

## Test plan

- `torusGeometry.test.ts` (new): ring count, bounded 3-decimal precision,
  in-bounds coordinates, monotonic rise (bottom→top), and width/height scaling.
- `TorusSpiralVisual.test.tsx` (new): renders with testID, `image` role,
  non-empty accessibility label, and `pointerEvents="none"`.
- `WavelengthExplainer.test.tsx`: +1 assertion pinning the illustration into the
  visible sheet (existing 12 tests intact).
- Local gates green: `npx tsc --noEmit`, `npm run lint` (`--max-warnings=0`),
  full Jest suite (2798 passing), and `scripts/frontend/check-all.sh` (all 4).

Closes #1076
Refs #948. Refs #943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)