### PR TITLE
feat(journal): carry the Return arc and invitation cards onto the Journal shelf

### DIFF
--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -25,6 +25,8 @@ import { Button } from '@/components/Button';
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { ScreenHeader } from '@/components/layout/ScreenHeader';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import InvitationStack from '@/features/Today/InvitationStack';
+import ReturnStack from '@/features/Today/ReturnStack';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
@@ -350,6 +352,8 @@ function ShelfTopMatter({
     <View>
       <JournalHero />
       <StatTileRow />
+      <ReturnStack />
+      <InvitationStack />
       <ScreenHeader
         title="Journal"
         action={<Button label="New entry" onPress={onNew} testID="journal-new-entry" />}

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -61,7 +61,40 @@ jest.mock('../StatTileRow', () => {
   return { __esModule: true, default: Stub };
 });
 
+// The Return and invitation surfaces render on the shelf from Today; stub them
+// so shelf tests stay focused on ordering, not on Return/invitation state.
+jest.mock('@/features/Today/ReturnStack', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="return-stack-stub" />;
+  return { __esModule: true, default: Stub };
+});
+jest.mock('@/features/Today/InvitationStack', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="invitation-stack-stub" />;
+  return { __esModule: true, default: Stub };
+});
+
 const JournalShelfScreen = require('../JournalShelfScreen').default;
+
+type RenderedNode = {
+  props: { testID?: unknown };
+  children: (RenderedNode | string)[] | null;
+};
+
+// Depth-first list of testID markers (#id) and raw text nodes, in render order.
+// Walks only children (never props) so React element props stay non-circular.
+function flattenOrder(node: RenderedNode | RenderedNode[] | string | null): string[] {
+  if (node === null) return [];
+  if (typeof node === 'string') return [node];
+  if (Array.isArray(node)) return node.flatMap((child) => flattenOrder(child));
+  const out: string[] = [];
+  const testID = node.props.testID;
+  if (typeof testID === 'string') out.push(`#${testID}`);
+  const children = node.children;
+  if (children === null) return out;
+  for (const child of children) out.push(...flattenOrder(child));
+  return out;
+}
 
 function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {
   return {
@@ -457,5 +490,19 @@ describe('JournalShelfScreen', () => {
     const { findByTestId } = render(<JournalShelfScreen />);
     fireEvent.press(await findByTestId('journal-hero-position'));
     expect(mockNavigate).toHaveBeenCalledWith('Map');
+  });
+
+  it('stacks Return above invitations, after the stat tiles and before the header', async () => {
+    const { findByTestId, toJSON } = render(<JournalShelfScreen />);
+    await findByTestId('stat-tile-row-stub');
+    const order = flattenOrder(toJSON());
+    const statIndex = order.indexOf('#stat-tile-row-stub');
+    const returnIndex = order.indexOf('#return-stack-stub');
+    const invitationIndex = order.indexOf('#invitation-stack-stub');
+    const headerIndex = order.indexOf('Journal');
+    expect(statIndex).toBeGreaterThan(-1);
+    expect(returnIndex).toBeGreaterThan(statIndex);
+    expect(invitationIndex).toBeGreaterThan(returnIndex);
+    expect(headerIndex).toBeGreaterThan(invitationIndex);
   });
 });

--- a/frontend/src/features/Today/InvitationStack.tsx
+++ b/frontend/src/features/Today/InvitationStack.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import InvitationNote from './InvitationNote';
+import { useInvitations } from './useInvitations';
+
+/** The pending invitations (NORTH-STAR §6): silent when empty, one card each. */
+const InvitationStack = (): React.JSX.Element | null => {
+  const { invitations, dismiss } = useInvitations();
+  if (invitations.length === 0) return null;
+  return (
+    <>
+      {invitations.map((invitation) => (
+        <InvitationNote key={invitation.id} invitation={invitation} onDismiss={dismiss} />
+      ))}
+    </>
+  );
+};
+
+export default InvitationStack;

--- a/frontend/src/features/Today/ReturnStack.tsx
+++ b/frontend/src/features/Today/ReturnStack.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import ReturnArcCard from './ReturnArcCard';
+import ReturnCompletionCard from './ReturnCompletionCard';
+import ReturnOfferCard from './ReturnOfferCard';
+import { useMettaReturn } from './useMettaReturn';
+
+/** The Return surface: the soft-landing offer when invited, or the active arc. */
+const ReturnStack = (): React.JSX.Element | null => {
+  const { weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave } = useMettaReturn();
+  if (arc !== null && arc.complete) {
+    return <ReturnCompletionCard onLeave={() => void leave()} />;
+  }
+  if (arc !== null) {
+    return (
+      <ReturnArcCard
+        weeks={weeks}
+        arc={arc}
+        onPause={() => void pause()}
+        onResume={() => void resume()}
+        onLeave={() => void leave()}
+      />
+    );
+  }
+  if (offerVisible) {
+    return <ReturnOfferCard onAccept={() => void start()} onDismiss={dismissOffer} />;
+  }
+  return null;
+};
+
+export default ReturnStack;

--- a/frontend/src/features/Today/TodayScreen.tsx
+++ b/frontend/src/features/Today/TodayScreen.tsx
@@ -3,13 +3,9 @@ import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { Animated, Pressable, Text } from 'react-native';
 
-import InvitationNote from './InvitationNote';
-import ReturnArcCard from './ReturnArcCard';
-import ReturnCompletionCard from './ReturnCompletionCard';
-import ReturnOfferCard from './ReturnOfferCard';
+import InvitationStack from './InvitationStack';
+import ReturnStack from './ReturnStack';
 import { todayStyles as s } from './Today.styles';
-import { useInvitations } from './useInvitations';
-import { useMettaReturn } from './useMettaReturn';
 
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { SkeletonCard } from '@/components/feedback/Skeleton';
@@ -150,42 +146,6 @@ const HabitsBand = ({ index, onPress }: { index: number; onPress: () => void }) 
       testID="today-habits-band"
     />
   );
-};
-
-/** The pending invitations (NORTH-STAR §6): silent when empty, one card each. */
-const InvitationStack = (): React.JSX.Element | null => {
-  const { invitations, dismiss } = useInvitations();
-  if (invitations.length === 0) return null;
-  return (
-    <>
-      {invitations.map((invitation) => (
-        <InvitationNote key={invitation.id} invitation={invitation} onDismiss={dismiss} />
-      ))}
-    </>
-  );
-};
-
-/** The Return surface: the soft-landing offer when invited, or the active arc. */
-const ReturnStack = (): React.JSX.Element | null => {
-  const { weeks, arc, offerVisible, dismissOffer, start, pause, resume, leave } = useMettaReturn();
-  if (arc !== null && arc.complete) {
-    return <ReturnCompletionCard onLeave={() => void leave()} />;
-  }
-  if (arc !== null) {
-    return (
-      <ReturnArcCard
-        weeks={weeks}
-        arc={arc}
-        onPause={() => void pause()}
-        onResume={() => void resume()}
-        onLeave={() => void leave()}
-      />
-    );
-  }
-  if (offerVisible) {
-    return <ReturnOfferCard onAccept={() => void start()} onDismiss={dismissOffer} />;
-  }
-  return null;
 };
 
 /** The editorial home tab: where am I in the journey, and what's next today. */

--- a/frontend/src/features/Today/__tests__/InvitationStack.test.tsx
+++ b/frontend/src/features/Today/__tests__/InvitationStack.test.tsx
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+import { jest, beforeEach, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockDismiss = jest.fn();
+let mockInvitations: Invitation[] = [];
+jest.mock('../useInvitations', () => ({
+  useInvitations: () => ({ invitations: mockInvitations, dismiss: mockDismiss }),
+}));
+
+import InvitationStack from '../InvitationStack';
+
+import type { Invitation } from '@/api';
+
+const makeInvitation = (id: number): Invitation => ({
+  id,
+  target_type: 'practice',
+  target_id: null,
+  kind: 'readiness',
+  created_at: '2026-01-01T00:00:00Z',
+});
+
+beforeEach(() => {
+  mockDismiss.mockClear();
+  mockInvitations = [];
+});
+
+describe('InvitationStack', () => {
+  it('renders nothing when there are no pending invitations', () => {
+    const { toJSON } = render(<InvitationStack />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders one card per pending invitation', () => {
+    mockInvitations = [makeInvitation(1), makeInvitation(2)];
+    const { getByTestId } = render(<InvitationStack />);
+    expect(getByTestId('invitation-1')).toBeTruthy();
+    expect(getByTestId('invitation-2')).toBeTruthy();
+  });
+
+  it('dismisses the invitation by id when its decline button is pressed', () => {
+    mockInvitations = [makeInvitation(5)];
+    const { getByTestId } = render(<InvitationStack />);
+    fireEvent.press(getByTestId('invitation-5-dismiss'));
+    expect(mockDismiss).toHaveBeenCalledWith(5);
+  });
+});

--- a/frontend/src/features/Today/__tests__/ReturnStack.test.tsx
+++ b/frontend/src/features/Today/__tests__/ReturnStack.test.tsx
@@ -1,0 +1,143 @@
+/* eslint-env jest */
+import { jest, beforeEach, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+const mockDismissOffer = jest.fn();
+const mockStart = jest.fn();
+const mockPause = jest.fn();
+const mockResume = jest.fn();
+const mockLeave = jest.fn();
+let mockMettaReturn: {
+  eligible: boolean;
+  weeks: ReturnWeek[];
+  arc: ReturnArc | null;
+  offerVisible: boolean;
+};
+jest.mock('../useMettaReturn', () => ({
+  useMettaReturn: () => ({
+    ...mockMettaReturn,
+    dismissOffer: mockDismissOffer,
+    start: mockStart,
+    pause: mockPause,
+    resume: mockResume,
+    leave: mockLeave,
+  }),
+}));
+
+import ReturnStack from '../ReturnStack';
+
+import type { ReturnArc, ReturnWeek } from '@/api';
+
+const makeWeek = (weekNumber: number): ReturnWeek => ({
+  week_number: weekNumber,
+  focus: 'self',
+  title: `Toward yourself, week ${weekNumber}`,
+  framing: 'Begin where you already are.',
+});
+
+const makeArc = (weekNumber: number, complete = false, paused = false): ReturnArc => ({
+  started_at: '2026-06-24T00:00:00Z',
+  paused,
+  week: weekNumber,
+  focus: 'self',
+  complete,
+});
+
+beforeEach(() => {
+  mockDismissOffer.mockClear();
+  mockStart.mockClear();
+  mockPause.mockClear();
+  mockResume.mockClear();
+  mockLeave.mockClear();
+  mockMettaReturn = { eligible: false, weeks: [], arc: null, offerVisible: false };
+});
+
+describe('ReturnStack', () => {
+  it('renders nothing with no active arc and no visible offer', () => {
+    const { toJSON } = render(<ReturnStack />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('shows the completion card, not the arc card, when the arc is complete', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(5)],
+      arc: makeArc(5, true),
+      offerVisible: false,
+    };
+    const { getByTestId, queryByTestId } = render(<ReturnStack />);
+    expect(getByTestId('return-completion-card')).toBeTruthy();
+    expect(queryByTestId('return-arc-card')).toBeNull();
+    fireEvent.press(getByTestId('return-completion-leave'));
+    expect(mockLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the arc card, not the completion card, when the arc is active and not complete', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(2)],
+      arc: makeArc(2),
+      offerVisible: false,
+    };
+    const { getByTestId, queryByTestId } = render(<ReturnStack />);
+    expect(getByTestId('return-arc-card')).toBeTruthy();
+    expect(queryByTestId('return-completion-card')).toBeNull();
+  });
+
+  it('pauses the active arc when the pause action is pressed', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(2)],
+      arc: makeArc(2),
+      offerVisible: false,
+    };
+    const { getByTestId } = render(<ReturnStack />);
+    fireEvent.press(getByTestId('return-arc-pause'));
+    expect(mockPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes a paused arc when the resume action is pressed', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(2)],
+      arc: makeArc(2, false, true),
+      offerVisible: false,
+    };
+    const { getByTestId } = render(<ReturnStack />);
+    fireEvent.press(getByTestId('return-arc-resume'));
+    expect(mockResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the active arc when the leave action is pressed', () => {
+    mockMettaReturn = {
+      eligible: true,
+      weeks: [makeWeek(2)],
+      arc: makeArc(2),
+      offerVisible: false,
+    };
+    const { getByTestId } = render(<ReturnStack />);
+    fireEvent.press(getByTestId('return-arc-leave'));
+    expect(mockLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the offer card when there is no arc and the offer is visible', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: true };
+    const { getByTestId } = render(<ReturnStack />);
+    expect(getByTestId('return-offer-card')).toBeTruthy();
+  });
+
+  it('starts the arc when the offer is accepted', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: true };
+    const { getByTestId } = render(<ReturnStack />);
+    fireEvent.press(getByTestId('return-offer-accept'));
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses the offer when it is declined', () => {
+    mockMettaReturn = { eligible: true, weeks: [makeWeek(1)], arc: null, offerVisible: true };
+    const { getByTestId } = render(<ReturnStack />);
+    fireEvent.press(getByTestId('return-offer-dismiss'));
+    expect(mockDismissOffer).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Re-homes the two live conditional Today surfaces onto the Journal shelf so the epic can later remove the Today tab without silently killing them:

- Extracts `ReturnStack` (the declinable Metta Return offer/arc + guided-session entry) and `InvitationStack` (the pending-invitation cards, silent when empty) from `TodayScreen` into their own default-exported components under `frontend/src/features/Today/`, each with its own test.
- Renders them in `JournalShelfScreen`'s `ShelfTopMatter`, between the stat-tile row and the "Journal" header, in the same order as on Today (`ReturnStack` above `InvitationStack`).
- Switches `TodayScreen` to the extracted components so there is a single implementation (no duplicated stack logic).
- Behavior is unchanged: the extracted bodies are byte-identical to the originals, and both stacks stay completely silent when there is no arc, offer, or invitation. `useMettaReturn` / `useInvitations` internals are untouched.

The Journal shelf imports from `@/features/Today/...` for now; the removal issue (#1172) relocates the files to their durable home.

## Test plan
- New `ReturnStack.test.tsx` covers all four render branches (completion / arc / offer / null) plus pause/resume/leave/start/dismiss passthrough (including the completion-card leave action).
- New `InvitationStack.test.tsx` covers empty → null, one card per invitation, and dismiss-by-id.
- Extended `JournalShelfScreen.test.tsx` stubs both stacks and asserts render order (stat tiles → ReturnStack → InvitationStack → "Journal" header) via a DFS traversal.
- Existing `TodayScreen.test.tsx` passes unchanged, confirming behavior-identical extraction.
- `./scripts/frontend/check-all.sh` green: ESLint (0 warnings), tsc, prettier, and the full Jest suite (3280 tests).

Closes #1171
Refs #1168