### PR TITLE
fix(frontend): guard token-refresh writes by issued-for token identity

### DIFF
--- a/frontend/src/api/__tests__/token-refresh.test.ts
+++ b/frontend/src/api/__tests__/token-refresh.test.ts
@@ -104,7 +104,7 @@ describe('retry-after-refresh on 401', () => {
     // server's stored timezone so the AuthContext can keep
     // ``userTimezone`` in sync.  ``undefined`` is the value when the
     // server omits the field (legacy / mocked responses).
-    expect(mockOnTokenRefreshed).toHaveBeenCalledWith(refreshedToken, undefined);
+    expect(mockOnTokenRefreshed).toHaveBeenCalledWith(refreshedToken, undefined, 'original-token');
 
     expect(result).toEqual([sampleHabit]);
   });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -162,12 +162,17 @@ let onUnauthorizedCallback: ((reason: UnauthorizedReason) => void) | null = null
 /**
  * Callback invoked when the API layer refreshes the JWT.
  *
- * Receives the new token plus the server's record of `User.timezone` so
- * the auth context can keep `userTimezone` in sync without a follow-up
- * `GET /users/me`.  The timezone is `string | undefined` because legacy
- * API builds may omit it; consumers should fall back to `'UTC'`.
+ * Receives the new token, the server's record of `User.timezone`, and the
+ * token the refresh was issued FOR (the third arg). The auth context uses
+ * the timezone to keep `userTimezone` in sync without a follow-up
+ * `GET /users/me`, and the prior token to identity-guard the write so a
+ * stale refresh cannot clobber a fresher session. The timezone is
+ * `string | undefined` because legacy API builds may omit it; consumers
+ * should fall back to `'UTC'`.
  */
-let onTokenRefreshedCallback: ((token: string, timezone: string | undefined) => void) | null = null;
+let onTokenRefreshedCallback:
+  | ((token: string, timezone: string | undefined, expectedPriorToken: string) => void)
+  | null = null;
 let llmApiKeyGetter: (() => string | null) | null = null;
 
 /** Header used to forward a user-provided LLM API key (BYOK, issue #185). */
@@ -211,7 +216,9 @@ export function setOnUnauthorized(callback: ((reason: UnauthorizedReason) => voi
 }
 
 export function setOnTokenRefreshed(
-  callback: ((token: string, timezone: string | undefined) => void) | null,
+  callback:
+    | ((token: string, timezone: string | undefined, expectedPriorToken: string) => void)
+    | null,
 ) {
   onTokenRefreshedCallback = callback;
 }
@@ -479,7 +486,7 @@ async function performTokenRefresh(currentToken: string): Promise<RefreshResult>
     // ``userTimezone`` in sync after a cold-start refresh.  Without
     // this, ``userTimezone`` would stay at its ``"UTC"`` default until
     // the user manually re-authenticated.
-    onTokenRefreshedCallback?.(data.token, data.timezone);
+    onTokenRefreshedCallback?.(data.token, data.timezone, currentToken);
     return { token: data.token, hadToken: true };
   } catch {
     return { token: null, hadToken: true };

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -90,10 +90,10 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 function silentRefresh(
   currentToken: string,
-  onSuccess: (t: string, timezone: string | undefined) => void,
+  onSuccess: (t: string, timezone: string | undefined, expectedPriorToken: string) => void,
 ): void {
   authApi.refresh(currentToken).then(
-    (res) => onSuccess(res.token, res.timezone),
+    (res) => onSuccess(res.token, res.timezone, currentToken),
     () => {
       /* silent fail — 401 retry is the fallback */
     },
@@ -104,7 +104,7 @@ function silentRefresh(
 function useProactiveRefresh(
   token: string | null,
   tokenRef: React.MutableRefObject<string | null>,
-  applyNewToken: (t: string, timezone: string | undefined) => void,
+  applyNewToken: (t: string, timezone: string | undefined, expectedPriorToken: string) => void,
 ): void {
   useEffect(() => {
     if (!token || isTokenExpired(token)) return undefined;
@@ -199,9 +199,13 @@ async function clearTokenForReauth(
  * the app is killed between the refresh response and the secure-storage
  * write. Await the persistence before surfacing the token to React state.
  *
- * BUG-FRONTEND-INFRA-012: if the user logged out while a refresh was in
- * flight, ``tokenRef.current`` is ``null`` and we must NOT resurrect the
- * session. Apply the new token only when the ref still holds the old value.
+ * BUG-FRONTEND-INFRA-012: identity-guard the write against the exact token
+ * the refresh was issued FOR. Apply the new token only while
+ * ``tokenRef.current`` still equals ``expectedPriorToken`` (re-checked after
+ * the async save). This drops a late refresh after a plain logout (ref is
+ * null) AND a stale refresh of a prior session after logout->re-login (ref
+ * holds the new session token), so a stale refresh can never clobber a
+ * fresh login in React state.
  */
 async function saveTokenThenApply(
   newToken: string,
@@ -209,9 +213,10 @@ async function saveTokenThenApply(
   mutators: AuthMutators,
   tokenRef: React.MutableRefObject<string | null>,
   warnLabel: string,
+  expectedPriorToken: string,
 ): Promise<void> {
-  if (tokenRef.current === null) {
-    // Logout won the race — drop the late refresh response on the floor.
+  if (tokenRef.current !== expectedPriorToken) {
+    // Logout or a re-login won the race — drop the stale refresh response.
     return;
   }
   try {
@@ -220,7 +225,7 @@ async function saveTokenThenApply(
     console.warn(`saveToken failed in ${warnLabel}`, err);
     return;
   }
-  if (tokenRef.current === null) return;
+  if (tokenRef.current !== expectedPriorToken) return;
   mutators.setToken(newToken);
   // Refresh responses carry the user's stored IANA zone so a cold-start
   // → proactive-refresh sequence restores ``userTimezone`` without an
@@ -246,8 +251,8 @@ function useApiCallbacks(
     setOnUnauthorized((reason: UnauthorizedReason) => {
       void clearTokenForReauth(mutators, reason);
     });
-    setOnTokenRefreshed((t: string, tz: string | undefined) => {
-      void saveTokenThenApply(t, tz, mutators, tokenRef, 'onTokenRefreshed');
+    setOnTokenRefreshed((t: string, tz: string | undefined, prior: string) => {
+      void saveTokenThenApply(t, tz, mutators, tokenRef, 'onTokenRefreshed', prior);
     });
     return () => {
       setTokenGetter(null);
@@ -431,13 +436,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // ``undefined`` falls back to UTC so a legacy API build that omits
   // the field still works.
   //
-  // The two ``tokenRef.current === null`` guards mirror
-  // ``saveTokenThenApply`` so a logout that wins the race against a
-  // proactive refresh does NOT silently resurrect the session by
-  // re-applying a stale token after the user explicitly signed out.
+  // ``expectedPriorToken`` is the token the proactive refresh was issued
+  // for; ``saveTokenThenApply`` applies the result only while
+  // ``tokenRef.current`` still equals it, so a logout OR a logout->re-login
+  // that wins the race against the refresh does NOT resurrect a prior
+  // session by re-applying its stale token.
   const applyNewToken = useCallback(
-    async (newToken: string, newTimezone: string | undefined) => {
-      await saveTokenThenApply(newToken, newTimezone, mutators, tokenRef, 'applyNewToken');
+    async (newToken: string, newTimezone: string | undefined, expectedPriorToken: string) => {
+      await saveTokenThenApply(
+        newToken,
+        newTimezone,
+        mutators,
+        tokenRef,
+        'applyNewToken',
+        expectedPriorToken,
+      );
     },
     [mutators],
   );

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -463,7 +463,7 @@ describe('AuthContext', () => {
       expect(typeof refreshed).toBe('function');
 
       await act(async () => {
-        refreshed?.('fresh-jwt', undefined);
+        refreshed?.('fresh-jwt', undefined, 'old-jwt');
       });
 
       // Save is in-flight — state must not have flipped yet.
@@ -494,7 +494,7 @@ describe('AuthContext', () => {
       expect(typeof refreshed).toBe('function');
 
       await act(async () => {
-        refreshed?.('fresh-jwt', 'America/Los_Angeles');
+        refreshed?.('fresh-jwt', 'America/Los_Angeles', 'old-jwt');
       });
 
       await waitFor(() => expect(result.current.token).toBe('fresh-jwt'));
@@ -511,7 +511,7 @@ describe('AuthContext', () => {
 
       const refreshed = mockSetOnTokenRefreshed.mock.calls.at(-1)?.[0];
       await act(async () => {
-        refreshed?.('fresh-jwt', undefined);
+        refreshed?.('fresh-jwt', undefined, 'old-jwt');
       });
 
       await waitFor(() => expect(result.current.token).toBe('fresh-jwt'));
@@ -530,7 +530,7 @@ describe('AuthContext', () => {
       expect(typeof refreshed).toBe('function');
 
       await act(async () => {
-        refreshed?.('fresh-jwt', undefined);
+        refreshed?.('fresh-jwt', undefined, 'old-jwt');
       });
 
       expect(mockSaveToken).toHaveBeenCalledWith('fresh-jwt');
@@ -674,7 +674,7 @@ describe('AuthContext', () => {
       // Mid-flight refresh completes AFTER logout — do not resurrect the session.
       await act(async () => {
         resolveRefresh?.({ token: 'late-jwt', user_id: 1 });
-        refreshed?.('late-jwt', undefined);
+        refreshed?.('late-jwt', undefined, 'existing-jwt');
       });
       await waitFor(() => expect(result.current.token).toBeNull());
     });
@@ -693,6 +693,97 @@ describe('AuthContext', () => {
       await act(async () => {
         await result.current.login('new@test.com', 'p'); // pragma: allowlist secret
       });
+      expect(result.current.token).toBe('second-jwt');
+    });
+
+    it('a stale in-flight refresh must not clobber a fresh re-login token', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      const refreshed = mockSetOnTokenRefreshed.mock.calls.at(-1)?.[0];
+      mockAuth.login.mockResolvedValue({ token: 'second-jwt', user_id: 2 });
+
+      await act(async () => {
+        await result.current.logout();
+      });
+      await act(async () => {
+        await result.current.login('new@test.com', 'p'); // pragma: allowlist secret
+      });
+      expect(result.current.token).toBe('second-jwt');
+
+      await act(async () => {
+        refreshed?.('late-jwt', undefined, 'existing-jwt');
+      });
+
+      expect(result.current.token).toBe('second-jwt');
+      expect(mockSaveToken).not.toHaveBeenCalledWith('late-jwt');
+    });
+
+    it('a stale save that resolves after re-login must not clobber the token', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      let resolveSave: (() => void) | null = null;
+      mockSaveToken.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      const refreshed = mockSetOnTokenRefreshed.mock.calls.at(-1)?.[0];
+      mockAuth.login.mockResolvedValue({ token: 'second-jwt', user_id: 2 });
+
+      act(() => {
+        refreshed?.('late-jwt', undefined, 'existing-jwt');
+      });
+
+      await act(async () => {
+        await result.current.logout();
+      });
+      await act(async () => {
+        await result.current.login('new@test.com', 'p'); // pragma: allowlist secret
+      });
+      expect(result.current.token).toBe('second-jwt');
+
+      await act(async () => {
+        resolveSave?.();
+      });
+
+      expect(result.current.token).toBe('second-jwt');
+    });
+
+    it('a stale in-flight proactive refresh must not clobber a fresh re-login token', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      // Only the stale session is due for a proactive refresh; the fresh
+      // login token is not, so no second refresh races the assertion.
+      mockShouldRefreshToken.mockImplementation((t: string) => t === 'existing-jwt');
+      let resolveRefresh: ((value: { token: string; user_id: number }) => void) | null = null;
+      mockAuth.refresh.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      expect(mockAuth.refresh).toHaveBeenCalledWith('existing-jwt');
+      mockAuth.login.mockResolvedValue({ token: 'second-jwt', user_id: 2 });
+
+      await act(async () => {
+        await result.current.logout();
+      });
+      await act(async () => {
+        await result.current.login('new@test.com', 'p'); // pragma: allowlist secret
+      });
+      expect(result.current.token).toBe('second-jwt');
+
+      await act(async () => {
+        resolveRefresh?.({ token: 'late-jwt', user_id: 1 });
+      });
+
       expect(result.current.token).toBe('second-jwt');
     });
   });


### PR DESCRIPTION
## Summary
Fixes an async TOCTOU / last-writer-wins race where a stale in-flight token
refresh could clobber a fresh re-login token in `AuthContext`.

`saveTokenThenApply` guarded the refresh apply path only with
`tokenRef.current === null`. That correctly drops a late refresh after a plain
logout, but not after a **logout -> re-login**: the ref then holds the *new*
session's token (non-null), so both guards passed and the stale refresh of the
*old* session silently overwrote the just-issued login token. The same hole
existed on the proactive-refresh path (`applyNewToken` -> `saveTokenThenApply`).

The fix threads the token the refresh was issued **for** (`expectedPriorToken`)
through both apply paths:
- **Reactive path** — the API layer (`src/api/index.ts`) now forwards the
  `currentToken` the refresh was performed against as a third arg to the
  `onTokenRefreshed` callback; `AuthContext` passes it into `saveTokenThenApply`.
- **Proactive path** — `silentRefresh` already holds `currentToken`; it is now
  threaded through `applyNewToken` into `saveTokenThenApply`.

Both the pre-save and post-save guards become
`tokenRef.current !== expectedPriorToken`. This strictly subsumes the old null
guard (plain-logout drop still holds) and additionally drops a stale
prior-session refresh after a re-login. The previously inaccurate comments
(which claimed a comparison the code could not make) are rewritten to describe
the identity guard the code now enforces.

## Test plan
- New regression tests in `context/__tests__/AuthContext.test.tsx` covering all
  three race variants: reactive stale refresh, stale save that resolves during a
  re-login (post-save guard), and stale proactive refresh — each asserts the
  fresh `second-jwt` login token survives.
- Existing "survives a logout that fires while a token refresh is in flight"
  test still passes (plain-logout drop preserved).
- `token-refresh.test.ts` asserts the API layer forwards the issued-for token.
- Local verification (in worktree): `npx tsc --noEmit` clean, `npm run lint`
  zero warnings, `./scripts/frontend/check-all.sh` exit 0 (3158 tests pass).

## Follow-up (not in this PR)
Security self-review flagged one residual, pre-existing, **LOW** window: on
native (`expo-secure-store`), the awaited `saveToken(staleToken)` is committed
before the post-save guard, so a mid-await logout->re-login could theoretically
leave a stale token in the keychain even though React state is correctly
protected. Recommend a follow-up to serialize/sequence token storage writes
(could not auto-file the issue — external write not authorized in this session).

Closes #1139