### PR TITLE
refactor(today): honest-simplify useMettaReturn — drop vestigial arc-snapshot revert

### DIFF
--- a/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Today/__tests__/useMettaReturn.test.tsx
@@ -219,7 +219,7 @@ describe('useMettaReturn', () => {
     expect(result.current.arc?.focus).toBe('self');
   });
 
-  it('pause calls the API and updates arc.paused optimistically, reverting on error', async () => {
+  it('pause surfaces the API error and leaves the arc unchanged', async () => {
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc({ paused: false }) }));
     mockPause.mockRejectedValue(new Error('network error'));
     const { result } = renderHook(() => useMettaReturn());

--- a/frontend/src/features/Today/useMettaReturn.ts
+++ b/frontend/src/features/Today/useMettaReturn.ts
@@ -6,9 +6,10 @@
  * the tab, and the offer only becomes visible when the person is eligible, a
  * contraction is currently observed, they have not already set the offer aside,
  * and no arc is running. ``dismissOffer`` hides the offer and persists the
- * decline; ``start``/``pause``/``resume``/``leave`` update the local arc
- * optimistically and revert on error. An unmount guard keeps late resolutions
- * from setting state on a dead hook.
+ * decline; ``start``/``pause``/``resume``/``leave`` commit the local arc only
+ * after the API confirms — a rejected call propagates the error and leaves the
+ * arc unchanged. An unmount guard keeps late resolutions from setting state on a
+ * dead hook.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
@@ -93,13 +94,6 @@ function useLoadedReturn(): LoadedReturn {
 export function useMettaReturn(): UseMettaReturnResult {
   const { eligible, weeks, arc, dismissed, setArc, setDismissed, mountedRef } = useLoadedReturn();
   const contractionActive = useContractionSignalActive();
-  const arcRef = useRef<ReturnArc | null>(null);
-
-  // Mirror the committed arc into a ref so a lifecycle call can snapshot it
-  // synchronously for the revert branch when the API rejects immediately.
-  useEffect(() => {
-    arcRef.current = arc;
-  }, [arc]);
 
   const dismissOffer = useCallback(async (): Promise<void> => {
     setDismissed(true);
@@ -118,14 +112,8 @@ export function useMettaReturn(): UseMettaReturnResult {
 
   const runLifecycle = useCallback(
     async (call: () => Promise<ReturnArc>): Promise<void> => {
-      const snapshot = arcRef.current;
-      try {
-        const updated = await call();
-        if (mountedRef.current) setArc(updated);
-      } catch (err) {
-        if (mountedRef.current) setArc(snapshot);
-        throw err;
-      }
+      const updated = await call();
+      if (mountedRef.current) setArc(updated);
     },
     [mountedRef, setArc],
   );


### PR DESCRIPTION
## Summary

`useMettaReturn`'s module docstring claimed that `start`/`pause`/`resume`/`leave` update the local arc **optimistically and revert on error** — but no verb ever mutated the arc before its `await`. The `runLifecycle` catch branch restored `arcRef.current`, which equalled the already-committed arc, so the "revert" was a guaranteed no-op, and the `arcRef` mirror effect existed solely to feed it (a lying docstring plus vestigial machinery).

This is Direction A (honest-simplify) from the issue:

- Delete the `arcRef` mirror effect and the snapshot/revert branch, collapsing `runLifecycle` to await-then-commit (`const updated = await call(); if (mountedRef.current) setArc(updated);`).
- Rewrite the docstring to describe the real behavior: the lifecycle verbs commit the arc **after** the API confirms; a rejected call propagates the error and leaves the arc unchanged.
- Rename the misleading pause test to `'pause surfaces the API error and leaves the arc unchanged'` to match what it actually asserts.

Behavior-preserving — no functional change; the public `UseMettaReturnResult` API is untouched. Scope is strictly the docstring + vestigial snapshot machinery; the offer-visibility logic, load path, and unmount guard are unchanged.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- Full Jest suite via `./scripts/frontend/check-all.sh` — 322 suites / 3275 tests pass, coverage gate holds (≥90%)
- The renamed pause test still asserts the real behavior (error propagates, `arc.paused` unchanged); the success path stays covered by the resume test
- Gate 2.5 self-review (code-review-orchestrator): CLEAN, no blockers

Closes #1201