### PR TITLE
fix(habits): wrap GoalModal Log Units footer so it stops overflowing the modal

### DIFF
--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -106,8 +106,17 @@ export const styles = StyleSheet.create({
   },
 
   // ===== Action Buttons =====
+  // The footer holds two fixed-min-width children (the ~204pt log-date stepper
+  // and the ~190pt input + "Log Units" group) whose combined width exceeds the
+  // modal content box on phone-sized viewports. RN Views can't shrink
+  // (flexShrink: 0) and don't clip overflow, so without wrap the button paints
+  // past the modal's right edge. flexWrap lets the group drop to a second line
+  // when tight while staying single-line on wide (tablet/desktop) layouts; the
+  // rowGap keeps the wrapped rows from touching.
   actionButtons: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    rowGap: SPACING.sm,
     justifyContent: JUSTIFY_SPACE_BETWEEN,
     marginTop: SPACING.lg,
     paddingTop: SPACING.md,

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -1,6 +1,7 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import type { DimensionValue } from 'react-native';
 
 // EmojiSelector pulls in native bindings; render a stub that exposes a
@@ -510,6 +511,39 @@ describe('GoalModal log-unit guards', () => {
     expect(calls).toHaveLength(1);
     const [, amount] = calls[0] as [number, number, Date];
     expect(amount).toBe(0);
+  });
+});
+
+describe('GoalModal footer layout contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // The footer row holds two fixed-min-width children (date stepper +
+  // input+"Log Units" group) whose combined width exceeds the modal content
+  // box on phone viewports; RN Views don't clip and can't shrink, so without
+  // wrap the button paints past the modal's right edge. Wrap is the layout
+  // contract that lets the group drop to a second line instead of overflowing.
+  // (See Habits.styles.ts actionButtons for the measured widths.)
+  const flattenFooterStyle = (getByTestId: (_id: string) => { props: { style: unknown } }) =>
+    StyleSheet.flatten(getByTestId('goal-modal-log-unit-section').props.style) as {
+      flexWrap?: string;
+      rowGap?: number;
+    };
+
+  it('wrap-enables the footer row in the compact (editor-collapsed) state', () => {
+    const { getByTestId } = render(<GoalModal {...buildProps()} />);
+    const footer = flattenFooterStyle(getByTestId);
+    expect(footer.flexWrap).toBe('wrap');
+    // A row gap keeps the wrapped input+button group off the stepper above it.
+    expect(footer.rowGap).toBeGreaterThan(0);
+  });
+
+  it('wrap-enables the footer row in the edit-expanded state', () => {
+    const { getByTestId } = renderModal();
+    const footer = flattenFooterStyle(getByTestId);
+    expect(footer.flexWrap).toBe('wrap');
+    expect(footer.rowGap).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The GoalModal's **Log Units** footer painted its terracotta button past the
modal's right edge on every phone width, in both the compact and edit-expanded
states — the primary habit-logging CTA looked broken on 100% of phone-sized
viewports.

Root cause: the footer row (`styles.actionButtons`) was a non-wrapping flex row
(`flexDirection: 'row'`, `justifyContent: 'space-between'`, no `flexWrap`)
holding two fixed-min-width children — the log-date stepper (~204pt) and the
input + "Log Units" group (~190pt). Their combined intrinsic width exceeds the
~90% modal content box (~305pt at 375pt, ~353pt at 428pt). Because RN Views
can't shrink (`flexShrink: 0`) and don't clip overflow, the excess painted
straight across the modal border onto the dark overlay.

Fix: add `flexWrap: 'wrap'` + `rowGap: SPACING.sm` to `actionButtons`. The
input+button group drops to a second line when the row is genuinely tight,
while staying single-line on wide (tablet/desktop) viewports. The 44pt
touch-target floor on the stepper arrows is untouched — no font/padding shrink
hacks.

## Test plan

- New `GoalModal footer layout contract` describe block asserts the footer row
  is wrap-enabled (`flexWrap: 'wrap'`, positive `rowGap`) in both the compact
  (editor-collapsed) and edit-expanded modal states — a genuine RED→GREEN
  regression guard (pre-fix the flattened style had no `flexWrap`).
- `./scripts/frontend/check-all.sh` green (eslint, tsc, prettier, jest+coverage;
  3177 tests pass).
- Gate 2.5 self-review: `CLEAN`, no blockers.

Closes #1165