### PR TITLE
fix(safety): flag passive/indirect suicidal ideation missed by crisis matcher

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -93,7 +93,9 @@ _PATTERNS: tuple[tuple[DistressCategory, tuple[str, ...]], ...] = (
             r"better off dead",
             r"suicidal",
             r"commit suicide",
-            r"don'?t want to (?:be alive|live) anymore",
+            r"don'?t want to (?:be alive(?: anymore)?|live anymore)",
+            r"no longer want to (?:be alive|live anymore)",
+            r"wish i wasn'?t here",
         ),
     ),
     (

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -27,6 +27,11 @@ from domain.safety import DistressCategory, DistressSignal, assess_distress
         ("I'm quitting my antidepressants.", DistressCategory.MEDICATION_CESSATION),
         ("I went off my medication last week.", DistressCategory.MEDICATION_CESSATION),
         ("I flushed my pills down the toilet.", DistressCategory.MEDICATION_CESSATION),
+        ("I no longer want to be alive anymore", DistressCategory.SUICIDAL_INTENT),
+        ("I no longer want to be alive", DistressCategory.SUICIDAL_INTENT),
+        ("I don't want to be alive", DistressCategory.SUICIDAL_INTENT),
+        ("I no longer want to live anymore", DistressCategory.SUICIDAL_INTENT),
+        ("I wish I wasn't here", DistressCategory.SUICIDAL_INTENT),
     ],
 )
 def test_acute_phrases_flag_elevated_with_category(text: str, category: DistressCategory) -> None:
@@ -53,6 +58,7 @@ _ORDINARY_DARKNESS = [
     "I cried myself to sleep again.",
     "I feel hopeless about the future.",
     "My heart is broken after the breakup.",
+    "I no longer want to live in fear.",
 ]
 
 
@@ -103,6 +109,8 @@ _NEGATED_DENIALS = [
     "I no longer want to die",
     "I used to cut myself",
     f"I don{_CURLY}t want to die",
+    "I would never say I no longer want to be alive",
+    "I don't wish I wasn't here",
 ]
 
 
@@ -127,6 +135,7 @@ def test_negated_denials_do_not_flag(text: str) -> None:
         ("No. I want to kill myself tonight.", DistressCategory.SUICIDAL_INTENT),
         ("I don't want to be alive anymore", DistressCategory.SUICIDAL_INTENT),
         (f"I don{_CURLY}t want to be alive anymore", DistressCategory.SUICIDAL_INTENT),
+        (f"I wish I wasn{_CURLY}t here", DistressCategory.SUICIDAL_INTENT),
         ("Now more than I used to I want to die", DistressCategory.SUICIDAL_INTENT),
         ("I am not okay and lonely and I want to die", DistressCategory.SUICIDAL_INTENT),
     ],


### PR DESCRIPTION
## Summary

The acute-distress crisis screen (`backend/src/domain/safety.py`) returned `none` for **"I no longer want to be alive anymore"** and similar passive/indirect suicidal-ideation phrasings — a false negative in crisis detection. The only phrase covering "be alive" required a `don't`-style prefix, so "no longer …" constructions slipped through.

This extends the `SUICIDAL_INTENT` phrase set with three embedded-negator phrasings:

- `don'?t want to (?:be alive(?: anymore)?|live anymore)` — loosens the existing phrase so "I don't want to be alive" flags without requiring "anymore" (the "live" branch still requires "anymore").
- `no longer want to (?:be alive|live anymore)` — covers the reported gap.
- `wish i wasn'?t here` — passive-ideation phrasing named in the issue (matches the folded iOS curly-apostrophe variant too).

Each embeds the leading negator **inside** the matched phrase, mirroring the existing design: `_is_negated` inspects only text strictly before `match.start()`, so the phrase can never self-suppress, while an earlier "never"/"don't" still suppresses genuine denials.

### Invariants preserved
- **#1005 negation-awareness intact** — "I would never say I no longer want to be alive" and "I don't wish I wasn't here" still return `none`.
- **Recovery stays unflagged** — "I no longer want to die" remains suppressed by the abutting temporal negator on the unchanged `want to die` phrase.
- **Conservative charter honored** — the "live" branch requires trailing "anymore", so growth phrasings ("I no longer want to live in fear") pass through as `none` (guarded by a new ordinary-darkness test).

### Deliberate trade-off
`wish i wasn'?t here` is the broadest new phrase and can match situational usages ("I wish I wasn't here at this meeting"). This false positive is accepted per the issue's explicit request: in a journaling screen the care surface is **additive and non-shaming** (it accompanies, never replaces, the reflection), so a mild false positive is low-harm, while a missed passive-ideation signal is not.

## Test plan
- Added 5 positive cases (the exact reported phrase + paraphrases) to `test_acute_phrases_flag_elevated_with_category`, a smart-apostrophe positive to `test_negation_does_not_suppress_genuine_signals`, 2 denial guards to `_NEGATED_DENIALS`, and 1 conservatism guard to `_ORDINARY_DARKNESS`.
- Confirmed RED (6 new positives failed) → GREEN (68/68 in `tests/domain/test_safety.py`).
- Full backend `check-all.sh`: 7/7 quality checks, 2260 passed, coverage 96.4%.
- xenon A-grade + radon MI A on `safety.py`.

Closes #1095
Refs #1005