### PR TITLE
refactor(frontend): tidy up residual Habits dead code + log-0 coercion

### DIFF
--- a/frontend/src/features/Habits/HabitDefaults.tsx
+++ b/frontend/src/features/Habits/HabitDefaults.tsx
@@ -1,4 +1,12 @@
+import { DEFAULT_ICONS } from './constants';
 import type { Habit } from './Habits.types';
+
+/** Default energy cost/return assigned to a newly-created habit. */
+export const DEFAULT_ENERGY = 5;
+
+/** Pick a random default icon, falling back to a star when the list is empty. */
+export const randomDefaultIcon = (): string =>
+  DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐';
 
 /**
  * Default habit definitions for the APTITUDE onboarding flow.

--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -37,38 +37,6 @@ export const styles = StyleSheet.create({
   iconLarge: {
     fontSize: 24,
   },
-  name: {
-    fontSize: 16,
-    fontWeight: '600',
-    textAlign: 'center',
-    color: COLORS.text.primary,
-  },
-
-  // ===== Progress Bars =====
-  progressBarContainer: {
-    width: '100%',
-    height: 16,
-    backgroundColor: COLORS.background.accent,
-    borderRadius: BORDER_RADIUS.xs,
-    marginTop: SPACING.xs,
-    overflow: 'hidden',
-    position: 'relative',
-  },
-  progressBar: {
-    height: '100%',
-    width: '100%',
-    backgroundColor: 'transparent', // Changed to transparent
-    borderRadius: BORDER_RADIUS.md,
-    position: 'relative',
-  },
-  progressBarFill: {
-    height: '100%',
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    borderRadius: BORDER_RADIUS.md,
-  },
-
   // ===== Modals =====
   modalOverlay: {
     flex: 1,
@@ -1053,12 +1021,6 @@ export const styles = StyleSheet.create({
     shadowOpacity: 0.2,
     shadowRadius: 4,
     elevation: 10,
-  },
-  streak: {
-    marginTop: 4,
-    fontSize: 12,
-    color: '#555',
-    fontWeight: '500',
   },
 });
 

--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
-import { DEFAULT_ICONS } from '../constants';
+import { DEFAULT_ENERGY, randomDefaultIcon } from '../HabitDefaults';
 import styles from '../Habits.styles';
 import type { AddHabitInput } from '../Habits.types';
 
@@ -13,11 +13,6 @@ interface AddHabitModalProps {
   onClose: () => void;
   onAdd: (_input: AddHabitInput) => void | Promise<void>;
 }
-
-const DEFAULT_ENERGY = 5;
-
-const randomDefaultIcon = (): string =>
-  DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐';
 
 const AddHabitHeader = ({ onClose }: { onClose: () => void }) => (
   <View style={styles.modalHeader}>

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -1094,7 +1094,8 @@ const useLogState = (
 
   const handleLogUnit = () => {
     if (!habit.id) return;
-    onLogUnit(habit.id, parseFloat(logAmount) || 1, logDate);
+    const parsed = Number.parseFloat(logAmount);
+    onLogUnit(habit.id, Number.isNaN(parsed) ? 1 : parsed, logDate);
     setLogAmount('1');
     setLogDate(new Date());
   };

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -584,11 +584,10 @@ const useOnboardingEffects = (
   }, [step, scrollRef]);
 
   useEffect(() => {
-    if (Platform.OS === 'web' && (step === 2 || step === 3)) {
+    if (Platform.OS === 'web' && step === 3) {
       const handler = (e: KeyboardEvent) => {
         if (!(e.metaKey || e.ctrlKey) || e.key !== 'Enter') return;
-        if (step === 2) return;
-        if (step === 3) prepareHabitsForReorder();
+        prepareHabitsForReorder();
       };
       document.addEventListener('keydown', handler);
       return () => document.removeEventListener('keydown', handler);

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -481,6 +481,19 @@ describe('GoalModal log-unit guards', () => {
     const [, amount] = calls[0] as [number, number, Date];
     expect(amount).toBe(1);
   });
+
+  it('logs an explicit 0 as 0 rather than coercing it to 1', () => {
+    const { getByTestId, getByText, props } = renderModal();
+    const logSection = getByTestId('goal-modal-log-unit-section');
+    const amountInput = within(logSection).getByDisplayValue('1');
+    fireEvent.changeText(amountInput, '0');
+    fireEvent.press(getByText('Log Units'));
+
+    const calls = (props.onLogUnit as unknown as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [, amount] = calls[0] as [number, number, Date];
+    expect(amount).toBe(0);
+  });
 });
 
 describe('GoalModal progress-bar zero/equal-target guards', () => {

--- a/frontend/src/features/Habits/components/onboardingValidation.ts
+++ b/frontend/src/features/Habits/components/onboardingValidation.ts
@@ -5,10 +5,9 @@
  * in the modal's React Native + reanimated + gesture-handler tree.  The
  * modal re-exports the same names for its own use.
  */
-import { DEFAULT_ICONS, MAX_HABITS } from '../constants';
+import { MAX_HABITS } from '../constants';
+import { DEFAULT_ENERGY, randomDefaultIcon } from '../HabitDefaults';
 import type { OnboardingHabit } from '../Habits.types';
-
-const DEFAULT_ENERGY = 5;
 
 // BUG-FE-HABIT-105: maximum length for an onboarding habit name.  TextInput
 // also enforces the cap; the parse-time guard is defence in depth so a
@@ -42,7 +41,7 @@ export const sanitizeHabitName = (raw: string): string => {
 export const createNewHabit = (name: string): OnboardingHabit => ({
   id: generateHabitId(),
   name: sanitizeHabitName(name),
-  icon: DEFAULT_ICONS[Math.floor(Math.random() * DEFAULT_ICONS.length)] ?? '⭐',
+  icon: randomDefaultIcon(),
   energy_cost: DEFAULT_ENERGY,
   energy_return: DEFAULT_ENERGY,
   stage: 'Beige',

--- a/frontend/src/features/Habits/components/parseEnergyValue.ts
+++ b/frontend/src/features/Habits/components/parseEnergyValue.ts
@@ -5,9 +5,9 @@
  *
  * BUG-FE-HABIT-201: the prior ``parseInt(text) || 0`` silently coerced
  * "foo", "1.5", "" all to ``0`` and accepted them as valid energy
- * values.  Strict integer regex + finite check + range guard rejects
- * the malformed cases so the caller can surface a validation error
- * instead of writing 0 to the planner.
+ * values.  Strict integer regex + range guard rejects the malformed
+ * cases so the caller can surface a validation error instead of writing
+ * 0 to the planner.
  */
 // Bounds mirror those expressed in ``HabitSettingsModal``; kept here so
 // the parser stays a single source of truth across the input row + the
@@ -19,6 +19,5 @@ export const parseEnergyValue = (text: string): number | null => {
   if (text.trim() === '') return null;
   if (!/^-?\d+$/.test(text.trim())) return null;
   const value = Number.parseInt(text.trim(), 10);
-  if (!Number.isFinite(value)) return null;
   return value >= ENERGY_MIN && value <= ENERGY_MAX ? value : null;
 };


### PR DESCRIPTION
## Summary

A bundle of corroborated, low-risk Habits-area de-slop cleanups. Each finding was **re-verified against the current post-churn base** before acting.

- **A — dead style keys (removed):** deleted the five unreferenced `StyleSheet` keys `name`, `progressBarContainer`, `progressBar`, `progressBarFill`, `streak` from `Habits.styles.ts`. Grep confirms zero references remain in the Habits feature.
- **B — slider clamp/round guard (NULL FINDING — left in place):** the proposed removal of the `updateHabitEnergy` `if (value < 0 || value > 10) return;` + `Math.round` was **reverted**. Dedicated tests in `OnboardingModal.energySliders.test.tsx` fire `valueChange` with `-1`, `11`, and `6.6` to pin the clamp+round as the handler's contract, so removing it would be a behavior change contrary to the issue's own "no behavior change (B)" constraint.
- **C — inert step-2 keydown registration (fixed):** narrowed the onboarding reorder `keydown` effect from `step === 2 || step === 3` (which early-returned on step 2) to `step === 3` only. Behavior-preserving.
- **D — unreachable `isFinite` guard (removed):** dropped `if (!Number.isFinite(value)) return null;` in `parseEnergyValue.ts` — the `^-?\d+$` regex + `Number.parseInt` already guarantee a finite integer, and the range check rejects out-of-range values. Docstring updated to match.
- **E — logging `0` coerced to `1` (fixed):** replaced `parseFloat(logAmount) || 1` with an explicit `Number.isNaN` check so a deliberate `0` logs `0`, while preserving the empty/non-numeric → `1` fallback.
- **F — duplicated default-habit seed (consolidated):** hoisted `DEFAULT_ENERGY` and `randomDefaultIcon()` into the existing `HabitDefaults.tsx` seed module; `AddHabitModal.tsx` and `onboardingValidation.ts` now import the single shared source instead of each redeclaring them.

## Test plan

- Added a regression test: logging an explicit `0` logs `0` (not `1`); the existing non-numeric → `1` fallback test still passes.
- `npx tsc --noEmit` — clean.
- `npm run lint` — zero warnings.
- `./scripts/frontend/check-all.sh` — 4/0 passed (jest: 3159 tests green, coverage ≥ threshold).

Closes #1135