### PR TITLE
refactor(practice): migrate remaining session views onto shared primitives

### DIFF
--- a/frontend/src/features/Practice/configurator/defaults.ts
+++ b/frontend/src/features/Practice/configurator/defaults.ts
@@ -10,6 +10,7 @@
  * round-trip to a 422.
  */
 
+import { SECONDS_PER_MINUTE } from '../engine/types';
 import type {
   CardMeditationConfig,
   CountUpConfig,
@@ -34,7 +35,6 @@ const DEFAULT_REP_TARGET = 10;
 const DEFAULT_TALLIED_ROUNDS = 3;
 const DEFAULT_TALLIED_TARGET = 3;
 const DEFAULT_MINDFUL_ANCHOR_MIN_SECONDS = 120;
-const SECONDS_PER_MINUTE = 60;
 
 const DEFAULT_SENSE_PROMPTS: SenseGroundingConfig['prompts'] = [
   { sense: 'sight', label: 'something blue' },

--- a/frontend/src/features/Practice/insights/format.ts
+++ b/frontend/src/features/Practice/insights/format.ts
@@ -14,10 +14,8 @@
  * The caller strips these fields before POSTing to ``/practice-sessions``.
  */
 
-import type { SenseKind } from '../engine/types';
+import { MS_PER_MINUTE, type SenseKind } from '../engine/types';
 import { formatTime } from '../views/formatTime';
-
-const MS_PER_MINUTE = 60_000;
 
 export interface ModeSummaryMeditationTimer {
   readonly mode: 'meditation_timer';

--- a/frontend/src/features/Practice/views/IntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/IntervalBellView.tsx
@@ -8,6 +8,7 @@ import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import type { SessionSurface } from './sessionSurface';
 import { useSessionSurface } from './sessionSurface';
+import { SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -25,10 +26,7 @@ const IntervalBellView = ({ config, state, controls }: Props): React.JSX.Element
   const untilNextMs =
     state.nextCueAtMs !== null ? Math.max(0, state.nextCueAtMs - state.elapsedMs) : 0;
   return (
-    <View
-      style={[styles.container, { backgroundColor: surface.ground }]}
-      testID="interval-bell-view"
-    >
+    <SessionContainer testID="interval-bell-view" style={styles.container}>
       <Text style={[styles.label, { color: surface.textSoft }]}>next bell</Text>
       <Text style={[styles.time, { color: surface.text }]} testID="interval-bell-next">
         {formatTime(untilNextMs)}
@@ -53,7 +51,7 @@ const IntervalBellView = ({ config, state, controls }: Props): React.JSX.Element
         ))}
       </ScrollView>
       <RitualControlsBar status={state.status} controls={controls} />
-    </View>
+    </SessionContainer>
   );
 };
 
@@ -104,7 +102,7 @@ const OffsetRow = ({
 );
 
 const styles = StyleSheet.create({
-  container: { alignItems: 'center', padding: SPACING.xl, flex: 1 },
+  container: { flex: 1 },
   label: {
     fontSize: 14,
     textTransform: 'uppercase',

--- a/frontend/src/features/Practice/views/MeditationTimerView.tsx
+++ b/frontend/src/features/Practice/views/MeditationTimerView.tsx
@@ -7,6 +7,7 @@ import type { RitualControls, RitualState } from '../engine/types';
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
+import { SessionContainer } from './shared';
 
 import { SPACING, shadows } from '@/design/tokens';
 
@@ -26,10 +27,7 @@ const MeditationTimerView = ({ state, controls }: Props): React.JSX.Element => {
   const dashOffset = CIRCUMFERENCE * (1 - Math.min(1, Math.max(0, state.progress)));
   const remainingMs = state.remainingMs ?? 0;
   return (
-    <View
-      style={[styles.container, { backgroundColor: surface.ground }]}
-      testID="meditation-timer-view"
-    >
+    <SessionContainer testID="meditation-timer-view">
       <View style={styles.ringContainer}>
         <Svg width={RING_SIZE} height={RING_SIZE} testID="meditation-timer-ring">
           <Circle
@@ -60,12 +58,11 @@ const MeditationTimerView = ({ state, controls }: Props): React.JSX.Element => {
         </View>
       </View>
       <RitualControlsBar status={state.status} controls={controls} />
-    </View>
+    </SessionContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { alignItems: 'center', padding: SPACING.xl },
   ringContainer: {
     width: RING_SIZE,
     height: RING_SIZE,

--- a/frontend/src/features/Practice/views/MetronomeView.tsx
+++ b/frontend/src/features/Practice/views/MetronomeView.tsx
@@ -6,6 +6,7 @@ import type { MetronomeConfig, RitualControls, RitualState } from '../engine/typ
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
+import { SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -42,7 +43,7 @@ const MetronomeView = ({ config, state, controls }: Props): React.JSX.Element =>
   const surface = useSessionSurface();
   const elapsedMs = state.elapsedMs;
   return (
-    <View style={[styles.container, { backgroundColor: surface.ground }]} testID="metronome-view">
+    <SessionContainer testID="metronome-view">
       <Text style={[styles.bpm, { color: surface.text }]} testID="metronome-bpm">
         {config.bpm}
       </Text>
@@ -56,12 +57,11 @@ const MetronomeView = ({ config, state, controls }: Props): React.JSX.Element =>
       </Text>
       <View style={styles.spacer} />
       <RitualControlsBar status={state.status} controls={controls} />
-    </View>
+    </SessionContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { alignItems: 'center', padding: SPACING.xl },
   bpm: {
     fontSize: 84,
     fontWeight: '200',

--- a/frontend/src/features/Practice/views/RepCounterView.tsx
+++ b/frontend/src/features/Practice/views/RepCounterView.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text } from 'react-native';
 
 import type { RepCounterConfig, RitualControls, RitualState } from '../engine/types';
 
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
+import { SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -21,7 +22,7 @@ const RepCounterView = ({ config, state, controls }: Props): React.JSX.Element =
   const timeCapMs = config.time_cap_minutes != null ? config.time_cap_minutes * 60_000 : null;
   const remaining = timeCapMs !== null ? Math.max(0, timeCapMs - state.elapsedMs) : null;
   return (
-    <View style={[styles.container, { backgroundColor: surface.ground }]} testID="rep-counter-view">
+    <SessionContainer testID="rep-counter-view">
       <Pressable
         style={[styles.tapZone, { backgroundColor: surface.raised }]}
         onPress={canTap ? controls.tap : undefined}
@@ -44,12 +45,11 @@ const RepCounterView = ({ config, state, controls }: Props): React.JSX.Element =
         </Text>
       )}
       <RitualControlsBar status={state.status} controls={controls} />
-    </View>
+    </SessionContainer>
   );
 };
 
 const styles = StyleSheet.create({
-  container: { alignItems: 'center', padding: SPACING.xl },
   tapZone: {
     width: '100%',
     minHeight: 260,


### PR DESCRIPTION
## Summary

Follow-up to #1044 (PR #1116). Migrates the four remaining in-session Practice
views onto the shared session primitives introduced in that PR:

- **MeditationTimerView**, **MetronomeView**, **RepCounterView**, **IntervalBellView**
  now render their outer scaffold through `SessionContainer` instead of a
  hand-rolled `container` style plus inline `backgroundColor: surface.ground`.
  `IntervalBellView` keeps its `flex: 1` by passing it through
  `SessionContainer`'s `style` override prop (non-overlapping keys → identical
  flattened style).
- `insights/format.ts` now sources `MS_PER_MINUTE` from `engine/types`, and
  `configurator/defaults.ts` sources `SECONDS_PER_MINUTE` from `engine/types`,
  removing the duplicated local constants.

Rendered output, testIDs, and a11y strings are unchanged — this is a pure
de-slop refactor.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` (`eslint --max-warnings=0`) — clean
- `./scripts/frontend/check-all.sh` — green (287 suites, 2833 tests pass)
- The existing behavior tests (`MeditationTimerView`, `MetronomeView`,
  `RepCounterView`, `IntervalBellView`) plus the `sessionSurfaceMigration` /
  `calmSurfaceMigration` suites — which flatten each container's style and
  assert `backgroundColor === surface.ground/raised/canvas` and unchanged
  testIDs — prove the migration preserves rendered output.

Closes #1117
Refs #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)