### PR TITLE
fix(map): taper the wave spiral and add a faded far-side coil

### DIFF
--- a/frontend/src/features/Map/WaveOverlay.tsx
+++ b/frontend/src/features/Map/WaveOverlay.tsx
@@ -9,8 +9,10 @@ import { waveArrowheads, waveSegments } from './waveGeometry';
 /**
  * Continuous sine-wave artwork for the Map's center column, rendered behind the
  * per-stage tap cells. The wave rises upward like a struck tuning fork, wobbling
- * left for even stages and right for odd ones and converging toward center at
- * the top. Each segment and arrowhead carries its stage's textColor.
+ * left for even stages and right for odd ones and tapering toward center at the
+ * top. Each segment draws a faded far-side path behind its full-opacity near
+ * side so the whole reads as a three-dimensional coil. Each segment and
+ * arrowhead carries its stage's textColor.
  *
  * The overlay is purely decorative: it is non-interactive and hidden from the
  * accessibility tree so the stage hotspots remain the sole tap/read targets.
@@ -18,6 +20,17 @@ import { waveArrowheads, waveSegments } from './waveGeometry';
 
 /** Stroke thickness of each wave segment, in pixels. */
 const WAVE_STROKE_WIDTH = 3;
+
+/** Stroke opacity of the faded far half of each coil turn (< 1). */
+const FAR_SIDE_OPACITY = 0.35;
+
+/** Stroke styling shared by every wave path, near and far alike. */
+const WAVE_STROKE_PROPS = {
+  fill: 'none',
+  strokeWidth: WAVE_STROKE_WIDTH,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+} as const;
 
 /** Smallest positive layout extent worth drawing; below it there is no wave. */
 const MIN_DRAWABLE_EXTENT = 1;
@@ -46,13 +59,21 @@ export const WaveOverlay = ({ width, height }: WaveOverlayProps): React.JSX.Elem
     >
       {segments.map((segment) => (
         <Path
-          key={segment.stageNumber}
+          key={`far-${segment.stageNumber}`}
+          testID={`far-${segment.stageNumber}`}
+          d={segment.farD}
+          stroke={segment.color}
+          strokeOpacity={FAR_SIDE_OPACITY}
+          {...WAVE_STROKE_PROPS}
+        />
+      ))}
+      {segments.map((segment) => (
+        <Path
+          key={`near-${segment.stageNumber}`}
+          testID={`near-${segment.stageNumber}`}
           d={segment.d}
           stroke={segment.color}
-          fill="none"
-          strokeWidth={WAVE_STROKE_WIDTH}
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          {...WAVE_STROKE_PROPS}
         />
       ))}
       {arrowheads.map((arrowhead) => (

--- a/frontend/src/features/Map/__tests__/WaveOverlay.test.tsx
+++ b/frontend/src/features/Map/__tests__/WaveOverlay.test.tsx
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import React from 'react';
+import { Path, Polygon } from 'react-native-svg';
+import { create } from 'react-test-renderer';
+
+import { STAGE_DISPLAY } from '../mapLayout';
+import { STAGE_COUNT } from '../stageData';
+import WaveOverlay from '../WaveOverlay';
+
+type Renderer = ReturnType<typeof create>;
+type WavePath = ReturnType<Renderer['root']['findAll']>[number];
+
+const WIDTH = 100;
+const HEIGHT = 200;
+const SEGMENT_COUNT = STAGE_COUNT - 1;
+const FULL_OPACITY = 1;
+const NOT_FOUND = -1;
+
+const FAR_PREFIX = 'far-';
+const NEAR_PREFIX = 'near-';
+
+// react-native-svg's Polygon renders an internal Path, so raw findAllByType(Path)
+// over-counts. Select wave paths by our explicit testIDs and the Path type only.
+const testIdOf = (node: WavePath): string =>
+  typeof node.props.testID === 'string' ? node.props.testID : '';
+
+const wavePathsWithPrefix = (tree: Renderer, prefix: string): WavePath[] =>
+  tree.root.findAll((node: WavePath) => node.type === Path && testIdOf(node).startsWith(prefix));
+
+const orderedWavePaths = (tree: Renderer): WavePath[] =>
+  tree.root.findAll(
+    (node: WavePath) =>
+      node.type === Path &&
+      (testIdOf(node).startsWith(FAR_PREFIX) || testIdOf(node).startsWith(NEAR_PREFIX)),
+  );
+
+describe('WaveOverlay', () => {
+  it('renders one far and one near wave path per segment', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    expect(wavePathsWithPrefix(tree, FAR_PREFIX)).toHaveLength(SEGMENT_COUNT);
+    expect(wavePathsWithPrefix(tree, NEAR_PREFIX)).toHaveLength(SEGMENT_COUNT);
+  });
+
+  it('gives each far-<stage> path the exact stage color and reduced opacity', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
+      const far = tree.root.findByProps({ testID: `${FAR_PREFIX}${stage}` });
+      const expectedColor = STAGE_DISPLAY[stage]?.textColor;
+      expect(far.props.stroke).toBe(expectedColor);
+      expect(far.props.strokeOpacity).toBeLessThan(FULL_OPACITY);
+    }
+  });
+
+  it('leaves every near-<stage> path at full opacity', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    const nearPaths = wavePathsWithPrefix(tree, NEAR_PREFIX);
+    expect(nearPaths).toHaveLength(SEGMENT_COUNT);
+    for (const near of nearPaths) {
+      const opacity = near.props.strokeOpacity;
+      const isFullOpacity = opacity === undefined || opacity === FULL_OPACITY;
+      expect(isFullOpacity).toBe(true);
+    }
+  });
+
+  it('colors each near-<stage> path the same exact stage color as its far path', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
+      const near = tree.root.findByProps({ testID: `${NEAR_PREFIX}${stage}` });
+      expect(near.props.stroke).toBe(STAGE_DISPLAY[stage]?.textColor);
+    }
+  });
+
+  it('renders the far path before the near path for every segment', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    const ordered = orderedWavePaths(tree);
+    for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
+      const farIndex = ordered.findIndex((path) => testIdOf(path) === `${FAR_PREFIX}${stage}`);
+      const nearIndex = ordered.findIndex((path) => testIdOf(path) === `${NEAR_PREFIX}${stage}`);
+      expect(farIndex).toBeGreaterThan(NOT_FOUND);
+      expect(nearIndex).toBeGreaterThan(NOT_FOUND);
+      expect(farIndex).toBeLessThan(nearIndex);
+    }
+  });
+
+  it('still renders all 10 arrowheads on top of the far and near paths', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    const arrowheads = tree.root.findAllByType(Polygon);
+    expect(arrowheads).toHaveLength(STAGE_COUNT);
+  });
+});

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -15,6 +15,20 @@ const LARGE_WIDTH = 200;
 const LARGE_HEIGHT = 400;
 const REPRESENTATIVE_STAGE = 4;
 
+/** Reads the number at ``index`` out of a parsed coordinate list. */
+const numberAt = (numbers: readonly number[], index: number): number => numbers[index] as number;
+
+/** The leading "M x y" and trailing "x y" point of an SVG path string. */
+const parsePathPoints = (d: string): { first: [number, number]; last: [number, number] } => {
+  const matches = d.match(/-?\d+\.?\d*/g);
+  const numbers = matches === null ? [] : matches.map(Number);
+  const lastIndex = numbers.length - 1;
+  return {
+    first: [numberAt(numbers, 0), numberAt(numbers, 1)],
+    last: [numberAt(numbers, lastIndex - 1), numberAt(numbers, lastIndex)],
+  };
+};
+
 describe('stageWavePoint', () => {
   it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
     const ys = Array.from({ length: STAGE_COUNT }, (_, i) => stageWavePoint(i + 1).y);
@@ -41,6 +55,21 @@ describe('stageWavePoint', () => {
     const offset10 = Math.abs(stageWavePoint(10).x - CENTER_X);
     expect(offset10).toBeLessThan(offset9);
     expect(offset9).toBeLessThan(offset8);
+    expect(offset10).toBeLessThan(CONVERGENCE_EPSILON);
+  });
+
+  it('tapers the horizontal offset strictly monotonically as stage rises from 1 to 10', () => {
+    const offsetAt = (stage: number): number => Math.abs(stageWavePoint(stage).x - CENTER_X);
+    for (let stage = 2; stage <= STAGE_COUNT; stage += 1) {
+      expect(offsetAt(stage)).toBeLessThan(offsetAt(stage - 1));
+    }
+  });
+
+  it('spans stage 1 (widest offset) to stage 10 (non-degenerate apex)', () => {
+    const offset1 = Math.abs(stageWavePoint(1).x - CENTER_X);
+    const offset10 = Math.abs(stageWavePoint(10).x - CENTER_X);
+    expect(offset1).toBeCloseTo(0.32, 2);
+    expect(offset10).toBeGreaterThan(0);
     expect(offset10).toBeLessThan(CONVERGENCE_EPSILON);
   });
 
@@ -97,6 +126,34 @@ describe('waveSegments', () => {
     const large = waveSegments(LARGE_WIDTH, LARGE_HEIGHT);
     for (let i = 0; i < small.length; i += 1) {
       expect(large[i]?.d).not.toBe(small[i]?.d);
+    }
+  });
+
+  it('gives every segment a non-empty farD distinct from its near-side d', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (const segment of segments) {
+      expect(segment.farD.length).toBeGreaterThan(0);
+      expect(segment.farD).not.toBe(segment.d);
+    }
+  });
+
+  it('mirrors farD across the column center: far x = width - near x, y unchanged', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (const segment of segments) {
+      const near = parsePathPoints(segment.d);
+      const far = parsePathPoints(segment.farD);
+      expect(far.first[0]).toBeCloseTo(SMALL_WIDTH - near.first[0], 2);
+      expect(far.first[1]).toBeCloseTo(near.first[1], 2);
+      expect(far.last[0]).toBeCloseTo(SMALL_WIDTH - near.last[0], 2);
+      expect(far.last[1]).toBeCloseTo(near.last[1], 2);
+    }
+  });
+
+  it('scales farD coordinates with width and height like d', () => {
+    const small = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const large = waveSegments(LARGE_WIDTH, LARGE_HEIGHT);
+    for (let i = 0; i < small.length; i += 1) {
+      expect(large[i]?.farD).not.toBe(small[i]?.farD);
     }
   });
 });

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -7,8 +7,12 @@
  * math is testable in isolation from rendering.
  *
  * The wave wobbles left for even (Divine-Feminine / WE-returning) stages and
- * right for odd (I-pointing) stages, then converges toward center at the top
- * (stages 9-10) as the two poles resolve into the whole apex.
+ * right for odd (I-pointing) stages. Its horizontal swing tapers smoothly and
+ * monotonically from the widest stage-1 offset down to a tiny non-degenerate
+ * apex at stage 10, so the two poles resolve into the whole as the wave rises.
+ * Each segment also carries a mirrored far-side path (drawn faded behind the
+ * near side) so the whole reads as a three-dimensional coil rather than a flat
+ * wobble.
  */
 
 import { STAGE_DISPLAY } from './mapLayout';
@@ -24,34 +28,23 @@ const CENTER_X = 0.5;
 const Y_BAND_MIDPOINT = 0.5;
 
 /**
- * Base horizontal swing from center for stages 1-8. Kept below 0.5 so a pole at
+ * Widest horizontal swing from center, at stage 1. Kept below 0.5 so a pole at
  * full amplitude (x = CENTER_X +/- WAVE_AMPLITUDE) stays comfortably inside the
  * unit column with margin for the arrowhead.
  */
 const WAVE_AMPLITUDE = 0.32;
 
 /**
- * Stage 9 begins the convergence: its swing is the base amplitude tapered by
- * this ratio, so it sits inside stage 8 but outside the near-center apex.
+ * Converged swing at the stage-10 apex. A tiny non-zero offset keeps the path
+ * from degenerating to a vertical stub while reading as fully resolved; it is
+ * the lower bound of the smooth taper that starts from WAVE_AMPLITUDE.
  */
-const TAPER_9 = 0.45;
-
-/**
- * Stage 10 is the converged apex. A tiny non-zero offset keeps the path from
- * degenerating to a vertical stub while staying visually centered; it must be
- * smaller than every stage-9 swing so the wave reads as fully resolved.
- */
-const CONVERGENCE_OFFSET = 0.01;
+const APEX_AMPLITUDE = 0.02;
 
 /** Pole encoding: even stages return left, odd stages point right, apex neutral. */
 const POLE_LEFT = -1;
 const POLE_RIGHT = 1;
 const POLE_NEUTRAL = 0;
-
-/** Stages whose swing stays at full base amplitude (before convergence). */
-const FULL_AMPLITUDE_MAX_STAGE = 8;
-/** The lone taper stage that begins the convergence toward center. */
-const TAPER_STAGE = 9;
 
 /** Half-width of the arrowhead triangle base, in pixels. */
 const ARROWHEAD_HALF_WIDTH = 6;
@@ -90,12 +83,14 @@ export interface WavePoint {
   pole: -1 | 0 | 1;
 }
 
-/** Signed horizontal swing from center for a stage, in unit space. */
-const amplitudeFor = (stageNumber: number): number => {
-  if (stageNumber <= FULL_AMPLITUDE_MAX_STAGE) return WAVE_AMPLITUDE;
-  if (stageNumber === TAPER_STAGE) return WAVE_AMPLITUDE * TAPER_9;
-  return CONVERGENCE_OFFSET;
-};
+/**
+ * Horizontal swing from center for a stage, in unit space. Interpolates
+ * linearly from WAVE_AMPLITUDE at stage 1 down to APEX_AMPLITUDE at stage
+ * STAGE_COUNT, so the offset shrinks strictly and smoothly as the wave rises.
+ */
+const amplitudeFor = (stageNumber: number): number =>
+  APEX_AMPLITUDE +
+  ((WAVE_AMPLITUDE - APEX_AMPLITUDE) * (STAGE_COUNT - stageNumber)) / (STAGE_COUNT - 1);
 
 /** The pole a stage swings toward: left for even, right for odd, neutral at apex. */
 const poleFor = (stageNumber: number): -1 | 0 | 1 => {
@@ -106,10 +101,11 @@ const poleFor = (stageNumber: number): -1 | 0 | 1 => {
 /**
  * Anchor point for a stage on the rising wave, in unit space [0,1]. y strictly
  * decreases as stageNumber climbs (the wave rises); x swings around center by
- * the stage's amplitude toward its pole, converging near center at the top.
+ * the stage's amplitude toward its pole, tapering smoothly toward center at the
+ * top.
  *
  * The apex (stage 10) reports a neutral pole but its x still uses the left/right
- * rule, so it lands a hair off dead-center (by CONVERGENCE_OFFSET) rather than
+ * rule, so it lands a hair off dead-center (by APEX_AMPLITUDE) rather than
  * degenerating into a vertical stub. This apparent mismatch is deliberate.
  */
 export const stageWavePoint = (stageNumber: number): WavePoint => {
@@ -119,10 +115,15 @@ export const stageWavePoint = (stageNumber: number): WavePoint => {
   return { x, y, pole: poleFor(stageNumber) };
 };
 
-/** A rendered wave segment: its SVG path, stroke color, and lower stage number. */
+/** A rendered wave segment: its near and far SVG paths, color, and lower stage. */
 export interface WaveSegment {
   /** SVG path data in pixel space connecting the two stage points. */
   d: string;
+  /**
+   * The near-side bezier mirrored across the column center, drawn faded behind
+   * ``d`` to read as a coil's far side.
+   */
+  farD: string;
   /** Stroke color, taken from the lower stage's textColor. */
   color: string;
   /** The lower of the two stage numbers this segment connects (1..9). */
@@ -132,20 +133,50 @@ export interface WaveSegment {
 /** Round a unit coordinate into a pixel coordinate string at fixed precision. */
 const toPixel = (unit: number, extent: number): string => (unit * extent).toFixed(COORD_PRECISION);
 
+/** Reflect a unit x across the column center: same distance on the far side. */
+const mirrorAcrossCenter = (unitX: number): number => CENTER_X + (CENTER_X - unitX);
+
 /**
- * A smooth cubic Bezier between two stage points. The control points sit at the
- * vertical midpoint of the pair, each anchored to its own stage's x, giving the
- * center column its continuous sine wobble rather than straight zig-zags.
+ * A smooth cubic Bezier between two points given by their unit x's and y's. The
+ * control points sit at the vertical midpoint of the pair, each anchored to its
+ * own x, giving the center column its continuous sine wobble rather than
+ * straight zig-zags. Shared by the near and far paths so the string assembly
+ * lives in exactly one place.
  */
-const segmentPath = (lower: WavePoint, upper: WavePoint, width: number, height: number): string => {
-  const midY = (lower.y + upper.y) / 2;
-  const x1 = toPixel(lower.x, width);
-  const y1 = toPixel(lower.y, height);
-  const x2 = toPixel(upper.x, width);
-  const y2 = toPixel(upper.y, height);
+const bezierPath = (
+  lowerX: number,
+  upperX: number,
+  lowerY: number,
+  upperY: number,
+  width: number,
+  height: number,
+): string => {
+  const midY = (lowerY + upperY) / 2;
+  const x1 = toPixel(lowerX, width);
+  const y1 = toPixel(lowerY, height);
+  const x2 = toPixel(upperX, width);
+  const y2 = toPixel(upperY, height);
   const midYPixel = toPixel(midY, height);
   return `M ${x1} ${y1} C ${x1} ${midYPixel} ${x2} ${midYPixel} ${x2} ${y2}`;
 };
+
+/** Near-side and mirrored far-side bezier paths for a stage pair, in pixels. */
+const segmentPaths = (
+  lower: WavePoint,
+  upper: WavePoint,
+  width: number,
+  height: number,
+): { d: string; farD: string } => ({
+  d: bezierPath(lower.x, upper.x, lower.y, upper.y, width, height),
+  farD: bezierPath(
+    mirrorAcrossCenter(lower.x),
+    mirrorAcrossCenter(upper.x),
+    lower.y,
+    upper.y,
+    width,
+    height,
+  ),
+});
 
 /**
  * The full wave as STAGE_COUNT-1 (9) segments in pixel space. Segment i connects
@@ -159,8 +190,10 @@ export const waveSegments = (width: number, height: number): readonly WaveSegmen
     if (previous !== null) {
       const lower = stageWavePoint(previous.stageNumber);
       const upper = stageWavePoint(current.stageNumber);
+      const { d, farD } = segmentPaths(lower, upper, width, height);
       segments.push({
-        d: segmentPath(lower, upper, width, height),
+        d,
+        farD,
         color: previous.textColor,
         stageNumber: previous.stageNumber,
       });


### PR DESCRIPTION
## Summary

The Map center-column "spiral of becoming" had two fidelity failures against the reference art:

1. **No gradual tightening.** `amplitudeFor` returned a flat `WAVE_AMPLITUDE` for stages 1-8, one tapered value for stage 9, and a tiny offset for stage 10 — a plateau followed by a cliff. It now interpolates linearly from the widest swing at stage 1 down to a small non-zero apex offset (`APEX_AMPLITUDE`) at stage 10, so the horizontal swing shrinks **strictly and smoothly** stage-over-stage.
2. **No light "far side" per turn.** Every segment stroked at one flat opacity, so the shape read as a 2D S-curve. Each `WaveSegment` now carries a `farD` path — the near bezier mirrored across the column center — rendered *behind* the near side at reduced `strokeOpacity` (`FAR_SIDE_OPACITY`) in the **exact same stage `textColor`** (hue-preserving; opacity is the only difference). Each turn now reads as a 3D coil with a lighter far half.

Dead taper constants (`TAPER_9`, `CONVERGENCE_OFFSET`, `FULL_AMPLITUDE_MAX_STAGE`, `TAPER_STAGE`) removed; near and far paths share a single `bezierPath` builder to avoid duplication. Geometry stays pure in `waveGeometry.ts`; `Map.styles.ts` is untouched.

Acceptance criteria: monotonic taper (AC1), lighter far side per turn (AC2), exact `STAGE_DISPLAY` textColors with opacity-only light part (AC3), pure geometry + unit-tested progression (AC4) — all met.

## ⚠️ Merge coordination — overlaps with #1221

This branch was cut from `e000219`, **before** #1221 (`7455085`, "confine wave overlay to the center-column band") landed on `main`. That PR added `toColumnPixelX` / `centerColumnBounds` / `GRID_COLUMN_FLEX`-based confinement to the same `waveGeometry.ts` path-building this PR rewrites, so a merge will **conflict**. The resolution must preserve **both**: #1221's center-column band confinement (map unit-x through `toColumnPixelX`, and mirror the far side across the *column* midline, not the grid midline) **and** this PR's monotonic taper + faded `farD` coil. A naive merge favoring either side would regress the other.

## Test plan

- `waveGeometry.test.ts`: `|stageWavePoint(s).x - center|` strictly decreases for every stage 1→10 (pins the taper); stage-1 widest / stage-10 non-degenerate apex; `farD` non-empty, distinct from `d`, mirrored across center (far x = width - near x, y unchanged), and scales with width/height.
- `WaveOverlay.test.tsx` (new): one `far-<stage>` + one `near-<stage>` path per segment (selected by testID to avoid Polygon-internal-Path over-counting); far paths carry `strokeOpacity < 1` and the exact stage color; near paths full opacity, same color; far renders before near; 10 arrowheads intact.
- `./scripts/frontend/check-all.sh` exits 0 (ESLint zero-warnings, strict tsc, prettier, 3166 jest tests).

Closes #1161
Refs #943, #944