### PR TITLE
fix(backend): reconcile third divergent additive-streak path

### DIFF
--- a/backend/src/services/streaks.py
+++ b/backend/src/services/streaks.py
@@ -84,20 +84,22 @@ async def _fetch_day_totals(
 
 
 def _additive_streak_from_day_totals(day_totals: dict[date, float], user_timezone: str) -> int:
-    """Additive consecutive-day streak from bucketed totals (incl. zero days).
+    """Additive consecutive-day streak from bucketed per-day totals.
 
-    A most-recent *logged* day that wasn't a completion (a persisted
-    ``completed_units == 0`` "did not complete" row) breaks the chain
-    immediately, so the streak is 0 even though earlier days completed.  The
-    leading completed days then go to the shared
-    :func:`domain.streaks.current_consecutive_streak`, which owns the recency
-    grace gate + backward walk that the frontend ``streakFromCompletions``
-    mirrors — keeping GET /habits and GET /habits/{id}/stats in lockstep.
+    Backs :func:`compute_consecutive_streak` and
+    :func:`compute_streak_before_and_after` — the per-goal DB / check-in +
+    milestone path.  It filters ``day_totals`` to the user-local days that were
+    actually completed (total > 0) and delegates the ordering-sensitive work to
+    the shared :func:`domain.streaks.current_consecutive_streak`, which owns the
+    recency grace gate + backward walk (and returns 0 for an empty sequence).
+
+    Because only completed days are passed on, a most-recent
+    ``completed_units == 0`` "did not complete" row is ignored like an absent
+    day.  That keeps this DB path in lockstep with the in-memory
+    :func:`domain.habit_stats.compute_habit_streak` path, which applies the same
+    completed-days filter + grace gate.
     """
-    sorted_days = sorted(day_totals, reverse=True)
-    completed_days = [d for d in sorted_days if day_totals[d] > 0]
-    if not completed_days or completed_days[0] != sorted_days[0]:
-        return 0
+    completed_days = sorted((d for d in day_totals if day_totals[d] > 0), reverse=True)
     return current_consecutive_streak(completed_days, today_in_tz(user_timezone))
 
 

--- a/backend/tests/services/test_streaks.py
+++ b/backend/tests/services/test_streaks.py
@@ -178,10 +178,10 @@ async def test_compute_consecutive_streak_collapses_same_day_rows(
 
 
 @pytest.mark.asyncio
-async def test_compute_consecutive_streak_resets_on_most_recent_miss(
+async def test_compute_consecutive_streak_ignores_most_recent_zero_unit_row(
     db_session: AsyncSession,
 ) -> None:
-    """A miss day after completions zeros the reported streak."""
+    """A most-recent did-not-complete row is ignored, like an absent day."""
     user = await _make_user(db_session)
     assert user.id is not None
     goal = await _make_goal(db_session, user.id)
@@ -202,7 +202,71 @@ async def test_compute_consecutive_streak_resets_on_most_recent_miss(
     )
     await db_session.commit()
 
-    assert await compute_consecutive_streak(db_session, goal.id, user.id) == 0
+    assert await compute_consecutive_streak(db_session, goal.id, user.id) == 1
+
+
+@pytest.mark.asyncio
+async def test_compute_consecutive_streak_matches_compute_habit_streak_on_zero_unit_row(
+    db_session: AsyncSession,
+) -> None:
+    """The DB path and the in-memory path agree on a trailing zero-unit row."""
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    now = datetime.now(UTC)
+    yesterday_completion = GoalCompletion(
+        goal_id=goal.id,
+        user_id=user.id,
+        completed_units=goal.target,
+        timestamp=now - timedelta(days=1),
+    )
+    today_zero_row = GoalCompletion(
+        goal_id=goal.id, user_id=user.id, completed_units=0, timestamp=now
+    )
+    db_session.add(yesterday_completion)
+    await db_session.commit()
+    db_session.add(today_zero_row)
+    await db_session.commit()
+
+    db_streak = await compute_consecutive_streak(db_session, goal.id, user.id, "UTC")
+    memory_streak = compute_habit_streak([yesterday_completion, today_zero_row], "UTC")
+
+    assert db_streak == memory_streak
+    assert db_streak == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("frozen_clock")
+async def test_compute_consecutive_streak_zero_unit_row_does_not_extend_grace(
+    db_session: AsyncSession,
+) -> None:
+    """A trailing zero-unit row cannot rescue a chain that is already stale."""
+    user = await _make_user(db_session)
+    assert user.id is not None
+    goal = await _make_goal(db_session, user.id)
+    assert goal.id is not None
+
+    stale_completion = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+    today_zero_row = datetime(2026, 6, 15, 18, 0, tzinfo=UTC)
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal.id,
+            user_id=user.id,
+            completed_units=goal.target,
+            timestamp=stale_completion,
+        )
+    )
+    await db_session.commit()
+    db_session.add(
+        GoalCompletion(
+            goal_id=goal.id, user_id=user.id, completed_units=0, timestamp=today_zero_row
+        )
+    )
+    await db_session.commit()
+
+    assert await compute_consecutive_streak(db_session, goal.id, user.id, "UTC") == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -210,7 +210,7 @@ async def test_consecutive_day_completions_build_streak(
     assert data["streak"] == expected_streak
 
 
-# ── Miss resets streak ───────────────────────────────────────────────────
+# ── Miss holds streak (recency grace) ─────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -278,7 +278,10 @@ async def test_miss_on_unscheduled_day_holds_streak(
 
 
 @pytest.mark.asyncio
-async def test_miss_resets_streak(async_client: AsyncClient, db_session: AsyncSession) -> None:
+async def test_miss_within_grace_holds_streak(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A miss logged today does not zero a chain that is still within grace."""
     headers, user_id = await _signup(async_client)
     goal = await _seed_goal(db_session, user_id)
 
@@ -301,8 +304,8 @@ async def test_miss_resets_streak(async_client: AsyncClient, db_session: AsyncSe
     )
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
-    assert data["streak"] == 0
-    assert data["reason_code"] == "streak_reset"
+    assert data["streak"] == 1
+    assert data["reason_code"] == "streak_held"
     assert data["milestones"] == []
 
 


### PR DESCRIPTION
## Summary

The additive current-streak had two service-layer paths that disagreed on a
most-recent explicit "did not complete" (`completed_units == 0`) row:

- `compute_consecutive_streak` (per-goal DB / check-in + milestone path, via
  `_additive_streak_from_day_totals`) treated a most-recent 0-unit row as a
  break and returned **0**.
- `compute_habit_streak` (in-memory `GET /habits` path) filtered 0-unit rows
  out and returned **1**.

So after logging a "did not complete" today, the check-in/milestone math saw
streak 0 while the Habits list and stats screen both showed 1 — the third,
un-reconciled path that the `compute_habit_stats` parity work never touched.

This reconciles onto the domain's single source of truth: a most-recent 0-unit
row is **ignored like an absent day**, with the additive streak governed solely
by completed days plus the recency-grace gate owned by
`domain.streaks.current_consecutive_streak`. The divergent guard in
`_additive_streak_from_day_totals` is removed so both paths funnel identically
into the domain owner, matching the two paths already reconciled. Subtractive
behavior is unchanged. The stale docstring that falsely claimed the helper kept
`GET /habits` in lockstep (it never routed through it) is rewritten to name the
real call paths.

Downstream: a scheduled additive miss within grace now reports
`streak_held` / streak 1 (the POST response agrees with what `GET /habits`
shows), instead of the old `streak_reset` / streak 0.

A fourth latent divergence on the client (`streakFromCompletions` counts
did-not-complete rows) is filed as a follow-up: #1183.

## Test plan

- Reconciled `test_compute_consecutive_streak_ignores_most_recent_zero_unit_row`
  (was `..._resets_on_most_recent_miss`): a most-recent 0-unit row now yields 1.
- New parity test: DB path (`compute_consecutive_streak`) and in-memory path
  (`compute_habit_streak`) return identical values (both 1) for identical data
  with a trailing 0-unit row.
- New grace test: a trailing 0-unit row cannot rescue an already-stale chain
  (still 0).
- Reconciled end-to-end `test_miss_within_grace_holds_streak` (was
  `test_miss_resets_streak`): scheduled miss -> streak 1, `streak_held`.
- Subtractive transgression test left untouched (still resets to 0).
- Full backend `check-all.sh` green (2319 passed, coverage 96.41%);
  xenon rank A + radon MI A on `services/streaks.py`.

Closes #1126