### PR TITLE
fix(today): locked habits inflate the "Today's habits" daily count

### DIFF
--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -17,6 +17,7 @@ import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
 import { STAGE_ORDER } from '@/design/tokens';
 import type { Habit } from '@/features/Habits/Habits.types';
+import { isHabitLockedToday } from '@/features/Habits/HabitUtils';
 import { useEntrance } from '@/hooks/useEntrance';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { useHabitStore } from '@/store/useHabitStore';
@@ -101,13 +102,19 @@ const TodayBand = ({ index, title, value, subtitle, onPress, testID }: BandProps
   );
 };
 
-/** Today's-habits band: skeleton while loading, empty state with no habits. */
+/** Today's-habits band: skeleton while loading, empty state with no habits, a
+ * gentle "unlocks soon" band when every habit is still locked, else the count.
+ *
+ * Locked habits (those whose start date is still in the future) are excluded
+ * from the daily count so the denominator reflects only what can actually be
+ * completed today — otherwise "All caught up" would be unreachable until the
+ * final unlock.
+ */
 const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) => {
   const loading = useHabitStore((state) => state.loading);
   const habits = useHabitStore((state) => state.habits);
-  const total = habits.length;
-  if (loading && total === 0) return <SkeletonCard testID="today-habits-skeleton" />;
-  if (total === 0) {
+  if (loading && habits.length === 0) return <SkeletonCard testID="today-habits-skeleton" />;
+  if (habits.length === 0) {
     return (
       <EmptyState
         glyph="🌱"
@@ -126,7 +133,20 @@ const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) 
       />
     );
   }
-  const done = countDoneToday(habits);
+  const unlocked = habits.filter((h) => !isHabitLockedToday(h));
+  const total = unlocked.length;
+  if (total === 0) {
+    return (
+      <TodayBand
+        index={index}
+        title="Today's habits"
+        subtitle="Your first habit unlocks soon."
+        onPress={onPress}
+        testID="today-habits-band"
+      />
+    );
+  }
+  const done = countDoneToday(unlocked);
   return (
     <TodayBand
       index={index}

--- a/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
+++ b/frontend/src/features/Today/__tests__/TodayScreen.test.tsx
@@ -67,6 +67,23 @@ const makeHabit = (id: number, completedToday: boolean): Habit =>
       : [],
   }) as Habit;
 
+const DAYS_AHEAD_MS = 12 * 24 * 60 * 60 * 1000;
+
+const makeLockedHabit = (id: number): Habit =>
+  ({
+    id,
+    stage: 'beige',
+    name: `Habit ${id}`,
+    icon: '🌱',
+    streak: 0,
+    energy_cost: 1,
+    energy_return: 2,
+    start_date: new Date(Date.now() + DAYS_AHEAD_MS),
+    revealed: false,
+    goals: [],
+    completions: [],
+  }) as Habit;
+
 const makeWeek = (weekNumber: number): ReturnWeek => ({
   week_number: weekNumber,
   focus: 'self',
@@ -124,6 +141,48 @@ describe('TodayScreen', () => {
     const { getByText } = render(<TodayScreen />);
     expect(getByText('2/2 done')).toBeTruthy();
     expect(getByText('All caught up — beautiful.')).toBeTruthy();
+  });
+
+  it('counts only unlocked habits in the daily total (locked habits excluded)', () => {
+    useHabitStore.setState({
+      habits: [
+        makeHabit(1, true),
+        makeHabit(2, false),
+        makeHabit(3, false),
+        makeLockedHabit(4),
+        makeLockedHabit(5),
+        makeLockedHabit(6),
+        makeLockedHabit(7),
+      ],
+      loading: false,
+    });
+    const { getByText, queryByText } = render(<TodayScreen />);
+    expect(getByText('1/3 done')).toBeTruthy();
+    expect(queryByText('1/7 done')).toBeNull();
+  });
+
+  it('celebrates when every unlocked habit is done even while later habits stay locked', () => {
+    useHabitStore.setState({
+      habits: [makeHabit(1, true), makeHabit(2, true), makeLockedHabit(3)],
+      loading: false,
+    });
+    const { getByText } = render(<TodayScreen />);
+    expect(getByText('2/2 done')).toBeTruthy();
+    expect(getByText('All caught up — beautiful.')).toBeTruthy();
+  });
+
+  it('shows neither the empty state nor 0/0 when every habit is still locked', () => {
+    useHabitStore.setState({
+      habits: [makeLockedHabit(1), makeLockedHabit(2)],
+      loading: false,
+    });
+    const { queryByText, queryByTestId, getByTestId } = render(<TodayScreen />);
+    expect(queryByText('No habits yet')).toBeNull();
+    expect(queryByTestId('today-habits-empty-cta')).toBeNull();
+    // No misleading "x/y done" count when nothing is unlocked yet.
+    expect(queryByText(/done/)).toBeNull();
+    // The band still renders so the tab remains reachable.
+    expect(getByTestId('today-habits-band')).toBeTruthy();
   });
 
   it('shows a habits skeleton while loading', () => {


### PR DESCRIPTION
## Summary

The Today tab's "Today's habits" band counted **locked** (not-yet-unlocked) habits in its daily `x/y done` total, so a user at Week 8 with 3 unlocked + 4 locked habits saw `1/7 done` instead of `1/3 done`. Because the denominator included habits that cannot be completed yet, "All caught up — beautiful." was unreachable for essentially every user before the final habit unlock — the band always nagged "Keep the streak alive.", against the north-star principle of no gamified pressure.

`HabitsBand` now filters the habit store through the existing canonical `isHabitLockedToday` predicate (already used by the Habits screen), so numerator and denominator are both derived from the unlocked set. The all-habits-locked edge renders a gentle, value-less band ("Your first habit unlocks soon.") — never the misleading "No habits yet" empty state or a degenerate "0/0 done". The no-habits-at-all empty state stays keyed off `habits.length === 0`.

## Test plan

- `npx jest src/features/Today/__tests__/TodayScreen.test.tsx` — 3 new tests, RED before the fix, GREEN after:
  - 3 unlocked (1 done) + 4 locked → reads `1/3 done`, not `1/7 done`.
  - all unlocked done + a later locked habit → `2/2 done` + "All caught up — beautiful.".
  - all habits locked → no "No habits yet", no empty CTA, no "…done" count; band still renders.
- `./scripts/frontend/check-all.sh` — all quality checks pass (3194 tests, tsc, eslint, prettier).
- Gate 2.5 self-review (code-review-orchestrator): CLEAN, no blockers.

Closes #1173