### PR TITLE
fix(map): confine wave overlay to the center-column band

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -17,13 +17,16 @@ import {
   touchTarget,
 } from '../../design/tokens';
 
+import { GRID_COLUMN_FLEX } from './mapLayout';
+
 // --- Grid weights for the three cells of every stage row -------------------
 // One responsive row grid is the single source of vertical truth: each stage
 // row is [LeftCell | CenterCell | RightCell] with these flex weights (≈40/40/20),
-// so the three columns are siblings in the same row and cannot drift.
-const LEFT_FLEX = 2;
-const CENTER_FLEX = 2;
-const RIGHT_FLEX = 1;
+// so the three columns are siblings in the same row and cannot drift. The
+// weights live in mapLayout so the wave geometry can share the same truth.
+const LEFT_FLEX = GRID_COLUMN_FLEX.left;
+const CENTER_FLEX = GRID_COLUMN_FLEX.center;
+const RIGHT_FLEX = GRID_COLUMN_FLEX.right;
 const CENTER = 'center';
 
 /**

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -2,7 +2,14 @@
 /* global describe, it, expect */
 import { STAGE_DISPLAY } from '../mapLayout';
 import { STAGE_COUNT, isLeftReturning } from '../stageData';
-import { arrowheadAt, stageWavePoint, waveSegments } from '../waveGeometry';
+import {
+  arrowheadAt,
+  centerColumnBounds,
+  stageWavePoint,
+  waveArrowheads,
+  waveSegments,
+} from '../waveGeometry';
+import type { WaveSegment } from '../waveGeometry';
 
 const CENTER_X = 0.5;
 const CONVERGENCE_EPSILON = 0.05;
@@ -14,6 +21,24 @@ const SMALL_HEIGHT = 200;
 const LARGE_WIDTH = 200;
 const LARGE_HEIGHT = 400;
 const REPRESENTATIVE_STAGE = 4;
+
+const PHONE_WIDTHS = [320, 375, 393, 430];
+const REPRESENTATIVE_HEIGHT = 800;
+
+const WAVE_STROKE_HALF_WIDTH = 1.5;
+const HALF_ARROWHEAD_WIDTH = 6;
+const SAFE_MARGIN_PX = WAVE_STROKE_HALF_WIDTH + HALF_ARROWHEAD_WIDTH;
+
+const LEFT_COLUMN_FLEX = 2;
+const CENTER_COLUMN_FLEX = 2;
+const RIGHT_COLUMN_FLEX = 1;
+const TOTAL_COLUMN_FLEX = LEFT_COLUMN_FLEX + CENTER_COLUMN_FLEX + RIGHT_COLUMN_FLEX;
+const CENTER_LEFT_FRACTION = LEFT_COLUMN_FLEX / TOTAL_COLUMN_FLEX;
+const CENTER_RIGHT_FRACTION = (LEFT_COLUMN_FLEX + CENTER_COLUMN_FLEX) / TOTAL_COLUMN_FLEX;
+
+const WOBBLE_VISIBILITY_FRACTION = 0.4;
+const LEFT_WOBBLE_STAGE = 2;
+const RIGHT_WOBBLE_STAGE = 1;
 
 describe('stageWavePoint', () => {
   it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
@@ -112,5 +137,86 @@ describe('arrowheadAt', () => {
     const apexY = Math.min(...ys);
     const baseY = Math.max(...ys);
     expect(apexY).toBeLessThan(baseY);
+  });
+});
+
+describe('center-column containment', () => {
+  // x tokens in the "M x1 y1 C x1 mY x2 mY x2 y2" segment path stream.
+  const SEGMENT_X_TOKEN_INDICES = [1, 4, 6, 8];
+  const segmentPathXs = (d: string): number[] => {
+    const tokens = d.trim().split(' ');
+    return SEGMENT_X_TOKEN_INDICES.map((index) => Number(tokens[index]));
+  };
+
+  const arrowheadXs = (points: string): number[] =>
+    points
+      .trim()
+      .split(' ')
+      .map((pair) => pair.split(',').map(Number))
+      .map(([x]) => x as number);
+
+  const findSegmentX = (segments: readonly WaveSegment[], stageNumber: number): number => {
+    for (const segment of segments) {
+      if (segment.stageNumber === stageNumber) {
+        const xs = segmentPathXs(segment.d);
+        return xs[0] as number;
+      }
+    }
+    throw new Error(`no segment found for stage ${stageNumber}`);
+  };
+
+  it('reports center-column bounds as flex-derived fractions of width', () => {
+    for (const width of PHONE_WIDTHS) {
+      const bounds = centerColumnBounds(width);
+      expect(bounds.left).toBeCloseTo(CENTER_LEFT_FRACTION * width);
+      expect(bounds.right).toBeCloseTo(CENTER_RIGHT_FRACTION * width);
+    }
+  });
+
+  it('keeps every wave-segment x-coordinate within the margin-shrunk center column', () => {
+    for (const width of PHONE_WIDTHS) {
+      const { left, right } = centerColumnBounds(width);
+      const minX = left + SAFE_MARGIN_PX;
+      const maxX = right - SAFE_MARGIN_PX;
+      const segments = waveSegments(width, REPRESENTATIVE_HEIGHT);
+      for (const segment of segments) {
+        for (const x of segmentPathXs(segment.d)) {
+          expect(x).toBeGreaterThanOrEqual(minX);
+          expect(x).toBeLessThanOrEqual(maxX);
+        }
+      }
+    }
+  });
+
+  it('keeps every arrowhead vertex x-coordinate within the margin-shrunk center column', () => {
+    for (const width of PHONE_WIDTHS) {
+      const { left, right } = centerColumnBounds(width);
+      const minX = left + SAFE_MARGIN_PX;
+      const maxX = right - SAFE_MARGIN_PX;
+      const arrowheads = waveArrowheads(width, REPRESENTATIVE_HEIGHT);
+      for (const arrowhead of arrowheads) {
+        for (const x of arrowheadXs(arrowhead.points)) {
+          expect(x).toBeGreaterThanOrEqual(minX);
+          expect(x).toBeLessThanOrEqual(maxX);
+        }
+      }
+    }
+  });
+
+  it('keeps the wobble visible: full-amplitude stages swing past 0.4 of the column half-width', () => {
+    for (const width of PHONE_WIDTHS) {
+      const { left, right } = centerColumnBounds(width);
+      const columnMidline = (left + right) / 2;
+      const columnHalfWidth = (right - left) / 2;
+      const segments = waveSegments(width, REPRESENTATIVE_HEIGHT);
+      const leftX = findSegmentX(segments, LEFT_WOBBLE_STAGE);
+      const rightX = findSegmentX(segments, RIGHT_WOBBLE_STAGE);
+      expect(Math.abs(leftX - columnMidline)).toBeGreaterThanOrEqual(
+        WOBBLE_VISIBILITY_FRACTION * columnHalfWidth,
+      );
+      expect(Math.abs(rightX - columnMidline)).toBeGreaterThanOrEqual(
+        WOBBLE_VISIBILITY_FRACTION * columnHalfWidth,
+      );
+    }
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -15,6 +15,9 @@
  * match the supplied spiral PNG rather than the app-wide spiral-dynamics swatches.
  */
 
+/** Flex weights of each stage row's three cells (left / center / right). */
+export const GRID_COLUMN_FLEX = { left: 2, center: 2, right: 1 } as const;
+
 /** Static, design-specific copy + color for a single stage's left-column text. */
 export interface StageDisplay {
   stageNumber: number;

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -4,15 +4,24 @@
  * Pure geometry for the Map center column's continuous sine-wave (a
  * struck-tuning-fork rising upward). Every helper works in unit space [0,1] or
  * scales that unit space into pixel space; none of them touch React, so the wave
- * math is testable in isolation from rendering.
+ * math is testable in isolation from rendering. Horizontal unit space maps only
+ * across the center column's grid band, not the full grid width, so the wave
+ * stays inside its lane even though the SVG spans the whole screen.
  *
  * The wave wobbles left for even (Divine-Feminine / WE-returning) stages and
  * right for odd (I-pointing) stages, then converges toward center at the top
  * (stages 9-10) as the two poles resolve into the whole apex.
  */
 
-import { STAGE_DISPLAY } from './mapLayout';
+import { GRID_COLUMN_FLEX, STAGE_DISPLAY } from './mapLayout';
 import { STAGE_COUNT, isLeftReturning } from './stageData';
+
+/** Combined flex weight of all three row cells; the denominator for band fractions. */
+const TOTAL_COLUMN_FLEX = GRID_COLUMN_FLEX.left + GRID_COLUMN_FLEX.center + GRID_COLUMN_FLEX.right;
+/** Grid fraction where the center column begins (left flex over total flex). */
+const CENTER_COLUMN_START_FRACTION = GRID_COLUMN_FLEX.left / TOTAL_COLUMN_FLEX;
+/** Grid fraction the center column spans (center flex over total flex). */
+const CENTER_COLUMN_WIDTH_FRACTION = GRID_COLUMN_FLEX.center / TOTAL_COLUMN_FLEX;
 
 /** Horizontal midline of the column in unit space; both poles swing around it. */
 const CENTER_X = 0.5;
@@ -24,9 +33,10 @@ const CENTER_X = 0.5;
 const Y_BAND_MIDPOINT = 0.5;
 
 /**
- * Base horizontal swing from center for stages 1-8. Kept below 0.5 so a pole at
- * full amplitude (x = CENTER_X +/- WAVE_AMPLITUDE) stays comfortably inside the
- * unit column with margin for the arrowhead.
+ * Base horizontal swing from center for stages 1-8, as a fraction of the column
+ * half-lane. Kept below 0.5 so a pole at full amplitude (x = CENTER_X +/-
+ * WAVE_AMPLITUDE) stays comfortably inside the center column with margin for the
+ * arrowhead.
  */
 const WAVE_AMPLITUDE = 0.32;
 
@@ -129,19 +139,36 @@ export interface WaveSegment {
   stageNumber: number;
 }
 
+/** Round a raw pixel value to a coordinate string at fixed precision. */
+const roundCoord = (value: number): string => value.toFixed(COORD_PRECISION);
+
 /** Round a unit coordinate into a pixel coordinate string at fixed precision. */
-const toPixel = (unit: number, extent: number): string => (unit * extent).toFixed(COORD_PRECISION);
+const toPixel = (unit: number, extent: number): string => roundCoord(unit * extent);
+
+/** Map a unit x within the center-column band to a pixel x across the grid. */
+const toColumnPixelX = (unitX: number, gridWidth: number): number =>
+  (CENTER_COLUMN_START_FRACTION + unitX * CENTER_COLUMN_WIDTH_FRACTION) * gridWidth;
+
+/**
+ * The center column's left/right pixel edges within a grid of the given width,
+ * derived from the shared flex weights.
+ */
+export const centerColumnBounds = (width: number): { left: number; right: number } => ({
+  left: CENTER_COLUMN_START_FRACTION * width,
+  right: (CENTER_COLUMN_START_FRACTION + CENTER_COLUMN_WIDTH_FRACTION) * width,
+});
 
 /**
  * A smooth cubic Bezier between two stage points. The control points sit at the
  * vertical midpoint of the pair, each anchored to its own stage's x, giving the
- * center column its continuous sine wobble rather than straight zig-zags.
+ * center column its continuous sine wobble rather than straight zig-zags. x is
+ * confined to the center-column band; y still spans the full height.
  */
 const segmentPath = (lower: WavePoint, upper: WavePoint, width: number, height: number): string => {
   const midY = (lower.y + upper.y) / 2;
-  const x1 = toPixel(lower.x, width);
+  const x1 = roundCoord(toColumnPixelX(lower.x, width));
   const y1 = toPixel(lower.y, height);
-  const x2 = toPixel(upper.x, width);
+  const x2 = roundCoord(toColumnPixelX(upper.x, width));
   const y2 = toPixel(upper.y, height);
   const midYPixel = toPixel(midY, height);
   return `M ${x1} ${y1} C ${x1} ${midYPixel} ${x2} ${midYPixel} ${x2} ${y2}`;
@@ -149,9 +176,9 @@ const segmentPath = (lower: WavePoint, upper: WavePoint, width: number, height: 
 
 /**
  * The full wave as STAGE_COUNT-1 (9) segments in pixel space. Segment i connects
- * stage i to stage i+1 and carries the lower stage's number and textColor.
- * Coordinates scale with width and height, so a larger layout yields a larger
- * wave.
+ * stage i to stage i+1 and carries the lower stage's number and textColor. y
+ * scales with height and x with width within the center-column band, so a larger
+ * layout yields a larger wave that still stays inside its lane.
  */
 export const waveSegments = (width: number, height: number): readonly WaveSegment[] => {
   const segments: WaveSegment[] = [];
@@ -179,20 +206,20 @@ export interface Arrowhead {
 /**
  * An upward-pointing triangle centered on a stage's wave point, in pixel space.
  * The apex sits ARROWHEAD_HEIGHT above the base (numerically smaller y) so the
- * arrow leads toward the higher stages at the top of the wave.
+ * arrow leads toward the higher stages at the top of the wave. cx is confined to
+ * the center-column band.
  */
 export const arrowheadAt = (stageNumber: number, width: number, height: number): Arrowhead => {
   const point = stageWavePoint(stageNumber);
-  const cx = point.x * width;
+  const cx = toColumnPixelX(point.x, width);
   const baseY = point.y * height;
   const apexY = baseY - ARROWHEAD_HEIGHT;
   const leftX = cx - ARROWHEAD_HALF_WIDTH;
   const rightX = cx + ARROWHEAD_HALF_WIDTH;
-  const fmt = (value: number): string => value.toFixed(COORD_PRECISION);
   const points = [
-    `${fmt(cx)},${fmt(apexY)}`,
-    `${fmt(leftX)},${fmt(baseY)}`,
-    `${fmt(rightX)},${fmt(baseY)}`,
+    `${roundCoord(cx)},${roundCoord(apexY)}`,
+    `${roundCoord(leftX)},${roundCoord(baseY)}`,
+    `${roundCoord(rightX)},${roundCoord(baseY)}`,
   ].join(' ');
   return { points };
 };


### PR DESCRIPTION
## Summary

The Map's sine-wave/spiral overlay was rendered with `StyleSheet.absoluteFill` across the **entire** grid, while its geometry swung `x = 0.5 ± 0.32` in unit space of that full width. Because the center column only occupies the middle band (row flex `left 2 / center 2 / right 1`), the wave overflowed its lane — curve segments and arrowheads swept under the left-column stage text ("Adept", "Victim", …) and into the right-column Aspect labels ("Wisdom", "Love"). The wave was designed in column-unit space but emitted in grid space.

Root-cause fix, all in the pure geometry layer (no `WaveOverlay`/`MapScreen` change needed — the SVG still spans the measured grid, but every emitted `x` is now constrained):

- Map the wave's horizontal unit space `[0,1]` into the center-column grid band `[0.4, 0.8]` via a new `toColumnPixelX` helper, applied in both `segmentPath` (x1/x2) and `arrowheadAt` (cx). `y` still spans the full height.
- Hoist the row flex weights into `mapLayout.ts` as `GRID_COLUMN_FLEX` so `Map.styles.ts` and `waveGeometry.ts` share one source of truth (band fractions derived from the weights, no drift).
- Export `centerColumnBounds(width)` so the geometry's lane is unit-testable.
- Amplitude now scales with column width (0.32 of the column half-lane), so the wobble still visibly reaches left/right within its lane; the apex still converges toward center.

## Test plan

- Extended `frontend/src/features/Map/__tests__/waveGeometry.test.ts` with a `center-column containment` block that, for representative phone widths 320–430pt, asserts:
  - every `waveSegments` path x-coordinate lies inside the margin-shrunk center-column band (safe margin = stroke half-width + arrowhead half-width),
  - every `waveArrowheads` vertex x (including the ±6px base corners) lies inside that band,
  - `centerColumnBounds` returns the flex-derived fractions of width,
  - the wobble still swings past 0.4 of the column half-width (guards against over-constraining the wave flat).
- All 16 tests in the file pass; full frontend suite green (3159 tests), `tsc --noEmit` clean, ESLint zero-warnings, `./scripts/frontend/check-all.sh` exits 0.

Closes #1160
Refs #943, #944