### PR TITLE
feat(full-stack): warm completion state for a finished Metta "Return" arc

### DIFF
--- a/backend/src/domain/metta_return.py
+++ b/backend/src/domain/metta_return.py
@@ -29,6 +29,8 @@ RETURN_WEEK_COUNT = 5
 # Blue is stage 4; reaching stage 5 (Orange) means Blue was passed to get there.
 RETURN_MINIMUM_STAGE = 5
 DAYS_PER_WEEK = 7
+# The full arc: five weeks of seven days. Living all of them is completion.
+RETURN_TOTAL_DAYS = RETURN_WEEK_COUNT * DAYS_PER_WEEK
 # A user mid-way through a second 10-stage cycle has, by definition, already
 # passed Blue in the prior cycle, so the arc is offered regardless of where the
 # current cycle sits.
@@ -189,3 +191,18 @@ def active_return_week(started_at: datetime, paused_at: datetime | None, now: da
     reference = paused_at if paused_at is not None else now
     week = _elapsed_days(started_at, reference) // DAYS_PER_WEEK + 1
     return min(max(week, 1), RETURN_WEEK_COUNT)
+
+
+def is_return_complete(started_at: datetime, paused_at: datetime | None, now: datetime) -> bool:
+    """Return True once the arc's full five weeks have been lived through.
+
+    Completion is a pure time-derived predicate — nothing is written and no stage
+    is mutated. Elapsed time is frozen exactly as :func:`active_return_week` does:
+    measured to the pause instant when the arc is paused, otherwise to ``now``, so
+    a pause before the boundary keeps completion frozen at False. The arc is
+    complete once at least :data:`RETURN_TOTAL_DAYS` have elapsed — the fifth week
+    has fully closed, a reflective close rather than a reward. Mixed naive/aware
+    datetimes are normalized by the shared elapsed-day helper rather than raising.
+    """
+    reference = paused_at if paused_at is not None else now
+    return _elapsed_days(started_at, reference) >= RETURN_TOTAL_DAYS

--- a/backend/src/routers/metta_return.py
+++ b/backend/src/routers/metta_return.py
@@ -28,6 +28,7 @@ from database import get_session
 from domain.metta_return import (
     RETURN_SEQUENCE,
     active_return_week,
+    is_return_complete,
     is_return_eligible,
     resumed_start,
 )
@@ -57,6 +58,7 @@ def _to_arc_response(arc: MettaReturnArc, now: datetime) -> ReturnArcResponse:
         paused=arc.paused_at is not None,
         week=week,
         focus=_week_focus(week),
+        complete=is_return_complete(arc.started_at, arc.paused_at, now),
     )
 
 

--- a/backend/src/schemas/metta_return.py
+++ b/backend/src/schemas/metta_return.py
@@ -32,12 +32,15 @@ class ReturnArcResponse(BaseModel):
 
     ``week`` is the arc's current (or, when paused, frozen) week; ``paused``
     reflects whether the arc is resting. No ``user_id`` or row ``id`` is exposed.
+    ``complete`` is True once the fifth week has fully closed — a reflective
+    close, never a reward or rank.
     """
 
     started_at: datetime
     paused: bool
     week: int
     focus: str
+    complete: bool
 
 
 class MettaReturnStateResponse(BaseModel):

--- a/backend/tests/domain/test_metta_return.py
+++ b/backend/tests/domain/test_metta_return.py
@@ -1,8 +1,8 @@
 """Pure-domain tests for the Metta "Return" arc sequence and eligibility.
 
-These tests FAIL on import until the implementation-specialist creates
-``backend/src/domain/metta_return.py`` with the contracts pinned below.
-That is the correct RED state for Gate 1.
+The import of ``RETURN_TOTAL_DAYS`` and ``is_return_complete`` FAILs until the
+implementation-specialist adds them to ``backend/src/domain/metta_return.py``.
+That is the correct RED state for Gate 1 (warm completion state).
 
 Pinned public surface:
   MettaFocus(StrEnum): self, benefactor, stranger, antagonist, all_beings
@@ -11,8 +11,10 @@ Pinned public surface:
   RETURN_WEEK_COUNT = 5
   RETURN_MINIMUM_STAGE = 5
   DAYS_PER_WEEK = 7
+  RETURN_TOTAL_DAYS = RETURN_WEEK_COUNT * DAYS_PER_WEEK  (== 35)
   is_return_eligible(progress: StageProgress | None) -> bool
   active_return_week(started_at, paused_at, now) -> int
+  is_return_complete(started_at, paused_at, now) -> bool
 """
 
 from __future__ import annotations
@@ -26,10 +28,12 @@ from domain.metta_return import (
     DAYS_PER_WEEK,
     RETURN_MINIMUM_STAGE,
     RETURN_SEQUENCE,
+    RETURN_TOTAL_DAYS,
     RETURN_WEEK_COUNT,
     MettaFocus,
     ReturnWeek,
     active_return_week,
+    is_return_complete,
     is_return_eligible,
     resumed_start,
 )
@@ -180,6 +184,69 @@ def test_active_return_week_handles_naive_and_aware_datetime_mix() -> None:
     now_aware = datetime(2026, 1, 8, tzinfo=UTC)
     week = active_return_week(started_at_naive, None, now_aware)
     assert week == 2
+
+
+# ---------------------------------------------------------------------------
+# RETURN_TOTAL_DAYS and is_return_complete.
+# ---------------------------------------------------------------------------
+
+
+def test_return_total_days_constant() -> None:
+    """RETURN_TOTAL_DAYS pins the full arc length to five weeks of seven days."""
+    assert RETURN_TOTAL_DAYS == 35
+    assert RETURN_TOTAL_DAYS == RETURN_WEEK_COUNT * DAYS_PER_WEEK
+
+
+def test_is_return_complete_day_thirty_four_is_not_complete() -> None:
+    """One day short of the full arc length has not yet completed."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=34)
+    assert is_return_complete(started_at, None, now) is False
+
+
+def test_is_return_complete_day_thirty_five_is_complete() -> None:
+    """Exactly RETURN_TOTAL_DAYS elapsed is the completion boundary, inclusive."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=35)
+    assert is_return_complete(started_at, None, now) is True
+
+
+def test_is_return_complete_day_one_hundred_is_complete() -> None:
+    """Far beyond the arc length remains complete."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=100)
+    assert is_return_complete(started_at, None, now) is True
+
+
+def test_is_return_complete_day_thirty_is_week_five_but_not_complete() -> None:
+    """Day 30 sits in week 5 but has not finished living it: week5 != complete."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = started_at + timedelta(days=30)
+    assert active_return_week(started_at, None, now) == 5
+    assert is_return_complete(started_at, None, now) is False
+
+
+def test_is_return_complete_paused_before_boundary_stays_incomplete() -> None:
+    """A pause frozen before day 35 keeps completion frozen at False."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = started_at + timedelta(days=30)
+    now = started_at + timedelta(days=50)
+    assert is_return_complete(started_at, paused_at, now) is False
+
+
+def test_is_return_complete_paused_at_or_after_boundary_is_complete() -> None:
+    """A pause frozen at or after day 35 reports the arc as already complete."""
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = started_at + timedelta(days=40)
+    now = started_at + timedelta(days=50)
+    assert is_return_complete(started_at, paused_at, now) is True
+
+
+def test_is_return_complete_handles_naive_and_aware_datetime_mix() -> None:
+    """Mixed naive/aware inputs past the boundary must not raise."""
+    started_at_naive = datetime(2026, 1, 1)  # noqa: DTZ001 - deliberately naive
+    now_aware = datetime(2026, 2, 10, tzinfo=UTC)  # 40 days later
+    assert is_return_complete(started_at_naive, None, now_aware) is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_metta_return.py
+++ b/backend/tests/routers/test_metta_return.py
@@ -1,9 +1,9 @@
 """Tests for the Metta "Return" arc lifecycle endpoints (/metta-return).
 
-These tests FAIL on import/collection until the implementation-specialist
-creates ``backend/src/routers/metta_return.py`` (and the supporting model /
-schemas) and mounts the router in ``backend/src/main.py``. That is the
-correct RED state for Gate 1.
+The router, model, and schemas already exist; the ``complete`` key on
+``ReturnArcResponse`` does not yet, so every assertion on ``arc["complete"]``
+below FAILs (missing key or wrong value) until the implementation-specialist
+adds it. That is the correct RED state for Gate 1 (warm completion state).
 
 The Return is a declinable five-week Metta arc, offered only after Blue
 Stage has been passed (highest stage reached >= 5). Accepting it starts a
@@ -583,3 +583,146 @@ async def test_full_lifecycle_never_mutates_stage_progress(
     assert refreshed.current_stage == before_stage
     assert list(refreshed.completed_stages) == before_completed
     assert refreshed.cycle_number == before_cycle
+
+
+# ---------------------------------------------------------------------------
+# 8. Completion: a finished arc reports a warm complete state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_arc_fresh_returns_complete_false(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A freshly started arc is nowhere near finished: complete is False."""
+    headers = await _signup(async_client, "mr_freshcomplete17")
+    user = await _get_user(db_session, "mr_freshcomplete17@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+
+    resp = await async_client.post(_START_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_state_thirty_five_day_arc_is_complete_at_week_five(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An arc backdated the full RETURN_TOTAL_DAYS reports week 5 and complete True."""
+    headers = await _signup(async_client, "mr_complete18")
+    user = await _get_user(db_session, "mr_complete18@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    started_at = datetime.now(UTC) - timedelta(days=35)
+    await _seed_active_arc(db_session, user.id, started_at=started_at)
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    arc = resp.json()["arc"]
+    assert arc["week"] == 5
+    assert arc["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_state_thirty_day_arc_is_week_five_but_not_complete(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An arc backdated 30 days sits in week 5 but has not finished living it."""
+    headers = await _signup(async_client, "mr_notcomplete19")
+    user = await _get_user(db_session, "mr_notcomplete19@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    started_at = datetime.now(UTC) - timedelta(days=30)
+    await _seed_active_arc(db_session, user.id, started_at=started_at)
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    arc = resp.json()["arc"]
+    assert arc["week"] == 5
+    assert arc["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_state_arc_payload_carries_complete_key_and_no_user_id(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The arc payload carries a complete key and still leaks no user_id."""
+    headers = await _signup(async_client, "mr_completekey20")
+    user = await _get_user(db_session, "mr_completekey20@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    await _seed_active_arc(db_session, user.id, started_at=datetime.now(UTC))
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    arc = resp.json()["arc"]
+    assert "complete" in arc
+    assert _FORBIDDEN_KEY not in arc
+
+
+@pytest.mark.asyncio
+async def test_completion_never_mutates_stage_progress(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Reading a complete arc never touches current_stage/completed_stages/cycle_number."""
+    headers = await _signup(async_client, "mr_completenomutate21")
+    user = await _get_user(db_session, "mr_completenomutate21@example.com")
+    assert user.id is not None
+    user_id = user.id
+    progress = await _seed_progress(
+        db_session,
+        user_id,
+        current_stage=_ELIGIBLE_STAGE,
+        completed_stages=[1, 2, 3, 4],
+        cycle_number=1,
+    )
+    before_stage = progress.current_stage
+    before_completed = list(progress.completed_stages)
+    before_cycle = progress.cycle_number
+    started_at = datetime.now(UTC) - timedelta(days=35)
+    await _seed_active_arc(db_session, user_id, started_at=started_at)
+
+    resp = await async_client.get(_BASE_URL, headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["arc"]["complete"] is True
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(StageProgress).where(col(StageProgress.user_id) == user_id)
+    )
+    refreshed = result.scalars().one()
+    assert refreshed.current_stage == before_stage
+    assert list(refreshed.completed_stages) == before_completed
+    assert refreshed.cycle_number == before_cycle
+
+
+@pytest.mark.asyncio
+async def test_leave_complete_arc_then_restart_lands_on_week_one_incomplete(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Setting down a finished arc frees the slot; the next arc starts fresh."""
+    headers = await _signup(async_client, "mr_leavecomplete22")
+    user = await _get_user(db_session, "mr_leavecomplete22@example.com")
+    assert user.id is not None
+    await _seed_progress(db_session, user.id, current_stage=_ELIGIBLE_STAGE)
+    started_at = datetime.now(UTC) - timedelta(days=35)
+    await _seed_active_arc(db_session, user.id, started_at=started_at)
+
+    leave_resp = await async_client.post(_LEAVE_URL, headers=headers)
+    assert leave_resp.status_code == HTTPStatus.OK
+
+    restart_resp = await async_client.post(_START_URL, headers=headers)
+    assert restart_resp.status_code == HTTPStatus.CREATED
+    assert restart_resp.json()["week"] == 1
+    assert restart_resp.json()["complete"] is False

--- a/frontend/src/api/__tests__/mettaReturn.test.ts
+++ b/frontend/src/api/__tests__/mettaReturn.test.ts
@@ -42,6 +42,7 @@ function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
     paused: false,
     week: 1,
     focus: 'self',
+    complete: false,
     ...overrides,
   };
 }
@@ -114,6 +115,15 @@ describe('mettaReturn.state', () => {
 
   test('rejects an over-bound arc week via Zod', async () => {
     const payload = { eligible: true, weeks: fiveWeeks(), arc: arc({ week: 6 }) };
+    mockFetch.mockReturnValueOnce(jsonResponse(payload));
+    await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('rejects an arc payload missing the required complete field via Zod', async () => {
+    const fullArc = arc();
+    const { complete: _omit, ...withoutComplete } = fullArc as ReturnArc & { complete: boolean };
+    void _omit;
+    const payload = { eligible: true, weeks: fiveWeeks(), arc: withoutComplete };
     mockFetch.mockReturnValueOnce(jsonResponse(payload));
     await expect(mettaReturn.state('tok')).rejects.toBeInstanceOf(ApiValidationError);
   });

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -577,6 +577,8 @@ export const returnArcSchema = z.object({
   paused: z.boolean(),
   week: returnWeekNumber,
   focus: mettaFocusSchema,
+  // The backend always sends it; completion is the arc's reflective close.
+  complete: z.boolean(),
 });
 
 /** Eligibility plus the full week sequence and the active arc, if any. */

--- a/frontend/src/features/Today/ReturnCompletionCard.tsx
+++ b/frontend/src/features/Today/ReturnCompletionCard.tsx
@@ -1,0 +1,98 @@
+/**
+ * ``ReturnCompletionCard`` — the warm close of a finished Return arc: all five
+ * foci met, self through all beings. A quiet, reflective set-down rather than a
+ * reward or rank, with the single ``set it down`` affordance. Presentational +
+ * reduced-motion-safe; tokens only. Reads as a softer sibling of ``ReturnArcCard``.
+ */
+import React from 'react';
+import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  RETURN_ARC_LEAVE,
+  RETURN_ARC_LEAVE_A11Y,
+  RETURN_COMPLETE_BODY,
+  RETURN_COMPLETE_HEADING,
+} from './returnCopy';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  paperShadow,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
+import { usePressScale } from '@/hooks/usePressScale';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+export interface ReturnCompletionCardProps {
+  onLeave: () => void;
+}
+
+function ReturnCompletionCard({ onLeave }: ReturnCompletionCardProps): React.JSX.Element {
+  const press = usePressScale(useReducedMotion());
+  return (
+    <Animated.View style={{ transform: [{ scale: press.scale }] }}>
+      <View style={styles.card} testID="return-completion-card">
+        <Text style={styles.heading} accessibilityRole="header">
+          {RETURN_COMPLETE_HEADING}
+        </Text>
+        <Text style={styles.body}>{RETURN_COMPLETE_BODY}</Text>
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={styles.leave}
+            onPress={onLeave}
+            onPressIn={press.onPressIn}
+            onPressOut={press.onPressOut}
+            accessibilityRole="button"
+            accessibilityLabel={RETURN_ARC_LEAVE_A11Y}
+            testID="return-completion-leave"
+          >
+            <Text style={styles.leaveText}>{RETURN_ARC_LEAVE}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.background,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.tier.low,
+    ...paperShadow.card,
+  },
+  heading: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+  },
+  body: {
+    ...editorialType.marginNote,
+    color: colors.paper.ink,
+    marginTop: spacing(1),
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing(1.5),
+  },
+  leave: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  leaveText: {
+    ...editorialType.caption,
+    color: colors.paper.inkSoft,
+  },
+});
+
+export default ReturnCompletionCard;

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -5,6 +5,7 @@ import { Animated, Pressable, Text } from 'react-native';
 
 import InvitationNote from './InvitationNote';
 import ReturnArcCard from './ReturnArcCard';
+import ReturnCompletionCard from './ReturnCompletionCard';
 import ReturnOfferCard from './ReturnOfferCard';
 import { todayStyles as s } from './Today.styles';
 import { useInvitations } from './useInvitations';
@@ -154,6 +155,9 @@ const InvitationStack = (): React.JSX.Element | null => {
 /** The Return surface: the soft-landing offer when invited, or the active arc. */
 const ReturnStack = (): React.JSX.Element | null => {
   const { weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave } = useMettaReturn();
+  if (arc !== null && arc.complete) {
+    return <ReturnCompletionCard onLeave={() => void leave()} />;
+  }
   if (arc !== null) {
     return (
       <ReturnArcCard

--- a/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnArcCard.test.tsx
@@ -59,6 +59,7 @@ function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
     paused: false,
     week: 1,
     focus: 'self',
+    complete: false,
     ...overrides,
   };
 }

--- a/frontend/src/features/Today/__tests__/ReturnCompletionCard.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnCompletionCard.test.tsx
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import ReturnCompletionCard from '../ReturnCompletionCard';
+import {
+  RETURN_ARC_LEAVE_A11Y,
+  RETURN_COMPLETE_BODY,
+  RETURN_COMPLETE_HEADING,
+} from '../returnCopy';
+
+const noop = () => undefined;
+
+describe('ReturnCompletionCard', () => {
+  it('renders the warm completion heading and body', () => {
+    const { getByText } = render(<ReturnCompletionCard onLeave={noop} />);
+    expect(getByText(RETURN_COMPLETE_HEADING)).toBeTruthy();
+    expect(getByText(RETURN_COMPLETE_BODY)).toBeTruthy();
+  });
+
+  it('carries the completion-card testID', () => {
+    const { getByTestId } = render(<ReturnCompletionCard onLeave={noop} />);
+    expect(getByTestId('return-completion-card')).toBeTruthy();
+  });
+
+  it('the set-down affordance reuses the leave a11y label and calls onLeave once', () => {
+    const onLeave = jest.fn();
+    const { getByTestId } = render(<ReturnCompletionCard onLeave={onLeave} />);
+    const leaveBtn = getByTestId('return-completion-leave');
+    expect(leaveBtn.props.accessibilityLabel).toBe(RETURN_ARC_LEAVE_A11Y);
+    fireEvent.press(leaveBtn);
+    expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no pause or resume affordance', () => {
+    const { queryByTestId } = render(<ReturnCompletionCard onLeave={noop} />);
+    expect(queryByTestId('return-arc-pause')).toBeNull();
+    expect(queryByTestId('return-arc-resume')).toBeNull();
+  });
+});

--- a/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
+++ b/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
@@ -74,11 +74,12 @@ const makeWeek = (weekNumber: number): ReturnWeek => ({
   framing: 'Begin where you already are.',
 });
 
-const makeArc = (weekNumber: number): ReturnArc => ({
+const makeArc = (weekNumber: number, complete = false): ReturnArc => ({
   started_at: '2026-06-24T00:00:00Z',
   paused: false,
   week: weekNumber,
   focus: 'self',
+  complete,
 });
 
 beforeEach(() => {
@@ -177,5 +178,29 @@ describe('TodayScreen', () => {
     mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: false };
     const { queryByTestId } = render(<TodayScreen />);
     expect(queryByTestId('return-arc-card')).toBeNull();
+  });
+
+  it('shows the Return completion card, not the arc card, when the arc is complete', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(5)],
+      arc: makeArc(5, true),
+      offerVisible: false,
+    };
+    const { getByTestId, queryByTestId } = render(<TodayScreen />);
+    expect(getByTestId('return-completion-card')).toBeTruthy();
+    expect(queryByTestId('return-arc-card')).toBeNull();
+  });
+
+  it('shows the Return arc card, not the completion card, when the arc is not complete', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(2)],
+      arc: makeArc(2, false),
+      offerVisible: false,
+    };
+    const { getByTestId, queryByTestId } = render(<TodayScreen />);
+    expect(getByTestId('return-arc-card')).toBeTruthy();
+    expect(queryByTestId('return-completion-card')).toBeNull();
   });
 });

--- a/frontend/src/features/Today/__tests__/returnCopy.test.ts
+++ b/frontend/src/features/Today/__tests__/returnCopy.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { describe, it, expect } from '@jest/globals';
 
-import { RETURN_COPY_ENTRIES } from '../returnCopy';
+import { RETURN_COMPLETE_HEADING, RETURN_COPY_ENTRIES } from '../returnCopy';
 
 import { ranksOrShames } from '@/features/Map/__tests__/copyIntentRule';
 
@@ -14,5 +14,9 @@ describe('returnCopy — balance-not-altitude intent rule', () => {
     for (const entry of RETURN_COPY_ENTRIES) {
       expect(ranksOrShames(entry)).toBe(false);
     }
+  });
+
+  it('includes the warm completion heading in RETURN_COPY_ENTRIES', () => {
+    expect(RETURN_COPY_ENTRIES).toContain(RETURN_COMPLETE_HEADING);
   });
 });

--- a/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
@@ -60,6 +60,7 @@ function arc(overrides: Partial<ReturnArc> = {}): ReturnArc {
     paused: false,
     week: 1,
     focus: 'self',
+    complete: false,
     ...overrides,
   };
 }

--- a/frontend/src/features/Today/returnCopy.ts
+++ b/frontend/src/features/Today/returnCopy.ts
@@ -45,6 +45,13 @@ export const RETURN_ARC_LEAVE = 'Set it down';
 /** The accessibility label for leaving the arc. */
 export const RETURN_ARC_LEAVE_A11Y = 'Set the Return down; nothing about your progress changes';
 
+/** The completion-card heading — a quiet, reflective close, not a reward. */
+export const RETURN_COMPLETE_HEADING = 'The circle has come full round';
+
+/** The completion-card body — all five foci met, self through all beings; a soft close. */
+export const RETURN_COMPLETE_BODY =
+  'Five weeks of loving-kindness, from yourself outward to all beings — every focus met, gently and in your own time. There is nothing more to reach for here; you might simply rest in the warmth you have grown, and set the arc down whenever it feels finished.';
+
 /** Every user-facing Return string, gathered for the balance-not-altitude sweep. */
 export const RETURN_COPY_ENTRIES: readonly string[] = [
   RETURN_OFFER_HEADING,
@@ -59,4 +66,6 @@ export const RETURN_COPY_ENTRIES: readonly string[] = [
   RETURN_ARC_RESUME_A11Y,
   RETURN_ARC_LEAVE,
   RETURN_ARC_LEAVE_A11Y,
+  RETURN_COMPLETE_HEADING,
+  RETURN_COMPLETE_BODY,
 ];


### PR DESCRIPTION
## Summary

- Recognize and expose an arc **complete** lifecycle state on the Metta "Return" arc, distinct from paused and left. Completion is a pure time-derived predicate (`is_return_complete`): an arc is complete once its fifth week has fully closed (35 elapsed days), frozen at the pause instant when paused. Nothing is persisted, no migration, no new endpoint, and nothing mutates `StageProgress` — completion is a reflective close, never a reward or rank.
- Backend surfaces a `complete: bool` on `ReturnArcResponse`, projected uniformly by `_to_arc_response` across all five handlers.
- Frontend renders a warm, quiet `ReturnCompletionCard` (Candle & Ink tokens, reduced-motion-safe) when the arc is complete, offering only to set it down; a fresh arc remains startable afterward. New completion copy passes the balance-not-altitude no-shame/no-ranking sweep.

## Test plan

- Backend `./scripts/backend/check-all.sh`: green — 2286 passed, 96.38% coverage; plus `xenon` A-grade and `radon` MI clean (not covered by check-all).
- Frontend `./scripts/frontend/check-all.sh`: green — 2832 passed, ESLint zero-warning, `tsc --noEmit`, prettier.
- New backend tests: `is_return_complete` day-34/35/100 boundary, day-30 arc is week 5 yet not complete, pause-freeze on both sides of the boundary, naive/aware mix; router asserts `complete` on GET/start, completion never mutates `current_stage`/`completed_stages`/`cycle_number`, and leave-then-restart lands on week 1 incomplete.
- New frontend tests: `returnArcSchema` requires `complete`; `ReturnCompletionCard` render/a11y/no-pause-resume/onLeave; `TodayScreen` branches to the completion card when `arc.complete`, else the arc card; copy sweep covers the new constants.

Closes #1099
Refs #1090
