### PR TITLE
feat(journal): half-width Habits + Practices stat tiles under the hero

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     '^expo-haptics$': '<rootDir>/src/__mocks__/expo-haptics.js',
     '^expo-image-picker$': '<rootDir>/src/__mocks__/expo-image-picker.js',
     '^expo-keep-awake$': '<rootDir>/src/__mocks__/expo-keep-awake.js',
+    '^expo-notifications$': '<rootDir>/src/__mocks__/expo-notifications.js',
     '^@react-native-community/netinfo$': '<rootDir>/src/__mocks__/netinfo.js',
   },
   transformIgnorePatterns: [

--- a/frontend/src/__mocks__/expo-notifications.js
+++ b/frontend/src/__mocks__/expo-notifications.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+/* global jest */
+// Manual mock for the native ``expo-notifications`` module so any test that
+// transitively imports the habit-notifications hook (e.g. via the habit
+// manager pulled in by the journal habit tile) runs under Node without the
+// package's untransformed ESM tripping the parser. Mirrors the other expo
+// manual mocks in this directory; a test needing bespoke behavior still
+// overrides these with a local ``jest.mock('expo-notifications', ...)``.
+module.exports = {
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),
+  SchedulableTriggerInputTypes: { DAILY: 'daily', WEEKLY: 'weekly' },
+};

--- a/frontend/src/features/Habits/__tests__/habitCounts.test.ts
+++ b/frontend/src/features/Habits/__tests__/habitCounts.test.ts
@@ -1,0 +1,104 @@
+/* eslint-env jest */
+import { jest, afterEach, describe, it, expect } from '@jest/globals';
+
+import { countDoneToday, unlockedToday } from '../habitCounts';
+import type { Habit } from '../Habits.types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 1,
+  stage: 'Beige',
+  name: 'Test Habit',
+  icon: 'leaf',
+  streak: 0,
+  energy_cost: 5,
+  energy_return: 5,
+  start_date: new Date('2020-01-01T00:00:00Z'),
+  goals: [],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+describe('countDoneToday', () => {
+  it('counts a habit with a completed_units > 0 completion timestamped today', () => {
+    const habit = makeHabit({
+      completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+    });
+    expect(countDoneToday([habit])).toBe(1);
+  });
+
+  it('excludes a completion with completed_units === 0', () => {
+    const habit = makeHabit({
+      completions: [{ id: 'c1', timestamp: new Date(), completed_units: 0 }],
+    });
+    expect(countDoneToday([habit])).toBe(0);
+  });
+
+  it('excludes completions logged on a different calendar day', () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * DAY_MS);
+    const habit = makeHabit({
+      completions: [{ id: 'c1', timestamp: twoDaysAgo, completed_units: 1 }],
+    });
+    expect(countDoneToday([habit])).toBe(0);
+  });
+
+  it('returns 0 for an empty habit list', () => {
+    expect(countDoneToday([])).toBe(0);
+  });
+
+  it('buckets a near-midnight completion by the passed timezone, not UTC', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-02T02:00:00Z'));
+    const habit = makeHabit({
+      completions: [{ id: 'c1', timestamp: new Date('2026-07-01T20:00:00Z'), completed_units: 1 }],
+    });
+    // In UTC the completion (Jul 1) and now (Jul 2) fall on different days.
+    expect(countDoneToday([habit], 'UTC')).toBe(0);
+    // In Tokyo (UTC+9) both instants land on Jul 2, so it counts as done today.
+    expect(countDoneToday([habit], 'Asia/Tokyo')).toBe(1);
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('unlockedToday', () => {
+  it('drops a habit that is unrevealed with a future start_date', () => {
+    const locked = makeHabit({
+      id: 2,
+      revealed: false,
+      start_date: new Date(Date.now() + 7 * DAY_MS),
+    });
+    expect(unlockedToday([locked])).toEqual([]);
+  });
+
+  it('keeps a revealed habit even with a future start_date', () => {
+    const unlocked = makeHabit({
+      id: 3,
+      revealed: true,
+      start_date: new Date(Date.now() + 7 * DAY_MS),
+    });
+    expect(unlockedToday([unlocked])).toEqual([unlocked]);
+  });
+
+  it('keeps an unrevealed habit whose start_date has already passed', () => {
+    const unlocked = makeHabit({
+      id: 4,
+      revealed: false,
+      start_date: new Date('2020-01-01T00:00:00Z'),
+    });
+    expect(unlockedToday([unlocked])).toEqual([unlocked]);
+  });
+
+  it('filters a mixed list down to only the unlocked habits', () => {
+    const locked = makeHabit({
+      id: 5,
+      revealed: false,
+      start_date: new Date(Date.now() + 7 * DAY_MS),
+    });
+    const unlocked = makeHabit({ id: 6, revealed: true });
+    expect(unlockedToday([locked, unlocked])).toEqual([unlocked]);
+  });
+});

--- a/frontend/src/features/Habits/habitCounts.ts
+++ b/frontend/src/features/Habits/habitCounts.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure habit-count helpers shared by summary surfaces (e.g. the journal stat
+ * tiles). Kept free of any store or hook usage so callers pass in the habit
+ * list they already subscribe to, rather than reading an imperative snapshot.
+ */
+import type { Habit } from '@/features/Habits/Habits.types';
+import { isHabitLockedToday } from '@/features/Habits/HabitUtils';
+import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
+
+/**
+ * Count habits with a real completion on today's calendar day — a completion
+ * with `completed_units > 0` bucketed into today's day for the given timezone.
+ *
+ * `tz` defaults to `DEFAULT_TIMEZONE`, but callers that know the user's zone
+ * (the journal habit tile passes the auth-hydrated one) should thread it so the
+ * "today" bucket matches the user's calendar day near a midnight boundary.
+ */
+export function countDoneToday(habits: readonly Habit[], tz: string = DEFAULT_TIMEZONE): number {
+  const todayKey = dayKeyInTZ(new Date(), tz);
+  return habits.filter((h) =>
+    (h.completions ?? []).some(
+      (c) => c.completed_units > 0 && dayKeyInTZ(c.timestamp, tz) === todayKey,
+    ),
+  ).length;
+}
+
+/** The subset of habits that are unlocked today (dropping still-locked ones). */
+export function unlockedToday(habits: readonly Habit[]): Habit[] {
+  return habits.filter((h) => !isHabitLockedToday(h));
+}

--- a/frontend/src/features/Journal/HabitsStatTile.tsx
+++ b/frontend/src/features/Journal/HabitsStatTile.tsx
@@ -1,0 +1,99 @@
+/**
+ * The journal "Today's habits" stat tile: a compact summary of how many of the
+ * user's unlocked habits are done today, with graceful loading, empty, and
+ * still-locked states. Loads habits on mount and taps through to the Habits tab.
+ */
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import React, { useEffect } from 'react';
+
+import StatTile from './StatTile';
+
+import { useAuth } from '@/context/AuthContext';
+import { countDoneToday, unlockedToday } from '@/features/Habits/habitCounts';
+import { habitManager } from '@/features/Habits/services/habitManager';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+import { useHabitStore } from '@/store/useHabitStore';
+
+type HabitsTileNav = BottomTabNavigationProp<RootTabParamList>;
+
+const TITLE = "Today's habits";
+const OPEN_CUE = 'Open habits →';
+const ADD_CUE = 'Add a habit →';
+
+interface HabitsDescriptor {
+  loading: boolean;
+  stat?: string;
+  cue: string;
+  accessibilityLabel: string;
+}
+
+/**
+ * Resolve the tile's stat line, cue, loading flag, and a11y label from plain
+ * counts — pure so the loading branch reads the store's flag directly.
+ */
+function describeHabits(
+  loading: boolean,
+  habitCount: number,
+  unlockedCount: number,
+  doneCount: number,
+): HabitsDescriptor {
+  if (loading && habitCount === 0) {
+    return { loading: true, cue: OPEN_CUE, accessibilityLabel: `${TITLE}, loading. Open habits` };
+  }
+  if (habitCount === 0) {
+    return {
+      loading: false,
+      stat: 'No habits yet',
+      cue: ADD_CUE,
+      accessibilityLabel: `${TITLE}, no habits yet. Add a habit`,
+    };
+  }
+  if (unlockedCount === 0) {
+    return {
+      loading: false,
+      stat: 'Unlocks soon',
+      cue: OPEN_CUE,
+      accessibilityLabel: `${TITLE}, unlocks soon. Open habits`,
+    };
+  }
+  return {
+    loading: false,
+    stat: `${doneCount}/${unlockedCount} done`,
+    cue: OPEN_CUE,
+    accessibilityLabel: `${TITLE}, ${doneCount} of ${unlockedCount} done. Open habits`,
+  };
+}
+
+const HabitsStatTile = (): React.JSX.Element => {
+  const navigation = useNavigation<HabitsTileNav>();
+  const { userTimezone } = useAuth();
+  const loading = useHabitStore((state) => state.loading);
+  const habits = useHabitStore((state) => state.habits);
+
+  useEffect(() => {
+    void habitManager.loadHabits(userTimezone);
+  }, [userTimezone]);
+
+  const unlocked = unlockedToday(habits);
+  const descriptor = describeHabits(
+    loading,
+    habits.length,
+    unlocked.length,
+    countDoneToday(unlocked, userTimezone),
+  );
+
+  return (
+    <StatTile
+      testID="journal-habits-tile"
+      title={TITLE}
+      cue={descriptor.cue}
+      stat={descriptor.stat}
+      loading={descriptor.loading}
+      accessibilityLabel={descriptor.accessibilityLabel}
+      onPress={() => navigation.navigate('Habits')}
+    />
+  );
+};
+
+export default HabitsStatTile;

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -16,6 +16,7 @@ import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
 import SearchBar from './SearchBar';
+import StatTileRow from './StatTileRow';
 
 import { journal, prompts } from '@/api';
 import type { JournalMessage, PromptDetail } from '@/api';
@@ -345,6 +346,7 @@ function ShelfTopMatter({
   return (
     <View>
       <JournalHero />
+      <StatTileRow />
       <ScreenHeader
         title="Journal"
         action={<Button label="New entry" onPress={onNew} testID="journal-new-entry" />}

--- a/frontend/src/features/Journal/PracticesStatTile.tsx
+++ b/frontend/src/features/Journal/PracticesStatTile.tsx
@@ -1,0 +1,67 @@
+/**
+ * The journal "Practices" stat tile: this week's raw session count against the
+ * weekly target. Shows a skeleton while loading and degrades to a countless but
+ * still-pressable tile on error, so a failed fetch never crashes the shelf.
+ */
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+
+import StatTile from './StatTile';
+
+import { WEEKLY_TARGET } from '@/features/Practice/constants';
+import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+
+type PracticesTileNav = BottomTabNavigationProp<RootTabParamList>;
+
+const TITLE = 'Practices';
+const CUE = 'Open practice →';
+
+interface PracticesDescriptor {
+  loading: boolean;
+  stat?: string;
+  accessibilityLabel: string;
+}
+
+/** Resolve the tile's stat and a11y label from the weekly-progress hook state. */
+function describePractices(
+  count: number,
+  isLoading: boolean,
+  error: Error | null,
+): PracticesDescriptor {
+  if (isLoading) {
+    return { loading: true, accessibilityLabel: 'Practices this week, loading. Open practice' };
+  }
+  if (error !== null) {
+    return {
+      loading: false,
+      accessibilityLabel: 'Practices this week, count unavailable. Open practice',
+    };
+  }
+  return {
+    loading: false,
+    stat: `${count}/${WEEKLY_TARGET} this week`,
+    accessibilityLabel: `Practices this week, ${count} of ${WEEKLY_TARGET} done. Open practice`,
+  };
+}
+
+const PracticesStatTile = (): React.JSX.Element => {
+  const navigation = useNavigation<PracticesTileNav>();
+  const { count, isLoading, error } = useWeeklyProgress();
+  const descriptor = describePractices(count, isLoading, error);
+
+  return (
+    <StatTile
+      testID="journal-practices-tile"
+      title={TITLE}
+      cue={CUE}
+      stat={descriptor.stat}
+      loading={descriptor.loading}
+      accessibilityLabel={descriptor.accessibilityLabel}
+      onPress={() => navigation.navigate('Practice')}
+    />
+  );
+};
+
+export default PracticesStatTile;

--- a/frontend/src/features/Journal/StatTile.styles.ts
+++ b/frontend/src/features/Journal/StatTile.styles.ts
@@ -1,0 +1,53 @@
+/** Styles for the two-up journal stat tiles (Candle & Ink paper tiles). */
+import { StyleSheet } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+
+/** Skeleton block sized to stand in for a single line of stat text. */
+export const SKELETON_WIDTH = '60%';
+export const SKELETON_HEIGHT = 20;
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: SPACING.md,
+    marginTop: SPACING.lg,
+  },
+  tile: {
+    flex: 1,
+    minHeight: touchTarget.minimum,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    // A warm paper tile lifted off the canvas by the shared card shadow.
+    backgroundColor: surface.desk,
+    ...surfaceShadow.card,
+    justifyContent: 'center',
+  },
+  title: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+  },
+  stat: {
+    ...editorialType.title,
+    color: ink.primary,
+    marginTop: SPACING.xs,
+  },
+  cue: {
+    ...editorialType.caption,
+    color: accent.primary,
+    fontWeight: '600',
+    marginTop: SPACING.xs,
+  },
+});
+
+export default styles;

--- a/frontend/src/features/Journal/StatTile.tsx
+++ b/frontend/src/features/Journal/StatTile.tsx
@@ -1,0 +1,60 @@
+/**
+ * A single half-width journal stat tile: a pressable paper card showing a
+ * caption title, an optional stat line (or a loading skeleton), and an accent
+ * cue. Purely presentational — parents own the data and the press action.
+ */
+import React from 'react';
+import { Pressable, Text } from 'react-native';
+
+import s, { SKELETON_HEIGHT, SKELETON_WIDTH } from './StatTile.styles';
+
+import { Skeleton } from '@/components/feedback/Skeleton';
+
+interface StatTileProps {
+  title: string;
+  cue: string;
+  onPress: () => void;
+  accessibilityLabel: string;
+  testID: string;
+  loading?: boolean;
+  stat?: string;
+}
+
+/** Render the tile's middle line: a skeleton while loading, else the stat text. */
+function StatBody({
+  loading,
+  stat,
+  testID,
+}: Pick<StatTileProps, 'loading' | 'stat' | 'testID'>): React.JSX.Element | null {
+  if (loading) {
+    return (
+      <Skeleton testID={`${testID}-skeleton`} width={SKELETON_WIDTH} height={SKELETON_HEIGHT} />
+    );
+  }
+  if (stat) return <Text style={s.stat}>{stat}</Text>;
+  return null;
+}
+
+const StatTile = ({
+  title,
+  cue,
+  onPress,
+  accessibilityLabel,
+  testID,
+  loading = false,
+  stat,
+}: StatTileProps): React.JSX.Element => (
+  <Pressable
+    style={s.tile}
+    onPress={onPress}
+    accessibilityRole="button"
+    accessibilityLabel={accessibilityLabel}
+    testID={testID}
+  >
+    <Text style={s.title}>{title}</Text>
+    <StatBody loading={loading} stat={stat} testID={testID} />
+    <Text style={s.cue}>{cue}</Text>
+  </Pressable>
+);
+
+export default StatTile;

--- a/frontend/src/features/Journal/StatTileRow.tsx
+++ b/frontend/src/features/Journal/StatTileRow.tsx
@@ -1,0 +1,33 @@
+/**
+ * The two-up row of journal stat tiles under the hero. Each tile is ring-gated
+ * by the user's depth preferences: a tile appears only when its ring is on, and
+ * the whole row disappears when both rings are off (nothing to summarise).
+ */
+import React from 'react';
+import { View } from 'react-native';
+
+import HabitsStatTile from './HabitsStatTile';
+import PracticesStatTile from './PracticesStatTile';
+import s from './StatTile.styles';
+
+import {
+  selectEnableHabits,
+  selectEnablePractices,
+  useDepthPreferencesStore,
+} from '@/store/useDepthPreferencesStore';
+
+const StatTileRow = (): React.JSX.Element | null => {
+  const habitsOn = useDepthPreferencesStore(selectEnableHabits);
+  const practicesOn = useDepthPreferencesStore(selectEnablePractices);
+
+  if (!habitsOn && !practicesOn) return null;
+
+  return (
+    <View style={s.row} testID="journal-stat-tile-row">
+      {habitsOn ? <HabitsStatTile /> : null}
+      {practicesOn ? <PracticesStatTile /> : null}
+    </View>
+  );
+};
+
+export default StatTileRow;

--- a/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ userTimezone: 'UTC' }),
+}));
+
+const mockLoadHabits = jest.fn();
+jest.mock('@/features/Habits/services/habitManager', () => ({
+  habitManager: {
+    loadHabits: (...args: unknown[]) => mockLoadHabits(...args),
+  },
+}));
+
+import HabitsStatTile from '../HabitsStatTile';
+
+import type { Habit } from '@/features/Habits/Habits.types';
+import { useHabitStore } from '@/store/useHabitStore';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 1,
+  stage: 'Beige',
+  name: 'Test Habit',
+  icon: 'leaf',
+  streak: 0,
+  energy_cost: 5,
+  energy_return: 5,
+  start_date: new Date('2020-01-01T00:00:00Z'),
+  goals: [],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockLoadHabits.mockClear();
+  useHabitStore.setState({
+    loading: false,
+    habits: [],
+    habitsById: {},
+    habitOrder: [],
+    error: null,
+  });
+});
+
+describe('HabitsStatTile', () => {
+  it('shows the skeleton while loading with no habits yet', () => {
+    useHabitStore.setState({ loading: true, habits: [] });
+    const { getByTestId } = render(<HabitsStatTile />);
+    expect(getByTestId('journal-habits-tile-skeleton')).toBeTruthy();
+    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
+    expect(label).toBe("Today's habits, loading. Open habits");
+  });
+
+  it('shows the no-habits stat and cue when the user has no habits', () => {
+    useHabitStore.setState({ loading: false, habits: [] });
+    const { getByText, getByTestId } = render(<HabitsStatTile />);
+    expect(getByText('No habits yet')).toBeTruthy();
+    expect(getByText('Add a habit →')).toBeTruthy();
+    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
+    expect(label).toBe("Today's habits, no habits yet. Add a habit");
+  });
+
+  it('navigates to Habits when the empty-state tile is pressed', () => {
+    useHabitStore.setState({ loading: false, habits: [] });
+    const { getByTestId } = render(<HabitsStatTile />);
+    fireEvent.press(getByTestId('journal-habits-tile'));
+    expect(mockNavigate).toHaveBeenCalledWith('Habits');
+  });
+
+  it('shows "Unlocks soon" when every habit is still locked', () => {
+    const lockedOne = makeHabit({
+      id: 2,
+      revealed: false,
+      start_date: new Date(Date.now() + 7 * DAY_MS),
+    });
+    const lockedTwo = makeHabit({
+      id: 3,
+      revealed: false,
+      start_date: new Date(Date.now() + 14 * DAY_MS),
+    });
+    useHabitStore.setState({ loading: false, habits: [lockedOne, lockedTwo] });
+    const { getByText, getByTestId } = render(<HabitsStatTile />);
+    expect(getByText('Unlocks soon')).toBeTruthy();
+    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
+    expect(label).toBe("Today's habits, unlocks soon. Open habits");
+  });
+
+  it('shows "1/2 done" when one of two unlocked habits was completed today', () => {
+    const done = makeHabit({
+      id: 4,
+      revealed: true,
+      completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+    });
+    const notDone = makeHabit({ id: 5, revealed: true, completions: [] });
+    useHabitStore.setState({ loading: false, habits: [done, notDone] });
+    const { getByText, getByTestId } = render(<HabitsStatTile />);
+    expect(getByText('1/2 done')).toBeTruthy();
+    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
+    expect(label).toContain('1 of 2 done');
+  });
+
+  it('calls habitManager.loadHabits with the user timezone on mount', () => {
+    useHabitStore.setState({ loading: false, habits: [] });
+    render(<HabitsStatTile />);
+    expect(mockLoadHabits).toHaveBeenCalledWith('UTC');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -44,6 +44,14 @@ jest.mock('../SearchBar', () => {
   return { __esModule: true, default: Stub };
 });
 
+// The stat-tile row owns its own stores, hooks, and dedicated suite; stub it so
+// the shelf tests stay focused on list/prompt/search behavior.
+jest.mock('../StatTileRow', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="stat-tile-row-stub" />;
+  return { __esModule: true, default: Stub };
+});
+
 const JournalShelfScreen = require('../JournalShelfScreen').default;
 
 function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {

--- a/frontend/src/features/Journal/__tests__/PracticesStatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/PracticesStatTile.test.tsx
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+interface WeeklyProgressMock {
+  count: number;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+let mockWeeklyProgress: WeeklyProgressMock = { count: 0, isLoading: false, error: null };
+
+jest.mock('@/features/Practice/hooks/useWeeklyProgress', () => ({
+  useWeeklyProgress: () => mockWeeklyProgress,
+}));
+
+import PracticesStatTile from '../PracticesStatTile';
+
+import { WEEKLY_TARGET } from '@/features/Practice/constants';
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockWeeklyProgress = { count: 0, isLoading: false, error: null };
+});
+
+describe('PracticesStatTile', () => {
+  it('shows the raw session count against the weekly target', () => {
+    mockWeeklyProgress = { count: 2, isLoading: false, error: null };
+    const { getByText } = render(<PracticesStatTile />);
+    expect(getByText(`2/${String(WEEKLY_TARGET)} this week`)).toBeTruthy();
+  });
+
+  it('navigates to Practice when pressed and labels the count in the a11y string', () => {
+    mockWeeklyProgress = { count: 2, isLoading: false, error: null };
+    const { getByTestId } = render(<PracticesStatTile />);
+    fireEvent.press(getByTestId('journal-practices-tile'));
+    expect(mockNavigate).toHaveBeenCalledWith('Practice');
+    const label = getByTestId('journal-practices-tile').props.accessibilityLabel as string;
+    expect(label).toContain(`2 of ${String(WEEKLY_TARGET)} done`);
+  });
+
+  it('does not clamp a count that exceeds the weekly target', () => {
+    mockWeeklyProgress = { count: 9, isLoading: false, error: null };
+    const { getByText } = render(<PracticesStatTile />);
+    expect(getByText(`9/${String(WEEKLY_TARGET)} this week`)).toBeTruthy();
+  });
+
+  it('shows the skeleton and no stat text while loading', () => {
+    mockWeeklyProgress = { count: 0, isLoading: true, error: null };
+    const { getByTestId, queryByText } = render(<PracticesStatTile />);
+    expect(getByTestId('journal-practices-tile-skeleton')).toBeTruthy();
+    expect(queryByText(/this week/)).toBeNull();
+  });
+
+  it('degrades to a countless, still-pressable tile on error', () => {
+    mockWeeklyProgress = { count: 0, isLoading: false, error: new Error('boom') };
+    const { getByTestId, queryByText } = render(<PracticesStatTile />);
+    expect(queryByText(/this week/)).toBeNull();
+    const tile = getByTestId('journal-practices-tile');
+    expect(tile).toBeTruthy();
+    const label = tile.props.accessibilityLabel as string;
+    expect(label).toContain('count unavailable');
+    fireEvent.press(tile);
+    expect(mockNavigate).toHaveBeenCalledWith('Practice');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/StatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/StatTile.test.tsx
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import StatTile from '../StatTile';
+
+const baseProps = {
+  title: 'Today',
+  cue: 'Open →',
+  accessibilityLabel: 'Today. Open',
+  testID: 'stat-tile',
+};
+
+describe('StatTile', () => {
+  it('renders the stat line when a stat is provided and not loading', () => {
+    const { getByText, queryByTestId } = render(
+      <StatTile {...baseProps} stat="1/3 done" onPress={jest.fn()} />,
+    );
+    expect(getByText('1/3 done')).toBeTruthy();
+    expect(queryByTestId('stat-tile-skeleton')).toBeNull();
+  });
+
+  it('renders the skeleton and no stat while loading', () => {
+    const { getByTestId, queryByText } = render(
+      <StatTile {...baseProps} loading stat="1/3 done" onPress={jest.fn()} />,
+    );
+    expect(getByTestId('stat-tile-skeleton')).toBeTruthy();
+    expect(queryByText('1/3 done')).toBeNull();
+  });
+
+  it('renders no stat body when neither loading nor a stat is given', () => {
+    const { queryByTestId, getByText } = render(<StatTile {...baseProps} onPress={jest.fn()} />);
+    expect(queryByTestId('stat-tile-skeleton')).toBeNull();
+    expect(getByText('Today')).toBeTruthy();
+    expect(getByText('Open →')).toBeTruthy();
+  });
+
+  it('is a button that fires onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(<StatTile {...baseProps} onPress={onPress} />);
+    const tile = getByTestId('stat-tile');
+    expect(tile.props.accessibilityRole).toBe('button');
+    fireEvent.press(tile);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/StatTileRow.test.tsx
+++ b/frontend/src/features/Journal/__tests__/StatTileRow.test.tsx
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('../HabitsStatTile', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="stub-habits" />;
+  return { __esModule: true, default: Stub };
+});
+
+jest.mock('../PracticesStatTile', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="stub-practices" />;
+  return { __esModule: true, default: Stub };
+});
+
+import StatTileRow from '../StatTileRow';
+
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+beforeEach(() => {
+  useDepthPreferencesStore.setState({ enable_habits: true, enable_practices: true });
+});
+
+describe('StatTileRow', () => {
+  it('renders the row with both tiles when both rings are on', () => {
+    const { getByTestId } = render(<StatTileRow />);
+    expect(getByTestId('journal-stat-tile-row')).toBeTruthy();
+    expect(getByTestId('stub-habits')).toBeTruthy();
+    expect(getByTestId('stub-practices')).toBeTruthy();
+  });
+
+  it('hides the habits tile when the habits ring is off', () => {
+    useDepthPreferencesStore.setState({ enable_habits: false, enable_practices: true });
+    const { getByTestId, queryByTestId } = render(<StatTileRow />);
+    expect(getByTestId('journal-stat-tile-row')).toBeTruthy();
+    expect(queryByTestId('stub-habits')).toBeNull();
+    expect(getByTestId('stub-practices')).toBeTruthy();
+  });
+
+  it('hides the practices tile when the practices ring is off', () => {
+    useDepthPreferencesStore.setState({ enable_habits: true, enable_practices: false });
+    const { getByTestId, queryByTestId } = render(<StatTileRow />);
+    expect(getByTestId('journal-stat-tile-row')).toBeTruthy();
+    expect(getByTestId('stub-habits')).toBeTruthy();
+    expect(queryByTestId('stub-practices')).toBeNull();
+  });
+
+  it('renders nothing when both rings are off', () => {
+    useDepthPreferencesStore.setState({ enable_habits: false, enable_practices: false });
+    const { queryByTestId } = render(<StatTileRow />);
+    expect(queryByTestId('journal-stat-tile-row')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/WeeklyProgress.tsx
+++ b/frontend/src/features/Practice/WeeklyProgress.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { WEEKLY_TARGET } from './constants';
+
 import { Celebration } from '@/components/feedback/Celebration';
 import { colors, SPACING, BORDER_RADIUS } from '@/design/tokens';
-
-const WEEKLY_TARGET = 4;
 
 /** Fixed segment indices so each completed session fills one visible block. */
 const SEGMENTS = Array.from({ length: WEEKLY_TARGET }, (_, i) => i);

--- a/frontend/src/features/Practice/constants.ts
+++ b/frontend/src/features/Practice/constants.ts
@@ -22,6 +22,9 @@ export const MIN_STAGE = 1;
 export const MAX_STAGE = 10;
 export const FALLBACK_STAGE = 1;
 
+/** Practice sessions that make up a full week's goal — the single source of truth for the weekly target. */
+export const WEEKLY_TARGET = 4;
+
 /** The inclusive integer stage range ``MIN_STAGE..MAX_STAGE`` as an array. */
 export const stageRange = (): number[] =>
   Array.from({ length: MAX_STAGE - MIN_STAGE + 1 }, (_, i) => MIN_STAGE + i);


### PR DESCRIPTION
## Summary

Adds a two-up stat-tile row directly under the Journal hero on the shelf, the day's pulse row for the merged journal home (epic #1168):

- **Habits tile** (half width) — "Today's habits", value "N/M done" for today over the unlocked habits, with a loading skeleton, a compact "No habits yet / Add a habit" state, and an "Unlocks soon" state; taps through to the Habits tab. Rendered only when the habits ring is on.
- **Practices tile** (half width) — "Practices", value "N/4 this week" (raw, unclamped) against the shared weekly target; loading skeleton while the hook resolves and a graceful **countless-but-still-pressable** degrade on fetch error so a failure never crashes the shelf. Rendered only when the practices ring is on.
- Ring gating via `selectEnableHabits` / `selectEnablePractices`: both on → two half-width tiles; one off → the remaining tile spans the row; both off → no row.

Implementation notes:
- New presentational `StatTile` primitive using the shelf's Candle & Ink paper-card recipe (`surface.desk` + `surfaceShadow.card`), tokens only, `accessibilityRole="button"` with spelled-out labels and a 44pt target.
- Habit counting lives in a new pure `habitCounts` helper (`countDoneToday` / `unlockedToday`). `countDoneToday` takes the user's timezone so the "today" bucket matches the Habits tab near a midnight boundary (completion semantics — `completed_units > 0` — mirror the Today band this tile replaces; `TodayScreen` is left untouched per the issue).
- `WEEKLY_TARGET` is extracted into `Practice/constants.ts` and reused by `WeeklyProgress` and the tile, so the denominator can never drift (grep-clean for a second weekly-target literal).
- The tile fires a one-shot `habitManager.loadHabits(userTimezone)` on mount: the Journal is now the app's initial tab and otherwise only the Habits screen populates the shared store, so without it the tile would show a false "No habits yet" on cold start.
- Added a global `expo-notifications` manual mock + `moduleNameMapper` entry — it was the one expo module not already mapped, and the shelf now transitively imports the habit manager; this keeps every test that renders the shelf loadable under Node (mirrors the six existing expo mocks).

## Test plan

- `frontend/src/features/Habits/__tests__/habitCounts.test.ts` — pure counts, `completed_units === 0` exclusion, other-day exclusion, unlocked filtering, and a deterministic timezone-bucketing test.
- `StatTile.test.tsx` — skeleton / stat / empty body branches + button press.
- `StatTileRow.test.tsx` — ring-gating matrix (both / habits-off / practices-off / both-off → null).
- `HabitsStatTile.test.tsx` — loading, empty + CTA, all-locked, `1/2 done` + a11y label, mount load.
- `PracticesStatTile.test.tsx` — raw count, unclamped over-target, loading skeleton, error degrade (countless, still navigates, "count unavailable" a11y).
- `JournalShelfScreen.test.tsx` stubs `StatTileRow` (mirroring its `SearchBar` stub); the shelf's list/prompt/search behavior is unchanged.
- `./scripts/frontend/check-all.sh` green (321 suites / 3254 tests, eslint `--max-warnings=0`, tsc, prettier); coverage thresholds unchanged.

Closes #1170
Refs #1168