### PR TITLE
test(frontend): harden entry-surface test scaffolding and fix stale comments

### DIFF
--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -344,8 +344,8 @@ describe('Welcome → Journal landing', () => {
     });
   });
 
-  // Journal is TAB_CONFIGS[0] (physical tab order), end-to-end from the Welcome path.
-  it('Journal is the first route in the tab bar (TAB_CONFIGS[0])', async () => {
+  // Journal is LEADING_TABS[0] (physical tab order), end-to-end from the Welcome path.
+  it('Journal is the first route in the tab bar (LEADING_TABS[0])', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: true }));
 

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -640,7 +640,7 @@ describe('AuthContext', () => {
   // documented here exercises the full logout lifecycle rather than spot-
   // checking internals — matching how users actually hit these paths.
   describe('logout lifecycle (BUG-012)', () => {
-    it('handles back-to-back logout calls without double-clearing', async () => {
+    it('settles the token to null when two logout calls race, each tearing down independently', async () => {
       mockLoadToken.mockResolvedValue('existing-jwt');
       const { result } = renderHook(() => useAuth(), { wrapper });
       await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
@@ -649,8 +649,10 @@ describe('AuthContext', () => {
         await Promise.all([result.current.logout(), result.current.logout()]);
       });
 
+      // Teardown is idempotent, not deduplicated: each logout runs its own
+      // clearToken, and the session still settles cleanly to a null token.
       expect(result.current.token).toBeNull();
-      expect(mockClearToken).toHaveBeenCalled();
+      expect(mockClearToken).toHaveBeenCalledTimes(2);
     });
 
     it('survives a logout that fires while a token refresh is in flight', async () => {

--- a/frontend/src/features/Settings/__tests__/ChooseDepthsSection.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ChooseDepthsSection.test.tsx
@@ -19,8 +19,6 @@ type MockState = {
   enable_practices: boolean;
   enable_course: boolean;
   enable_sangha: boolean;
-  loading: boolean;
-  error: string | null;
 };
 
 let mockStoreState: MockState = {
@@ -28,8 +26,6 @@ let mockStoreState: MockState = {
   enable_practices: true,
   enable_course: true,
   enable_sangha: true,
-  loading: false,
-  error: null,
 };
 
 const setMockState = (patch: Partial<MockState>): void => {
@@ -44,8 +40,6 @@ jest.mock('@/store/useDepthPreferencesStore', () => ({
   selectEnablePractices: (s: MockState): boolean => s.enable_practices,
   selectEnableCourse: (s: MockState): boolean => s.enable_course,
   selectEnableSangha: (s: MockState): boolean => s.enable_sangha,
-  selectDepthPreferencesLoading: (s: MockState): boolean => s.loading,
-  selectDepthPreferencesError: (s: MockState): string | null => s.error,
   // Expose actions on the store mock so the component can call them
   get load() {
     return mockLoad;
@@ -91,8 +85,6 @@ beforeEach(() => {
     enable_practices: true,
     enable_course: true,
     enable_sangha: true,
-    loading: false,
-    error: null,
   };
 });
 

--- a/frontend/src/features/Welcome/welcomeContent.ts
+++ b/frontend/src/features/Welcome/welcomeContent.ts
@@ -32,7 +32,7 @@ export const WELCOME_PILLARS: readonly WelcomePillar[] = [
   { glyph: '🧭', name: 'Map' },
 ];
 
-/** The 3–4 swipeable editorial panels, in order. */
+/** The four swipeable editorial panels, in order. */
 export const WELCOME_PANELS: readonly WelcomePanel[] = [
   {
     eyebrow: 'Welcome',

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -133,7 +133,7 @@ describe('BottomTabs', () => {
     // The focused tab's icon may render more than once (active-state
     // animation in @react-navigation/bottom-tabs); only assert each icon
     // appears at least once, which is what makeTabIcon being invoked
-    // for every TAB_CONFIGS entry guarantees.
+    // for every assembled tab (LEADING_TABS + rings + TRAILING_TABS) guarantees.
     for (const Icon of [Home, Sprout, Flower2, BookOpen, NotebookPen, Compass]) {
       expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
     }


### PR DESCRIPTION
## Summary

Low-severity de-slop tidy-up (#1143) of test-quality and comment-accuracy issues
across the entry/account surfaces (taxonomy families 6 + 9). No production
behavior changes — only test assertions, dead mock scaffolding, and comment text.

- **AuthContext test** — renamed the back-to-back-logout test to reflect its real
  contract and tightened the assertion from `toHaveBeenCalled()`
  (pass-for-any-count) to `toHaveBeenCalledTimes(2)` + `token === null`. This
  matches `tearDownSession`, which runs `clearToken` once per `logout()` with no
  dedup guard, so the count is deterministically 2. The old name ("without
  double-clearing") was false.
- **ChooseDepthsSection test** — removed dead mock scaffolding
  (`selectDepthPreferencesLoading`/`selectDepthPreferencesError` selectors and
  `loading`/`error` mock state) that `ChooseDepthsSection.tsx` never imports.
- **BottomTabs test + welcomeLandsOnJournal test** — fixed phantom `TAB_CONFIGS`
  comment references (refactored to `RING_TABS`/`LEADING_TABS`/`TRAILING_TABS`).
- **welcomeContent.ts** — corrected the "3–4 swipeable editorial panels" comment
  to "four" (`WELCOME_PANELS` is pinned at exactly 4 by `WelcomeScreen.test.tsx`).

### Re-verification (findings that were already remediated by churn)

Today's frontend churn had already fixed two of the six original findings, so
they required no change and are noted here for the audit trail:

- **Finding 2** — `ApiKeyContext.test.tsx` already covers `loadError` on the
  initial-read, save-reject, and clear-reject paths (plus non-Error wrapping).
- **Finding 3** — `ApiKeySettingsScreen.test.tsx` already has a clear-reject test
  ("shows an error banner when removing the stored key fails").

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (`--max-warnings=0`)
- `./scripts/frontend/check-all.sh` — all 4 checks pass; 312 suites / 3155 tests
  green; coverage gate satisfied
- The renamed logout test now fails if the asserted contract (two independent
  teardowns settling to a null token) is broken, rather than passing for any
  call count.

Closes #1143