### PR TITLE
feat(frontend): wire the Metta "Return" offer to the live contraction signal

### DIFF
--- a/frontend/src/features/Journal/__tests__/useResonanceContraction.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonanceContraction.test.tsx
@@ -17,6 +17,7 @@ import type {
   Marginalia,
   ResonanceResponse,
 } from '@/api';
+import { useContractionSignalStore } from '@/store/useContractionSignalStore';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_id: number) => Promise<{ items: Marginalia[] }>
@@ -98,6 +99,7 @@ beforeEach(() => {
   mockSugList.mockReset();
   mockList.mockResolvedValue({ items: [] });
   mockSugList.mockResolvedValue({ items: [] });
+  useContractionSignalStore.getState().reset();
 });
 
 // ---------------------------------------------------------------------------
@@ -189,5 +191,69 @@ describe('useResonance — contraction field threading', () => {
 
     expect(result.current.marginalia).toHaveLength(1);
     expect(result.current.contraction).not.toBeNull();
+  });
+});
+
+describe('useResonance — wiring the contraction signal store', () => {
+  it('activates the signal when a generate pass returns a return_offer contraction', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(
+      resonancePayload({ contraction: contractionPayload({ variant: 'return_offer' }) }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(true);
+  });
+
+  it('leaves the signal inactive when a generate pass returns a simple_ease_off contraction', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(
+      resonancePayload({ contraction: contractionPayload({ variant: 'simple_ease_off' }) }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('retracts a previously-active signal when a healthy pass returns no contraction', async () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(contractionPayload({ variant: 'return_offer' }));
+    });
+    expect(useContractionSignalStore.getState().active).toBe(true);
+
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValue(resonancePayload({ contraction: null }));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('leaves the signal unchanged when a generate pass fails', async () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(contractionPayload({ variant: 'return_offer' }));
+    });
+    expect(useContractionSignalStore.getState().active).toBe(true);
+
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(true);
   });
 });

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -27,6 +27,7 @@ import type {
   Marginalia,
 } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
+import { useContractionSignalStore } from '@/store/useContractionSignalStore';
 
 const EMPTY_BODY_MESSAGE = 'Write a little first, then ask for its resonance.';
 
@@ -249,6 +250,8 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
       setCare(result.care ?? null);
       // ``contraction`` is nullable/absent on healthy entries — normalise to null.
       setContraction(result.contraction ?? null);
+      // Feed the shared signal only on a completed pass — never on loading/error.
+      useContractionSignalStore.getState().observe(result.contraction ?? null);
       // ``private_message`` is present only when the pass was withheld.
       setPrivateMessage(result.private_message ?? null);
     } catch (err) {

--- a/frontend/src/features/Today/__tests__/contractionSignal.test.tsx
+++ b/frontend/src/features/Today/__tests__/contractionSignal.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useContractionSignalActive } from '../contractionSignal';
+
+import { useContractionSignalStore } from '@/store/useContractionSignalStore';
+
+beforeEach(() => {
+  act(() => {
+    useContractionSignalStore.getState().reset();
+  });
+});
+
+describe('useContractionSignalActive', () => {
+  it('returns false initially', () => {
+    const { result } = renderHook(() => useContractionSignalActive());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true once the store observes a return_offer contraction', () => {
+    const { result } = renderHook(() => useContractionSignalActive());
+
+    act(() => {
+      useContractionSignalStore.getState().observe({ variant: 'return_offer', message: 'x' });
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false again once the signal is retracted', () => {
+    const { result } = renderHook(() => useContractionSignalActive());
+    act(() => {
+      useContractionSignalStore.getState().observe({ variant: 'return_offer', message: 'x' });
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      useContractionSignalStore.getState().observe(null);
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
@@ -24,9 +24,9 @@ jest.mock('@/api', () => {
   };
 });
 
-const mockIsContractionSignalActive = jest.fn() as jest.MockedFunction<() => boolean>;
+const mockUseContractionSignalActive = jest.fn() as jest.MockedFunction<() => boolean>;
 jest.mock('../contractionSignal', () => ({
-  isContractionSignalActive: () => mockIsContractionSignalActive(),
+  useContractionSignalActive: () => mockUseContractionSignalActive(),
 }));
 
 const mockSaveDismissed = jest.fn() as jest.MockedFunction<() => Promise<void>>;
@@ -74,7 +74,7 @@ beforeEach(() => {
   mockPause.mockReset();
   mockResume.mockReset();
   mockLeave.mockReset();
-  mockIsContractionSignalActive.mockReset();
+  mockUseContractionSignalActive.mockReset();
   mockSaveDismissed.mockReset();
   mockLoadDismissed.mockReset();
 
@@ -83,7 +83,7 @@ beforeEach(() => {
   mockPause.mockResolvedValue(arc({ paused: true }));
   mockResume.mockResolvedValue(arc({ paused: false }));
   mockLeave.mockResolvedValue(arc());
-  mockIsContractionSignalActive.mockReturnValue(false);
+  mockUseContractionSignalActive.mockReturnValue(false);
   mockSaveDismissed.mockResolvedValue(undefined);
   mockLoadDismissed.mockResolvedValue(false);
 });
@@ -99,7 +99,7 @@ describe('useMettaReturn', () => {
   });
 
   it('offerVisible is false when the contraction signal is inactive, even if eligible', async () => {
-    mockIsContractionSignalActive.mockReturnValue(false);
+    mockUseContractionSignalActive.mockReturnValue(false);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
     await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
@@ -107,14 +107,22 @@ describe('useMettaReturn', () => {
   });
 
   it('offerVisible is true when eligible, no arc, and the contraction signal is active', async () => {
-    mockIsContractionSignalActive.mockReturnValue(true);
+    mockUseContractionSignalActive.mockReturnValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
     await waitFor(() => expect(result.current.offerVisible).toBe(true));
   });
 
+  it('offerVisible is false when ineligible, even with an active contraction signal', async () => {
+    mockUseContractionSignalActive.mockReturnValue(true);
+    mockState.mockResolvedValue(stateResult({ eligible: false, arc: null }));
+    const { result } = renderHook(() => useMettaReturn());
+    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    expect(result.current.offerVisible).toBe(false);
+  });
+
   it('offerVisible is false when an arc already exists, even with an active signal', async () => {
-    mockIsContractionSignalActive.mockReturnValue(true);
+    mockUseContractionSignalActive.mockReturnValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc() }));
     const { result } = renderHook(() => useMettaReturn());
     await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
@@ -123,7 +131,7 @@ describe('useMettaReturn', () => {
   });
 
   it('dismissOffer hides the offer and persists the dismissal', async () => {
-    mockIsContractionSignalActive.mockReturnValue(true);
+    mockUseContractionSignalActive.mockReturnValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
     await waitFor(() => expect(result.current.offerVisible).toBe(true));
@@ -137,7 +145,7 @@ describe('useMettaReturn', () => {
   });
 
   it('a persisted dismissal keeps the offer hidden on reload', async () => {
-    mockIsContractionSignalActive.mockReturnValue(true);
+    mockUseContractionSignalActive.mockReturnValue(true);
     mockLoadDismissed.mockResolvedValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());

--- a/frontend/src/features/Today/contractionSignal.ts
+++ b/frontend/src/features/Today/contractionSignal.ts
@@ -3,12 +3,13 @@
  * currently observed for the person. The Return offer is only ever surfaced
  * when this returns true AND the person is eligible.
  *
- * It returns ``false`` for now: the descriptive contraction detector lands in a
- * later slice, and until it does the offer stays quietly out of sight. Keeping
- * the decision behind this single named function means wiring the real detector
- * later is a one-line change, and every offer/accept path is already built and
- * tested against it.
+ * It reads the shared contraction-signal store, which the journal resonance
+ * pass feeds each time it observes a contraction. A reactive selector so a
+ * still-mounted Today tab re-renders the moment the signal flips.
  */
-export function isContractionSignalActive(): boolean {
-  return false;
+import { useContractionSignalStore } from '@/store/useContractionSignalStore';
+
+/** Reactive read of whether a contraction is currently observed for the person. */
+export function useContractionSignalActive(): boolean {
+  return useContractionSignalStore((s) => s.active);
 }

--- a/frontend/src/features/Today/useMettaReturn.ts
+++ b/frontend/src/features/Today/useMettaReturn.ts
@@ -13,7 +13,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
 
-import { isContractionSignalActive } from './contractionSignal';
+import { useContractionSignalActive } from './contractionSignal';
 
 import { mettaReturn } from '@/api';
 import type { ReturnArc, ReturnWeek } from '@/api';
@@ -79,6 +79,7 @@ function useLoadedReturn(): LoadedReturn {
 
 export function useMettaReturn(): UseMettaReturnResult {
   const { eligible, weeks, arc, dismissed, setArc, setDismissed, mountedRef } = useLoadedReturn();
+  const contractionActive = useContractionSignalActive();
   const arcRef = useRef<ReturnArc | null>(null);
 
   // Mirror the committed arc into a ref so a lifecycle call can snapshot it
@@ -121,7 +122,7 @@ export function useMettaReturn(): UseMettaReturnResult {
     if (mountedRef.current) setArc(null);
   }, [mountedRef, setArc]);
 
-  const offerVisible = eligible && isContractionSignalActive() && !dismissed && arc === null;
+  const offerVisible = eligible && contractionActive && !dismissed && arc === null;
 
   return { eligible, weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave };
 }

--- a/frontend/src/store/__tests__/useContractionSignalStore.test.ts
+++ b/frontend/src/store/__tests__/useContractionSignalStore.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { act } from '@testing-library/react-native';
+
+import { useContractionSignalStore } from '../useContractionSignalStore';
+
+import type { ContractionReflection } from '@/api';
+
+function returnOffer(): ContractionReflection {
+  return { variant: 'return_offer', message: 'x' };
+}
+
+function simpleEaseOff(): ContractionReflection {
+  return { variant: 'simple_ease_off', message: 'x' };
+}
+
+beforeEach(() => {
+  act(() => {
+    useContractionSignalStore.getState().reset();
+  });
+});
+
+describe('useContractionSignalStore', () => {
+  it('starts inactive', () => {
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('observe sets active true for a return_offer contraction', () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(returnOffer());
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(true);
+  });
+
+  it('observe sets active false for a simple_ease_off contraction, retracting a prior true', () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(returnOffer());
+    });
+    expect(useContractionSignalStore.getState().active).toBe(true);
+
+    act(() => {
+      useContractionSignalStore.getState().observe(simpleEaseOff());
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('observe(null) retracts a prior true signal', () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(returnOffer());
+    });
+    expect(useContractionSignalStore.getState().active).toBe(true);
+
+    act(() => {
+      useContractionSignalStore.getState().observe(null);
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('reset returns to the initial inactive state', () => {
+    act(() => {
+      useContractionSignalStore.getState().observe(returnOffer());
+      useContractionSignalStore.getState().reset();
+    });
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+
+  it('registers its reset with the shared store registry so logout wipes it', () => {
+    const { resetAllStores } = require('../registry');
+
+    act(() => {
+      useContractionSignalStore.getState().observe(returnOffer());
+    });
+    expect(useContractionSignalStore.getState().active).toBe(true);
+
+    act(() => resetAllStores());
+
+    expect(useContractionSignalStore.getState().active).toBe(false);
+  });
+});

--- a/frontend/src/store/useContractionSignalStore.ts
+++ b/frontend/src/store/useContractionSignalStore.ts
@@ -1,0 +1,45 @@
+// In-memory signal for a currently-observed contraction. Not persisted: the
+// signal is derived fresh from each journal resonance pass, so it lives only
+// for the session and is wiped on logout via the shared store registry.
+import { create } from 'zustand';
+
+import { registerStoreReset } from './registry';
+
+import type { ContractionReflection } from '@/api';
+
+/**
+ * Shared contraction-signal store. The journal resonance pass feeds it each
+ * observed contraction; the Today seam reads ``active`` to decide whether the
+ * declinable Return offer may surface. Latest pass wins, so a healthy or
+ * simple-ease-off pass retracts a prior offer signal.
+ */
+export interface ContractionSignalState {
+  // ``true`` only while the most recent observation was a ``return_offer``
+  // contraction; ``false`` otherwise (initial, healthy, simple_ease_off).
+  active: boolean;
+  // Record the latest observed contraction (or its absence) and set ``active``
+  // accordingly. Only a ``return_offer`` variant raises the signal.
+  observe: (_contraction: ContractionReflection | null) => void;
+  // Wipe back to the initial inactive state (logout / test reset).
+  reset: () => void;
+}
+
+const INITIAL_STATE = {
+  active: false,
+};
+
+export const useContractionSignalStore = create<ContractionSignalState>((set) => ({
+  ...INITIAL_STATE,
+
+  observe: (contraction) => {
+    const active = contraction !== null && contraction.variant === 'return_offer';
+    set({ active });
+  },
+  reset: () => {
+    set({ ...INITIAL_STATE });
+  },
+}));
+
+registerStoreReset(() => {
+  useContractionSignalStore.getState().reset();
+});


### PR DESCRIPTION
## Summary

- Surface the declinable five-week Metta "Return" offer in response to a **real contraction** rather than only the static eligibility gate. The offer's visibility now reads a live contraction signal *in addition to* the existing eligibility / no-active-arc / not-dismissed gates — this changes *when* it appears, never the no-penalty, never-shaming semantics ("you choose your depth").
- New in-memory `useContractionSignalStore` (`active` / `observe` / `reset`, logout-wipe registered) is fed by the journal resonance pass: only a `return_offer` contraction raises the signal; a healthy (`null`) or `simple_ease_off` pass retracts it (latest-pass-wins), and a failed pass leaves it unchanged.
- The Today seam becomes a **reactive** hook `useContractionSignalActive()` (a Zustand selector), so a still-mounted Today tab re-renders the moment the signal flips. No backend change — the signal source is the existing resonance response.

## Test plan

- `npx jest` — full suite green (285 suites / 2825 tests), including new coverage: store (initial / return_offer / simple_ease_off retract / null retract / reset / logout-wipe), the reactive hook, the resonance wiring (all four pass outcomes), and `useMettaReturn` (offer surfaced when eligible + signal; hidden when ineligible; hidden when no signal; hidden when an arc exists).
- `npx tsc --noEmit` — clean (strict).
- `npm run lint` — zero warnings.
- `./scripts/frontend/check-all.sh` — exit 0.

Closes #1097
Refs #943
