### PR TITLE
fix(habits): add scroll affordance to goal-editor chip rows

### DIFF
--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -383,6 +383,11 @@ const goalEditorStyles = StyleSheet.create({
   chipRow: {
     paddingVertical: SPACING.xs,
   },
+  // Trailing gap so the last chip clears the modal border with breathing room
+  // instead of terminating in a hard flush cut that reads as broken layout.
+  chipRowContent: {
+    paddingRight: SPACING.md,
+  },
   chip: {
     paddingVertical: GOAL_CHIP_VERTICAL_PADDING,
     paddingHorizontal: GOAL_CHIP_HORIZONTAL_PADDING,
@@ -527,6 +532,31 @@ interface UnitChipRowProps {
 
 const formatUnitLabel = (value: string): string => value.replace(/_/g, ' ');
 
+interface ChipScrollRowProps {
+  testID: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Horizontal scroller shared by every editor chip row (Type / Unit / Every).
+ * The visible scroll indicator plus trailing content padding are the scroll
+ * *affordance*: a half-clipped pill flush against the modal border reads as
+ * broken layout, so the row must advertise that more options lie off-screen
+ * — done in the Candle & Ink language without a native picker or gradient
+ * dependency.
+ */
+const ChipScrollRow = ({ testID, children }: ChipScrollRowProps) => (
+  <ScrollView
+    horizontal
+    showsHorizontalScrollIndicator
+    style={goalEditorStyles.chipRow}
+    contentContainerStyle={goalEditorStyles.chipRowContent}
+    testID={testID}
+  >
+    {children}
+  </ScrollView>
+);
+
 /**
  * Horizontal chip selector used for ``target_unit`` and ``frequency_unit``.
  * A chip set fits the existing modal aesthetic without pulling in
@@ -540,12 +570,7 @@ const formatUnitLabel = (value: string): string => value.replace(/_/g, ' ');
  * "per day" rather than reading the raw "per_day" backend token.
  */
 const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) => (
-  <ScrollView
-    horizontal
-    showsHorizontalScrollIndicator={false}
-    style={goalEditorStyles.chipRow}
-    testID={testID}
-  >
+  <ChipScrollRow testID={testID}>
     {options.map((opt) => {
       const isSelected = opt === selected;
       const label = formatUnitLabel(opt);
@@ -567,7 +592,7 @@ const UnitChipRow = ({ options, selected, testID, onSelect }: UnitChipRowProps) 
         </TouchableOpacity>
       );
     })}
-  </ScrollView>
+  </ChipScrollRow>
 );
 
 /**
@@ -676,12 +701,7 @@ interface GoalDirectionRowProps {
 const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
   <View style={goalEditorStyles.row} testID="goal-direction-row">
     <Text style={goalEditorStyles.fieldLabel}>Type</Text>
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      style={goalEditorStyles.chipRow}
-      testID="goal-direction-chips"
-    >
+    <ChipScrollRow testID="goal-direction-chips">
       {DIRECTION_OPTIONS.map((opt) => {
         const selected = opt.value === isAdditive;
         return (
@@ -702,7 +722,7 @@ const GoalDirectionRow = ({ isAdditive, onChange }: GoalDirectionRowProps) => (
           </TouchableOpacity>
         );
       })}
-    </ScrollView>
+    </ChipScrollRow>
   </View>
 );
 

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../../../../context/AuthContext', () => ({
 // fireEvent.changeText / press behave as on a real device.
 
 import { dayKeyInTZ } from '../../../../utils/dateUtils';
+import { TARGET_UNITS, FREQUENCY_UNITS } from '../../constants';
 import type { Goal, Habit } from '../../Habits.types';
 import { GoalModal } from '../GoalModal';
 
@@ -769,5 +770,44 @@ describe('GoalModal icon editing', () => {
     expect(props.onUpdateHabit).toHaveBeenCalledWith(expect.objectContaining({ icon: '🎉' }));
     // Selecting an emoji closes the picker.
     expect(queryByTestId('emoji-selector-stub')).toBeNull();
+  });
+});
+
+describe('GoalModal chip-row scroll affordance', () => {
+  // The Type / Unit / Every chip rows are all horizontal ScrollViews. Without a
+  // scroll hint a half-clipped pill at the modal edge reads as broken layout, so
+  // each row must advertise that it scrolls.
+  const CHIP_ROW_TEST_IDS = ['goal-direction-chips', 'goal-target-unit', 'goal-frequency-unit'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(CHIP_ROW_TEST_IDS)('shows a horizontal scroll indicator on %s', (rowTestID) => {
+    const { getByTestId } = renderModal();
+    expect(getByTestId(rowTestID).props.showsHorizontalScrollIndicator).toBe(true);
+  });
+
+  it.each(CHIP_ROW_TEST_IDS)(
+    'gives %s trailing content padding so the last chip clears the modal edge',
+    (rowTestID) => {
+      const { getByTestId } = renderModal();
+      const contentStyle = StyleSheet.flatten(getByTestId(rowTestID).props.contentContainerStyle);
+      expect(contentStyle.paddingRight as number).toBeGreaterThan(0);
+    },
+  );
+
+  it('keeps every target-unit chip reachable inside its scroll row', () => {
+    const { getByTestId } = renderModal();
+    for (const unit of TARGET_UNITS) {
+      expect(getByTestId(`goal-target-unit-${unit}`)).toBeTruthy();
+    }
+  });
+
+  it('keeps every frequency-unit chip reachable inside its scroll row', () => {
+    const { getByTestId } = renderModal();
+    for (const unit of FREQUENCY_UNITS) {
+      expect(getByTestId(`goal-frequency-unit-${unit}`)).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
## Summary

The GoalModal goal editor's three horizontal chip rows — **Type** (`GoalDirectionRow`), **Unit** and **Every** (`UnitChipRow`) — clipped chips flush against the modal border with no scroll hint, so a half-visible pill (`cups`, `per mon…`) read as broken overflow even though the content is correctly contained (per the pixel measurement in #1166).

This routes all three rows through a shared `ChipScrollRow` wrapper that:

- re-enables the horizontal scroll indicator (`showsHorizontalScrollIndicator`), and
- adds trailing `contentContainerStyle` padding (`SPACING.md`) so the last chip clears the border with breathing room.

Both affordances are in the Candle & Ink language — no gradient library or native picker dependency. Every `TARGET_UNITS` / `FREQUENCY_UNITS` option stays reachable on 320–430 pt widths.

## Test plan

- New TDD block in `GoalModal.test.tsx` (written RED first): parametrized assertions that all three chip rows expose `showsHorizontalScrollIndicator === true` and a trailing `paddingRight > 0`, plus reachability loops over every target-unit and frequency-unit chip.
- `cd frontend && npx tsc --noEmit` — clean
- `npm run lint` — clean
- `./scripts/frontend/check-all.sh` — all 4 checks pass (3235 tests green)

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)