### PR TITLE
refactor(frontend): extract shared EnergyCostReturnEditor for both habit modals

### DIFF
--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -4,9 +4,8 @@ import { Modal, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { DEFAULT_ICONS } from '../constants';
 import styles from '../Habits.styles';
 import type { AddHabitInput } from '../Habits.types';
-import { calculateNetEnergy } from '../HabitUtils';
 
-import { EnergyTextInput } from './EnergyTextInput';
+import { EnergyCostReturnEditor } from './EnergyCostReturnEditor';
 import HabitEmojiPicker from './HabitEmojiPicker';
 
 interface AddHabitModalProps {
@@ -77,46 +76,6 @@ const IconRow = ({ icon, showEmojiPicker, setShowEmojiPicker, setIcon }: IconRow
       </View>
     )}
   </>
-);
-
-interface EnergyRowProps {
-  energyCost: number;
-  energyReturn: number;
-  setEnergyCost: (_v: number) => void;
-  setEnergyReturn: (_v: number) => void;
-}
-
-const EnergyRow = ({
-  energyCost,
-  energyReturn,
-  setEnergyCost,
-  setEnergyReturn,
-}: EnergyRowProps) => (
-  <View style={styles.energyContainer}>
-    <View style={styles.energyHeader}>
-      <Text style={styles.energyHeaderText}>Cost</Text>
-      <Text style={styles.energyHeaderText}>Return</Text>
-      <Text style={styles.energyHeaderText}>Net</Text>
-    </View>
-    <View style={styles.energyRow}>
-      <EnergyTextInput
-        testID="add-habit-cost"
-        style={styles.energyInput}
-        value={energyCost}
-        onCommit={setEnergyCost}
-      />
-      <EnergyTextInput
-        testID="add-habit-return"
-        style={styles.energyInput}
-        value={energyReturn}
-        onCommit={setEnergyReturn}
-      />
-      <Text style={styles.netEnergyValue}>{calculateNetEnergy(energyCost, energyReturn)}</Text>
-    </View>
-    <View style={styles.validationNote}>
-      <Text style={styles.validationText}>Enter a whole number from -10 to 10.</Text>
-    </View>
-  </View>
 );
 
 interface SaveRowProps {
@@ -230,11 +189,13 @@ export const AddHabitModal = ({ visible, onClose, onAdd }: AddHabitModalProps) =
             setShowEmojiPicker={f.setShowEmojiPicker}
             setIcon={f.setIcon}
           />
-          <EnergyRow
-            energyCost={f.energyCost}
+          <EnergyCostReturnEditor
+            cost={f.energyCost}
             energyReturn={f.energyReturn}
-            setEnergyCost={f.setEnergyCost}
-            setEnergyReturn={f.setEnergyReturn}
+            onCommitCost={f.setEnergyCost}
+            onCommitReturn={f.setEnergyReturn}
+            costTestID="add-habit-cost"
+            returnTestID="add-habit-return"
           />
           <SaveRow saving={saving} canSave={canSave} onSave={() => void handleSave()} />
         </View>

--- a/frontend/src/features/Habits/components/EnergyCostReturnEditor.tsx
+++ b/frontend/src/features/Habits/components/EnergyCostReturnEditor.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import styles from '../Habits.styles';
+import { calculateNetEnergy } from '../HabitUtils';
+
+import { EnergyTextInput } from './EnergyTextInput';
+
+const ENERGY_VALIDATION_NOTE = 'Enter a whole number from -10 to 10.';
+
+interface EnergyCostReturnEditorProps {
+  cost: number;
+  energyReturn: number;
+  onCommitCost: (_value: number) => void;
+  onCommitReturn: (_value: number) => void;
+  costTestID?: string;
+  returnTestID?: string;
+}
+
+/**
+ * Shared Cost/Return/Net energy editor. Renders the header row, the two
+ * `EnergyTextInput`s, the computed Net value, and the single canonical
+ * validation note so every Habits call site edits energy identically. Callers
+ * bind their own value source (persisted habit fields or local draft state) via
+ * `cost`/`energyReturn` and the two commit callbacks.
+ */
+export const EnergyCostReturnEditor = ({
+  cost,
+  energyReturn,
+  onCommitCost,
+  onCommitReturn,
+  costTestID,
+  returnTestID,
+}: EnergyCostReturnEditorProps) => (
+  <View style={styles.energyContainer}>
+    <View style={styles.energyHeader}>
+      <Text style={styles.energyHeaderText}>Cost</Text>
+      <Text style={styles.energyHeaderText}>Return</Text>
+      <Text style={styles.energyHeaderText}>Net</Text>
+    </View>
+    <View style={styles.energyRow}>
+      <EnergyTextInput
+        testID={costTestID}
+        style={styles.energyInput}
+        value={cost}
+        onCommit={onCommitCost}
+      />
+      <EnergyTextInput
+        testID={returnTestID}
+        style={styles.energyInput}
+        value={energyReturn}
+        onCommit={onCommitReturn}
+      />
+      <Text style={styles.netEnergyValue}>{calculateNetEnergy(cost, energyReturn)}</Text>
+    </View>
+    <View style={styles.validationNote}>
+      <Text style={styles.validationText}>{ENERGY_VALIDATION_NOTE}</Text>
+    </View>
+  </View>
+);
+
+export default EnergyCostReturnEditor;

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -15,10 +15,9 @@ import { STAGE_COLORS } from '../../../design/tokens';
 import { DAYS_OF_WEEK } from '../constants';
 import styles from '../Habits.styles';
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
-import { calculateNetEnergy } from '../HabitUtils';
 
 import ConfirmDialog from './ConfirmDialog';
-import { EnergyTextInput } from './EnergyTextInput';
+import { EnergyCostReturnEditor } from './EnergyCostReturnEditor';
 import HabitEmojiPicker from './HabitEmojiPicker';
 
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
@@ -26,38 +25,6 @@ const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'cust
   if (current === 'weekly') return 'custom';
   return 'daily';
 };
-
-interface EnergySettingsProps {
-  habit: Habit;
-  netEnergy: number;
-  onChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
-}
-
-const EnergySettings = ({ habit, netEnergy, onChange }: EnergySettingsProps) => (
-  <View style={styles.energyContainer}>
-    <View style={styles.energyHeader}>
-      <Text style={styles.energyHeaderText}>Cost</Text>
-      <Text style={styles.energyHeaderText}>Return</Text>
-      <Text style={styles.energyHeaderText}>Net</Text>
-    </View>
-    <View style={styles.energyRow}>
-      <EnergyTextInput
-        style={styles.energyInput}
-        value={habit.energy_cost}
-        onCommit={(value) => onChange('energy_cost', value)}
-      />
-      <EnergyTextInput
-        style={styles.energyInput}
-        value={habit.energy_return}
-        onCommit={(value) => onChange('energy_return', value)}
-      />
-      <Text style={styles.netEnergyValue}>{netEnergy}</Text>
-    </View>
-    <View style={styles.validationNote}>
-      <Text style={styles.validationText}>Enter a whole number from -10 to 10.</Text>
-    </View>
-  </View>
-);
 
 interface NotificationSettingsProps {
   habit: Habit;
@@ -354,10 +321,11 @@ const EnergyAndDateSection = ({
     <View style={styles.settingRow}>
       <Text style={styles.settingLabel}>Energy Rating:</Text>
     </View>
-    <EnergySettings
-      habit={editedHabit}
-      netEnergy={calculateNetEnergy(editedHabit.energy_cost, editedHabit.energy_return)}
-      onChange={handleChange}
+    <EnergyCostReturnEditor
+      cost={editedHabit.energy_cost}
+      energyReturn={editedHabit.energy_return}
+      onCommitCost={(value) => handleChange('energy_cost', value)}
+      onCommitReturn={(value) => handleChange('energy_return', value)}
     />
     <View style={styles.settingRow}>
       <Text style={styles.settingLabel}>Start Date:</Text>

--- a/frontend/src/features/Habits/components/__tests__/EnergyCostReturnEditor.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/EnergyCostReturnEditor.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { EnergyCostReturnEditor } from '../EnergyCostReturnEditor';
+
+describe('EnergyCostReturnEditor', () => {
+  it('renders the Cost/Return/Net headers, computed net, and validation note', () => {
+    const { getByText } = render(
+      <EnergyCostReturnEditor
+        cost={3}
+        energyReturn={7}
+        onCommitCost={jest.fn()}
+        onCommitReturn={jest.fn()}
+      />,
+    );
+    getByText('Cost');
+    getByText('Return');
+    getByText('Net');
+    getByText('4');
+    getByText('Enter a whole number from -10 to 10.');
+  });
+
+  it('renders a negative net when cost exceeds return', () => {
+    const { getByText } = render(
+      <EnergyCostReturnEditor
+        cost={8}
+        energyReturn={2}
+        onCommitCost={jest.fn()}
+        onCommitReturn={jest.fn()}
+      />,
+    );
+    getByText('-6');
+  });
+
+  it('commits parsed cost and return values through the two inputs', () => {
+    const onCommitCost = jest.fn();
+    const onCommitReturn = jest.fn();
+    const { getByTestId } = render(
+      <EnergyCostReturnEditor
+        cost={1}
+        energyReturn={2}
+        onCommitCost={onCommitCost}
+        onCommitReturn={onCommitReturn}
+        costTestID="cost-input"
+        returnTestID="return-input"
+      />,
+    );
+    fireEvent.changeText(getByTestId('cost-input'), '6');
+    fireEvent.changeText(getByTestId('return-input'), '9');
+    expect(onCommitCost).toHaveBeenCalledWith(6);
+    expect(onCommitReturn).toHaveBeenCalledWith(9);
+  });
+});


### PR DESCRIPTION
## Summary

De-slop dedup (family 3, duplicated code): the Cost/Return/Net energy editor
was duplicated near-verbatim across two Habits modals — `HabitSettingsModal`'s
`EnergySettings` and `AddHabitModal`'s `EnergyRow`. The two blocks differed only
in their value source (persisted habit fields vs. local draft state) and commit
wiring.

- Adds `frontend/src/features/Habits/components/EnergyCostReturnEditor.tsx` — a
  single presentational editor (header row, two `EnergyTextInput`s, computed Net,
  and the validation note) parameterized by `cost`/`energyReturn`, two commit
  callbacks, and optional input testIDs.
- The `"Enter a whole number from -10 to 10."` validation note now lives in
  exactly one source location.
- Both modals now render the editor from the shared component. Rendered output,
  testIDs, styles, and net computation are byte-identical to before.
- Builds on the freshly merged #1189 (shared `HabitEmojiPicker`), which touched
  the same two modals.

## Test plan

- New `EnergyCostReturnEditor.test.tsx`: headers/net/validation-note render,
  negative-net sign convention, and cost/return commit wiring (100% coverage of
  the new component).
- Existing `AddHabitModal` and `HabitSettingsModal` suites pass unchanged,
  confirming behavioral parity through the two call sites.
- Full frontend suite: 3157 jest tests pass; `tsc --noEmit` clean;
  `eslint --max-warnings=0` clean; `scripts/frontend/check-all.sh` exit 0.

Closes #1132