### PR TITLE
refactor(frontend): extract shared note-card chrome across Journal notes

### DIFF
--- a/frontend/src/features/Journal/CareSupportNote.tsx
+++ b/frontend/src/features/Journal/CareSupportNote.tsx
@@ -10,23 +10,17 @@
  * of resources. ``Dismiss`` collapses the list to a persistent ``Re-open``
  * affordance rather than removing the surface entirely, so the user can never
  * lose their way back to help. Presentational, reduced-motion-safe, tokens only
- * (mirrors ``CompletionSuggestionNote``).
+ * (mirrors ``ContractionReflectionNote``).
  */
 import React, { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+import { reflectionCardStyles } from './noteCards';
+import ReflectionDismiss from './ReflectionDismiss';
+
 import type { CareResource, CareResponse } from '@/api';
 import CareResourceCard from '@/components/care/CareResourceCard';
-import {
-  BORDER_RADIUS,
-  SPACING,
-  accent,
-  editorialType,
-  ink,
-  paperShadow,
-  surface,
-  touchTarget,
-} from '@/design/tokens';
+import { SPACING, accent, editorialType, touchTarget } from '@/design/tokens';
 
 const DISMISS_LABEL = 'Dismiss';
 const REOPEN_LABEL = 'Show support options';
@@ -66,15 +60,12 @@ function ExpandedBody({
       {resources.map((resource) => (
         <CareResourceCard key={resource.kind} resource={resource} />
       ))}
-      <TouchableOpacity
-        style={styles.dismiss}
-        onPress={onDismiss}
-        accessibilityRole="button"
+      <ReflectionDismiss
+        label={DISMISS_LABEL}
         accessibilityLabel={DISMISS_A11Y}
         testID="care-dismiss"
-      >
-        <Text style={styles.dismissText}>{DISMISS_LABEL}</Text>
-      </TouchableOpacity>
+        onPress={onDismiss}
+      />
     </>
   );
 }
@@ -83,8 +74,8 @@ function CareSupportNote({ care }: CareSupportNoteProps): React.JSX.Element | nu
   const [expanded, setExpanded] = useState(true);
   if (care == null) return null;
   return (
-    <View style={styles.root} testID="care-support">
-      <Text style={styles.message} accessibilityRole="header">
+    <View style={reflectionCardStyles.root} testID="care-support">
+      <Text style={reflectionCardStyles.header} accessibilityRole="header">
         {care.message}
       </Text>
       {expanded ? (
@@ -97,34 +88,6 @@ function CareSupportNote({ care }: CareSupportNoteProps): React.JSX.Element | nu
 }
 
 const styles = StyleSheet.create({
-  root: {
-    margin: SPACING.lg,
-    padding: SPACING.lg,
-    borderRadius: BORDER_RADIUS.lg,
-    backgroundColor: surface.raised,
-    borderLeftWidth: 4,
-    borderLeftColor: accent.primary,
-    ...paperShadow.card,
-  },
-  message: {
-    ...editorialType.title,
-    color: ink.primary,
-    marginBottom: SPACING.md,
-  },
-  dismiss: {
-    minHeight: touchTarget.minimum,
-    minWidth: touchTarget.minimum,
-    alignSelf: 'flex-start',
-    paddingHorizontal: SPACING.md,
-    marginTop: SPACING.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  dismissText: {
-    ...editorialType.note,
-    fontWeight: '600',
-    color: ink.soft,
-  },
   reopen: {
     minHeight: touchTarget.minimum,
     minWidth: touchTarget.minimum,

--- a/frontend/src/features/Journal/CompletionSuggestionNote.tsx
+++ b/frontend/src/features/Journal/CompletionSuggestionNote.tsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import { Animated, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { usePressScale } from './motion';
+import { paperMarginCard } from './noteCards';
 
 import type { CheckInResult, CompletionSuggestion } from '@/api';
 import {
@@ -21,7 +22,6 @@ import {
   SPACING,
   colors,
   editorialType,
-  paperShadow,
   spacing,
   touchTarget,
 } from '@/design/tokens';
@@ -174,15 +174,7 @@ function CompletionSuggestionNote({
 }
 
 const styles = StyleSheet.create({
-  card: {
-    minHeight: touchTarget.minimum,
-    padding: SPACING.md,
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: colors.paper.background,
-    borderLeftWidth: 3,
-    borderLeftColor: colors.tier.clear,
-    ...paperShadow.card,
-  },
+  card: paperMarginCard(colors.tier.clear),
   question: {
     ...editorialType.marginNote,
     color: colors.paper.ink,

--- a/frontend/src/features/Journal/ContractionReflectionNote.tsx
+++ b/frontend/src/features/Journal/ContractionReflectionNote.tsx
@@ -11,19 +11,13 @@
  * Presentational, reduced-motion-safe, tokens only.
  */
 import React, { useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { reflectionCardStyles } from './noteCards';
+import ReflectionDismiss from './ReflectionDismiss';
 
 import type { ContractionReflection, ContractionVariant } from '@/api';
-import {
-  BORDER_RADIUS,
-  SPACING,
-  accent,
-  editorialType,
-  ink,
-  paperShadow,
-  surface,
-  touchTarget,
-} from '@/design/tokens';
+import { editorialType, ink } from '@/design/tokens';
 
 /** Warm, declinable titles per contraction variant — never punishing copy. */
 const VARIANT_TITLES: Record<ContractionVariant, string> = {
@@ -33,8 +27,6 @@ const VARIANT_TITLES: Record<ContractionVariant, string> = {
 
 const DISMISS_LABEL = 'Not now';
 const DISMISS_A11Y = 'Set this reflection aside';
-/** The warm accent stripe width; matches the care surface's foundation cue. */
-const ACCENT_STRIPE_WIDTH = 4;
 
 export interface ContractionReflectionNoteProps {
   /** The contraction surface from the latest pass; ``null`` hides everything. */
@@ -50,56 +42,29 @@ function ContractionReflectionNote({
   const [dismissedFor, setDismissedFor] = useState<ContractionReflection | null>(null);
   if (contraction == null || dismissedFor === contraction) return null;
   return (
-    <View style={styles.root} testID="contraction-reflection">
-      <Text style={styles.title} accessibilityRole="header" testID="contraction-reflection-title">
+    <View style={reflectionCardStyles.root} testID="contraction-reflection">
+      <Text
+        style={reflectionCardStyles.header}
+        accessibilityRole="header"
+        testID="contraction-reflection-title"
+      >
         {VARIANT_TITLES[contraction.variant]}
       </Text>
       <Text style={styles.message}>{contraction.message}</Text>
-      <TouchableOpacity
-        style={styles.dismiss}
-        onPress={() => setDismissedFor(contraction)}
-        accessibilityRole="button"
+      <ReflectionDismiss
+        label={DISMISS_LABEL}
         accessibilityLabel={DISMISS_A11Y}
         testID="contraction-dismiss"
-      >
-        <Text style={styles.dismissText}>{DISMISS_LABEL}</Text>
-      </TouchableOpacity>
+        onPress={() => setDismissedFor(contraction)}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
-    margin: SPACING.lg,
-    padding: SPACING.lg,
-    borderRadius: BORDER_RADIUS.lg,
-    backgroundColor: surface.raised,
-    borderLeftWidth: ACCENT_STRIPE_WIDTH,
-    borderLeftColor: accent.primary,
-    ...paperShadow.card,
-  },
-  title: {
-    ...editorialType.title,
-    color: ink.primary,
-    marginBottom: SPACING.md,
-  },
   message: {
     ...editorialType.body,
     color: ink.primary,
-  },
-  dismiss: {
-    minHeight: touchTarget.minimum,
-    minWidth: touchTarget.minimum,
-    alignSelf: 'flex-start',
-    paddingHorizontal: SPACING.md,
-    marginTop: SPACING.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  dismissText: {
-    ...editorialType.note,
-    fontWeight: '600',
-    color: ink.soft,
   },
 });
 

--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -1,24 +1,17 @@
 /**
  * ``MarginNote`` — one of the AI's margin notes, pinned beside the passage it
  * refers to. Presentational: a serif card with a kind pin (in the kind accent),
- * the note text, and a subtle open affordance. Stale notes render dimmed;
- * staleness is not otherwise styled. Tapping signals ``onOpen``.
+ * the note text, and a subtle open affordance. Stale notes render dimmed and
+ * show a caption noting the passage has changed. Tapping signals ``onOpen``.
  */
 import React from 'react';
 import { Animated, StyleSheet, Text, TouchableOpacity } from 'react-native';
 
 import { usePressScale } from './motion';
+import { paperMarginCard } from './noteCards';
 
 import type { Marginalia } from '@/api';
-import {
-  BORDER_RADIUS,
-  SPACING,
-  colors,
-  editorialType,
-  paperShadow,
-  spacing,
-  touchTarget,
-} from '@/design/tokens';
+import { colors, editorialType, spacing } from '@/design/tokens';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
 export interface MarginNoteProps {
@@ -58,18 +51,8 @@ function MarginNote({ note, onOpen }: MarginNoteProps): React.JSX.Element {
 }
 
 const styles = StyleSheet.create({
-  card: {
-    minHeight: touchTarget.minimum,
-    padding: SPACING.md,
-    borderRadius: BORDER_RADIUS.md,
-    // Sits a touch above the page, lifted by paperShadow.card — the shadow does
-    // the separation, so the slip can match the page ground (was backgroundAlt)
-    // and still read as a lifted note pinned to the margin.
-    backgroundColor: colors.paper.background,
-    borderLeftWidth: 3,
-    borderLeftColor: colors.paper.hairline, // default; overridden per kind inline
-    ...paperShadow.card,
-  },
+  // default hairline stripe; overridden per kind inline at the callsite
+  card: paperMarginCard(colors.paper.hairline),
   cardStale: {
     opacity: 0.55,
   },

--- a/frontend/src/features/Journal/ReflectionDismiss.tsx
+++ b/frontend/src/features/Journal/ReflectionDismiss.tsx
@@ -1,0 +1,50 @@
+/** Shared dismiss affordance for the raised reflection cards — identical chrome. */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import { SPACING, editorialType, ink, touchTarget } from '@/design/tokens';
+
+export interface ReflectionDismissProps {
+  label: string;
+  accessibilityLabel: string;
+  testID: string;
+  onPress: () => void;
+}
+
+function ReflectionDismiss({
+  label,
+  accessibilityLabel,
+  testID,
+  onPress,
+}: ReflectionDismissProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.dismiss}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+    >
+      <Text style={styles.dismissText}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  dismiss: {
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+    alignSelf: 'flex-start',
+    paddingHorizontal: SPACING.md,
+    marginTop: SPACING.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dismissText: {
+    ...editorialType.note,
+    fontWeight: '600',
+    color: ink.soft,
+  },
+});
+
+export default ReflectionDismiss;

--- a/frontend/src/features/Journal/noteCards.ts
+++ b/frontend/src/features/Journal/noteCards.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared card chrome for the Journal note surfaces. Two deliberately distinct
+ * families live here and must NOT be merged:
+ *
+ *   - The *paper* margin card (``paperMarginCard``) — a flat slip pinned beside
+ *     a passage, lifted only by ``paperShadow.card`` (MarginNote,
+ *     CompletionSuggestionNote).
+ *   - The *raised* reflection card (``reflectionCardStyles``) — a larger,
+ *     rounded panel on ``surface.raised`` with a warm accent stripe
+ *     (CareSupportNote, ContractionReflectionNote).
+ *
+ * They share a shadow token but differ in ground, radius, spacing, and stripe;
+ * collapsing them into one primitive would erase that intended contrast.
+ */
+import { StyleSheet } from 'react-native';
+import type { ViewStyle } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  editorialType,
+  ink,
+  paperShadow,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
+
+/** The paper margin slip's left border width, in dp. */
+const PAPER_STRIPE_WIDTH = 3;
+
+/** The raised reflection card's warm left stripe width, in dp. */
+const ACCENT_STRIPE_WIDTH = 4;
+
+/**
+ * The flat paper margin card, parameterised by its left-stripe colour. Callers
+ * pass a per-kind accent (or a hairline default) for ``borderLeftColor``. It
+ * sits a touch above the page, lifted only by ``paperShadow.card`` — the shadow
+ * does the separation, so the slip can match the page ground and still read as
+ * a lifted note pinned to the margin.
+ */
+export function paperMarginCard(borderLeftColor: string): ViewStyle {
+  return {
+    minHeight: touchTarget.minimum,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.background,
+    borderLeftWidth: PAPER_STRIPE_WIDTH,
+    borderLeftColor,
+    ...paperShadow.card,
+  };
+}
+
+/** The raised reflection card shared by CareSupportNote and ContractionReflectionNote. */
+export const reflectionCardStyles = StyleSheet.create({
+  root: {
+    margin: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: surface.raised,
+    borderLeftWidth: ACCENT_STRIPE_WIDTH,
+    borderLeftColor: accent.primary,
+    ...paperShadow.card,
+  },
+  header: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginBottom: SPACING.md,
+  },
+});


### PR DESCRIPTION
## Summary

De-slop refactor (#1147): the Journal's four note/reflection surfaces were built from two families of copy-pasted card chrome with byte-identical style objects. This folds each family into a shared presentational primitive and has the four components compose it — deleting the duplication without changing any rendered output, testID, or a11y role.

- **Cluster A — "paper margin card":** `MarginNote` and `CompletionSuggestionNote` now compose `paperMarginCard(borderLeftColor)` from a new `noteCards.ts` module instead of an identical inline `card` style (they differed only in `borderLeftColor`).
- **Cluster B — "raised reflection card":** `CareSupportNote` and `ContractionReflectionNote` share `reflectionCardStyles` (root/header) plus a new `ReflectionDismiss` affordance component, replacing the identical `root`/`dismiss`/`dismissText` style objects. The stripe width is now the named `ACCENT_STRIPE_WIDTH` constant.

The two families stay deliberately distinct — they are genuinely different cards (paper ground, radius `md`, 3dp stripe vs `surface.raised`, radius `lg`, 4dp accent stripe) — and are documented as "must NOT be merged" in `noteCards.ts`.

Also corrects two misleading docstrings surfaced by the same de-slop scan:
- `MarginNote` — "staleness is not otherwise styled" was false (a stale caption *is* rendered).
- `CareSupportNote` — "(mirrors CompletionSuggestionNote)" was wrong; it mirrors `ContractionReflectionNote`.

No behavior or public-prop changes. No test files were touched (a sibling test-hardening PR is in flight over some of them).

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — zero warnings
- `npx jest src/features/Journal` — 253 pass across 24 suites
- `./scripts/frontend/check-all.sh` — all 4 quality checks pass (3227 tests, exit 0)
- The four component tests (55 tests pinning testIDs, a11y roles, flattened 44dp touch targets, and per-kind `borderLeftColor`) pass **unchanged** — the extraction preserves rendering exactly.

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)