### PR TITLE
refactor(backend): extract shared DB-probe helper + deterministic 503 health tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": "backend/tests/test_database.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 50
       }
     ],
     "prompts/github-issues/phase-1-03-auth-router-to-db.md": [
@@ -164,5 +164,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-11T19:31:51Z"
+  "generated_at": "2026-07-02T18:24:27Z"
 }

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,7 +1,9 @@
 import os
 import sys
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 
 # Set SECRET_KEY for tests before any app modules are imported
 os.environ.setdefault("SECRET_KEY", "test-secret-key-for-unit-tests-only")
@@ -19,9 +21,10 @@ sys.path.insert(0, str(REPO_ROOT / "backend/src"))
 
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
-from httpx import ASGITransport, AsyncClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient, Response  # noqa: E402
 from sqlalchemy import JSON, text  # noqa: E402
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY  # noqa: E402
+from sqlalchemy.exc import SQLAlchemyError  # noqa: E402
 from sqlalchemy.ext.asyncio import (  # noqa: E402
     AsyncConnection,
     AsyncSession,
@@ -250,3 +253,48 @@ async def concurrent_session_factory(
         msg = "concurrent_async_client must be requested before concurrent_session_factory"
         raise RuntimeError(msg)
     return factory
+
+
+# ---------------------------------------------------------------------------
+# DB-probe failure helpers: drive the /health & /health/ready 503 branch
+# deterministically without a live (or broken) database.  The readiness /
+# health handlers touch the session only via ``execute(text("SELECT 1"))``, so
+# a ``SimpleNamespace`` with a single ``execute`` coroutine is a sufficient,
+# dependency-free stand-in.
+# ---------------------------------------------------------------------------
+def failing_probe_session(execute: Callable[..., Awaitable[object]]) -> AsyncSession:
+    """Return a stand-in session whose ``execute`` runs ``execute``."""
+    return cast("AsyncSession", SimpleNamespace(execute=execute))
+
+
+def db_error_session(exc: Exception | None = None) -> AsyncSession:
+    """Return a stand-in session whose probe ``execute`` raises ``exc``.
+
+    Defaults to ``SQLAlchemyError`` -- the dropped-connection failure the
+    readiness / health 503 branch exists to catch.
+    """
+    error = exc if exc is not None else SQLAlchemyError("connection refused")
+
+    async def _execute(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    return failing_probe_session(_execute)
+
+
+async def probe_via_session(path: str, session: AsyncSession) -> Response:
+    """GET ``path`` with ``get_session`` overridden to yield ``session``.
+
+    The override is always removed in ``finally`` so a stand-in session cannot
+    leak into other tests sharing the process.
+    """
+
+    async def _override() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get(path)
+    finally:
+        app.dependency_overrides.pop(get_session, None)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -460,6 +460,27 @@ app.include_router(metta_return_router)
 _DB_PROBE_TIMEOUT_SECONDS = 2.0
 
 
+async def _probe_db(session: AsyncSession, *, log_event: str, detail: str) -> None:
+    """Run the bounded ``SELECT 1`` readiness probe, raising 503 on failure.
+
+    Shared by ``readiness`` and ``health_check`` so the timeout window, the
+    caught-exception tuple, and the 503 contract live in one place -- the single
+    seam behind the BUG-APP-004 liveness/readiness split.  ``log_event`` and
+    ``detail`` let each caller keep its own log-event name and 503 ``detail``
+    (``"not_ready"`` vs. the legacy ``"Database unavailable"``) while sharing the
+    probe body.
+
+    Session lifecycle is owned by ``Depends(get_session)`` -- we don't open or
+    close the session here, so a failed ``SELECT 1`` cannot leak a connection.
+    """
+    try:
+        async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
+            await session.execute(text("SELECT 1"))
+    except (TimeoutError, OSError, SQLAlchemyError) as exc:
+        logger.exception(log_event)
+        raise HTTPException(status_code=503, detail=detail) from exc
+
+
 @app.get("/health/live")
 async def liveness() -> dict[str, str]:
     """Liveness probe: process is responsive (no DB dependency).
@@ -490,12 +511,7 @@ async def readiness(
     ``database.py``) guarantees ``close()`` runs even when the handler
     raises.
     """
-    try:
-        async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
-            await session.execute(text("SELECT 1"))
-    except (TimeoutError, OSError, SQLAlchemyError) as exc:
-        logger.exception("readiness_check_failed")
-        raise HTTPException(status_code=503, detail="not_ready") from exc
+    await _probe_db(session, log_event="readiness_check_failed", detail="not_ready")
     return {"status": "ready", "database": "connected"}
 
 
@@ -511,13 +527,8 @@ async def health_check(
     ``/health/live`` and ``/health/ready`` directly so liveness and
     readiness can be configured independently (BUG-APP-004).
     """
-    try:
-        async with asyncio.timeout(_DB_PROBE_TIMEOUT_SECONDS):
-            await session.execute(text("SELECT 1"))
-    except (TimeoutError, OSError, SQLAlchemyError) as exc:
-        logger.exception("health_check_failed")
-        raise HTTPException(status_code=503, detail="Database unavailable") from exc
-    # Issue #397: surface the live content pin so dashboards can alert on
-    # an unexpected value after a deploy. "none" = nothing vendored yet.
+    await _probe_db(session, log_event="health_check_failed", detail="Database unavailable")
+    # Surface the live content pin so dashboards can alert on an unexpected
+    # value after a deploy. "none" = nothing vendored yet.
     content_version = (content_version_info() or {}).get("sha", "none")
     return {"status": "healthy", "database": "connected", "content_version": content_version}

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -3,12 +3,12 @@
 from http import HTTPStatus
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from conftest import db_error_session, probe_via_session
 from database import normalize_database_url
-from main import app
 
 
 @pytest.mark.asyncio
@@ -22,13 +22,18 @@ async def test_health_returns_db_status(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_health_returns_error_on_bad_db() -> None:
-    """GET /health without a working DB should still respond (gracefully)."""
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/health")
-        # Even without test override, endpoint should not crash
-        assert response.status_code in (HTTPStatus.OK, HTTPStatus.SERVICE_UNAVAILABLE)
+async def test_health_returns_503_when_db_unavailable() -> None:
+    """GET /health returns 503 ``Database unavailable`` when the DB probe errors.
+
+    Replaces the environment-dependent tautology that asserted
+    ``status in (200, 503)`` (which passed whether or not a DB was reachable and
+    checked nothing about the body): this drives the failure branch
+    deterministically -- the probe's ``SELECT 1`` raises ``SQLAlchemyError`` --
+    so a handler that returned 200 or swallowed the error would fail.
+    """
+    response = await probe_via_session("/health", db_error_session())
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == "Database unavailable"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,9 +1,13 @@
+import asyncio
 import re
+from http import HTTPStatus
 
 import pytest
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
+import main
+from conftest import db_error_session, failing_probe_session, probe_via_session
 from main import app
 
 client = TestClient(app)
@@ -66,3 +70,53 @@ async def test_health_reports_content_version(async_client: AsyncClient) -> None
     content_version = body["content_version"]
     assert content_version != "none"
     assert re.fullmatch(r"[0-9a-f]{40}", content_version)
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_when_db_unavailable() -> None:
+    """``/health/ready`` returns 503 ``not_ready`` when the DB probe errors.
+
+    Drives the readiness failure branch deterministically -- the probe's
+    ``SELECT 1`` raises ``SQLAlchemyError`` -- so a regression that swallowed the
+    error or returned 200 would fail this test (unlike the environment-dependent
+    tautology this replaces).
+    """
+    response = await probe_via_session("/health/ready", db_error_session())
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == "not_ready"
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_when_db_socket_drops() -> None:
+    """``/health/ready`` returns 503 when the probe raises ``OSError``.
+
+    Pins the ``OSError`` member of the probe's caught-exception tuple (a dropped
+    socket / connection reset) alongside the ``SQLAlchemyError`` and timeout
+    cases, so narrowing the tuple would be caught.
+    """
+    response = await probe_via_session(
+        "/health/ready", db_error_session(OSError("connection reset"))
+    )
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == "not_ready"
+
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_when_db_probe_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``/health/ready`` returns 503 when the DB probe exceeds its timeout.
+
+    The probe timeout is shrunk to a few milliseconds and ``execute`` stalls
+    past it, so ``asyncio.timeout`` raises ``TimeoutError`` into the 503 branch
+    without a multi-second wait.
+    """
+    monkeypatch.setattr(main, "_DB_PROBE_TIMEOUT_SECONDS", 0.01)
+
+    async def _stall(*_args: object, **_kwargs: object) -> object:
+        await asyncio.sleep(0.5)
+        return None
+
+    response = await probe_via_session("/health/ready", failing_probe_session(_stall))
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == "not_ready"


### PR DESCRIPTION
## Summary
- Extract the byte-identical DB-probe block duplicated between the `readiness` (`/health/ready`) and `health_check` (`/health`) handlers into one private `_probe_db(session, *, log_event, detail)` coroutine — the single seam behind the BUG-APP-004 liveness/readiness split. Each caller keeps its own log-event name and 503 `detail` (`not_ready` vs the legacy `Database unavailable`), so public status codes and response shapes are unchanged (back-compat with Railway/dashboard probes preserved).
- Replace the environment-dependent tautology `test_health_returns_error_on_bad_db` (asserted `status in (200, 503)` and checked nothing about the body — it passed whether or not a DB was reachable) with deterministic error-path tests.
- Add reusable failing-probe helpers to `backend/conftest.py` (`failing_probe_session`, `db_error_session`, `probe_via_session`) that override `get_session` with a stand-in whose probe `execute` raises or stalls.

## Test plan
- New deterministic tests drive the DB-failure path and assert an exact 503 plus the correct `detail`: `/health` → `Database unavailable`, `/health/ready` → `not_ready`. A handler that returned 200 or swallowed the error now fails.
- The `SQLAlchemyError`, `OSError`, and timeout members of the probe's caught-exception tuple are each pinned by a dedicated test.
- Full backend `check-all.sh` green: 2305 passed, coverage 96% (≥90% gate); ruff lint/format clean; mypy, bandit, pip-audit, detect-secrets pass; xenon A-grade, radon MI A.

Closes #1125