### PR TITLE
refactor(frontend): extract shared RadioOption primitive for Journal editor controls

### DIFF
--- a/frontend/src/components/RadioOption.tsx
+++ b/frontend/src/components/RadioOption.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+export interface RadioOptionProps {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+  testID: string;
+  accessibilityHint?: string;
+  style: StyleProp<ViewStyle>;
+  selectedStyle: StyleProp<ViewStyle>;
+  labelStyle: StyleProp<TextStyle>;
+  selectedLabelStyle: StyleProp<TextStyle>;
+}
+
+export interface RadioGroupProps {
+  style: StyleProp<ViewStyle>;
+  accessibilityLabel?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A single radio-like option. The label doubles as the visible text and the
+ * screen-reader accessibilityLabel, and the selected state drives both the
+ * container and label style overlays as well as the announced selection.
+ */
+export function RadioOption({
+  label,
+  selected,
+  onPress,
+  testID,
+  accessibilityHint,
+  style,
+  selectedStyle,
+  labelStyle,
+  selectedLabelStyle,
+}: RadioOptionProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={[style, selected && selectedStyle]}
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityHint={accessibilityHint}
+      accessibilityState={{ selected }}
+      testID={testID}
+    >
+      <Text style={[labelStyle, selected && selectedLabelStyle]}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+/**
+ * The container for a set of {@link RadioOption} children. Exposes the
+ * radiogroup role so assistive tech treats the options as one exclusive choice.
+ */
+export function RadioGroup({
+  style,
+  accessibilityLabel,
+  children,
+}: RadioGroupProps): React.JSX.Element {
+  return (
+    <View style={style} accessibilityRole="radiogroup" accessibilityLabel={accessibilityLabel}>
+      {children}
+    </View>
+  );
+}

--- a/frontend/src/components/__tests__/RadioOption.test.tsx
+++ b/frontend/src/components/__tests__/RadioOption.test.tsx
@@ -1,0 +1,211 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { RadioGroup, RadioOption } from '../RadioOption';
+
+const selectedStyle = { backgroundColor: 'rgb(1, 2, 3)' };
+const selectedLabelStyle = { color: 'rgb(4, 5, 6)' };
+const baseStyle = { borderWidth: 1 };
+const baseLabelStyle = { fontSize: 14 };
+const groupStyle = { gap: 8 };
+
+describe('RadioOption', () => {
+  it('renders the label text and passes through accessibility role/label/testID', () => {
+    const { getByText, getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByText('Morning')).toBeTruthy();
+    const node = getByTestId('opt-morning');
+    expect(node.props.accessibilityRole).toBe('radio');
+    expect(node.props.accessibilityLabel).toBe('Morning');
+  });
+
+  it('reflects selected=true in accessibilityState', () => {
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({ selected: true });
+  });
+
+  it('reflects selected=false in accessibilityState', () => {
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({ selected: false });
+  });
+
+  it('fires onPress exactly once when pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={onPress}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    fireEvent.press(getByTestId('opt-morning'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes accessibilityHint through when provided', () => {
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={jest.fn()}
+        testID="opt-morning"
+        accessibilityHint="Sets your practice window to morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByTestId('opt-morning').props.accessibilityHint).toBe(
+      'Sets your practice window to morning',
+    );
+  });
+
+  it('omits accessibilityHint when not provided', () => {
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByTestId('opt-morning').props.accessibilityHint).toBeUndefined();
+  });
+
+  it('applies the selected container and label styles only when selected', () => {
+    const { getByTestId, getByText, rerender } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    const unselectedContainer = StyleSheet.flatten(getByTestId('opt-morning').props.style);
+    expect(unselectedContainer.backgroundColor).toBeUndefined();
+    const unselectedLabel = StyleSheet.flatten(getByText('Morning').props.style);
+    expect(unselectedLabel.color).toBeUndefined();
+
+    rerender(
+      <RadioOption
+        label="Morning"
+        selected
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    const selectedContainer = StyleSheet.flatten(getByTestId('opt-morning').props.style);
+    expect(selectedContainer.backgroundColor).toBe('rgb(1, 2, 3)');
+    const selectedLabel = StyleSheet.flatten(getByText('Morning').props.style);
+    expect(selectedLabel.color).toBe('rgb(4, 5, 6)');
+  });
+});
+
+// A plain View carrying only accessibilityRole is not an accessibility element,
+// so getByRole cannot find it; read the flattened host tree via toJSON instead.
+function groupNode(element: React.JSX.Element) {
+  const tree = render(element).toJSON();
+  if (tree === null || Array.isArray(tree)) throw new Error('expected a single group node');
+  return tree;
+}
+
+describe('RadioGroup', () => {
+  it('exposes the radiogroup accessibility role', () => {
+    const node = groupNode(
+      <RadioGroup style={groupStyle}>
+        <View testID="child" />
+      </RadioGroup>,
+    );
+    expect(node.props.accessibilityRole).toBe('radiogroup');
+  });
+
+  it('renders its children', () => {
+    const { getByTestId } = render(
+      <RadioGroup style={groupStyle}>
+        <Text testID="child">A child</Text>
+      </RadioGroup>,
+    );
+    expect(getByTestId('child')).toBeTruthy();
+  });
+
+  it('passes accessibilityLabel through when provided', () => {
+    const node = groupNode(
+      <RadioGroup style={groupStyle} accessibilityLabel="Practice time">
+        <View testID="child" />
+      </RadioGroup>,
+    );
+    expect(node.props.accessibilityLabel).toBe('Practice time');
+  });
+
+  it('omits accessibilityLabel when not provided', () => {
+    const node = groupNode(
+      <RadioGroup style={groupStyle}>
+        <View testID="child" />
+      </RadioGroup>,
+    );
+    expect(node.props.accessibilityLabel).toBeUndefined();
+  });
+
+  it('applies the passed style to the group container', () => {
+    const node = groupNode(
+      <RadioGroup style={groupStyle}>
+        <View testID="child" />
+      </RadioGroup>,
+    );
+    const flat = StyleSheet.flatten(node.props.style);
+    expect(flat.gap).toBe(8);
+  });
+});

--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -15,6 +15,7 @@ import { Text, TouchableOpacity, View } from 'react-native';
 
 import styles from './JournalEntry.styles';
 
+import { RadioGroup, RadioOption } from '@/components/RadioOption';
 import { STAGE_DISPLAY } from '@/features/Map/mapLayout';
 
 /** The controlled chord value: a primary Aspect and an optional secondary. */
@@ -47,31 +48,6 @@ export interface AspectChordControlProps {
   onChange: (_next: AspectChordValue) => void;
 }
 
-interface AspectChipProps {
-  option: AspectOption;
-  selected: boolean;
-  testID: string;
-  onPress: () => void;
-}
-
-/** A single Aspect chip; announces its selection state to screen readers. */
-function AspectChip({ option, selected, testID, onPress }: AspectChipProps): React.JSX.Element {
-  return (
-    <TouchableOpacity
-      style={[styles.aspectChordChip, selected && styles.aspectChordChipSelected]}
-      onPress={onPress}
-      accessibilityRole="radio"
-      accessibilityLabel={option.label}
-      accessibilityState={{ selected }}
-      testID={testID}
-    >
-      <Text style={[styles.aspectChordChipLabel, selected && styles.aspectChordChipLabelSelected]}>
-        {option.label}
-      </Text>
-    </TouchableOpacity>
-  );
-}
-
 interface AspectChipRowProps {
   prefix: string;
   selectedStage: number | null;
@@ -87,17 +63,21 @@ function AspectChipRow({
   onSelect,
 }: AspectChipRowProps): React.JSX.Element {
   return (
-    <View style={styles.aspectChordRow} accessibilityRole="radiogroup">
+    <RadioGroup style={styles.aspectChordRow}>
       {ASPECT_OPTIONS.filter((option) => option.stage !== omitStage).map((option) => (
-        <AspectChip
+        <RadioOption
           key={option.stage}
-          option={option}
+          label={option.label}
           selected={option.stage === selectedStage}
-          testID={`${prefix}-${option.stage}`}
           onPress={() => onSelect(option.stage)}
+          testID={`${prefix}-${option.stage}`}
+          style={styles.aspectChordChip}
+          selectedStyle={styles.aspectChordChipSelected}
+          labelStyle={styles.aspectChordChipLabel}
+          selectedLabelStyle={styles.aspectChordChipLabelSelected}
         />
       ))}
-    </View>
+    </RadioGroup>
   );
 }
 

--- a/frontend/src/features/Journal/PrivacyTierControl.tsx
+++ b/frontend/src/features/Journal/PrivacyTierControl.tsx
@@ -11,11 +11,12 @@
  * the tier and persists it (create/update).
  */
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import styles from './JournalEntry.styles';
 
 import type { JournalClassification } from '@/api';
+import { RadioGroup, RadioOption } from '@/components/RadioOption';
 
 /** Privacy tier for a journal entry; alias of the canonical API type. */
 export type PrivacyTier = JournalClassification;
@@ -47,31 +48,6 @@ export interface PrivacyTierControlProps {
   onChange: (_tier: PrivacyTier) => void;
 }
 
-interface TierButtonProps {
-  option: TierOption;
-  selected: boolean;
-  onChange: (_tier: PrivacyTier) => void;
-}
-
-/** A single radio-like tier option; announces its selection state. */
-function TierButton({ option, selected, onChange }: TierButtonProps): React.JSX.Element {
-  return (
-    <TouchableOpacity
-      style={[styles.privacyTierOption, selected && styles.privacyTierOptionSelected]}
-      onPress={() => onChange(option.tier)}
-      accessibilityRole="radio"
-      accessibilityLabel={option.label}
-      accessibilityHint={option.hint}
-      accessibilityState={{ selected }}
-      testID={`privacy-tier-${option.tier}`}
-    >
-      <Text style={[styles.privacyTierLabel, selected && styles.privacyTierLabelSelected]}>
-        {option.label}
-      </Text>
-    </TouchableOpacity>
-  );
-}
-
 /**
  * The privacy tier segmented control plus its intimate-only explainer. Rendered
  * in the writing column of {@link JournalEntryScreen}.
@@ -82,20 +58,22 @@ function PrivacyTierControl({
 }: PrivacyTierControlProps): React.JSX.Element {
   return (
     <View style={styles.privacyTierControl}>
-      <View
-        style={styles.privacyTierRow}
-        accessibilityRole="radiogroup"
-        accessibilityLabel="Entry privacy"
-      >
+      <RadioGroup style={styles.privacyTierRow} accessibilityLabel="Entry privacy">
         {TIER_OPTIONS.map((option) => (
-          <TierButton
+          <RadioOption
             key={option.tier}
-            option={option}
+            label={option.label}
             selected={option.tier === value}
-            onChange={onChange}
+            onPress={() => onChange(option.tier)}
+            testID={`privacy-tier-${option.tier}`}
+            accessibilityHint={option.hint}
+            style={styles.privacyTierOption}
+            selectedStyle={styles.privacyTierOptionSelected}
+            labelStyle={styles.privacyTierLabel}
+            selectedLabelStyle={styles.privacyTierLabelSelected}
           />
         ))}
-      </View>
+      </RadioGroup>
       {value === 'intimate' ? (
         <Text style={styles.privacyTierExplainer} testID="privacy-tier-explainer">
           {INTIMATE_EXPLAINER}


### PR DESCRIPTION
## Summary

The two Journal editor controls each hand-rolled the **same** radio-group option independently (`AspectChip` in `AspectChordControl.tsx` and `TierButton` in `PrivacyTierControl.tsx`) — differing only in style-key names and one control's `accessibilityHint`. This extracts a single shared primitive and adopts it in both, eliminating the duplication (taxonomy Family 5 / Family 12 de-slop).

- New `frontend/src/components/RadioOption.tsx` exports two named primitives:
  - `RadioOption` — a `TouchableOpacity` radio option (`accessibilityRole="radio"` + `accessibilityState`, label/hint passthrough, selected container + label style overlays passed as props so each control keeps its own style keys).
  - `RadioGroup` — the thin `radiogroup` `View` wrapper (optional `accessibilityLabel`).
- `AspectChordControl` and `PrivacyTierControl` now consume the primitive; their distinct outer logic (collapse/trigger, primary+secondary rows, intimate explainer) is untouched.
- Rendered output is **byte-identical**: same testIDs (`aspect-primary-*`, `aspect-secondary-*`, `privacy-tier-*`), a11y roles/labels/hints, and selected styling. `JournalEntry.styles.ts` is unchanged.
- The `Practice`/`Habits` hand-rolls (`ModePicker`, `GoalModal`) are explicit non-goals; the primitive lives in `components/` so they can adopt it later without a second extraction.

## Test plan

- New `frontend/src/components/__tests__/RadioOption.test.tsx` (12 cases): label render, role/label/testID passthrough, `accessibilityState.selected` (true/false), `onPress` fires once, `accessibilityHint` present-when-passed / absent-when-omitted, selected container + label styles applied only when selected; `RadioGroup` role, children, `accessibilityLabel` present/absent, style passthrough.
- The four existing Journal tests (`AspectChordControl`, `PrivacyTierControl`, `JournalEntryScreenChord`, `JournalEntryScreenPrivacy`) pass **unchanged** — the byte-identity regression net.
- `./scripts/frontend/check-all.sh` green (3239 tests, coverage gate held); `tsc --noEmit` and `eslint --max-warnings=0` clean.

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)