### PR TITLE
feat(frontend): launch a guided Metta session from the Return weekly focus

### DIFF
--- a/frontend/src/features/Today/MettaSessionModal.tsx
+++ b/frontend/src/features/Today/MettaSessionModal.tsx
@@ -1,0 +1,253 @@
+/**
+ * ``MettaSessionModal`` — the guided loving-kindness session launched from the
+ * Return arc. A three-phase local machine (idle -> running -> rest) walks the
+ * person through the current week's focus phrases. Wholly optional: a close
+ * affordance sits in every phase, closing issues no network call and mutates no
+ * arc or stage state. Reduced-motion-safe; tokens only.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  METTA_SESSION_ADVANCE,
+  METTA_SESSION_ADVANCE_A11Y,
+  METTA_SESSION_BEGIN,
+  METTA_SESSION_BEGIN_A11Y,
+  METTA_SESSION_CLOSE,
+  METTA_SESSION_CLOSE_A11Y,
+  METTA_SESSION_HEADING,
+  METTA_SESSION_PHRASES,
+  METTA_SESSION_REST,
+} from './mettaSessionCopy';
+
+import type { ReturnWeek } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+import { CALM_SURFACE, SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
+import { PrimaryButton, SessionContainer } from '@/features/Practice/views/shared';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/** The first phrase index — a running session always opens on the opening wish. */
+const FIRST_PHRASE = 0;
+
+/** Stand-in when no phrase is active (the idle and rest phases never read it). */
+const NO_PHRASE = '';
+
+type Phase = 'idle' | 'running' | 'rest';
+
+export interface MettaSessionModalProps {
+  visible: boolean;
+  focus: ReturnWeek['focus'];
+  weekTitle?: string;
+  onClose: () => void;
+}
+
+interface MettaSession {
+  phase: Phase;
+  phrase: string;
+  begin: () => void;
+  advance: () => void;
+}
+
+/** The three-phase session machine: idle opening, phrase walk, then rest. */
+function useMettaSession(visible: boolean, focus: ReturnWeek['focus']): MettaSession {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [index, setIndex] = useState(FIRST_PHRASE);
+  const phrases = METTA_SESSION_PHRASES[focus];
+
+  // Re-opening the session always returns to the idle opening screen.
+  useEffect(() => {
+    if (visible) {
+      setPhase('idle');
+      setIndex(FIRST_PHRASE);
+    }
+  }, [visible]);
+
+  const begin = useCallback(() => {
+    setIndex(FIRST_PHRASE);
+    setPhase('running');
+  }, []);
+
+  const advance = useCallback(() => {
+    const next = index + 1;
+    if (next >= phrases.length) {
+      setPhase('rest');
+    } else {
+      setIndex(next);
+    }
+  }, [index, phrases]);
+
+  return { phase, phrase: phrases[index] ?? NO_PHRASE, begin, advance };
+}
+
+/** The opening screen: heading, optional week title, and the begin affordance. */
+function IdlePhase({
+  weekTitle,
+  onBegin,
+}: {
+  weekTitle?: string;
+  onBegin: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <Text style={styles.heading}>{METTA_SESSION_HEADING}</Text>
+      {weekTitle ? <Text style={styles.weekTitle}>{weekTitle}</Text> : null}
+      <PrimaryButton
+        label={METTA_SESSION_BEGIN}
+        onPress={onBegin}
+        testID="metta-session-begin"
+        accessibilityLabel={METTA_SESSION_BEGIN_A11Y}
+      />
+    </>
+  );
+}
+
+/** The running screen: the current phrase and the advance affordance. */
+function RunningPhase({
+  phrase,
+  onAdvance,
+}: {
+  phrase: string;
+  onAdvance: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <Text style={styles.phrase}>{phrase}</Text>
+      <PrimaryButton
+        label={METTA_SESSION_ADVANCE}
+        onPress={onAdvance}
+        testID="metta-session-advance"
+        accessibilityLabel={METTA_SESSION_ADVANCE_A11Y}
+      />
+    </>
+  );
+}
+
+/** The quiet close affordance, present in every phase. */
+function CloseButton({ onClose }: { onClose: () => void }): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.close}
+      onPress={onClose}
+      accessibilityRole="button"
+      accessibilityLabel={METTA_SESSION_CLOSE_A11Y}
+      testID="metta-session-close"
+    >
+      <Text style={styles.closeText}>{METTA_SESSION_CLOSE}</Text>
+    </TouchableOpacity>
+  );
+}
+
+/** Pick the phase body — idle by default, running mid-session, rest at the end. */
+function SessionBody({
+  phase,
+  phrase,
+  weekTitle,
+  onBegin,
+  onAdvance,
+}: {
+  phase: Phase;
+  phrase: string;
+  weekTitle?: string;
+  onBegin: () => void;
+  onAdvance: () => void;
+}): React.JSX.Element {
+  if (phase === 'running') {
+    return <RunningPhase phrase={phrase} onAdvance={onAdvance} />;
+  }
+  if (phase === 'rest') {
+    return <Text style={styles.rest}>{METTA_SESSION_REST}</Text>;
+  }
+  return <IdlePhase weekTitle={weekTitle} onBegin={onBegin} />;
+}
+
+function MettaSessionModal({
+  visible,
+  focus,
+  weekTitle,
+  onClose,
+}: MettaSessionModalProps): React.JSX.Element {
+  const reducedMotion = useReducedMotion();
+  const { phase, phrase, begin, advance } = useMettaSession(visible, focus);
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType={reducedMotion ? 'none' : 'fade'}
+      onRequestClose={onClose}
+      testID="metta-session-modal"
+    >
+      <View style={styles.scrim}>
+        <SessionSurfaceProvider value={CALM_SURFACE}>
+          <SessionContainer testID="metta-session-container" style={styles.card}>
+            <SessionBody
+              phase={phase}
+              phrase={phrase}
+              weekTitle={weekTitle}
+              onBegin={begin}
+              onAdvance={advance}
+            />
+            <CloseButton onClose={onClose} />
+          </SessionContainer>
+        </SessionSurfaceProvider>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrim: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+  },
+  card: {
+    borderRadius: BORDER_RADIUS.lg,
+  },
+  heading: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    textAlign: 'center',
+    marginBottom: spacing(1),
+  },
+  weekTitle: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+    textAlign: 'center',
+    marginBottom: spacing(2),
+  },
+  phrase: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+    textAlign: 'center',
+    marginBottom: spacing(2.5),
+  },
+  rest: {
+    ...editorialType.body,
+    color: colors.paper.ink,
+    textAlign: 'center',
+    marginBottom: spacing(2),
+  },
+  close: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    marginTop: spacing(1.5),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeText: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default MettaSessionModal;

--- a/frontend/src/features/Today/ReturnArcCard.tsx
+++ b/frontend/src/features/Today/ReturnArcCard.tsx
@@ -4,9 +4,11 @@
  * rest (pause), continue (resume), or set the arc down (leave) at any time with
  * no penalty. Presentational + reduced-motion-safe; tokens only.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+import { METTA_SESSION_BEGIN, METTA_SESSION_BEGIN_A11Y } from './mettaSessionCopy';
+import MettaSessionModal from './MettaSessionModal';
 import {
   RETURN_ARC_LEAVE,
   RETURN_ARC_LEAVE_A11Y,
@@ -103,6 +105,21 @@ function RestToggle({
   );
 }
 
+/** The begin-a-session affordance: opens the optional guided Metta practice. */
+function BeginSessionButton({ onPress }: { onPress: () => void }): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.action}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={METTA_SESSION_BEGIN_A11Y}
+      testID="return-arc-begin-session"
+    >
+      <Text style={styles.actionText}>{METTA_SESSION_BEGIN}</Text>
+    </TouchableOpacity>
+  );
+}
+
 function ReturnArcCard({
   weeks,
   arc,
@@ -112,6 +129,7 @@ function ReturnArcCard({
 }: ReturnArcCardProps): React.JSX.Element {
   const press = usePressScale(useReducedMotion());
   const focusWeek = currentWeek(weeks, arc.week);
+  const [sessionOpen, setSessionOpen] = useState(false);
   return (
     <Animated.View style={{ transform: [{ scale: press.scale }] }}>
       <View style={styles.card} testID="return-arc-card">
@@ -123,6 +141,7 @@ function ReturnArcCard({
         ) : null}
         <WeekSegments week={arc.week} />
         <View style={styles.actions}>
+          <BeginSessionButton onPress={() => setSessionOpen(true)} />
           <RestToggle paused={arc.paused} onPause={onPause} onResume={onResume} press={press} />
           <TouchableOpacity
             style={styles.leave}
@@ -135,6 +154,12 @@ function ReturnArcCard({
           </TouchableOpacity>
         </View>
       </View>
+      <MettaSessionModal
+        visible={sessionOpen}
+        focus={arc.focus}
+        weekTitle={focusWeek?.title}
+        onClose={() => setSessionOpen(false)}
+      />
     </Animated.View>
   );
 }
@@ -178,6 +203,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: spacing(1.5),
+    gap: spacing(1),
   },
   action: {
     minHeight: touchTarget.minimum,
@@ -198,7 +224,6 @@ const styles = StyleSheet.create({
     minWidth: touchTarget.minimum,
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.sm,
-    marginLeft: spacing(1),
     borderRadius: BORDER_RADIUS.sm,
     alignItems: 'center',
     justifyContent: 'center',

--- a/frontend/src/features/Today/__tests__/MettaSessionModal.test.tsx
+++ b/frontend/src/features/Today/__tests__/MettaSessionModal.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('@/hooks/usePressScale', () => ({
+  usePressScale: () => ({ scale: 1, onPressIn: jest.fn(), onPressOut: jest.fn() }),
+}));
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => true,
+}));
+
+const MOCK_PHRASES = {
+  self: ['May I be at ease.', 'May I be well.'],
+  benefactor: ['May they be at ease.'],
+  stranger: ['May they be at ease.'],
+  antagonist: ['May they be free from suffering.', 'May they be at peace.'],
+  all_beings: ['May all beings be at ease.'],
+} as const;
+
+jest.mock('../mettaSessionCopy', () => ({
+  METTA_SESSION_HEADING: 'A guided Metta session',
+  METTA_SESSION_BEGIN: 'Begin',
+  METTA_SESSION_BEGIN_A11Y: 'Begin the guided phrases',
+  METTA_SESSION_ADVANCE: 'Next',
+  METTA_SESSION_ADVANCE_A11Y: 'Move to the next phrase',
+  METTA_SESSION_CLOSE: 'Close',
+  METTA_SESSION_CLOSE_A11Y: 'Close the session',
+  METTA_SESSION_REST: 'Rest here as long as you like.',
+  METTA_SESSION_PHRASES: MOCK_PHRASES,
+}));
+
+const MettaSessionModal = require('../MettaSessionModal').default;
+
+describe('MettaSessionModal', () => {
+  let fetchSpy: jest.SpiedFunction<typeof global.fetch>;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch') as jest.SpiedFunction<typeof global.fetch>;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('renders nothing when visible is false', () => {
+    const { queryByTestId } = render(
+      <MettaSessionModal visible={false} focus="self" onClose={jest.fn()} />,
+    );
+    expect(queryByTestId('metta-session-begin')).toBeNull();
+  });
+
+  it('shows a heading and a begin affordance with role and label when visible', () => {
+    const { getByTestId, getByText } = render(
+      <MettaSessionModal visible focus="self" onClose={jest.fn()} />,
+    );
+    expect(getByText('A guided Metta session')).toBeTruthy();
+    const begin = getByTestId('metta-session-begin');
+    expect(begin.props.accessibilityRole).toBe('button');
+    const label: string = begin.props.accessibilityLabel;
+    expect(label).toBeTruthy();
+    expect(label.length).toBeGreaterThan(0);
+  });
+
+  it('pressing begin enters the running phase and shows the self focus first phrase', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <MettaSessionModal visible focus="self" onClose={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('metta-session-begin'));
+    expect(getByText(MOCK_PHRASES.self[0])).toBeTruthy();
+    expect(queryByText(MOCK_PHRASES.antagonist[0])).toBeNull();
+  });
+
+  it('pressing begin enters the running phase and shows the antagonist focus first phrase', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <MettaSessionModal visible focus="antagonist" onClose={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('metta-session-begin'));
+    expect(getByText(MOCK_PHRASES.antagonist[0])).toBeTruthy();
+    expect(queryByText(MOCK_PHRASES.self[0])).toBeNull();
+  });
+
+  it('advance affordance has role and label and steps through phrases in order', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <MettaSessionModal visible focus="self" onClose={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('metta-session-begin'));
+    const advance = getByTestId('metta-session-advance');
+    expect(advance.props.accessibilityRole).toBe('button');
+    const label: string = advance.props.accessibilityLabel;
+    expect(label).toBeTruthy();
+    expect(label.length).toBeGreaterThan(0);
+
+    fireEvent.press(advance);
+    expect(getByText(MOCK_PHRASES.self[1])).toBeTruthy();
+    expect(queryByText(MOCK_PHRASES.self[0])).toBeNull();
+  });
+
+  it('advancing past the last phrase lands on the rest state', () => {
+    const { getByTestId, getByText } = render(
+      <MettaSessionModal visible focus="self" onClose={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('metta-session-begin'));
+    fireEvent.press(getByTestId('metta-session-advance'));
+    fireEvent.press(getByTestId('metta-session-advance'));
+    expect(getByText('Rest here as long as you like.')).toBeTruthy();
+  });
+
+  it('close affordance is present in idle, running, and rest phases with role and label', () => {
+    const onCloseIdle = jest.fn();
+    const idle = render(<MettaSessionModal visible focus="self" onClose={onCloseIdle} />);
+    const idleClose = idle.getByTestId('metta-session-close');
+    expect(idleClose.props.accessibilityRole).toBe('button');
+    expect((idleClose.props.accessibilityLabel as string).length).toBeGreaterThan(0);
+    fireEvent.press(idleClose);
+    expect(onCloseIdle).toHaveBeenCalledTimes(1);
+
+    const onCloseRunning = jest.fn();
+    const running = render(<MettaSessionModal visible focus="self" onClose={onCloseRunning} />);
+    fireEvent.press(running.getByTestId('metta-session-begin'));
+    fireEvent.press(running.getByTestId('metta-session-close'));
+    expect(onCloseRunning).toHaveBeenCalledTimes(1);
+
+    const onCloseRest = jest.fn();
+    const rest = render(<MettaSessionModal visible focus="self" onClose={onCloseRest} />);
+    fireEvent.press(rest.getByTestId('metta-session-begin'));
+    fireEvent.press(rest.getByTestId('metta-session-advance'));
+    fireEvent.press(rest.getByTestId('metta-session-advance'));
+    fireEvent.press(rest.getByTestId('metta-session-close'));
+    expect(onCloseRest).toHaveBeenCalledTimes(1);
+  });
+
+  it('closing issues no network call', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<MettaSessionModal visible focus="self" onClose={onClose} />);
+    fireEvent.press(getByTestId('metta-session-begin'));
+    fireEvent.press(getByTestId('metta-session-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-opening after a close resets to the idle begin affordance', () => {
+    const onClose = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <MettaSessionModal visible focus="self" onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('metta-session-begin'));
+    fireEvent.press(getByTestId('metta-session-close'));
+
+    rerender(<MettaSessionModal visible={false} focus="self" onClose={onClose} />);
+    expect(queryByTestId('metta-session-begin')).toBeNull();
+
+    rerender(<MettaSessionModal visible focus="self" onClose={onClose} />);
+    expect(getByTestId('metta-session-begin')).toBeTruthy();
+  });
+
+  it('renders an optional weekTitle when provided', () => {
+    const { getByText } = render(
+      <MettaSessionModal visible focus="self" weekTitle="Toward yourself" onClose={jest.fn()} />,
+    );
+    expect(getByText('Toward yourself')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
@@ -177,4 +177,55 @@ describe('ReturnArcCard', () => {
     expect(label).toBeTruthy();
     expect(label.length).toBeGreaterThan(0);
   });
+
+  it('begin-session affordance renders with accessibilityRole button and a non-empty label', () => {
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc()}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    const beginSession = getByTestId('return-arc-begin-session');
+    expect(beginSession.props.accessibilityRole).toBe('button');
+    const label: string = beginSession.props.accessibilityLabel;
+    expect(label).toBeTruthy();
+    expect(label.length).toBeGreaterThan(0);
+  });
+
+  it('pressing begin-session reveals the guided Metta session', () => {
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ week: 1, focus: 'self' })}
+        onPause={noop}
+        onResume={noop}
+        onLeave={noop}
+      />,
+    );
+    fireEvent.press(getByTestId('return-arc-begin-session'));
+    expect(getByTestId('metta-session-begin')).toBeTruthy();
+  });
+
+  it('opening then closing the session calls none of onPause, onResume, or onLeave', () => {
+    const onPause = jest.fn();
+    const onResume = jest.fn();
+    const onLeave = jest.fn();
+    const { getByTestId } = render(
+      <ReturnArcCard
+        weeks={fiveWeeks()}
+        arc={arc({ week: 1, focus: 'self' })}
+        onPause={onPause}
+        onResume={onResume}
+        onLeave={onLeave}
+      />,
+    );
+    fireEvent.press(getByTestId('return-arc-begin-session'));
+    fireEvent.press(getByTestId('metta-session-close'));
+    expect(onPause).not.toHaveBeenCalled();
+    expect(onResume).not.toHaveBeenCalled();
+    expect(onLeave).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/features/Today/__tests__/mettaSessionCopy.test.ts
+++ b/frontend/src/features/Today/__tests__/mettaSessionCopy.test.ts
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { METTA_SESSION_COPY_ENTRIES, METTA_SESSION_PHRASES } from '../mettaSessionCopy';
+
+import type { ReturnWeek } from '@/api';
+import { ranksOrShames } from '@/features/Map/__tests__/copyIntentRule';
+
+const ALL_FOCI: ReturnWeek['focus'][] = [
+  'self',
+  'benefactor',
+  'stranger',
+  'antagonist',
+  'all_beings',
+];
+
+describe('mettaSessionCopy — balance-not-altitude intent rule', () => {
+  it('exposes at least one copy entry to sweep', () => {
+    expect(METTA_SESSION_COPY_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it('no METTA_SESSION_COPY_ENTRIES entry ranks or shames the person', () => {
+    for (const entry of METTA_SESSION_COPY_ENTRIES) {
+      expect(ranksOrShames(entry)).toBe(false);
+    }
+  });
+
+  it('every focus has a non-empty phrase list', () => {
+    for (const focus of ALL_FOCI) {
+      const phrases = METTA_SESSION_PHRASES[focus];
+      expect(Array.isArray(phrases)).toBe(true);
+      expect(phrases.length).toBeGreaterThan(0);
+      for (const phrase of phrases) {
+        expect(typeof phrase).toBe('string');
+        expect(phrase.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/frontend/src/features/Today/mettaSessionCopy.ts
+++ b/frontend/src/features/Today/mettaSessionCopy.ts
@@ -1,0 +1,86 @@
+/**
+ * Microcopy for the guided Metta session launched from the Return arc — the
+ * declinable loving-kindness practice offered as a soft landing (NORTH-STAR
+ * "you choose your depth").
+ *
+ * Every line reads like a wise friend sitting beside you, never a verdict.
+ * Closing or leaving mid-session costs nothing, so nothing here ranks, shames,
+ * or pressures. ``METTA_SESSION_COPY_ENTRIES`` flattens every user-facing
+ * string — headings, affordances, and every phrase — for the
+ * balance-not-altitude sweep.
+ */
+
+import type { ReturnWeek } from '@/api';
+
+/** The idle-screen heading — an invitation into the practice. */
+export const METTA_SESSION_HEADING = 'A guided Metta session';
+
+/** The begin affordance label. */
+export const METTA_SESSION_BEGIN = 'Begin';
+
+/** The accessibility label for beginning the guided phrases. */
+export const METTA_SESSION_BEGIN_A11Y = 'Begin the guided loving-kindness phrases';
+
+/** The advance affordance label. */
+export const METTA_SESSION_ADVANCE = 'Next phrase';
+
+/** The accessibility label for advancing to the next phrase. */
+export const METTA_SESSION_ADVANCE_A11Y = 'Move to the next phrase';
+
+/** The close affordance label, present in every phase. */
+export const METTA_SESSION_CLOSE = 'Close';
+
+/** The accessibility label for closing the session; closing changes nothing. */
+export const METTA_SESSION_CLOSE_A11Y = 'Close the session; nothing about your Return changes';
+
+/** The closing rest screen — an open invitation to linger. */
+export const METTA_SESSION_REST = 'Rest here for as long as you like.';
+
+/** The outward loving-kindness wish, shared by the benefactor and stranger weeks. */
+const TOWARD_ANOTHER: readonly string[] = [
+  'May you be safe.',
+  'May you be happy.',
+  'May you be healthy.',
+  'May you be at ease.',
+];
+
+/**
+ * Loving-kindness phrases adapted to each week's focus. Self turns the wish
+ * inward ("May I be…"); every other focus turns it outward ("May you be…"),
+ * with the difficult-person week leaning on release rather than fondness.
+ */
+export const METTA_SESSION_PHRASES: Record<ReturnWeek['focus'], readonly string[]> = {
+  self: ['May I be safe.', 'May I be happy.', 'May I be healthy.', 'May I be at ease.'],
+  benefactor: TOWARD_ANOTHER,
+  stranger: TOWARD_ANOTHER,
+  antagonist: [
+    'May you be safe.',
+    'May you be free from suffering.',
+    'May you be at peace.',
+    'May you be at ease.',
+  ],
+  all_beings: [
+    'May all beings be safe.',
+    'May all beings be happy.',
+    'May all beings be healthy.',
+    'May all beings be at ease.',
+  ],
+};
+
+/** Every fixed user-facing string, gathered for the balance-not-altitude sweep. */
+const STATIC_ENTRIES: readonly string[] = [
+  METTA_SESSION_HEADING,
+  METTA_SESSION_BEGIN,
+  METTA_SESSION_BEGIN_A11Y,
+  METTA_SESSION_ADVANCE,
+  METTA_SESSION_ADVANCE_A11Y,
+  METTA_SESSION_CLOSE,
+  METTA_SESSION_CLOSE_A11Y,
+  METTA_SESSION_REST,
+];
+
+/** The static strings plus every focus phrase, flattened for the sweep. */
+export const METTA_SESSION_COPY_ENTRIES: readonly string[] = [
+  ...STATIC_ENTRIES,
+  ...Object.values(METTA_SESSION_PHRASES).flat(),
+];


### PR DESCRIPTION
## Summary

Adds a declinable "begin session" affordance to the Return weekly-focus card (`ReturnArcCard`) that opens a self-contained guided Metta session for the current week's focus (self / benefactor / stranger / antagonist / all beings).

- New `MettaSessionModal` — a three-phase local flow (idle → guided phrases → rest) built on the Practice shared session primitives (`SessionContainer`, `PrimaryButton`) on the calm lifted-paper surface. Reduced-motion-safe; tokens only.
- New `mettaSessionCopy` — per-focus loving-kindness phrase sets plus session labels/a11y strings, all swept by the no-shame intent rule.
- The session is purely presentational: no API calls and no arc/stage mutation, so declining or leaving mid-session carries no penalty.

Scoped to the session-launch flow only — `useMettaReturn.ts` and the `TodayScreen` Return wiring are untouched to stay clear of the sibling Return-surface lanes.

## Test plan

- `mettaSessionCopy`: sweep list non-empty; every entry clears `ranksOrShames`; every focus has a non-empty phrase list.
- `MettaSessionModal`: per-focus phrases render; begin → advance steps through phrases to the rest state; close present in every phase and calls `onClose` once; no `fetch`; idle reset on re-open; hidden when `visible=false`.
- `ReturnArcCard`: begin-session affordance has role/label; pressing it opens the session for the current focus; open/close mutates nothing (`onPause`/`onResume`/`onLeave` uncalled).
- Local gates green: Jest 2833 pass, tsc clean, ESLint 0 warnings, `./scripts/frontend/check-all.sh` all checks pass.

Closes #1100