### PR TITLE
refactor(frontend): tidy Course feature dead styles, guard idiom, naming

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -46,7 +46,7 @@ interface ChapterReaderProps {
  * the content repo — nothing the OS can open — so taps on them are
  * swallowed rather than thrown at the system as broken URLs.
  */
-function handleLinkPress(url: string): boolean {
+function isExternalWebUrl(url: string): boolean {
   return url.startsWith('https://') || url.startsWith('http://');
 }
 
@@ -62,7 +62,7 @@ function handleLinkPress(url: string): boolean {
 const markdownRules = {
   image: (node: { key?: string; attributes?: { src?: string; alt?: string } }): React.ReactNode => {
     const src = node.attributes?.src ?? '';
-    if (!handleLinkPress(src)) {
+    if (!isExternalWebUrl(src)) {
       return null;
     }
     // RN's Image with bounded sizing instead of the library's FitImage
@@ -151,9 +151,7 @@ const EmptyView = (): React.JSX.Element => (
   </View>
 );
 
-function describeError(): string {
-  return 'This chapter couldn’t load right now. Please try again.';
-}
+const READER_ERROR_MESSAGE = 'This chapter couldn’t load right now. Please try again.';
 
 function fetchBody(source: ChapterReaderSource): Promise<ContentBody> {
   switch (source.kind) {
@@ -203,7 +201,7 @@ function useContentBody(source: ChapterReaderSource): {
       })
       .catch(() => {
         if (!isMountedRef.current) return;
-        setError(describeError());
+        setError(READER_ERROR_MESSAGE);
       })
       .finally(() => {
         if (!isMountedRef.current) return;
@@ -229,7 +227,7 @@ function renderBody(body: ContentBody): React.ReactElement {
     >
       <View style={styles.readerSheet}>
         <ReaderSheetHeader eyebrow={READER_EYEBROWS[body.content_type]} title={body.title} />
-        <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={handleLinkPress}>
+        <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={isExternalWebUrl}>
           {markdown}
         </Markdown>
       </View>

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -134,17 +134,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.lg,
     paddingVertical: SPACING.md,
   },
-  stageTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: ink.primary,
-    marginBottom: 2,
-  },
-  stageSubtitle: {
-    fontSize: 14,
-    color: ink.soft,
-    marginBottom: SPACING.sm,
-  },
   stageDetailRow: {
     flexDirection: 'row',
     gap: SPACING.md,

--- a/frontend/src/features/Course/SiteResourcesPanel.tsx
+++ b/frontend/src/features/Course/SiteResourcesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 
 import { course as courseApi, type SiteResource } from '../../api';
@@ -21,16 +21,9 @@ interface SiteResourcesPanelProps {
  */
 const SiteResourcesPanel = ({ onSelect }: SiteResourcesPanelProps): React.JSX.Element | null => {
   const [resources, setResources] = useState<SiteResource[]>([]);
-  const isMountedRef = useRef(true);
-
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-    },
-    [],
-  );
 
   useEffect(() => {
+    let active = true;
     // ``siteResources()`` is called without an explicit token — the
     // shared ``request()`` helper in ``api/index.ts`` falls back to the
     // global ``tokenGetter`` set by ``AuthContext``, matching how
@@ -38,14 +31,16 @@ const SiteResourcesPanel = ({ onSelect }: SiteResourcesPanelProps): React.JSX.El
     courseApi
       .siteResources()
       .then((list) => {
-        if (!isMountedRef.current) return;
-        setResources(list);
+        if (active) setResources(list);
       })
       .catch((err: unknown) => {
         // Don't surface a banner — the resources panel is supplementary.
         // Logging keeps the failure visible in dev without spooking users.
         console.warn('Failed to load site resources:', err);
       });
+    return () => {
+      active = false;
+    };
   }, []);
 
   if (resources.length === 0) return null;

--- a/frontend/src/features/Course/__tests__/Course.styles.test.ts
+++ b/frontend/src/features/Course/__tests__/Course.styles.test.ts
@@ -10,7 +10,6 @@ describe('Course.styles reader sheet', () => {
     const readerSheet = StyleSheet.flatten(styles.readerSheet);
     const readerScroll = StyleSheet.flatten(styles.readerScroll);
     expect(readerSheet.backgroundColor).toBe(surface.canvas);
-    expect(readerSheet.backgroundColor).not.toBe('#ffffff');
     expect(readerScroll.backgroundColor).toBe(surface.desk);
   });
 


### PR DESCRIPTION
## Summary
Five small, independently-corroborated de-slop tidy-ups in the Course feature (from the de-slopify scan). No behavior change intended for any item.

- **A** — deleted dead style keys `stageTitle` / `stageSubtitle` from `Course.styles.ts` (zero consumers; superseded by `stageCover*` / `stageDetail*`).
- **B** — replaced the `isMountedRef` + unmount-only `useEffect` in `SiteResourcesPanel.tsx` with the house-standard `let active = true` closure flag inside the fetch effect (now matches sibling `StageIntroCard.tsx`).
- **C** — renamed the misleadingly-named `handleLinkPress` (a pure URL-scheme predicate) to `isExternalWebUrl` in `ChapterReader.tsx`; both call sites updated.
- **D** — inlined the param-less `describeError()` into a module-level `READER_ERROR_MESSAGE` const; message string unchanged.
- **E** — dropped the redundant `.not.toBe('#ffffff')` assertion in `Course.styles.test.ts`; the load-bearing `.toBe(surface.canvas)` pin remains.

## Test plan
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`--max-warnings=0`)
- `npx jest --coverage` — 313 suites / 3148 tests pass; coverage gate met
- `./scripts/frontend/check-all.sh` — 4/4 quality checks pass
- Gate 2.5 self-review (code-review-orchestrator) — CLEAN, no blockers; confirmed the diff does not touch the Spiral-Dynamics color-resolution area under concurrent refactor.

Closes #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)