### PR TITLE
fix(course): make content seeding resilient so unlocked stages never blank

### DIFF
--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -8,18 +8,20 @@ Reconciliation is idempotent and never destructive: rows update in place
 when their fields drift, and nothing is ever deleted — rows referenced
 by ``ContentCompletion`` stay put.
 
-Seeding fails loudly when the manifest ships a stage that has no matching
-``CourseStage`` row: that mismatch means stages and content were seeded
-out of order (or a stage rollback left content orphaned), so we raise
-``SeedContentStageMissingError`` before touching the DB rather than
-silently dropping the stage's chapters.  ``_seed_startup_data`` catches
-it per seeder and surfaces it as ``seed_failed seeder=content`` in the
-boot logs.
+Seeding is resilient, never all-or-nothing.  Every manifest stage that
+has a matching ``CourseStage`` row is reconciled and committed.  A
+manifest stage whose ``CourseStage`` row is absent (stages seeded out of
+order, or a stage rollback that left content orphaned) is skipped and
+surfaced as a ``content_seed_partial`` WARNING in the logs — never an
+abort.  This guarantees an always-unlocked stage such as Stage 1 always
+seeds even when higher stages have no row yet.
 
 Editing happens in the content repo; see ``docs/content.md``.
 """
 
 from __future__ import annotations
+
+import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -28,9 +30,7 @@ from content_config import ChapterRecord, all_chapter_records
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 
-
-class SeedContentStageMissingError(ValueError):
-    """Raised when a manifest stage has no matching ``CourseStage`` row."""
+logger = logging.getLogger(__name__)
 
 
 def desired_content_records() -> list[ChapterRecord]:
@@ -116,12 +116,16 @@ def _reconcile_one(
     return False, False
 
 
-def _guard_manifest_stages_mapped(stage_map: dict[int, int]) -> None:
-    """Raise loudly when a manifest stage has no ``CourseStage`` row."""
+def _warn_unmapped_manifest_stages(stage_map: dict[int, int]) -> None:
+    """Emit a loud WARNING when a manifest stage has no ``CourseStage`` row.
+
+    Called after the commit so mapped rows persist regardless; the skipped
+    stages are surfaced (never raised) so an operator can spot the partial
+    seed and add the missing ``CourseStage`` rows.
+    """
     unmapped = _unmapped_manifest_stages(stage_map)
     if unmapped:
-        message = f"Manifest stages have no CourseStage row: {unmapped}"
-        raise SeedContentStageMissingError(message)
+        logger.warning("content_seed_partial stages_without_course_stage_row=%s", unmapped)
 
 
 def _reconcile_all(
@@ -145,14 +149,15 @@ async def seed_content(session: AsyncSession) -> int:
     Returns the number of newly-inserted rows.  Existing rows whose fields
     have drifted from the config are updated in place; the function is
     idempotent — running it twice with the same config inserts nothing the
-    second time.
+    second time.  Manifest stages without a ``CourseStage`` row are skipped
+    and warned about after the commit, never aborting the seed.
     """
     stage_map = await _load_stage_map(session)
-    _guard_manifest_stages_mapped(stage_map)
     existing = await _load_existing_keys(session)
 
     inserted, dirty = _reconcile_all(session, stage_map, existing)
 
     if dirty:
         await session.commit()
+    _warn_unmapped_manifest_stages(stage_map)
     return inserted

--- a/backend/tests/test_course_vendored_content.py
+++ b/backend/tests/test_course_vendored_content.py
@@ -23,7 +23,7 @@ from content_config import CONTENT_REF_SCHEME
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from seed_content import seed_content
-from seed_stages import seed_stages
+from seed_stages import STAGE_DEFINITIONS, seed_stages
 from services.content_repository import (
     ContentRepository,
     reset_content_repository_for_tests,
@@ -34,6 +34,10 @@ _VENDORED_CONTENT_DIR = Path(__file__).resolve().parents[1] / "content"
 
 #: Stage 1 (Beige) ships exactly 17 chapters in the vendored manifest.
 _STAGE_ONE_CHAPTER_COUNT = 17
+
+#: Only the first three (unlocked) stages get a CourseStage row in the
+#: partial-coverage fixture -- the manifest still ships stages 4-10.
+_UNLOCKED_STAGE_COUNT = 3
 
 #: The first Beige chapter drips on day 0 (immediately visible at signup).
 _DAY_ZERO = 0
@@ -62,6 +66,40 @@ async def _signup(async_client: AsyncClient, username: str) -> dict[str, str]:
     )
     assert resp.status_code == HTTPStatus.OK
     return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+@pytest_asyncio.fixture
+async def partially_seeded_vendored_course(db_session: AsyncSession) -> AsyncIterator[None]:
+    """Seed only the unlocked stages' CourseStage rows, then the real content.
+
+    Mirrors a production database whose CourseStage table does not cover
+    every manifest stage: the seeder must still populate the mapped
+    (unlocked) stages instead of aborting the whole seed and blanking
+    Stage 1.
+    """
+    set_content_repository_for_tests(ContentRepository(_VENDORED_CONTENT_DIR))
+    for definition in STAGE_DEFINITIONS[:_UNLOCKED_STAGE_COUNT]:
+        db_session.add(CourseStage(**definition))
+    await db_session.commit()
+    await seed_content(db_session)
+    yield
+    reset_content_repository_for_tests()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("partially_seeded_vendored_course")
+async def test_stage_one_serves_chapters_when_higher_stages_have_no_row(
+    async_client: AsyncClient,
+) -> None:
+    """P0: unlocked Stage 1 still shows all 17 chapters when stages 4-10 are unmapped."""
+    headers = await _signup(async_client, "partial-stage-adept")
+
+    resp = await async_client.get("/course/stages/1/progress", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["total_items"] == _STAGE_ONE_CHAPTER_COUNT
+    assert body["read_items"] == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -9,6 +9,7 @@ reference instead of a remote CMS URL.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -23,11 +24,7 @@ from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from models.user import User
-from seed_content import (
-    SeedContentStageMissingError,
-    desired_content_records,
-    seed_content,
-)
+from seed_content import desired_content_records, seed_content
 from services.content_repository import (
     ContentRepository,
     reset_content_repository_for_tests,
@@ -204,33 +201,61 @@ async def test_seed_content_populates_stage_one_from_vendored_manifest(
 
 
 @pytest.mark.asyncio
-async def test_seed_content_raises_when_manifest_stage_has_no_course_stage_row(
+async def test_seed_content_with_no_stage_rows_writes_nothing_and_warns(
     db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A manifest stage with no matching CourseStage row must fail loudly, not silently."""
+    """No CourseStage rows at all: stays resilient, warns loudly, writes nothing."""
     set_content_repository_for_tests(ContentRepository(_VENDORED_CONTENT_DIR))
     try:
-        with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[1"):
-            await seed_content(db_session)
+        with caplog.at_level(logging.WARNING, logger="seed_content"):
+            inserted = await seed_content(db_session)
+        assert inserted == 0
+        rows = (await db_session.execute(select(StageContent))).scalars().all()
+        assert rows == []
+        warnings = [record.getMessage() for record in caplog.records]
+        assert any("content_seed_partial" in message for message in warnings)
     finally:
         reset_content_repository_for_tests()
 
 
 @pytest.mark.asyncio
-async def test_seed_content_raises_naming_only_the_unmapped_manifest_stage(
+async def test_seed_content_seeds_stage_one_even_when_higher_stages_unmapped(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A partial seed raises for the missing manifest stage while mapped stages seed fine."""
+    """A mapped stage seeds fully while an unmapped higher stage only draws a warning."""
     install_manifest(_MANIFEST)  # ships stages 1 and 4
     await _seed_stages(db_session, count=1)  # only stage 1 has a CourseStage row
 
-    with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[4\]"):
-        await seed_content(db_session)
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        inserted = await seed_content(db_session)
 
-    # The raise fires before any write, so stage 1's mapped chapters never land.
+    assert inserted == 2
     rows = (await db_session.execute(select(StageContent))).scalars().all()
-    assert rows == []
+    assert [r.title for r in rows] == ["Survival", "Breath as Anchor"]
+    warnings = [record.getMessage() for record in caplog.records]
+    assert any("4" in message for message in warnings)
+
+
+@pytest.mark.asyncio
+async def test_seed_content_preserves_stage_one_chapter_count_when_stage_four_unmapped(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Unlocked stages must always show their content, even with higher stages unmapped."""
+    install_manifest(_MANIFEST)  # ships stages 1 and 4
+    await _seed_stages(db_session, count=1)  # only stage 1 has a CourseStage row
+
+    await seed_content(db_session)
+
+    expected_stage_one_chapters = sum(1 for c in _MANIFEST["chapters"] if c["stage"] == 1)
+    result = await db_session.execute(
+        select(StageContent).join(CourseStage).where(CourseStage.stage_number == 1)
+    )
+    rows = result.scalars().all()
+    assert len(rows) == expected_stage_one_chapters
 
 
 @pytest.mark.asyncio
@@ -287,14 +312,22 @@ async def test_seed_content_idempotent(
 
 
 @pytest.mark.asyncio
-async def test_seed_content_no_stages_raises_for_manifest_coverage(
+async def test_seed_content_no_stages_warns_for_manifest_coverage(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """No CourseStage rows at all means every manifest stage is unmapped -- loud, not silent."""
+    """No CourseStage rows at all means every manifest stage is unmapped -- warn, not raise."""
     install_manifest(_MANIFEST)  # ships stages 1 and 4
-    with pytest.raises(SeedContentStageMissingError, match=r"no CourseStage row: \[1, 4\]"):
-        await seed_content(db_session)
+
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        inserted = await seed_content(db_session)
+
+    assert inserted == 0
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    assert rows == []
+    warnings = [record.getMessage() for record in caplog.records]
+    assert any("1" in message and "4" in message for message in warnings)
 
 
 @pytest.mark.asyncio

--- a/docs/content.md
+++ b/docs/content.md
@@ -85,11 +85,25 @@ Everything happens in the **content repo**, then gets vendored here:
 The seeder never deletes rows (deletion would orphan
 `ContentCompletion` read-marks). A chapter dropped from the manifest
 simply stops being referenced; write a one-off migration if a row must
-actually go. If the manifest instead ships a stage with no matching
-`CourseStage` row (stages and content seeded out of order, or a stage
-rollback orphaned content), seeding fails loudly
-before writing anything, surfacing as `seed_failed seeder=content` in
-the boot logs; boot continues regardless.
+actually go. Seeding is per-stage and resilient: the seeder reconciles
+and commits `StageContent` rows for every manifest stage that has a
+matching `CourseStage` row, so an always-unlocked stage (e.g. Stage 1)
+seeds even if other stages are missing theirs. If the manifest ships a
+stage with no matching `CourseStage` row (stages and content seeded
+out of order, or a stage rollback orphaned content), that stage's
+chapters are skipped and the seeder logs a loud
+`content_seed_partial` WARNING naming the unmapped stage numbers — it
+never aborts the seed for the stages it *can* map.
+
+A prior version of this guard was all-or-nothing: any unmapped
+manifest stage raised before a single row was written, so a gap in
+the `CourseStage` table (e.g. a failed `seed_stages` run) blanked
+*every* unlocked stage — including Stage 1 — not just the missing
+one, and surfaced in production as "0 of 0 read" / "No Content Yet"
+across the whole Course screen. The regression test suite had no case
+covering "one manifest stage is unmapped, do the mapped stages still
+seed?"; that gap is now pinned by a test asserting Stage 1 serves its
+17 chapters even when stages 4–10 have no `CourseStage` row.
 
 ## How the app serves it
 


### PR DESCRIPTION
## Summary

P0 production outage: the Course screen on `app.aptitude.guru` showed **"0 of 0 read"** / **"No Content Yet"** for **every unlocked stage** (1–3), and three prior closures (#767, #773, #938 / PR #1078) did not make it stick.

**Root cause (an in-repo regression introduced by PR #1078).** `seed_content` called `_guard_manifest_stages_mapped`, which raised `SeedContentStageMissingError` **before any DB write** whenever a single manifest stage lacked a matching `CourseStage` row. The vendored manifest covers **stages 1–10** (209 chapters). So any gap in the production `CourseStage` table — a stale/partial DB, or a `seed_stages` run that failed or short-circuited — aborted the **entire** content seed and wrote **zero** `StageContent` rows for **all** stages, Stage 1 included. That is precisely the "all unlocked colors empty" symptom, and it explains the recurrence: #722/#883 got the content into the image, but #1078's all-or-nothing guard then prevented it from ever reaching a prod DB that didn't perfectly cover all ten manifest stages.

**Reproduced end-to-end:** with all 10 `CourseStage` rows present, `seed_content` inserts 209 rows and Stage 1 gets 17; with only stages 1–3 present (a plausible prod state), the guard raised `Manifest stages have no CourseStage row: [4, 5, 6, 7, 8, 9, 10]` and wrote **0 rows** — Stage 1's 17 chapters vanished.

**Fix — per-stage resilience, never all-or-nothing.** `_reconcile_one` already skips unmapped stages gracefully, so removing the guard lets every **mapped** stage reconcile and commit (the always-unlocked Stage 1 always seeds). Unmapped manifest stages are now surfaced as a loud `content_seed_partial` WARNING **after** the commit — the operator's diagnostic breadcrumb for an incomplete `CourseStage` table — instead of aborting. The dead `SeedContentStageMissingError` class and guard are removed. No schema change, no migration, no dependency change; the frontend `ContentCard` already renders tappable cards, so the outage was entirely data-side.

The issue's secondary ask — restyle `ContentCard` as "journal-entry-adjacent but visually distinct" — is deliberately **out of scope** for this P0 outage fix (one-issue-one-PR); it warrants a separate design issue.

## Test plan

- Rewrote the three tests that asserted the buggy raise/abort to assert the resilient contract (mapped stages seed + a `caplog` `content_seed_partial` WARNING; no exception).
- Added a data-layer regression: Stage 1's chapters seed even when stage 4 is unmapped.
- Added an **HTTP-level** regression (`test_course_vendored_content.py`): seed only stages 1–3's `CourseStage` rows against the **real** vendored manifest, then assert `GET /course/stages/1/progress` returns `total_items == 17`, `read_items == 0` — the exact production acceptance criterion.
- Updated `docs/content.md` with the resilient-seed contract and a retrospective on why the outage recurred and the test-suite gap now closed.
- Gate 2: `./scripts/backend/check-all.sh` exit 0 (7/7, 2335 passed, 96.31% coverage). `xenon --max-absolute A --max-modules A --max-average A src/seed_content.py` clean; `radon mi -s src/seed_content.py` = A (71.11) — run separately since `check-all.sh` omits them.
- Gate 2.5: `code-review-orchestrator` verdict CLEAN.

Note for the operator: once deployed, this fix makes Stage 1 (and any stage whose `CourseStage` row exists) self-heal on the next boot; a residual `content_seed_partial` WARNING in the Railway logs would pinpoint any stages still missing a `CourseStage` row upstream.

Closes #1175
Refs #716