### PR TITLE
refactor(course): read stage-cover colors from showcase tokens

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -4,11 +4,13 @@ import {
   accent,
   editorialType,
   ink,
+  onShowcase,
   paperShadow,
   radius,
   rhythm,
   SPACING,
   shadows,
+  showcase,
   surface,
   surfaceShadow,
   touchTarget,
@@ -79,18 +81,18 @@ const styles = StyleSheet.create({
   },
   stageCoverEyebrow: {
     ...editorialType.caption,
-    color: '#a8967c', // onShowcase.muted — small-caps eyebrow on the umber
+    color: onShowcase.muted,
     textTransform: 'uppercase',
     letterSpacing: 1,
     marginBottom: SPACING.xs,
   },
   stageCoverTitle: {
     ...editorialType.title,
-    color: '#f3ece0', // onShowcase.primary
+    color: onShowcase.primary,
   },
   stageCoverSubtitle: {
     ...editorialType.note,
-    color: '#cdbfae', // onShowcase.soft
+    color: onShowcase.soft,
     marginTop: 2,
   },
   // Spiral-Dynamics accent rule under the title.
@@ -103,7 +105,7 @@ const styles = StyleSheet.create({
   stageCoverProgressTrack: {
     height: STAGE_COVER_ARC,
     borderRadius: STAGE_COVER_ARC / 2,
-    backgroundColor: '#352a20', // showcase.raised — a recessed step on the band
+    backgroundColor: showcase.raised,
     overflow: 'hidden',
     marginTop: SPACING.md,
   },
@@ -113,7 +115,7 @@ const styles = StyleSheet.create({
   },
   stageCoverProgressLabel: {
     ...editorialType.caption,
-    color: '#a8967c', // onShowcase.muted
+    color: onShowcase.muted,
     marginTop: SPACING.xs,
   },
 

--- a/frontend/src/features/Course/__tests__/Course.styles.test.ts
+++ b/frontend/src/features/Course/__tests__/Course.styles.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { StyleSheet } from 'react-native';
 
-import { accent, editorialType, ink, surface } from '../../../design/tokens';
+import { accent, editorialType, ink, onShowcase, showcase, surface } from '../../../design/tokens';
 import styles, { markdownStyles } from '../Course.styles';
 
 describe('Course.styles reader sheet', () => {
@@ -39,5 +39,21 @@ describe('Course.styles reader sheet', () => {
     const hr = StyleSheet.flatten(markdownStyles.hr);
     expect(blockquote.borderLeftColor).toBe(accent.primary);
     expect(hr.backgroundColor).toBe(accent.primary);
+  });
+
+  it('reads the stage-cover ink from the WCAG-asserted showcase tokens', () => {
+    const eyebrow = StyleSheet.flatten(styles.stageCoverEyebrow);
+    const title = StyleSheet.flatten(styles.stageCoverTitle);
+    const subtitle = StyleSheet.flatten(styles.stageCoverSubtitle);
+    const progressLabel = StyleSheet.flatten(styles.stageCoverProgressLabel);
+    expect(eyebrow.color).toBe(onShowcase.muted);
+    expect(title.color).toBe(onShowcase.primary);
+    expect(subtitle.color).toBe(onShowcase.soft);
+    expect(progressLabel.color).toBe(onShowcase.muted);
+  });
+
+  it('recesses the stage-cover progress track with the showcase.raised step', () => {
+    const track = StyleSheet.flatten(styles.stageCoverProgressTrack);
+    expect(track.backgroundColor).toBe(showcase.raised);
   });
 });


### PR DESCRIPTION
## Summary
`Course.styles.ts` hardcoded four color hexes in the `stageCover*` block that
were byte-for-byte copies of the `showcase` / `onShowcase` tokens in
`design/tokens.ts`. Because the copies lived outside the token file, the Course
"book cover" was invisible to the WCAG-AA contrast guard in
`showcaseTokens.test.ts` and would silently drift below contrast on a token
retune. This imports `showcase` / `onShowcase` and reads the four literals from
the tokens instead:

- `#a8967c` (eyebrow + progress label) → `onShowcase.muted`
- `#f3ece0` (title) → `onShowcase.primary`
- `#cdbfae` (subtitle) → `onShowcase.soft`
- `#352a20` (progress track) → `showcase.raised`

The now-redundant `// onShowcase.*` trailing comments are removed. Token values
are byte-identical to the removed hexes, so rendered colors are unchanged.

## Test plan
- New `Course.styles` guard test pins each stage-cover color to its token
  (`onShowcase.muted/primary/soft`, `showcase.raised`), locking against future
  drift.
- Existing `CourseScreen` Spiral-Dynamics color tests still pass unchanged.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, tsc, 3274 tests).

Closes #1210