### PR TITLE
fix(frontend): include own drafts when resolving the active practice

### DIFF
--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -338,6 +338,31 @@ describe('PracticeScreen', () => {
     );
   });
 
+  it('renders an active custom (draft) practice by including own drafts in the catalogue fetch', async () => {
+    // A user-created practice is an unapproved draft: the backend lets its
+    // author select it (POST /user-practices/ succeeds), but the approved-only
+    // practices list omits it. The screen must fetch with includeMine so the
+    // active row's practice resolves — otherwise the saved selection falls
+    // into the "No practice yet" empty state (custom-practices selection bug).
+    const draft = samplePractice({
+      id: 42,
+      name: 'My Custom Sit',
+      approved: false,
+      submitted_by_user_id: 1,
+    });
+    mockPracticesList.mockImplementation((options: unknown) => {
+      const includeMine =
+        typeof options === 'object' &&
+        options !== null &&
+        (options as { includeMine?: boolean }).includeMine === true;
+      return Promise.resolve(includeMine ? [samplePractice(), draft] : [samplePractice()]);
+    });
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice({ practice_id: 42 })]);
+    const { getByTestId, queryByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+    expect(queryByTestId('practice-empty-state')).toBeNull();
+  });
+
   it('wraps the running session mode view in the calm SessionSurface', async () => {
     // The active session now provides the calm lifted-paper surface to the mode
     // view, so the interior renders on the light raised ground; the deep umber

--- a/frontend/src/features/Practice/hooks/useActivePractice.ts
+++ b/frontend/src/features/Practice/hooks/useActivePractice.ts
@@ -105,8 +105,12 @@ function useRefreshAction(
         error: null,
       }));
       try {
+        // ``includeMine`` matters: a user-created practice is an unapproved
+        // draft the backend lets its author select, but the approved-only
+        // list omits it — without the flag the active row's practice never
+        // resolves and the screen wrongly shows the "No practice yet" state.
         const [practiceList, userPracticeList] = await Promise.all([
-          practices.listAll(stageNumber),
+          practices.listAll({ stageNumber, includeMine: true }),
           userPractices.list(),
         ]);
         if (!mountedRef.current) return;


### PR DESCRIPTION
A user-created practice is an unapproved draft: the backend permits its
author to select it (POST /user-practices/ succeeds), but useActivePractice
fetched the stage catalogue approved-only, so the active row's practice_id
never resolved and PracticeScreen fell into the "No practice yet" empty
state — making custom practices appear unselectable despite the selection
saving. Fetch with includeMine: true (as the catalog screen already does)
so the author's draft resolves and the active session renders.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SaXiimrRR8VEZtQH3wx9ba