### PR TITLE
refactor(frontend): source invitation enums from the API schema

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1344,6 +1344,11 @@ export const completionSuggestions = {
 // Invitations client (subtle invitation surface, NORTH-STAR §6)
 export type Invitation = InvitationT;
 
+// Re-export the invitation enums so callers derive target/kind values and types
+// from this single API-owned source rather than hand-rolling parallel copies.
+export { invitationTargetTypeSchema, invitationKindSchema } from './schemas';
+export type { InvitationTargetTypeT, InvitationKindT } from './schemas';
+
 /**
  * The declinable invitation surface (silent-by-default, one-tap decline). ``list``
  * returns a bare array (not an ``{ items }`` envelope); ``dismiss`` permanently

--- a/frontend/src/features/Today/__tests__/invitationCopy.test.ts
+++ b/frontend/src/features/Today/__tests__/invitationCopy.test.ts
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { invitationCopy, INVITATION_COPY_ENTRIES } from '../invitationCopy';
+
+import { invitationTargetTypeSchema, invitationKindSchema } from '@/api';
+
+/**
+ * Drift guard: ``invitationCopy`` must derive its target/kind enums from the
+ * API schema, never from a hand-rolled parallel copy. These assertions fail the
+ * moment a schema member gains no copy or the enumeration stops matching the
+ * schema's cartesian product — the runtime backstop to the compile-time check.
+ */
+describe('invitationCopy drift guard', () => {
+  const targets = invitationTargetTypeSchema.options;
+  const kinds = invitationKindSchema.options;
+
+  it('enumerates exactly the schema target × kind cartesian product', () => {
+    expect(INVITATION_COPY_ENTRIES).toHaveLength(targets.length * kinds.length);
+
+    const seen = new Set(INVITATION_COPY_ENTRIES.map((e) => `${e.targetType}:${e.kind}`));
+    const expected = new Set(targets.flatMap((t) => kinds.map((k) => `${t}:${k}`)));
+    expect(seen).toEqual(expected);
+  });
+
+  it('names every schema member — no line contains a literal "undefined"', () => {
+    for (const targetType of targets) {
+      for (const kind of kinds) {
+        const { line } = invitationCopy(targetType, kind);
+        expect(line).not.toContain('undefined');
+      }
+    }
+  });
+
+  it('every enumerated entry carries a non-empty rendered line', () => {
+    for (const entry of INVITATION_COPY_ENTRIES) {
+      expect(entry.line.length).toBeGreaterThan(0);
+      expect(entry.line).not.toContain('undefined');
+    }
+  });
+});

--- a/frontend/src/features/Today/invitationCopy.ts
+++ b/frontend/src/features/Today/invitationCopy.ts
@@ -5,22 +5,16 @@
  * declinable invitation, never a growth nudge, never shame, never urgency.
  * ``invitationCopy`` derives one line + its decline accessibility label from a
  * target/kind pair; ``INVITATION_COPY_ENTRIES`` enumerates all 15 combinations.
+ *
+ * The target/kind enums are the single source of truth owned by the API schema
+ * (``@/api``); this file derives its values and types from there so a new enum
+ * member forces a compile error here rather than a silent ``undefined`` line.
  */
-
-/** The 5 invitation target types the backend can offer (NORTH-STAR §6). */
-const TARGET_TYPES = ['habit', 'practice', 'course', 'sangha', 'embodied_community'] as const;
-
-/** The 3 invitation kinds — the moment that occasioned the offer. */
-const KINDS = ['readiness', 'consistency', 'mastery'] as const;
-
-/** A backend invitation target type (structurally identical to the API enum). */
-export type InvitationTargetType = (typeof TARGET_TYPES)[number];
-
-/** A backend invitation kind. */
-export type InvitationKind = (typeof KINDS)[number];
+import { invitationTargetTypeSchema, invitationKindSchema } from '@/api';
+import type { InvitationTargetTypeT, InvitationKindT } from '@/api';
 
 /** The named thing each target invites toward, phrased for the middle of a sentence. */
-const TARGET_NOUN: Record<InvitationTargetType, string> = {
+const TARGET_NOUN: Record<InvitationTargetTypeT, string> = {
   habit: 'a small daily habit',
   practice: 'a practice',
   course: 'the next reading',
@@ -29,7 +23,7 @@ const TARGET_NOUN: Record<InvitationTargetType, string> = {
 };
 
 /** The gentle framing for each kind — why this door is being opened, softly. */
-const KIND_OPENER: Record<InvitationKind, string> = {
+const KIND_OPENER: Record<InvitationKindT, string> = {
   readiness: 'If it feels right, there’s',
   consistency: 'Whenever you’d like, there’s',
   mastery: 'If you’re curious, there’s a deeper',
@@ -44,14 +38,14 @@ export interface InvitationCopy {
 
 /** One flattened copy row: its target/kind key alongside its rendered strings. */
 export interface InvitationCopyEntry extends InvitationCopy {
-  targetType: InvitationTargetType;
-  kind: InvitationKind;
+  targetType: InvitationTargetTypeT;
+  kind: InvitationKindT;
 }
 
 /** Compose the invitation line + its decline accessibility label for a pair. */
 export function invitationCopy(
-  targetType: InvitationTargetType,
-  kind: InvitationKind,
+  targetType: InvitationTargetTypeT,
+  kind: InvitationKindT,
 ): InvitationCopy {
   return {
     line: `${KIND_OPENER[kind]} ${TARGET_NOUN[targetType]} ${LINE_TAIL}`,
@@ -60,6 +54,11 @@ export function invitationCopy(
 }
 
 /** All 15 target/kind combinations, precomputed for the banned-copy sweep. */
-export const INVITATION_COPY_ENTRIES: ReadonlyArray<InvitationCopyEntry> = TARGET_TYPES.flatMap(
-  (targetType) => KINDS.map((kind) => ({ targetType, kind, ...invitationCopy(targetType, kind) })),
-);
+export const INVITATION_COPY_ENTRIES: ReadonlyArray<InvitationCopyEntry> =
+  invitationTargetTypeSchema.options.flatMap((targetType) =>
+    invitationKindSchema.options.map((kind) => ({
+      targetType,
+      kind,
+      ...invitationCopy(targetType, kind),
+    })),
+  );


### PR DESCRIPTION
## Summary

`invitationCopy.ts` hand-rolled the invitation target-type and kind enums that `api/schemas.ts` already owns, creating two parallel sources of truth kept in lock-step by hand (Family 3 duplication / Family 4 cross-layer coupling). This sources both enums from the single API-owned definition:

- Re-exports `invitationTargetTypeSchema` / `invitationKindSchema` and their inferred `InvitationTargetTypeT` / `InvitationKindT` types from `@/api`.
- Rewrites `invitationCopy.ts` to type `TARGET_NOUN` / `KIND_OPENER` `Record`s on the API types and drive `INVITATION_COPY_ENTRIES` off `schema.options` — deleting the local `TARGET_TYPES` / `KINDS` tuples and duplicate `InvitationTargetType` / `InvitationKind` types (which had zero external importers).

Now adding a member to `invitationTargetTypeSchema` forces a TypeScript compile error in `invitationCopy.ts` (verified locally) instead of a silent `undefined` invitation line.

Behavior-preserving: copy strings, `INVITATION_COPY_ENTRIES` shape, and target-major/kind-minor ordering are unchanged (`schema.options` order is element-identical to the removed tuples).

## Test plan

- Added `frontend/src/features/Today/__tests__/invitationCopy.test.ts` — a drift guard pinning the enumeration to the schema's cartesian product and asserting no member renders a literal `undefined` (runtime backstop to the compile-time `Record` check).
- Existing `InvitationNote.test.tsx` banned-copy sweep (length 15, per-entry copy content) still passes unchanged.
- `npx tsc --noEmit`, `npm run lint`, and the full Jest suite (3278 tests) pass; `./scripts/frontend/check-all.sh` green.
- Verified the compile-error criterion by temporarily adding a schema member (TS2741 raised in `invitationCopy.ts`), then reverting.

Closes #1202
Refs #1168