### PR TITLE
refactor(backend): remove dead placeholder seed rows suppressed by the manifest

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -354,7 +354,7 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     _get_secret_key()
 
     # ritual-practice ops: on every boot, seed the catalog (stages, presets,
-    # placeholder course content) so a fresh database is immediately usable.
+    # course content) so a fresh database is immediately usable.
     # Opt-out via ``SKIP_STARTUP_SEED=1`` for tests and contexts where the
     # database is intentionally empty (e.g. integration suites mounting a
     # mocked alembic chain). A seeder failure is logged and swallowed — the

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -1,14 +1,9 @@
 """Seed StageContent rows from the vendored content manifest.
 
 Chapters are reconciled from ``manifest.json`` for **every stage the
-manifest ships** (issue #392): title, content type, and release day come
+manifest ships**: title, content type, and release day come
 from the manifest verbatim, and the ``url`` column carries a local
 ``content://<chapter-id>`` reference instead of a remote CMS URL.
-Stages the manifest does not cover yet keep their historic placeholder
-rows so the rest of the app has something to render; the moment a stage
-appears in the manifest its placeholders stop seeding (suppression is
-decided at seed time because the manifest is runtime data).
-
 Reconciliation is idempotent and never destructive: rows update in place
 when their fields drift, and nothing is ever deleted — rows referenced
 by ``ContentCompletion`` stay put.
@@ -19,8 +14,7 @@ out of order (or a stage rollback left content orphaned), so we raise
 ``SeedContentStageMissingError`` before touching the DB rather than
 silently dropping the stage's chapters.  ``_seed_startup_data`` catches
 it per seeder and surfaces it as ``seed_failed seeder=content`` in the
-boot logs.  Placeholder rows for stages the manifest does not cover keep
-skipping quietly — their ``CourseStage`` row may legitimately be absent.
+boot logs.
 
 Editing happens in the content repo; see ``docs/content.md``.
 """
@@ -39,99 +33,9 @@ class SeedContentStageMissingError(ValueError):
     """Raised when a manifest stage has no matching ``CourseStage`` row."""
 
 
-# Placeholder rows for stages the content manifest does not cover yet.
-# Once the manifest ships a stage, its placeholders are suppressed
-# automatically at seed time; remove the entries here once that stage's
-# content is live.
-_PLACEHOLDER_DEFINITIONS: list[dict[str, str | int]] = [
-    # Stage 2 — Magick
-    {
-        "stage_number": 2,
-        "title": "Introduction to Magick",
-        "content_type": "essay",
-        "release_day": 0,
-        "url": "https://cms.adepthood.com/stage-2/intro",
-    },
-    {
-        "stage_number": 2,
-        "title": "Tribal Connection Exercise",
-        "content_type": "video",
-        "release_day": 3,
-        "url": "https://cms.adepthood.com/stage-2/tribal-connection",
-    },
-    {
-        "stage_number": 2,
-        "title": "Magick Reflection Prompt",
-        "content_type": "prompt",
-        "release_day": 7,
-        "url": "https://cms.adepthood.com/stage-2/reflection",
-    },
-    # Stage 3 — Power
-    {
-        "stage_number": 3,
-        "title": "Introduction to Power",
-        "content_type": "essay",
-        "release_day": 0,
-        "url": "https://cms.adepthood.com/stage-3/intro",
-    },
-    {
-        "stage_number": 3,
-        "title": "Self-Assertion Practice",
-        "content_type": "video",
-        "release_day": 3,
-        "url": "https://cms.adepthood.com/stage-3/self-assertion",
-    },
-    {
-        "stage_number": 3,
-        "title": "Power Reflection Prompt",
-        "content_type": "prompt",
-        "release_day": 7,
-        "url": "https://cms.adepthood.com/stage-3/reflection",
-    },
-]
-
-# BUG-SEED-001 (preserved): a duplicate (stage_number, release_day) on a
-# placeholder row would scramble drip-feed ordering.  Configured chapters
-# may legitimately share a release_day with a placeholder of a different
-# stage, so we only assert uniqueness within the placeholder set.
-_placeholder_pairs = [(d["stage_number"], d["release_day"]) for d in _PLACEHOLDER_DEFINITIONS]
-if len(set(_placeholder_pairs)) != len(_placeholder_pairs):
-    _dupes = sorted(p for p in _placeholder_pairs if _placeholder_pairs.count(p) > 1)
-    _err = f"Duplicate (stage_number, release_day) in placeholders: {_dupes}"
-    raise ValueError(_err)
-
-
-def _placeholder_records(covered_stages: frozenset[int]) -> list[ChapterRecord]:
-    """Convert placeholder dicts into ``ChapterRecord``.
-
-    ``covered_stages`` — stage numbers present in the content manifest —
-    suppresses placeholders for stages whose real content has shipped.
-    The old import-time overlap check is gone because the manifest is
-    runtime data; suppression replaces fail-loudly.
-    """
-    return [
-        ChapterRecord(
-            stage_number=int(d["stage_number"]),
-            title=str(d["title"]),
-            content_type=str(d["content_type"]),
-            release_day=int(d["release_day"]),
-            url=str(d["url"]),
-        )
-        for d in _PLACEHOLDER_DEFINITIONS
-        if int(d["stage_number"]) not in covered_stages
-    ]
-
-
 def desired_content_records() -> list[ChapterRecord]:
-    """Return the full set of records that should exist after seeding.
-
-    Order is (manifest chapters first, then surviving placeholders) —
-    callers that need a stable ordering can ``sorted(...)`` on the fields
-    they care about.
-    """
-    manifest_records = all_chapter_records()
-    covered = frozenset(record.stage_number for record in manifest_records)
-    return [*manifest_records, *_placeholder_records(covered)]
+    """The full set of records that should exist after seeding -- one per manifest chapter."""
+    return all_chapter_records()
 
 
 def _unmapped_manifest_stages(stage_map: dict[int, int]) -> list[int]:

--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -41,8 +41,7 @@ def _expected_content_count() -> int:
     """Rows the content seeder should produce in this environment.
 
     Sourced from ``desired_content_records()`` — manifest chapters (none
-    in the test environment until a content pin is vendored) plus the
-    placeholder rows for stages the manifest does not cover.  Computed at
+    in the test environment until a content pin is vendored).  Computed at
     call time because the manifest is runtime data.
     """
     return len(desired_content_records())
@@ -77,7 +76,7 @@ async def test_seed_startup_data_inserts_stages_practices_and_content(
     assert len(stages) == 10
     assert len(practices) == _EXPECTED_PRACTICE_COUNT
     assert len(contents) == _expected_content_count()
-    assert len(contents) > 0, "content seeder must produce rows even without a manifest"
+    assert len(contents) > 0, "content seeder must produce rows from the vendored manifest"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -1,10 +1,9 @@
-"""Tests for the manifest-driven seed_content script (issue #392).
+"""Tests for the manifest-driven seed_content script.
 
 ``StageContent`` rows are now reconciled from the vendored content
 manifest via :class:`ContentRepository` — not from the deleted
 ``STAGE_PLANS`` hardcode. Chapters carry a local ``content://<id>``
-reference instead of a remote CMS URL; placeholder rows survive only
-for stages the manifest does not cover yet.
+reference instead of a remote CMS URL.
 """
 
 from __future__ import annotations
@@ -13,12 +12,13 @@ import json
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from content_config import all_chapter_records, content_ref
+from content_config import CONTENT_REF_SCHEME, all_chapter_records, content_ref
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
@@ -33,9 +33,6 @@ from services.content_repository import (
     reset_content_repository_for_tests,
     set_content_repository_for_tests,
 )
-
-# Placeholders kept for stages 2 and 3 (3 each) until the manifest covers them.
-_PLACEHOLDER_COUNT = 6
 
 # Resolved once at import (not inside async tests — pathlib in an async def trips
 # ASYNC240) so the real vendored content dir is reusable across tests.
@@ -77,8 +74,7 @@ _MANIFEST: dict[str, Any] = {
     "site_resources": [],
 }
 
-# Covers only stage 1 -- used to isolate "placeholder unmapped stays quiet"
-# from "manifest-mapped stage missing its CourseStage row raises loudly".
+# Covers only stage 1 -- a partial manifest whose only stage has a CourseStage row.
 _STAGE_ONE_ONLY_MANIFEST: dict[str, Any] = {
     "schema_version": "1.0.0",
     "chapters": [
@@ -238,11 +234,11 @@ async def test_seed_content_raises_naming_only_the_unmapped_manifest_stage(
 
 
 @pytest.mark.asyncio
-async def test_seed_content_placeholder_stages_stay_quiet_when_unmapped(
+async def test_seed_content_partial_manifest_seeds_when_its_stages_are_mapped(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],
 ) -> None:
-    """Unmapped placeholder stages (no manifest coverage) never raise, unlike manifest stages."""
+    """A subset manifest seeds cleanly when its stages all have CourseStage rows."""
     install_manifest(_STAGE_ONE_ONLY_MANIFEST)
     await _seed_stages(db_session, count=1)
 
@@ -262,15 +258,15 @@ def test_content_ref_format() -> None:
 
 
 @pytest.mark.asyncio
-async def test_seed_content_inserts_manifest_chapters_and_placeholders(
+async def test_seed_content_inserts_manifest_chapters(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],
 ) -> None:
-    """Every manifest chapter plus placeholders for uncovered stages."""
+    """Every manifest chapter is inserted as a StageContent row."""
     install_manifest(_MANIFEST)
     await _seed_stages(db_session, count=4)
     inserted = await seed_content(db_session)
-    expected_total = len(_MANIFEST["chapters"]) + _PLACEHOLDER_COUNT
+    expected_total = len(_MANIFEST["chapters"])
     assert inserted == expected_total
 
     result = await db_session.execute(select(StageContent))
@@ -320,7 +316,7 @@ async def test_seeded_rows_carry_local_refs_not_urls(
     assert [i.release_day for i in items] == [0, 3]
 
     everything = (await db_session.execute(select(StageContent))).scalars().all()
-    assert not any("aptitude.guru" in row.url for row in everything)
+    assert all(urlparse(row.url).scheme == CONTENT_REF_SCHEME for row in everything)
 
 
 @pytest.mark.asyncio
@@ -378,30 +374,10 @@ async def test_read_completions_survive_content_resync(
     assert completions[0].content_id == row.id
 
 
-@pytest.mark.asyncio
-async def test_placeholders_suppressed_when_manifest_covers_stage(
-    db_session: AsyncSession,
-    install_manifest: Callable[[dict[str, Any]], None],
-) -> None:
-    """Once the manifest ships a stage, its placeholders stop seeding."""
-    covering = json.loads(json.dumps(_MANIFEST))
-    covering["chapters"].append(_chapter("purple-1", 2, "Tribal Rhythm", 0))
-    install_manifest(covering)
-    await _seed_stages(db_session, count=4)
-    await seed_content(db_session)
-
-    result = await db_session.execute(
-        select(StageContent).join(CourseStage).where(CourseStage.stage_number == 2)
-    )
-    stage_two = result.scalars().all()
-    assert [i.title for i in stage_two] == ["Tribal Rhythm"]
-
-
 def test_desired_content_records_counts(
     install_manifest: Callable[[dict[str, Any]], None],
 ) -> None:
     install_manifest(_MANIFEST)
     records = desired_content_records()
-    assert len(records) == len(_MANIFEST["chapters"]) + _PLACEHOLDER_COUNT
-    manifest_urls = {content_ref(c["id"]) for c in _MANIFEST["chapters"]}
-    assert manifest_urls.issubset({r.url for r in records})
+    assert len(records) == len(_MANIFEST["chapters"])
+    assert {r.url for r in records} == {content_ref(c["id"]) for c in _MANIFEST["chapters"]}

--- a/docs/content.md
+++ b/docs/content.md
@@ -85,11 +85,9 @@ Everything happens in the **content repo**, then gets vendored here:
 The seeder never deletes rows (deletion would orphan
 `ContentCompletion` read-marks). A chapter dropped from the manifest
 simply stops being referenced; write a one-off migration if a row must
-actually go. Stages the manifest does not cover yet keep placeholder
-rows (`seed_content.py`); those suppress automatically once the
-manifest ships the stage. If the manifest instead ships a stage with
-no matching `CourseStage` row (stages and content seeded out of
-order, or a stage rollback orphaned content), seeding fails loudly
+actually go. If the manifest instead ships a stage with no matching
+`CourseStage` row (stages and content seeded out of order, or a stage
+rollback orphaned content), seeding fails loudly
 before writing anything, surfacing as `seed_failed seeder=content` in
 the boot logs; boot continues regardless.
 


### PR DESCRIPTION
## Summary
The vendored content manifest now ships all 10 stages (209 chapters), so the six `_PLACEHOLDER_DEFINITIONS` rows for stages 2 (Magick) and 3 (Power) were suppressed on every real seed — dead seed data whose legacy `https://cms.adepthood.com/...` URLs were unreachable anyway (the released-content resolver only serves `content://` rows). This removes the stale data and its now-vacuous plumbing:

- Deleted `_PLACEHOLDER_DEFINITIONS`, the BUG-SEED-001 uniqueness guard, and `_placeholder_records()`; collapsed `desired_content_records()` to `return all_chapter_records()`.
- Replaced the tautological "no remote URLs" assertion in `test_seeded_rows_carry_local_refs_not_urls` (it only checked for an `aptitude.guru` substring the placeholder URLs never contained) with a real invariant: every seeded row URL uses the `content://` scheme, so a remote `https://` URL would now fail the test.
- Dropped the test that exercised only the removed suppression mechanism, renamed the surviving partial-manifest guard, and refreshed the placeholder-era comments/docs (`main.py`, `docs/content.md`, `test_lifespan_seeding.py`).

No schema change and no migration — the seeder is non-destructive and only rows that were already suppressed are affected.

## Test plan
- `./scripts/backend/check-all.sh` → 7/7 passed, 2298 tests, 96.40% line coverage.
- `xenon` A-grade and `radon mi` A (70.34) on `seed_content.py`.
- `test_seeded_rows_carry_local_refs_not_urls` now fails if any seeded row carries a non-`content://` URL.

Closes #1123