### PR TITLE
fix(ralph): honor the repo's priority-* labels in picker tiering

### DIFF
--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -27,8 +27,9 @@
 #                         issue carrying no P-label. Default 1 (== P1). See the
 #                         priority-tiering block below.
 #
-# Priority ordering: candidates are walked by [priority tier, number ascending]
-# — P0 → P1 → P2 → P3, oldest-first within a tier (see the tiering block below).
+# Priority ordering: candidates are walked by [priority tier, number ascending],
+# oldest-first within a tier. Tier 0 = P0 / priority-critical … tier 3 = P3 /
+# priority-low (see the tiering block below — both label vocabularies are honored).
 #
 # Parallel awareness (see scripts/ralph/FLEET.md):
 #   Issues already being worked — either an open PR (`Closes|Fixes|Resolves #N`)
@@ -59,10 +60,18 @@ SOLO_LABEL="${RALPH_SOLO_LABEL:-solo}"
 PARALLEL_LABEL="${RALPH_PARALLEL_LABEL:-parallelizable}"
 RESPECT_EPICS="${RALPH_RESPECT_EPICS:-1}"
 
-# Priority tiering (autonomous maintenance pipeline). Candidates are ordered by
-# priority tier first, then oldest-first WITHIN a tier: P0 (security/breakage)
-# preempts P1 (bugs + Geoff's feature issues) preempts P2 (quality) preempts P3
-# (hygiene). An issue with no P-label sorts at RALPH_DEFAULT_PRIORITY_RANK.
+# Priority tiering. Candidates are ordered by priority tier first, then
+# oldest-first WITHIN a tier: tier 0 (critical/breakage) preempts tier 1
+# (bugs + feature issues) preempts tier 2 (quality) preempts tier 3 (hygiene).
+#
+# TWO label vocabularies map onto the same four tiers, so the picker honors both
+# the repo's long-standing `priority-*` labels AND the maintenance pipeline's
+# P0–P3 labels:
+#   tier 0  ← `P0` or `priority-critical`
+#   tier 1  ← `P1` or `priority-high`
+#   tier 2  ← `P2` or `priority-medium`
+#   tier 3  ← `P3` or `priority-low`
+# An issue with none of these sorts at RALPH_DEFAULT_PRIORITY_RANK.
 #
 #   RALPH_DEFAULT_PRIORITY_RANK  Tier an unlabeled issue is treated as. Default
 #                                1 (== P1), so legacy/unlabeled feature work
@@ -101,10 +110,10 @@ open_tsv=$(
               and ( \$exc | any(. as \$x | \$names | index(\$x)) | not )
             )
           | { number: \$i.number, names: \$names,
-              rank: ( if   (\$names | index(\"P0\")) then 0
-                      elif (\$names | index(\"P1\")) then 1
-                      elif (\$names | index(\"P2\")) then 2
-                      elif (\$names | index(\"P3\")) then 3
+              rank: ( if   ((\$names | index(\"P0\")) or (\$names | index(\"priority-critical\"))) then 0
+                      elif ((\$names | index(\"P1\")) or (\$names | index(\"priority-high\")))     then 1
+                      elif ((\$names | index(\"P2\")) or (\$names | index(\"priority-medium\")))   then 2
+                      elif ((\$names | index(\"P3\")) or (\$names | index(\"priority-low\")))      then 3
                       else $DEFAULT_RANK end ) })
       | sort_by([.rank, .number])
       | .[]

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -219,6 +219,32 @@ ij_add 10 "P0"; ij_add 11 "P3,agent-ready"; ij_finalize
 check "require agent-ready filters out ungated P0" "11" \
   "$(cd "$REPO" && PATH="$BIN:$PATH" RALPH_REQUIRE_LABELS=agent-ready "$PICK")"
 
+# --- repo's native priority-* vocabulary maps onto the same tiers -------------
+
+# 16) The exact production bug: a `priority-critical` issue (#1175-style) must
+# preempt an OLDER non-critical backlog, not sit behind it by number.
+new_scenario prio_critical_preempts
+ij_add 100 "bug,frontend"; ij_add 101 "priority-medium"; ij_add 175 "bug,priority-critical,full-stack"
+ij_finalize
+check "priority-critical preempts older non-critical backlog" "175" "$(run_pick)"
+
+# 17) Full priority-* tier order, oldest-first within a tier.
+new_scenario prio_named_order
+ij_add 40 "priority-low"; ij_add 30 "priority-medium"; ij_add 20 "priority-high"
+ij_add 10 "priority-critical"; ij_finalize
+check "priority-critical is tier 0" "10" "$(run_pick)"
+
+# 18) The two vocabularies are interchangeable within a tier (P0 == critical):
+# oldest of the two tier-0 issues wins regardless of which label spelling.
+new_scenario prio_mixed_vocab
+ij_add 50 "P0"; ij_add 40 "priority-critical"; ij_add 30 "P1"; ij_finalize
+check "mixed P0/priority-critical share tier 0 (oldest wins)" "40" "$(run_pick)"
+
+# 19) priority-high outranks a P2 and an unlabeled default (rank 1 beats 2).
+new_scenario prio_high_beats_medium
+ij_add 5 "priority-medium"; ij_add 9 "priority-high"; ij_finalize
+check "priority-high (tier 1) beats priority-medium (tier 2)" "9" "$(run_pick)"
+
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Problem

A `priority-critical` issue (#1175 — a Course outage) sat in the queue for 5+ hours instead of being picked next.

The priority tiering shipped in #1105 only recognized `P0`–`P3` labels. But this repo's actual priority vocabulary is **`priority-critical` / `priority-high` / `priority-medium` / `priority-low`** — and none of `P0`–`P3` exist as labels. So *every* open issue fell through to the default rank, the ordering **collapsed back to plain oldest-first**, and a freshly-filed `priority-critical` issue (high issue number) sorted to the *back* of the backlog rather than preempting it.

## Fix

Map **both** label vocabularies onto the same four tiers in `pick-next.sh`:

| Tier | Labels |
|---|---|
| 0 (preempts all) | `P0` or `priority-critical` |
| 1 | `P1` or `priority-high` |
| 2 | `P2` or `priority-medium` |
| 3 | `P3` or `priority-low` |

## Tests

`test_pick_next.sh`: **23/23** (was 19). Four new scenarios, including the exact production bug — *a `priority-critical` issue must preempt an older non-critical backlog* — plus mixed-vocabulary interchangeability (`P0` ≡ `priority-critical`) and the full `priority-*` tier order.

## Note

This does not preempt work already in flight (Ralph never interrupts a running lane) — it fixes which issue a **free** worker picks next. Once merged and the loop syncs, `priority-critical` #1175 jumps to tier 0 (behind only any older still-open criticals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAZg1LsJfcTf9TwSZBAoJq)_