### PR TITLE
fix(frontend): align additive stats with backend, ignoring 0-unit rows

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -451,16 +451,30 @@ export const generateStatsForHabit = (
   habit: Habit,
   tz: string = DEFAULT_TIMEZONE,
 ): HabitStatsData => {
-  const completions = habit.completions;
-  if (!completions || completions.length === 0) {
-    // Subtractive habits accrue a streak even with zero rows — abstaining
-    // every day since `start_date` is the success case, not the no-data
-    // case — so emptyStats() would zero out an active abstention chain.
-    return {
-      ...emptyStats(),
-      currentStreak: computeCurrentStreak(habit, [], tz),
-      longestStreak: computeLongestStreakFor(habit, [], [], tz),
-    };
+  const rawCompletions = habit.completions;
+  // Subtractive habits accrue a streak even with zero rows — abstaining every
+  // day since `start_date` is the success case, not the no-data case — so
+  // emptyStats() would zero out an active abstention chain.
+  const emptyStreakStats = (): HabitStatsData => ({
+    ...emptyStats(),
+    currentStreak: computeCurrentStreak(habit, [], tz),
+    longestStreak: computeLongestStreakFor(habit, [], [], tz),
+  });
+  if (!rawCompletions || rawCompletions.length === 0) {
+    return emptyStreakStats();
+  }
+
+  // Additive habits: a persisted "did not complete" (`completed_units == 0`)
+  // row is ignored like an absent day across every stat field — matching the
+  // backend owner `_additive_stats`, which filters once at entry so buckets,
+  // streaks, rate, and total all describe actual completions. Subtractive
+  // habits keep those rows — a zero-log day is an abstention win, not a gap.
+  const isSubtractive = subtractiveStreakInputs(habit, tz) !== null;
+  const completions = isSubtractive
+    ? rawCompletions
+    : rawCompletions.filter((c) => c.completed_units > 0);
+  if (completions.length === 0) {
+    return emptyStreakStats();
   }
 
   const { unitsByDay, countsByDay, daysWithCompletions } = aggregateByDayOfWeek(completions, tz);

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -153,6 +153,41 @@ describe('generateStatsForHabit', () => {
     }
   });
 
+  test('additive stats ignore a trailing did-not-complete (0-unit) row', () => {
+    // Mirrors the backend owner `_additive_stats`, which filters
+    // `completed_units > 0` once at entry: a persisted "did not complete" row
+    // is ignored like an absent day across every field, so a set with a
+    // trailing 0-unit row yields the same stats as the same set without it.
+    // Without the filter the client counted the 0-unit "today" as a completed
+    // day, over-reporting currentStreak, longestStreak, and totalCompletions.
+    jest.useFakeTimers().setSystemTime(new Date('2026-06-15T18:00:00Z'));
+    try {
+      const base = [
+        { id: 'c-2', timestamp: new Date('2026-06-13T18:00:00Z'), completed_units: 1 },
+        { id: 'c-3', timestamp: new Date('2026-06-14T18:00:00Z'), completed_units: 1 },
+      ];
+      const withDidNotComplete: Habit = {
+        ...baseHabit,
+        completions: [
+          ...base,
+          { id: 'c-4', timestamp: new Date('2026-06-15T18:00:00Z'), completed_units: 0 },
+        ],
+      };
+      const withoutRow: Habit = { ...baseHabit, completions: base };
+      const stats = generateStatsForHabit(withDidNotComplete);
+      const baseline = generateStatsForHabit(withoutRow);
+      // A 0-unit today is ignored, so yesterday-grace keeps the two-day chain.
+      expect(stats.currentStreak).toBe(2);
+      expect(stats.longestStreak).toBe(2);
+      expect(stats.totalCompletions).toBe(2);
+      expect(stats.currentStreak).toBe(baseline.currentStreak);
+      expect(stats.longestStreak).toBe(baseline.longestStreak);
+      expect(stats.totalCompletions).toBe(baseline.totalCompletions);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('currentStreak is 0 when last completion is more than yesterday', () => {
     // Pin BUG-FE-HABIT-207 directly: a stale chain that ended a week
     // ago must not still report a non-zero streak.


### PR DESCRIPTION
## Summary

Fourth divergent additive-streak path — this one on the client. The frontend `generateStatsForHabit` (via `computeCurrentStreak` / `streakFromCompletions`) bucketed **all** completion timestamps to days without a `completed_units > 0` filter, so a persisted "did not complete" row (`completed_units == 0`, exactly as `routers/goal_completions.py` writes it) locally counted as a completed day — over-reporting `currentStreak`, `longestStreak`, `totalCompletions`, `completionRate`, and the day buckets versus the server.

This aligns the client to the backend owner `_additive_stats` (`backend/src/domain/habit_stats.py`), which filters `completed_units > 0` **once at entry** so buckets, streaks, rate, and total all describe actual completions. The filter is applied in the **additive branch only** — the subtractive path is untouched, since for an abstention habit a zero-log day is a success, not a gap (mirroring the backend's `_subtractive_stats`, which deliberately does not filter).

The backend reconciliation shipped in #1184; this closes the remaining client-side divergence.

## Test plan

- Added a Jest regression test in `HabitStats.test.ts`: a completion set with a trailing 0-unit row yields the same `currentStreak`, `longestStreak`, and `totalCompletions` as the same set without that row (fake-timer-pinned "today"). Fails against the pre-fix code (Current/Longest reported 2/3), passes after.
- `npx tsc --noEmit` — clean
- `npm run lint` (`eslint --max-warnings=0`) — clean
- `./scripts/frontend/check-all.sh` — 3206 tests pass, 4/4 quality checks

Closes #1183
Refs #1184, #1126