### PR TITLE
test(frontend): harden StageSelector completed-checkmark test

### DIFF
--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -72,14 +72,21 @@ describe('StageSelector', () => {
     expect(queryByTestId('stage-pill-4')).toBeNull();
   });
 
-  it('shows checkmark for completed stages', () => {
+  it('shows checkmark for completed stages and the number for uncompleted ones', () => {
     const { getByTestId } = render(
       <StageSelector stages={sampleStages} selectedStage={2} onSelectStage={onSelectStage} />,
     );
 
-    // Stage 1 has progress === 1.0, should show checkmark
+    // Stage 1 (progress 1.0) renders the checkmark glyph and flags completion.
     const pill1 = getByTestId('stage-pill-1');
-    expect(pill1).toBeTruthy();
+    expect(within(pill1).getByText('✓')).toBeTruthy();
+    expect(pill1.props.accessibilityLabel).toBe('Stage 1, completed');
+
+    // Stage 2 (unlocked, progress 0.5) renders its number, never the checkmark.
+    const pill2 = getByTestId('stage-pill-2');
+    expect(within(pill2).getByText('2')).toBeTruthy();
+    expect(within(pill2).queryByText('✓')).toBeNull();
+    expect(pill2.props.accessibilityLabel).toBe('Stage 2');
   });
 
   it('calls onSelectStage when an unlocked stage is tapped', () => {
@@ -186,19 +193,6 @@ describe('StageSelector', () => {
     const pill11 = getByTestId('stage-pill-11');
     const style = pill11.props.style as StyleProp<ViewStyle>;
     expect(backgroundColorOf(style)).toBe(colors.neutral);
-  });
-
-  it('renders the checkmark glyph for a completed stage and the number for an active one', () => {
-    const stages = [
-      makeStage({ stage_number: 1, is_unlocked: true, progress: 1.0 }),
-      makeStage({ stage_number: 2, is_unlocked: true, progress: 0.2 }),
-    ];
-    const { getByTestId } = render(
-      <StageSelector stages={stages} selectedStage={2} onSelectStage={onSelectStage} />,
-    );
-
-    expect(within(getByTestId('stage-pill-1')).getByText('✓')).toBeTruthy();
-    expect(within(getByTestId('stage-pill-2')).getByText('2')).toBeTruthy();
   });
 
   it('renders the lock glyph for a locked, non-completed stage', () => {


### PR DESCRIPTION
## Summary
The `'shows checkmark for completed stages'` test in `StageSelector.test.tsx` was coverage theater (de-slop Family 9): its only assertion was `expect(pill1).toBeTruthy()`, which never queried the `✓` glyph. Removing or inverting the `completed ? <Text>✓</Text>` branch in `StageSelector.tsx` left the test green, so the entire completed-render path was behaviorally untested.

This PR rewrites that test to pin real behavior:
- Asserts the actual `✓` glyph and the `Stage 1, completed` accessibility label for a completed stage (progress 1.0).
- Adds a negative case proving an uncompleted, unlocked pill renders its number and **no** `✓` (stage 2, progress 0.5).
- Removes the now-redundant `'renders the checkmark glyph ... and the number for an active one'` test, whose assertions are a strict subset of the hardened one.

Test-only change — no production code touched (none needed; the component was already correct).

## Test plan
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (0 warnings)
- `./scripts/frontend/check-all.sh` — all 4 checks pass; full suite 3146 tests green, coverage ≥ 90%
- Mutation check (traced): dropping/inverting the `completed ? ✓` branch or stripping the `, completed` label suffix now fails the hardened test.

Closes #1137