### PR TITLE
fix(frontend): guard concurrent journal.create on a new entry

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -337,6 +337,84 @@ function useErrorSurfacingPersist<T>(
   );
 }
 
+/** Persist once, tracking the save state; the returned task never rejects. */
+function trackedWrite(
+  refs: WriteEntryRefs,
+  title: string,
+  body: string,
+  ctx: SaveContext,
+  setSaveState: (_state: SaveState) => void,
+  onSaved: (() => void) | undefined,
+): Promise<void> {
+  return (async () => {
+    try {
+      await writeEntry(refs, title, body, ctx);
+      setSaveState('saved');
+      onSaved?.();
+    } catch {
+      // Surface a distinct error state so the hint isn't mistaken for "untouched".
+      setSaveState('error');
+    }
+  })();
+}
+
+/** The refs the single-flight writer reads: the write payload plus its gates. */
+type SaveRunnerRefs = WriteEntryRefs & {
+  loadFailedRef: React.MutableRefObject<boolean>;
+  ctxRef: React.MutableRefObject<SaveContext>;
+  onSavedRef: React.MutableRefObject<(() => void) | undefined>;
+  inFlightRef: React.MutableRefObject<Promise<void> | null>;
+};
+
+/**
+ * The debounced writer, single-flighted: if a save is already in flight, this
+ * awaits it (letting a pending create set ``entryIdRef``) before starting, so two
+ * overlapping saves of an id-less entry never each fire ``journal.create``.
+ */
+function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) => void): RunSave {
+  const { entryIdRef, respondedRef, classificationRef, chordRef } = refs;
+  const { loadFailedRef, ctxRef, onSavedRef, inFlightRef } = refs;
+  return useCallback<RunSave>(
+    async (title, body) => {
+      if (loadFailedRef.current) return; // never overwrite an entry that failed to load
+      if (!body.trim()) return; // never persist an empty draft
+      // Drain every in-flight save before starting: a released run re-registers
+      // inFlightRef synchronously, so this serializes the whole pile onto one
+      // create. Awaiting only once would let a create that fails release all
+      // queued saves together — each re-creating (the duplicate this guards).
+      // The tracked task never rejects, so awaiting a pending save never throws.
+      while (inFlightRef.current) await inFlightRef.current;
+      setSaveState('saving');
+      const writeRefs = { entryIdRef, respondedRef, classificationRef, chordRef };
+      const task = trackedWrite(
+        writeRefs,
+        title,
+        body,
+        ctxRef.current,
+        setSaveState,
+        onSavedRef.current,
+      );
+      inFlightRef.current = task;
+      try {
+        await task;
+      } finally {
+        if (inFlightRef.current === task) inFlightRef.current = null;
+      }
+    },
+    [
+      entryIdRef,
+      respondedRef,
+      classificationRef,
+      chordRef,
+      loadFailedRef,
+      ctxRef,
+      onSavedRef,
+      inFlightRef,
+      setSaveState,
+    ],
+  );
+}
+
 /** Debounced create-then-update draft saver; tracks the save state. */
 function useDebouncedSave(
   routeEntryId: number | null,
@@ -348,6 +426,9 @@ function useDebouncedSave(
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const entryIdRef = useRef<number | null>(routeEntryId);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Single-flight guard: the in-flight save, so overlapping saves of an id-less
+  // entry can't each fire journal.create (a duplicate-entry TOCTOU otherwise).
+  const inFlightRef = useRef<Promise<void> | null>(null);
   // A weekly-prompt response is write-once; this guards against the debounce or
   // flush submitting it twice (the backend 409s on a duplicate week).
   const respondedRef = useRef(false);
@@ -366,22 +447,18 @@ function useDebouncedSave(
   });
   useTimerCleanup(timerRef);
 
-  const run = useCallback<RunSave>(
-    async (title, body) => {
-      if (loadFailedRef.current) return; // never overwrite an entry that failed to load
-      if (!body.trim()) return; // never persist an empty draft
-      setSaveState('saving');
-      const refs = { entryIdRef, respondedRef, classificationRef, chordRef };
-      try {
-        await writeEntry(refs, title, body, ctxRef.current);
-        setSaveState('saved');
-        onSavedRef.current?.();
-      } catch {
-        // Surface a distinct error state so the hint isn't mistaken for "untouched".
-        setSaveState('error');
-      }
+  const run = useSaveRunner(
+    {
+      entryIdRef,
+      respondedRef,
+      classificationRef,
+      chordRef,
+      loadFailedRef,
+      ctxRef,
+      onSavedRef,
+      inFlightRef,
     },
-    [classificationRef, chordRef],
+    setSaveState,
   );
 
   const setTyping = useCallback(() => setSaveState('typing'), []);

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -282,6 +282,101 @@ describe('JournalEntryScreen', () => {
     }
   });
 
+  it('creates only once when a second save overlaps an in-flight create on a new entry', async () => {
+    jest.useFakeTimers();
+    try {
+      // A create that stays pending so the second save overlaps it.
+      mockCreate.mockReturnValue(new Promise<JournalMessage>(() => {}));
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First and second.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // The in-flight guard makes the overlapping save await the pending create
+      // instead of POSTing a duplicate — still exactly one create.
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('routes the overlapping save to update once the in-flight create resolves', async () => {
+    jest.useFakeTimers();
+    try {
+      let resolveCreate!: (_v: JournalMessage) => void;
+      mockCreate.mockReturnValue(
+        new Promise<JournalMessage>((res) => {
+          resolveCreate = res;
+        }),
+      );
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First and second.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Release the create: the queued save now sees the created id and PATCHes it
+      // rather than starting a second create.
+      await act(async () => {
+        resolveCreate(entry({ id: 42 }));
+        await jest.advanceTimersByTimeAsync(1);
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith(
+        42,
+        expect.objectContaining({ message: 'First and second.' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drains queued saves onto one retry when a create fails with saves piled behind it', async () => {
+    jest.useFakeTimers();
+    try {
+      let rejectCreate!: (_e: Error) => void;
+      // The first create stays pending, then fails; the retry (2nd call) resolves
+      // via the beforeEach default. Saves that pile up behind the failing create
+      // must serialize onto that single retry, never fan out into parallel creates.
+      mockCreate.mockReturnValueOnce(
+        new Promise<JournalMessage>((_res, rej) => {
+          rejectCreate = rej;
+        }),
+      );
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'First.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Second.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Third.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      await act(async () => {
+        rejectCreate(new Error('network'));
+        await jest.advanceTimersByTimeAsync(1);
+      });
+      // One failed create + exactly one retry — never three concurrent creates.
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      expect(mockUpdate).toHaveBeenCalledWith(42, expect.objectContaining({ message: 'Third.' }));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('shows a distinct error hint when a save fails', async () => {
     mockCreate.mockRejectedValue(new Error('network'));
     jest.useFakeTimers();


### PR DESCRIPTION
## Summary
`JournalEntryScreen`'s draft saver had **no in-flight guard** on the create path, so two overlapping saves of a brand-new (id-less) entry each `POST /journal`, creating **two duplicate journal entries** for one draft. This is a TOCTOU/idempotency hole: `writeEntry`'s create branch checks `entryIdRef.current == null` then `await journal.create(...)` — an `await` straddles the null-check and the id assignment, and nothing serialized concurrent `run` invocations (unlike the sibling weekly-prompt `respondedRef` and resonance `inFlightRef` guards).

The fix single-flights the writer:
- New `inFlightRef: Promise<void> | null` tracks the current save.
- Before starting, `run` **drains** any in-flight save (`while (inFlightRef.current) await inFlightRef.current`) so a pending create sets `entryIdRef` first — the overlapping save then routes to `journal.update` instead of a second create. A released run re-registers `inFlightRef` synchronously, so the whole pile serializes onto one create at a time.
- The writer is extracted into a module helper `trackedWrite` (runs `writeEntry`, tracks save state, never rejects) and a `useSaveRunner` hook, keeping each function small.

The **drain** (vs. awaiting a single captured task) also closes the fail-then-requeue window: a create that *fails* with ≥2 saves queued behind it would otherwise release them together, each seeing `entryIdRef` still null and each re-creating. With the drain they serialize onto one retry.

Debounce, `flush`, error-revert, weekly-prompt, and resonance semantics are all preserved. `flush()` during an in-flight create resolves to the created id without a second POST.

## Test plan
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 warnings
- `npx jest` — 3199 passed (314 suites)
- `./scripts/frontend/check-all.sh` — 4/4 passed
- Three new regression tests in `JournalEntryScreen.test.tsx`, each confirmed RED on the unguarded/one-shot code and GREEN after the fix:
  1. Exactly one `journal.create` when a second save overlaps a never-resolving in-flight create.
  2. The overlapping save becomes `journal.update` on the created id once the create resolves.
  3. A failing create with saves piled behind it drains onto one retry (exactly 2 creates, never 3 concurrent) with the last save landing as `journal.update`.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)