### PR TITLE
refactor(frontend): collapse the triplicated Spiral-Dynamics color resolver

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -8,6 +8,7 @@ import {
   brightenColor,
   colors,
   radius,
+  resolveStageColor,
   shadows,
   spacing,
   touchTarget,
@@ -134,6 +135,26 @@ describe('design tokens', () => {
       const colorKeys = Object.keys(STAGE_COLORS).sort();
       const orderKeys = [...STAGE_ORDER].sort();
       expect(orderKeys).toEqual(colorKeys);
+    });
+  });
+
+  describe('resolveStageColor', () => {
+    it('maps a known Spiral-Dynamics color name to its hex value', () => {
+      expect(resolveStageColor('Beige')).toBe(STAGE_COLORS['Beige']);
+      expect(resolveStageColor('Purple')).toBe(STAGE_COLORS['Purple']);
+      expect(resolveStageColor('Clear Light')).toBe(STAGE_COLORS['Clear Light']);
+    });
+
+    it('falls back to the neutral gray for an unrecognized color name', () => {
+      expect(resolveStageColor('Mauve')).toBe(colors.neutral);
+    });
+
+    it('falls back to the neutral gray when the color name is undefined', () => {
+      expect(resolveStageColor(undefined)).toBe(colors.neutral);
+    });
+
+    it('falls back to the neutral gray for an empty color name', () => {
+      expect(resolveStageColor('')).toBe(colors.neutral);
     });
   });
 

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -185,6 +185,15 @@ export const STAGE_ORDER: readonly string[] = [
   'Clear Light',
 ];
 
+/**
+ * Resolve a Spiral-Dynamics color name to its hex value, falling back to the
+ * neutral gray when the name is missing or unrecognized. This is the single
+ * resolution used across the Course stage cover, progress bar, and pill
+ * selector — keep it here so the fallback can never silently diverge.
+ */
+export const resolveStageColor = (spiralColor: string | undefined): string =>
+  spiralColor ? STAGE_COLORS[spiralColor] ?? colors.neutral : colors.neutral;
+
 /** How far each channel is pushed from the gray point when brightening. */
 const SATURATION_BOOST = 1.7;
 

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -17,7 +17,7 @@ import { EmptyState } from '../../components/feedback/EmptyState';
 import { EditorialSection } from '../../components/layout/EditorialSection';
 import { ScreenHeader } from '../../components/layout/ScreenHeader';
 import { ShowcaseCard } from '../../components/layout/ShowcaseCard';
-import { STAGE_COLORS, colors } from '../../design/tokens';
+import { resolveStageColor } from '../../design/tokens';
 import { useAppRoute } from '../../navigation/hooks';
 import type { RootStackParamList } from '../../navigation/RootStack';
 import { useProgramStore, programStage } from '../../store/useProgramStore';
@@ -125,9 +125,6 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
 
 // --- Sub-components ---
 
-const stageAccent = (spiralColor: string | undefined): string =>
-  spiralColor ? STAGE_COLORS[spiralColor] ?? colors.neutral : colors.neutral;
-
 const stageIsComplete = (progress: CourseProgress | null): boolean =>
   progress != null && progress.total_items > 0 && progress.read_items >= progress.total_items;
 
@@ -140,7 +137,7 @@ interface StageCoverProps {
 /** The showcase "book cover" for the selected stage: serif title, Spiral-Dynamics
  *  accent rule, progress arc, and a celebration when the stage is finished. */
 const StageCover = ({ stage, progress, spiralColor }: StageCoverProps): React.JSX.Element => {
-  const accentColor = stageAccent(spiralColor);
+  const accentColor = resolveStageColor(spiralColor);
   const percent = progress ? progress.progress_percent : 0;
   const complete = stageIsComplete(progress);
   return (
@@ -201,7 +198,7 @@ const CourseProgressBar = ({
   error = false,
 }: ProgressBarProps): React.JSX.Element => {
   const progressPercent = progress ? progress.progress_percent : 0;
-  const barColor = spiralColor ? STAGE_COLORS[spiralColor] ?? colors.neutral : colors.neutral;
+  const barColor = resolveStageColor(spiralColor);
 
   return (
     <View style={styles.progressBarContainer} testID="progress-bar">

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
 import type { Stage } from '../../api';
-import { STAGE_COLORS, STAGE_ORDER, colors } from '../../design/tokens';
+import { STAGE_ORDER, resolveStageColor } from '../../design/tokens';
 
 import styles from './Course.styles';
 
@@ -20,12 +20,11 @@ interface StageSelectorProps {
 
 /** Get the spiral dynamics color for a stage number (1-indexed). */
 function getStageColor(stageNumber: number, stageById: Map<number, Stage>): string {
-  const stage = stageById.get(stageNumber);
-  if (stage) {
-    return STAGE_COLORS[stage.spiral_dynamics_color] ?? colors.neutral;
-  }
-  const name = STAGE_ORDER[stageNumber - 1];
-  return name ? STAGE_COLORS[name] ?? colors.neutral : colors.neutral;
+  // Prefer the stage's own API color; fall back to its progression-order name
+  // when the API omits that stage number. The shared resolver handles the
+  // neutral fallback for missing or unrecognized names.
+  const name = stageById.get(stageNumber)?.spiral_dynamics_color ?? STAGE_ORDER[stageNumber - 1];
+  return resolveStageColor(name);
 }
 
 /** Determine if a stage is unlocked based on API data. */

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -1,8 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { StyleSheet } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 
 import type { ContentItem, CourseProgress, Stage } from '../../../api';
+import { colors, STAGE_COLORS } from '../../../design/tokens';
+
+function backgroundColorOf(style: StyleProp<ViewStyle>): string {
+  const flat = StyleSheet.flatten(style) ?? {};
+  return (flat.backgroundColor as string | undefined) ?? '';
+}
 
 const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
   id: 1,
@@ -523,5 +531,61 @@ describe('single scroll surface', () => {
     const list = within(getByTestId('content-list'));
     expect(list.getByText('Welcome Essay')).toBeTruthy();
     expect(list.getByTestId('stage-cover')).toBeTruthy();
+  });
+});
+
+// Pins the rendered Spiral-Dynamics accent so the shared color resolver can
+// never silently change what the cover and progress bar are tinted with.
+describe('CourseScreen Spiral-Dynamics accent colors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStagesList.mockResolvedValue(sampleStages);
+    mockStageContent.mockResolvedValue(sampleContent);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+    mockStageIntro.mockRejectedValue({ detail: 'content_not_found' });
+  });
+
+  it('tints the stage cover progress with the selected stage color', async () => {
+    // Default selection is stage 2 (Purple).
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(backgroundColorOf(getByTestId('stage-cover-progress').props.style)).toBe(
+        STAGE_COLORS['Purple'],
+      );
+    });
+  });
+
+  it('tints the course progress bar fill with the same selected stage color', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(backgroundColorOf(getByTestId('progress-bar-fill').props.style)).toBe(
+        STAGE_COLORS['Purple'],
+      );
+    });
+  });
+
+  it('falls back to the neutral color when the stage color is unrecognized', async () => {
+    const mauveStages: Stage[] = [
+      makeStage({ id: 1, stage_number: 1, is_unlocked: true, progress: 1 }),
+      makeStage({
+        id: 2,
+        stage_number: 2,
+        spiral_dynamics_color: 'Mauve',
+        is_unlocked: true,
+        progress: 0,
+      }),
+    ];
+    mockStagesList.mockResolvedValue(mauveStages);
+
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(backgroundColorOf(getByTestId('stage-cover-progress').props.style)).toBe(
+        colors.neutral,
+      );
+      expect(backgroundColorOf(getByTestId('progress-bar-fill').props.style)).toBe(colors.neutral);
+    });
   });
 });


### PR DESCRIPTION
## Summary

De-slop dedupe (#1136): the "resolve a Spiral-Dynamics color name → hex, with a
`colors.neutral` fallback" expression was implemented three times across the
Course feature. This collapses them into one shared resolver.

- Add `resolveStageColor(spiralColor)` to `frontend/src/design/tokens.ts` — the
  single source of truth for the `STAGE_COLORS[name] ?? colors.neutral` rule.
- `CourseScreen.tsx`: `StageCover` and `CourseProgressBar` both derive their
  accent via `resolveStageColor` (the local `stageAccent` helper and the
  re-inlined `barColor` expression are gone).
- `StageSelector.tsx`: `getStageColor` delegates to the shared resolver instead
  of writing the fallback twice.

Pure dedupe — **no rendered color changes**. Behavioral equivalence holds for
every input class (known name, unrecognized name, `undefined`, empty string,
out-of-range stage number); it relies on `Stage.spiral_dynamics_color` being a
non-nullable `string`, which the API type and zod schema enforce.

After this change the `?? colors.neutral` fallback expression appears at exactly
one implementation site (grep-verified). The Habits/Map lookups use different
fallbacks (`#000`/`#ccc`/`#888`) and are intentionally untouched.

## Test plan

- New characterization tests pin the accent colors **before** the collapse:
  - `design/__tests__/tokens.test.ts`: `resolveStageColor` maps known names,
    and falls back to `colors.neutral` for unrecognized / `undefined` / empty.
  - `Course/__tests__/CourseScreen.test.tsx`: stage-cover progress and
    progress-bar fill are tinted with the selected stage color, and fall back to
    neutral for an unrecognized color.
  - Existing `StageSelector` color tests (neutral fallback, STAGE_ORDER
    fallback, out-of-range) continue to pass unchanged.
- `./scripts/frontend/check-all.sh` green (tsc, eslint, prettier, jest +
  coverage — 3164 tests pass).

Closes #1136