### PR TITLE
refactor(frontend): collapse reinvented clear-key submit and reconcile Settings form screens

### DIFF
--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -13,6 +13,7 @@ import {
 
 import { BYOK_PROVIDERS, providerForKey } from './byokProviders';
 import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
+import { SETTINGS_BUTTON_PADDING } from './shared/settingsFormLayout';
 import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
@@ -38,7 +39,7 @@ const MASK_VISIBLE_CHARS = 4;
 
 // Built from the provider map so the error copy can never drift from the
 // supported set: e.g. `"sk-" (OpenAI) or "sk-ant-" (Anthropic)`.
-const _PREFIX_SUMMARY = BYOK_PROVIDERS.map((p) => `"${p.keyPrefix}" (${p.label})`).join(' or ');
+const PREFIX_SUMMARY = BYOK_PROVIDERS.map((p) => `"${p.keyPrefix}" (${p.label})`).join(' or ');
 
 interface KeyValidationError {
   code: 'empty' | 'too_short' | 'too_long' | 'bad_prefix';
@@ -59,7 +60,7 @@ export function validateUserApiKey(raw: string): KeyValidationError | null {
   if (providerForKey(key) === null) {
     return {
       code: 'bad_prefix',
-      message: `API keys start with ${_PREFIX_SUMMARY}.`,
+      message: `API keys start with ${PREFIX_SUMMARY}.`,
     };
   }
   return null;
@@ -319,7 +320,8 @@ function useSaveKeyHandler(
     setStatus('API key saved on this device.');
   }, [draft, saveApiKey, setDraft, setReveal, setStatus]);
   const onError = useCallback(
-    (err: unknown) => (err as Error).message ?? 'Could not save the API key.',
+    (err: unknown) =>
+      err instanceof Error && err.message ? err.message : 'Could not save the API key.',
     [],
   );
   return useSettingsSubmit(form, { validate, perform, onError });
@@ -329,19 +331,18 @@ function useClearKeyHandler(
   form: SettingsFormState,
   clearApiKey: () => Promise<void>,
 ): () => Promise<void> {
-  const { setStatus, setError, setSubmitting } = form;
-  return useCallback(async () => {
-    setStatus(null);
-    setSubmitting(true);
-    try {
-      await clearApiKey();
-      setStatus('API key removed from this device.');
-    } catch (err) {
-      setError((err as Error).message ?? 'Could not remove the API key.');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [clearApiKey, setStatus, setError, setSubmitting]);
+  const { setStatus } = form;
+  const validate = useCallback(() => null, []);
+  const perform = useCallback(async () => {
+    await clearApiKey();
+    setStatus('API key removed from this device.');
+  }, [clearApiKey, setStatus]);
+  const onError = useCallback(
+    (err: unknown) =>
+      err instanceof Error && err.message ? err.message : 'Could not remove the API key.',
+    [],
+  );
+  return useSettingsSubmit(form, { validate, perform, onError });
 }
 
 export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.JSX.Element {
@@ -471,7 +472,11 @@ const styles = StyleSheet.create({
     backgroundColor: surface.sunken,
   },
   revealButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
-  button: { borderRadius: BORDER_RADIUS.md, padding: SPACING.md + 2, alignItems: 'center' },
+  button: {
+    borderRadius: BORDER_RADIUS.md,
+    padding: SETTINGS_BUTTON_PADDING,
+    alignItems: 'center',
+  },
   primaryButton: { backgroundColor: accent.primary, marginTop: SPACING.xs },
   primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   destructiveButton: {

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
+import { SETTINGS_BUTTON_PADDING } from './shared/settingsFormLayout';
 import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
@@ -22,10 +23,6 @@ import { detectDeviceTimezone } from '@/utils/dateUtils';
  */
 
 const EXAMPLE_ZONE = 'America/Los_Angeles';
-
-// Visual parity with ApiKeySettingsScreen's primary button, whose padding is
-// also SPACING.md nudged up to balance the larger label font.
-const SAVE_BUTTON_PADDING = SPACING.md + 2;
 
 const EMPTY_ZONE_MESSAGE =
   `Enter a time zone name like "${EXAMPLE_ZONE}", ` +
@@ -275,7 +272,7 @@ const styles = StyleSheet.create({
   secondaryButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
   primaryButton: {
     borderRadius: BORDER_RADIUS.md,
-    padding: SAVE_BUTTON_PADDING,
+    padding: SETTINGS_BUTTON_PADDING,
     alignItems: 'center',
     backgroundColor: accent.primary,
     marginTop: SPACING.xs,

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -250,6 +250,56 @@ describe('ApiKeySettingsScreen', () => {
     alertSpy.mockRestore();
   });
 
+  test('confirms with a status banner when the stored key is removed', async () => {
+    setApiKeyState({ apiKey: VALID_KEY });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    const status = await findByTestId('api-key-status');
+    expect(status.props.children).toContain('removed from this device');
+    alertSpy.mockRestore();
+  });
+
+  test('falls back to a default message when saving fails with a blank error', async () => {
+    setApiKeyState({ saveApiKey: jest.fn(() => Promise.reject(new Error(''))) });
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    const error = await findByTestId('api-key-error');
+    expect(error.props.children).toContain('Could not save the API key.');
+  });
+
+  test('falls back to a default message when removing fails with a blank error', async () => {
+    setApiKeyState({
+      apiKey: VALID_KEY,
+      clearApiKey: jest.fn(() => Promise.reject(new Error(''))),
+    });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    const error = await findByTestId('api-key-error');
+    expect(error.props.children).toContain('Could not remove the API key.');
+    alertSpy.mockRestore();
+  });
+
   test('masks a short stored key entirely rather than partially revealing it', () => {
     setApiKeyState({ apiKey: 'sk-short' }); // pragma: allowlist secret
     const { getByText, queryByText } = render(<ApiKeySettingsScreen />);

--- a/frontend/src/features/Settings/shared/settingsFormLayout.ts
+++ b/frontend/src/features/Settings/shared/settingsFormLayout.ts
@@ -1,0 +1,10 @@
+import { SPACING } from '@/design/tokens';
+
+/**
+ * Vertical padding for the action buttons on the Settings form screens.
+ *
+ * ``SPACING.md`` nudged up by 2 to balance the larger button-label font, shared
+ * by both the API-key and time-zone screens so the two stay in visual parity
+ * without a manual "keep in sync" comment.
+ */
+export const SETTINGS_BUTTON_PADDING = SPACING.md + 2;

--- a/frontend/src/features/Settings/shared/useSettingsForm.ts
+++ b/frontend/src/features/Settings/shared/useSettingsForm.ts
@@ -11,19 +11,19 @@ import type { Dispatch, SetStateAction } from 'react';
  * screen has to re-derive it.
  */
 
-export interface SettingsFormState<T = string> {
-  draft: T;
+export interface SettingsFormState {
+  draft: string;
   submitting: boolean;
   error: string | null;
   status: string | null;
-  setDraft: Dispatch<SetStateAction<T>>;
+  setDraft: Dispatch<SetStateAction<string>>;
   setSubmitting: Dispatch<SetStateAction<boolean>>;
   setError: Dispatch<SetStateAction<string | null>>;
   setStatus: Dispatch<SetStateAction<string | null>>;
 }
 
-export function useSettingsFormState<T = string>(initialDraft: T): SettingsFormState<T> {
-  const [draft, setDraft] = useState<T>(initialDraft);
+export function useSettingsFormState(initialDraft: string): SettingsFormState {
+  const [draft, setDraft] = useState<string>(initialDraft);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

De-slop refactor of the two Settings form screens (`ApiKeySettingsScreen`,
`TimezoneSettingsScreen`) and their shared `useSettingsForm` scaffolding. The
API-key screen had re-derived logic the shared hook already owns, and the two
screens had drifted in small ways.

- Reimplement `useClearKeyHandler` via `useSettingsSubmit(form, { validate:
  () => null, perform, onError })`, deleting the duplicated try/catch/finally
  submit state machine (the shared hook now owns it for both save and clear).
- Fix both API-key error mappers to `err instanceof Error && err.message ?
  err.message : fallback` so an `Error` with an empty message shows the
  fallback instead of a blank banner (previously `?? ` only guarded
  null/undefined).
- Promote one shared `SETTINGS_BUTTON_PADDING` constant (new
  `shared/settingsFormLayout.ts`) used by both screens; remove the cross-file
  "visual parity" sync comment.
- Rename `_PREFIX_SUMMARY` → `PREFIX_SUMMARY` (the underscore falsely implied
  "unused"; it is used).
- Drop the speculative `<T = string>` generic from `SettingsFormState` /
  `useSettingsFormState` — both call sites only ever use `string`.

Behavior is identical apart from the deliberate empty-message fallback fix.

## Test plan

- New tests pin: clear-success status banner, and blank-`Error` fallback for
  both the save and clear paths.
- `./scripts/frontend/check-all.sh` green (tsc, eslint `--max-warnings=0`,
  prettier, jest 3155 tests).
- Pre-commit hooks pass.

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)