### PR TITLE
refactor(frontend): extract shared Habits emoji-picker + fix placeholder drift

### DIFF
--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View, Modal } from 'react-native';
-import EmojiSelector from 'react-native-emoji-selector';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { habits as habitsApi } from '../../api';
@@ -22,6 +21,7 @@ import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
 import GoalModal from './components/GoalModal';
+import HabitEmojiPicker from './components/HabitEmojiPicker';
 import { HabitsEmptyState } from './components/HabitsEmptyState';
 import HabitSettingsModal from './components/HabitSettingsModal';
 import MissedDaysModal from './components/MissedDaysModal';
@@ -221,7 +221,7 @@ const EmojiPickerModal = ({
             <Text style={styles.closeEmojiPickerText}>×</Text>
           </TouchableOpacity>
         </View>
-        <EmojiSelector onEmojiSelected={onSelect} showSearchBar columns={6} emojiSize={28} />
+        <HabitEmojiPicker onEmojiSelected={onSelect} />
       </View>
     </View>
   </Modal>

--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import EmojiSelector from 'react-native-emoji-selector';
 
 import { DEFAULT_ICONS } from '../constants';
 import styles from '../Habits.styles';
@@ -8,6 +7,7 @@ import type { AddHabitInput } from '../Habits.types';
 import { calculateNetEnergy } from '../HabitUtils';
 
 import { EnergyTextInput } from './EnergyTextInput';
+import HabitEmojiPicker from './HabitEmojiPicker';
 
 interface AddHabitModalProps {
   visible: boolean;
@@ -68,15 +68,11 @@ const IconRow = ({ icon, showEmojiPicker, setShowEmojiPicker, setIcon }: IconRow
     </View>
     {showEmojiPicker && (
       <View style={styles.emojiSelectorContainer}>
-        <EmojiSelector
+        <HabitEmojiPicker
           onEmojiSelected={(emoji) => {
             setIcon(emoji);
             setShowEmojiPicker(false);
           }}
-          showSearchBar
-          columns={6}
-          emojiSize={28}
-          placeholder="Search emoji..."
         />
       </View>
     )}

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -12,7 +12,6 @@ import {
   StyleSheet,
 } from 'react-native';
 import type { GestureResponderHandlers, LayoutChangeEvent, TextStyle } from 'react-native';
-import EmojiSelector from 'react-native-emoji-selector';
 
 import { goalGroups as goalGroupsApi, type ApiGoalGroup } from '../../../api';
 import { Button } from '../../../components/Button';
@@ -47,6 +46,7 @@ import {
 } from '../TierMarkerOverlay';
 
 import ConfirmDialog from './ConfirmDialog';
+import HabitEmojiPicker from './HabitEmojiPicker';
 
 /** Height of the goal progress bar; tier star markers are centered on it. */
 const MODAL_BAR_HEIGHT = 12;
@@ -1005,14 +1005,11 @@ const GoalModalHeader = ({
     )}
     {showEmojiSelector && (
       <View style={styles.emojiSelectorContainer}>
-        <EmojiSelector
+        <HabitEmojiPicker
           onEmojiSelected={(emoji) => {
             onUpdateHabit({ ...habit, icon: emoji });
             setShowEmojiSelector(false);
           }}
-          showSearchBar
-          columns={6}
-          emojiSize={28}
         />
       </View>
     )}

--- a/frontend/src/features/Habits/components/HabitEmojiPicker.tsx
+++ b/frontend/src/features/Habits/components/HabitEmojiPicker.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import EmojiSelector from 'react-native-emoji-selector';
+
+const EMOJI_COLUMNS = 6;
+const EMOJI_SIZE = 28;
+const EMOJI_SEARCH_PLACEHOLDER = 'Search emoji...';
+
+interface HabitEmojiPickerProps {
+  onEmojiSelected: (_emoji: string) => void;
+}
+
+/**
+ * Shared Habits emoji picker. Wraps `react-native-emoji-selector` with the one
+ * canonical search-bar configuration so every Habits call site renders the same
+ * placeholder, column count, and glyph size.
+ */
+const HabitEmojiPicker = ({ onEmojiSelected }: HabitEmojiPickerProps) => (
+  <EmojiSelector
+    onEmojiSelected={onEmojiSelected}
+    showSearchBar
+    columns={EMOJI_COLUMNS}
+    emojiSize={EMOJI_SIZE}
+    placeholder={EMOJI_SEARCH_PLACEHOLDER}
+  />
+);
+
+export default HabitEmojiPicker;

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -10,7 +10,6 @@ import {
   ScrollView,
   Switch,
 } from 'react-native';
-import EmojiSelector from 'react-native-emoji-selector';
 
 import { STAGE_COLORS } from '../../../design/tokens';
 import { DAYS_OF_WEEK } from '../constants';
@@ -20,6 +19,7 @@ import { calculateNetEnergy } from '../HabitUtils';
 
 import ConfirmDialog from './ConfirmDialog';
 import { EnergyTextInput } from './EnergyTextInput';
+import HabitEmojiPicker from './HabitEmojiPicker';
 
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
   if (current === 'daily') return 'weekly';
@@ -325,15 +325,11 @@ const BasicFields = ({
     </View>
     {showEmojiSelector && (
       <View style={styles.emojiSelectorContainer}>
-        <EmojiSelector
+        <HabitEmojiPicker
           onEmojiSelected={(emoji) => {
             handleChange('icon', emoji);
             setShowEmojiSelector(false);
           }}
-          showSearchBar
-          columns={6}
-          emojiSize={28}
-          placeholder="Search emoji..."
         />
       </View>
     )}

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -16,7 +16,6 @@ import {
   type TextInputKeyPressEventData,
 } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
-import EmojiSelector from 'react-native-emoji-selector';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 
@@ -28,6 +27,7 @@ import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
 import { STAGE_ORDER, calculateHabitStartDate, calculateNetEnergy } from '../HabitUtils';
 
 import { ConfirmDialog } from './ConfirmDialog';
+import HabitEmojiPicker from './HabitEmojiPicker';
 import { HABIT_NAME_MAX_LENGTH, MAX_HABITS, validateAndAddHabit } from './onboardingValidation';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -406,7 +406,7 @@ const ReorderEmojiOverlay = ({
         <Text style={styles.closeEmojiPickerText}>×</Text>
       </TouchableOpacity>
     </View>
-    <EmojiSelector onEmojiSelected={onEmojiSelected} showSearchBar columns={6} emojiSize={28} />
+    <HabitEmojiPicker onEmojiSelected={onEmojiSelected} />
   </View>
 );
 

--- a/frontend/src/features/Habits/components/__tests__/HabitEmojiPicker.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitEmojiPicker.test.tsx
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+import { describe, it, expect, jest } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitEmojiPicker from '../HabitEmojiPicker';
+
+jest.mock('react-native-emoji-selector', () => 'EmojiSelector');
+
+describe('HabitEmojiPicker', () => {
+  it('renders the emoji selector with the consistent search placeholder', () => {
+    const { UNSAFE_root } = render(<HabitEmojiPicker onEmojiSelected={() => {}} />);
+    const selector = UNSAFE_root.findByType('EmojiSelector');
+
+    expect(selector.props.placeholder).toBe('Search emoji...');
+    expect(selector.props.showSearchBar).toBe(true);
+    expect(selector.props.columns).toBe(6);
+    expect(selector.props.emojiSize).toBe(28);
+  });
+
+  it('forwards the selected emoji to the onEmojiSelected callback', () => {
+    const onEmojiSelected = jest.fn();
+    const { UNSAFE_root } = render(<HabitEmojiPicker onEmojiSelected={onEmojiSelected} />);
+    const selector = UNSAFE_root.findByType('EmojiSelector');
+
+    selector.props.onEmojiSelected('\u{1F600}');
+
+    expect(onEmojiSelected).toHaveBeenCalledWith('\u{1F600}');
+  });
+});


### PR DESCRIPTION
## Summary
The `react-native-emoji-selector` picker was hand-rolled at five production call
sites in the Habits feature with the same `showSearchBar columns={6}
emojiSize={28}` config, and the copy-paste had drifted: `placeholder="Search
emoji..."` was present in two sites and absent in three, so the emoji search bar
showed different placeholder text depending on which modal opened it.

This extracts one shared `HabitEmojiPicker` component wrapping `EmojiSelector`
with the canonical config (named constants for columns, glyph size, and the
single `"Search emoji..."` placeholder) and routes all five sites through it:

- `HabitsScreen.tsx`
- `components/OnboardingModal.tsx`
- `components/GoalModal.tsx`
- `components/HabitSettingsModal.tsx`
- `components/AddHabitModal.tsx`

Caller-owned visibility state (`showEmojiSelector` / `showEmojiPicker`) is
untouched. The only user-visible behavior change is the now-consistent
placeholder — the exact drift the issue names. No testIDs or rendered output
otherwise change.

## Test plan
- New unit test (`HabitEmojiPicker.test.tsx`) asserts the shared config props
  (placeholder, showSearchBar, columns, emojiSize) and the `onEmojiSelected`
  forwarding path — 100% coverage on the new component.
- `npx tsc --noEmit` — clean.
- `npm run lint` (`--max-warnings=0`) — clean.
- `npx jest --coverage` — 313 suites / 3154 tests pass; coverage gate (≥90%) met.
- `./scripts/frontend/check-all.sh` — 4/4 passed.

Closes #1131