### PR TITLE
feat(backend): wire in the orphaned LLM cost-metering write path

### DIFF
--- a/backend/src/models/llm_usage_log.py
+++ b/backend/src/models/llm_usage_log.py
@@ -47,8 +47,10 @@ class LLMUsageLog(SQLModel, table=True):
     it" and is logged as a warning so ops can fill in the rate, not
     silently averaged in as ``$0`` (which the previous float default did).
 
-    ``journal_entry_id`` points at the bot's reply (``sender='bot'``) so a
-    single JOIN reconstructs the conversational context of any logged call.
+    ``journal_entry_id`` points at the journal entry the call was about — the
+    user's source entry on the resonance path, the annotated entry on the essay
+    path — so a single JOIN reconstructs the call's context and the soft-delete
+    audit trail stays intact.
     """
 
     id: int | None = Field(default=None, primary_key=True)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -69,6 +69,7 @@ from services.botmason import LLMProviderError, resolve_chat_api_key
 from services.checkin import CheckInContext, current_check_in, record_goal_completion
 from services.completion_candidates import gather_candidates
 from services.contraction import gather_contraction_aggregates
+from services.llm_usage import record_llm_usage
 from services.marginalia import (
     BotmasonResonanceLLM,
     reanchor_entry_marginalia,
@@ -722,6 +723,12 @@ async def run_resonance(
         return await _care_only_response(session, current_user, cast("CareResponse", care))
     rows, suggestions = await _persist_resonance(session, entry, current_user, llm, anchored)
     spent_user = await require_user_fresh(session, current_user)
+    await record_llm_usage(
+        session,
+        user_id=current_user,
+        journal_entry_id=cast("int", entry.id),
+        responses=llm.usage,
+    )
     await session.commit()
     for row in (*rows, *suggestions):
         await session.refresh(row)
@@ -1036,6 +1043,12 @@ async def _cache_essay(
         raise bad_gateway("llm_provider_error") from exc
     note.essay = essay
     note.essay_generated_at = datetime.now(UTC)
+    await record_llm_usage(
+        session,
+        user_id=note.user_id,
+        journal_entry_id=note.journal_entry_id,
+        responses=llm.usage,
+    )
     await session.commit()
     await session.refresh(note)
     logger.info("marginalia_essay_generated", extra={"user_id": note.user_id, "id": note.id})

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -53,6 +53,10 @@ LLM_API_KEY_MAX_LENGTH = 256
 # module constant so callers can branch on it without magic strings.
 STUB_MODEL_NAME = "stub"
 
+# Identifier the stub provider reports as its ``provider`` in usage logs.  The
+# metering pipeline branches on it to skip stub traffic (zero real tokens).
+STUB_PROVIDER_NAME = "stub"
+
 
 @dataclass(frozen=True)
 class ProviderSpec:
@@ -644,7 +648,7 @@ def _stub_response(user_message: str) -> LLMResponse:
     )
     return LLMResponse(
         text=text,
-        provider="stub",
+        provider=STUB_PROVIDER_NAME,
         model=STUB_MODEL_NAME,
         prompt_tokens=0,
         completion_tokens=0,

--- a/backend/src/services/llm_usage.py
+++ b/backend/src/services/llm_usage.py
@@ -1,0 +1,57 @@
+"""LLM cost-metering write path — one ``LLMUsageLog`` row per real provider call.
+
+The resonance and essay endpoints hand their adapter's accumulated responses to
+:func:`record_llm_usage`, which stages one usage row per non-stub response inside
+the caller's transaction.  Stub responses spend zero real tokens and are skipped
+so the per-model dashboard stays clean and the pricing table never sees the stub
+model.  The caller owns the commit, so metering shares the reflection's atomicity.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from models.llm_usage_log import LLMUsageLog
+from services.botmason import STUB_PROVIDER_NAME
+from services.llm_pricing import estimate_cost_usd
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from services.botmason import LLMResponse
+
+
+async def record_llm_usage(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    journal_entry_id: int,
+    responses: Sequence[LLMResponse],
+) -> None:
+    """Stage an ``LLMUsageLog`` row for each real (non-stub) response.
+
+    ``journal_entry_id`` is the entry the calls were about — the user's source
+    entry on the resonance path, the annotated entry on the essay path — so the
+    audit trail reconstructs each call's context with a single JOIN.  Stub
+    responses are skipped (zero real tokens, no pricing-table lookup).  No commit
+    is issued here; the row shares the caller's transaction with the reflection.
+    """
+    for response in responses:
+        if response.provider == STUB_PROVIDER_NAME:
+            continue
+        session.add(
+            LLMUsageLog(
+                user_id=user_id,
+                journal_entry_id=journal_entry_id,
+                provider=response.provider,
+                model=response.model,
+                prompt_tokens=response.prompt_tokens,
+                completion_tokens=response.completion_tokens,
+                total_tokens=response.total_tokens,
+                estimated_cost_usd=estimate_cost_usd(
+                    response.model, response.prompt_tokens, response.completion_tokens
+                ),
+            )
+        )

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -17,7 +17,7 @@ from domain.marginalia_anchoring import reanchor_one
 from models.completion_suggestion import CompletionSuggestion, SuggestionStatus
 from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia, MarginaliaStatus
-from services.botmason import generate_response
+from services.botmason import LLMResponse, generate_response
 
 
 class BotmasonResonanceLLM:
@@ -25,15 +25,19 @@ class BotmasonResonanceLLM:
 
     The domain only needs ``complete(prompt) -> text``; this maps that onto
     ``generate_response`` (no conversation history, no system prompt) so the
-    resonance feature reuses the single LLM integration / BYOK seam.
+    resonance feature reuses the single LLM integration / BYOK seam.  The
+    adapter also accumulates each call's full ``LLMResponse`` in ``self.usage``
+    (one entry per successful provider call) so the caller can meter cost.
     """
 
     def __init__(self, api_key: str | None) -> None:
-        """Store the optional BYOK key used for each completion."""
+        """Store the optional BYOK key and the per-instance usage accumulator."""
         self._api_key = api_key
+        self.usage: list[LLMResponse] = []
 
     async def complete(self, prompt: str) -> str:
         response = await generate_response(prompt, [], system_prompt=None, api_key=self._api_key)
+        self.usage.append(response)
         return response.text
 
 

--- a/backend/tests/routers/test_contraction_reflection.py
+++ b/backend/tests/routers/test_contraction_reflection.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import json
 from datetime import UTC, date, datetime, timedelta
 from http import HTTPStatus
-from types import SimpleNamespace
 
 import pytest
 from httpx import AsyncClient
@@ -29,6 +28,7 @@ from models.habit import Habit
 from models.journal_entry import JournalEntry
 from models.stage_progress import StageProgress
 from services import marginalia as marginalia_service
+from services.botmason import STUB_MODEL_NAME, LLMResponse
 
 _BODY = "I walked by the river and the willow bent without breaking."
 
@@ -71,9 +71,15 @@ def _fake_llm(monkeypatch: pytest.MonkeyPatch, *notes: dict[str, str]) -> None:
 
     async def _complete(
         prompt: str, history: object, *, system_prompt: object, api_key: object
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del prompt, history, system_prompt, api_key
-        return SimpleNamespace(text=payload)
+        return LLMResponse(
+            text=payload,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
 
     monkeypatch.setattr(marginalia_service, "generate_response", _complete)
 
@@ -231,10 +237,16 @@ async def test_intimate_entry_keeps_contraction_null_and_stays_private(
 
         async def __call__(
             self, prompt: str, history: object, *, system_prompt: object, api_key: object
-        ) -> SimpleNamespace:
+        ) -> LLMResponse:
             del prompt, history, system_prompt, api_key
             self.calls += 1
-            return SimpleNamespace(text='{"notes":[]}')
+            return LLMResponse(
+                text='{"notes":[]}',
+                provider="stub",
+                model=STUB_MODEL_NAME,
+                prompt_tokens=0,
+                completion_tokens=0,
+            )
 
     spy = _SpyLLM()
     monkeypatch.setattr(marginalia_service, "generate_response", spy)

--- a/backend/tests/test_completion_detection_endpoint.py
+++ b/backend/tests/test_completion_detection_endpoint.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from datetime import date
 from http import HTTPStatus
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -20,7 +19,7 @@ from models.habit import Habit
 from models.marginalia import Marginalia
 from models.user import User
 from services import marginalia as marginalia_service
-from services.botmason import LLMProviderError
+from services.botmason import STUB_MODEL_NAME, LLMProviderError, LLMResponse
 
 _BODY = "I meditated by the river and the willow bent without breaking."
 _NOTE = {"kind": "theme", "quote": "the willow bent without breaking", "note": "It holds."}
@@ -90,9 +89,18 @@ def _fake(
     notes_payload = json.dumps({"notes": [_NOTE]})
     hits_payload = json.dumps({"hits": hits})
 
+    def _stub(text: str) -> LLMResponse:
+        return LLMResponse(
+            text=text,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
+
     async def _complete(
         prompt: str, history: object, *, system_prompt: object, api_key: object
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del history, system_prompt, api_key
         # Routes by prompt content: the detection prompt asks for a JSON ``{"hits": ...}``
         # payload and labels resolved spans ``COMPLETED``, while the literary/marginalia
@@ -103,8 +111,8 @@ def _fake(
                 detection_calls.append(prompt)
             if detection_raises:
                 raise LLMProviderError("detector down")
-            return SimpleNamespace(text=hits_payload)
-        return SimpleNamespace(text=notes_payload)
+            return _stub(hits_payload)
+        return _stub(notes_payload)
 
     monkeypatch.setattr(marginalia_service, "generate_response", _complete)
 

--- a/backend/tests/test_essay_endpoint.py
+++ b/backend/tests/test_essay_endpoint.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from types import SimpleNamespace
 
 import pytest
 from httpx import AsyncClient
@@ -13,6 +12,7 @@ from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia, MarginaliaKind
 from routers import journal as journal_router
 from services import marginalia as marginalia_service
+from services.botmason import STUB_MODEL_NAME, LLMResponse
 
 _BODY = "I walked by the river and the willow bent without breaking."
 
@@ -59,10 +59,16 @@ class _CountingLLM:
 
     async def __call__(
         self, prompt: str, history: object, *, system_prompt: object, api_key: object
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del prompt, history, system_prompt, api_key
         self.calls += 1
-        return SimpleNamespace(text=self.text)
+        return LLMResponse(
+            text=self.text,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_intimate_privacy_guard.py
+++ b/backend/tests/test_intimate_privacy_guard.py
@@ -22,7 +22,6 @@ cloud call made by both endpoints.
 from __future__ import annotations
 
 from http import HTTPStatus
-from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -36,6 +35,7 @@ from models.llm_usage_log import LLMUsageLog
 from models.marginalia import Marginalia, MarginaliaKind
 from models.user import User
 from services import marginalia as marginalia_service
+from services.botmason import STUB_MODEL_NAME, LLMResponse
 
 # ---------------------------------------------------------------------------
 # Exact private-response copy (the implementation MUST match this string)
@@ -90,10 +90,16 @@ class _SpyLLM:
 
     async def __call__(
         self, prompt: str, history: object, *, system_prompt: object, api_key: object
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del prompt, history, system_prompt, api_key
         self.calls += 1
-        return SimpleNamespace(text=self._reply)
+        return LLMResponse(
+            text=self._reply,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
 
 
 async def _seed_marginalia_for_entry(session: AsyncSession, entry_id: int, user_id: int) -> int:
@@ -399,11 +405,17 @@ class _CapturingSpyLLM:
         *,
         system_prompt: object,
         api_key: object,
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del history, system_prompt, api_key
         self.calls += 1
         self.captured_prompts.append(prompt)
-        return SimpleNamespace(text=self._reply)
+        return LLMResponse(
+            text=self._reply,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_usage_metering.py
+++ b/backend/tests/test_llm_usage_metering.py
@@ -1,0 +1,379 @@
+"""RED tests -- LLM cost-metering pipeline (LLMUsageLog writes on resonance + essay).
+
+Covers the write path both endpoints must call before their commit:
+``record_llm_usage`` accumulating one row per successful ``complete()`` call,
+skipping stub-provider responses, and recording ``None`` cost for an unpriced
+model. These tests fail against current code because neither ``run_resonance``
+nor ``expand_marginalia_essay`` writes any ``LLMUsageLog`` row yet.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from decimal import Decimal
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.goal import Goal
+from models.habit import Habit
+from models.journal_entry import JournalEntry
+from models.llm_usage_log import LLMUsageLog
+from models.marginalia import Marginalia, MarginaliaKind
+from models.user import User
+from services import marginalia as marginalia_service
+from services.botmason import STUB_MODEL_NAME, LLMProviderError, LLMResponse
+from services.llm_pricing import estimate_cost_usd
+
+_BODY = "I walked by the river and the willow bent without breaking."
+_PRICED_MODEL = "gpt-4o-mini"
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Sign up a user and return (auth headers, user_id)."""
+    email = f"{username}@example.com"
+    resp = await client.post(
+        "/auth/signup",
+        json={"email": email, "password": "secret12345"},  # pragma: allowlist secret
+    )
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    return {"Authorization": f"Bearer {payload['token']}"}, int(payload["user_id"])
+
+
+async def _promote_to_admin(db_session: AsyncSession, user_id: int) -> None:
+    await db_session.execute(update(User).where(col(User.id) == user_id).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _signup_admin(client: AsyncClient, db_session: AsyncSession) -> dict[str, str]:
+    headers, user_id = await _signup(client, "metering_admin")
+    await _promote_to_admin(db_session, user_id)
+    return headers
+
+
+async def _create_entry(client: AsyncClient, headers: dict[str, str], body: str = _BODY) -> int:
+    resp = await client.post("/journal/", json={"message": body}, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _seed_habit(session: AsyncSession, user_id: int, name: str = "Meditation") -> None:
+    """Seed one habit with a clear-tier goal so gather_candidates is non-empty."""
+    habit = Habit(
+        name=name,
+        icon="flame",
+        start_date=date(2025, 1, 1),
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    session.add(
+        Goal(
+            habit_id=habit.id,
+            title="clear",
+            tier="clear",
+            target=1.0,
+            target_unit="x",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=True,
+        )
+    )
+    await session.commit()
+
+
+async def _usage_rows_for_entry(session: AsyncSession, entry_id: int) -> list[LLMUsageLog]:
+    result = await session.execute(
+        select(LLMUsageLog).where(col(LLMUsageLog.journal_entry_id) == entry_id)
+    )
+    return list(result.scalars().all())
+
+
+def _stub_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        text=text, provider="stub", model=STUB_MODEL_NAME, prompt_tokens=0, completion_tokens=0
+    )
+
+
+def _priced_response(
+    text: str,
+    *,
+    model: str = _PRICED_MODEL,
+    prompt_tokens: int = 1000,
+    completion_tokens: int = 500,
+) -> LLMResponse:
+    return LLMResponse(
+        text=text,
+        provider="openai",
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Priced row on the resonance path + admin dashboard reflects it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_priced_resonance_call_writes_row_admin_reflects_it(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single priced marginalia call writes exactly one LLMUsageLog row the admin sees."""
+    notes_payload = json.dumps(
+        {"notes": [{"kind": "theme", "quote": "I walked by the river", "note": "You return."}]}
+    )
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del prompt, history, system_prompt, api_key
+        return _priced_response(notes_payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+    headers, _ = await _signup(async_client, "priced_one")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.provider == "openai"
+    assert row.model == _PRICED_MODEL
+    assert row.prompt_tokens == 1000
+    assert row.completion_tokens == 500
+    assert row.total_tokens == 1500
+    expected_cost = estimate_cost_usd(_PRICED_MODEL, 1000, 500)
+    assert expected_cost == Decimal("0.000450")
+    assert row.estimated_cost_usd == expected_cost
+
+    admin_headers = await _signup_admin(async_client, db_session)
+    stats_resp = await async_client.get("/admin/usage-stats", headers=admin_headers)
+    assert stats_resp.status_code == HTTPStatus.OK
+    data = stats_resp.json()
+    assert data["total_calls"] == 1
+    assert data["total_prompt_tokens"] == 1000
+    assert data["total_completion_tokens"] == 500
+    assert data["total_tokens"] == 1500
+    assert Decimal(data["total_estimated_cost_usd"]) == Decimal("0.000450")
+
+
+# ---------------------------------------------------------------------------
+# 2. Two complete() calls accumulate two rows (not last-call-wins)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_llm_calls_accumulate_two_usage_rows(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Marginalia + detection each write a row -- the adapter accumulates, not overwrites."""
+    notes_payload = json.dumps(
+        {"notes": [{"kind": "theme", "quote": "I meditated", "note": "You return."}]}
+    )
+    hits_payload = json.dumps({"hits": [{"index": 0, "quote": "I meditated"}]})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del history, system_prompt, api_key
+        if '"hits"' in prompt or "COMPLETED" in prompt:
+            return _priced_response(
+                hits_payload, model="gpt-4o", prompt_tokens=200, completion_tokens=50
+            )
+        return _priced_response(notes_payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+    headers, user_id = await _signup(async_client, "two_calls")
+    await _seed_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, body="I meditated by the river today.")
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert len(rows) == 2
+    models = sorted(row.model for row in rows)
+    assert models == sorted([_PRICED_MODEL, "gpt-4o"])
+
+
+# ---------------------------------------------------------------------------
+# 3. Stub-provider responses are skipped; a sibling priced call still logs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stub_provider_is_skipped_alongside_a_priced_sibling_call(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Detection's stub reply is skipped; marginalia's priced reply still logs."""
+    notes_payload = json.dumps(
+        {"notes": [{"kind": "theme", "quote": "I meditated", "note": "You return."}]}
+    )
+    hits_payload = json.dumps({"hits": [{"index": 0, "quote": "I meditated"}]})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del history, system_prompt, api_key
+        if '"hits"' in prompt or "COMPLETED" in prompt:
+            return _stub_response(hits_payload)
+        return _priced_response(notes_payload)
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+    headers, user_id = await _signup(async_client, "stub_skip")
+    await _seed_habit(db_session, user_id)
+    entry_id = await _create_entry(async_client, headers, body="I meditated by the river today.")
+
+    with caplog.at_level("WARNING"):
+        resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert len(rows) == 1
+    assert rows[0].provider == "openai"
+    assert rows[0].model == _PRICED_MODEL
+    # The skipped stub call must never reach the pricing table.
+    assert "llm_pricing_unknown_model" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 4. An unknown real model still writes a row, with a None cost
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_writes_row_with_null_cost(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A priced-provider call against an unrated model logs the row with a None cost."""
+    notes_payload = json.dumps(
+        {"notes": [{"kind": "theme", "quote": "I walked by the river", "note": "You return."}]}
+    )
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del prompt, history, system_prompt, api_key
+        return _priced_response(notes_payload, model="not-in-pricing-table")
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+    headers, _ = await _signup(async_client, "unknown_model")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert len(rows) == 1
+    assert rows[0].model == "not-in-pricing-table"
+    assert rows[0].estimated_cost_usd is None
+
+
+# ---------------------------------------------------------------------------
+# 5. A provider error writes zero rows -- metering never happens on failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_error_writes_zero_rows(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed LLM call must never leave a partial LLMUsageLog row behind."""
+
+    async def _boom(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del prompt, history, system_prompt, api_key
+        raise LLMProviderError("provider down")
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _boom)
+
+    headers, _ = await _signup(async_client, "provider_err")
+    entry_id = await _create_entry(async_client, headers)
+
+    resp = await async_client.post(f"/journal/{entry_id}/resonance", headers=headers)
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Essay path: a priced call writes one row FK'd to the entry
+# ---------------------------------------------------------------------------
+
+
+async def _seed_marginalia(
+    session: AsyncSession, user_id: int, body: str = _BODY
+) -> tuple[int, int]:
+    """Persist an entry + one marginalia row; return (marginalia_id, entry_id)."""
+    entry = JournalEntry(sender="user", user_id=user_id, message=body)
+    session.add(entry)
+    await session.flush()
+    assert entry.id is not None
+    note = Marginalia(
+        journal_entry_id=entry.id,
+        user_id=user_id,
+        kind=MarginaliaKind.SYMBOL,
+        anchor_start=0,
+        anchor_end=6,
+        anchor_text="I walk",
+        note="A beginning.",
+    )
+    session.add(note)
+    await session.commit()
+    await session.refresh(note)
+    assert note.id is not None
+    return note.id, entry.id
+
+
+@pytest.mark.asyncio
+async def test_essay_priced_call_writes_one_row(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A priced essay-generation call writes one LLMUsageLog row FK'd to the note's entry."""
+    headers, user_id = await _signup(async_client, "essay_metering")
+    marg_id, entry_id = await _seed_marginalia(db_session, user_id)
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del prompt, history, system_prompt, api_key
+        return _priced_response(
+            "A warm letter about beginnings.", prompt_tokens=800, completion_tokens=200
+        )
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+    resp = await async_client.post(f"/journal/marginalia/{marg_id}/essay", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+    rows = await _usage_rows_for_entry(db_session, entry_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.provider == "openai"
+    assert row.model == _PRICED_MODEL
+    assert row.prompt_tokens == 800
+    assert row.completion_tokens == 200
+    assert row.estimated_cost_usd is not None
+    assert row.estimated_cost_usd == estimate_cost_usd(_PRICED_MODEL, 800, 200)

--- a/backend/tests/test_resonance_endpoints.py
+++ b/backend/tests/test_resonance_endpoints.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from http import HTTPStatus
-from types import SimpleNamespace
 
 import pytest
 from httpx import AsyncClient
@@ -16,7 +15,7 @@ from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia
 from models.user import User
 from services import marginalia as marginalia_service
-from services.botmason import LLMProviderError
+from services.botmason import STUB_MODEL_NAME, LLMProviderError, LLMResponse
 
 _BODY = "I walked by the river and the willow bent without breaking."
 
@@ -45,9 +44,15 @@ def _fake_llm(monkeypatch: pytest.MonkeyPatch, *notes: dict[str, str]) -> None:
 
     async def _complete(
         prompt: str, history: object, *, system_prompt: object, api_key: object
-    ) -> SimpleNamespace:
+    ) -> LLMResponse:
         del prompt, history, system_prompt, api_key
-        return SimpleNamespace(text=payload)
+        return LLMResponse(
+            text=payload,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
 
     monkeypatch.setattr(marginalia_service, "generate_response", _complete)
 


### PR DESCRIPTION
## Summary

The LLM cost-metering pipeline was built at both ends but disconnected in the middle: `services/llm_pricing.py` (`MODEL_PRICING`, `estimate_cost_usd`) and the `LLMUsageLog` model existed and were read by the admin usage dashboard (`routers/admin.py`), but nothing in `backend/src` ever wrote a row — the dashboard summed a table production never populated (a facade). This wires in the write path (the issue's `wire-in` decision, not retire).

- **New `services/llm_usage.py::record_llm_usage`** — stages one `LLMUsageLog` row per real (non-stub) `LLMResponse`, computing `estimated_cost_usd` via `estimate_cost_usd`. No commit: the row shares the caller's transaction, so metering inherits the reflection's atomicity (a failed provider call rolls back before any row is staged).
- **`services/marginalia.py`** — `BotmasonResonanceLLM` now accumulates each `complete()` call's full `LLMResponse` in `self.usage`, so both the marginalia and the detection call are metered per-call (not last-call-wins).
- **`routers/journal.py`** — `run_resonance` records usage before its commit (FK = the user's source entry); `_cache_essay` records usage before its commit (FK = the annotated entry).
- **Stub is deliberately skipped** — the stub provider spends zero real tokens; recording it would pollute the per-model view and trigger the unknown-model warning. Adds a `STUB_PROVIDER_NAME` constant for the sentinel.
- **Truth fixes** — corrects the `LLMUsageLog.journal_entry_id` docstring, which claimed a `sender='bot'` reply FK that never existed on these paths.
- Five existing LLM test fakes converted from a text-only namespace to real `LLMResponse` instances so `complete()` can read their metering fields.

## Test plan

- New `backend/tests/test_llm_usage_metering.py` (6 tests): priced resonance call writes exactly one row with the exact `Decimal` cost and the admin `/admin/usage-stats` endpoint reflects it; two-call accumulation writes two rows; stub is skipped (zero rows, no warning); unknown real model writes a row with null cost; a provider error writes zero rows; the essay path writes one row FK'd to the note's entry.
- Full backend suite: 2326 passed / 2 skipped, coverage 96.34% (≥90).
- `./scripts/backend/check-all.sh`: 7/7 passed. xenon A-grade; radon MI all A.

Closes #1127