### PR TITLE
refactor(backend): collapse marginalia reanchor twins; drop unreachable botmason fallback

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -472,13 +472,8 @@ def _build_messages(
 
 
 def _provider_default_model(provider: str) -> str:
-    """Return the built-in default model for ``provider``.
-
-    Unknown providers fall back to the OpenAI default — they never reach a
-    real provider, so the value is only a placeholder for logging.
-    """
-    spec = PROVIDER_REGISTRY.get(provider)
-    return spec.default_model if spec else PROVIDER_REGISTRY["openai"].default_model
+    """Return the built-in default model for ``provider``."""
+    return PROVIDER_REGISTRY[provider].default_model
 
 
 def _get_model(provider: str) -> str:

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -10,6 +10,9 @@ user to resolve. The PATCH endpoint calls this after persisting a body edit.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import Protocol
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -37,6 +40,30 @@ class BotmasonResonanceLLM:
         return response.text
 
 
+class _AnchoredRow(Protocol):
+    """Structural view of a re-anchorable row (marginalia or suggestion)."""
+
+    anchor_text: str
+    anchor_start: int
+    anchor_end: int
+    status: str
+
+
+def _reanchor(
+    rows: Iterable[_AnchoredRow],
+    new_message: str,
+    terminal_status: str,
+) -> None:
+    """Re-anchor each row to ``new_message`` or flip it to ``terminal_status``."""
+    for row in rows:
+        outcome = reanchor_one(row.anchor_text, row.anchor_start, new_message)
+        if outcome.stale:
+            row.status = terminal_status
+        else:
+            row.anchor_start = outcome.anchor_start
+            row.anchor_end = outcome.anchor_end
+
+
 async def reanchor_entry_marginalia(
     entry: JournalEntry,
     new_message: str,
@@ -50,17 +77,12 @@ async def reanchor_entry_marginalia(
     offsets alone, so the new body is the only input the logic needs.
     """
     result = await session.execute(
-        select(Marginalia).where(Marginalia.journal_entry_id == entry.id)
+        select(Marginalia).where(
+            Marginalia.journal_entry_id == entry.id,
+            Marginalia.status == MarginaliaStatus.ACTIVE,
+        )
     )
-    for note in result.scalars().all():
-        if note.status == MarginaliaStatus.STALE:
-            continue  # once stale, stays stale
-        outcome = reanchor_one(note.anchor_text, note.anchor_start, new_message)
-        if outcome.stale:
-            note.status = MarginaliaStatus.STALE
-        else:
-            note.anchor_start = outcome.anchor_start
-            note.anchor_end = outcome.anchor_end
+    _reanchor(result.scalars().all(), new_message, MarginaliaStatus.STALE)
 
 
 async def reanchor_entry_suggestions(
@@ -82,10 +104,4 @@ async def reanchor_entry_suggestions(
             CompletionSuggestion.status == SuggestionStatus.PENDING,
         )
     )
-    for suggestion in result.scalars().all():
-        outcome = reanchor_one(suggestion.anchor_text, suggestion.anchor_start, new_message)
-        if outcome.stale:
-            suggestion.status = SuggestionStatus.DISMISSED
-        else:
-            suggestion.anchor_start = outcome.anchor_start
-            suggestion.anchor_end = outcome.anchor_end
+    _reanchor(result.scalars().all(), new_message, SuggestionStatus.DISMISSED)

--- a/backend/tests/test_marginalia_reanchoring.py
+++ b/backend/tests/test_marginalia_reanchoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from http import HTTPStatus
 
 import pytest
@@ -9,8 +10,16 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from domain.marginalia_anchoring import reanchor_one
+from models.completion_suggestion import (
+    CompletionSuggestion,
+    CompletionTargetType,
+    SuggestionStatus,
+)
+from models.goal import Goal
+from models.habit import Habit
 from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia, MarginaliaKind, MarginaliaStatus
+from services.marginalia import reanchor_entry_suggestions
 
 _BODY = "I walked by the river and the willow bent without breaking."
 _ANCHOR = "the willow"
@@ -120,3 +129,177 @@ async def test_patch_inserting_before_keeps_note_active_with_shifted_span(
     ]
     assert items[0]["status"] == MarginaliaStatus.ACTIVE
     assert items[0]["anchor_start"] == new_body.index(_ANCHOR)
+
+
+@pytest.mark.asyncio
+async def test_stale_note_stays_stale_after_passage_returns(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Once a note goes stale, restoring the original passage does not revive it."""
+    headers, user_id = await _signup(async_client, "staleguard")
+    entry_id, _note_id = await _seed(db_session, user_id)
+    start = _BODY.index(_ANCHOR)
+
+    removed = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": "A completely new page."}, headers=headers
+    )
+    assert removed.status_code == HTTPStatus.OK
+
+    restored = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": _BODY}, headers=headers
+    )
+    assert restored.status_code == HTTPStatus.OK
+
+    listing = await async_client.get(f"/journal/{entry_id}/marginalia", headers=headers)
+    items = listing.json()["items"]
+    assert len(items) == 1
+    assert items[0]["status"] == MarginaliaStatus.STALE
+    assert items[0]["anchor_start"] == start
+    assert items[0]["anchor_end"] == start + len(_ANCHOR)
+
+
+async def _seed_entry(session: AsyncSession, user_id: int) -> int:
+    entry = JournalEntry(sender="user", user_id=user_id, message=_BODY)
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+    assert entry.id is not None
+    return entry.id
+
+
+async def _seed_goal(session: AsyncSession, user_id: int) -> int:
+    habit = Habit(
+        name="Run",
+        icon="running",
+        start_date=date(2025, 1, 1),
+        energy_cost=1,
+        energy_return=2,
+        user_id=user_id,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="clear",
+        tier="clear",
+        target=5.0,
+        target_unit="miles",
+        frequency=1.0,
+        frequency_unit="per_day",
+        is_additive=True,
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    assert goal.id is not None
+    return goal.id
+
+
+async def _seed_suggestion(
+    session: AsyncSession,
+    *,
+    entry_id: int,
+    user_id: int,
+    goal_id: int,
+    status: SuggestionStatus = SuggestionStatus.PENDING,
+) -> int:
+    start = _BODY.index(_ANCHOR)
+    suggestion = CompletionSuggestion(
+        journal_entry_id=entry_id,
+        user_id=user_id,
+        target_type=CompletionTargetType.HABIT,
+        goal_id=goal_id,
+        user_practice_id=None,
+        label="a walk by the willow",
+        anchor_start=start,
+        anchor_end=start + len(_ANCHOR),
+        anchor_text=_ANCHOR,
+        status=status,
+    )
+    session.add(suggestion)
+    await session.commit()
+    await session.refresh(suggestion)
+    assert suggestion.id is not None
+    return suggestion.id
+
+
+@pytest.mark.asyncio
+async def test_reanchor_suggestions_dismisses_when_passage_removed(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A pending suggestion auto-dismisses when its anchored passage is deleted."""
+    _headers, user_id = await _signup(async_client, "sugdismiss")
+    entry_id = await _seed_entry(db_session, user_id)
+    entry = await db_session.get(JournalEntry, entry_id)
+    assert entry is not None
+    goal_id = await _seed_goal(db_session, user_id)
+    sug_id = await _seed_suggestion(
+        db_session,
+        entry_id=entry_id,
+        user_id=user_id,
+        goal_id=goal_id,
+    )
+
+    await reanchor_entry_suggestions(entry, "An entirely different entry today.", db_session)
+    await db_session.commit()
+
+    suggestion = await db_session.get(CompletionSuggestion, sug_id)
+    assert suggestion is not None
+    assert suggestion.status == SuggestionStatus.DISMISSED
+
+
+@pytest.mark.asyncio
+async def test_reanchor_suggestions_shifts_offset_and_stays_pending(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A pending suggestion re-anchors to the shifted offset when the passage moves."""
+    _headers, user_id = await _signup(async_client, "sugshift")
+    entry_id = await _seed_entry(db_session, user_id)
+    entry = await db_session.get(JournalEntry, entry_id)
+    assert entry is not None
+    goal_id = await _seed_goal(db_session, user_id)
+    sug_id = await _seed_suggestion(
+        db_session,
+        entry_id=entry_id,
+        user_id=user_id,
+        goal_id=goal_id,
+    )
+    new_body = "Yesterday: " + _BODY
+
+    await reanchor_entry_suggestions(entry, new_body, db_session)
+    await db_session.commit()
+
+    suggestion = await db_session.get(CompletionSuggestion, sug_id)
+    assert suggestion is not None
+    assert suggestion.status == SuggestionStatus.PENDING
+    assert suggestion.anchor_start == new_body.index(_ANCHOR)
+
+
+@pytest.mark.asyncio
+async def test_reanchor_suggestions_leaves_accepted_untouched(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An already-accepted suggestion is left alone even when its passage is removed."""
+    _headers, user_id = await _signup(async_client, "sugaccepted")
+    entry_id = await _seed_entry(db_session, user_id)
+    entry = await db_session.get(JournalEntry, entry_id)
+    assert entry is not None
+    goal_id = await _seed_goal(db_session, user_id)
+    start = _BODY.index(_ANCHOR)
+    sug_id = await _seed_suggestion(
+        db_session,
+        entry_id=entry_id,
+        user_id=user_id,
+        goal_id=goal_id,
+        status=SuggestionStatus.ACCEPTED,
+    )
+
+    await reanchor_entry_suggestions(entry, "An entirely different entry today.", db_session)
+    await db_session.commit()
+
+    suggestion = await db_session.get(CompletionSuggestion, sug_id)
+    assert suggestion is not None
+    assert suggestion.status == SuggestionStatus.ACCEPTED
+    assert suggestion.anchor_start == start
+    assert suggestion.anchor_end == start + len(_ANCHOR)


### PR DESCRIPTION
## Summary
- Collapse the byte-identical `reanchor_entry_marginalia` / `reanchor_entry_suggestions` loop bodies into one shared `_reanchor` helper, typed against a small `_AnchoredRow` Protocol; the marginalia STALE-skip moves into the query as `status == ACTIVE` (behavior-identical for the two-valued, DB-CHECK-pinned enum), while the suggestions path keeps its load-bearing in-query `status == PENDING` filter.
- Simplify `_provider_default_model` in `botmason.py` to the single reachable case (`return PROVIDER_REGISTRY[provider].default_model`), dropping an unreachable else branch and its stale "placeholder for logging" docstring comment.
- Pure behavior-preserving de-slop tidy-up; no other files touched.

## Test plan
- Added 4 characterization tests for the previously-uncovered suggestion reanchor paths (auto-dismiss, offset shift, non-pending untouched) plus a marginalia stale-stays-stale regression; confirmed GREEN against the pre-refactor code, then still GREEN after.
- `./scripts/backend/check-all.sh` — 7/7 quality checks pass (2323 passed, 96.41% coverage, `marginalia.py` at 100%); ruff + mypy strict clean.
- `xenon --max-absolute A --max-modules A --max-average A` and `radon mi` — both changed modules grade A.
- code-review-orchestrator self-review over the diff: verdict CLEAN, no blockers.

Closes #1129
