### PR TITLE
fix(frontend): clamp usePagination goLast so backward paging works on the last page

### DIFF
--- a/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
@@ -30,7 +30,7 @@ describe('usePagination', () => {
     expect(result.current.page).toBe(2);
   });
 
-  it('goLast jumps to the last page (clamped via internal state)', () => {
+  it('goLast jumps to the last page', () => {
     const { result } = renderHook(() => usePagination(35, PAGE_SIZE));
     act(() => result.current.goLast());
     expect(result.current.page).toBe(3);
@@ -59,5 +59,22 @@ describe('usePagination', () => {
     rerender({ count: 25 });
     act(() => result.current.goLast());
     expect(result.current.page).toBe(2);
+  });
+
+  it('goPrev after goLast steps back to the immediately-previous page', () => {
+    const { result } = renderHook(() => usePagination(12, PAGE_SIZE));
+    expect(result.current.pageCount).toBe(2);
+    act(() => result.current.goLast());
+    expect(result.current.page).toBe(1);
+    act(() => result.current.goPrev());
+    expect(result.current.page).toBe(0);
+  });
+
+  it('goNext after goLast stays on the last page', () => {
+    const { result } = renderHook(() => usePagination(12, PAGE_SIZE));
+    act(() => result.current.goLast());
+    expect(result.current.page).toBe(1);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(1);
   });
 });

--- a/frontend/src/features/Habits/hooks/usePagination.ts
+++ b/frontend/src/features/Habits/hooks/usePagination.ts
@@ -1,15 +1,16 @@
 import { useCallback, useState } from 'react';
 
 /**
- * Window a list into fixed-size pages. Returns a clamped `page` so callers
- * always read a valid index even when `habitCount` shrinks beneath the
- * current internal state — that's the reason there is no corrective effect:
- * the clamp at the read site is sufficient and avoids an extra render.
+ * Window a list into fixed-size pages. The setters never advance the internal
+ * `page` above `pageCount - 1` (`goNext` caps it, `goLast` targets it, `goPrev`
+ * only decreases), so `goPrev`/`goNext` always step relative to a valid index.
+ * The read site additionally clamps `page` to guard the one case the setters
+ * cannot: `habitCount` shrinking beneath the stored index without a setter call
+ * (e.g. items are removed) — resolving it on the next read without an extra
+ * render.
  *
- * `goLast` sets internal state to `habitCount`, which is always above
- * `pageCount - 1`; the clamp resolves it to the actual last page on the next
- * read. Use this after appending a new item so the user lands on the page
- * that contains it.
+ * `goLast` jumps to the true last page (`pageCount - 1`). Use it after
+ * appending a new item so the user lands on the page that contains it.
  */
 export interface PaginationState {
   /** Clamped current page (0-based). */
@@ -27,7 +28,7 @@ export const usePagination = (habitCount: number, pageSize: number): PaginationS
 
   const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
   const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
-  const goLast = useCallback(() => setPage(habitCount), [habitCount]);
+  const goLast = useCallback(() => setPage(pageCount - 1), [pageCount]);
 
   return {
     page: Math.min(page, pageCount - 1),


### PR DESCRIPTION
## Summary
`usePagination` stored an un-clamped internal `page` and clamped only at the read site. `goLast()` set the internal state to `habitCount` — far above `pageCount - 1` — so a subsequent `goPrev()` decremented the inflated raw value instead of the displayed page. Backward paging was a no-op right after the list jumped to the last page (e.g. after adding a habit, where `HabitsScreen.handleAddHabit` calls `goLast()`).

The fix makes `goLast` target the clamped last index (`pageCount - 1`) so all three setters (`goPrev`/`goNext`/`goLast`) operate on a valid page index. The read-site clamp is retained solely to absorb the case the setters cannot cover: `habitCount` shrinking beneath the stored index without a setter call (items removed). The docstring is rewritten to state the corrected invariant, replacing the previously confidently-wrong "the clamp at the read site is sufficient / no corrective effect" claim.

## Test plan
- Added regression test: after `goLast()`, a single `goPrev()` returns to the immediately-previous page (`usePagination(12, 10)` → `goLast` lands on page 1 → `goPrev` → page 0).
- Added regression test: `goNext()` after `goLast()` stays on the last page.
- Existing behaviors preserved (goLast lands on the page containing a new item; read-value clamp on shrink; goLast bound to latest `habitCount`); one stale existing test name corrected.
- `npx tsc --noEmit`, `npm run lint`, and `npx jest --coverage` all green (312 suites / 3152 tests; coverage gate ≥ 90% satisfied); `./scripts/frontend/check-all.sh` passes 4/4.

Closes #1130