### PR TITLE
fix(map): keep right-column Aspect labels whole with single-line auto-fit

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
   rightCell: {
     flex: RIGHT_FLEX,
     justifyContent: CENTER,
-    paddingLeft: spacing(1),
+    paddingHorizontal: spacing(1),
   },
 
   // Left-column stage text block (also the tap target -0)
@@ -97,7 +97,8 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
 
-  // Right-column aspect label (wraps to fit — never clipped)
+  // Right-column aspect label: a single line that auto-scales down to fit its
+  // cell width, so the text is never clipped or broken mid-word.
   rightLabelText: {
     fontFamily: editorialType.serif,
     fontSize: 15,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -43,7 +43,7 @@ import {
   unlockTimeline,
 } from './journeyNarrative';
 import styles from './Map.styles';
-import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
+import { MAP_ROWS, RIGHT_LABEL_MIN_FONT_SCALE, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
@@ -241,7 +241,14 @@ const MapRowView = ({
         ))}
       </View>
       <View style={styles.rightCell}>
-        <Text style={styles.rightLabelText}>{row.rightLabel}</Text>
+        <Text
+          style={styles.rightLabelText}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={RIGHT_LABEL_MIN_FONT_SCALE}
+        >
+          {row.rightLabel}
+        </Text>
       </View>
     </View>
   );

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
+import styles from '../Map.styles';
+import { RIGHT_LABEL_MIN_FONT_SCALE } from '../mapLayout';
 import MapScreen from '../MapScreen';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
@@ -526,6 +528,29 @@ describe('MapScreen', () => {
         0,
       );
     }
+  });
+
+  it('renders each right-column Aspect label as a single-line auto-fitting Text', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    const aspectLabels = ['Awareness', 'Being', 'Wisdom', 'Understanding', 'Love', 'Yes-And-Ness'];
+    for (const label of aspectLabels) {
+      const candidates = tree.root.findAll((n: TestNode) => n.props.children === label);
+      const autoFitting = candidates.some(
+        (n: TestNode) =>
+          n.props.numberOfLines === 1 &&
+          n.props.adjustsFontSizeToFit === true &&
+          n.props.minimumFontScale === RIGHT_LABEL_MIN_FONT_SCALE,
+      );
+      expect(autoFitting).toBe(true);
+    }
+  });
+
+  // --- right-cell edge padding ---
+
+  it('gives the right cell symmetric horizontal padding (no left-only padding)', () => {
+    expect(styles.rightCell.paddingHorizontal).toBeTruthy();
+    expect('paddingLeft' in styles.rightCell).toBe(false);
   });
 
   it('renders the wave overlay independent of MAP_BACKGROUND_URI (MapBackdrop is a no-op)', () => {

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,6 +1,12 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from '../mapLayout';
+import {
+  GRID_COLUMN_FLEX,
+  MAP_ROWS,
+  MAP_TITLE_LINES,
+  RIGHT_LABEL_MIN_FONT_SCALE,
+  STAGE_DISPLAY,
+} from '../mapLayout';
 import { STAGE_COUNT } from '../stageData';
 
 const HEX_COLOR = /^#[\da-f]{6}$/i;
@@ -35,5 +41,14 @@ describe('mapLayout', () => {
 
   it('exposes the EMPTINESS / UNITY title', () => {
     expect(MAP_TITLE_LINES).toEqual(['EMPTINESS', 'UNITY']);
+  });
+
+  it('keeps the right-label font-scale floor within the auto-fit range', () => {
+    expect(RIGHT_LABEL_MIN_FONT_SCALE).toBeGreaterThan(0);
+    expect(RIGHT_LABEL_MIN_FONT_SCALE).toBeLessThan(1);
+  });
+
+  it('keeps the shared column-flex weights the wave geometry also depends on', () => {
+    expect(GRID_COLUMN_FLEX).toEqual({ left: 2, center: 2, right: 1 });
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -18,6 +18,14 @@
 /** Flex weights of each stage row's three cells (left / center / right). */
 export const GRID_COLUMN_FLEX = { left: 2, center: 2, right: 1 } as const;
 
+/**
+ * Minimum auto-fit font scale for the right-column aspect label. Worst case is
+ * "Understanding" (13 glyphs) on a ~320pt screen, where the ~20% right band
+ * leaves ~48pt of usable width; 0.55 lets that word shrink onto a single line
+ * without ellipsis or a mid-word break.
+ */
+export const RIGHT_LABEL_MIN_FONT_SCALE = 0.55;
+
 /** Static, design-specific copy + color for a single stage's left-column text. */
 export interface StageDisplay {
   stageNumber: number;


### PR DESCRIPTION
## Summary

On device the Map's right-column Aspect labels broke mid-word and clipped at the right screen edge: "Understanding" rendered as "Understandi / ng" running into the edge, and "Yes-And-Ness" wrapped awkwardly. These labels are the sacred vocabulary of the six octaves and must never be mangled.

Root cause: the right column takes flex 1 of the 2/2/1 row split (~20% of screen width) with `paddingLeft` only, so at 15pt serif the long labels wrapped at the glyph limit and the first fragment abutted the screen edge.

Fix (scoped to the right-column label rendering — `GRID_COLUMN_FLEX`, shared with the wave geometry, is left unchanged):
- Render each aspect label as a single auto-fitting line: `numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={RIGHT_LABEL_MIN_FONT_SCALE}` (0.55, a named constant with intent docstring). The serif scales down to fit instead of glyph-breaking, so a mid-word break is structurally impossible.
- Give `rightCell` symmetric `paddingHorizontal` (was `paddingLeft` only) so glyphs never abut the right edge. Vertical centering is preserved by the cell's existing `justifyContent: 'center'`.

## Test plan

- New RTL assertion: each of the six aspect labels (`Awareness`, `Being`, `Wisdom`, `Understanding`, `Love`, `Yes-And-Ness`) renders as a single-line auto-fitting `Text` with the shared `minimumFontScale` constant.
- New style assertion: `rightCell` has symmetric horizontal padding (no left-only padding).
- New unit guards in `mapLayout.test.ts`: the font-scale floor stays within `(0, 1)`, and `GRID_COLUMN_FLEX` is unchanged (protects the sibling wave-geometry lane's shared truth).
- `scripts/frontend/check-all.sh` passes (313 suites / 3174 tests), `tsc --noEmit` clean, ESLint zero-warning.
- Manual: on a narrow (iPhone SE, 320pt) simulator "Understanding" and "Yes-And-Ness" read whole with no edge clipping.

Closes #1163
Refs #943