### PR TITLE
fix(map): stack center-cell overlays in flow so they stop colliding

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -129,11 +129,9 @@ const styles = StyleSheet.create({
     backgroundColor: surface.desk,
     ...shadows.medium,
   },
-  // "You are here" pill anchored to the current stage's center cell.
+  // "You are here" pill stacked in flow above the current stage's label.
   youAreHere: {
-    position: 'absolute',
-    top: spacing(0.25),
-    left: spacing(0.25),
+    marginBottom: spacing(0.25),
     paddingVertical: spacing(0.25),
     paddingHorizontal: spacing(0.5),
     borderRadius: radius.sm,
@@ -175,11 +173,10 @@ const styles = StyleSheet.create({
     backgroundColor: surface.hairline,
   },
 
-  // Lock icon overlay for locked stages
-  lockOverlay: {
-    ...StyleSheet.absoluteFillObject,
+  // Lock glyph row, stacked in flow beneath a locked stage's label
+  lockRow: {
     alignItems: CENTER,
-    justifyContent: CENTER,
+    marginTop: spacing(0.25),
   },
   lockText: {
     fontSize: 14,
@@ -189,12 +186,9 @@ const styles = StyleSheet.create({
   locked: {
     opacity: 0.4,
   },
-  // Unlock timeline beneath the lock glyph ("Unlocks in N days").
+  // Unlock timeline stacked beneath the lock glyph ("Unlocks in N days").
   unlockTimeline: {
-    position: 'absolute',
-    bottom: spacing(0.25),
-    left: 0,
-    right: 0,
+    marginTop: spacing(0.25),
     fontSize: 9,
     color: ink.muted,
     textAlign: CENTER,

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -187,7 +187,11 @@ const styles = StyleSheet.create({
     opacity: 0.4,
   },
   // Unlock timeline stacked beneath the lock glyph ("Unlocks in N days").
+  // ``alignSelf: 'stretch'`` restores the full-width box the old absolute
+  // ``left: 0, right: 0`` gave, so ``textAlign: CENTER`` still centers the
+  // longer multi-line unlock-condition copy across the whole cell.
   unlockTimeline: {
+    alignSelf: 'stretch',
     marginTop: spacing(0.25),
     fontSize: 9,
     color: ink.muted,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -79,8 +79,8 @@ const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
 // in the same row, so they cannot drift the way the old content-driven flex
 // table + absolute-percentage center overlay did. The Map reads with no PNG.
 
-const LockOverlay = (): React.JSX.Element => (
-  <View style={styles.lockOverlay}>
+const LockGlyph = (): React.JSX.Element => (
+  <View style={styles.lockRow}>
     <Text style={styles.lockText}>🔒</Text>
   </View>
 );
@@ -137,7 +137,7 @@ const StageTextBlock = ({
     <Text style={[styles.personaText, { color: display.textColor }]}>{display.persona}</Text>
     <Text style={[styles.lineText, { color: display.textColor }]}>{display.descriptor}</Text>
     <Text style={[styles.lineText, { color: display.textColor }]}>{display.practice}</Text>
-    {locked ? <LockOverlay /> : null}
+    {locked ? <LockGlyph /> : null}
   </TouchableOpacity>
 );
 
@@ -178,10 +178,10 @@ const StageCenterCell = ({
     accessibilityRole="button"
     accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
   >
-    <CenterContent display={display} />
-    {locked ? <LockOverlay /> : null}
-    {locked ? <UnlockTimeline stageNumber={display.stageNumber} /> : null}
     {isCurrent ? <YouAreHereMarker /> : null}
+    <CenterContent display={display} />
+    {locked ? <LockGlyph /> : null}
+    {locked ? <UnlockTimeline stageNumber={display.stageNumber} /> : null}
     {stage.progress >= FULL_PROGRESS ? (
       <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
         <Text style={styles.completedBadgeText}>✓</Text>

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -587,6 +587,22 @@ describe('MapScreen center-cell overlay layout', () => {
     }
   });
 
+  it('unlock countdown spans the full cell width so its centered copy stays centered', () => {
+    // Restores the full-width box the old ``left: 0, right: 0`` absolute
+    // positioning gave: without ``alignSelf: 'stretch'`` an in-flow Text
+    // shrink-wraps to its widest wrapped line and ``textAlign: 'center'``
+    // becomes a no-op for the multi-line unlock-condition copy.
+    mockDaysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    const countdown = tree.root.findByProps({ testID: 'stage-unlock-8' });
+    const flat = StyleSheet.flatten(countdown.props.style) as {
+      alignSelf?: string;
+      textAlign?: string;
+    };
+    expect(flat.alignSelf).toBe('stretch');
+    expect(flat.textAlign).toBe('center');
+  });
+
   it('locked stages keep the recessed opacity treatment', () => {
     const tree = create(<MapScreen />);
     const centerHotspot = tree.root.findByProps({ testID: 'stage-hotspot-8-1' });

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 import React from 'react';
-import { Image } from 'react-native';
+import { Image, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
@@ -535,5 +535,83 @@ describe('MapScreen', () => {
     // and the wave overlay renders alongside it with no dependency between them.
     expect(tree.root.findByProps({ testID: 'map-background' })).toBeTruthy();
     expect(tree.root.findByProps({ testID: 'map-wave' })).toBeTruthy();
+  });
+});
+
+describe('MapScreen center-cell overlay layout', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockLoadStages.mockClear();
+    mockBeginAgain.mockClear();
+    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => false,
+    );
+    mockCycleNumber = 1;
+    mockDerivedStage = 1;
+    mockDerivedWeek = 1;
+    mockDaysUntilStage = null;
+    mockWheelFullnessByStage = {};
+    mockWheelLoading = false;
+    mockWheelError = null;
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('you-are-here pill is laid out in flow (not absolutely positioned)', () => {
+    const tree = create(<MapScreen />);
+    const pill = tree.root.findByProps({ testID: 'you-are-here' });
+    const flat = StyleSheet.flatten(pill.props.style) as { position?: string };
+    expect(flat.position).not.toBe('absolute');
+  });
+
+  it('locked center cell renders the unlock countdown in flow (not absolutely positioned)', () => {
+    mockDaysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    const countdown = tree.root.findByProps({ testID: 'stage-unlock-8' });
+    const flat = StyleSheet.flatten(countdown.props.style) as {
+      position?: string;
+      bottom?: number;
+    };
+    expect(flat.position).not.toBe('absolute');
+    expect(flat.bottom).toBeUndefined();
+  });
+
+  it('locked cell lock glyph is not an absolute-fill overlay in either column', () => {
+    const tree = create(<MapScreen />);
+    const leftHotspot = tree.root.findByProps({ testID: 'stage-hotspot-8-0' });
+    const centerHotspot = tree.root.findByProps({ testID: 'stage-hotspot-8-1' });
+    for (const hotspot of [leftHotspot, centerHotspot]) {
+      const lockIcon = hotspot.findAll(isLockIcon)[0];
+      const lockWrapper = lockIcon.parent as TestNode;
+      const flat = StyleSheet.flatten(lockWrapper.props.style) as { position?: string };
+      expect(flat.position).not.toBe('absolute');
+    }
+  });
+
+  it('locked stages keep the recessed opacity treatment', () => {
+    const tree = create(<MapScreen />);
+    const centerHotspot = tree.root.findByProps({ testID: 'stage-hotspot-8-1' });
+    const flat = StyleSheet.flatten(centerHotspot.props.style) as { opacity?: number };
+    expect(flat.opacity).toBe(0.4);
+  });
+
+  it('stacks the pill above the label and the countdown below the lock', () => {
+    mockDaysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    const textOrder = (testID: string): string[] =>
+      tree.root
+        .findByProps({ testID })
+        .findAll((node: TestNode) => typeof node.props.children === 'string')
+        .map((node: TestNode) => node.props.children as string);
+
+    // Current stage 1: the pill renders before its centered label ('Agency').
+    const currentText = textOrder('stage-hotspot-1-1');
+    expect(currentText.indexOf('YOU ARE HERE')).toBeLessThan(currentText.indexOf('Agency'));
+    expect(currentText.indexOf('YOU ARE HERE')).toBeGreaterThanOrEqual(0);
+
+    // Locked stage 8: the lock renders before the countdown copy.
+    const lockedText = textOrder('stage-hotspot-8-1');
+    const countdownIndex = lockedText.findIndex((text) => text.startsWith('Unlocks'));
+    expect(lockedText.indexOf('🔒')).toBeGreaterThanOrEqual(0);
+    expect(lockedText.indexOf('🔒')).toBeLessThan(countdownIndex);
   });
 });


### PR DESCRIPTION
## Summary

The Map's center-column adornments were all absolutely positioned over a cell as short as the minimum touch target, so they painted on top of each other and the surrounding stage text:

- the 🔒 lock glyph (`absoluteFillObject`) covered every locked stage label and the `EMPTINESS`/`UNITY` serif titles,
- the "Unlocks in N days" countdown (absolute, pinned to the cell bottom) crossed neighboring content,
- the "YOU ARE HERE" pill (absolute, top-left) overlapped the current-stage label.

Root-cause fix — convert the three adornments from absolute positioning to normal flex-flow siblings inside the already-centered cell column, and reorder `StageCenterCell`'s children so the pill stacks above the label and the label / lock / countdown stack cleanly beneath it. The shared lock glyph now flows below the left-column stage text instead of painting over its letters (`lockOverlay` → `lockRow`, `LockOverlay` → `LockGlyph`). Row/cell geometry is unchanged, so the wave overlay is untouched. The recessed `opacity: 0.4` treatment and every `testID` (`stage-unlock-*`, `you-are-here`, `stage-hotspot-*`, `stage-complete-*`, `stage-connection-*`) are preserved.

## Test plan

- New RTL tests in `MapScreen.test.tsx` assert the pill, countdown, and lock render in flow (flattened style has no `position: 'absolute'` / `bottom`), that the lock is not an absolute-fill overlay in either column, that the pill stacks above the label and the countdown below the lock, and that locked stages keep their `opacity: 0.4` recess.
- `./scripts/frontend/check-all.sh` exits 0 (313 suites / 3176 tests, typecheck, lint, prettier all green).
- Manual verification recommended on a small-height simulator per the issue's test plan.

Closes #1164
Refs #943