### PR TITLE
fix(ralph): key CI-pending detection off gh pr checks exit code, not text grep

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -105,15 +105,23 @@ call `/loop` to **stop**.
 
 ### Step 1 — Merge every ready lane (serialized, up-to-date only)
 
-Read each in-flight PR once:
+Classify each in-flight PR with the authoritative readiness helper — never
+eyeball the CI rollup or grep `gh pr checks` (its output is TAB-delimited, so a
+`': pending'` grep silently misses a still-running check and a false READY can
+merge a pending/failing PR). The helper keys CI off the `gh pr checks` **exit
+code** (`0`=green, `8`=pending, else=failed) and only honours an LGTM verdict
+posted **after** the PR's HEAD commit (stale-verdict guard):
+```bash
+STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM")   # ready | behind | pending | ci-failed | awaiting-review
+```
+Read the PR's comments once for context (which issue it closes, verdict text):
 ```bash
 gh pr view "$PR_NUM" --comments --json state,mergeable,mergeStateStatus,statusCheckRollup,comments
 ```
-For each PR, classify from the latest top-level `Verdict:` comment
-(`claude-code-review.yml`), the CI rollup, and `mergeStateStatus`:
+Then act on `$STATUS`:
 
-- **Ready** = `Verdict: LGTM` AND CI fully green AND `mergeStateStatus` is `CLEAN`
-  (i.e. up-to-date with `main`). **Merge it now** — do not wait for any other
+- **`ready`** (`Verdict: LGTM` fresh + CI green + `mergeStateStatus` `CLEAN`,
+  i.e. up-to-date with `main`). **Merge it now** — do not wait for any other
   lane:
   ```bash
   gh pr merge "$PR_NUM" --squash --delete-branch
@@ -125,14 +133,19 @@ For each PR, classify from the latest top-level `Verdict:` comment
   ```
   (Idempotent if `iteration-trigger.yml` or a prior wake already merged it — the
   PR shows MERGED; do the same close + `release` + state bump.)
-- **Behind** = `LGTM` + green but `mergeStateStatus` is `BEHIND` (a sibling merged
-  after this lane went green). **Do not merge stale.** Sync it and let CI re-run:
+- **`behind`** (`LGTM` + green but `mergeStateStatus` is `BEHIND` — a sibling
+  merged after this lane went green). **Do not merge stale.** Sync it and let CI
+  re-run:
   ```bash
   scripts/ralph/fleet.sh sync "$ISSUE_N" || echo "SYNC-CONFLICT $ISSUE_N"
   ```
   A clean sync → dispatch its `ralph-worker` to re-clear Gate 2 locally and push;
   it re-merges on a later wake once green. `SYNC-CONFLICT` → that lane drops to
   Gate 1 (worker resolves the conflict as a root-cause change, re-greens, pushes).
+- **`pending`** / **`awaiting-review`** — CI is still running or no fresh LGTM
+  verdict exists yet. Leave the lane; its Step 5 subscription wakes you when CI
+  or the verdict changes.
+- **`ci-failed`** — a check failed. Advance it via Step 2 (`ci-debugging`).
 
 You may merge more than one lane in a wake, but **re-check `mergeStateStatus`
 before each merge** — merging one lane can push the others `BEHIND`. Serialized,

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -41,3 +41,4 @@ jobs:
           git config --global user.name ci
           bash scripts/ralph/test_fleet.sh
           bash scripts/ralph/test_pick_next.sh
+          bash scripts/ralph/test_pr_ready.sh

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# scripts/ralph/pr-ready.sh
+#
+# Authoritative "is this lane safe to merge?" check for the Ralph orchestrator
+# (ralph-tick.md Step 1). Prints exactly one status token and exits 0 (it is a
+# query — a non-zero exit means a usage/tooling error, never a PR verdict):
+#
+#   ready            LGTM (fresh) + CI green + up-to-date with main  → merge now
+#   behind           LGTM (fresh) + CI green but mergeStateStatus BEHIND → sync first
+#   pending          CI still running → wait for a later wake
+#   ci-failed        CI has a failing/errored check → Step 2 (ci-debugging)
+#   awaiting-review  no fresh LGTM verdict (missing, stale, or non-LGTM) → wait / Step 2
+#
+# WHY THIS EXISTS: the previous all-lanes Monitor grepped `gh pr checks` output
+# for ': pending'. That output is TAB-delimited (name<TAB>pending<TAB>...), so the
+# grep never matched and a still-running CI was read as settled — a false READY
+# that could merge a PR with pending/failing checks. CI state here is keyed off
+# the `gh pr checks` EXIT CODE, which is authoritative: 0 = all passed, 8 = some
+# pending, anything else = failure. No text parsing of the checks table at all.
+#
+# Stale-verdict guard: a review verdict only counts when it was posted AFTER the
+# PR's HEAD commit. An LGTM from before the latest push is stale (it reviewed
+# older code) and must not gate a merge.
+#
+# Usage:  pr-ready.sh <PR_NUMBER> [--repo <owner/repo>]
+set -euo pipefail
+
+# `gh pr checks` exit code that means "checks still pending" (gh's documented
+# contract: 0 = pass, 8 = pending, other = failure).
+readonly CHECKS_PENDING_EC=8
+
+die() { echo "pr-ready: $1" >&2; exit 2; }
+
+pr=""
+repo_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) [[ $# -ge 2 ]] || die "--repo needs a value"; repo_args+=(--repo "$2"); shift 2 ;;
+    -*)     die "unknown option: $1" ;;
+    *)      [[ -z "$pr" ]] || die "unexpected extra argument: $1"; pr="$1"; shift ;;
+  esac
+done
+[[ "$pr" =~ ^[0-9]+$ ]] || die "usage: pr-ready.sh <PR_NUMBER> [--repo <owner/repo>]"
+
+# The canonical verdict line `claude-code-review.yml` posts is
+# `## Verdict: <LGTM|CHANGES_REQUESTED|COMMENTS>` (also tolerated: `**Verdict:**`
+# and a bare `Verdict:`), sitting at the END of a longer `## Summary …` body — so
+# the match must be case-insensitive AND multiline (`m`, so `^` anchors to the
+# verdict line — which sits at the END of a multi-line `## Summary …` body, not
+# at string start), prefix-tolerant, and keyed to the verdict LINE (a stray
+# "LGTM" in prose must not count). This mirrors the canonical parser in
+# `.claude/skills/await-claude-review/SKILL.md`. Backslashes are doubled because
+# this text is spliced into a jq string literal, where `\s` is an invalid escape
+# and must reach the regex engine as `\\s`.
+readonly VERDICT_RE='(?im)^\\s*(?:#{1,6}\\s+|\\*\\*)?verdict[:*\\s]'
+readonly VERDICT_LGTM_RE="${VERDICT_RE}+lgtm"
+
+# `${arr[@]+"${arr[@]}"}` expands to nothing when the array is empty instead of
+# tripping `set -u` on bash 3.2 (stock /bin/bash on macOS).
+gh_args=("$pr" ${repo_args[@]+"${repo_args[@]}"})
+
+# --- CI state from the exit code, not the text table -----------------------
+ci_ec=0
+gh pr checks "${gh_args[@]}" >/dev/null 2>&1 || ci_ec=$?
+if [[ "$ci_ec" -eq "$CHECKS_PENDING_EC" ]]; then
+  echo "pending"; exit 0
+elif [[ "$ci_ec" -ne 0 ]]; then
+  echo "ci-failed"; exit 0
+fi
+
+# --- CI is green: check mergeability + a FRESH LGTM verdict -----------------
+# One call yields "<mergeStateStatus>|<HEAD committedDate>", another the latest
+# top-level verdict as "<createdAt>|<isLGTM>". gh applies --jq server-side.
+merge_line="$(gh pr view "${gh_args[@]}" \
+  --json mergeStateStatus,commits \
+  --jq '(.mergeStateStatus // "") + "|" + (.commits[-1].committedDate // "")')"
+merge_state="${merge_line%%|*}"
+head_date="${merge_line#*|}"
+
+verdict_line="$(gh pr view "${gh_args[@]}" \
+  --json comments \
+  --jq "([.comments[] | select(.body != null and (.body | test(\"$VERDICT_RE\")))] | last) as \$v
+        | ((\$v.createdAt // \"\") + \"|\" + ((\$v.body // \"\" | test(\"$VERDICT_LGTM_RE\")) | tostring))")"
+verdict_date="${verdict_line%%|*}"
+verdict_lgtm="${verdict_line#*|}"
+
+# Without a HEAD commit time we cannot prove the verdict is fresh — fail closed.
+if [[ -z "$head_date" ]]; then
+  echo "awaiting-review"; exit 0
+fi
+
+# Fresh LGTM ⇔ latest verdict is LGTM AND its createdAt is strictly newer than
+# the HEAD commit. RFC3339 UTC timestamps are fixed-width, so a lexical string
+# compare is a correct chronological compare (portable — no date arithmetic).
+if [[ "$verdict_lgtm" != "true" || -z "$verdict_date" ]] || ! [[ "$verdict_date" > "$head_date" ]]; then
+  echo "awaiting-review"; exit 0
+fi
+
+if [[ "$merge_state" == "CLEAN" ]]; then
+  echo "ready"
+else
+  echo "behind"
+fi

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# scripts/ralph/test_pr_ready.sh
+#
+# Offline tests for pr-ready.sh — the authoritative CI + review-verdict
+# readiness check the orchestrator (ralph-tick.md Step 1) uses before merging a
+# lane. CI state is keyed off the `gh pr checks` EXIT CODE (0=green, 8=pending,
+# else=failed), never a text grep of its TAB-delimited output, and an LGTM
+# verdict only counts when it is fresher than the PR's HEAD commit (stale-verdict
+# guard). We put a fake, arg-aware `gh` on PATH and assert every classification.
+#
+# Run:  bash scripts/ralph/test_pr_ready.sh
+set -euo pipefail
+
+READY="$(cd "$(dirname "$0")" && pwd)/pr-ready.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+
+# Arg-aware fake gh. Behaviour is driven by env vars the test sets per case:
+#   CHECKS_EC     — exit code `gh pr checks` should return (0 green / 8 pending / other failed)
+#   MERGE_STATE   — mergeStateStatus (CLEAN / BEHIND / ...)
+#   HEAD_DATE     — RFC3339 committedDate of the PR HEAD commit
+#   VERDICT       — the "<createdAt>|<isLGTM>" scalar the verdict jq resolves to
+#   COMMENTS_JSON — raw `--json comments` payload; when set, the stub runs the
+#                   REAL jq with pr-ready.sh's own `--jq` expression against it,
+#                   so the production verdict regex is genuinely exercised
+#                   (otherwise a scalar stub would mask a broken regex).
+# Real gh applies --jq, so — like test_fleet.sh — the stub emits the already
+# extracted scalar and branches on which --json field the caller asked for.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"pr checks"*)            exit "${CHECKS_EC:-0}" ;;
+  *"--json mergeStateStatus"*) printf '%s|%s\n' "${MERGE_STATE:-CLEAN}" "${HEAD_DATE:-}" ;;
+  *"--json comments"*)
+    if [[ -n "${COMMENTS_JSON:-}" ]]; then
+      expr="" prev=""
+      for a in "$@"; do [[ "$prev" == "--jq" ]] && expr="$a"; prev="$a"; done
+      printf '%s' "$COMMENTS_JSON" | jq -rc "$expr"
+    else
+      printf '%s\n' "${VERDICT:-|false}"
+    fi ;;
+  *)                        echo '' ;;
+esac
+STUB
+chmod +x "$BIN/gh"
+
+run() { PATH="$BIN:$PATH" "$READY" "$@" 2>/dev/null; }
+
+H="2026-07-01T10:00:00Z"          # HEAD commit time baseline
+FRESH="2026-07-01T11:00:00Z"      # a verdict posted AFTER HEAD (valid)
+STALE="2026-07-01T09:00:00Z"      # a verdict posted BEFORE HEAD (stale)
+
+# --- usage: missing PR number exits 2 --------------------------------------
+rc=0
+PATH="$BIN:$PATH" "$READY" >/dev/null 2>&1 || rc=$?
+check "missing PR number exits 2" "2" "$rc"
+
+# --- pending: gh pr checks exit 8 is NEVER ready (the core bug) -------------
+check "exit 8 → pending" "pending" \
+  "$(CHECKS_EC=8 run 100)"
+
+# --- CI failure surfaced: non-0/non-8 exit → ci-failed ---------------------
+check "exit 1 → ci-failed" "ci-failed" \
+  "$(CHECKS_EC=1 run 100)"
+check "exit 2 → ci-failed" "ci-failed" \
+  "$(CHECKS_EC=2 run 100)"
+
+# --- ready: green + CLEAN + fresh LGTM -------------------------------------
+check "green + CLEAN + fresh LGTM → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" run 100)"
+
+# --- behind: green + fresh LGTM but not up-to-date -------------------------
+check "green + BEHIND + fresh LGTM → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=BEHIND HEAD_DATE=$H VERDICT="$FRESH|true" run 100)"
+
+# --- stale-verdict guard: an LGTM older than HEAD does NOT count ------------
+check "green + CLEAN + STALE LGTM → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$STALE|true" run 100)"
+
+# --- no verdict yet → awaiting-review --------------------------------------
+check "green + CLEAN + no verdict → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="|false" run 100)"
+
+# --- fresh but non-LGTM verdict (e.g. changes requested) → awaiting-review --
+check "green + CLEAN + fresh non-LGTM → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|false" run 100)"
+
+# --- REAL jq: exercise the production verdict regex against real bodies ----
+# The verdict `claude-code-review.yml` posts is `## Verdict: <X>` at the END of a
+# long `## Summary …` body. These cases feed raw comment JSON through pr-ready.sh's
+# own `--jq`, so a regex that fails to match `## Verdict:` — or that reads "LGTM"
+# from prose instead of the verdict line — is caught here (a scalar stub can't).
+if command -v jq >/dev/null 2>&1; then
+  cj() { printf '{"comments":[%s]}' "$1"; }   # wrap comment object(s) as a payload
+
+  # Canonical `## Verdict: LGTM`, fresh + CLEAN → ready.
+  check "real ## Verdict: LGTM (fresh) → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # `**Verdict:** CHANGES_REQUESTED` whose prose mentions "LGTM" must NOT count as
+  # LGTM — the exact false-positive a whole-body match would cause.
+  check "real CHANGES_REQUESTED w/ 'LGTM' in prose → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"Not ready for LGTM yet.\n\n**Verdict:** CHANGES_REQUESTED\n"}')" \
+       run 100)"
+
+  # No verdict-bearing comment at all → awaiting-review.
+  check "real no-verdict comment → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"just a chat comment"}')" \
+       run 100)"
+
+  # Latest verdict wins: an LGTM posted after an earlier CHANGES_REQUESTED → ready.
+  check "real latest-verdict-wins (LGTM after CR) → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"## Verdict: CHANGES_REQUESTED\n"},{"createdAt":"'"$FRESH"'","body":"## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # A real, fresh `## Verdict: LGTM` that predates HEAD is still stale → awaiting.
+  check "real ## Verdict: LGTM but stale → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"## Verdict: LGTM\n"}')" \
+       run 100)"
+else
+  echo "  skip - real-jq verdict-regex cases (jq not installed)"
+fi
+
+# --- summary ---------------------------------------------------------------
+echo
+echo "pr-ready tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What & why

Closes #1085.

The Step 5 combined CI+verdict Monitor grepped `gh pr checks` output for `': pending'` to decide whether CI had settled. That output is **TAB-delimited** (`name<TAB>pending<TAB>0<TAB>url`), so the colon-space pattern never matched — pending checks went undetected and the Monitor emitted a false `READY`, risking a merge of a PR whose CI was still running or failing. The `#1074` non-blocking-fleet refactor had already removed that Monitor, but it left Step 1's merge decision as fragile prose over the rollup and **dropped the stale-verdict guard** the issue also calls for.

## Approach (root cause)

New helper `scripts/ralph/pr-ready.sh` is the single authoritative "is this lane safe to merge?" check. It keys CI state off the **`gh pr checks` exit code** — the documented, portable contract (`0`=green, `8`=pending, else=failed) — with no text parsing of the checks table at all, and only honours an `LGTM` verdict whose `createdAt` is newer than the PR HEAD commit (stale-verdict guard). It prints one token:

| token | meaning |
|---|---|
| `ready` | fresh LGTM + CI green + `mergeStateStatus` CLEAN → merge now |
| `behind` | fresh LGTM + green but BEHIND → sync first |
| `pending` | `gh pr checks` exit 8 → wait |
| `ci-failed` | exit non-0/non-8 → Step 2 (ci-debugging) |
| `awaiting-review` | no fresh LGTM (missing / stale / non-LGTM) |

`.claude/commands/ralph-tick.md` Step 1 now calls the helper and acts on the token instead of eyeballing the rollup.

## Acceptance criteria

- [x] Never reports READY/terminal while `gh pr checks` exits 8 (`pending`).
- [x] CI failures surfaced (exit non-0/non-8 → `ci-failed`).
- [x] Garbled awk removed (the helper uses exit codes + `gh --jq`, no awk).
- [x] Stale-verdict guard preserved (verdict `createdAt` must post-date HEAD commit).
- [x] Shell tests green, bash + macOS/BSD portable.

## Testing

`scripts/ralph/test_pr_ready.sh` (14 cases, wired into `ralph-recap-tests.yml`): a PATH-shimmed fake `gh` covers every exit-code branch and the stale-verdict case; a **real-jq mode** feeds raw comment JSON through the helper's own `--jq` so the production verdict regex is genuinely exercised against realistic `## Verdict:` / `**Verdict:**` bodies (this caught a jq string-literal escaping bug during review). shellcheck clean; `test_fleet.sh` + `test_pick_next.sh` + the pytest recap suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)