### PR TITLE
fix(ci): enforce frontend jest coverage threshold in CI and pre-push

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -49,6 +49,6 @@ jobs:
         working-directory: frontend
         run: npx prettier -c .
 
-      - name: Tests
+      - name: Tests (with coverage thresholds)
         working-directory: frontend
-        run: npx jest --passWithNoTests
+        run: npx jest --coverage --passWithNoTests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,6 +131,10 @@ repos:
         pass_filenames: false
         files: ^frontend/
         exclude: ^frontend/(?:node_modules|dist|build|coverage)/
+        # Fast (no-coverage) run for pre-commit only; pre-push runs the
+        # coverage-enforcing `frontend-tests-coverage` hook instead, so Jest
+        # is not executed twice on push.
+        stages: [pre-commit]
 
       # Expensive hooks run on pre-push only. This keeps `git commit` under
       # ~10s while still gating pushes on the full quality suite.
@@ -156,6 +160,15 @@ repos:
         entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90'
         pass_filenames: false
         files: ^backend/
+        stages: [pre-push]
+
+      - id: frontend-tests-coverage
+        name: frontend tests (coverage required)
+        language: system
+        entry: bash -c 'cd frontend && npx jest --coverage --passWithNoTests'
+        pass_filenames: false
+        files: ^frontend/
+        exclude: ^frontend/(?:node_modules|dist|build|coverage)/
         stages: [pre-push]
 
       - id: commitlint

--- a/frontend/__tests__/DatePicker.test.tsx
+++ b/frontend/__tests__/DatePicker.test.tsx
@@ -1,7 +1,17 @@
 /* eslint-disable import/order */
-import { describe, expect, test, jest, beforeAll, afterAll } from '@jest/globals';
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
 
 import React from 'react';
+import { Platform } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 
 import DatePicker, {
@@ -9,11 +19,13 @@ import DatePicker, {
   isDateWithinRange,
   parseISODate,
   toISODate,
+  getNextMonday,
 } from '../src/components/DatePicker';
 
+const mockDateTimePickerModal = jest.fn((_props: Record<string, unknown>) => null);
 jest.mock('react-native-modal-datetime-picker', () => ({
   __esModule: true,
-  default: () => null,
+  default: (props: Record<string, unknown>) => mockDateTimePickerModal(props),
 }));
 
 describe('date utilities', () => {
@@ -28,6 +40,29 @@ describe('date utilities', () => {
     expect(parseDateInput('9/1/25')?.toISOString().slice(0, 10)).toBe('2025-09-01');
     expect(parseDateInput('Sep 1 2025')?.toISOString().slice(0, 10)).toBe('2025-09-01');
     expect(parseDateInput('invalid')).toBeNull();
+  });
+
+  test('parseDateInput fills in the current year for a bare M/D with no year', () => {
+    // System time here is faked to 2025-01-01, so a year-less M/D resolves against it.
+    expect(parseDateInput('9/1')?.toISOString().slice(0, 10)).toBe('2025-09-01');
+  });
+
+  test('parseDateInput keeps an explicit 4-digit M/D/YYYY year as-is', () => {
+    expect(parseDateInput('9/1/2025')?.toISOString().slice(0, 10)).toBe('2025-09-01');
+  });
+
+  test('parseDateInput returns null for a blank/whitespace-only string', () => {
+    expect(parseDateInput('')).toBeNull();
+    expect(parseDateInput('   ')).toBeNull();
+  });
+
+  test('a "Word Day" whose word is not a real month falls through to the loose Date fallback', () => {
+    // parseMonthDay rejects it (Date.parse of the reconstructed string is NaN),
+    // so it reaches the permissive `new Date()` fallback, which treats the number
+    // as a month rather than returning null.
+    const parsed = parseDateInput('Nope 10');
+    expect(parsed).not.toBeNull();
+    expect(parsed!.getUTCMonth()).toBe(9);
   });
 
   test('parseDateInput preserves local day for ISO input', () => {
@@ -100,6 +135,125 @@ describe('DatePicker component', () => {
     });
     expect(handleChange).toHaveBeenLastCalledWith('2025-06-15');
   });
+
+  test('typing a bare "Month Day" (no year) parses via the current year', () => {
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onChangeText('Aug 5');
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('2025-08-05');
+  });
+
+  test('rolls an ISO-shaped date that fails the strict round-trip through the loose fallback', () => {
+    // '2025-02-30' fails the strict parseISO round-trip guard (Feb has no 30th),
+    // so it flows to the permissive `new Date()` fallback, which rolls it to Mar 2.
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onChangeText('2025-02-30');
+    });
+    expect(tree!.root.findAllByProps({ accessibilityRole: 'alert' })).toHaveLength(0);
+    expect(handleChange).toHaveBeenLastCalledWith('2025-03-02');
+  });
+
+  test('typing unparseable text shows the format-hint error', () => {
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onChangeText('not a date at all');
+    });
+    const error = tree!.root.findByProps({ accessibilityRole: 'alert' });
+    expect(error.props.children).toBe('Use the format YYYY-MM-DD (for example, 2026-04-13).');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test('typing a date blocked by disabledDate shows the unavailable-day message', () => {
+    const handleChange = jest.fn();
+    const blockJuly4 = (d: Date): boolean =>
+      d.getFullYear() === 2025 && d.getMonth() === 6 && d.getDate() === 4;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(
+        <DatePicker value="" onChange={handleChange} disabledDate={blockJuly4} />,
+      );
+    });
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onChangeText('2025-07-04');
+    });
+    const error = tree!.root.findByProps({ accessibilityRole: 'alert' });
+    expect(error.props.children).toBe("That day isn't available — choose another.");
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test('native picker onConfirm commits the picked date and hides the modal', () => {
+    const handleChange = jest.fn();
+    act(() => {
+      renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+
+    const props = mockDateTimePickerModal.mock.calls.at(-1)?.[0] as {
+      isVisible: boolean;
+      onConfirm: (_d: Date) => void;
+    };
+    expect(props.isVisible).toBe(false);
+
+    act(() => {
+      props.onConfirm(new Date(2025, 5, 20));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('2025-06-20');
+    const propsAfter = mockDateTimePickerModal.mock.calls.at(-1)?.[0] as { isVisible: boolean };
+    expect(propsAfter.isVisible).toBe(false);
+  });
+
+  test('native picker onCancel hides the modal without committing a date', () => {
+    const handleChange = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+
+    const input = tree!.root.findByProps({ accessibilityLabel: 'Date' });
+    act(() => {
+      input.props.onFocus();
+    });
+
+    let props = mockDateTimePickerModal.mock.calls.at(-1)?.[0] as {
+      isVisible: boolean;
+      onCancel: () => void;
+    };
+    expect(props.isVisible).toBe(true);
+
+    act(() => {
+      props.onCancel();
+    });
+
+    expect(handleChange).not.toHaveBeenCalled();
+    props = mockDateTimePickerModal.mock.calls.at(-1)?.[0] as {
+      isVisible: boolean;
+      onCancel: () => void;
+    };
+    expect(props.isVisible).toBe(false);
+  });
 });
 
 describe('ISO helpers', () => {
@@ -117,5 +271,60 @@ describe('ISO helpers', () => {
     expect(d.getMonth()).toBe(8);
     expect(d.getDate()).toBe(10);
     expect(toISODate(d)).toBe('2025-09-10');
+  });
+
+  test('parseISODate defaults a missing month/day to the 1st', () => {
+    const d = parseISODate('2025');
+    expect(d.getFullYear()).toBe(2025);
+    expect(d.getMonth()).toBe(0);
+    expect(d.getDate()).toBe(1);
+  });
+});
+
+describe('DatePicker on web platform', () => {
+  let originalOS: typeof Platform.OS;
+
+  beforeEach(() => {
+    originalOS = Platform.OS;
+    Platform.OS = 'web';
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  test('renders a native date input and commits the parsed value on change', () => {
+    const handleChange = jest.fn();
+    let tree: ReturnType<typeof renderer.create>;
+    act(() => {
+      tree = renderer.create(<DatePicker value="2025-06-01" onChange={handleChange} />);
+    });
+    const input = tree!.root.findByProps({ type: 'date' });
+    act(() => {
+      input.props.onChange({ target: { value: '2025-06-20' } });
+    });
+    expect(handleChange).toHaveBeenCalledWith('2025-06-20');
+  });
+
+  test('does not mount the native picker modal on web', () => {
+    const handleChange = jest.fn();
+    act(() => {
+      renderer.create(<DatePicker value="" onChange={handleChange} />);
+    });
+    expect(mockDateTimePickerModal).not.toHaveBeenCalled();
+  });
+});
+
+describe('getNextMonday when today is already Monday', () => {
+  beforeAll(() => {
+    // 2025-06-16 is a Monday, where (8 - dow) % 7 alone would compute 0.
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-16T12:00:00'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('rolls forward a full week instead of returning today', () => {
+    expect(toISODate(getNextMonday())).toBe('2025-06-23');
   });
 });

--- a/frontend/src/api/__tests__/errorMessagesEdgeCases.test.ts
+++ b/frontend/src/api/__tests__/errorMessagesEdgeCases.test.ts
@@ -1,0 +1,49 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+import {
+  formatApiError,
+  GENERIC_FALLBACK,
+  TIMEOUT_MESSAGE,
+  VALIDATION_MESSAGE,
+} from '../errorMessages';
+
+describe('formatApiError edge-case resolution branches', () => {
+  it('falls back to GENERIC_FALLBACK when a plain Error carries an empty message', () => {
+    expect(formatApiError(new Error(''))).toBe(GENERIC_FALLBACK);
+  });
+
+  it('suppresses the synthetic "Request failed with status" debug message', () => {
+    expect(formatApiError(new Error('Request failed with status 500: boom'))).toBe(
+      GENERIC_FALLBACK,
+    );
+  });
+
+  it('ignores an empty-string detail rather than treating it as a known code', () => {
+    expect(formatApiError({ detail: '' })).toBe(GENERIC_FALLBACK);
+  });
+
+  it('recognises a timeout error even when it is not the real ApiTimeoutError class', () => {
+    class ForeignTimeout extends Error {}
+    const fake = new ForeignTimeout('timed out');
+    fake.name = 'ApiTimeoutError';
+
+    expect(formatApiError(fake)).toBe(TIMEOUT_MESSAGE);
+  });
+
+  it('recognises a validation error even when it is not the real ApiValidationError class', () => {
+    class ForeignValidation extends Error {}
+    const fake = new ForeignValidation('bad shape');
+    fake.name = 'ApiValidationError';
+
+    expect(formatApiError(fake)).toBe(VALIDATION_MESSAGE);
+  });
+
+  it('falls through to the caller fallback when a TypeError message matches no known network fragment', () => {
+    const err = new TypeError('Something completely unrelated happened');
+
+    expect(formatApiError(err, { fallback: 'Could not complete the request.' })).toBe(
+      'Could not complete the request.',
+    );
+  });
+});

--- a/frontend/src/api/__tests__/miscEndpoints-api.test.ts
+++ b/frontend/src/api/__tests__/miscEndpoints-api.test.ts
@@ -1,0 +1,314 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiValidationError, course, frequency, practiceShare, practices, prompts } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe('frequency.current', () => {
+  const validFrequency = {
+    stage_number: 3,
+    color: 'Orange',
+    aspect: 'Mind',
+    practice_name: 'Box Breath',
+    practice_id: 5,
+    user_practice_id: 9,
+    banner_text: 'You are in the Orange frequency.',
+  };
+
+  test('omits stage_number from the query string when not supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(validFrequency));
+
+    await frequency.current();
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/current/frequency');
+  });
+
+  test('appends stage_number when an override is supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(validFrequency));
+
+    const result = await frequency.current(3, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/user-practices/current/frequency?stage_number=3');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+    expect(result).toEqual(validFrequency);
+  });
+
+  test('raises ApiValidationError on a malformed banner payload', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ ...validFrequency, color: 5 }));
+
+    await expect(frequency.current()).rejects.toBeInstanceOf(ApiValidationError);
+  });
+});
+
+describe('practices.get and practices.create', () => {
+  const validPractice = {
+    id: 4,
+    stage_number: 2,
+    name: 'Box Breath',
+    description: 'desc',
+    instructions: 'inst',
+    default_duration_minutes: 5,
+    approved: true,
+  };
+
+  test('practices.get fetches a single practice by id', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(validPractice));
+
+    const result = await practices.get(4, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/4');
+    expect(result).toEqual(validPractice);
+  });
+
+  test('practices.create POSTs a new draft practice', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ ...validPractice, approved: false }, 201));
+
+    const result = await practices.create({
+      stage_number: 2,
+      name: 'New Practice',
+      description: 'desc',
+      instructions: 'inst',
+      default_duration_minutes: 5,
+    });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/');
+    expect(init.method).toBe('POST');
+    expect(result.approved).toBe(false);
+  });
+});
+
+describe('course misc endpoints', () => {
+  test('markRead POSTs the mark-read endpoint', async () => {
+    const completion = { id: 1, user_id: 2, content_id: 9, completed_at: '2026-05-01T00:00:00Z' };
+    mockFetch.mockReturnValueOnce(jsonResponse(completion));
+
+    const result = await course.markRead(9, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/content/9/mark-read');
+    expect(init.method).toBe('POST');
+    expect(result).toEqual(completion);
+  });
+
+  test('stageProgress GETs the stage progress summary', async () => {
+    const progress = { total_items: 5, read_items: 2, progress_percent: 40, next_unlock_day: 3 };
+    mockFetch.mockReturnValueOnce(jsonResponse(progress));
+
+    const result = await course.stageProgress(1, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/stages/1/progress');
+    expect(result).toEqual(progress);
+  });
+
+  test('contentBody GETs the raw markdown body', async () => {
+    const body = { title: 'Intro', content_type: 'essay', body_markdown: '# Hi' };
+    mockFetch.mockReturnValueOnce(jsonResponse(body));
+
+    const result = await course.contentBody(9, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/content/9/body');
+    expect(result).toEqual(body);
+  });
+
+  test('siteResources GETs the always-available resource list', async () => {
+    const resources = [{ slug: 'faq', title: 'FAQ', description: 'desc', url: 'https://x' }];
+    mockFetch.mockReturnValueOnce(jsonResponse(resources));
+
+    const result = await course.siteResources('tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/site-resources');
+    expect(result).toEqual(resources);
+  });
+
+  test('siteResourceBody GETs a single resource body by slug', async () => {
+    const body = { title: 'FAQ', content_type: 'resource', body_markdown: '# FAQ' };
+    mockFetch.mockReturnValueOnce(jsonResponse(body));
+
+    const result = await course.siteResourceBody('faq', 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/course/site-resources/faq/body');
+    expect(result).toEqual(body);
+  });
+});
+
+describe('prompts client', () => {
+  test('current GETs the active weekly prompt', async () => {
+    const prompt = {
+      week_number: 3,
+      question: 'What surprised you?',
+      has_responded: false,
+      response: null,
+      timestamp: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(prompt));
+
+    const result = await prompts.current('tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/prompts/current');
+    expect(result).toEqual(prompt);
+  });
+
+  test('respond POSTs the free-text answer for a given week', async () => {
+    const prompt = {
+      week_number: 3,
+      question: 'What surprised you?',
+      has_responded: true,
+      response: 'Everything.',
+      timestamp: '2026-05-01T00:00:00Z',
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(prompt));
+
+    const result = await prompts.respond(3, 'Everything.', 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/prompts/3/respond');
+    expect(JSON.parse(init.body)).toEqual({ response: 'Everything.' });
+    expect(result.has_responded).toBe(true);
+  });
+
+  test('history omits query params when none are supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ items: [], total: null, has_more: false }));
+
+    await prompts.history();
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/prompts/history');
+  });
+
+  test('history appends limit and offset when supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ items: [], total: 0, has_more: false }));
+
+    await prompts.history({ limit: 10, offset: 5 }, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/prompts/history?limit=10&offset=5');
+  });
+});
+
+describe('practiceShare client', () => {
+  test('create mints a share link with the default empty payload', async () => {
+    const link = {
+      id: 1,
+      token: 'share-tok',
+      practice_id: 4,
+      created_at: '2026-05-01T00:00:00Z',
+      expires_at: null,
+      max_uses: null,
+      use_count: 0,
+      revoked_at: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(link, 201));
+
+    const result = await practiceShare.create(4);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/4/share-link');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({});
+    expect(result).toEqual(link);
+  });
+
+  test('list GETs the caller outstanding share links for a practice', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse([]));
+
+    const result = await practiceShare.list(4, 'tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/4/share-links');
+    expect(result).toEqual([]);
+  });
+
+  test('preview GETs a share link by token', async () => {
+    const preview = {
+      practice_id: 4,
+      stage_number: 2,
+      name: 'Box Breath',
+      description: 'desc',
+      instructions: 'inst',
+      default_duration_minutes: 5,
+      mode: 'meditation_timer',
+      mode_config: {},
+      created_by_display_name: 'friend',
+      expires_at: null,
+      max_uses: null,
+      use_count: 1,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(preview));
+
+    const result = await practiceShare.preview('share-tok');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/share/share-tok');
+    expect(result).toEqual(preview);
+  });
+
+  test('import POSTs to redeem the share token', async () => {
+    const imported = { practice_id: 4, stage_number: 2, name: 'Box Breath', approved: false };
+    mockFetch.mockReturnValueOnce(jsonResponse(imported, 201));
+
+    const result = await practiceShare.import('share-tok', 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/share/share-tok/import');
+    expect(init.method).toBe('POST');
+    expect(result).toEqual(imported);
+  });
+
+  test('revoke DELETEs a share link the caller minted', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(null, 204));
+
+    await practiceShare.revoke(7, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/share-links/7');
+    expect(init.method).toBe('DELETE');
+  });
+
+  test('preview URL-encodes a token containing reserved characters', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        practice_id: 1,
+        stage_number: 1,
+        name: 'X',
+        description: '',
+        instructions: '',
+        default_duration_minutes: 5,
+        mode: 'meditation_timer',
+        mode_config: {},
+        created_by_display_name: null,
+        expires_at: null,
+        max_uses: null,
+        use_count: 0,
+      }),
+    );
+
+    await practiceShare.preview('a/b c');
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/practices/share/a%2Fb%20c');
+  });
+});

--- a/frontend/src/api/__tests__/networkAndRefreshEdgeCases.test.ts
+++ b/frontend/src/api/__tests__/networkAndRefreshEdgeCases.test.ts
@@ -1,0 +1,164 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, afterEach, jest */
+import {
+  habits,
+  goalCompletions,
+  practiceSessions,
+  setTokenGetter,
+  setOnUnauthorized,
+  setNetworkOnlineGetter,
+} from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const mockOnUnauthorized = jest.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockOnUnauthorized.mockReset();
+  setTokenGetter(null);
+  setOnUnauthorized(null);
+  setNetworkOnlineGetter(null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  setNetworkOnlineGetter(null);
+});
+
+describe('known-offline fast fail', () => {
+  test('rejects a GET immediately without calling fetch when known offline', async () => {
+    setNetworkOnlineGetter(() => false);
+
+    await expect(habits.list()).rejects.toMatchObject({ name: 'ApiError', status: 0 });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('proceeds with a GET when the online getter reports true', async () => {
+    setNetworkOnlineGetter(() => true);
+    mockFetch.mockReturnValueOnce(jsonResponse([]));
+
+    const result = await habits.list();
+
+    expect(result).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fast-fail a non-GET request even when known offline', async () => {
+    setNetworkOnlineGetter(() => false);
+    mockFetch.mockReturnValueOnce(jsonResponse({ streak: 1, milestones: [], reason_code: 'ok' }));
+
+    const result = await goalCompletions.create({ goal_id: 1, did_complete: true });
+
+    expect(result.streak).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('malformed /auth/refresh response body', () => {
+  test('treats a schema-invalid refresh body as a refresh failure', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    setTokenGetter(() => 'stored-token');
+    setOnUnauthorized(mockOnUnauthorized);
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
+    mockFetch.mockReturnValueOnce(jsonResponse({ token: 'not-a-jwt', user_id: 1 }));
+
+    await expect(habits.list()).rejects.toMatchObject({ name: 'ApiError' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockOnUnauthorized).toHaveBeenCalledWith('session_expired');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('explicit token override matching the live session', () => {
+  test('fires onUnauthorized when the override equals the live session token', async () => {
+    setTokenGetter(() => 'shared-token');
+    setOnUnauthorized(mockOnUnauthorized);
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
+
+    await expect(habits.list('shared-token')).rejects.toMatchObject({ name: 'ApiError' });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockOnUnauthorized).toHaveBeenCalledWith('session_expired');
+  });
+});
+
+describe('fetch rejecting with a raw exception (not an HTTP error status)', () => {
+  test('retries a GET after a network-level TypeError and succeeds', async () => {
+    jest.useFakeTimers();
+    mockFetch
+      .mockImplementationOnce(() => Promise.reject(new TypeError('Network request failed')))
+      .mockReturnValueOnce(jsonResponse([]));
+
+    const promise = habits.list();
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry a non-idempotent POST after a network-level TypeError', async () => {
+    mockFetch.mockImplementationOnce(() => Promise.reject(new TypeError('Network request failed')));
+
+    await expect(
+      practiceSessions.create({
+        user_practice_id: 1,
+        started_at: '2026-04-28T10:00:00.000Z',
+        ended_at: '2026-04-28T10:10:00.000Z',
+      }),
+    ).rejects.toThrow(TypeError);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry a GET when fetch rejects with a non-Error value', async () => {
+    mockFetch.mockImplementationOnce(() => Promise.reject('boom'));
+
+    await expect(habits.list()).rejects.toBe('boom');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('error responses without a usable JSON detail', () => {
+  test('falls back to a generic message when the error body is not JSON', async () => {
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.reject(new Error('not json')),
+      }),
+    );
+
+    await expect(habits.getStats(1)).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 404,
+      detail: 'Request failed',
+    });
+  });
+
+  test('falls back to a generic message when the error body has no detail string', async () => {
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) }),
+    );
+
+    await expect(habits.getStats(1)).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 404,
+      detail: 'Request failed',
+    });
+  });
+});

--- a/frontend/src/context/__tests__/ApiKeyContext.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyContext.test.tsx
@@ -122,4 +122,98 @@ describe('ApiKeyProvider', () => {
     expect(() => render(<NakedConsumer />)).toThrow(/ApiKeyProvider/);
     suppress.mockRestore();
   });
+
+  test('sets loadError when the initial SecureStore read fails', async () => {
+    mockStorage.loadLlmApiKey.mockRejectedValueOnce(new Error('keychain locked'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(ctx?.isLoading).toBe(false));
+
+    expect(ctx!.apiKey).toBeNull();
+    expect(ctx!.loadError).toBeInstanceOf(Error);
+    expect(ctx!.loadError?.message).toBe('keychain locked');
+    warnSpy.mockRestore();
+  });
+
+  test('wraps a non-Error thrown value from the initial load in an Error', async () => {
+    mockStorage.loadLlmApiKey.mockRejectedValueOnce('string rejection');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(ctx?.isLoading).toBe(false));
+
+    expect(ctx!.loadError).toBeInstanceOf(Error);
+    expect(ctx!.loadError?.message).toBe('string rejection');
+    warnSpy.mockRestore();
+  });
+
+  test('saveApiKey sets loadError but still updates the key when the write fails', async () => {
+    mockStorage.saveLlmApiKey.mockRejectedValueOnce(new Error('disk full'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+    await waitFor(() => expect(ctx?.isLoading).toBe(false));
+
+    await act(async () => {
+      await ctx!.saveApiKey('sk-fallback');
+    });
+
+    expect(ctx!.loadError).toBeInstanceOf(Error);
+    expect(ctx!.loadError?.message).toBe('disk full');
+    expect(ctx!.apiKey).toBe('sk-fallback');
+    warnSpy.mockRestore();
+  });
+
+  test('clearApiKey sets loadError but still nulls the key when the clear fails', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-existing');
+    mockStorage.clearLlmApiKey.mockRejectedValueOnce(new Error('locked'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+    await waitFor(() => expect(ctx?.apiKey).toBe('sk-existing'));
+
+    await act(async () => {
+      await ctx!.clearApiKey();
+    });
+
+    expect(ctx!.loadError).toBeInstanceOf(Error);
+    expect(ctx!.loadError?.message).toBe('locked');
+    expect(ctx!.apiKey).toBeNull();
+    warnSpy.mockRestore();
+  });
 });

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -246,6 +246,42 @@ describe('AuthContext', () => {
       expect(mockClearToken).toHaveBeenCalled();
       expect(result.current.token).toBeNull();
     });
+
+    // BUG-API-018: an anonymous request that hits a protected endpoint never
+    // had a session, so the navigator should collapse straight to 'anonymous'
+    // rather than showing the "session expired" re-auth sheet.
+    it("collapses to 'anonymous' (not 'reauth-required') when reason is not_authenticated", async () => {
+      mockLoadToken.mockResolvedValue('stored-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('authenticated'));
+
+      const unauthorized = mockSetOnUnauthorized.mock.calls.at(-1)?.[0];
+      expect(typeof unauthorized).toBe('function');
+
+      await act(async () => {
+        unauthorized?.('not_authenticated');
+      });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+      expect(result.current.token).toBeNull();
+    });
+
+    it('still transitions to reauth-required when clearToken rejects', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('SecureStore unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+      expect(result.current.token).toBeNull();
+      warnSpy.mockRestore();
+    });
   });
 
   // BUG-NAV-001 / BUG-NAV-002: the navigator must discriminate between
@@ -381,6 +417,30 @@ describe('AuthContext', () => {
       expect(result.current.token).toBe('valid-jwt');
       expect(mockClearToken).not.toHaveBeenCalled();
     });
+
+    it('resolves to anonymous when loadToken itself rejects on bootstrap', async () => {
+      mockLoadToken.mockRejectedValueOnce(new Error('storage unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+      expect(result.current.token).toBeNull();
+      warnSpy.mockRestore();
+    });
+
+    it('still resolves to anonymous when discarding an expired token fails to clear', async () => {
+      mockLoadToken.mockResolvedValue('expired-jwt');
+      mockIsTokenExpired.mockReturnValue(true);
+      mockClearToken.mockRejectedValueOnce(new Error('locked'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+      expect(result.current.token).toBeNull();
+      warnSpy.mockRestore();
+    });
   });
 
   describe('api-layer token callbacks (BUG-AUTH-001 / BUG-AUTH-005)', () => {
@@ -456,6 +516,26 @@ describe('AuthContext', () => {
 
       await waitFor(() => expect(result.current.token).toBe('fresh-jwt'));
       expect(result.current.userTimezone).toBe('UTC');
+    });
+
+    it('leaves the token untouched when saveToken fails during onTokenRefreshed', async () => {
+      mockLoadToken.mockResolvedValue('old-jwt');
+      mockSaveToken.mockRejectedValueOnce(new Error('disk full'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('old-jwt'));
+
+      const refreshed = mockSetOnTokenRefreshed.mock.calls.at(-1)?.[0];
+      expect(typeof refreshed).toBe('function');
+
+      await act(async () => {
+        refreshed?.('fresh-jwt', undefined);
+      });
+
+      expect(mockSaveToken).toHaveBeenCalledWith('fresh-jwt');
+      expect(result.current.token).toBe('old-jwt');
+      warnSpy.mockRestore();
     });
 
     it('awaits clearToken before nulling state when API reports 401', async () => {

--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -11,6 +11,7 @@ import {
   shadows,
   spacing,
   touchTarget,
+  type,
   typography,
 } from '../tokens';
 
@@ -232,6 +233,25 @@ describe('design tokens', () => {
       const sizes = typography(600);
       expect(sizes.title).toBeGreaterThan(sizes.body);
       expect(sizes.body).toBeGreaterThan(sizes.caption);
+    });
+
+    it('steps the base size across every breakpoint bracket', () => {
+      // Widths land in the sm, md, lg, xl and above-xl brackets in turn.
+      expect(typography(300).body).toBe(14);
+      expect(typography(400).body).toBe(16);
+      expect(typography(700).body).toBe(18);
+      expect(typography(1000).body).toBe(20);
+      expect(typography(1300).body).toBe(22);
+    });
+  });
+
+  describe('type', () => {
+    it('steps the base size across every breakpoint bracket', () => {
+      expect(type(300).body.fontSize).toBe(15);
+      expect(type(400).body.fontSize).toBe(16);
+      expect(type(700).body.fontSize).toBe(17);
+      expect(type(1000).body.fontSize).toBe(18);
+      expect(type(1300).body.fontSize).toBe(19);
     });
   });
 });

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -262,6 +262,20 @@ describe('ChapterReader', () => {
     expect(queryByText(/title:/)).toBeNull();
   });
 
+  it('renders images from absolute URLs and drops repo-relative image references', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Image Test',
+      content_type: 'chapter',
+      body_markdown:
+        '# Image Test\n\n![Good Image](https://example.com/pic.png)\n\n![Bad Image](assets/relative.png)\n',
+    });
+    const { findByLabelText, queryByLabelText } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByLabelText('Good Image');
+    expect(queryByLabelText('Bad Image')).toBeNull();
+  });
+
   it('renders the manifest title in the reader sheet header', async () => {
     const { findByTestId } = render(
       <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -294,6 +294,27 @@ describe('CourseScreen', () => {
     expect(queryByTestId('chapter-reader')).toBeNull();
   });
 
+  it('opens a site resource in the reader and returns to the course on back', async () => {
+    const { getByTestId, findByText, queryByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('site-resources-panel')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('site-resource-chip-philosophy'));
+    });
+
+    await waitFor(() => expect(getByTestId('chapter-reader')).toBeTruthy());
+    expect(mockSiteResourceBody).toHaveBeenCalledWith('philosophy');
+    await findByText('philosophy');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('reader-back-button'));
+    });
+
+    expect(queryByTestId('chapter-reader')).toBeNull();
+    expect(getByTestId('stage-selector')).toBeTruthy();
+  });
+
   it('returns from content viewer when back is pressed', async () => {
     const { getByText, getByTestId, queryByTestId } = render(<CourseScreen />);
 

--- a/frontend/src/features/Course/__tests__/CourseScreenUnmatchedStage.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenUnmatchedStage.test.tsx
@@ -1,0 +1,94 @@
+/* eslint-env jest */
+// When a route stageNumber has no matching entry in the loaded stage list,
+// selectedStageData stays undefined for the life of the render. Pins the
+// header's conditional branches (stage cover / metadata hidden) and the
+// progress bar's spiralColor fallback for that case.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import type { ContentItem, CourseProgress, Stage } from '../../../api';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage 1',
+  subtitle: 'First stage',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const sampleStages: Stage[] = [makeStage({ id: 1, stage_number: 1 })];
+const sampleContent: ContentItem[] = [];
+const sampleProgress: CourseProgress = {
+  total_items: 0,
+  read_items: 0,
+  progress_percent: 0,
+  next_unlock_day: null,
+};
+
+const mockStagesList = jest.fn<(...a: unknown[]) => Promise<Stage[]>>();
+const mockStageContent = jest.fn<(...a: unknown[]) => Promise<ContentItem[]>>();
+const mockStageProgress = jest.fn<(...a: unknown[]) => Promise<CourseProgress>>();
+
+jest.mock('../../../api', () => ({
+  stages: { listAll: (...a: unknown[]) => mockStagesList(...a) },
+  course: {
+    stageContentAll: (...a: unknown[]) => mockStageContent(...a),
+    stageProgress: (...a: unknown[]) => mockStageProgress(...a),
+    markRead: jest.fn(),
+    contentBody: jest.fn(),
+    siteResources: () => Promise.resolve([]),
+    siteResourceBody: jest.fn(),
+    stageIntro: () => Promise.reject(new Error('content_not_found')),
+    stageIntroBody: jest.fn(),
+  },
+}));
+
+// Route requests stage 99, which is not in the loaded stage list.
+jest.mock('../../../navigation/hooks', () => ({
+  useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: { stageNumber: 99 } }),
+  useAppNavigation: () => ({ navigate: jest.fn() }),
+}));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: unknown }) =>
+      ReactMod.createElement(ReactMod.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// eslint-disable-next-line import/order
+const { render, waitFor } = require('@testing-library/react-native');
+const CourseScreen = require('../CourseScreen').default;
+
+describe('CourseScreen with an unmatched route stage number', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStagesList.mockResolvedValue(sampleStages);
+    mockStageContent.mockResolvedValue(sampleContent);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+  });
+
+  it('hides the stage cover and metadata when the route stage is not in the loaded list', async () => {
+    const view = render(<CourseScreen />);
+
+    await waitFor(() => expect(view.getByTestId('content-list')).toBeTruthy());
+    expect(view.queryByTestId('stage-cover')).toBeNull();
+    expect(view.queryByTestId('stage-metadata')).toBeNull();
+    await waitFor(() => expect(view.getByText('0/0 completed')).toBeTruthy());
+    expect(view.getByText('No Content Yet')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -1,10 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, within } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import type { Stage } from '../../../api';
+import { colors, STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
 import StageSelector from '../StageSelector';
+
+function backgroundColorOf(style: StyleProp<ViewStyle>): string {
+  const flat = StyleSheet.flatten(style) ?? {};
+  return (flat.backgroundColor as string | undefined) ?? '';
+}
 
 const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
   id: 1,
@@ -132,5 +140,87 @@ describe('StageSelector', () => {
       selected: false,
       disabled: true,
     });
+  });
+
+  it('renders no pills when the stages list is empty', () => {
+    const { queryByTestId } = render(
+      <StageSelector stages={[]} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    expect(queryByTestId('stage-pill-1')).toBeNull();
+  });
+
+  it('falls back to the neutral color for an unrecognized spiral_dynamics_color', () => {
+    const stages = [makeStage({ stage_number: 1, spiral_dynamics_color: 'Mauve' })];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    const style = getByTestId('stage-pill-1').props.style as StyleProp<ViewStyle>;
+    expect(backgroundColorOf(style)).toBe(colors.neutral);
+  });
+
+  it('falls back to the STAGE_ORDER position color when the API omits a stage number', () => {
+    // Only stage 2 comes back from the API; pill 1 still renders and is
+    // colored by its STAGE_ORDER position (Beige) since it has no matching
+    // API record to read spiral_dynamics_color from.
+    const stages = [makeStage({ stage_number: 2, spiral_dynamics_color: 'Purple' })];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    const pill1 = getByTestId('stage-pill-1');
+    const style = pill1.props.style as StyleProp<ViewStyle>;
+    expect(backgroundColorOf(style)).toBe(STAGE_COLORS[STAGE_ORDER[0]!]);
+    expect(pill1.props.accessibilityState).toMatchObject({ selected: true, disabled: true });
+  });
+
+  it('falls back to neutral when a missing stage number also exceeds STAGE_ORDER', () => {
+    // stage_number 12 forces pills 1..12; pill 11 has neither an API record
+    // nor a STAGE_ORDER entry (only 10 named stages), so it resolves neutral.
+    const stages = [makeStage({ stage_number: 12 })];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    const pill11 = getByTestId('stage-pill-11');
+    const style = pill11.props.style as StyleProp<ViewStyle>;
+    expect(backgroundColorOf(style)).toBe(colors.neutral);
+  });
+
+  it('renders the checkmark glyph for a completed stage and the number for an active one', () => {
+    const stages = [
+      makeStage({ stage_number: 1, is_unlocked: true, progress: 1.0 }),
+      makeStage({ stage_number: 2, is_unlocked: true, progress: 0.2 }),
+    ];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={2} onSelectStage={onSelectStage} />,
+    );
+
+    expect(within(getByTestId('stage-pill-1')).getByText('✓')).toBeTruthy();
+    expect(within(getByTestId('stage-pill-2')).getByText('2')).toBeTruthy();
+  });
+
+  it('renders the lock glyph for a locked, non-completed stage', () => {
+    const stages = [makeStage({ stage_number: 1, is_unlocked: false, progress: 0 })];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    expect(within(getByTestId('stage-pill-1')).getByText('🔒')).toBeTruthy();
+  });
+
+  it('prioritizes the completed checkmark over the lock glyph when a stage is both', () => {
+    // Unusual API data (progress complete but is_unlocked false) pins the
+    // ternary order: completed wins the glyph even though the pill is locked.
+    const stages = [makeStage({ stage_number: 1, is_unlocked: false, progress: 1.0 })];
+    const { getByTestId } = render(
+      <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+    );
+
+    const pill1 = getByTestId('stage-pill-1');
+    expect(within(pill1).getByText('✓')).toBeTruthy();
+    expect(within(pill1).queryByText('🔒')).toBeNull();
+    expect(pill1.props.accessibilityLabel).toBe('Stage 1, locked, completed');
   });
 });

--- a/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/__tests__/GoalModal.test.tsx
@@ -2,6 +2,7 @@
 /* global describe, it, expect */
 import { jest } from '@jest/globals';
 import React from 'react';
+import { TouchableOpacity } from 'react-native';
 import renderer from 'react-test-renderer';
 
 import { GoalModal } from '../components/GoalModal';
@@ -498,5 +499,45 @@ describe('GoalModal edit toggle', () => {
     expect(
       testRenderer.root.findByProps({ testID: 'goal-modal-edit-toggle' }).props.accessibilityState,
     ).toEqual({ expanded: false });
+  });
+});
+
+describe('GoalModal icon editing', () => {
+  it('opens the emoji selector via the header icon and applies the selected emoji to the habit', () => {
+    const onUpdateHabit = jest.fn();
+    const testRenderer = renderer.create(
+      <GoalModal
+        visible
+        habit={sampleHabit}
+        onClose={() => {}}
+        onUpdateGoal={() => {}}
+        onUpdateGoalUnits={() => {}}
+        onLogUnit={() => {}}
+        onUpdateHabit={onUpdateHabit}
+      />,
+    );
+
+    expect(() => testRenderer.root.findByType('EmojiSelector')).toThrow();
+
+    const iconText = testRenderer.root.findByProps({ children: sampleHabit.icon });
+    let iconButton = iconText.parent;
+    while (iconButton && iconButton.type !== TouchableOpacity) {
+      iconButton = iconButton.parent;
+    }
+    if (!iconButton) throw new Error('Icon button not found');
+    const foundButton = iconButton;
+    renderer.act(() => {
+      foundButton.props.onPress();
+    });
+
+    const selector = testRenderer.root.findByType('EmojiSelector');
+    expect(selector).toBeTruthy();
+
+    renderer.act(() => {
+      selector.props.onEmojiSelected('🎉');
+    });
+
+    expect(onUpdateHabit).toHaveBeenCalledWith({ ...sampleHabit, icon: '🎉' });
+    expect(() => testRenderer.root.findByType('EmojiSelector')).toThrow();
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -348,6 +348,15 @@ describe('calculateMissedDays', () => {
     expect(missed).toEqual([]);
   });
 
+  test('returns empty array when there is exactly one completion (no span to bound a gap)', () => {
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [{ id: 'c-1', timestamp: new Date('2024-01-01T08:00:00'), completed_units: 1 }],
+    };
+    const missed = calculateMissedDays(habit);
+    expect(missed).toEqual([]);
+  });
+
   test('identifies days without completions between first and last completion', () => {
     const habit: Habit = {
       ...baseHabit,

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -2,14 +2,18 @@
 /* global describe, test, expect, jest */
 import { validate as uuidValidate } from 'uuid';
 
-import { brightenColor, STAGE_COLORS } from '../../../design/tokens';
+import { brightenColor, colors, STAGE_COLORS } from '../../../design/tokens';
 import type { Habit, Goal } from '../Habits.types';
 import {
   getProgressPercentage,
   getMarkerPositions,
   getGoalTier,
+  getGoalTarget,
+  getTierColor,
+  calculateNetEnergy,
   calculateTodaysProgress,
   getProgressBarColor,
+  isEarlyUnlocked,
   isGoalAchieved,
   isHabitLockedToday,
   logHabitUnits,
@@ -628,6 +632,288 @@ describe('HabitUtils', () => {
       expect(currentGoal.tier).toBe('low');
       expect(completedAllGoals).toBe(false);
     });
+  });
+});
+
+describe('getTierColor', () => {
+  test('returns the low tier color', () => {
+    expect(getTierColor('low')).toBe(colors.tier.low);
+  });
+
+  test('returns the clear tier color', () => {
+    expect(getTierColor('clear')).toBe(colors.tier.clear);
+  });
+
+  test('returns the stretch tier color', () => {
+    expect(getTierColor('stretch')).toBe(colors.tier.stretch);
+  });
+
+  test('falls back to the default color for an unrecognized tier', () => {
+    expect(getTierColor('mystery' as unknown as 'low')).toBe(colors.tier.default);
+  });
+});
+
+describe('getGoalTarget frequency-unit normalization', () => {
+  test('per_day returns the raw target unchanged', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 4,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    expect(getGoalTarget(goal)).toBe(4);
+  });
+
+  test('per_week normalizes to a daily-equivalent target', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 14,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_week',
+      is_additive: true,
+    };
+    expect(getGoalTarget(goal)).toBe(2);
+  });
+
+  test('per_month normalizes to a daily-equivalent target', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 30.437,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_month',
+      is_additive: true,
+    };
+    expect(getGoalTarget(goal)).toBeCloseTo(1, 5);
+  });
+
+  test('an unrecognized frequency_unit falls back to the raw target', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 9,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_fortnight',
+      is_additive: true,
+    };
+    expect(getGoalTarget(goal)).toBe(9);
+  });
+
+  test('a missing goal yields a zero target', () => {
+    expect(getGoalTarget(undefined as unknown as Goal)).toBe(0);
+  });
+});
+
+const makeBareHabit = (stage: string, goals: Goal[]): Habit =>
+  ({
+    id: 1,
+    name: 'Meditate',
+    icon: 'x',
+    stage,
+    streak: 0,
+    energy_cost: 1,
+    energy_return: 1,
+    start_date: new Date(2020, 0, 1),
+    goals,
+    completions: [],
+    revealed: true,
+  }) as unknown as Habit;
+
+describe('isGoalAchieved default timezone', () => {
+  test('falls back to the default timezone when none is supplied', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 1,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    };
+    expect(isGoalAchieved(goal, makeBareHabit('Beige', [goal]))).toBe(false);
+  });
+});
+
+describe('getProgressBarColor stage-color resolution', () => {
+  test('uses the explicit override and short-circuits when there is no clear goal', () => {
+    expect(getProgressBarColor(makeBareHabit('Beige', []), 'UTC', '#123456')).toBe('#123456');
+  });
+
+  test('falls back to #000 for an unrecognized stage with no clear goal', () => {
+    expect(getProgressBarColor(makeBareHabit('Unknown', []), 'UTC')).toBe('#000');
+  });
+});
+
+describe('calculateTodaysProgress guards', () => {
+  test('returns zero when the habit has no completions', () => {
+    expect(calculateTodaysProgress(makeBareHabit('Beige', []), 'UTC')).toBe(0);
+  });
+});
+
+describe('calculateNetEnergy', () => {
+  test('returns the difference between energy return and cost', () => {
+    expect(calculateNetEnergy(3, 8)).toBe(5);
+  });
+
+  test('returns a negative value when cost exceeds return', () => {
+    expect(calculateNetEnergy(10, 4)).toBe(-6);
+  });
+});
+
+describe('isEarlyUnlocked', () => {
+  const earlyUnlockedBase = {
+    id: 1,
+    name: 'H',
+    icon: '\u{1F512}',
+    stage: 'Purple',
+    streak: 0,
+    energy_cost: 0,
+    energy_return: 0,
+    goals: [] as Goal[],
+    completions: [],
+  };
+
+  test('true when manually revealed ahead of its start_date', () => {
+    const habit: Habit = {
+      ...earlyUnlockedBase,
+      revealed: true,
+      start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    };
+    expect(isEarlyUnlocked(habit)).toBe(true);
+  });
+
+  test('false when the start_date has already passed', () => {
+    const habit: Habit = {
+      ...earlyUnlockedBase,
+      revealed: true,
+      start_date: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    };
+    expect(isEarlyUnlocked(habit)).toBe(false);
+  });
+
+  test('false when not revealed, regardless of start_date', () => {
+    const habit: Habit = {
+      ...earlyUnlockedBase,
+      revealed: false,
+      start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    };
+    expect(isEarlyUnlocked(habit)).toBe(false);
+  });
+});
+
+describe('isGoalAchieved for subtractive goals', () => {
+  const subtractiveBase = {
+    id: 1,
+    name: 'Test',
+    icon: '\u{1F525}',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 0,
+    energy_return: 0,
+    start_date: new Date(),
+  };
+
+  test('achieved when todays progress stays at or under the target', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'clear',
+      title: 'clear',
+      target: 5,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    };
+    const habit: Habit = {
+      ...subtractiveBase,
+      goals: [goal],
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 3 }],
+    };
+    expect(isGoalAchieved(goal, habit, 'UTC')).toBe(true);
+  });
+
+  test('not achieved once todays progress exceeds the target', () => {
+    const goal: Goal = {
+      id: 1,
+      tier: 'clear',
+      title: 'clear',
+      target: 5,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    };
+    const habit: Habit = {
+      ...subtractiveBase,
+      goals: [goal],
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 6 }],
+    };
+    expect(isGoalAchieved(goal, habit, 'UTC')).toBe(false);
+  });
+});
+
+describe('getGoalTier subtractive total-failure branch', () => {
+  test('falls back to the low tier with no next goal when todays total exceeds every limit', () => {
+    const goals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+    const habit: Habit = {
+      id: 1,
+      name: 'Test',
+      icon: '\u{1F525}',
+      stage: 'Beige',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 15 }],
+    };
+    const { currentGoal, nextGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+    expect(currentGoal.tier).toBe('low');
+    expect(nextGoal).toBeNull();
+    expect(completedAllGoals).toBe(false);
   });
 });
 

--- a/frontend/src/features/Habits/__tests__/HabitsContent.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsContent.test.tsx
@@ -1,0 +1,161 @@
+/* eslint-env jest */
+// The loading / error+retry / empty / list branches of HabitsContent are
+// otherwise only exercised indirectly through the full HabitsScreen, whose
+// data-loading hook makes it awkward to pin each rendering branch directly.
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import type { Habit } from '../Habits.types';
+import { HabitsContent } from '../HabitsScreen';
+
+// Stub the modal components — importing HabitsScreen pulls them in, and some
+// carry native deps (e.g. datetimepicker) that don't load under jest.
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+}));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => () => null);
+
+function makeHabit(id: number): Habit {
+  return {
+    id,
+    name: `Habit ${id}`,
+    icon: '🧪',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 5,
+    energy_return: 7,
+    start_date: new Date(2020, 0, 1),
+    goals: [],
+    completions: [],
+    revealed: true,
+  } as Habit;
+}
+
+const renderRow = ({ item }: { item: Habit }) => <View testID={`row-${item.id}`} />;
+
+describe('HabitsContent', () => {
+  it('shows the loading spinner and hides the list while loading', () => {
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent
+        habits={[]}
+        loading
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={null}
+      />,
+    );
+    expect(getByTestId('loading-spinner')).toBeTruthy();
+    expect(queryByTestId('habits-list')).toBeNull();
+  });
+
+  it('shows the error banner and fires onRetry when pressed', () => {
+    const onRetry = jest.fn();
+    const { getByTestId, getByText } = render(
+      <HabitsContent
+        habits={[]}
+        loading={false}
+        error="Could not load habits"
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={onRetry}
+        onAddHabit={jest.fn()}
+        pagination={null}
+      />,
+    );
+    expect(getByText('Could not load habits')).toBeTruthy();
+    fireEvent.press(getByTestId('retry-button'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('co-renders the list under the error banner instead of hiding it', () => {
+    const habits = [makeHabit(1)];
+    const { getByTestId } = render(
+      <HabitsContent
+        habits={habits}
+        loading={false}
+        error="Could not refresh"
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={null}
+      />,
+    );
+    expect(getByTestId('habits-list')).toBeTruthy();
+  });
+
+  it('shows the empty state and fires onAddHabit when there are no habits', () => {
+    const onAddHabit = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <HabitsContent
+        habits={[]}
+        loading={false}
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={onAddHabit}
+        pagination={null}
+      />,
+    );
+    expect(queryByTestId('habits-list')).toBeNull();
+    fireEvent.press(getByTestId('habits-empty-add'));
+    expect(onAddHabit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the pagination bar when pagination is supplied', () => {
+    const habits = [makeHabit(1), makeHabit(2)];
+    const { getByTestId } = render(
+      <HabitsContent
+        habits={habits}
+        loading={false}
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={{ page: 0, pageCount: 3, onPrev: jest.fn(), onNext: jest.fn(), scale: 1 }}
+      />,
+    );
+    expect(getByTestId('habits-pagination')).toBeTruthy();
+  });
+
+  it('omits the pagination bar when none is supplied', () => {
+    const habits = [makeHabit(1)];
+    const { queryByTestId } = render(
+      <HabitsContent
+        habits={habits}
+        loading={false}
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={null}
+      />,
+    );
+    expect(queryByTestId('habits-pagination')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
@@ -1,0 +1,112 @@
+/* eslint-env jest */
+// Pins the Edit-mode branch of ``openModalForMode``: tapping a tile while
+// Edit mode is active opens the habit-settings modal, not the goal modal.
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsScreen from '../HabitsScreen';
+
+interface SettingsModalProps {
+  visible: boolean;
+}
+
+const mockHabitSettingsModal = jest.fn((_props: SettingsModalProps) => null);
+
+jest.mock('../../../api', () => ({
+  habits: {
+    list: () =>
+      Promise.resolve([
+        {
+          id: 1,
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          stage: 'Beige',
+          streak: 0,
+          energy_cost: 1,
+          energy_return: 1,
+          start_date: new Date(2020, 0, 1),
+          goals: [
+            {
+              title: 'Low',
+              tier: 'low',
+              target: 1,
+              target_unit: 'u',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+          completions: [],
+          revealed: true,
+        },
+      ]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: () =>
+      Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => ({
+  __esModule: true,
+  default: (props: SettingsModalProps) => mockHabitSettingsModal(props),
+}));
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('Habits Edit-mode tile tap', () => {
+  it('opens the habit settings modal when a tile is tapped in Edit mode', async () => {
+    const { getByTestId, getByText, getAllByTestId } = render(<HabitsScreen />);
+
+    await waitFor(() => expect(getAllByTestId('habit-tile').length).toBeGreaterThan(0));
+
+    fireEvent.press(getByTestId('overflow-menu-toggle'));
+    fireEvent.press(getByText('Edit'));
+    fireEvent.press(getAllByTestId('habit-tile')[0]!);
+
+    await waitFor(() => {
+      const calls = mockHabitSettingsModal.mock.calls;
+      const last = calls[calls.length - 1]!;
+      expect(last[0].visible).toBe(true);
+    });
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
@@ -1,0 +1,96 @@
+/* eslint-env jest */
+// Pins the emoji-picker branch: pressing a tile's icon opens the picker
+// modal (``modals.emojiPicker && <EmojiPickerModal ... />``).
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsScreen from '../HabitsScreen';
+
+jest.mock('../../../api', () => ({
+  habits: {
+    list: () =>
+      Promise.resolve([
+        {
+          id: 1,
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          stage: 'Beige',
+          streak: 0,
+          energy_cost: 1,
+          energy_return: 1,
+          start_date: new Date(2020, 0, 1),
+          goals: [
+            {
+              title: 'Low',
+              tier: 'low',
+              target: 1,
+              target_unit: 'u',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+          completions: [],
+          revealed: true,
+        },
+      ]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: () =>
+      Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('Habits icon-tap emoji picker', () => {
+  it('opens the emoji picker modal when a tile icon is pressed', async () => {
+    const { getAllByTestId, findByText } = render(<HabitsScreen />);
+
+    const icons = await waitFor(() => getAllByTestId('habit-icon'));
+    fireEvent.press(icons[0]!);
+
+    expect(await findByText('Select Icon')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
@@ -1,0 +1,101 @@
+/* eslint-env jest */
+// Pins the overflow menu's reveal toggle in its other direction: pressing
+// "Lock Unstarted Habits" flips an early-unlocked (revealed, future
+// start_date) habit back to locked.
+import { describe, it, expect, jest } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsScreen from '../HabitsScreen';
+
+jest.mock('../../../api', () => ({
+  habits: {
+    list: () =>
+      Promise.resolve([
+        {
+          id: 2,
+          name: 'Early Habit',
+          icon: '\u{1F331}',
+          stage: 'Beige',
+          streak: 0,
+          energy_cost: 1,
+          energy_return: 1,
+          start_date: new Date('2099-01-01'),
+          goals: [
+            {
+              title: 'Low',
+              tier: 'low',
+              target: 1,
+              target_unit: 'u',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+          completions: [],
+          revealed: true,
+        },
+      ]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: () =>
+      Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('Habits overflow menu lock-unstarted toggle', () => {
+  it('locks an early-unlocked habit via Lock Unstarted Habits', async () => {
+    const { getAllByTestId, getByTestId, getByText, queryByText } = render(<HabitsScreen />);
+
+    await waitFor(() => expect(getAllByTestId('habit-icon').length).toBeGreaterThan(0));
+
+    // All seeded habits are revealed, so the toggle offers the lock action.
+    fireEvent.press(getByTestId('overflow-menu-toggle'));
+    fireEvent.press(getByText('Lock Unstarted Habits'));
+
+    // Acting on a menu item closes the overflow menu.
+    await waitFor(() => expect(queryByText('Lock Unstarted Habits')).toBeNull());
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsScreen.flatlist-config.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreen.flatlist-config.test.tsx
@@ -77,6 +77,27 @@ describe('Habits FlatList getItemLayout', () => {
   });
 });
 
+describe('Habits FlatList keyExtractor and column layout', () => {
+  it('keys rows by id, falling back to the habit name when id is missing', () => {
+    const habits = [1, 2].map(makeHabit);
+    const { getByTestId } = render(
+      <HabitList habits={habits} columns={1} gridGutter={8} renderItem={renderRow} />,
+    );
+    const keyExtractor = getByTestId('habits-list').props.keyExtractor as (_item: Habit) => string;
+    expect(keyExtractor(habits[0]!)).toBe(String(habits[0]!.id));
+    const noIdHabit = { ...habits[0]!, id: undefined } as unknown as Habit;
+    expect(keyExtractor(noIdHabit)).toBe(noIdHabit.name);
+  });
+
+  it('omits columnWrapperStyle in a single-column layout', () => {
+    const habits = [1, 2].map(makeHabit);
+    const { getByTestId } = render(
+      <HabitList habits={habits} columns={1} gridGutter={8} renderItem={renderRow} />,
+    );
+    expect(getByTestId('habits-list').props.columnWrapperStyle).toBeUndefined();
+  });
+});
+
 describe('missed-days computation gating', () => {
   it('does not scan completions while the modal is closed', () => {
     mockCalculateMissedDays.mockClear();

--- a/frontend/src/features/Habits/__tests__/useHabitNotifications.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabitNotifications.test.ts
@@ -116,6 +116,99 @@ describe('registerForPushNotificationsAsync', () => {
   });
 });
 
+describe('registerForPushNotificationsAsync retry behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('retries after a registration error and eventually succeeds', async () => {
+    jest.useFakeTimers();
+    mockStorage.loadPushToken.mockResolvedValue(null);
+    mockNotifications.getPermissionsAsync
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce({ status: 'granted' });
+    mockNotifications.getExpoPushTokenAsync.mockResolvedValue({
+      data: 'ExponentPushToken[retry]',
+    });
+
+    const promise = registerForPushNotificationsAsync();
+    await jest.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token).toBe('ExponentPushToken[retry]');
+    expect(mockNotifications.getPermissionsAsync).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
+  it('gives up and returns undefined after exhausting all registration retries', async () => {
+    jest.useFakeTimers();
+    mockStorage.loadPushToken.mockResolvedValue(null);
+    mockNotifications.getPermissionsAsync.mockRejectedValue(new Error('always fails'));
+
+    const promise = registerForPushNotificationsAsync();
+    await jest.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token).toBeUndefined();
+    expect(mockNotifications.getPermissionsAsync).toHaveBeenCalledTimes(3);
+    jest.useRealTimers();
+  });
+});
+
+describe('scheduleHabitNotification fallback default', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotifications.scheduleNotificationAsync.mockResolvedValue('fallback-notif');
+  });
+
+  it('defaults to a single daily trigger when frequency is custom with no selected days', async () => {
+    const habit: Habit = {
+      ...baseHabit,
+      notificationFrequency: 'custom',
+      notificationDays: [],
+    };
+    const ids = await scheduleHabitNotification(habit, '06:15');
+    expect(ids).toEqual(['fallback-notif']);
+    expect(mockNotifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: expect.objectContaining({ type: 'daily', hour: 6, minute: 15 }),
+      }),
+    );
+  });
+
+  it('defaults to a single daily trigger when notificationFrequency is unset', async () => {
+    const habit: Habit = { ...baseHabit };
+    const ids = await scheduleHabitNotification(habit, '06:15');
+    expect(ids).toEqual(['fallback-notif']);
+  });
+});
+
+describe('updateHabitNotifications retry-then-succeed scheduling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorage.loadNotificationIds.mockResolvedValue([]);
+  });
+
+  it('recovers on the retry attempt after the first scheduling pass fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockNotifications.scheduleNotificationAsync
+      .mockRejectedValueOnce(new Error('flaky'))
+      .mockResolvedValueOnce('recovered-notif');
+
+    const habit: Habit = {
+      ...baseHabit,
+      notificationFrequency: 'daily',
+      notificationTimes: ['08:00'],
+    };
+
+    const ids = await updateHabitNotifications(habit);
+
+    expect(ids).toEqual(['recovered-notif']);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
 describe('scheduleHabitNotification', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.goalGroup.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.goalGroup.test.tsx
@@ -1,0 +1,105 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+// EmojiSelector pulls in native bindings; render a stub.
+jest.mock('react-native-emoji-selector', () => () => null);
+
+jest.mock('../../../../api', () => ({
+  __esModule: true,
+  goalGroups: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+import { goalGroups as goalGroupsApi } from '../../../../api';
+import type { Goal, Habit } from '../../Habits.types';
+import { GoalModal } from '../GoalModal';
+
+const mockGet = goalGroupsApi.get as jest.MockedFunction<typeof goalGroupsApi.get>;
+
+const makeGoal = (tier: 'low' | 'clear' | 'stretch', overrides: Partial<Goal> = {}): Goal => ({
+  id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  title: `${tier} goal`,
+  tier,
+  target: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  target_unit: 'units',
+  frequency: 1,
+  frequency_unit: 'per_day',
+  is_additive: true,
+  ...overrides,
+});
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 42,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: '🧘',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 2,
+  start_date: new Date('2025-01-01'),
+  goals: [makeGoal('low'), makeGoal('clear'), makeGoal('stretch')],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+const renderModal = (habit: Habit) =>
+  render(
+    <GoalModal
+      visible
+      habit={habit}
+      onClose={jest.fn()}
+      onUpdateGoal={jest.fn()}
+      onUpdateGoalUnits={jest.fn()}
+      onLogUnit={jest.fn()}
+      onUpdateHabit={jest.fn()}
+    />,
+  );
+
+describe('GoalModal goal-group badge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not fetch a goal group when no goal references one', () => {
+    renderModal(makeHabit());
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('shows the goal-group badge once the linked group resolves', async () => {
+    mockGet.mockResolvedValueOnce({
+      id: 5,
+      name: 'Meditation Bundle',
+      icon: '🧘',
+      shared_template: true,
+      goals: [],
+    });
+    const habit = makeHabit({
+      goals: [makeGoal('low', { goal_group_id: 5 }), makeGoal('clear'), makeGoal('stretch')],
+    });
+
+    const { findByTestId, findByText } = renderModal(habit);
+
+    expect(await findByTestId('goal-group-badge')).toBeTruthy();
+    expect(await findByText(/Meditation Bundle/)).toBeTruthy();
+    expect(mockGet).toHaveBeenCalledWith(5);
+  });
+
+  it('leaves the badge hidden when the linked group fetch fails', async () => {
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    const habit = makeHabit({
+      goals: [makeGoal('low', { goal_group_id: 7 }), makeGoal('clear'), makeGoal('stretch')],
+    });
+
+    const { queryByTestId } = renderModal(habit);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith(7));
+    expect(queryByTestId('goal-group-badge')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 import type { DimensionValue } from 'react-native';
 
@@ -342,6 +342,15 @@ describe('GoalModal direction toggle', () => {
     fireEvent.press(getByTestId('goal-direction-additive'));
     expect(props.onUpdateGoal).not.toHaveBeenCalled();
   });
+
+  it('skips a missing tier when flipping direction with fewer than three goals', () => {
+    const habit = makeHabit({
+      goals: [makeGoal('low', { target: 1 }), makeGoal('clear', { target: 2 })],
+    });
+    const { getByTestId, props } = renderModal(habit);
+    fireEvent.press(getByTestId('goal-direction-subtractive'));
+    expect(props.onUpdateGoal).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('GoalModal editor visibility guards', () => {
@@ -449,6 +458,31 @@ describe('GoalModal log-date stepper', () => {
   });
 });
 
+describe('GoalModal log-unit guards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips logging when the habit has no id', () => {
+    const { getByText, props } = renderModal(makeHabit({ id: 0 }));
+    fireEvent.press(getByText('Log Units'));
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an amount of 1 when the log-amount field is non-numeric', () => {
+    const { getByTestId, getByText, props } = renderModal();
+    const logSection = getByTestId('goal-modal-log-unit-section');
+    const amountInput = within(logSection).getByDisplayValue('1');
+    fireEvent.changeText(amountInput, 'abc');
+    fireEvent.press(getByText('Log Units'));
+
+    const calls = (props.onLogUnit as unknown as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [, amount] = calls[0] as [number, number, Date];
+    expect(amount).toBe(1);
+  });
+});
+
 describe('GoalModal progress-bar zero/equal-target guards', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -490,5 +524,61 @@ describe('GoalModal progress-bar zero/equal-target guards', () => {
     const width = fillWidth(habit);
     expect(width).toBe('0%');
     expect(String(width)).not.toContain('NaN');
+  });
+
+  it('falls back to the low goal for the progress percentage when no stretch goal exists', () => {
+    const habit = makeHabit({
+      goals: [makeGoal('low', { target: 4, frequency_unit: 'per_day' })],
+      completions: [{ timestamp: new Date(), completed_units: 2 }],
+    });
+    const width = fillWidth(habit);
+    expect(String(width)).not.toContain('NaN');
+  });
+
+  it('falls back to the first goal for the progress percentage when neither low nor stretch exists', () => {
+    const habit = makeHabit({
+      goals: [makeGoal('clear', { target: 4, frequency_unit: 'per_day' })],
+      completions: [{ timestamp: new Date(), completed_units: 2 }],
+    });
+    const width = fillWidth(habit);
+    expect(String(width)).not.toContain('NaN');
+  });
+});
+
+describe('GoalModal stretch marker tooltip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the stretch tooltip on press-in and hides it on press-out', () => {
+    const { getByTestId, queryByTestId } = renderModal();
+    const stretchMarker = getByTestId('modal-marker-stretch');
+    expect(queryByTestId('modal-tooltip-stretch')).toBeNull();
+
+    fireEvent(stretchMarker, 'pressIn');
+    expect(getByTestId('modal-tooltip-stretch')).toBeTruthy();
+
+    fireEvent(stretchMarker, 'pressOut');
+    expect(queryByTestId('modal-tooltip-stretch')).toBeNull();
+  });
+});
+
+describe('GoalModal goal-target editor sync guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not clobber an in-progress target draft when the goal prop updates externally', () => {
+    const { getByTestId, rerender, props } = renderModal();
+    fireEvent.press(getByTestId('goal-target-display-low'));
+    const input = getByTestId('goal-target-input-low');
+    fireEvent.changeText(input, '9');
+
+    const externallyUpdatedHabit = makeHabit({
+      goals: [makeGoal('low', { target: 42 }), makeGoal('clear'), makeGoal('stretch')],
+    });
+    rerender(<GoalModal {...props} habit={externallyUpdatedHabit} />);
+
+    expect(getByTestId('goal-target-input-low').props.value).toBe('9');
   });
 });

--- a/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Switch } from 'react-native';
+
+import type { Habit, HabitSettingsModalProps } from '../../Habits.types';
+import { HabitSettingsModal } from '../HabitSettingsModal';
+
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+
+const baseHabit: Habit = {
+  id: 42,
+  stage: 'Beige',
+  name: 'Morning walk',
+  icon: '🚶',
+  streak: 3,
+  energy_cost: 3,
+  energy_return: 5,
+  start_date: new Date('2026-01-01T00:00:00.000Z'),
+  goals: [],
+  notificationFrequency: 'daily',
+  notificationTimes: [],
+  notificationDays: [],
+  milestoneNotifications: false,
+};
+
+const renderModal = (overrides: Partial<HabitSettingsModalProps> = {}) => {
+  const onClose = jest.fn();
+  const onUpdate = jest.fn();
+  const onDelete = jest.fn();
+  const onOpenReorderModal = jest.fn();
+  const utils = render(
+    <HabitSettingsModal
+      visible
+      habit={baseHabit}
+      onClose={onClose}
+      onUpdate={onUpdate}
+      onDelete={onDelete}
+      onOpenReorderModal={onOpenReorderModal}
+      allHabits={[baseHabit]}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onClose, onUpdate, onDelete, onOpenReorderModal };
+};
+
+describe('HabitSettingsModal visibility', () => {
+  it('renders nothing when there is no habit to edit', () => {
+    const { toJSON } = render(
+      <HabitSettingsModal
+        visible
+        habit={null}
+        onClose={jest.fn()}
+        onUpdate={jest.fn()}
+        onDelete={jest.fn()}
+        onOpenReorderModal={jest.fn()}
+        allHabits={[]}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the header, basic fields, and computed net energy', () => {
+    const { getByText, getByDisplayValue } = renderModal();
+    getByText('Edit Habit');
+    getByDisplayValue('Morning walk');
+    getByText('🚶');
+    getByText('Beige');
+    getByText('2');
+  });
+});
+
+describe('HabitSettingsModal name and icon editing', () => {
+  it('updates the controlled name input as the user types', () => {
+    const { getByDisplayValue } = renderModal();
+    const nameInput = getByDisplayValue('Morning walk');
+    fireEvent.changeText(nameInput, 'Evening walk');
+    getByDisplayValue('Evening walk');
+  });
+
+  it('selecting an emoji updates the icon and closes the selector', () => {
+    const { getByText, UNSAFE_root } = renderModal();
+    fireEvent.press(getByText('🚶'));
+
+    const selector = UNSAFE_root.findByType('EmojiSelector');
+    fireEvent(selector, 'onEmojiSelected', '🔥');
+
+    getByText('🔥');
+    expect(() => UNSAFE_root.findByType('EmojiSelector')).toThrow();
+  });
+});
+
+describe('HabitSettingsModal energy inputs', () => {
+  it('recalculates net energy when the cost input commits a new value', () => {
+    const { getByDisplayValue, getByText } = renderModal();
+    const costInput = getByDisplayValue('3');
+    fireEvent.changeText(costInput, '7');
+    getByText('-2');
+  });
+
+  it('reverts to the last committed value when the return field blurs on invalid input', () => {
+    const { getByDisplayValue, getByText } = renderModal();
+    const returnInput = getByDisplayValue('5');
+    fireEvent.changeText(returnInput, 'abc');
+    fireEvent(returnInput, 'blur');
+    getByDisplayValue('5');
+    getByText('2');
+  });
+});
+
+describe('HabitSettingsModal notification frequency', () => {
+  it('cycles daily to weekly to custom and back to daily', () => {
+    const { getByText } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: undefined },
+    });
+    const frequencyButton = getByText('daily');
+
+    fireEvent.press(frequencyButton);
+    getByText('daily');
+
+    fireEvent.press(getByText('daily'));
+    getByText('weekly');
+
+    fireEvent.press(getByText('weekly'));
+    getByText('custom');
+
+    fireEvent.press(getByText('custom'));
+    getByText('daily');
+  });
+
+  it('reveals the day-picker grid and updates the days summary when a day is toggled', () => {
+    const { getByText, getAllByText, queryByText } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: 'custom', notificationDays: [] },
+    });
+    getByText('Select days');
+
+    fireEvent.press(getByText('Select days'));
+    const mondayGridOption = getByText('Mon');
+    fireEvent.press(mondayGridOption);
+
+    expect(queryByText('Select days')).toBeNull();
+    expect(getAllByText('Mon')).toHaveLength(2);
+  });
+
+  it('deselects a day via the grid, returning the summary label to the default', () => {
+    const { getByText, getAllByText } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: 'custom', notificationDays: ['Monday'] },
+    });
+    getByText('Mon');
+
+    fireEvent.press(getByText('Mon'));
+    const gridMonday = getAllByText('Mon')[1]!;
+    fireEvent.press(gridMonday);
+
+    expect(getAllByText('Mon')).toHaveLength(1);
+    getByText('Select days');
+  });
+});
+
+describe('HabitSettingsModal notification and milestone toggles', () => {
+  it('turns notifications off and hides frequency controls, then back on', () => {
+    const { getByText, queryByText, UNSAFE_root } = renderModal();
+    const notifSwitch = UNSAFE_root.findAllByType(Switch)[0]!;
+
+    fireEvent(notifSwitch, 'valueChange', false);
+    expect(queryByText('Frequency:')).toBeNull();
+
+    fireEvent(notifSwitch, 'valueChange', true);
+    getByText('Frequency:');
+  });
+
+  it('toggles milestone notifications independently', () => {
+    const { onUpdate, UNSAFE_root, getByText } = renderModal();
+    const milestoneSwitch = UNSAFE_root.findAllByType(Switch)[1]!;
+
+    fireEvent(milestoneSwitch, 'valueChange', true);
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ milestoneNotifications: true }),
+    );
+  });
+});
+
+describe('HabitSettingsModal notification times', () => {
+  it('adds a picked time and ignores a duplicate add', () => {
+    const { getByText, onUpdate, UNSAFE_root } = renderModal();
+
+    fireEvent.press(getByText('08:00'));
+    const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'time',
+    )!;
+    fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
+
+    fireEvent.press(getByText('+'));
+    fireEvent.press(getByText('+'));
+
+    fireEvent.press(getByText('Save Changes'));
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ notificationTimes: ['09:05'] }),
+    );
+  });
+
+  it('removes an added notification time before saving', () => {
+    const { getByText, getAllByText, onUpdate, UNSAFE_root } = renderModal();
+
+    fireEvent.press(getByText('08:00'));
+    const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'time',
+    )!;
+    fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
+    fireEvent.press(getByText('+'));
+
+    const removeButtons = getAllByText('×');
+    fireEvent.press(removeButtons[removeButtons.length - 1]!);
+
+    fireEvent.press(getByText('Save Changes'));
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ notificationTimes: [] }));
+  });
+});
+
+describe('HabitSettingsModal start date', () => {
+  it('ignores a change event without a selected date', () => {
+    const { UNSAFE_root, onUpdate, getByText } = renderModal();
+    const datePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'date',
+    )!;
+
+    fireEvent(datePicker, 'onChange', {}, undefined);
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ start_date: baseHabit.start_date }),
+    );
+  });
+
+  it('commits a newly picked start date on save', () => {
+    const { UNSAFE_root, onUpdate, getByText } = renderModal();
+    const datePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'date',
+    )!;
+    const newDate = new Date('2026-03-01T00:00:00.000Z');
+
+    fireEvent(datePicker, 'onChange', {}, newDate);
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ start_date: newDate }));
+  });
+});
+
+describe('HabitSettingsModal time picker platform behavior', () => {
+  const Platform = require('react-native').Platform as { OS: string };
+  let originalOS: string;
+
+  beforeEach(() => {
+    originalOS = Platform.OS;
+    Platform.OS = 'android';
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  it('collapses the time picker immediately after a pick on non-iOS platforms', () => {
+    const { getByText, UNSAFE_root } = renderModal();
+    fireEvent.press(getByText('08:00'));
+    const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'time',
+    )!;
+    fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 10, 30));
+
+    getByText('10:30');
+    const remaining = UNSAFE_root.findAllByType('DateTimePicker').filter(
+      (node: { props: { mode?: string } }) => node.props.mode === 'time',
+    );
+    expect(remaining).toHaveLength(0);
+  });
+});
+
+describe('HabitSettingsModal missing optional notification arrays', () => {
+  it('adds a time when the habit has no existing notificationTimes array', () => {
+    const { getByText, onUpdate, UNSAFE_root } = renderModal({
+      habit: { ...baseHabit, notificationTimes: undefined },
+    });
+
+    fireEvent.press(getByText('08:00'));
+    const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
+      (node: { props: { mode?: string } }) => node.props.mode === 'time',
+    )!;
+    fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
+    fireEvent.press(getByText('+'));
+
+    fireEvent.press(getByText('Save Changes'));
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ notificationTimes: ['09:05'] }),
+    );
+  });
+
+  it('toggles a day when the habit has no existing notificationDays array', () => {
+    const { getByText, onUpdate } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: 'custom', notificationDays: undefined },
+    });
+
+    fireEvent.press(getByText('Select days'));
+    fireEvent.press(getByText('Mon'));
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ notificationDays: ['Monday'] }),
+    );
+  });
+});
+
+describe('HabitSettingsModal actions', () => {
+  it('opens the reorder modal with the full habit list', () => {
+    const { getByText, onOpenReorderModal } = renderModal();
+    fireEvent.press(getByText('Reorder Habits'));
+    expect(onOpenReorderModal).toHaveBeenCalledWith([baseHabit]);
+  });
+
+  it('saves the edited habit and closes', () => {
+    const { getByDisplayValue, getByText, onUpdate, onClose } = renderModal();
+    fireEvent.changeText(getByDisplayValue('Morning walk'), 'Evening walk');
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 42, name: 'Evening walk' }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes via the header close button without saving', () => {
+    const { getAllByText, onClose, onUpdate } = renderModal();
+    fireEvent.press(getAllByText('×')[0]!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('cancels a delete via the confirmation dialog', () => {
+    const { getByText, getByTestId, onDelete, onClose } = renderModal();
+    fireEvent.press(getByText('Delete Habit'));
+    getByTestId('delete-habit-confirm');
+
+    fireEvent.press(getByTestId('delete-habit-cancel'));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('confirms a delete, calling onDelete then onClose', () => {
+    const { getByText, getByTestId, onDelete, onClose } = renderModal();
+    fireEvent.press(getByText('Delete Habit'));
+
+    fireEvent.press(getByTestId('delete-habit-confirm-button'));
+    expect(onDelete).toHaveBeenCalledWith(42);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips saving when the habit has no id', () => {
+    const { getByText, onUpdate, onClose } = renderModal({ habit: { ...baseHabit, id: 0 } });
+    fireEvent.press(getByText('Save Changes'));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('skips opening the delete confirmation when the habit has no id', () => {
+    const { getByText, queryByTestId } = renderModal({ habit: { ...baseHabit, id: 0 } });
+    fireEvent.press(getByText('Delete Habit'));
+    expect(queryByTestId('delete-habit-confirm')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
@@ -11,13 +11,26 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
 // ``react-native-calendars`` ships as ESM; the parent module is only used
-// at runtime for the date-picker calendar so a stub is fine for the
-// ``ResetConfirmation``-only render tests.
-jest.mock('react-native-calendars', () => ({
-  Calendar: () => null,
-}));
+// at runtime for the date-picker calendar. This stub records ``onDayPress``
+// via a jest.fn passthrough and forwards a fixed day pick through a
+// pressable so calendar-driven branches can be exercised without pulling
+// in the real native calendar implementation.
+jest.mock('react-native-calendars', () => {
+  const ReactLib = require('react');
+  const RN = require('react-native');
+  const Calendar = (props: { onDayPress: (_day: { dateString: string }) => void }) => {
+    const handlePress = jest.fn(() => props.onDayPress({ dateString: '2026-08-10' }));
+    return ReactLib.createElement(
+      RN.TouchableOpacity,
+      { testID: 'calendar-mock-day', onPress: handlePress },
+      ReactLib.createElement(RN.Text, null, 'calendar-mock'),
+    );
+  };
+  return { Calendar };
+});
 
-import { ResetConfirmation } from '../MissedDaysModal';
+import type { Habit, MissedDaysModalProps } from '../../Habits.types';
+import { MissedDaysModal, ResetConfirmation } from '../MissedDaysModal';
 
 describe('ResetConfirmation (BUG-FE-HABIT-202)', () => {
   const pendingDate = new Date(2026, 4, 15); // May 15 2026 in local TZ
@@ -68,5 +81,150 @@ describe('ResetConfirmation (BUG-FE-HABIT-202)', () => {
     fireEvent.press(getByTestId('reset-confirm-cancel'));
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+const baseHabit: Habit = {
+  id: 7,
+  stage: 'Beige',
+  name: 'Journaling',
+  icon: '📓',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 1,
+  start_date: new Date('2026-01-01T00:00:00.000Z'),
+  goals: [],
+};
+
+const missedDays = [new Date('2026-07-01T00:00:00.000Z'), new Date('2026-07-02T00:00:00.000Z')];
+
+const renderMissedDaysModal = (overrides: Partial<MissedDaysModalProps> = {}) => {
+  const onClose = jest.fn();
+  const onBackfill = jest.fn();
+  const onNewStartDate = jest.fn();
+  const utils = render(
+    <MissedDaysModal
+      visible
+      habit={baseHabit}
+      missedDays={missedDays}
+      onClose={onClose}
+      onBackfill={onBackfill}
+      onNewStartDate={onNewStartDate}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onClose, onBackfill, onNewStartDate };
+};
+
+describe('MissedDaysModal visibility guards', () => {
+  it('renders nothing when there is no habit', () => {
+    const { toJSON } = render(
+      <MissedDaysModal
+        visible
+        habit={null}
+        missedDays={missedDays}
+        onClose={jest.fn()}
+        onBackfill={jest.fn()}
+        onNewStartDate={jest.fn()}
+      />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when there are no missed days', () => {
+    const { toJSON } = renderMissedDaysModal({ missedDays: [] });
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('MissedDaysModal message content', () => {
+  it('names the habit and pluralizes the missed-day count', () => {
+    const { getByText } = renderMissedDaysModal();
+    getByText("We missed 2 days for 'Journaling'.");
+    getByText("Did you keep up with 'Journaling' while you were gone?");
+  });
+
+  it('does not pluralize a single missed day', () => {
+    const { getByText } = renderMissedDaysModal({ missedDays: [missedDays[0]!] });
+    getByText("We missed 1 day for 'Journaling'.");
+  });
+});
+
+describe('MissedDaysModal backfill and dismiss actions', () => {
+  it('backfills every missed day and closes', () => {
+    const { getByText, onBackfill, onClose } = renderMissedDaysModal();
+    fireEvent.press(getByText('Yes, I did it!'));
+    expect(onBackfill).toHaveBeenCalledWith(7, missedDays);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes without backfilling when the user just continues', () => {
+    const { getByText, onBackfill, onClose } = renderMissedDaysModal();
+    fireEvent.press(getByText('Just continue'));
+    expect(onBackfill).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MissedDaysModal guards against a missing habit id', () => {
+  it('skips the backfill call when the habit has no id', () => {
+    const { getByText, onBackfill, onClose } = renderMissedDaysModal({
+      habit: { ...baseHabit, id: 0 },
+    });
+    fireEvent.press(getByText('Yes, I did it!'));
+    expect(onBackfill).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('skips the start-date reset when the habit has no id', () => {
+    const { getByText, getByTestId, onNewStartDate, onClose } = renderMissedDaysModal({
+      habit: { ...baseHabit, id: 0 },
+    });
+    fireEvent.press(getByText('Set new start date'));
+    fireEvent.press(getByTestId('calendar-mock-day'));
+    fireEvent.press(getByTestId('reset-confirm-yes'));
+
+    expect(onNewStartDate).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('MissedDaysModal reset-start-date flow', () => {
+  it('shows the calendar after choosing to set a new start date', () => {
+    const { getByText, getByTestId } = renderMissedDaysModal();
+    fireEvent.press(getByText('Set new start date'));
+    getByTestId('calendar-mock-day');
+  });
+
+  it('holds the picked day for confirmation instead of resetting immediately', () => {
+    const { getByText, getByTestId, onNewStartDate } = renderMissedDaysModal();
+    fireEvent.press(getByText('Set new start date'));
+    fireEvent.press(getByTestId('calendar-mock-day'));
+
+    getByTestId('reset-confirm-warning');
+    expect(onNewStartDate).not.toHaveBeenCalled();
+  });
+
+  it('returns to the calendar when the pending reset is cancelled', () => {
+    const { getByText, getByTestId, queryByTestId } = renderMissedDaysModal();
+    fireEvent.press(getByText('Set new start date'));
+    fireEvent.press(getByTestId('calendar-mock-day'));
+
+    fireEvent.press(getByTestId('reset-confirm-cancel'));
+    expect(queryByTestId('reset-confirm-warning')).toBeNull();
+    getByTestId('calendar-mock-day');
+  });
+
+  it('resets the start date and closes on confirmation', () => {
+    const { getByText, getByTestId, onNewStartDate, onClose } = renderMissedDaysModal();
+    fireEvent.press(getByText('Set new start date'));
+    fireEvent.press(getByTestId('calendar-mock-day'));
+
+    fireEvent.press(getByTestId('reset-confirm-yes'));
+    expect(onNewStartDate).toHaveBeenCalledTimes(1);
+    const [habitId, newDate] = onNewStartDate.mock.calls[0] as [number, Date];
+    expect(habitId).toBe(7);
+    expect(newDate.toISOString().slice(0, 10)).toBe('2026-08-10');
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.energySliders.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.energySliders.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent, within } from '@testing-library/react-native';
+import React from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('@react-native-community/slider', () => 'Slider');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+
+const setupToCostStep = () => {
+  const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, 'Habit');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+  fireEvent.press(result.getByTestId('continue-button'));
+  fireEvent.press(result.getByTestId('count-warning-continue'));
+  return result;
+};
+
+const setupToReturnStep = () => {
+  const result = setupToCostStep();
+  fireEvent.press(result.getByTestId('continue-button'));
+  return result;
+};
+
+describe('OnboardingModal cost slider bounds', () => {
+  it('updates the tile value when the slider moves within range', () => {
+    const { getByTestId } = setupToCostStep();
+    fireEvent(getByTestId('cost-slider'), 'valueChange', 8);
+
+    const tile = getByTestId('energy-tile-0');
+    expect(within(tile).getByText('8')).toBeTruthy();
+  });
+
+  it('ignores a slider value below the valid 0-10 range', () => {
+    const { getByTestId } = setupToCostStep();
+    fireEvent(getByTestId('cost-slider'), 'valueChange', -1);
+
+    const tile = getByTestId('energy-tile-0');
+    expect(within(tile).getByText('5')).toBeTruthy();
+  });
+
+  it('ignores a slider value above the valid 0-10 range', () => {
+    const { getByTestId } = setupToCostStep();
+    fireEvent(getByTestId('cost-slider'), 'valueChange', 11);
+
+    const tile = getByTestId('energy-tile-0');
+    expect(within(tile).getByText('5')).toBeTruthy();
+  });
+
+  it('rounds a fractional slider value to the nearest whole number', () => {
+    const { getByTestId } = setupToCostStep();
+    fireEvent(getByTestId('cost-slider'), 'valueChange', 6.6);
+
+    const tile = getByTestId('energy-tile-0');
+    expect(within(tile).getByText('7')).toBeTruthy();
+  });
+});
+
+describe('OnboardingModal return energy step', () => {
+  it('shows the Energy Return title and subtitle copy', () => {
+    const { getByText } = setupToReturnStep();
+    getByText('Energy Return');
+    getByText(/lights you up and feels deeply rewarding/i);
+  });
+
+  it('updates the return-energy tile value when its slider moves', () => {
+    const { getByTestId } = setupToReturnStep();
+    fireEvent(getByTestId('return-slider'), 'valueChange', 9);
+
+    const tile = getByTestId('energy-tile-0');
+    expect(within(tile).getByText('9')).toBeTruthy();
+  });
+
+  it('navigates back to the cost step via the Back button', () => {
+    const { getByText, queryByText } = setupToReturnStep();
+    fireEvent.press(getByText('Back'));
+
+    getByText('Energy Cost');
+    expect(queryByText('Energy Return')).toBeNull();
+  });
+});
+
+describe('OnboardingModal cost step Back-and-forth navigation', () => {
+  it('navigates back to step 1 via the cost step Back button', () => {
+    const { getByText, queryByText } = setupToCostStep();
+    fireEvent.press(getByText('Back'));
+
+    getByText('Create Your Habits');
+    expect(queryByText('Energy Cost')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.keyboardShortcut.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.keyboardShortcut.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+
+describe('OnboardingModal Ctrl+Enter shortcut', () => {
+  it('advances to the cost step on Ctrl+Enter, not just Cmd+Enter', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Read');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter', ctrlKey: true } });
+    getByText('Energy Cost');
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.reorderIcons.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.reorderIcons.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { ReactElement, ReactNode } from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return ({
+    data,
+    renderItem,
+    onDragEnd,
+    testID,
+    contentContainerStyle,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    data: { id: string }[];
+    renderItem: (info: {
+      item: { id: string };
+      index: number;
+      drag: () => void;
+      isActive: boolean;
+      getIndex: () => number;
+    }) => ReactElement;
+    onDragEnd?: (info: unknown) => void;
+    testID?: string;
+    contentContainerStyle?: unknown;
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) => (
+    <View testID={testID} onDragEnd={onDragEnd} data={data} style={contentContainerStyle}>
+      {ListHeaderComponent}
+      {data.map((item, index) =>
+        React.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id },
+        ),
+      )}
+      {ListFooterComponent}
+    </View>
+  );
+});
+
+const REVEAL_TOTAL_MS = 150 * 2 + 500 + 100; // 2 habits x 150ms stagger + 500ms pause + 100ms settle
+
+const setupToReorder = () => {
+  const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, 'Habit A');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+  jest.advanceTimersByTime(1); // ensure unique Date.now() IDs
+  fireEvent.changeText(input, 'Habit B');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+  const advance = () => {
+    fireEvent.press(result.getByTestId('continue-button'));
+    const warn = result.queryByTestId('count-warning-continue');
+    if (warn) fireEvent.press(warn);
+  };
+  advance();
+  advance();
+  act(() => {
+    advance();
+  });
+  act(() => {
+    jest.advanceTimersByTime(REVEAL_TOTAL_MS);
+  });
+  return result;
+};
+
+describe('OnboardingModal reorder step icon editing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('opens the emoji picker for a habit and applies the selected icon', () => {
+    const { getAllByText, getByText, UNSAFE_root } = setupToReorder();
+    fireEvent.press(getAllByText('📝')[0]!);
+
+    const selector = UNSAFE_root.findByType('EmojiSelector');
+    fireEvent(selector, 'onEmojiSelected', '🎯');
+
+    getByText('🎯 Habit A');
+    expect(() => UNSAFE_root.findByType('EmojiSelector')).toThrow();
+  });
+
+  it('closes the emoji picker without changing the icon when dismissed via the close button', () => {
+    const { getAllByText, getByText, queryByText, UNSAFE_root } = setupToReorder();
+    fireEvent.press(getAllByText('📝')[0]!);
+    expect(UNSAFE_root.findByType('EmojiSelector')).toBeTruthy();
+
+    const closeButtons = getAllByText('×');
+    fireEvent.press(closeButtons[closeButtons.length - 1]!);
+
+    expect(() => UNSAFE_root.findByType('EmojiSelector')).toThrow();
+    expect(queryByText('🎯 Habit A')).toBeNull();
+    getByText('⭐ Habit A');
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.replay.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.replay.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+// Only the header/footer slots matter here (no test in this file interacts
+// with an individual reorder row), so the mock skips ``renderItem`` and the
+// drag wiring entirely rather than reproducing the full fixture used by the
+// reorder-focused suites.
+jest.mock('react-native-draggable-flatlist', () => {
+  const { View } = require('react-native');
+  return function MockDraggableFlatList({
+    testID,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    testID?: string;
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) {
+    return (
+      <View testID={testID}>
+        {ListHeaderComponent}
+        {ListFooterComponent}
+      </View>
+    );
+  };
+});
+jest.mock('../../../../api', () => ({
+  goalGroups: {
+    list: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+const STAGGER_DELAY_MS = 150;
+const SORT_PAUSE_MS = 500;
+const REVEAL_SETTLE_MS = 100;
+const REVEAL_TOTAL_MS = STAGGER_DELAY_MS * 1 + SORT_PAUSE_MS + REVEAL_SETTLE_MS;
+
+const runOnePass = (result: ReturnType<typeof render>, habitName: string) => {
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, habitName);
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+
+  fireEvent.press(result.getByTestId('continue-button'));
+  const warn = result.queryByTestId('count-warning-continue');
+  if (warn) fireEvent.press(warn);
+  fireEvent.press(result.getByTestId('continue-button'));
+
+  act(() => {
+    fireEvent.press(result.getByTestId('continue-button'));
+  });
+};
+
+describe('OnboardingModal reveal replay guard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('skips the reveal animation on a second pass through onboarding in the same session', async () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+
+    // First pass: the reveal animation plays out and finishes.
+    runOnePass(result, 'Habit A');
+    act(() => {
+      jest.advanceTimersByTime(REVEAL_TOTAL_MS);
+    });
+    expect(result.getByText('Your optimal habit order:')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+    fireEvent.press(result.getByTestId('finish-setup'));
+
+    // Finishing resets to step 1 with an empty habit list, but the modal
+    // instance stays mounted -- add a fresh habit and run the flow again.
+    expect(result.getByText('Create Your Habits')).toBeTruthy();
+    runOnePass(result, 'Habit B');
+
+    // The second pass must land directly on the reorder step: the
+    // multi-second stagger/sort reveal animation must not replay.
+    expect(result.queryByText('Calculating your energy order...')).toBeNull();
+    expect(result.getByTestId('reorder-list')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1b.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.step1b.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent, within } from '@testing-library/react-native';
+import React from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+
+describe('OnboardingModal step 1 extra interactions', () => {
+  it('ignores key presses other than Enter', () => {
+    const { getByPlaceholderText, getByTestId } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Stretch');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'a' } });
+
+    expect(getByTestId('habit-count')).toHaveTextContent('0 / 10');
+    expect(input.props.value).toBe('Stretch');
+  });
+
+  it('pressing Enter with a blank input does not add a habit', () => {
+    const { getByPlaceholderText, getByTestId } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, '   ');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+
+    expect(getByTestId('habit-count')).toHaveTextContent('0 / 10');
+  });
+
+  it('Cmd+Enter does nothing when there are no habits yet', () => {
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter', metaKey: true } });
+
+    expect(queryByText('Energy Cost')).toBeNull();
+    getByText('Create Your Habits');
+  });
+
+  it('removes a habit from the list when its chip X is pressed', () => {
+    const { getByPlaceholderText, getByTestId, queryByTestId } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Yoga');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    expect(getByTestId('habit-count')).toHaveTextContent('1 / 10');
+
+    const chip = getByTestId('habit-chip');
+    fireEvent.press(within(chip).getByText('×'));
+
+    expect(queryByTestId('habit-chip')).toBeNull();
+    expect(getByTestId('habit-count')).toHaveTextContent('0 / 10');
+  });
+
+  it('Keep Adding on the count-warning dialog stays on step 1', () => {
+    const { getByPlaceholderText, getByTestId, getByText, queryByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    fireEvent.changeText(input, 'Read');
+    fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    fireEvent.press(getByTestId('continue-button'));
+    getByText("You've entered 1 of 10. Continue anyway?");
+
+    fireEvent.press(getByTestId('count-warning-keep'));
+
+    expect(queryByText('Energy Cost')).toBeNull();
+    getByText('Create Your Habits');
+  });
+
+  it('Continue with exactly 10 habits skips the count-warning dialog', () => {
+    const { getByPlaceholderText, getByTestId, getByText, queryByText } = render(
+      <OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Enter habit name');
+    for (let i = 0; i < 10; i++) {
+      fireEvent.changeText(input, `Habit ${i}`);
+      fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+    }
+    expect(getByTestId('habit-count')).toHaveTextContent('10 / 10');
+
+    fireEvent.press(getByTestId('continue-button'));
+
+    expect(queryByText(/Continue anyway/i)).toBeNull();
+    getByText('Energy Cost');
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.templateStep.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.templateStep.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { ReactElement, ReactNode } from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return ({
+    data,
+    renderItem,
+    onDragEnd,
+    testID,
+    contentContainerStyle,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    data: { id: string }[];
+    renderItem: (info: {
+      item: { id: string };
+      index: number;
+      drag: () => void;
+      isActive: boolean;
+      getIndex: () => number;
+    }) => ReactElement;
+    onDragEnd?: (info: unknown) => void;
+    testID?: string;
+    contentContainerStyle?: unknown;
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) => (
+    <View testID={testID} onDragEnd={onDragEnd} data={data} style={contentContainerStyle}>
+      {ListHeaderComponent}
+      {data.map((item, index) =>
+        React.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id },
+        ),
+      )}
+      {ListFooterComponent}
+    </View>
+  );
+});
+jest.mock('../../../../api', () => ({
+  goalGroups: {
+    list: jest.fn(() =>
+      Promise.resolve([
+        { id: 1, name: 'Meditation Goals', icon: '🧘', shared_template: true, goals: [] },
+        { id: 2, name: 'Private Goals', icon: '🔒', shared_template: false, goals: [] },
+        { id: 3, name: 'Unlabeled Goals', shared_template: true, goals: [] },
+      ]),
+    ),
+  },
+}));
+
+const STAGGER_DELAY_MS = 150;
+const SORT_PAUSE_MS = 500;
+
+const advanceToTemplatesGate = (result: ReturnType<typeof render>) => {
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, 'Habit A');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+
+  fireEvent.press(result.getByTestId('continue-button'));
+  const warn = result.queryByTestId('count-warning-continue');
+  if (warn) fireEvent.press(warn);
+  fireEvent.press(result.getByTestId('continue-button'));
+
+  act(() => {
+    fireEvent.press(result.getByTestId('continue-button'));
+  });
+  act(() => {
+    jest.advanceTimersByTime(STAGGER_DELAY_MS + SORT_PAUSE_MS + 100);
+  });
+};
+
+describe('OnboardingModal template step (success path)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('lists only shared templates and hides private ones', async () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.getByText(/Meditation Goals/)).toBeTruthy();
+    expect(result.queryByText(/Private Goals/)).toBeNull();
+  });
+
+  it('renders a template missing an icon without crashing', async () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    expect(result.getByText(/Unlabeled Goals/)).toBeTruthy();
+  });
+
+  it('assigns a selected template to the habit and includes it when saving', async () => {
+    const onSave = jest.fn();
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={onSave} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    fireEvent.press(result.getByTestId('template-1-0'));
+    fireEvent.press(result.getByTestId('finish-setup'));
+
+    const saved = (
+      onSave.mock.calls[0]?.[0] as { goal_group_id: number | null }[] | undefined
+    )?.[0];
+    expect(saved?.goal_group_id).toBe(1);
+  });
+
+  it('reassigning None after selecting a template clears the goal_group_id', async () => {
+    const onSave = jest.fn();
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={onSave} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    fireEvent.press(result.getByTestId('template-1-0'));
+    fireEvent.press(result.getByTestId('template-none-0'));
+    fireEvent.press(result.getByTestId('finish-setup'));
+
+    const saved = (
+      onSave.mock.calls[0]?.[0] as { goal_group_id: number | null }[] | undefined
+    )?.[0];
+    expect(saved?.goal_group_id).toBeNull();
+  });
+
+  it('returns to the reorder step via the Back button', async () => {
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={jest.fn()} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    fireEvent.press(result.getByText('Back'));
+    // Back returns to step 4; the reveal phase reset to idle on the way out, so
+    // the reorder step re-renders with its pre-reveal header and the templates CTA.
+    expect(result.getByText('Reorder Your Habits')).toBeTruthy();
+    expect(result.getByTestId('continue-to-templates')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.templateStepError.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.templateStepError.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { ReactElement, ReactNode } from 'react';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return ({
+    data,
+    renderItem,
+    onDragEnd,
+    testID,
+    contentContainerStyle,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    data: { id: string }[];
+    renderItem: (info: {
+      item: { id: string };
+      index: number;
+      drag: () => void;
+      isActive: boolean;
+      getIndex: () => number;
+    }) => ReactElement;
+    onDragEnd?: (info: unknown) => void;
+    testID?: string;
+    contentContainerStyle?: unknown;
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) => (
+    <View testID={testID} onDragEnd={onDragEnd} data={data} style={contentContainerStyle}>
+      {ListHeaderComponent}
+      {data.map((item, index) =>
+        React.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id },
+        ),
+      )}
+      {ListFooterComponent}
+    </View>
+  );
+});
+jest.mock('../../../../api', () => ({
+  goalGroups: {
+    list: jest.fn(() => Promise.reject(new Error('network down'))),
+  },
+}));
+
+const STAGGER_DELAY_MS = 150;
+const SORT_PAUSE_MS = 500;
+
+const advanceToTemplatesGate = (result: ReturnType<typeof render>) => {
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, 'Habit A');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+
+  fireEvent.press(result.getByTestId('continue-button'));
+  const warn = result.queryByTestId('count-warning-continue');
+  if (warn) fireEvent.press(warn);
+  fireEvent.press(result.getByTestId('continue-button'));
+
+  act(() => {
+    fireEvent.press(result.getByTestId('continue-button'));
+  });
+  act(() => {
+    jest.advanceTimersByTime(STAGGER_DELAY_MS + SORT_PAUSE_MS + 100);
+  });
+};
+
+describe('OnboardingModal template step (fetch failure)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('saves the habits and closes immediately when the templates fetch fails', async () => {
+    const onSave = jest.fn();
+    const onClose = jest.fn();
+    const result = render(<OnboardingModal visible onClose={onClose} onSaveHabits={onSave} />);
+    advanceToTemplatesGate(result);
+
+    await act(async () => {
+      fireEvent.press(result.getByTestId('continue-to-templates'));
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(result.queryByTestId('finish-setup')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.templatesRace.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.templatesRace.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import type { ReactNode } from 'react';
+
+import { goalGroups as goalGroupsApi } from '../../../../api';
+
+const OnboardingModal = require('../OnboardingModal').default;
+
+jest.mock('../../constants', () => ({ DEFAULT_ICONS: ['⭐'] }));
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+// Only the header/footer slots matter here (no test in this file interacts
+// with an individual reorder row), so the mock skips ``renderItem`` and the
+// drag wiring entirely rather than reproducing the full fixture used by the
+// reorder-focused suites.
+jest.mock('react-native-draggable-flatlist', () => {
+  const { View } = require('react-native');
+  return function MockDraggableFlatList({
+    testID,
+    ListHeaderComponent,
+    ListFooterComponent,
+  }: {
+    testID?: string;
+    ListHeaderComponent?: ReactNode;
+    ListFooterComponent?: ReactNode;
+  }) {
+    return (
+      <View testID={testID}>
+        {ListHeaderComponent}
+        {ListFooterComponent}
+      </View>
+    );
+  };
+});
+jest.mock('../../../../api', () => ({
+  goalGroups: { list: jest.fn() },
+}));
+
+const mockList = goalGroupsApi.list as jest.MockedFunction<typeof goalGroupsApi.list>;
+
+const STAGGER_DELAY_MS = 150;
+const SORT_PAUSE_MS = 500;
+
+const advanceToTemplatesGate = (result: ReturnType<typeof render>) => {
+  const input = result.getByPlaceholderText('Enter habit name');
+  fireEvent.changeText(input, 'Habit A');
+  fireEvent(input, 'onKeyPress', { nativeEvent: { key: 'Enter' } });
+
+  fireEvent.press(result.getByTestId('continue-button'));
+  const warn = result.queryByTestId('count-warning-continue');
+  if (warn) fireEvent.press(warn);
+  fireEvent.press(result.getByTestId('continue-button'));
+
+  act(() => {
+    fireEvent.press(result.getByTestId('continue-button'));
+  });
+  act(() => {
+    jest.advanceTimersByTime(STAGGER_DELAY_MS + SORT_PAUSE_MS + 100);
+  });
+};
+
+describe('OnboardingModal handleGoToTemplates stale-request guard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('drops the stale success response when continue is tapped twice before the first resolves', async () => {
+    mockList.mockResolvedValue([
+      { id: 1, name: 'Meditation Goals', icon: '🧘', shared_template: true, goals: [] },
+    ]);
+    const onSave = jest.fn();
+    const result = render(<OnboardingModal visible onClose={jest.fn()} onSaveHabits={onSave} />);
+    advanceToTemplatesGate(result);
+
+    const button = result.getByTestId('continue-to-templates');
+    await act(async () => {
+      fireEvent.press(button);
+      fireEvent.press(button);
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    // Both taps resolve, but the stale first response must not be allowed
+    // to route the user anywhere other than the current (second) request.
+    expect(result.getByTestId('finish-setup')).toBeTruthy();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('drops the stale failure response when continue is tapped twice and both fetches fail', async () => {
+    mockList.mockRejectedValue(new Error('network down'));
+    const onSave = jest.fn();
+    const onClose = jest.fn();
+    const result = render(<OnboardingModal visible onClose={onClose} onSaveHabits={onSave} />);
+    advanceToTemplatesGate(result);
+
+    const button = result.getByTestId('continue-to-templates');
+    await act(async () => {
+      fireEvent.press(button);
+      fireEvent.press(button);
+      await jest.advanceTimersByTimeAsync(10);
+    });
+
+    // Without the stale-request guard, the fallback save-and-close path
+    // would fire once per in-flight request instead of once overall.
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ReorderHabitsModal.test.tsx
@@ -268,6 +268,39 @@ describe('ReorderHabitsModal — program-anchor wiring', () => {
     const data = result.getByTestId('reorder-list').props.data as Habit[];
     expect(new Date(data[0]!.start_date).toISOString().slice(0, 10)).toBe('2024-03-15');
   });
+
+  it('re-syncs the displayed start date to the program anchor after a dismiss and re-open', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    // Anchor changes while open, then the modal is dismissed: the not-visible
+    // effect re-seeds startDate from the anchor so the next open reflects it.
+    act(() => useProgramStore.getState().hydrateProgramStartDate(new Date(2025, 0, 10)));
+    result.rerender(
+      <ReorderHabitsModal
+        visible={false}
+        habits={HABITS}
+        onClose={jest.fn()}
+        onSaveOrder={jest.fn()}
+      />,
+    );
+    result.rerender(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    expect(result.getByTestId('reorder-start-date')).toHaveTextContent('Jan 10, 2025');
+  });
+});
+
+describe('ReorderHabitsModal — empty habit list', () => {
+  it('seeds no rows when the modal opens with zero habits', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={[]} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    expect(getOrderedIds(result)).toEqual([]);
+  });
 });
 
 describe('ReorderHabitsModal — save flow', () => {
@@ -374,5 +407,18 @@ describe('ReorderHabitsModal — date picker on web', () => {
     expect(stored.getFullYear()).toBe(2026);
     expect(stored.getMonth()).toBe(8);
     expect(stored.getDate()).toBe(1);
+  });
+
+  it('ignores an empty web date-input change without touching the program anchor', () => {
+    const result = render(
+      <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+    );
+
+    const input = result.UNSAFE_root.findByProps({ type: 'date' });
+    act(() => {
+      input.props.onChange({ target: { value: '' } });
+    });
+
+    expect(useProgramStore.getState().programStartDate).toBeNull();
   });
 });

--- a/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/StatsModal.test.tsx
@@ -3,12 +3,23 @@ import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-// Mock chart libraries that don't render in test env
+// Mock chart libraries that don't render in test env. The captured-props refs
+// let branch tests inspect the color/config values computed by StatsModal
+// without needing the real chart/calendar implementations.
+const lastCalendarProps: { current: any } = { current: null };
+const lastLineChartProps: { current: any } = { current: null };
+
 jest.mock('react-native-calendars', () => ({
-  Calendar: () => null,
+  Calendar: (props: any) => {
+    lastCalendarProps.current = props;
+    return null;
+  },
 }));
 jest.mock('react-native-chart-kit', () => ({
-  LineChart: () => null,
+  LineChart: (props: any) => {
+    lastLineChartProps.current = props;
+    return null;
+  },
   BarChart: () => null,
 }));
 
@@ -158,6 +169,28 @@ describe('StatsModal', () => {
     // Switch to by-day tab
     fireEvent.press(getByText('By Day'));
     expect(getByText('Completions by Day of Week')).toBeTruthy();
+  });
+
+  it('falls back to the default calendar marker color for a stage without a design token', () => {
+    const habit = { ...baseHabit, stage: 'NotARealStage' };
+    const statsWithDates: HabitStatsData = { ...localStats, completionDates: ['2024-01-01'] };
+
+    render(
+      <StatsModal visible={true} habit={habit} stats={statsWithDates} onClose={jest.fn() as any} />,
+    );
+
+    expect(lastCalendarProps.current.markedDates['2024-01-01'].selectedColor).toBe('#50cebb');
+  });
+
+  it('falls back to the default chart color for a stage without a design token', () => {
+    const habit = { ...baseHabit, stage: 'NotARealStage' };
+
+    const { getByText } = render(
+      <StatsModal visible={true} habit={habit} stats={localStats} onClose={jest.fn() as any} />,
+    );
+    fireEvent.press(getByText('Progress'));
+
+    expect(lastLineChartProps.current.chartConfig.color()).toBe('rgba(134, 65, 244, 1)');
   });
 
   it('does not fetch when not visible', () => {

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -663,6 +663,144 @@ describe('habitManager', () => {
         { goal_id: 3, did_complete: true, timestamp: '2025-04-03T00:00:00Z' },
       ]);
     });
+
+    it('keeps cached habits and does not set an error when a real cache exists and the API fails', async () => {
+      const cached: Habit[] = [makeHabit({ id: 5, name: 'From Cache' })];
+      (loadHabits as jest.Mock).mockResolvedValueOnce(cached as never);
+      (habitsApi.listAll as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
+
+      await habitManager.loadHabits();
+
+      const { habits, error } = useHabitStore.getState();
+      expect(habits).toHaveLength(1);
+      expect(habits[0]!.name).toBe('From Cache');
+      expect(error).toBeNull();
+    });
+
+    it('does not replay cached goal targets when the post-recovery refetch fails', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, target: 30, target_unit: 'minutes' } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (habitsApi.listAll as jest.Mock)
+        .mockResolvedValueOnce([] as never)
+        .mockRejectedValueOnce(new Error('still down') as never);
+
+      await habitManager.loadHabits();
+
+      expect(habitsApi.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Pranayama' }));
+      expect(goalsApi.update).not.toHaveBeenCalled();
+      const stored = useHabitStore.getState().habits;
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.name).toBe('Pranayama');
+    });
+
+    it('replays a goal whose only difference from the server default is frequency', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, frequency: 2 } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(992, expect.objectContaining({ frequency: 2 }));
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.frequency).toBe(2);
+    });
+
+    it('replays a goal whose only difference from the server default is is_additive', async () => {
+      const cachedHabit = makeHabit({ id: 1, name: 'Pranayama' });
+      cachedHabit.goals = cachedHabit.goals.map((g) =>
+        g.tier === 'clear' ? { ...g, is_additive: false } : g,
+      );
+      (loadHabits as jest.Mock).mockResolvedValueOnce([cachedHabit] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never).mockResolvedValueOnce([
+        {
+          id: 99,
+          name: 'Pranayama',
+          icon: cachedHabit.icon,
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [
+            freshServerGoal(991, 'Low', 'low', 1),
+            freshServerGoal(992, 'Clear', 'clear', 2),
+            freshServerGoal(993, 'Stretch', 'stretch', 3),
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(goalsApi.update).toHaveBeenCalledWith(
+        992,
+        expect.objectContaining({ is_additive: false }),
+      );
+      const clear = useHabitStore.getState().habits[0]!.goals.find((g) => g.tier === 'clear')!;
+      expect(clear.is_additive).toBe(false);
+    });
+
+    it('skips a habit with an unparseable start_date when computing the program anchor', async () => {
+      useProgramStore.getState().hydrateProgramStartDate(null);
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 1,
+          name: 'Broken Date',
+          icon: '\u{1F9D8}',
+          start_date: 'not-a-real-date',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+        {
+          id: 2,
+          name: 'Valid Date',
+          icon: '\u{1F49C}',
+          start_date: '2026-02-15',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Purple',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      const anchor = useProgramStore.getState().programStartDate;
+      expect(anchor).not.toBeNull();
+      expect(anchor!.getFullYear()).toBe(2026);
+      expect(anchor!.getMonth()).toBe(1);
+      expect(anchor!.getDate()).toBe(15);
+    });
   });
 
   describe('updateGoalUnits', () => {
@@ -699,6 +837,29 @@ describe('habitManager', () => {
       expect(goals.every((g) => g.target_unit === 'units')).toBe(true);
       const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
       expect(Alert.alert).toHaveBeenCalled();
+    });
+
+    it('does nothing when no habit matches the given id', () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1 })] });
+
+      habitManager.updateGoalUnits(999, { target_unit: 'hours' });
+
+      const goals = useHabitStore.getState().habits[0]!.goals;
+      expect(goals.every((g) => g.target_unit === 'units')).toBe(true);
+      expect(habitsApi.updateGoalUnits).not.toHaveBeenCalled();
+      expect(saveHabits).not.toHaveBeenCalled();
+    });
+
+    it('skips the network call when a tier goal has no synthetic id', () => {
+      const habit = makeHabit();
+      habit.goals = habit.goals.map((g, i) => (i === 0 ? { ...g, id: undefined } : g));
+      useHabitStore.setState({ habits: [habit] });
+
+      habitManager.updateGoalUnits(1, { target_unit: 'hours' });
+
+      const goals = useHabitStore.getState().habits[0]!.goals;
+      expect(goals.every((g) => g.target_unit === 'hours')).toBe(true);
+      expect(habitsApi.updateGoalUnits).not.toHaveBeenCalled();
     });
   });
 
@@ -1413,6 +1574,180 @@ describe('habitManager', () => {
       expect(saveHabits).toHaveBeenLastCalledWith(
         expect.arrayContaining([expect.objectContaining({ id: 1, icon: 'A' })]),
       );
+    });
+  });
+
+  describe('onboardingSave error handling', () => {
+    it('logs and continues when a single habit fails to sync during onboarding', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      (habitsApi.create as jest.Mock).mockRejectedValueOnce(new Error('offline') as never);
+      const newHabits: OnboardingHabit[] = [
+        {
+          id: 'a',
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Beige',
+          start_date: new Date('2025-01-01'),
+        },
+      ];
+
+      await habitManager.onboardingSave(newHabits, jest.fn());
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Meditate'));
+      expect(useHabitStore.getState().habits).toHaveLength(1);
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('updateGoalUnits edge cases', () => {
+    it('does nothing when the matched habit has no goals to read a reference from', () => {
+      const emptyHabit = { ...makeHabit({ id: 5 }), goals: [] };
+      useHabitStore.setState({ habits: [emptyHabit] });
+
+      habitManager.updateGoalUnits(5, { target_unit: 'hours' });
+
+      expect(useHabitStore.getState().habits[0]!.goals).toEqual([]);
+      expect(habitsApi.updateGoalUnits).not.toHaveBeenCalled();
+      expect(saveHabits).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveHabitOrder with no server ids', () => {
+    it('stamps sort_order and persists locally without calling the API when no habit has an id', () => {
+      const local1 = { ...makeHabit({ id: 1 }), id: undefined } as unknown as Habit;
+      const local2 = { ...makeHabit({ id: 2 }), id: undefined } as unknown as Habit;
+      useHabitStore.setState({ habits: [local1, local2] });
+
+      habitManager.saveHabitOrder([local2, local1]);
+
+      const stored = useHabitStore.getState().habits;
+      expect(stored.map((h) => h.sort_order)).toEqual([0, 1]);
+      expect(saveHabits).toHaveBeenCalled();
+      expect(habitsApi.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commitLogUnitContext with a synthetic (id-less) current goal', () => {
+    it('returns null and skips the API call when the current goal has no server id', async () => {
+      const habit = makeHabit();
+      habit.goals = habit.goals.map((g) => (g.tier === 'low' ? { ...g, id: undefined } : g));
+      useHabitStore.setState({ habits: [habit] });
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
+
+      const result = await habitManager.commitLogUnitContext(ctx);
+
+      expect(result).toBeNull();
+      expect(goalCompletionsApi.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buildLogUnitToast tier-specific milestone copy', () => {
+    it('returns the Clear Goal milestone toast when the log crosses the clear threshold', () => {
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            completions: [{ id: 'pre', timestamp: new Date(), completed_units: 1 }],
+          }),
+        ],
+      });
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
+
+      const toast = habitManager.buildLogUnitToast(ctx);
+
+      expect(toast.message).toMatch(/Clear Goal achieved/i);
+    });
+
+    it('returns the Stretch Goal milestone toast when the log crosses the stretch threshold', () => {
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            completions: [{ id: 'pre', timestamp: new Date(), completed_units: 2 }],
+          }),
+        ],
+      });
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
+
+      const toast = habitManager.buildLogUnitToast(ctx);
+
+      expect(toast.message).toMatch(/Stretch Goal achieved/i);
+    });
+
+    it('falls back to the confirmation toast for a subtractive goal even when a threshold is crossed', () => {
+      const subtractiveHabit = makeHabit();
+      subtractiveHabit.goals = subtractiveHabit.goals.map((g) => ({ ...g, is_additive: false }));
+      useHabitStore.setState({ habits: [subtractiveHabit] });
+      const ctx = habitManager.prepareLogUnit(1, 1, 'UTC')!;
+
+      const toast = habitManager.buildLogUnitToast(ctx);
+
+      expect(toast.message).toMatch(/logged/i);
+    });
+  });
+
+  describe('toApiPayload defensive start_date handling', () => {
+    it('stringifies a non-Date start_date instead of crashing (defensive cast)', () => {
+      const habit = { ...makeHabit(), start_date: '2025-06-01' } as unknown as Habit;
+      useHabitStore.setState({ habits: [habit] });
+
+      habitManager.updateHabit(habit);
+
+      expect(habitsApi.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ start_date: '2025-06-01' }),
+      );
+    });
+  });
+
+  describe('replayPendingCheckIns with an explicit completed_on already queued', () => {
+    it('forwards the explicit completed_on instead of re-deriving it from the timestamp', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce([] as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
+      (loadPendingCheckIns as jest.Mock).mockResolvedValueOnce([
+        {
+          goal_id: 1,
+          did_complete: true,
+          timestamp: '2025-04-05T00:00:00Z',
+          completed_on: '2025-03-01',
+        },
+      ] as never);
+
+      await habitManager.loadHabits('UTC');
+
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: '2025-03-01',
+      });
+    });
+  });
+
+  describe('syncProgramAnchorFromHabits idempotency', () => {
+    it('does not re-set the program anchor when it already matches the earliest habit start date', async () => {
+      const anchor = new Date('2026-01-01T00:00:00Z');
+      useProgramStore.getState().hydrateProgramStartDate(anchor);
+      const setStateSpy = jest.spyOn(useProgramStore, 'setState');
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 1,
+          name: 'Survive',
+          icon: '\u{1F9D8}',
+          start_date: '2026-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(setStateSpy).not.toHaveBeenCalled();
+      setStateSpy.mockRestore();
     });
   });
 });

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -63,6 +63,7 @@ function renderScreen(
     promptQuestion?: string;
     prefillTitle?: string;
     practiceSessionId?: number;
+    userPracticeId?: number;
   },
   extraProps: Record<string, unknown> = {},
 ) {
@@ -129,6 +130,52 @@ describe('JournalEntryScreen', () => {
         expect.objectContaining({ message: 'That was calming.', practice_session_id: 55 }),
       );
       expect(mockRespond).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('pre-links a user practice on the created entry', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        { userPracticeId: 91, prefillTitle: 'After a habit check-in' },
+        { autosaveDelayMs: 100 },
+      );
+      fireEvent.changeText(getByTestId('journal-body-input'), 'That felt grounding.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'That felt grounding.', user_practice_id: 91 }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('never double-submits a weekly-prompt response on a second autosave', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        {
+          weekNumber: 3,
+          promptQuestion: 'What did you notice?',
+          prefillTitle: 'Week 3 Reflection',
+        },
+        { autosaveDelayMs: 100 },
+      );
+      fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockRespond).toHaveBeenCalledTimes(1);
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow and the oak.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockRespond).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }
@@ -303,6 +350,15 @@ describe('JournalEntryScreen', () => {
     });
     expect(mockGet).toHaveBeenCalledWith(7);
     expect(getByTestId('journal-body-input').props.value).toBe('An existing page.');
+  });
+
+  it('loads an existing draft with no title into a blank title field', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, title: null, message: 'No title yet.' }));
+    const { getByTestId } = renderScreen({ entryId: 7 });
+    await waitFor(() => {
+      expect(getByTestId('journal-body-input').props.value).toBe('No title yet.');
+    });
+    expect(getByTestId('journal-title-input').props.value).toBe('');
   });
 
   describe('edit gate (finished entries)', () => {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -194,3 +194,34 @@ describe('JournalEntryScreen — chord change PATCH failure', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Chord chosen before the entry exists — rides the first create, no PATCH yet
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — chord chosen before the first save', () => {
+  it('creates with the chosen aspect chord when set before the first save', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'An Aspect-tagged reflection.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ primary_aspect: 5, secondary_aspect: null }),
+      );
+      // No PATCH: the chord rode the create — there is no existing entry to update yet.
+      expect(mockUpdate).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+// Every other JournalEntryScreen test resolves completionSuggestions.list empty; these pin the pending-card render and the dismissed-suggestion filter.
+import type { CompletionSuggestion, JournalMessage } from '@/api';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockCompletionList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: CompletionSuggestion[] }>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: jest.fn(),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: (...a: unknown[]) =>
+      (mockCompletionList as unknown as (...x: unknown[]) => unknown)(...a),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'A page about a daily run.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Runs',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function suggestionRow(overrides: Partial<CompletionSuggestion> = {}): CompletionSuggestion {
+  return {
+    id: 90,
+    journal_entry_id: 7,
+    target_type: 'habit',
+    goal_id: 3,
+    user_practice_id: null,
+    label: 'Daily run',
+    anchor_start: 2,
+    anchor_end: 10,
+    anchor_text: 'a daily',
+    status: 'pending',
+    accepted_at: null,
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+function renderScreen(params?: { entryId?: number }) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return render(<Screen navigation={navigation} route={route} />);
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockCompletionList.mockReset();
+  mockCompletionList.mockResolvedValue({ items: [] });
+});
+
+describe('JournalEntryScreen — completion-suggestion margin cards', () => {
+  it('renders a pending completion-suggestion card in the margin when there are no notes', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7 }));
+    mockCompletionList.mockResolvedValue({ items: [suggestionRow()] });
+
+    const { findByTestId } = renderScreen({ entryId: 7 });
+
+    expect(await findByTestId('suggestion-90')).toBeTruthy();
+    expect(await findByTestId('suggestion-90-accept')).toBeTruthy();
+  });
+
+  it('filters out a dismissed suggestion, leaving only the pending one in the margin', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7 }));
+    mockCompletionList.mockResolvedValue({
+      items: [suggestionRow({ id: 90 }), suggestionRow({ id: 91, status: 'dismissed' })],
+    });
+
+    const { findByTestId, queryByTestId } = renderScreen({ entryId: 7 });
+
+    expect(await findByTestId('suggestion-90')).toBeTruthy();
+    expect(queryByTestId('suggestion-91')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -147,6 +147,46 @@ describe('JournalShelfScreen', () => {
     expect(getByTestId('journal-shelf-card-3')).toBeTruthy();
   });
 
+  it('captions each page with a relative "saved ... ago" phrase by age', async () => {
+    const DAY_MS = 86_400_000;
+    const ago = (days: number) => new Date(Date.now() - days * DAY_MS).toISOString();
+    mockList.mockResolvedValue(
+      page([
+        entry(1, { timestamp: ago(0) }),
+        entry(2, { timestamp: ago(1) }),
+        entry(3, { timestamp: ago(5) }),
+      ]),
+    );
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    const card1 = await findByTestId('journal-shelf-card-1');
+    const card2 = getByTestId('journal-shelf-card-2');
+    const card3 = getByTestId('journal-shelf-card-3');
+    expect(within(card1).getByText(/saved today/)).toBeTruthy();
+    expect(within(card2).getByText(/saved 1 day ago/)).toBeTruthy();
+    expect(within(card3).getByText(/saved 5 days ago/)).toBeTruthy();
+  });
+
+  it('falls back to the absolute saved date once an entry is a month or older', async () => {
+    const DAY_MS = 86_400_000;
+    const oldTimestamp = new Date(Date.now() - 45 * DAY_MS).toISOString();
+    mockList.mockResolvedValue(page([entry(9, { timestamp: oldTimestamp })]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    const card = await findByTestId('journal-shelf-card-9');
+    // No relative "saved N days ago" phrasing once the entry ages out of that
+    // window — the caption falls back to the absolute saved date instead.
+    expect(within(card).queryByText(/saved \d+ days? ago/)).toBeNull();
+    expect(within(card).queryByText(/saved today/)).toBeNull();
+  });
+
+  it('truncates a long entry body to an ellipsis excerpt', async () => {
+    const longBody = 'word '.repeat(60).trim();
+    mockList.mockResolvedValue(page([entry(4, { message: longBody })]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    const card = await findByTestId('journal-shelf-card-4');
+    expect(within(card).getByText(new RegExp(`${String.fromCharCode(0x2026)}$`))).toBeTruthy();
+    expect(within(card).queryByText(longBody)).toBeNull();
+  });
+
   it('starts a blank page from the empty-state call to action', async () => {
     mockList.mockResolvedValue(page([]));
     const { findByTestId } = render(<JournalShelfScreen />);
@@ -313,6 +353,23 @@ describe('JournalShelfScreen', () => {
     const { findByTestId, queryByTestId } = render(<JournalShelfScreen />);
     await findByTestId('journal-shelf-error');
     expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
+  });
+
+  it('falls back to "Untitled" and a matching a11y label when the entry has no title', async () => {
+    mockList.mockResolvedValue(page([entry(1, { title: null })]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    const card = await findByTestId('journal-shelf-card-1');
+    expect(within(card).getByText('Untitled')).toBeTruthy();
+    expect(card.props.accessibilityLabel).toBe('Open untitled entry');
+  });
+
+  it('drops the "saved" phrase from the caption for an unparseable timestamp', async () => {
+    mockList.mockResolvedValue(page([entry(1, { timestamp: 'not-a-real-date' })]));
+    const { findByTestId } = render(<JournalShelfScreen />);
+    const card = await findByTestId('journal-shelf-card-1');
+    // The "saved ... ago" half of the caption drops entirely instead of showing a garbled date.
+    expect(within(card).getByText('1 min read')).toBeTruthy();
+    expect(within(card).queryByText(/saved/)).toBeNull();
   });
 
   it('hides the warm affordance when a search returns no results', async () => {

--- a/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
+++ b/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
@@ -2,8 +2,11 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 
 import SearchBar from '../SearchBar';
+
+import { accent } from '@/design/tokens';
 
 describe('SearchBar', () => {
   let onSearch: jest.Mock;
@@ -98,5 +101,42 @@ describe('SearchBar', () => {
     );
     fireEvent.press(getByTestId('search-toggle'));
     expect(getByText("No results for 'willow'")).toBeTruthy();
+  });
+
+  it('applies the accent focus border on focus and reverts it on blur', () => {
+    const { getByTestId } = render(<SearchBar onSearch={onSearch} />);
+    fireEvent.press(getByTestId('search-toggle'));
+    const input = getByTestId('search-input');
+
+    expect(StyleSheet.flatten(input.props.style).borderColor).not.toBe(accent.primary);
+
+    fireEvent(input, 'focus');
+    expect(StyleSheet.flatten(input.props.style).borderColor).toBe(accent.primary);
+
+    fireEvent(input, 'blur');
+    expect(StyleSheet.flatten(input.props.style).borderColor).not.toBe(accent.primary);
+  });
+
+  it('syncs the input text when the parent resets searchQuery externally', () => {
+    const { getByTestId, rerender } = render(
+      <SearchBar onSearch={onSearch} searchQuery="willow" />,
+    );
+    expect(getByTestId('search-input').props.value).toBe('willow');
+
+    rerender(<SearchBar onSearch={onSearch} searchQuery="" />);
+    expect(getByTestId('search-input').props.value).toBe('');
+  });
+
+  it('clears a pending debounce timer on unmount without ever calling onSearch', () => {
+    const { getByTestId, unmount } = render(<SearchBar onSearch={onSearch} />);
+    fireEvent.press(getByTestId('search-toggle'));
+    fireEvent.changeText(getByTestId('search-input'), 'partial query');
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onSearch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -250,4 +250,57 @@ describe('MapScreen — Stage History', () => {
     });
     expect(mockHistoryFn).toHaveBeenCalledWith(1);
   });
+
+  it('shows the history loading spinner before the fetch resolves', async () => {
+    let resolveHistory: ((_v: StageHistoryData) => void) | undefined;
+    mockHistoryFn.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+    const tree = create(<MapScreen />);
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    act(() => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'history-loading' })).toBeTruthy();
+
+    await act(async () => {
+      resolveHistory?.(EMPTY_HISTORY);
+    });
+  });
+
+  it('does not refetch on collapse then re-expand once history has already loaded', async () => {
+    mockHistoryFn.mockResolvedValueOnce(HISTORY_WITH_DATA);
+    const tree = create(<MapScreen />);
+
+    await act(async () => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+    expect(mockHistoryFn).toHaveBeenCalledTimes(1);
+
+    // Collapse — the history content leaves the tree.
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+    const collapsed = tree.root.findAll(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (node: any) => node.props.testID === 'history-content',
+    );
+    expect(collapsed.length).toBe(0);
+
+    // Re-expand — the already-loaded history renders without a second fetch.
+    await act(async () => {
+      tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
+    });
+    expect(mockHistoryFn).toHaveBeenCalledTimes(1);
+    expect(tree.root.findByProps({ testID: 'history-content' })).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
@@ -1,0 +1,140 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// Other MapScreen suites always seed 10 cached stages, so the store-driven MapLoading/MapError early returns never render; this file covers those plus a stage with no free-will description.
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
+  runAfterInteractions: (cb: () => void) => {
+    cb();
+    return { then: () => {}, done: () => {}, cancel: () => {} };
+  },
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate }),
+}));
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+jest.mock('../../../store/useProgramProgression', () => ({
+  useDerivedCurrentStage: (fallback: number) => fallback,
+  useDerivedCurrentWeek: (fallback: number) => fallback,
+  useDaysUntilStage: () => null,
+}));
+
+jest.mock('../../../api', () => ({
+  stages: { history: () => new Promise(() => {}) },
+}));
+
+function mockMakeStage(stageNumber: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    progress: 0,
+    color: '#aaa',
+    isUnlocked: stageNumber <= 2,
+    category: 'Test',
+    aspect: 'Aspect',
+    spiralDynamicsColor: 'Beige',
+    growingUpStage: 'Growing',
+    divineGenderPolarity: 'Polarity',
+    relationshipToFreeWill: 'Free Will',
+    freeWillDescription: 'Description of free will.',
+    overviewUrl: '',
+    ...overrides,
+  };
+}
+
+let mockStages: ReturnType<typeof mockMakeStage>[] = Array.from({ length: 10 }, (_, i) =>
+  mockMakeStage(10 - i),
+);
+let mockLoading = false;
+let mockError: string | null = null;
+const mockLoadStages = jest.fn();
+
+jest.mock('../services/stageService', () => ({
+  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
+  isEndOfCycle: () => false,
+  isStageUnlocked: (
+    stage: { isUnlocked: boolean; stageNumber: number },
+    currentStage: number | null,
+  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
+}));
+
+const buildMockStageState = () => ({
+  stages: mockStages,
+  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
+  stageOrder: mockStages.map((s) => s.stageNumber),
+  currentStage: 1,
+  loading: mockLoading,
+  error: mockError,
+  setStages: jest.fn(),
+  setCurrentStage: jest.fn(),
+  setLoading: jest.fn(),
+  setError: jest.fn(),
+  updateStageProgress: jest.fn(),
+});
+
+jest.mock('../../../store/useStageStore', () => ({
+  useStageStore: jest.fn((selector) => {
+    const state = buildMockStageState();
+    return selector ? selector(state) : state;
+  }),
+  selectStages: (s: { stages: unknown }) => s.stages,
+  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+  selectStagesLoading: (s: { loading: unknown }) => s.loading,
+  selectStagesError: (s: { error: unknown }) => s.error,
+  selectCycleNumber: () => 1,
+}));
+
+import styles from '../Map.styles';
+import MapScreen from '../MapScreen';
+
+type TestNode = { props: Record<string, unknown> };
+
+describe('MapScreen — cold start and metadata edge cases', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLoadStages.mockClear();
+    mockLoading = false;
+    mockError = null;
+    mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('shows the full-screen loader when no stages are cached yet', () => {
+    mockLoading = true;
+    mockStages = [];
+    const tree = create(<MapScreen />);
+    expect(tree.root.findByProps({ testID: 'map-loading' })).toBeTruthy();
+  });
+
+  it('shows the full-screen error when the load fails with nothing cached', () => {
+    mockError = 'Could not reach the server.';
+    mockStages = [];
+    const tree = create(<MapScreen />);
+    expect(tree.root.findByProps({ testID: 'map-error' })).toBeTruthy();
+    expect(tree.root.findByProps({ children: 'Could not reach the server.' })).toBeTruthy();
+  });
+
+  it('omits the free-will description line for a stage that has none', () => {
+    mockStages = mockStages.map((s) =>
+      s.stageNumber === 1 ? { ...s, freeWillDescription: '' } : s,
+    );
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    expect(
+      tree.root.findAll((node: TestNode) => node.props.style === styles.freeWillDescription),
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type {
+  IntervalBellConfig,
+  MeditationTimerConfig,
+  MetronomeConfig,
+  MindfulAnchorConfig,
+  MindfulAnchorMetadata,
+  RepCounterConfig,
+  SenseGroundingConfig,
+  TalliedGroundingConfig,
+  TarotConfig,
+} from '../../engine/types';
+import { fakeState } from '../../views/__tests__/fixtures';
+import { harvestMetadata, harvestSummaryMetadata } from '../ActiveRitualSession';
+
+const meditationTimerConfig: MeditationTimerConfig = {
+  mode: 'meditation_timer',
+  duration_minutes: 10,
+};
+
+const countUpConfig = { mode: 'count_up' as const };
+
+const metronomeConfig: MetronomeConfig = {
+  mode: 'metronome',
+  bpm: 72,
+  timer: meditationTimerConfig,
+};
+
+const intervalBellConfig: IntervalBellConfig = {
+  mode: 'interval_bell',
+  duration_minutes: 10,
+  interval_minutes: 2,
+  bell_tone: 'chime',
+};
+
+const repCounterConfig: RepCounterConfig = {
+  mode: 'rep_counter',
+  target_reps: 20,
+  unit_label: 'reps',
+};
+
+const senseGroundingConfig: SenseGroundingConfig = {
+  mode: 'sense_grounding',
+  prompts: [
+    { sense: 'sight', label: 'something blue' },
+    { sense: 'touch', label: 'something soft' },
+  ],
+};
+
+const talliedGroundingConfig: TalliedGroundingConfig = {
+  mode: 'tallied_grounding',
+  rounds: 2,
+  categories: [
+    { key: 'square', label: 'a square', target_count: 3 },
+    { key: 'circle', label: 'a circle', target_count: 2 },
+  ],
+};
+
+const tarotConfig: TarotConfig = { mode: 'tarot', deck: 'major_arcana' };
+
+const mindfulAnchorConfig: MindfulAnchorConfig = {
+  mode: 'mindful_anchor',
+  instruction: 'Step outside.',
+  min_duration_seconds: 60,
+  options: [{ key: 'touch_grass', label: 'Touch grass' }],
+  require_option_choice: false,
+};
+
+describe('ActiveRitualSession harvesters — simple engine modes', () => {
+  it('meditation_timer harvests a bare-mode wire and summary payload', () => {
+    const wire = harvestMetadata(meditationTimerConfig, fakeState(), null);
+    const summary = harvestSummaryMetadata(meditationTimerConfig, fakeState(), 0, null);
+    expect(wire).toEqual({ mode: 'meditation_timer' });
+    expect(summary).toEqual({ mode: 'meditation_timer' });
+  });
+
+  it('count_up harvests a bare-mode wire and summary payload', () => {
+    const wire = harvestMetadata(countUpConfig, fakeState(), null);
+    const summary = harvestSummaryMetadata(countUpConfig, fakeState(), 0, null);
+    expect(wire).toEqual({ mode: 'count_up' });
+    expect(summary).toEqual({ mode: 'count_up' });
+  });
+
+  it('metronome harvests the bpm actually used', () => {
+    const wire = harvestMetadata(metronomeConfig, fakeState(), null);
+    const summary = harvestSummaryMetadata(metronomeConfig, fakeState(), 0, null);
+    expect(wire).toEqual({ mode: 'metronome', bpm_used: 72 });
+    expect(summary).toEqual({ mode: 'metronome', bpm_used: 72 });
+  });
+
+  it('rep_counter harvests the rep count for the wire and adds unit_label for the summary', () => {
+    const state = fakeState({ repCount: 14 });
+    const wire = harvestMetadata(repCounterConfig, state, null);
+    const summary = harvestSummaryMetadata(repCounterConfig, state, 0, null);
+    expect(wire).toEqual({ mode: 'rep_counter', rep_count: 14 });
+    expect(summary).toEqual({ mode: 'rep_counter', rep_count: 14, unit_label: 'reps' });
+  });
+});
+
+describe('ActiveRitualSession harvesters — interval_bell', () => {
+  it('counts struck intervals up to the elapsed time', () => {
+    const state = fakeState({ elapsedMs: 5 * 60_000 });
+    const wire = harvestMetadata(intervalBellConfig, state, null);
+    const summary = harvestSummaryMetadata(intervalBellConfig, state, 0, null);
+    expect(wire).toEqual(
+      expect.objectContaining({ mode: 'interval_bell', total_intervals: expect.any(Number) }),
+    );
+    expect(summary).toEqual(wire);
+  });
+});
+
+describe('ActiveRitualSession harvesters — sense_grounding', () => {
+  it('lists only the senses completed so far', () => {
+    const state = fakeState({ currentStepIndex: 1 });
+    const wire = harvestMetadata(senseGroundingConfig, state, null);
+    const summary = harvestSummaryMetadata(senseGroundingConfig, state, 0, null);
+    expect(wire).toEqual({ mode: 'sense_grounding', senses_completed: ['sight'] });
+    expect(summary).toEqual({ mode: 'sense_grounding', senses_completed: ['sight'] });
+  });
+
+  it('clamps to every prompt when currentStepIndex overruns the list', () => {
+    const state = fakeState({ currentStepIndex: 99 });
+    const wire = harvestMetadata(senseGroundingConfig, state, null);
+    expect(wire).toEqual({ mode: 'sense_grounding', senses_completed: ['sight', 'touch'] });
+  });
+});
+
+describe('ActiveRitualSession harvesters — tallied_grounding', () => {
+  it('derives rounds_completed from items_completed and per-round total', () => {
+    // perRound = 3 + 2 = 5; currentStepIndex 7 -> 1 full round, 7 items completed.
+    const state = fakeState({ currentStepIndex: 7 });
+    const wire = harvestMetadata(talliedGroundingConfig, state, null);
+    expect(wire).toEqual({
+      mode: 'tallied_grounding',
+      rounds_completed: 1,
+      total_rounds: 2,
+      items_completed: 7,
+    });
+    // The summary harvester for tallied_grounding reuses the wire harvester verbatim.
+    const summary = harvestSummaryMetadata(talliedGroundingConfig, state, 0, null);
+    expect(summary).toEqual(wire);
+  });
+
+  it('clamps items_completed to the ritual total', () => {
+    const state = fakeState({ currentStepIndex: 999 });
+    const wire = harvestMetadata(talliedGroundingConfig, state, null);
+    // Total steps = rounds(2) * perRound(5) = 10.
+    expect(wire).toMatchObject({ items_completed: 10 });
+  });
+});
+
+describe('ActiveRitualSession harvesters — tarot', () => {
+  it('normalizes the card index modulo the deck size for both wire and summary', () => {
+    const state = fakeState({ currentStepIndex: 25 });
+    const wire = harvestMetadata(tarotConfig, state, null);
+    const summary = harvestSummaryMetadata(tarotConfig, state, 25, null);
+    expect(wire).toEqual({ mode: 'tarot', card_index: 3 });
+    if (summary.mode === 'tarot') {
+      expect(summary.card_index).toBe(3);
+      expect(typeof summary.card_name).toBe('string');
+    } else {
+      throw new Error('expected tarot summary');
+    }
+  });
+
+  it('wraps a negative card index into a valid deck position', () => {
+    const state = fakeState({ currentStepIndex: -1 });
+    const wire = harvestMetadata(tarotConfig, state, null);
+    expect(wire).toEqual({ mode: 'tarot', card_index: 21 });
+  });
+});
+
+describe('ActiveRitualSession harvesters — mindful_anchor', () => {
+  it('falls back to the pre-save sentinel when no lifted metadata is present', () => {
+    const wire = harvestMetadata(mindfulAnchorConfig, fakeState(), null, null, null);
+    expect(wire).toEqual({
+      mode: 'mindful_anchor',
+      chosen_option_key: null,
+      duration_seconds: 0,
+      met_min_duration: false,
+    });
+    // The summary harvester for mindful_anchor is a bare-mode payload,
+    // independent of the lifted metadata.
+    const summary = harvestSummaryMetadata(mindfulAnchorConfig, fakeState(), 0, null);
+    expect(summary).toEqual({ mode: 'mindful_anchor' });
+  });
+
+  it('threads the lifted save payload into the wire harvest', () => {
+    const lifted: MindfulAnchorMetadata = {
+      mode: 'mindful_anchor',
+      chosen_option_key: 'touch_grass',
+      duration_seconds: 75,
+      met_min_duration: true,
+    };
+    const wire = harvestMetadata(mindfulAnchorConfig, fakeState(), null, null, lifted);
+    expect(wire).toEqual(lifted);
+  });
+});

--- a/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
@@ -181,6 +181,78 @@ describe('ShareSheet', () => {
     expect(typeof result).toBe('boolean');
   });
 
+  it('does not load links while the sheet is not visible', () => {
+    renderSheet({ visible: false });
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('labels an exhausted link when use_count reaches max_uses', async () => {
+    const first = sampleLinks[0];
+    if (!first) throw new Error('test fixture missing');
+    mockList.mockResolvedValueOnce([{ ...first, max_uses: 2, use_count: 2 }]);
+    const { findByText } = renderSheet();
+    expect(await findByText(/Exhausted/)).toBeTruthy();
+  });
+
+  it('labels an expired link when expires_at is in the past', async () => {
+    const first = sampleLinks[0];
+    if (!first) throw new Error('test fixture missing');
+    mockList.mockResolvedValueOnce([{ ...first, expires_at: '2020-01-01T00:00:00Z' }]);
+    const { findByText } = renderSheet();
+    expect(await findByText(/Expired/)).toBeTruthy();
+  });
+
+  it('surfaces a revoke failure via the inline error banner', async () => {
+    mockList.mockResolvedValueOnce(sampleLinks);
+    mockRevoke.mockRejectedValueOnce(new Error('offline'));
+
+    const { findByTestId } = renderSheet();
+    const revokeBtn = await findByTestId('share-sheet-revoke-1');
+    fireEvent.press(revokeBtn);
+
+    const banner = await findByTestId('share-sheet-error');
+    expect(banner).toBeTruthy();
+    // The row is still active — the revoke button remains for a retry.
+    expect(await findByTestId('share-sheet-revoke-1')).toBeTruthy();
+  });
+
+  it('shows the copy-failed banner when the copy button is pressed and clipboard is unavailable', async () => {
+    mockList.mockResolvedValueOnce(sampleLinks);
+    const { findByTestId, getByText } = renderSheet();
+    const copyBtn = await findByTestId('share-sheet-copy-1');
+    fireEvent.press(copyBtn);
+    await waitFor(() => {
+      expect(getByText('Could not copy — long-press the link to copy manually.')).toBeTruthy();
+    });
+  });
+
+  it('shows a pending indicator on the mint button while the request is in flight', async () => {
+    mockList.mockResolvedValueOnce([]);
+    mockCreate.mockReturnValueOnce(new Promise<ShareLinkResponse>(() => {}));
+
+    const { findByTestId, getByTestId } = renderSheet();
+    await findByTestId('share-sheet-empty');
+    fireEvent.press(getByTestId('share-sheet-mint'));
+
+    await waitFor(() => {
+      expect(getByTestId('share-sheet-mint-pending')).toBeTruthy();
+    });
+  });
+
+  it('hides the Revoke label while a revoke request is in flight', async () => {
+    mockList.mockResolvedValueOnce(sampleLinks);
+    mockRevoke.mockReturnValueOnce(new Promise<void>(() => {}));
+
+    const { findByTestId, queryByText } = renderSheet();
+    const revokeBtn = await findByTestId('share-sheet-revoke-1');
+    fireEvent.press(revokeBtn);
+
+    await waitFor(() => {
+      expect(queryByText('Revoke')).toBeNull();
+    });
+    expect(await findByTestId('share-sheet-revoke-1')).toBeTruthy();
+  });
+
   describe('copy-banner auto-dismiss (PR #359 review)', () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/frontend/src/features/Practice/hooks/__tests__/useActivePractice.test.tsx
+++ b/frontend/src/features/Practice/hooks/__tests__/useActivePractice.test.tsx
@@ -1,0 +1,296 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { PracticeItem, UserPractice } from '@/api';
+
+const mockListAll = jest.fn() as jest.MockedFunction<(_stage: number) => Promise<PracticeItem[]>>;
+const mockUserPracticesList = jest.fn() as jest.MockedFunction<() => Promise<UserPractice[]>>;
+const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
+  (_payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
+>;
+
+jest.mock('@/api', () => ({
+  practices: {
+    listAll: (...args: unknown[]) =>
+      (mockListAll as unknown as (...a: unknown[]) => Promise<PracticeItem[]>)(...args),
+  },
+  userPractices: {
+    list: (...args: unknown[]) =>
+      (mockUserPracticesList as unknown as (...a: unknown[]) => Promise<UserPractice[]>)(...args),
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
+  },
+}));
+
+const { useActivePractice } = require('../useActivePractice');
+
+const stagePractice: PracticeItem = {
+  id: 17,
+  stage_number: 5,
+  name: 'Concentration on the breath',
+  description: 'A breath practice',
+  instructions: 'Breathe.',
+  default_duration_minutes: 10,
+  approved: true,
+};
+
+const activeRow: UserPractice = {
+  id: 42,
+  practice_id: 17,
+  stage_number: 5,
+  start_date: '2026-01-01',
+  end_date: null,
+};
+
+describe('useActivePractice', () => {
+  beforeEach(() => {
+    mockListAll.mockReset();
+    mockUserPracticesList.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('resolves the active row for the stage and derives effectiveName/effectiveConfig', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([activeRow]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.activeUserPractice).toEqual(activeRow);
+    expect(result.current.practice).toEqual(stagePractice);
+    expect(result.current.effectiveName).toBe('Concentration on the breath');
+    expect(result.current.effectiveConfig).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns null effectiveConfig/effectiveName when there is no active row', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.activeUserPractice).toBeNull();
+    expect(result.current.practice).toBeNull();
+    expect(result.current.effectiveName).toBeNull();
+    expect(result.current.effectiveConfig).toBeNull();
+  });
+
+  it('ignores a user-practice row for a different stage', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([{ ...activeRow, stage_number: 9 }]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.activeUserPractice).toBeNull();
+  });
+
+  it('ignores a closed row (non-null end_date) for the stage', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([{ ...activeRow, end_date: '2026-02-01' }]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.activeUserPractice).toBeNull();
+  });
+
+  it('prefers server-resolved effective_name/effective_config over local fallbacks', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([
+      {
+        ...activeRow,
+        custom_name: 'My custom name',
+        effective_name: 'Server name',
+        mode_config_override: { mode: 'count_up' },
+        effective_config: { mode: 'meditation_timer', duration_minutes: 15 },
+      },
+    ]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.effectiveName).toBe('Server name');
+    expect(result.current.effectiveConfig).toEqual({
+      mode: 'meditation_timer',
+      duration_minutes: 15,
+    });
+  });
+
+  it('falls back to custom_name then mode_config_override when no server-resolved fields', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([
+      {
+        ...activeRow,
+        custom_name: 'My custom name',
+        mode_config_override: { mode: 'count_up' },
+      },
+    ]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.effectiveName).toBe('My custom name');
+    expect(result.current.effectiveConfig).toEqual({ mode: 'count_up' });
+  });
+
+  it('falls back to the catalog practice.name and mode_config as the last resort', async () => {
+    mockListAll.mockResolvedValue([
+      { ...stagePractice, mode_config: { mode: 'tarot', deck: 'major_arcana' } },
+    ]);
+    mockUserPracticesList.mockResolvedValue([activeRow]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.effectiveName).toBe('Concentration on the breath');
+    expect(result.current.effectiveConfig).toEqual({ mode: 'tarot', deck: 'major_arcana' });
+  });
+
+  it('surfaces a load failure via formatApiError and keeps isLoading false', async () => {
+    mockListAll.mockRejectedValue(new Error('network down'));
+    mockUserPracticesList.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toEqual(expect.any(String));
+    expect(result.current.error).not.toBeNull();
+  });
+
+  it('a silent refresh keeps isLoading unchanged while it revalidates', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([activeRow]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let resolveList: ((value: UserPractice[]) => void) | undefined;
+    mockUserPracticesList.mockReturnValueOnce(
+      new Promise<UserPractice[]>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    act(() => {
+      void result.current.refresh({ silent: true });
+    });
+
+    // isLoading must not flip true during a silent refresh.
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      resolveList?.([activeRow]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('selectPractice creates a user-practice row and sets it active', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([]);
+    mockUserPracticesCreate.mockResolvedValue(activeRow);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectPractice(17);
+    });
+
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 17, stage_number: 5 });
+    expect(result.current.activeUserPractice).toEqual(activeRow);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('selectPractice surfaces a failure via formatApiError', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([]);
+    mockUserPracticesCreate.mockRejectedValue(new Error('rejected'));
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.selectPractice(17);
+    });
+
+    expect(result.current.error).toEqual(expect.any(String));
+    expect(result.current.error).not.toBeNull();
+  });
+
+  it('selectPractice guards against a second concurrent call while one is in flight', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([]);
+    let resolveCreate: ((value: UserPractice) => void) | undefined;
+    mockUserPracticesCreate.mockReturnValueOnce(
+      new Promise<UserPractice>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let firstDone = false;
+    let secondDone = false;
+    act(() => {
+      void result.current.selectPractice(17).then(() => {
+        firstDone = true;
+      });
+      void result.current.selectPractice(17).then(() => {
+        secondDone = true;
+      });
+    });
+
+    await act(async () => {
+      resolveCreate?.(activeRow);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockUserPracticesCreate).toHaveBeenCalledTimes(1);
+    expect(firstDone).toBe(true);
+    expect(secondDone).toBe(true);
+  });
+
+  it('updateActivePractice replaces the in-memory active row without a refetch', async () => {
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockResolvedValue([activeRow]);
+
+    const { result } = renderHook(() => useActivePractice(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const updated: UserPractice = { ...activeRow, custom_name: 'Renamed' };
+    act(() => {
+      result.current.updateActivePractice(updated);
+    });
+
+    expect(result.current.activeUserPractice).toEqual(updated);
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale refresh resolution after unmount', async () => {
+    let resolveList: ((value: UserPractice[]) => void) | undefined;
+    mockListAll.mockResolvedValue([stagePractice]);
+    mockUserPracticesList.mockReturnValueOnce(
+      new Promise<UserPractice[]>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useActivePractice(5));
+    unmount();
+    await act(async () => {
+      resolveList?.([activeRow]);
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.activeUserPractice).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/hooks/__tests__/useWeeklyProgress.test.tsx
+++ b/frontend/src/features/Practice/hooks/__tests__/useWeeklyProgress.test.tsx
@@ -1,0 +1,191 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { PracticeInsightsResponse, WeekCountResponse } from '@/api';
+
+const mockInsights = jest.fn() as jest.MockedFunction<() => Promise<PracticeInsightsResponse>>;
+const mockWeekCount = jest.fn() as jest.MockedFunction<() => Promise<WeekCountResponse>>;
+
+jest.mock('@/api', () => ({
+  practiceSessions: {
+    insights: (...args: unknown[]) =>
+      (mockInsights as unknown as (...a: unknown[]) => Promise<PracticeInsightsResponse>)(...args),
+    weekCount: (...args: unknown[]) =>
+      (mockWeekCount as unknown as (...a: unknown[]) => Promise<WeekCountResponse>)(...args),
+  },
+}));
+
+const { useWeeklyProgress } = require('../useWeeklyProgress');
+
+function insightsFixture(counts: number[]): PracticeInsightsResponse {
+  return {
+    weekly_counts: counts.map((count, i) => ({
+      week_start: `2026-01-${String(i + 1).padStart(2, '0')}`,
+      count,
+    })),
+    streak_weeks: 0,
+    total_minutes_30d: 0,
+    avg_duration_minutes_30d: null,
+    per_mode_counts: {},
+    last_insight: null,
+  };
+}
+
+describe('useWeeklyProgress', () => {
+  beforeEach(() => {
+    mockInsights.mockReset();
+    mockWeekCount.mockReset();
+  });
+
+  it('prefers the latest weekly_counts bucket when insights resolves', async () => {
+    mockInsights.mockResolvedValue(insightsFixture([2, 5]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.count).toBe(5);
+    expect(result.current.error).toBeNull();
+    expect(mockWeekCount).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 without calling the legacy endpoint when weekly_counts is empty', async () => {
+    mockInsights.mockResolvedValue(insightsFixture([]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.count).toBe(0);
+    expect(mockWeekCount).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy weekCount endpoint when insights rejects', async () => {
+    mockInsights.mockRejectedValue(new Error('insights unavailable'));
+    mockWeekCount.mockResolvedValue({ count: 3 });
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.count).toBe(3);
+    expect(result.current.error).toBeNull();
+    expect(mockWeekCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an error when both insights and the legacy fallback fail', async () => {
+    mockInsights.mockRejectedValue(new Error('insights down'));
+    mockWeekCount.mockRejectedValue(new Error('legacy down'));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('legacy down');
+  });
+
+  it('wraps a non-Error rejection into a real Error', async () => {
+    mockInsights.mockRejectedValue('boom');
+    mockWeekCount.mockRejectedValue('still boom');
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('still boom');
+  });
+
+  it('refresh() re-fetches and clears a prior error', async () => {
+    mockInsights.mockRejectedValueOnce(new Error('first try'));
+    mockWeekCount.mockRejectedValueOnce(new Error('first legacy'));
+    mockInsights.mockResolvedValueOnce(insightsFixture([9]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.count).toBe(9);
+  });
+
+  it('increment() bumps the count by one', async () => {
+    mockInsights.mockResolvedValue(insightsFixture([1]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.increment();
+    });
+
+    expect(result.current.count).toBe(2);
+  });
+
+  it('decrement() reduces the count but floors at zero', async () => {
+    mockInsights.mockResolvedValue(insightsFixture([1]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.decrement();
+      result.current.decrement();
+    });
+
+    expect(result.current.count).toBe(0);
+  });
+
+  it('setCount replaces the count with an authoritative value', async () => {
+    mockInsights.mockResolvedValue(insightsFixture([1]));
+
+    const { result } = renderHook(() => useWeeklyProgress());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setCount(42);
+    });
+
+    expect(result.current.count).toBe(42);
+  });
+
+  it('ignores a stale resolution if the component unmounted first', async () => {
+    let resolveInsights: ((value: PracticeInsightsResponse) => void) | undefined;
+    mockInsights.mockReturnValueOnce(
+      new Promise<PracticeInsightsResponse>((resolve) => {
+        resolveInsights = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useWeeklyProgress());
+    unmount();
+    await act(async () => {
+      resolveInsights?.(insightsFixture([7]));
+    });
+
+    // No setState should have landed post-unmount; state is whatever it was
+    // pre-unmount (still loading, count 0).
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.count).toBe(0);
+  });
+
+  it('ignores a stale rejection if the component unmounted first', async () => {
+    let rejectInsights: ((err: Error) => void) | undefined;
+    mockInsights.mockReturnValueOnce(
+      new Promise<PracticeInsightsResponse>((_resolve, reject) => {
+        rejectInsights = reject;
+      }),
+    );
+    mockWeekCount.mockRejectedValue(new Error('legacy down'));
+
+    const { result, unmount } = renderHook(() => useWeeklyProgress());
+    unmount();
+    await act(async () => {
+      rejectInsights?.(new Error('insights down'));
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
@@ -160,4 +160,69 @@ describe('RecipeEditorModal', () => {
     });
     expect(utils.queryByTestId('recipe-editor-rounds-value')).toBeNull();
   });
+
+  it('clamps the rounds stepper between 1 and the max', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    expect(utils.getByTestId('recipe-editor-rounds-value').props.children).toBe(1);
+    fireEvent.press(utils.getByTestId('recipe-editor-rounds-minus'));
+    expect(utils.getByTestId('recipe-editor-rounds-value').props.children).toBe(1);
+    fireEvent.press(utils.getByTestId('recipe-editor-rounds-plus'));
+    expect(utils.getByTestId('recipe-editor-rounds-value').props.children).toBe(2);
+  });
+
+  it('clamps the per-step count stepper between 1 and the max', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    const valueId = 'recipe-editor-step-0-count-value';
+    expect(utils.getByTestId(valueId).props.children).toBe(1);
+    fireEvent.press(utils.getByTestId('recipe-editor-step-0-count-minus'));
+    expect(utils.getByTestId(valueId).props.children).toBe(1);
+    fireEvent.press(utils.getByTestId('recipe-editor-step-0-count-plus'));
+    expect(utils.getByTestId(valueId).props.children).toBe(2);
+  });
+
+  it('moves a step down and disables the boundary move buttons', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-editor-add-step'));
+    expect(utils.getByTestId('recipe-editor-step-0-up').props.accessibilityState.disabled).toBe(
+      true,
+    );
+    expect(utils.getByTestId('recipe-editor-step-1-down').props.accessibilityState.disabled).toBe(
+      true,
+    );
+    fireEvent.changeText(utils.getByTestId('recipe-editor-step-0-prompt'), 'moved');
+    fireEvent.press(utils.getByTestId('recipe-editor-step-0-down'));
+    expect(utils.getByTestId('recipe-editor-step-1-prompt').props.value).toBe('moved');
+  });
+
+  it('pressing a disabled move button is a no-op', async () => {
+    const utils = mountEditor();
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-editor-step-0-up'));
+    expect(utils.getByTestId('recipe-editor-step-0-prompt').props.value).toBe('Find red');
+  });
+
+  it('renders an inline API error banner when save fails', async () => {
+    const create = jest.fn(async (_payload: unknown) => {
+      throw new Error('server exploded');
+    });
+    const utils = mountEditor({ create: create as never });
+    await waitFor(() => expect(utils.listTags).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-editor-save'));
+    });
+    await waitFor(() => expect(utils.getByTestId('recipe-editor-api-error')).toBeTruthy());
+    expect(utils.onSaved).not.toHaveBeenCalled();
+  });
+
+  it('leaves the tag library empty when listTags rejects', async () => {
+    const listTags = jest.fn(async (): Promise<PracticeTag[]> => {
+      throw new Error('tags down');
+    });
+    const utils = mountEditor({ listTags: listTags as never });
+    await waitFor(() => expect(listTags).toHaveBeenCalled());
+    expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
@@ -4,7 +4,23 @@ import React from 'react';
 
 import RecipePickerModal from '../RecipePickerModal';
 
+import { practiceTags } from '@/api';
 import type { PracticeRecipe, UserPractice } from '@/api';
+
+// RecipePickerModal mounts its nested RecipeEditorModal without injecting
+// listTags/create/update seams, so opening it falls through to the real
+// `@/api` bindings. Stub `practiceTags.list` so that fallthrough never
+// makes a real network call in tests; everything else stays real.
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    practiceTags: {
+      list: jest.fn(async () => []),
+      create: jest.fn(),
+    },
+  };
+});
 
 const systemRecipe: PracticeRecipe = {
   id: 1,
@@ -150,5 +166,69 @@ describe('RecipePickerModal', () => {
     const list = jest.fn(async () => []);
     const utils = mountPicker({ list: list as never });
     await waitFor(() => expect(utils.getByTestId('recipe-picker-empty')).toBeTruthy());
+  });
+
+  it('surfaces an apply failure inline and leaves the picker open', async () => {
+    const apply = jest.fn(async (_recipeId: number, _upId: number) => {
+      throw new Error('apply failed');
+    });
+    const utils = mountPicker({ apply: apply as never });
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-row-1-apply'));
+    });
+    await waitFor(() => expect(utils.getByTestId('recipe-picker-api-error')).toBeTruthy());
+    expect(utils.onApplied).not.toHaveBeenCalled();
+    expect(utils.onClose).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a delete failure inline and does not refresh the list', async () => {
+    const remove = jest.fn(async (_recipeId: number) => {
+      throw new Error('delete failed');
+    });
+    const utils = mountPicker({ remove: remove as never });
+    await waitFor(() => expect(utils.getByTestId('recipe-row-2')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('recipe-row-2-delete'));
+    });
+    await waitFor(() => expect(utils.getByTestId('recipe-picker-api-error')).toBeTruthy());
+    expect(utils.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the editor in create mode from the header + New button', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-picker-new'));
+    expect(await utils.findByTestId('recipe-editor-sheet')).toBeTruthy();
+    expect(utils.getByText('New recipe')).toBeTruthy();
+    await waitFor(() => expect(practiceTags.list).toHaveBeenCalled());
+  });
+
+  it('opens the editor in edit mode for a personal recipe', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-2')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-row-2-edit'));
+    expect(await utils.findByText('Edit recipe')).toBeTruthy();
+    expect(utils.getByTestId('recipe-editor-name').props.value).toBe('My Custom');
+    await waitFor(() => expect(practiceTags.list).toHaveBeenCalled());
+  });
+
+  it('forks a system recipe into a new draft named "<name> copy"', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-row-1-fork'));
+    expect(await utils.findByText('New recipe')).toBeTruthy();
+    expect(utils.getByTestId('recipe-editor-name').props.value).toBe('5-4-3-2-1 Grounding copy');
+    await waitFor(() => expect(practiceTags.list).toHaveBeenCalled());
+  });
+
+  it('closing the forked editor returns to the closed state without a refresh', async () => {
+    const utils = mountPicker();
+    await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
+    fireEvent.press(utils.getByTestId('recipe-row-1-fork'));
+    await waitFor(() => expect(practiceTags.list).toHaveBeenCalled());
+    fireEvent.press(utils.getByTestId('recipe-editor-cancel'));
+    expect(utils.queryByTestId('recipe-editor-sheet')).toBeNull();
+    expect(utils.list).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -330,10 +330,54 @@ describe('PracticeDetailScreen — config summary variants', () => {
     ],
     [{ mode: 'tarot', deck: 'major_arcana' } as const],
     [{ mode: 'card_meditation', deck_id: 'rws' } as const],
+    [
+      {
+        mode: 'mindful_anchor',
+        instruction: 'Step outside.',
+        min_duration_seconds: 60,
+        options: [],
+        require_option_choice: false,
+      } as const,
+    ],
+    [
+      {
+        mode: 'mindful_anchor',
+        instruction: 'Step outside.',
+        min_duration_seconds: 60,
+        options: [{ key: 'touch_grass', label: 'Touch grass' }],
+        require_option_choice: false,
+      } as const,
+    ],
   ])('summarises %p', async (config) => {
     mockPracticesGet.mockResolvedValueOnce({ ...samplePractice, mode_config: config });
     const { view } = renderScreen();
     await waitForLoad();
     expect(view.getByTestId('practice-detail-config-summary')).toBeTruthy();
+  });
+});
+
+describe('PracticeDetailScreen — badge + body fallbacks', () => {
+  beforeEach(() => {
+    mockPracticesGet.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('falls back to the meditation_timer badge label when mode is absent', async () => {
+    const noMode: PracticeItem = { ...samplePractice, mode: undefined };
+    mockPracticesGet.mockResolvedValueOnce(noMode);
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.getByTestId('practice-detail-mode-badge').props.children.props.children).toBe(
+      'meditation_timer',
+    );
+  });
+
+  it('omits the description and instructions sections when both are blank', async () => {
+    const blankBody: PracticeItem = { ...samplePractice, description: '', instructions: '' };
+    mockPracticesGet.mockResolvedValueOnce(blankBody);
+    const { view } = renderScreen();
+    await waitForLoad();
+    expect(view.queryByTestId('practice-detail-description')).toBeNull();
+    expect(view.queryByTestId('practice-detail-instructions')).toBeNull();
   });
 });

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -196,4 +196,82 @@ describe('ApiKeySettingsScreen', () => {
     await waitFor(() => expect(state.clearApiKey).toHaveBeenCalled());
     alertSpy.mockRestore();
   });
+
+  test('dismissing the remove confirmation does not clear the key', async () => {
+    const state = setApiKeyState({ apiKey: VALID_KEY });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      // Simulate the user tapping "Cancel" instead of the destructive action.
+      const cancel = buttons?.find((b) => b.style === 'cancel');
+      cancel?.onPress?.();
+    });
+
+    const { getByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    expect(state.clearApiKey).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  test('shows an error banner when saving a well-formed key fails', async () => {
+    const state = setApiKeyState({
+      saveApiKey: jest.fn(() => Promise.reject(new Error('network unreachable'))),
+    });
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    const error = await findByTestId('api-key-error');
+    expect(error.props.children).toContain('network unreachable');
+    expect(state.saveApiKey).toHaveBeenCalledWith(VALID_KEY);
+  });
+
+  test('shows an error banner when removing the stored key fails', async () => {
+    setApiKeyState({
+      apiKey: VALID_KEY,
+      clearApiKey: jest.fn(() => Promise.reject(new Error('keychain locked'))),
+    });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    const error = await findByTestId('api-key-error');
+    expect(error.props.children).toContain('keychain locked');
+    alertSpy.mockRestore();
+  });
+
+  test('masks a short stored key entirely rather than partially revealing it', () => {
+    setApiKeyState({ apiKey: 'sk-short' }); // pragma: allowlist secret
+    const { getByText, queryByText } = render(<ApiKeySettingsScreen />);
+    expect(getByText('••••••••')).toBeTruthy();
+    expect(queryByText(/sk-s/)).toBeNull();
+  });
+
+  test('renders a Back link that navigates back when navigation.goBack is provided', () => {
+    setApiKeyState({});
+    const goBack = jest.fn();
+    const { getByLabelText } = render(<ApiKeySettingsScreen navigation={{ goBack }} />);
+
+    fireEvent.press(getByLabelText('Go back'));
+
+    expect(goBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('omits the Back and Time zone links when no navigation is supplied', () => {
+    setApiKeyState({});
+    const { queryByLabelText, queryByTestId } = render(<ApiKeySettingsScreen />);
+
+    expect(queryByLabelText('Go back')).toBeNull();
+    expect(queryByTestId('open-timezone-settings')).toBeNull();
+  });
 });

--- a/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
+++ b/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { jest, beforeEach, describe, it, expect } from '@jest/globals';
+import { jest, beforeEach, afterEach, describe, it, expect } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
@@ -102,12 +102,27 @@ describe('TodayScreen', () => {
     expect(getByText(/Week 1 of 36/)).toBeTruthy();
   });
 
+  it('shows a not-yet-started journey and a generic journal prompt with no program anchor', () => {
+    useProgramStore.setState({ programStartDate: null });
+    const { getByText } = render(<TodayScreen />);
+    expect(getByText('Your journey awaits')).toBeTruthy();
+    expect(getByText('Open your journal.')).toBeTruthy();
+  });
+
   it('summarises today’s habits and routes to Habits on press', () => {
     useHabitStore.setState({ habits: [makeHabit(1, true), makeHabit(2, false)], loading: false });
     const { getByTestId, getByText } = render(<TodayScreen />);
     expect(getByText('1/2 done')).toBeTruthy();
+    expect(getByText('Keep the streak alive.')).toBeTruthy();
     fireEvent.press(getByTestId('today-habits-band'));
     expect(mockNavigate).toHaveBeenCalledWith('Habits');
+  });
+
+  it('celebrates when every habit is done today', () => {
+    useHabitStore.setState({ habits: [makeHabit(1, true), makeHabit(2, true)], loading: false });
+    const { getByText } = render(<TodayScreen />);
+    expect(getByText('2/2 done')).toBeTruthy();
+    expect(getByText('All caught up — beautiful.')).toBeTruthy();
   });
 
   it('shows a habits skeleton while loading', () => {
@@ -177,5 +192,29 @@ describe('TodayScreen', () => {
     mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: false };
     const { queryByTestId } = render(<TodayScreen />);
     expect(queryByTestId('return-arc-card')).toBeNull();
+  });
+
+  describe('time-of-day greeting', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('greets "Good morning" before noon', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-01T08:00:00'));
+      const { getByText } = render(<TodayScreen />);
+      expect(getByText('Good morning')).toBeTruthy();
+    });
+
+    it('greets "Good afternoon" between noon and 6pm', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-01T14:00:00'));
+      const { getByText } = render(<TodayScreen />);
+      expect(getByText('Good afternoon')).toBeTruthy();
+    });
+
+    it('greets "Good evening" after 6pm', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-01T20:00:00'));
+      const { getByText } = render(<TodayScreen />);
+      expect(getByText('Good evening')).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/utils/__tests__/dateUtils.test.ts
+++ b/frontend/src/utils/__tests__/dateUtils.test.ts
@@ -113,6 +113,10 @@ describe('addDaysInTZ', () => {
     expect(addDaysInTZ('2026-01-01', -1, 'UTC')).toBe('2025-12-31');
   });
 
+  it('returns the input unchanged when the day key has too few parts', () => {
+    expect(addDaysInTZ('baddate', 1, 'UTC')).toBe('baddate');
+  });
+
   it('does not skip leap day in 2024', () => {
     expect(addDaysInTZ('2024-02-28', 1, 'UTC')).toBe('2024-02-29');
     expect(addDaysInTZ('2024-02-29', 1, 'UTC')).toBe('2024-03-01');


### PR DESCRIPTION
## Summary

Frontend CI ran `npx jest --passWithNoTests` **without `--coverage`**, so the 90% `coverageThreshold` in `frontend/jest.config.js` (branches/functions/lines/statements) was never checked. Branch coverage had silently drifted to ~83.6% while the documented standard was still 90%.

This closes the quality-gate erosion **without weakening the documented threshold**:

- **`.github/workflows/frontend-ci.yml`** — the Tests step now runs `npx jest --coverage --passWithNoTests`, so Gate 3 (CI) fails on any coverage drop below the untouched 90% threshold.
- **`.pre-commit-config.yaml`** — adds a `frontend-tests-coverage` hook at `stages: [pre-push]`, mirroring the existing `backend-tests-coverage` hook, so the coverage gate is enforced locally too. The fast `frontend-tests` hook is scoped to `stages: [pre-commit]` so Jest is not run twice on push.
- **~50 new/extended Jest test files** — real behavior-pinning tests across previously untested / under-tested modules (Habits modals `HabitSettingsModal`/`MissedDaysModal`/`OnboardingModal`/`GoalModal`, Practice screens & hooks, the `api` client, screens/contexts, and pure utils), raising branch coverage to **90.0%+** and functions to **95%+**. No production/source code was modified.

`jest.config.js` thresholds are unchanged (90/90/90/90) — the gap was closed by adding coverage, not by lowering the bar.

## Test plan

- `npx jest --coverage --passWithNoTests` → exit 0; global coverage branches 90.06%, functions 95.39%, lines 97.41%, statements 96.43% (3114 tests passing).
- `./scripts/frontend/check-all.sh` → all four checks (lint, format, typecheck, tests) pass.
- `pre-commit validate-config` → valid; the new pre-push hook mirrors the backend coverage gate.

Closes #1104