### PR TITLE
feat(journal): hero greeting + tappable week/stage line on the Journal shelf

### DIFF
--- a/frontend/src/features/Journal/JournalHero.styles.ts
+++ b/frontend/src/features/Journal/JournalHero.styles.ts
@@ -1,0 +1,34 @@
+import { StyleSheet } from 'react-native';
+
+import { SPACING, editorialType, onShowcase, touchTarget } from '@/design/tokens';
+
+const EYEBROW_TRACKING = 1;
+
+/** Token-only styles for the journal showcase hero, mirroring the Today hub. */
+export const journalHeroStyles = StyleSheet.create({
+  eyebrow: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    textTransform: 'uppercase',
+    letterSpacing: EYEBROW_TRACKING,
+    marginBottom: SPACING.xs,
+  },
+  greeting: {
+    ...editorialType.display,
+    color: onShowcase.primary,
+  },
+  position: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    marginTop: SPACING.xs,
+  },
+  positionText: {
+    ...editorialType.note,
+    color: onShowcase.soft,
+  },
+  positionCue: {
+    ...editorialType.caption,
+    color: onShowcase.muted,
+    marginTop: SPACING.xs,
+  },
+});

--- a/frontend/src/features/Journal/JournalHero.tsx
+++ b/frontend/src/features/Journal/JournalHero.tsx
@@ -1,0 +1,75 @@
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { Animated, Pressable, Text } from 'react-native';
+
+import { journalHeroStyles as s } from './JournalHero.styles';
+
+import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
+import { STAGE_ORDER } from '@/design/tokens';
+import { useEntrance } from '@/hooks/useEntrance';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+import {
+  TOTAL_PROGRAM_WEEKS,
+  programStage,
+  programWeek,
+  selectProgramStartDate,
+  useProgramStore,
+} from '@/store/useProgramStore';
+import { greeting } from '@/utils/greeting';
+
+type JournalHeroNav = BottomTabNavigationProp<RootTabParamList>;
+
+const MAP_HINT = 'Open the map';
+
+interface HeroPosition {
+  text: string;
+  label: string;
+}
+
+/** Pair a position line with an a11y label that names its map-opening action. */
+function withMapHint(text: string): HeroPosition {
+  return { text, label: `${text}. ${MAP_HINT}` };
+}
+
+/** The reader's place in the 36-week journey, as display text + a11y label. */
+function heroPosition(week: number | null, stage: number | null): HeroPosition {
+  if (week === null) return withMapHint('Your journey awaits');
+  const base = `Week ${week} of ${TOTAL_PROGRAM_WEEKS}`;
+  if (stage === null) return withMapHint(base);
+  const stageName = STAGE_ORDER[stage - 1];
+  if (stageName === undefined) return withMapHint(base);
+  return withMapHint(`${base} · ${stageName}`);
+}
+
+/** The journal showcase hero: greeting + a tappable position that opens the map. */
+const JournalHero = (): React.JSX.Element => {
+  const navigation = useNavigation<JournalHeroNav>();
+  const anchor = useProgramStore(selectProgramStartDate);
+  const week = programWeek(anchor);
+  const stage = programStage(anchor);
+  const entrance = useEntrance(0);
+  const { text, label } = heroPosition(week, stage);
+  return (
+    <Animated.View style={entrance}>
+      <ShowcaseCard testID="journal-hero">
+        <Text style={s.eyebrow}>Today</Text>
+        <Text style={s.greeting} accessibilityRole="header">
+          {greeting()}
+        </Text>
+        <Pressable
+          style={s.position}
+          onPress={() => navigation.navigate('Map')}
+          accessibilityRole="button"
+          accessibilityLabel={label}
+          testID="journal-hero-position"
+        >
+          <Text style={s.positionText}>{text}</Text>
+          <Text style={s.positionCue}>{MAP_HINT} →</Text>
+        </Pressable>
+      </ShowcaseCard>
+    </Animated.View>
+  );
+};
+
+export default JournalHero;

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -12,6 +12,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Animated, SectionList, Text, TouchableOpacity, View } from 'react-native';
 import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 
+import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
 import SearchBar from './SearchBar';
@@ -251,7 +252,7 @@ function ShelfEmpty({
   return (
     <EmptyState
       glyph="📖"
-      title="Your shelf is empty"
+      title="Your journal is empty"
       body="Start your first page — a quiet place to think out loud."
       cta={
         <View style={styles.emptyCtaGroup}>
@@ -343,9 +344,9 @@ function ShelfTopMatter({
 }: TopMatterProps): React.JSX.Element {
   return (
     <View>
+      <JournalHero />
       <ScreenHeader
-        title="Your shelf"
-        eyebrow="Journal"
+        title="Journal"
         action={<Button label="New entry" onPress={onNew} testID="journal-new-entry" />}
       />
       {prompt ? <PromptCard week={week} question={prompt.question} onOpen={onPrompt} /> : null}

--- a/frontend/src/features/Journal/__tests__/JournalHero.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalHero.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+import { jest, beforeEach, afterEach, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+import JournalHero from '../JournalHero';
+
+import { STAGE_ORDER, onShowcase, touchTarget } from '@/design/tokens';
+import {
+  TOTAL_PROGRAM_WEEKS,
+  programStage,
+  programWeek,
+  useProgramStore,
+} from '@/store/useProgramStore';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MID_PROGRAM_DAYS_AGO = 50;
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  useProgramStore.getState().hydrateProgramStartDate(null);
+});
+
+afterEach(() => {
+  useProgramStore.getState().hydrateProgramStartDate(null);
+  jest.useRealTimers();
+});
+
+describe('JournalHero', () => {
+  it('renders the showcase card with the eyebrow and a not-yet-started position', () => {
+    const { getByTestId, getByText, getByRole } = render(<JournalHero />);
+    expect(getByTestId('journal-hero')).toBeTruthy();
+    expect(getByText('Today')).toBeTruthy();
+    expect(getByRole('header')).toBeTruthy();
+    expect(getByText('Your journey awaits')).toBeTruthy();
+  });
+
+  it('greets "Good morning" before noon', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T08:00:00'));
+    const { getByText } = render(<JournalHero />);
+    expect(getByText('Good morning')).toBeTruthy();
+  });
+
+  it('greets "Good afternoon" between noon and 6pm', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T14:00:00'));
+    const { getByText } = render(<JournalHero />);
+    expect(getByText('Good afternoon')).toBeTruthy();
+  });
+
+  it('greets "Good evening" after 6pm', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T20:00:00'));
+    const { getByText } = render(<JournalHero />);
+    expect(getByText('Good evening')).toBeTruthy();
+  });
+
+  it('shows the current week and stage once the program has started', () => {
+    const anchor = new Date(Date.now() - MID_PROGRAM_DAYS_AGO * DAY_MS);
+    useProgramStore.getState().hydrateProgramStartDate(anchor);
+    const week = programWeek(anchor);
+    const stage = programStage(anchor);
+    const stageName = stage === null ? null : STAGE_ORDER[stage - 1];
+    const { getByText } = render(<JournalHero />);
+    expect(getByText(new RegExp(`Week ${String(week)} of ${TOTAL_PROGRAM_WEEKS}`))).toBeTruthy();
+    expect(getByText(new RegExp(String(stageName)))).toBeTruthy();
+  });
+
+  it('exposes the position line as a pressable button with a map-opening label (no anchor)', () => {
+    const { getByTestId } = render(<JournalHero />);
+    const position = getByTestId('journal-hero-position');
+    expect(position.props.accessibilityRole).toBe('button');
+    const label: string = position.props.accessibilityLabel ?? '';
+    expect(label.length).toBeGreaterThan(0);
+    expect(label.endsWith('Open the map')).toBe(true);
+  });
+
+  it('navigates to the Map tab when the position line is pressed (no anchor)', () => {
+    const { getByTestId } = render(<JournalHero />);
+    fireEvent.press(getByTestId('journal-hero-position'));
+    expect(mockNavigate).toHaveBeenCalledWith('Map');
+  });
+
+  it('navigates to the Map tab when the position line is pressed (seeded anchor)', () => {
+    const anchor = new Date(Date.now() - MID_PROGRAM_DAYS_AGO * DAY_MS);
+    useProgramStore.getState().hydrateProgramStartDate(anchor);
+    const { getByTestId } = render(<JournalHero />);
+    fireEvent.press(getByTestId('journal-hero-position'));
+    expect(mockNavigate).toHaveBeenCalledWith('Map');
+  });
+
+  it('gives the seeded-anchor position line a map-opening label too', () => {
+    const anchor = new Date(Date.now() - MID_PROGRAM_DAYS_AGO * DAY_MS);
+    useProgramStore.getState().hydrateProgramStartDate(anchor);
+    const { getByTestId } = render(<JournalHero />);
+    const position = getByTestId('journal-hero-position');
+    const label: string = position.props.accessibilityLabel ?? '';
+    expect(label.endsWith('Open the map')).toBe(true);
+  });
+
+  it('sizes the position pressable to at least the minimum touch target', () => {
+    const { getByTestId } = render(<JournalHero />);
+    const position = getByTestId('journal-hero-position');
+    const style = StyleSheet.flatten(position.props.style);
+    expect(style.minHeight).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+
+  it('colors the position text with an on-showcase ink token', () => {
+    const { getByText } = render(<JournalHero />);
+    const text = getByText('Your journey awaits');
+    const style = StyleSheet.flatten(text.props.style);
+    expect(Object.values(onShowcase)).toContain(style.color);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -384,4 +384,28 @@ describe('JournalShelfScreen', () => {
     await findByTestId('journal-shelf-no-results');
     expect(queryByTestId('journal-empty-first-prompt')).toBeNull();
   });
+
+  it('renders the hero above the header in the top matter', async () => {
+    const { findByTestId } = render(<JournalShelfScreen />);
+    expect(await findByTestId('journal-hero')).toBeTruthy();
+  });
+
+  it('shows "Journal" as the header title and drops "Your shelf"', async () => {
+    const { findByTestId, getByText, queryByText } = render(<JournalShelfScreen />);
+    await findByTestId('journal-hero');
+    expect(getByText('Journal')).toBeTruthy();
+    expect(queryByText('Your shelf')).toBeNull();
+  });
+
+  it('renames the empty-state title to "Your journal is empty"', async () => {
+    mockList.mockResolvedValue(page([]));
+    const { findByText } = render(<JournalShelfScreen />);
+    expect(await findByText('Your journal is empty')).toBeTruthy();
+  });
+
+  it('navigates to the Map tab when the hero position line is pressed', async () => {
+    const { findByTestId } = render(<JournalShelfScreen />);
+    fireEvent.press(await findByTestId('journal-hero-position'));
+    expect(mockNavigate).toHaveBeenCalledWith('Map');
+  });
 });

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -29,16 +29,9 @@ import {
   useProgramStore,
 } from '@/store/useProgramStore';
 import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
+import { greeting } from '@/utils/greeting';
 
 type TodayNav = BottomTabNavigationProp<RootTabParamList>;
-
-/** A morning/afternoon/evening greeting from the local clock. */
-function greeting(): string {
-  const hour = new Date().getHours();
-  if (hour < 12) return 'Good morning';
-  if (hour < 18) return 'Good afternoon';
-  return 'Good evening';
-}
 
 /** Count habits with a real completion on today's calendar day.
  *

--- a/frontend/src/utils/__tests__/greeting.test.ts
+++ b/frontend/src/utils/__tests__/greeting.test.ts
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+
+import { greeting } from '../greeting';
+
+describe('greeting', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns "Good morning" before noon', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T08:00:00'));
+    expect(greeting()).toBe('Good morning');
+  });
+
+  it('returns "Good afternoon" at the noon boundary', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T12:00:00'));
+    expect(greeting()).toBe('Good afternoon');
+  });
+
+  it('returns "Good afternoon" mid-afternoon', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T14:00:00'));
+    expect(greeting()).toBe('Good afternoon');
+  });
+
+  it('returns "Good evening" at the 6pm boundary', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T18:00:00'));
+    expect(greeting()).toBe('Good evening');
+  });
+
+  it('returns "Good evening" at night', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-01-01T20:00:00'));
+    expect(greeting()).toBe('Good evening');
+  });
+});

--- a/frontend/src/utils/greeting.ts
+++ b/frontend/src/utils/greeting.ts
@@ -1,0 +1,7 @@
+/** A morning/afternoon/evening greeting from the local clock. */
+export function greeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}


### PR DESCRIPTION
## Summary
- Adds `JournalHero` to the top of the Journal shelf: a `ShowcaseCard` with an eyebrow, a time-of-day serif greeting header, and a "Week N of 36 · Stage" position line.
- The position line is a `Pressable` (≥44pt target, `accessibilityRole="button"`, "… Open the map" label) that navigates to the Map tab in both the seeded and `week === null` ("Your journey awaits") states.
- Retitles the shelf header "Your shelf" → "Journal" (drops the now-redundant eyebrow) and renames the empty state to "Your journal is empty".
- Extracts the `greeting()` helper from `TodayScreen` into shared `@/utils/greeting` so the hero and Today share one source; `TodayScreen` is import-swapped only (behavior unchanged).
- Token-only styles on the `onShowcase` palette (all AA on the umber ground); no navigation-graph or dependency changes.

## Test plan
- `frontend/src/utils/__tests__/greeting.test.ts` — morning/afternoon/evening + boundary hours under fake timers.
- `frontend/src/features/Journal/__tests__/JournalHero.test.tsx` — eyebrow/greeting/position render, clock-varying greeting, seeded week/stage copy, null-anchor copy, a11y role/label, 44pt target, `onShowcase` ink, and tap → `navigate('Map')` in both states.
- `frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx` — additive: hero renders in top matter, header shows "Journal" (no "Your shelf"), empty state "Your journal is empty", hero-position → Map.
- `./scripts/frontend/check-all.sh` green (316 suites / 3222 tests), `tsc`/eslint clean.

Closes #1169
Refs #1168