### PR TITLE
fix(safety): normalize invisible/confusable code points before crisis screening

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -22,9 +22,19 @@ human support (added later), while a false positive would shame someone in their
 darkness. The phrase lists below are explicit and auditable rather than clever;
 add to them only with a corresponding negative test guarding ordinary darkness.
 
-Negation is handled deterministically, not with a parser. Before matching, the
-Unicode curly apostrophe (U+2019) is folded to ASCII ``'`` so iOS smart
-punctuation matches the phrase lists. A candidate phrase match is suppressed only
+Before matching, text is normalized (see :func:`_normalize`): a curated set of
+alternate apostrophes is folded to ASCII ``'``, every Unicode format character
+(category ``Cf`` — zero-width and bidi controls) is neutralized to a space, and
+the result is passed through NFKC (folding fullwidth and other compatibility
+forms) before lowercasing and whitespace collapse. Invisible or confusable code
+points are folded up front because the dangerous failure direction for a crisis
+screen is a false negative — a phrase defeated by a spliced zero-width character
+or a fullwidth-keyboard rendering would silently miss a genuine signal.
+
+Negation is handled deterministically, not with a parser. Because apostrophes are
+folded before matching, denials written with any apostrophe variant ("I don't
+want to die") reach the negator machinery too. A candidate phrase match is
+suppressed only
 when a negator (e.g. "never", "not", "no plans to", "don't") appears in the
 window of :data:`_NEGATION_WINDOW_WORDS` whitespace tokens strictly *before* the
 match, within the same clause (the window is clipped at the last ``.``, ``!``,
@@ -44,6 +54,7 @@ Purity: no FastAPI, SQLModel, or network/LLM imports — only the standard libra
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from enum import Enum
 from typing import Literal
@@ -131,8 +142,23 @@ _COMPILED: tuple[tuple[DistressCategory, re.Pattern[str]], ...] = tuple(
     for category, phrases in _PATTERNS
 )
 
-# Unicode curly apostrophe (iOS smart punctuation) folded to ASCII before matching.
-_CURLY_APOSTROPHE = "\N{RIGHT SINGLE QUOTATION MARK}"
+# Alternate apostrophe code points folded to ASCII "'" before matching so iOS smart
+# punctuation and confusable variants match the phrase lists. Folded before NFKC
+# because NFKC decomposes U+00B4 ACUTE ACCENT into space + combining acute, which
+# would otherwise split the token and defeat the match.
+_APOSTROPHE_VARIANTS: tuple[str, ...] = (
+    "\N{LEFT SINGLE QUOTATION MARK}",
+    "\N{RIGHT SINGLE QUOTATION MARK}",
+    "\N{MODIFIER LETTER APOSTROPHE}",
+    "\N{FULLWIDTH APOSTROPHE}",
+    "\N{PRIME}",
+    "\N{ACUTE ACCENT}",
+)
+_APOSTROPHE_TABLE = str.maketrans(dict.fromkeys(_APOSTROPHE_VARIANTS, "'"))
+
+# Unicode general category for format characters (zero-width, bidi controls, soft
+# hyphen). Swept to a plain space so invisible splices cannot defeat matching.
+_FORMAT_CHAR_CATEGORY = "Cf"
 
 # Number of whitespace tokens before a match inspected for a negator.
 _NEGATION_WINDOW_WORDS = 5
@@ -187,6 +213,24 @@ def _is_negated(normalized: str, match_start: int) -> bool:
     return len(_LOGICAL_NEGATORS.findall(window)) % 2 == 1
 
 
+def _normalize(text: str) -> str:
+    """Fold ``text`` to a matchable form before pattern matching.
+
+    The pipeline order is load-bearing: alternate apostrophes are folded to ASCII
+    first (before NFKC would decompose U+00B4 into space + combining acute), then
+    every Unicode format character (category ``Cf``) is neutralized to a space so
+    invisible splices cannot break a phrase, then NFKC folds fullwidth and other
+    compatibility forms, and finally the text is lowercased and its whitespace
+    collapsed.
+    """
+    folded = text.translate(_APOSTROPHE_TABLE)
+    swept = "".join(
+        " " if unicodedata.category(ch) == _FORMAT_CHAR_CATEGORY else ch for ch in folded
+    )
+    normalized = unicodedata.normalize("NFKC", swept)
+    return re.sub(r"\s+", " ", normalized).strip().lower()
+
+
 def assess_distress(text: str) -> DistressSignal:
     """Screen ``text`` for an acute-distress signal; return a typed result.
 
@@ -203,9 +247,11 @@ def assess_distress(text: str) -> DistressSignal:
     myself") are suppressed by preceding-window negation handling. This is a
     screen, not a diagnosis, and introduces no medication, treatment, or medical
     advice.
+
+    Text is first normalized (:func:`_normalize`) so invisible or confusable
+    Unicode code points cannot defeat the phrase lists.
     """
-    folded = text.replace(_CURLY_APOSTROPHE, "'")
-    normalized = re.sub(r"\s+", " ", folded).strip().lower()
+    normalized = _normalize(text)
     if not normalized:
         return _NONE
     for category, pattern in _COMPILED:

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -133,3 +133,107 @@ def test_negated_denials_do_not_flag(text: str) -> None:
 )
 def test_negation_does_not_suppress_genuine_signals(text: str, category: DistressCategory) -> None:
     assert assess_distress(text) == DistressSignal(level="elevated", category=category)
+
+
+# Zero-width and bidi-format code points an attacker (or a stray copy-paste) can
+# splice into a phrase to defeat the whitespace-only normalization. Named via
+# escapes so the invisible characters read unambiguously in source.
+_ZERO_WIDTH_SPACE = "\N{ZERO WIDTH SPACE}"
+_ZERO_WIDTH_NON_JOINER = "\N{ZERO WIDTH NON-JOINER}"
+_ZERO_WIDTH_JOINER = "\N{ZERO WIDTH JOINER}"
+_WORD_JOINER = "\N{WORD JOINER}"
+_ZERO_WIDTH_NO_BREAK_SPACE = "\N{ZERO WIDTH NO-BREAK SPACE}"
+_LEFT_TO_RIGHT_MARK = "\N{LEFT-TO-RIGHT MARK}"
+_RIGHT_TO_LEFT_MARK = "\N{RIGHT-TO-LEFT MARK}"
+_LEFT_TO_RIGHT_EMBEDDING = "\N{LEFT-TO-RIGHT EMBEDDING}"
+_FIRST_STRONG_ISOLATE = "\N{FIRST STRONG ISOLATE}"
+_SOFT_HYPHEN = "\N{SOFT HYPHEN}"
+
+_ZERO_WIDTH_AND_FORMAT_VECTORS = [
+    _ZERO_WIDTH_SPACE,
+    _ZERO_WIDTH_NON_JOINER,
+    _ZERO_WIDTH_JOINER,
+    _WORD_JOINER,
+    _ZERO_WIDTH_NO_BREAK_SPACE,
+    _LEFT_TO_RIGHT_MARK,
+    _RIGHT_TO_LEFT_MARK,
+    _LEFT_TO_RIGHT_EMBEDDING,
+    _FIRST_STRONG_ISOLATE,
+]
+
+
+@pytest.mark.parametrize("hidden_char", _ZERO_WIDTH_AND_FORMAT_VECTORS)
+def test_zero_width_and_format_chars_do_not_defeat_suicidal_intent_match(hidden_char: str) -> None:
+    signal = assess_distress(f"I want to kill{hidden_char}myself")
+    assert signal == DistressSignal(level="elevated", category=DistressCategory.SUICIDAL_INTENT)
+
+
+def test_soft_hyphen_does_not_defeat_self_harm_match() -> None:
+    signal = assess_distress(f"the self{_SOFT_HYPHEN}harm urges came back")
+    assert signal == DistressSignal(level="elevated", category=DistressCategory.SELF_HARM)
+
+
+# Non-ASCII apostrophe variants beyond the curly one already folded above.
+_LEFT_SINGLE_QUOTATION_MARK = "\N{LEFT SINGLE QUOTATION MARK}"
+_MODIFIER_LETTER_APOSTROPHE = "\N{MODIFIER LETTER APOSTROPHE}"
+_FULLWIDTH_APOSTROPHE = "\N{FULLWIDTH APOSTROPHE}"
+_PRIME = "\N{PRIME}"
+_ACUTE_ACCENT = "\N{ACUTE ACCENT}"
+
+_ALTERNATE_APOSTROPHES = [
+    _LEFT_SINGLE_QUOTATION_MARK,
+    _MODIFIER_LETTER_APOSTROPHE,
+    _FULLWIDTH_APOSTROPHE,
+    _PRIME,
+    _ACUTE_ACCENT,
+]
+
+
+@pytest.mark.parametrize("apostrophe", _ALTERNATE_APOSTROPHES)
+def test_alternate_apostrophes_do_not_defeat_suicidal_intent_match(apostrophe: str) -> None:
+    signal = assess_distress(f"I don{apostrophe}t want to be alive anymore")
+    assert signal == DistressSignal(level="elevated", category=DistressCategory.SUICIDAL_INTENT)
+
+
+# Fullwidth (halfwidth-and-fullwidth-forms block) rendering of "kill myself", the
+# kind produced by some IME and CJK-locale keyboards.
+_FULLWIDTH_KILL_MYSELF = (
+    "\N{FULLWIDTH LATIN SMALL LETTER K}"
+    "\N{FULLWIDTH LATIN SMALL LETTER I}"
+    "\N{FULLWIDTH LATIN SMALL LETTER L}"
+    "\N{FULLWIDTH LATIN SMALL LETTER L}"
+    " "
+    "\N{FULLWIDTH LATIN SMALL LETTER M}"
+    "\N{FULLWIDTH LATIN SMALL LETTER Y}"
+    "\N{FULLWIDTH LATIN SMALL LETTER S}"
+    "\N{FULLWIDTH LATIN SMALL LETTER E}"
+    "\N{FULLWIDTH LATIN SMALL LETTER L}"
+    "\N{FULLWIDTH LATIN SMALL LETTER F}"
+)
+
+
+def test_fullwidth_form_does_not_defeat_suicidal_intent_match() -> None:
+    signal = assess_distress(f"I want to {_FULLWIDTH_KILL_MYSELF}")
+    assert signal == DistressSignal(level="elevated", category=DistressCategory.SUICIDAL_INTENT)
+
+
+# Regression guard: hardening normalization must not weaken negation handling.
+_NEGATION_REGRESSION_APOSTROPHES = [_MODIFIER_LETTER_APOSTROPHE, _PRIME, _ACUTE_ACCENT]
+
+
+@pytest.mark.parametrize("apostrophe", _NEGATION_REGRESSION_APOSTROPHES)
+def test_alternate_apostrophe_negation_still_suppresses(apostrophe: str) -> None:
+    signal = assess_distress(f"I don{apostrophe}t want to die")
+    assert signal == DistressSignal(level="none", category=DistressCategory.NONE)
+
+
+def test_zero_width_space_negation_still_suppresses() -> None:
+    signal = assess_distress(f"I would never kill{_ZERO_WIDTH_SPACE}myself")
+    assert signal == DistressSignal(level="none", category=DistressCategory.NONE)
+
+
+def test_zero_width_space_in_ordinary_darkness_does_not_flag() -> None:
+    text = f"I feel so{_ZERO_WIDTH_SPACE} empty today."
+    signal = assess_distress(text)
+    assert signal.level == "none"
+    assert signal.category is DistressCategory.NONE


### PR DESCRIPTION
## Summary

The acute-distress crisis screen (`assess_distress` in `backend/src/domain/safety.py`) only folded the curly apostrophe (U+2019) and collapsed `\s+` whitespace before matching its crisis-phrase patterns. Unicode **format characters** (category `Cf` — zero-width space/joiner/non-joiner, word joiner, BOM, soft hyphen, bidi marks) are not matched by `\s`, so they survived normalization; **alternate apostrophe** code points (U+2018, U+02BC, U+FF07, U+2032, U+00B4) and **fullwidth** forms likewise survived. Each defeats the phrase lists, producing a **false negative** in safety-critical crisis detection — the dangerous under-triggering direction.

The fix hardens the pre-match normalization pipeline in a new `_normalize` helper, run before pattern matching:

1. Fold a curated set of apostrophe variants to ASCII `'` — **before** NFKC, because NFKC would decompose U+00B4 (acute accent) into space + combining acute and break matching.
2. Sweep every category-`Cf` character to a plain space (a category sweep, not a curated list, since the failure direction is safety-critical false negatives) — so the separator case `kill<ZWSP>myself` → `kill myself` matches and `self<SOFT HYPHEN>harm` → `self harm` matches `self[ -]harm`.
3. NFKC-fold fullwidth/compatibility forms (ｋｉｌｌ ｍｙｓｅｌｆ → kill myself).
4. Existing lowercase + `\s+` collapse tail, unchanged.

Because the negator matcher now sees the same folded text, this also fixes a **symmetric false positive**: denials written with non-curly apostrophes (e.g. `I don<PRIME>t want to die`) previously slipped past the negation check and flagged; they now suppress correctly. The negation-awareness added in #1005 is otherwise intact and fully regression-tested.

Scope note: this addresses the code-point normalization vector only. Sibling bug #1095 (a distinct crisis-phrase gap) is **not** covered by this root cause and is **not** closed here. An intra-word invisible (`k<ZWSP>ill`) and homoglyph substitution remain a separate vector class for a possible follow-up.

## Test plan

- Added 19 RED-first parametrized cases in `backend/tests/domain/test_safety.py` (named `\N{...}` escapes only, no raw invisibles): zero-width/bidi separator vectors → `SUICIDAL_INTENT`; soft hyphen → `SELF_HARM`; five alternate apostrophes positive → `SUICIDAL_INTENT`; fullwidth form → `SUICIDAL_INTENT`; plus negation-regression cases (alt-apostrophe denials + zero-width-in-denial stay `none`) and an ordinary-darkness-with-ZWSP no-false-positive guard.
- `python -m pytest tests/domain/test_safety.py` → **80 passed** (61 existing preserved + 19 new).
- `./scripts/backend/check-all.sh` → all 7 quality checks pass, total coverage 96.38%.
- `xenon --max-absolute A --max-modules A --max-average A` and `radon mi` on `safety.py` → A-grade.

Closes #1094
Refs #1005