### PR TITLE
fix(ci): unblock iteration-trigger merge clearance

### DIFF
--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -15,7 +15,10 @@ on:
   workflow_run:
     # Must match the upstream workflows' ``name:`` exactly; the previous value
     # matched no workflow in this repo, so the trigger never fired.
-    workflows: ["Backend CI", "Frontend CI"]
+    # "Claude Code Review" is included so the trigger re-fires when the verdict
+    # comment lands AFTER both CI workflows have already completed — otherwise
+    # the merge clearance would never be evaluated for that ordering.
+    workflows: ["Backend CI", "Frontend CI", "Claude Code Review"]
     types: [completed]
 
 permissions:
@@ -63,8 +66,9 @@ jobs:
             exit 0
           fi
 
-          # Find latest Claude review comment (its body contains 'Verdict').
-          CLAUDE=$(jq -c '[.[] | select(.body | test("Verdict"))] | last // empty' comments.json)
+          # Find the latest Claude review comment via the deterministic
+          # "## Verdict: <verdict>" line that claude-code-review.yml appends.
+          CLAUDE=$(jq -c '[.[] | select(.body | test("(^|\\n)## Verdict:"))] | last // empty' comments.json)
           if [ -z "$CLAUDE" ]; then
             echo "No Claude review yet - skipping"
             exit 0
@@ -72,16 +76,24 @@ jobs:
           ID=$(jq -r '.id'   <<<"$CLAUDE")
           BODY=$(jq -r '.body' <<<"$CLAUDE")
 
-          # Summarize verdict via grep on the Claude comment body.
-          if   grep -qE 'CHANGES[_ ]REQUESTED' <<<"$BODY"; then VERDICT='CHANGES REQUESTED'
-          elif grep -q   'LGTM'                <<<"$BODY"; then VERDICT='LGTM'
-          else                                                  VERDICT='COMMENTS'
-          fi
+          # Parse the verdict from that line only — grepping the whole body is
+          # unsafe (a COMMENTS rationale may itself mention "LGTM").
+          VLINE=$(grep -m1 -E '^## Verdict:' <<<"$BODY" || true)
+          case "$VLINE" in
+            *CHANGES_REQUESTED*) VERDICT='CHANGES REQUESTED' ;;
+            *LGTM*)              VERDICT='LGTM' ;;
+            *)                   VERDICT='COMMENTS' ;;
+          esac
 
-          # CI status from check-runs on the head SHA.
+          # CI status from check-runs on the head SHA. Skipped/neutral runs are
+          # non-blocking: the Dependabot->Ralph bridge job is skipped on every
+          # non-Dependabot PR and would otherwise keep GREEN < TOTAL forever,
+          # so the merge clearance below could never fire. In-progress runs
+          # (conclusion null) still count in TOTAL, so nothing is cleared while
+          # a check is running.
           gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" > runs.json
-          TOTAL=$(jq '.check_runs | length'                                       runs.json)
-          GREEN=$(jq '[.check_runs[] | select(.conclusion=="success")] | length' runs.json)
+          TOTAL=$(jq '[.check_runs[] | select(.conclusion != "skipped" and .conclusion != "neutral")] | length' runs.json)
+          GREEN=$(jq '[.check_runs[] | select(.conclusion == "success")] | length'                             runs.json)
 
           if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
             ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."


### PR DESCRIPTION
Three fixes to the merge-clearance logic:

1. Exclude skipped/neutral check runs from the required-green count. The
   Dependabot->Ralph bridge job is skipped on every non-Dependabot PR,
   which kept GREEN < TOTAL forever, so the 'cleared to squash merge'
   action could never fire (every PR posted 'continue iterating' even
   with LGTM + green CI). In-progress runs still count in TOTAL, so
   nothing is cleared while a check is running.

2. Add 'Claude Code Review' to the workflow_run triggers so the
   clearance is re-evaluated when the verdict comment lands after both
   CI workflows have already completed.

3. Parse the verdict from the deterministic '## Verdict:' line instead
   of grepping the whole comment body, where a COMMENTS rationale
   mentioning LGTM would be misread as LGTM and could clear a merge
   wrongly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HbQmresGd1jYvSZfMnYt9F