### PR TITLE
refactor(frontend): dedup JournalTag union, id-merge helpers, token import (#1083)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -42,6 +42,7 @@ import {
   type CompletionTargetTypeT,
   type DepthPreferencesT,
   type InvitationT,
+  type journalTagSchema,
   type MettaReturnStateT,
   type Page,
   type ReturnArcT,
@@ -1070,7 +1071,9 @@ export const goalGroups = {
 };
 
 // Journal types and client
-export type JournalTag = 'freeform' | 'stage_reflection' | 'practice_note' | 'habit_note';
+// Derived from the Zod schema so the TS union can't drift from the runtime
+// validator (or the backend enum it mirrors) — includes ``weekly_prompt``.
+export type JournalTag = z.infer<typeof journalTagSchema>;
 
 /**
  * Privacy classification for a journal entry (mirrors the backend enum). An

--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -24,7 +24,7 @@ export interface AspectChordValue {
 }
 
 /** The empty chord used when no ``value`` is supplied. */
-const EMPTY_CHORD: AspectChordValue = { primary: null, secondary: null };
+export const EMPTY_CHORD: AspectChordValue = { primary: null, secondary: null };
 
 /** Warm, declinable copy for the collapsed trigger. */
 const TRIGGER_LABEL = 'Name an Aspect (optional)';

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import AspectChordControl, { type AspectChordValue } from './AspectChordControl';
+import AspectChordControl, { EMPTY_CHORD, type AspectChordValue } from './AspectChordControl';
 import CareSupportNote from './CareSupportNote';
 import CompletionSuggestionNote from './CompletionSuggestionNote';
 import ContractionReflectionNote from './ContractionReflectionNote';
@@ -53,9 +53,6 @@ export const AUTOSAVE_DELAY_MS = 1500;
 
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
-
-/** An untagged chord (no primary/secondary Aspect) for a fresh entry. */
-const EMPTY_CHORD: AspectChordValue = { primary: null, secondary: null };
 
 /** Fallback reason shown when resonance is gated off for an intimate entry. */
 const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonance is paused.';

--- a/frontend/src/features/Journal/SearchBar.tsx
+++ b/frontend/src/features/Journal/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
-import { accent, ink, radius, SPACING, surface } from '../../design/tokens';
+import { accent, ink, radius, SPACING, surface } from '@/design/tokens';
 
 const DEBOUNCE_DELAY_MS = 300;
 

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -75,22 +75,14 @@ export interface UseResonanceResult {
   dismissSuggestion: (_id: number) => Promise<void>;
 }
 
-/** Union of two note lists, keyed by id (incoming wins on conflict). */
-function mergeById(existing: Marginalia[], incoming: Marginalia[]): Marginalia[] {
-  const byId = new Map<number, Marginalia>();
-  for (const note of existing) byId.set(note.id, note);
-  for (const note of incoming) byId.set(note.id, note);
-  return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
-}
-
-/** Union of two suggestion lists, keyed by id, sorted by anchor span. */
-function mergeSuggestionsById(
-  existing: CompletionSuggestion[],
-  incoming: CompletionSuggestion[],
-): CompletionSuggestion[] {
-  const byId = new Map<number, CompletionSuggestion>();
-  for (const s of existing) byId.set(s.id, s);
-  for (const s of incoming) byId.set(s.id, s);
+/** Union of two anchored lists, keyed by id (incoming wins), sorted by anchor span. */
+function mergeByIdSorted<T extends { id: number; anchor_start: number }>(
+  existing: T[],
+  incoming: T[],
+): T[] {
+  const byId = new Map<number, T>();
+  for (const item of existing) byId.set(item.id, item);
+  for (const item of incoming) byId.set(item.id, item);
   return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
 }
 
@@ -136,7 +128,7 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
   useLoadOnOpen(routeEntryId, completionSuggestions.list, setSuggestions);
 
   const mergeFromGenerate = useCallback((incoming: CompletionSuggestion[]) => {
-    setSuggestions((prev) => mergeSuggestionsById(prev, incoming));
+    setSuggestions((prev) => mergeByIdSorted(prev, incoming));
   }, []);
 
   const acceptSuggestion = useCallback(
@@ -177,7 +169,7 @@ async function runAccept(id: number, deps: AcceptDeps): Promise<void> {
   deps.pendingIdsRef.current.add(id);
   try {
     const result = await completionSuggestions.accept(id);
-    deps.setSuggestions((prev) => mergeSuggestionsById(prev, [result.suggestion]));
+    deps.setSuggestions((prev) => mergeByIdSorted(prev, [result.suggestion]));
     deps.setAcceptedCheckIns((prev) => ({ ...prev, [id]: result.check_in }));
   } catch (err) {
     deps.setError(formatApiError(err)); // row stays pending; user can retry
@@ -251,7 +243,7 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
         return;
       }
       const result = await resonance.generate(entryId);
-      setMarginalia((prev) => mergeById(prev, result.marginalia));
+      setMarginalia((prev) => mergeByIdSorted(prev, result.marginalia));
       mergeFromGenerate(result.suggestions);
       // ``care`` is nullable/absent on ordinary entries — normalise to null.
       setCare(result.care ?? null);
@@ -303,7 +295,7 @@ export function useResonance({ routeEntryId, flush }: UseResonanceArgs): UseReso
   });
 
   const updateNote = useCallback((updated: Marginalia) => {
-    setMarginalia((prev) => mergeById(prev, [updated]));
+    setMarginalia((prev) => mergeByIdSorted(prev, [updated]));
   }, []);
 
   const refresh = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
## Summary
Three corroborated frontend Journal-area tidy-ups (de-slop run 2026-07-01), bundled per the one-tidy-up-per-area rule, plus one in-theme add-on from the issue thread. All behavior-preserving.

- **A — `JournalTag` union drift:** `frontend/src/api/index.ts` now derives `JournalTag` from `z.infer<typeof journalTagSchema>` instead of a hand-written union. The old 4-member union was missing `weekly_prompt`, which the runtime Zod validator and the backend `JournalTag` enum both already list — a genuine (contained) correctness fix, and it can't re-drift now.
- **B — duplicated id-merge helpers:** `frontend/src/features/Journal/useResonance.ts` — the byte-for-byte-identical `mergeById` (Marginalia) and `mergeSuggestionsById` (CompletionSuggestion) collapsed into one generic `mergeByIdSorted<T extends { id: number; anchor_start: number }>`; all four call sites updated.
- **C — SearchBar token-import drift:** `frontend/src/features/Journal/SearchBar.tsx` switched from the relative `../../design/tokens` to the `@/design/tokens` alias used by every other Journal source file (same module — pure path swap).
- **Add-on — `EMPTY_CHORD` dedup** (requested in the issue thread): exported from `AspectChordControl.tsx` and imported by `JournalEntryScreen.tsx`, mirroring the existing `DEFAULT_TIER` pattern; removes the duplicate local const.

## Test plan
- `npx tsc --noEmit` — clean
- `npm run lint` (`eslint . --max-warnings=0`) — clean
- `npx jest` — 281 suites / 2795 tests pass
- `./scripts/frontend/check-all.sh` — all 4 checks green
- Gate 2.5 self-review (code-review-orchestrator) — CLEAN, no blockers
- Verified against current `origin/main` (post chord-journaling #1113): the `JournalTag` drift claim still holds; `journalTagSchema` yields exactly the 5 members matching the backend enum.

Closes #1083