### PR TITLE
fix(frontend): journal search caption shows backend total, not loaded count

### DIFF
--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -107,6 +107,7 @@ function searchParam(query: string): string | undefined {
 
 interface ShelfState {
   items: JournalMessage[];
+  total: number;
   loading: boolean;
   error: string | null;
   query: string;
@@ -125,6 +126,7 @@ function isSearchable(next: string): boolean {
 /** Loads the shelf with offset paging + debounced search (via SearchBar). */
 function useShelf(): ShelfState {
   const [items, setItems] = useState<JournalMessage[]>([]);
+  const [total, setTotal] = useState(0);
   const [query, setQuery] = useState('');
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -136,6 +138,7 @@ function useShelf(): ShelfState {
     try {
       const page = await journal.list({ search, limit: PAGE_SIZE, offset });
       setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
+      setTotal(page.total);
       setHasMore(page.has_more);
     } catch (err) {
       // Surface the failure so a cold-start network error isn't mistaken for an
@@ -164,7 +167,7 @@ function useShelf(): ShelfState {
     if (hasMore && !loading) void load(searchParam(query), items.length);
   }, [hasMore, loading, load, query, items.length]);
 
-  return { items, loading, error, query, hasMore, onSearch, loadMore };
+  return { items, total, loading, error, query, hasMore, onSearch, loadMore };
 }
 
 function PageCard({
@@ -399,14 +402,14 @@ function renderSectionHeader({
 
 function JournalShelfScreen(): React.JSX.Element {
   const navigation = useNavigation<ShelfNavigation>();
-  const { items, loading, error, query, hasMore, onSearch, loadMore } = useShelf();
+  const { items, total, loading, error, query, hasMore, onSearch, loadMore } = useShelf();
   const prompt = usePrompt();
   const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
   const nav = useShelfNavigation(navigation, prompt, week);
   const now = Date.now();
   const sections = groupByRecency(items, now);
   const searching = query.length >= SEARCH_MIN_LENGTH;
-  const resultCount = searching ? items.length : undefined;
+  const resultCount = searching ? total : undefined;
 
   const renderItem = ({ item }: SectionListRenderItemInfo<JournalMessage, ShelfSection>) => (
     <PageCard entry={item} onOpen={nav.openEntry} now={now} />

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -37,9 +37,18 @@ jest.mock('@react-navigation/native', () => {
 
 // Isolate the shelf's search wiring from SearchBar's own debounce/expand UI.
 jest.mock('../SearchBar', () => {
-  const { TextInput } = require('react-native');
-  const Stub = ({ onSearch }: { onSearch: (_q: string) => void }) => (
-    <TextInput testID="shelf-search" onChangeText={onSearch} />
+  const { Text, TextInput, View } = require('react-native');
+  const Stub = ({
+    onSearch,
+    resultCount,
+  }: {
+    onSearch: (_q: string) => void;
+    resultCount?: number;
+  }) => (
+    <View>
+      <TextInput testID="shelf-search" onChangeText={onSearch} />
+      {resultCount == null ? null : <Text testID="shelf-result-count">{String(resultCount)}</Text>}
+    </View>
   );
   return { __esModule: true, default: Stub };
 });
@@ -272,6 +281,31 @@ describe('JournalShelfScreen', () => {
     });
     await waitFor(() => expect(getByTestId('journal-shelf-card-3')).toBeTruthy());
     expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 2 }));
+  });
+
+  it('captions a multi-page search with the backend total, stable across paging', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { findByTestId, getByTestId } = render(<JournalShelfScreen />);
+    await findByTestId('journal-shelf-card-1');
+
+    // A large match set: one page of 20 loaded, but 57 matches in total.
+    const firstPage = Array.from({ length: 20 }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValueOnce({ items: firstPage, total: 57, has_more: true });
+    await act(async () => {
+      fireEvent.changeText(getByTestId('shelf-search'), 'river');
+    });
+    await waitFor(() => expect(getByTestId('shelf-result-count')).toHaveTextContent('57'));
+
+    // Paging in the next 20 must not inflate the caption toward the loaded count.
+    const secondPage = Array.from({ length: 20 }, (_, i) => entry(i + 21));
+    mockList.mockResolvedValueOnce({ items: secondPage, total: 57, has_more: true });
+    await act(async () => {
+      fireEvent(getByTestId('journal-shelf-list'), 'onEndReached');
+    });
+    await waitFor(() =>
+      expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 20 })),
+    );
+    expect(getByTestId('shelf-result-count')).toHaveTextContent('57');
   });
 
   it('surfaces an unanswered weekly prompt and opens it as a pre-titled page', async () => {


### PR DESCRIPTION
## Summary

The journal search result caption ("N results for 'x'") was fed the accumulated **loaded item count** instead of the backend's true **match total**, so for any query matching more than one page the count was wrong and *grew as the user paged* (e.g. "20 results" → "40 results" → "57 results" for a 57-entry match).

`JournalListResponse.total` already carries the full match count; `useShelf` was discarding `page.total`. This threads it through:

- Add `total` to `ShelfState`, set it from `page.total` in `useShelf.load`.
- Compute `resultCount` from the threaded `total` (not `items.length`).

Scope is the search caption only — pagination, empty/no-results states, and min-length gating are unchanged.

## Test plan

- New regression test `captions a multi-page search with the backend total, stable across paging`: a `{items: 20, total: 57, has_more: true}` search renders "57", and the caption stays 57 after `onEndReached` pages in the next 20. Fails RED on the old `items.length` code, passes GREEN on the fix.
- `./scripts/frontend/check-all.sh` green (4/4): eslint, prettier, tsc, and full Jest (3206 tests). `JournalShelfScreen.tsx` at 100% line coverage.

Closes #1145