### PR TITLE
fix(map): anchor wave segments and arrowheads to measured stage-cell centers

### DIFF
--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -34,6 +34,8 @@ import {
 
 import { BEGIN_AGAIN_COPY, cycleLabel } from './beginAgain';
 import { useBeginAgainGuard } from './hooks/useBeginAgainGuard';
+import { useStageAnchors } from './hooks/useStageAnchors';
+import type { UseStageAnchorsResult } from './hooks/useStageAnchors';
 import { useWheelBalance } from './hooks/useWheelBalance';
 import {
   formatMinutes,
@@ -159,13 +161,22 @@ const CenterContent = ({ display }: { display: StageDisplay }): React.JSX.Elemen
   );
 };
 
+interface StageCenterCellProps extends StageCellProps {
+  /** Index of the row this cell sits in, for anchor measurement. */
+  rowIndex: number;
+  /** Record this cell's measured row-relative center on layout. */
+  onCellLayout: UseStageAnchorsResult['onCellLayout'];
+}
+
 const StageCenterCell = ({
   stage,
   display,
   locked,
   isCurrent,
   onPress,
-}: StageCellProps): React.JSX.Element => (
+  rowIndex,
+  onCellLayout,
+}: StageCenterCellProps): React.JSX.Element => (
   <TouchableOpacity
     testID={`stage-hotspot-${display.stageNumber}-1`}
     style={[
@@ -175,6 +186,7 @@ const StageCenterCell = ({
       isCurrent ? styles.cellCurrent : null,
     ]}
     onPress={() => onPress(stage)}
+    onLayout={(e) => onCellLayout(display.stageNumber, rowIndex, e)}
     accessibilityRole="button"
     accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
   >
@@ -196,50 +208,111 @@ const StageCenterCell = ({
 
 interface MapRowProps {
   row: MapRow;
+  rowIndex: number;
   lookup: StageLookup;
   fullnessByStage: FullnessLookup;
   currentStage: number | null;
   onPress: (_stage: StageData) => void;
+  onRowLayout: UseStageAnchorsResult['onRowLayout'];
+  onCellLayout: UseStageAnchorsResult['onCellLayout'];
 }
+
+/** A row's stages resolved to their loaded StageData + display copy. */
+type ResolvedStage = { stage: StageData; display: StageDisplay };
+
+const resolveRowStages = (row: MapRow, lookup: StageLookup): ResolvedStage[] =>
+  row.stageNumbers
+    .map((n) => ({ stage: lookup[n], display: STAGE_DISPLAY[n] }))
+    .filter((r): r is ResolvedStage => !!r.stage && !!r.display);
+
+/** Left column of one row: the colored stage-text tap targets, stacked. */
+const RowLeftColumn = ({
+  resolved,
+  fullnessByStage,
+  currentStage,
+  onPress,
+}: {
+  resolved: ResolvedStage[];
+  fullnessByStage: FullnessLookup;
+  currentStage: number | null;
+  onPress: (_stage: StageData) => void;
+}): React.JSX.Element => (
+  <View style={styles.leftCell}>
+    {resolved.map(({ stage, display }) => (
+      <StageTextBlock
+        key={stage.stageNumber}
+        stage={stage}
+        display={display}
+        locked={!isStageUnlocked(stage, currentStage)}
+        isCurrent={stage.stageNumber === currentStage}
+        fullness={fullnessByStage[stage.stageNumber] ?? THIN_FULLNESS}
+        onPress={onPress}
+      />
+    ))}
+  </View>
+);
+
+/** Center column of one row: the per-stage glyph cells that anchor the wave. */
+const RowCenterColumn = ({
+  resolved,
+  rowIndex,
+  currentStage,
+  onPress,
+  onCellLayout,
+}: {
+  resolved: ResolvedStage[];
+  rowIndex: number;
+  currentStage: number | null;
+  onPress: (_stage: StageData) => void;
+  onCellLayout: UseStageAnchorsResult['onCellLayout'];
+}): React.JSX.Element => (
+  <View style={styles.centerCell}>
+    {resolved.map(({ stage, display }) => (
+      <StageCenterCell
+        key={stage.stageNumber}
+        stage={stage}
+        display={display}
+        locked={!isStageUnlocked(stage, currentStage)}
+        isCurrent={stage.stageNumber === currentStage}
+        onPress={onPress}
+        rowIndex={rowIndex}
+        onCellLayout={onCellLayout}
+      />
+    ))}
+  </View>
+);
 
 /** One grid row: left text + center glyph stacked per stage, one aspect label. */
 const MapRowView = ({
   row,
+  rowIndex,
   lookup,
   fullnessByStage,
   currentStage,
   onPress,
+  onRowLayout,
+  onCellLayout,
 }: MapRowProps): React.JSX.Element => {
-  const resolved = row.stageNumbers
-    .map((n) => ({ stage: lookup[n], display: STAGE_DISPLAY[n] }))
-    .filter((r): r is { stage: StageData; display: StageDisplay } => !!r.stage && !!r.display);
+  const resolved = resolveRowStages(row, lookup);
   return (
-    <View style={[styles.groupRow, { flex: row.stageNumbers.length }]}>
-      <View style={styles.leftCell}>
-        {resolved.map(({ stage, display }) => (
-          <StageTextBlock
-            key={stage.stageNumber}
-            stage={stage}
-            display={display}
-            locked={!isStageUnlocked(stage, currentStage)}
-            isCurrent={stage.stageNumber === currentStage}
-            fullness={fullnessByStage[stage.stageNumber] ?? THIN_FULLNESS}
-            onPress={onPress}
-          />
-        ))}
-      </View>
-      <View style={styles.centerCell}>
-        {resolved.map(({ stage, display }) => (
-          <StageCenterCell
-            key={stage.stageNumber}
-            stage={stage}
-            display={display}
-            locked={!isStageUnlocked(stage, currentStage)}
-            isCurrent={stage.stageNumber === currentStage}
-            onPress={onPress}
-          />
-        ))}
-      </View>
+    <View
+      style={[styles.groupRow, { flex: row.stageNumbers.length }]}
+      testID={`map-row-${row.rightLabel}`}
+      onLayout={(e) => onRowLayout(rowIndex, e)}
+    >
+      <RowLeftColumn
+        resolved={resolved}
+        fullnessByStage={fullnessByStage}
+        currentStage={currentStage}
+        onPress={onPress}
+      />
+      <RowCenterColumn
+        resolved={resolved}
+        rowIndex={rowIndex}
+        currentStage={currentStage}
+        onPress={onPress}
+        onCellLayout={onCellLayout}
+      />
       <View style={styles.rightCell}>
         <Text style={styles.rightLabelText}>{row.rightLabel}</Text>
       </View>
@@ -727,17 +800,21 @@ const MapGrid = ({
   onSelectStage,
 }: MapGridProps): React.JSX.Element => {
   const [size, onLayout] = useGridSize();
+  const { anchors, onRowLayout, onCellLayout } = useStageAnchors(size.height);
   return (
     <View style={styles.grid} testID="map-grid" onLayout={onLayout}>
-      <WaveOverlay width={size.width} height={size.height} />
-      {MAP_ROWS.map((row) => (
+      <WaveOverlay width={size.width} height={size.height} anchors={anchors} />
+      {MAP_ROWS.map((row, index) => (
         <MapRowView
           key={row.rightLabel}
           row={row}
+          rowIndex={index}
           lookup={lookup}
           fullnessByStage={fullnessByStage}
           currentStage={currentStage}
           onPress={onSelectStage}
+          onRowLayout={onRowLayout}
+          onCellLayout={onCellLayout}
         />
       ))}
     </View>

--- a/frontend/src/features/Map/WaveOverlay.tsx
+++ b/frontend/src/features/Map/WaveOverlay.tsx
@@ -5,6 +5,7 @@ import { StyleSheet } from 'react-native';
 import Svg, { Path, Polygon } from 'react-native-svg';
 
 import { waveArrowheads, waveSegments } from './waveGeometry';
+import type { StageAnchors } from './waveGeometry';
 
 /**
  * Continuous sine-wave artwork for the Map's center column, rendered behind the
@@ -27,14 +28,20 @@ interface WaveOverlayProps {
   width: number;
   /** Measured height of the grid the wave fills, in pixels. */
   height: number;
+  /** Measured per-stage vertical centers; missing stages use nominal bands. */
+  anchors?: StageAnchors;
 }
 
 /** SVG sine-wave overlay sized to the measured grid; null until measured. */
-export const WaveOverlay = ({ width, height }: WaveOverlayProps): React.JSX.Element | null => {
+export const WaveOverlay = ({
+  width,
+  height,
+  anchors = {},
+}: WaveOverlayProps): React.JSX.Element | null => {
   const smallerExtent = Math.min(width, height);
   if (smallerExtent < MIN_DRAWABLE_EXTENT) return null;
-  const segments = waveSegments(width, height);
-  const arrowheads = waveArrowheads(width, height);
+  const segments = waveSegments(width, height, anchors);
+  const arrowheads = waveArrowheads(width, height, anchors);
   return (
     <Svg
       testID="map-wave"

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -5,6 +5,7 @@ import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
+import { STAGE_COUNT } from '../stageData';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
 import { ranksOrShames } from './copyIntentRule';
@@ -535,5 +536,81 @@ describe('MapScreen', () => {
     // and the wave overlay renders alongside it with no dependency between them.
     expect(tree.root.findByProps({ testID: 'map-background' })).toBeTruthy();
     expect(tree.root.findByProps({ testID: 'map-wave' })).toBeTruthy();
+  });
+
+  // --- wave overlay follows measured row/cell centers, not nominal bands ---
+
+  const MAP_ROW_LABELS = [
+    'Awareness',
+    'Being',
+    'Wisdom',
+    'Understanding',
+    'Love',
+    'Yes-And-Ness',
+  ] as const;
+  type MapRowLabel = (typeof MAP_ROW_LABELS)[number];
+  const ROW_Y_BY_LABEL: Record<MapRowLabel, number> = {
+    Awareness: 0,
+    Being: 40,
+    Wisdom: 90,
+    Understanding: 260,
+    Love: 380,
+    'Yes-And-Ness': 500,
+  };
+  const TARGET_ROW_LABEL: MapRowLabel = 'Yes-And-Ness';
+  const CELL_LAYOUT_Y = 0;
+  const CELL_LAYOUT_HEIGHT = 40;
+  const CELL_LAYOUT_WIDTH = 100;
+  const NOMINAL_BAND_MIDPOINT = 0.5;
+  const MEASURED_TARGET_STAGE = 1;
+
+  const nominalPixelY = (stageNumber: number, height: number): number =>
+    ((STAGE_COUNT - stageNumber + NOMINAL_BAND_MIDPOINT) / STAGE_COUNT) * height;
+
+  const parseArrowMidY = (points: string): number => {
+    const ys = points
+      .trim()
+      .split(' ')
+      .map((pair) => Number(pair.split(',')[1]));
+    return (Math.min(...ys) + Math.max(...ys)) / 2;
+  };
+
+  it('reflects measured non-uniform row/cell centers in wave-arrow y-coordinates, not the nominal equal bands', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+
+    act(() => {
+      for (const label of MAP_ROW_LABELS) {
+        tree.root.findByProps({ testID: `map-row-${label}` }).props.onLayout({
+          nativeEvent: {
+            layout: {
+              x: 0,
+              y: ROW_Y_BY_LABEL[label],
+              width: WAVE_LAYOUT_WIDTH,
+              height: CELL_LAYOUT_HEIGHT,
+            },
+          },
+        });
+      }
+      for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+        tree.root.findByProps({ testID: `stage-hotspot-${stage}-1` }).props.onLayout({
+          nativeEvent: {
+            layout: {
+              x: 0,
+              y: CELL_LAYOUT_Y,
+              width: CELL_LAYOUT_WIDTH,
+              height: CELL_LAYOUT_HEIGHT,
+            },
+          },
+        });
+      }
+    });
+
+    const arrow = tree.root.findByProps({ testID: `wave-arrow-${MEASURED_TARGET_STAGE}` });
+    const midY = parseArrowMidY(arrow.props.points as string);
+    const measuredCenterY = ROW_Y_BY_LABEL[TARGET_ROW_LABEL] + CELL_LAYOUT_HEIGHT / 2;
+
+    expect(midY).toBeCloseTo(measuredCenterY);
+    expect(midY).not.toBeCloseTo(nominalPixelY(MEASURED_TARGET_STAGE, WAVE_LAYOUT_HEIGHT));
   });
 });

--- a/frontend/src/features/Map/__tests__/useStageAnchors.test.ts
+++ b/frontend/src/features/Map/__tests__/useStageAnchors.test.ts
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { act, renderHook } from '@testing-library/react-native';
+import type { LayoutChangeEvent } from 'react-native';
+
+import { useStageAnchors } from '../hooks/useStageAnchors';
+
+const GRID_HEIGHT = 1000;
+const SUB_PIXEL_GRID_HEIGHT = 0;
+
+const ROW_INDEX_A = 0;
+const ROW_INDEX_B = 1;
+const ROW_Y_A = 40;
+const ROW_Y_B = 220;
+
+const STAGE_A = 10;
+const STAGE_B = 9;
+const CELL_Y_A = 12;
+const CELL_HEIGHT_A = 96;
+const CELL_Y_B = 4;
+const CELL_HEIGHT_B = 140;
+
+const layoutEvent = (y: number, height: number): LayoutChangeEvent =>
+  ({ nativeEvent: { layout: { x: 0, y, width: 0, height } } }) as LayoutChangeEvent;
+
+const anchorFor = (rowY: number, cellY: number, cellHeight: number, gridHeight: number): number =>
+  (rowY + cellY + cellHeight / 2) / gridHeight;
+
+describe('useStageAnchors', () => {
+  it('reports an empty anchors record before any layout event fires', () => {
+    const { result } = renderHook(() => useStageAnchors(GRID_HEIGHT));
+    expect(result.current.anchors).toEqual({});
+  });
+
+  it('resolves each measured stage anchor as (rowY + cellY + cellHeight/2) / gridHeight', () => {
+    const { result } = renderHook(() => useStageAnchors(GRID_HEIGHT));
+    act(() => {
+      result.current.onRowLayout(ROW_INDEX_A, layoutEvent(ROW_Y_A, 0));
+      result.current.onRowLayout(ROW_INDEX_B, layoutEvent(ROW_Y_B, 0));
+      result.current.onCellLayout(STAGE_A, ROW_INDEX_A, layoutEvent(CELL_Y_A, CELL_HEIGHT_A));
+      result.current.onCellLayout(STAGE_B, ROW_INDEX_B, layoutEvent(CELL_Y_B, CELL_HEIGHT_B));
+    });
+    expect(result.current.anchors[STAGE_A]).toBeCloseTo(
+      anchorFor(ROW_Y_A, CELL_Y_A, CELL_HEIGHT_A, GRID_HEIGHT),
+    );
+    expect(result.current.anchors[STAGE_B]).toBeCloseTo(
+      anchorFor(ROW_Y_B, CELL_Y_B, CELL_HEIGHT_B, GRID_HEIGHT),
+    );
+  });
+
+  it('omits a stage until BOTH its row and its cell have reported layout', () => {
+    const { result } = renderHook(() => useStageAnchors(GRID_HEIGHT));
+    act(() => {
+      result.current.onCellLayout(STAGE_A, ROW_INDEX_A, layoutEvent(CELL_Y_A, CELL_HEIGHT_A));
+    });
+    expect(result.current.anchors[STAGE_A]).toBeUndefined();
+
+    act(() => {
+      result.current.onRowLayout(ROW_INDEX_A, layoutEvent(ROW_Y_A, 0));
+    });
+    expect(result.current.anchors[STAGE_A]).toBeCloseTo(
+      anchorFor(ROW_Y_A, CELL_Y_A, CELL_HEIGHT_A, GRID_HEIGHT),
+    );
+  });
+
+  it('reports an empty anchors record when gridHeight is below one pixel', () => {
+    const { result } = renderHook(() => useStageAnchors(SUB_PIXEL_GRID_HEIGHT));
+    act(() => {
+      result.current.onRowLayout(ROW_INDEX_A, layoutEvent(ROW_Y_A, 0));
+      result.current.onCellLayout(STAGE_A, ROW_INDEX_A, layoutEvent(CELL_Y_A, CELL_HEIGHT_A));
+    });
+    expect(result.current.anchors).toEqual({});
+  });
+
+  it('keeps the anchors object identity stable when identical layout events re-fire', () => {
+    const { result } = renderHook(() => useStageAnchors(GRID_HEIGHT));
+    act(() => {
+      result.current.onRowLayout(ROW_INDEX_A, layoutEvent(ROW_Y_A, 0));
+      result.current.onCellLayout(STAGE_A, ROW_INDEX_A, layoutEvent(CELL_Y_A, CELL_HEIGHT_A));
+    });
+    const first = result.current.anchors;
+
+    act(() => {
+      result.current.onRowLayout(ROW_INDEX_A, layoutEvent(ROW_Y_A, 0));
+      result.current.onCellLayout(STAGE_A, ROW_INDEX_A, layoutEvent(CELL_Y_A, CELL_HEIGHT_A));
+    });
+    expect(Object.is(result.current.anchors, first)).toBe(true);
+  });
+});

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -5,11 +5,12 @@ import { STAGE_COUNT, isLeftReturning } from '../stageData';
 import {
   arrowheadAt,
   centerColumnBounds,
+  nominalAnchorY,
   stageWavePoint,
   waveArrowheads,
   waveSegments,
 } from '../waveGeometry';
-import type { WaveSegment } from '../waveGeometry';
+import type { StageAnchors, WaveSegment } from '../waveGeometry';
 
 const CENTER_X = 0.5;
 const CONVERGENCE_EPSILON = 0.05;
@@ -39,6 +40,20 @@ const CENTER_RIGHT_FRACTION = (LEFT_COLUMN_FLEX + CENTER_COLUMN_FLEX) / TOTAL_CO
 const WOBBLE_VISIBILITY_FRACTION = 0.4;
 const LEFT_WOBBLE_STAGE = 2;
 const RIGHT_WOBBLE_STAGE = 1;
+
+// x tokens in the "M x1 y1 C x1 mY x2 mY x2 y2" segment path stream.
+const SEGMENT_X_TOKEN_INDICES = [1, 4, 6, 8];
+const segmentPathXs = (d: string): number[] => {
+  const tokens = d.trim().split(' ');
+  return SEGMENT_X_TOKEN_INDICES.map((index) => Number(tokens[index]));
+};
+
+const arrowheadXs = (points: string): number[] =>
+  points
+    .trim()
+    .split(' ')
+    .map((pair) => pair.split(',').map(Number))
+    .map(([x]) => x as number);
 
 describe('stageWavePoint', () => {
   it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
@@ -141,20 +156,6 @@ describe('arrowheadAt', () => {
 });
 
 describe('center-column containment', () => {
-  // x tokens in the "M x1 y1 C x1 mY x2 mY x2 y2" segment path stream.
-  const SEGMENT_X_TOKEN_INDICES = [1, 4, 6, 8];
-  const segmentPathXs = (d: string): number[] => {
-    const tokens = d.trim().split(' ');
-    return SEGMENT_X_TOKEN_INDICES.map((index) => Number(tokens[index]));
-  };
-
-  const arrowheadXs = (points: string): number[] =>
-    points
-      .trim()
-      .split(' ')
-      .map((pair) => pair.split(',').map(Number))
-      .map(([x]) => x as number);
-
   const findSegmentX = (segments: readonly WaveSegment[], stageNumber: number): number => {
     for (const segment of segments) {
       if (segment.stageNumber === stageNumber) {
@@ -217,6 +218,118 @@ describe('center-column containment', () => {
       expect(Math.abs(rightX - columnMidline)).toBeGreaterThanOrEqual(
         WOBBLE_VISIBILITY_FRACTION * columnHalfWidth,
       );
+    }
+  });
+});
+
+describe('measured anchors: nominal fallback and pixel-space threading', () => {
+  const NOMINAL_BAND_MIDPOINT = 0.5;
+  const OVERRIDE_STAGE = 4;
+  const OVERRIDE_UNIT_Y = 0.42;
+  const NON_UNIFORM_ANCHORS: StageAnchors = {
+    1: 0.94,
+    2: 0.83,
+    3: 0.76,
+    4: 0.68,
+    5: 0.57,
+    6: 0.49,
+    7: 0.39,
+    8: 0.31,
+    9: 0.18,
+    10: 0.06,
+  };
+  const SEGMENT_Y1_TOKEN_INDEX = 2;
+  const SEGMENT_Y2_TOKEN_INDEX = 9;
+  const ANCHOR_COORD_PRECISION = 3;
+  const EXPECTED_ARROWHEAD_HEIGHT = 10;
+
+  const findSegment = (segments: readonly WaveSegment[], stageNumber: number): WaveSegment => {
+    const segment = segments.find((s) => s.stageNumber === stageNumber);
+    if (!segment) throw new Error(`no segment found for stage ${stageNumber}`);
+    return segment;
+  };
+
+  it('nominalAnchorY matches the legacy uniform-band formula for every stage', () => {
+    for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+      const expected = (STAGE_COUNT - stage + NOMINAL_BAND_MIDPOINT) / STAGE_COUNT;
+      expect(nominalAnchorY(stage)).toBeCloseTo(expected);
+    }
+  });
+
+  it('stageWavePoint(n) matches stageWavePoint(n, {}) for every stage', () => {
+    for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+      expect(stageWavePoint(stage, {})).toEqual(stageWavePoint(stage));
+    }
+  });
+
+  it('a measured override wins for its own stage; every other stage falls back to nominalAnchorY', () => {
+    const anchors: StageAnchors = { [OVERRIDE_STAGE]: OVERRIDE_UNIT_Y };
+    expect(stageWavePoint(OVERRIDE_STAGE, anchors).y).toBe(OVERRIDE_UNIT_Y);
+    for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+      if (stage === OVERRIDE_STAGE) continue;
+      const { y } = stageWavePoint(stage, anchors);
+      expect(Number.isNaN(y)).toBe(false);
+      expect(y).toBe(nominalAnchorY(stage));
+    }
+  });
+
+  it('non-uniform anchors flow into segment endpoints in pixel space', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
+    for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
+      const segment = findSegment(segments, stage);
+      const tokens = segment.d.trim().split(' ');
+      const expectedY1 = ((NON_UNIFORM_ANCHORS[stage] ?? 0) * SMALL_HEIGHT).toFixed(
+        ANCHOR_COORD_PRECISION,
+      );
+      const expectedY2 = ((NON_UNIFORM_ANCHORS[stage + 1] ?? 0) * SMALL_HEIGHT).toFixed(
+        ANCHOR_COORD_PRECISION,
+      );
+      expect(tokens[SEGMENT_Y1_TOKEN_INDEX]).toBe(expectedY1);
+      expect(tokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(expectedY2);
+    }
+  });
+
+  it('centers the arrowhead triangle exactly on the resolved anchor', () => {
+    const arrow = arrowheadAt(REPRESENTATIVE_STAGE, SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
+    const coordinatePairs = arrow.points
+      .trim()
+      .split(' ')
+      .map((pair) => pair.split(',').map(Number));
+    const ys = coordinatePairs.map(([, y]) => y as number);
+    const apexY = Math.min(...ys);
+    const baseY = Math.max(...ys);
+    const expectedCenter = (NON_UNIFORM_ANCHORS[REPRESENTATIVE_STAGE] ?? 0) * SMALL_HEIGHT;
+    expect((apexY + baseY) / 2).toBeCloseTo(expectedCenter);
+    expect(baseY - apexY).toBe(EXPECTED_ARROWHEAD_HEIGHT);
+  });
+
+  it('colors stay keyed to STAGE_DISPLAY textColor when anchors are non-uniform', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
+    for (const segment of segments) {
+      expect(segment.color).toBe(STAGE_DISPLAY[segment.stageNumber]?.textColor);
+    }
+    const arrowheads = waveArrowheads(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
+    for (const arrowhead of arrowheads) {
+      expect(arrowhead.color).toBe(STAGE_DISPLAY[arrowhead.stageNumber]?.textColor);
+    }
+  });
+
+  const expectXsWithin = (xs: number[], minX: number, maxX: number): void => {
+    for (const x of xs) {
+      expect(x).toBeGreaterThanOrEqual(minX);
+      expect(x).toBeLessThanOrEqual(maxX);
+    }
+  };
+
+  it('keeps x-coordinates within the margin-shrunk center column when anchors are non-uniform', () => {
+    for (const width of PHONE_WIDTHS) {
+      const { left, right } = centerColumnBounds(width);
+      const minX = left + SAFE_MARGIN_PX;
+      const maxX = right - SAFE_MARGIN_PX;
+      const segments = waveSegments(width, REPRESENTATIVE_HEIGHT, NON_UNIFORM_ANCHORS);
+      for (const segment of segments) expectXsWithin(segmentPathXs(segment.d), minX, maxX);
+      const arrowheads = waveArrowheads(width, REPRESENTATIVE_HEIGHT, NON_UNIFORM_ANCHORS);
+      for (const arrowhead of arrowheads) expectXsWithin(arrowheadXs(arrowhead.points), minX, maxX);
     }
   });
 });

--- a/frontend/src/features/Map/hooks/useStageAnchors.ts
+++ b/frontend/src/features/Map/hooks/useStageAnchors.ts
@@ -1,0 +1,93 @@
+// frontend/features/Map/hooks/useStageAnchors.ts
+
+/**
+ * Measure the real, content-driven vertical center of each stage cell so the
+ * center-column wave threads through the true row/cell midpoints instead of ten
+ * imagined equal bands. Row layout gives each row's grid-relative y; cell layout
+ * gives each stage's row-relative y + height. A stage only earns an anchor once
+ * both are known and the grid has a drawable height; missing stages fall back to
+ * the nominal band center in ``waveGeometry``.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
+
+import type { StageAnchors } from '../waveGeometry';
+
+/** Smallest grid height worth resolving; below it there is nothing to anchor. */
+const MIN_DRAWABLE_HEIGHT = 1;
+
+/** A stage cell's raw row-relative measurement plus the row it belongs to. */
+interface CellMeasurement {
+  rowIndex: number;
+  y: number;
+  height: number;
+}
+
+/** The measured-anchor API consumed by ``MapGrid`` and the wave overlay. */
+export interface UseStageAnchorsResult {
+  /** Unit-space vertical centers keyed by stage; only fully-measured stages. */
+  anchors: StageAnchors;
+  /** Record a row's grid-relative y from its onLayout event. */
+  onRowLayout: (rowIndex: number, event: LayoutChangeEvent) => void;
+  /** Record a stage cell's row-relative y + height from its onLayout event. */
+  onCellLayout: (stageNumber: number, rowIndex: number, event: LayoutChangeEvent) => void;
+}
+
+/** Resolve every fully-measured stage to its unit-space vertical center. */
+const computeAnchors = (
+  rowYs: Map<number, number>,
+  cells: Map<number, CellMeasurement>,
+  gridHeight: number,
+): StageAnchors => {
+  if (gridHeight < MIN_DRAWABLE_HEIGHT) return {};
+  const anchors: Record<number, number> = {};
+  for (const [stageNumber, cell] of cells) {
+    const rowY = rowYs.get(cell.rowIndex);
+    if (rowY === undefined) continue;
+    anchors[stageNumber] = (rowY + cell.y + cell.height / 2) / gridHeight;
+  }
+  return anchors;
+};
+
+/** Whether two anchor records hold the same stages with the same values. */
+const sameAnchors = (a: StageAnchors, b: StageAnchors): boolean => {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every((key) => a[Number(key)] === b[Number(key)]);
+};
+
+/**
+ * Track measured stage anchors from row/cell layout events. Raw measurements
+ * live in refs; ``anchors`` only re-identifies when its resolved contents
+ * actually change, so re-fired identical layouts never re-render the overlay.
+ */
+export const useStageAnchors = (gridHeight: number): UseStageAnchorsResult => {
+  const rowYsRef = useRef<Map<number, number>>(new Map());
+  const cellsRef = useRef<Map<number, CellMeasurement>>(new Map());
+  const [anchors, setAnchors] = useState<StageAnchors>({});
+
+  const recompute = useCallback(() => {
+    const next = computeAnchors(rowYsRef.current, cellsRef.current, gridHeight);
+    setAnchors((prev) => (sameAnchors(prev, next) ? prev : next));
+  }, [gridHeight]);
+
+  const onRowLayout = useCallback(
+    (rowIndex: number, event: LayoutChangeEvent) => {
+      rowYsRef.current.set(rowIndex, event.nativeEvent.layout.y);
+      recompute();
+    },
+    [recompute],
+  );
+
+  const onCellLayout = useCallback(
+    (stageNumber: number, rowIndex: number, event: LayoutChangeEvent) => {
+      const { y, height } = event.nativeEvent.layout;
+      cellsRef.current.set(stageNumber, { rowIndex, y, height });
+      recompute();
+    },
+    [recompute],
+  );
+
+  return { anchors, onRowLayout, onCellLayout };
+};

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -13,7 +13,8 @@
  * (stages 9-10) as the two poles resolve into the whole apex.
  */
 
-import { GRID_COLUMN_FLEX, STAGE_DISPLAY } from './mapLayout';
+import { GRID_COLUMN_FLEX, MAP_ROWS, STAGE_DISPLAY } from './mapLayout';
+import type { MapRow } from './mapLayout';
 import { STAGE_COUNT, isLeftReturning } from './stageData';
 
 /** Combined flex weight of all three row cells; the denominator for band fractions. */
@@ -67,6 +68,11 @@ const TAPER_STAGE = 9;
 const ARROWHEAD_HALF_WIDTH = 6;
 /** Distance from the arrowhead base up to its apex, in pixels. */
 const ARROWHEAD_HEIGHT = 10;
+/** Half the arrowhead height; the triangle straddles its anchor by this much. */
+const ARROWHEAD_HALF_HEIGHT = ARROWHEAD_HEIGHT / 2;
+
+/** Total row flex across the map: one unit per stage a row contains. */
+const TOTAL_ROW_FLEX = MAP_ROWS.reduce((sum, row) => sum + row.stageNumbers.length, 0);
 
 /** Decimal places kept in emitted SVG coordinates (matches TierStar). */
 const COORD_PRECISION = 3;
@@ -114,6 +120,41 @@ const poleFor = (stageNumber: number): -1 | 0 | 1 => {
 };
 
 /**
+ * Measured vertical centers keyed by stage number, in unit space [0,1]. May be
+ * partial or empty; any missing stage falls back to its nominal band center.
+ */
+export type StageAnchors = Readonly<Record<number, number>>;
+
+/** Unit-y center of stageNumber inside its row band, or undefined if absent. */
+const rowAnchorY = (row: MapRow, stageNumber: number, bandTop: number): number | undefined => {
+  const index = row.stageNumbers.indexOf(stageNumber);
+  if (index < 0) return undefined;
+  // Every stage owns an equal 1/TOTAL_ROW_FLEX sub-band inside its paired row.
+  const subBand = 1 / TOTAL_ROW_FLEX;
+  return bandTop + (index + Y_BAND_MIDPOINT) * subBand;
+};
+
+/**
+ * Fallback unit-y center for a stage, derived by walking MAP_ROWS top-to-bottom
+ * with each row weighted by how many stages it holds. This reproduces the legacy
+ * uniform-band formula ``(STAGE_COUNT - stageNumber + 0.5) / STAGE_COUNT`` while
+ * staying honest to the real row structure. Unknown stages get a safe midpoint.
+ */
+export const nominalAnchorY = (stageNumber: number): number => {
+  let bandTop = 0;
+  for (const row of MAP_ROWS) {
+    const center = rowAnchorY(row, stageNumber, bandTop);
+    if (center !== undefined) return center;
+    bandTop += row.stageNumbers.length / TOTAL_ROW_FLEX;
+  }
+  return Y_BAND_MIDPOINT;
+};
+
+/** Measured anchor for a stage when present, else its nominal band center. */
+const resolveAnchorY = (stageNumber: number, anchors: StageAnchors): number =>
+  anchors[stageNumber] ?? nominalAnchorY(stageNumber);
+
+/**
  * Anchor point for a stage on the rising wave, in unit space [0,1]. y strictly
  * decreases as stageNumber climbs (the wave rises); x swings around center by
  * the stage's amplitude toward its pole, converging near center at the top.
@@ -122,8 +163,8 @@ const poleFor = (stageNumber: number): -1 | 0 | 1 => {
  * rule, so it lands a hair off dead-center (by CONVERGENCE_OFFSET) rather than
  * degenerating into a vertical stub. This apparent mismatch is deliberate.
  */
-export const stageWavePoint = (stageNumber: number): WavePoint => {
-  const y = (STAGE_COUNT - stageNumber + Y_BAND_MIDPOINT) / STAGE_COUNT;
+export const stageWavePoint = (stageNumber: number, anchors: StageAnchors = {}): WavePoint => {
+  const y = resolveAnchorY(stageNumber, anchors);
   const direction = isLeftReturning(stageNumber) ? POLE_LEFT : POLE_RIGHT;
   const x = CENTER_X + amplitudeFor(stageNumber) * direction;
   return { x, y, pole: poleFor(stageNumber) };
@@ -180,12 +221,16 @@ const segmentPath = (lower: WavePoint, upper: WavePoint, width: number, height: 
  * scales with height and x with width within the center-column band, so a larger
  * layout yields a larger wave that still stays inside its lane.
  */
-export const waveSegments = (width: number, height: number): readonly WaveSegment[] => {
+export const waveSegments = (
+  width: number,
+  height: number,
+  anchors: StageAnchors = {},
+): readonly WaveSegment[] => {
   const segments: WaveSegment[] = [];
   STAGE_COLORS.reduce<StageColor | null>((previous, current) => {
     if (previous !== null) {
-      const lower = stageWavePoint(previous.stageNumber);
-      const upper = stageWavePoint(current.stageNumber);
+      const lower = stageWavePoint(previous.stageNumber, anchors);
+      const upper = stageWavePoint(current.stageNumber, anchors);
       segments.push({
         d: segmentPath(lower, upper, width, height),
         color: previous.textColor,
@@ -205,15 +250,21 @@ export interface Arrowhead {
 
 /**
  * An upward-pointing triangle centered on a stage's wave point, in pixel space.
- * The apex sits ARROWHEAD_HEIGHT above the base (numerically smaller y) so the
- * arrow leads toward the higher stages at the top of the wave. cx is confined to
- * the center-column band.
+ * The triangle straddles the resolved anchor: its apex sits half a height above
+ * and its base half a height below, so the arrow is centered on the stage row
+ * rather than hanging beneath it. cx is confined to the center-column band.
  */
-export const arrowheadAt = (stageNumber: number, width: number, height: number): Arrowhead => {
-  const point = stageWavePoint(stageNumber);
+export const arrowheadAt = (
+  stageNumber: number,
+  width: number,
+  height: number,
+  anchors: StageAnchors = {},
+): Arrowhead => {
+  const point = stageWavePoint(stageNumber, anchors);
   const cx = toColumnPixelX(point.x, width);
-  const baseY = point.y * height;
-  const apexY = baseY - ARROWHEAD_HEIGHT;
+  const yPx = point.y * height;
+  const apexY = yPx - ARROWHEAD_HALF_HEIGHT;
+  const baseY = yPx + ARROWHEAD_HALF_HEIGHT;
   const leftX = cx - ARROWHEAD_HALF_WIDTH;
   const rightX = cx + ARROWHEAD_HALF_WIDTH;
   const points = [
@@ -239,9 +290,13 @@ export interface WaveArrowhead {
  * stage's exact textColor. Built from ``STAGE_COLORS`` so the colors are total
  * (no optional-index fallback).
  */
-export const waveArrowheads = (width: number, height: number): readonly WaveArrowhead[] =>
+export const waveArrowheads = (
+  width: number,
+  height: number,
+  anchors: StageAnchors = {},
+): readonly WaveArrowhead[] =>
   STAGE_COLORS.map(({ stageNumber, textColor }) => ({
-    points: arrowheadAt(stageNumber, width, height).points,
+    points: arrowheadAt(stageNumber, width, height, anchors).points,
     color: textColor,
     stageNumber,
   }));


### PR DESCRIPTION
## Summary

The Map's center-column sine-wave (segments + arrowheads) was vertically misaligned with the stage rows carrying the same color: `stageWavePoint` assumed ten equal-height stage bands (`y = (STAGE_COUNT - stageNumber + 0.5)/STAGE_COUNT`), but real grid rows deviate from their flex share once content minimums (cell `minHeight`, stacked left text, the large serif titles, locked/timeline/connector children) push a row past its nominal 1/10.

This change makes the pure wave geometry accept measured per-stage y anchors (unit space) and derives them from `onLayout` measurements of each actual center cell:

- `waveGeometry.ts`: new `StageAnchors` type + `nominalAnchorY` (fallback derived from `MAP_ROWS` flex weights, provably equal to the legacy formula); optional trailing `anchors` param on `stageWavePoint`/`waveSegments`/`waveArrowheads`/`arrowheadAt`; each arrowhead is now centered **on** its anchor (apex/base each half-height from center) rather than sitting above it.
- New `hooks/useStageAnchors.ts`: composes `rowY + cellY + cellHeight/2` over the grid height into unit anchors, with an equality-bailing setState so identical layout passes don't churn re-renders. Empty until a stage has both its row and cell measured (and `gridHeight >= 1`), so the wave falls back to the nominal bands before/while measuring.
- `WaveOverlay.tsx`: threads an optional `anchors` prop into the geometry.
- `MapScreen.tsx`: `MapGrid` wires the hook and passes anchors; `MapRowView` gains a row `testID` + `onLayout`; `StageCenterCell` reports its own `onLayout`. Extracted `RowLeftColumn`/`RowCenterColumn` to keep functions within complexity limits.

Segment colors are unchanged (segment N still carries stage N's `textColor`); only the y anchoring moved.

## Test plan

- `waveGeometry.test.ts`: band-parity with the legacy formula, measured-override + partial-fallback totality, non-uniform anchors flowing into segment endpoints and arrowhead centering in pixel space, color/x-containment invariance under non-uniform anchors.
- New `useStageAnchors.test.ts`: empty-before-measurement, `(rowY + cellY + cellH/2)/gridHeight` resolution with non-uniform heights, partial-measurement omission, `gridHeight < 1` guard, stable object identity on identical re-fires.
- `MapScreen.test.tsx`: integration firing grid + non-uniform row/cell layouts asserts `wave-arrow-N` y coordinates reflect the measured centers, not the equal bands; the three existing wave-overlay tests stay green via the nominal fallback.
- `./scripts/frontend/check-all.sh` exits 0 (tsc, eslint, prettier, full jest 3172 passing).

Closes #1162
Refs #943, #944