### PR TITLE
test(map): extract a shared harness to kill duplicated MapScreen mock scaffold

### DIFF
--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -4,110 +4,33 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
-// Mock navigation
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
+import MapScreen from '../MapScreen';
 
-/** Inline type to avoid import/order conflict with type-only parent imports. */
-interface StageHistoryData {
-  stage_number: number;
-  practices: Array<{
-    name: string;
-    sessions_completed: number;
-    total_minutes: number;
-    last_session: string | null;
-  }>;
-  habits: Array<{
-    name: string;
-    icon: string;
-    goals_achieved: Record<string, boolean>;
-    best_streak: number;
-    total_completions: number;
-  }>;
-}
+import type { StageHistoryData } from './mapTestHarness';
+import { resetMapMocks } from './mapTestHarness';
 
-// Mock API — must be declared before use in jest.mock factory
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
+
 const mockHistoryFn = jest.fn<Promise<StageHistoryData>, [number, string?]>();
-
 jest.mock('../../../api', () => ({
   stages: {
     history: (...args: [number, string?]) => mockHistoryFn(...args),
   },
 }));
-
-function mockMakeStage(stageNumber: number, overrides: Partial<{ isUnlocked: boolean }> = {}) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress: 0,
-    color: '#aaa',
-    isUnlocked: overrides.isUnlocked ?? stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description',
-    overviewUrl: '',
-    hotspots: [
-      { top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 },
-      { top: (10 - stageNumber) * 8 + 4, left: 34, width: 40, height: 6 },
-    ],
-  };
-}
-
-const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
-
-const mockLoadStages = jest.fn();
-jest.mock('../services/stageService', () => ({
-  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
-  isEndOfCycle: () => false,
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: false,
-  error: null,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const mockState = buildMockStageState();
-    return selector ? selector(mockState) : mockState;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-  selectStageByNumber:
-    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
-      n == null ? undefined : s.stagesByNumber[n],
-}));
-
-import MapScreen from '../MapScreen';
 
 const HISTORY_WITH_DATA: StageHistoryData = {
   stage_number: 1,
@@ -138,8 +61,7 @@ const EMPTY_HISTORY: StageHistoryData = {
 
 describe('MapScreen — Stage History', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
+    resetMapMocks();
     mockHistoryFn.mockReset();
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });

--- a/frontend/src/features/Map/__tests__/MapJourney.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapJourney.test.tsx
@@ -4,23 +4,25 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
-jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
-  runAfterInteractions: (cb: () => void) => {
-    cb();
-    return { then: () => {}, done: () => {}, cancel: () => {} };
-  },
-}));
+import MapScreen from '../MapScreen';
 
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
+import type { StageHistoryData } from './mapTestHarness';
+import { mockMakeStage, mockMapState, mockNavigate, resetMapMocks } from './mapTestHarness';
+
+import { showcase } from '@/design/tokens';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
 
 // Reduced-motion-safe path: no Animated pulse (Animated trips the test
 // renderer's InteractionManager). Asserts the celebration still renders at rest.
@@ -28,31 +30,15 @@ jest.mock('@/hooks/useReducedMotion', () => ({
   useReducedMotion: () => true,
 }));
 
-let mockDerivedStage = 1;
-let mockDerivedWeek = 1;
-let mockDaysUntilStage: number | null = null;
-jest.mock('../../../store/useProgramProgression', () => ({
-  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
-  useDerivedCurrentWeek: (fallback: number) => mockDerivedWeek ?? fallback,
-  useDaysUntilStage: () => mockDaysUntilStage,
-}));
-
-interface StageHistoryData {
-  stage_number: number;
-  practices: Array<{
-    name: string;
-    sessions_completed: number;
-    total_minutes: number;
-    last_session: string | null;
-  }>;
-  habits: Array<{
-    name: string;
-    icon: string;
-    goals_achieved: Record<string, boolean>;
-    best_streak: number;
-    total_completions: number;
-  }>;
-}
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
 
 const mockHistoryFn = jest.fn<Promise<StageHistoryData>, [number, string?]>();
 jest.mock('../../../api', () => ({
@@ -60,67 +46,6 @@ jest.mock('../../../api', () => ({
     history: (...args: [number, string?]) => mockHistoryFn(...args),
   },
 }));
-
-function mockMakeStage(stageNumber: number, progress = 0) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress,
-    color: '#abcdef',
-    isUnlocked: stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description of free will.',
-    overviewUrl: '',
-  };
-}
-
-let mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
-
-const mockLoadStages = jest.fn();
-jest.mock('../services/stageService', () => ({
-  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
-  isEndOfCycle: () => false,
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: false,
-  error: null,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const mockState = buildMockStageState();
-    return selector ? selector(mockState) : mockState;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-}));
-
-import MapScreen from '../MapScreen';
-
-import { showcase } from '@/design/tokens';
 
 const findText = (tree: ReturnType<typeof create>, fragment: string): boolean =>
   tree.root.findAll(
@@ -137,13 +62,13 @@ const openStage = (tree: ReturnType<typeof create>, stageNumber: number): void =
 
 describe('MapScreen — journey narrative', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
+    resetMapMocks();
     mockHistoryFn.mockReset();
-    mockDerivedStage = 5;
-    mockDerivedWeek = 12;
-    mockDaysUntilStage = null;
-    mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    mockMapState.derivedStage = 5;
+    mockMapState.derivedWeek = 12;
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, { color: '#abcdef' }),
+    );
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
@@ -166,7 +91,7 @@ describe('MapScreen — journey narrative', () => {
 
   it('shows an "Unlocks in N days" timeline on a locked stage', () => {
     // Calendar at stage 5, so stage 8 is locked.
-    mockDaysUntilStage = 9;
+    mockMapState.daysUntilStage = 9;
     const tree = create(<MapScreen />);
     const unlock = tree.root.findByProps({ testID: 'stage-unlock-8' });
     expect(unlock).toBeTruthy();
@@ -255,7 +180,9 @@ describe('MapScreen — journey narrative', () => {
     expect(celebrations.length).toBe(0);
 
     // Stage 3 completes → re-render with the new progress.
-    mockStages = mockStages.map((s) => (s.stageNumber === 3 ? { ...s, progress: 1 } : s));
+    mockMapState.stages = mockMapState.stages.map((s) =>
+      s.stageNumber === 3 ? { ...s, progress: 1 } : s,
+    );
     act(() => {
       tree.update(<MapScreen />);
     });

--- a/frontend/src/features/Map/__tests__/MapRetry.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapRetry.test.tsx
@@ -7,116 +7,37 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
-jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
-  runAfterInteractions: (cb: () => void) => {
-    cb();
-    return { then: () => {}, done: () => {}, cancel: () => {} };
-  },
-}));
+import MapScreen from '../MapScreen';
 
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
-jest.mock('../../../store/useProgramProgression', () => ({
-  useDerivedCurrentStage: (fallback: number) => fallback,
-  useDerivedCurrentWeek: (fallback: number) => fallback,
-  useDaysUntilStage: () => null,
-}));
+import type { StageHistoryData } from './mapTestHarness';
+import { mockLoadStages, mockMapState, resetMapMocks } from './mapTestHarness';
 
-interface StageHistoryData {
-  stage_number: number;
-  practices: Array<{
-    name: string;
-    sessions_completed: number;
-    total_minutes: number;
-    last_session: string | null;
-  }>;
-  habits: Array<{
-    name: string;
-    icon: string;
-    goals_achieved: Record<string, boolean>;
-    best_streak: number;
-    total_completions: number;
-  }>;
-}
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
 
 const mockHistoryFn = jest.fn<Promise<StageHistoryData>, [number, string?]>();
 jest.mock('../../../api', () => ({
   stages: { history: (...args: [number, string?]) => mockHistoryFn(...args) },
 }));
-
-function mockMakeStage(stageNumber: number) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress: 0,
-    color: '#aaa',
-    isUnlocked: stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description',
-    overviewUrl: '',
-    hotspots: [{ top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 }],
-  };
-}
-
-const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
-const mockLoadStages = jest.fn();
-// Mutable so each test drives the store's error field (prefixed ``mock`` so the
-// jest.mock factory may reference it).
-let mockError: string | null = null;
-
-jest.mock('../services/stageService', () => ({
-  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
-  isEndOfCycle: () => false,
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: false,
-  error: mockError,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const state = buildMockStageState();
-    return selector ? selector(state) : state;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-  selectStageByNumber:
-    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
-      n == null ? undefined : s.stagesByNumber[n],
-}));
-
-import MapScreen from '../MapScreen';
 
 const EMPTY_HISTORY: StageHistoryData = { stage_number: 1, practices: [], habits: [] };
 
@@ -126,15 +47,15 @@ const countByTestId = (tree: ReturnType<typeof create>, testID: string): number 
 
 describe('MapScreen — refresh retry', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
+    resetMapMocks();
     mockHistoryFn.mockReset();
-    mockError = null;
+    mockMapState.derivedStage = null;
+    mockMapState.derivedWeek = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
   it('shows a retry banner when a refresh fails while stages are cached', () => {
-    mockError = 'Network error';
+    mockMapState.error = 'Network error';
     const tree = create(<MapScreen />);
     expect(tree.root.findByProps({ testID: 'map-refresh-error' })).toBeTruthy();
     const retry = tree.root.findByProps({ testID: 'map-refresh-retry' });
@@ -151,10 +72,10 @@ describe('MapScreen — refresh retry', () => {
 
 describe('MapScreen — stage history error vs empty', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
+    resetMapMocks();
     mockHistoryFn.mockReset();
-    mockError = null;
+    mockMapState.derivedStage = null;
+    mockMapState.derivedWeek = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -11,131 +11,38 @@ import { STAGE_COUNT } from '../stageData';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
 import { ranksOrShames } from './copyIntentRule';
+import {
+  mockBeginAgain,
+  mockMakeStage,
+  mockMapState,
+  mockNavigate,
+  resetMapMocks,
+} from './mapTestHarness';
 
-// Mock InteractionManager to run callbacks synchronously in tests.
-jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
-  runAfterInteractions: (cb: () => void) => {
-    cb();
-    return { then: () => {}, done: () => {}, cancel: () => {} };
-  },
-  createInteractionHandle: () => 1,
-  clearInteractionHandle: () => {},
-}));
-
-// Mock navigation so we can observe tab linking behaviour.
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
-
-// Default wheel state: all stages thin (zero fullness). Override per-test.
-let mockWheelFullnessByStage: Record<number, number> = {};
-let mockWheelLoading = false;
-let mockWheelError: string | null = null;
-jest.mock('../hooks/useWheelBalance', () => ({
-  useWheelBalance: () => ({
-    fullnessByStage: mockWheelFullnessByStage,
-    loading: mockWheelLoading,
-    error: mockWheelError,
-  }),
-}));
-
-// Control the date-derived current stage without importing the real program
-// store (which trips this suite's brittle Image-effect teardown). MapScreen
-// consumes ``useDerivedCurrentStage`` directly, so mocking it here drives both
-// the "current" highlight and the calendar-based unlock.
-let mockDerivedStage = 1;
-let mockDerivedWeek = 1;
-let mockDaysUntilStage: number | null = null;
-jest.mock('../../../store/useProgramProgression', () => ({
-  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
-  useDerivedCurrentWeek: (fallback: number) => mockDerivedWeek ?? fallback,
-  useDaysUntilStage: () => mockDaysUntilStage,
-}));
-
-/** Build a realistic StageData for testing (must be prefixed with mock). */
-function mockMakeStage(stageNumber: number) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress: stageNumber === 1 ? 0.5 : 0,
-    color: '#aaa',
-    isUnlocked: stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description of free will.',
-    overviewUrl: '',
-    hotspots: [
-      { top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 },
-      { top: (10 - stageNumber) * 8 + 4, left: 34, width: 40, height: 6 },
-    ],
-  };
-}
-
-const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
-
-let mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
-  () => false,
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
 );
-let mockCycleNumber = 1;
-
-const mockLoadStages = jest.fn();
-const mockBeginAgain = jest.fn();
-jest.mock('../services/stageService', () => ({
-  stageService: {
-    loadStages: (...args: unknown[]) => mockLoadStages(...args),
-    beginAgain: (...args: unknown[]) => mockBeginAgain(...args),
-  },
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-  isEndOfCycle: (stagesByNumber: Record<number, { progress: number }>, currentStage: number) =>
-    mockIsEndOfCycle(stagesByNumber, currentStage),
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: false,
-  error: null,
-  cycleNumber: mockCycleNumber,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-  setCycleNumber: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const mockState = buildMockStageState();
-    return selector ? selector(mockState) : mockState;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-  selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
-  selectStageByNumber:
-    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
-      n == null ? undefined : s.stagesByNumber[n],
-}));
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../hooks/useWheelBalance', () =>
+  jest.requireActual('./mapTestHarness').mockWheelBalanceModule(),
+);
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
 
 // react-test-renderer ships no node types, so structurally type just the props.
 type TestNode = { props: Record<string, unknown> };
@@ -153,19 +60,10 @@ const hotspotHasLock = (tree: ReturnType<typeof create>, stageNumber: number): b
 
 describe('MapScreen', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
-    mockBeginAgain.mockClear();
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
-      () => false,
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
     );
-    mockCycleNumber = 1;
-    mockDerivedStage = 1;
-    mockDerivedWeek = 1;
-    mockDaysUntilStage = null;
-    mockWheelFullnessByStage = {};
-    mockWheelLoading = false;
-    mockWheelError = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
@@ -278,7 +176,7 @@ describe('MapScreen', () => {
     // Calendar has reached stage 5. Stages 3–5 are server-locked
     // (isUnlocked: stageNumber <= 2) but the calendar overrides, so only
     // stages 6–10 stay padlocked: 5 stages × 2 hotspots = 10.
-    mockDerivedStage = 5;
+    mockMapState.derivedStage = 5;
     let tree!: ReturnType<typeof create>;
     act(() => {
       tree = create(<MapScreen />);
@@ -295,7 +193,7 @@ describe('MapScreen', () => {
 
   it('alive node (fullness >= threshold) renders with higher opacity than a thin node', () => {
     // Stage 3 is alive; stage 1 is thin.
-    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 1: 0.0 };
+    mockMapState.wheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 1: 0.0 };
     const tree = create(<MapScreen />);
 
     const aliveHotspot = tree.root.findByProps({ testID: 'stage-hotspot-3-0' });
@@ -322,21 +220,21 @@ describe('MapScreen', () => {
   });
 
   it('alive node accessibilityLabel contains "reads full" suffix', () => {
-    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD };
+    mockMapState.wheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD };
     const tree = create(<MapScreen />);
     const hotspot = tree.root.findByProps({ testID: 'stage-hotspot-3-0' });
     expect(hotspot.props.accessibilityLabel as string).toContain('reads full');
   });
 
   it('thin node accessibilityLabel contains "reads thin" suffix', () => {
-    mockWheelFullnessByStage = { 1: 0.0 };
+    mockMapState.wheelFullnessByStage = { 1: 0.0 };
     const tree = create(<MapScreen />);
     const hotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
     expect(hotspot.props.accessibilityLabel as string).toContain('reads thin');
   });
 
   it('BalanceSummary renders all-thin copy when every stage is 0.0', () => {
-    mockWheelFullnessByStage = Object.fromEntries(
+    mockMapState.wheelFullnessByStage = Object.fromEntries(
       Array.from({ length: 10 }, (_, i) => [i + 1, 0.0]),
     );
     const tree = create(<MapScreen />);
@@ -345,14 +243,14 @@ describe('MapScreen', () => {
   });
 
   it('BalanceSummary renders mixed copy when some stages are alive', () => {
-    mockWheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 7: 0.9 };
+    mockMapState.wheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 7: 0.9 };
     const tree = create(<MapScreen />);
     const summary = tree.root.findByProps({ testID: 'balance-summary' });
     expect(summary.props.children as string).toBe(BALANCE_COPY.mixed);
   });
 
   it('BalanceSummary renders all-alive copy when every stage is at full fullness', () => {
-    mockWheelFullnessByStage = Object.fromEntries(
+    mockMapState.wheelFullnessByStage = Object.fromEntries(
       Array.from({ length: 10 }, (_, i) => [i + 1, 1.0]),
     );
     const tree = create(<MapScreen />);
@@ -368,7 +266,7 @@ describe('MapScreen', () => {
   });
 
   it('Map spiral grid remains visible while wheel data is loading', () => {
-    mockWheelLoading = true;
+    mockMapState.wheelLoading = true;
     const tree = create(<MapScreen />);
 
     // The grid must be present — wheel loading never blanks the spiral.
@@ -384,14 +282,18 @@ describe('MapScreen', () => {
   // --- begin-again affordance ---
 
   it('shows begin-again-button at end of cycle', () => {
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => true,
+    );
     const tree = create(<MapScreen />);
     const btn = tree.root.findByProps({ testID: 'begin-again-button' });
     expect(btn).toBeTruthy();
   });
 
   it('pressing begin-again-button calls stageService.beginAgain', () => {
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => true,
+    );
     mockBeginAgain.mockResolvedValue(undefined);
     const tree = create(<MapScreen />);
     act(() => {
@@ -401,7 +303,9 @@ describe('MapScreen', () => {
   });
 
   it('double-pressing begin-again-button sends exactly one request', () => {
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => true,
+    );
     // Never-resolving so the in-flight guard stays true across both presses;
     // the second tap must be a no-op or a second POST would skip a cycle.
     mockBeginAgain.mockReturnValue(new Promise<void>(() => {}));
@@ -414,7 +318,9 @@ describe('MapScreen', () => {
   });
 
   it('disables begin-again-button while a begin-again request is in flight', () => {
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => true);
+    mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+      () => true,
+    );
     mockBeginAgain.mockReturnValue(new Promise<void>(() => {}));
     const tree = create(<MapScreen />);
     act(() => {
@@ -426,7 +332,7 @@ describe('MapScreen', () => {
   });
 
   it('begin-again-button is absent mid-cycle', () => {
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
+    mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
       () => false,
     );
     const tree = create(<MapScreen />);
@@ -438,7 +344,7 @@ describe('MapScreen', () => {
   // --- cycle-indicator ---
 
   it('shows cycle-indicator with "Cycle 2" when cycleNumber is 2', () => {
-    mockCycleNumber = 2;
+    mockMapState.cycleNumber = 2;
     const tree = create(<MapScreen />);
     const indicator = tree.root.findByProps({ testID: 'cycle-indicator' });
     expect(indicator).toBeTruthy();
@@ -450,7 +356,7 @@ describe('MapScreen', () => {
   });
 
   it('cycle-indicator is absent when cycleNumber is 1', () => {
-    mockCycleNumber = 1;
+    mockMapState.cycleNumber = 1;
     const tree = create(<MapScreen />);
     expect(tree.root.findAll((n: TestNode) => n.props.testID === 'cycle-indicator')).toHaveLength(
       0,
@@ -642,19 +548,10 @@ describe('MapScreen', () => {
 
 describe('MapScreen center-cell overlay layout', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
-    mockBeginAgain.mockClear();
-    mockIsEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
-      () => false,
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
     );
-    mockCycleNumber = 1;
-    mockDerivedStage = 1;
-    mockDerivedWeek = 1;
-    mockDaysUntilStage = null;
-    mockWheelFullnessByStage = {};
-    mockWheelLoading = false;
-    mockWheelError = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
@@ -666,7 +563,7 @@ describe('MapScreen center-cell overlay layout', () => {
   });
 
   it('locked center cell renders the unlock countdown in flow (not absolutely positioned)', () => {
-    mockDaysUntilStage = 42;
+    mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
     const countdown = tree.root.findByProps({ testID: 'stage-unlock-8' });
     const flat = StyleSheet.flatten(countdown.props.style) as {
@@ -694,7 +591,7 @@ describe('MapScreen center-cell overlay layout', () => {
     // positioning gave: without ``alignSelf: 'stretch'`` an in-flow Text
     // shrink-wraps to its widest wrapped line and ``textAlign: 'center'``
     // becomes a no-op for the multi-line unlock-condition copy.
-    mockDaysUntilStage = 42;
+    mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
     const countdown = tree.root.findByProps({ testID: 'stage-unlock-8' });
     const flat = StyleSheet.flatten(countdown.props.style) as {
@@ -713,7 +610,7 @@ describe('MapScreen center-cell overlay layout', () => {
   });
 
   it('stacks the pill above the label and the countdown below the lock', () => {
-    mockDaysUntilStage = 42;
+    mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
     const textOrder = (testID: string): string[] =>
       tree.root

--- a/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
@@ -5,128 +5,65 @@ import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
-jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
-  runAfterInteractions: (cb: () => void) => {
-    cb();
-    return { then: () => {}, done: () => {}, cancel: () => {} };
-  },
-}));
+import styles from '../Map.styles';
+import MapScreen from '../MapScreen';
 
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
-jest.mock('../../../store/useProgramProgression', () => ({
-  useDerivedCurrentStage: (fallback: number) => fallback,
-  useDerivedCurrentWeek: (fallback: number) => fallback,
-  useDaysUntilStage: () => null,
-}));
+import { mockMapState, resetMapMocks } from './mapTestHarness';
 
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
+
+// A never-resolving history keeps the cold-start paths free of async churn.
 jest.mock('../../../api', () => ({
   stages: { history: () => new Promise(() => {}) },
 }));
-
-function mockMakeStage(stageNumber: number, overrides: Record<string, unknown> = {}) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress: 0,
-    color: '#aaa',
-    isUnlocked: stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description of free will.',
-    overviewUrl: '',
-    ...overrides,
-  };
-}
-
-let mockStages: ReturnType<typeof mockMakeStage>[] = Array.from({ length: 10 }, (_, i) =>
-  mockMakeStage(10 - i),
-);
-let mockLoading = false;
-let mockError: string | null = null;
-const mockLoadStages = jest.fn();
-
-jest.mock('../services/stageService', () => ({
-  stageService: { loadStages: (...args: unknown[]) => mockLoadStages(...args) },
-  isEndOfCycle: () => false,
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: mockLoading,
-  error: mockError,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const state = buildMockStageState();
-    return selector ? selector(state) : state;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-  selectCycleNumber: () => 1,
-}));
-
-import styles from '../Map.styles';
-import MapScreen from '../MapScreen';
 
 type TestNode = { props: Record<string, unknown> };
 
 describe('MapScreen — cold start and metadata edge cases', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockLoadStages.mockClear();
-    mockLoading = false;
-    mockError = null;
-    mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    resetMapMocks();
+    mockMapState.derivedStage = null;
+    mockMapState.derivedWeek = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 
   it('shows the full-screen loader when no stages are cached yet', () => {
-    mockLoading = true;
-    mockStages = [];
+    mockMapState.loading = true;
+    mockMapState.stages = [];
     const tree = create(<MapScreen />);
     expect(tree.root.findByProps({ testID: 'map-loading' })).toBeTruthy();
   });
 
   it('shows the full-screen error when the load fails with nothing cached', () => {
-    mockError = 'Could not reach the server.';
-    mockStages = [];
+    mockMapState.error = 'Could not reach the server.';
+    mockMapState.stages = [];
     const tree = create(<MapScreen />);
     expect(tree.root.findByProps({ testID: 'map-error' })).toBeTruthy();
     expect(tree.root.findByProps({ children: 'Could not reach the server.' })).toBeTruthy();
   });
 
   it('omits the free-will description line for a stage that has none', () => {
-    mockStages = mockStages.map((s) =>
+    mockMapState.stages = mockMapState.stages.map((s) =>
       s.stageNumber === 1 ? { ...s, freeWillDescription: '' } : s,
     );
     const tree = create(<MapScreen />);

--- a/frontend/src/features/Map/__tests__/WavelengthExplainerTrigger.test.tsx
+++ b/frontend/src/features/Map/__tests__/WavelengthExplainerTrigger.test.tsx
@@ -10,6 +10,8 @@ import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
 
+import { mockMapState, resetMapMocks } from './mapTestHarness';
+
 // Mock ChapterReader so the explainer's live content fetch never runs in this
 // MapScreen wiring test; its back control (testID="reader-back-button") is the
 // explainer's close affordance.
@@ -25,118 +27,38 @@ jest.mock('../../Course/ChapterReader', () => {
   };
 });
 
-jest.mock('react-native/Libraries/Interaction/InteractionManager', () => ({
-  runAfterInteractions: (cb: () => void) => {
-    cb();
-    return { then: () => {}, done: () => {}, cancel: () => {} };
-  },
-  createInteractionHandle: () => 1,
-  clearInteractionHandle: () => {},
-}));
-
-const mockNavigate = jest.fn();
-jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
-}));
-jest.mock('@react-navigation/bottom-tabs', () => ({
-  useBottomTabBarHeight: () => 0,
-}));
-jest.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}));
-
-let mockWheelFullnessByStage: Record<number, number> = {};
-jest.mock('../hooks/useWheelBalance', () => ({
-  useWheelBalance: () => ({
-    fullnessByStage: mockWheelFullnessByStage,
-    loading: false,
-    error: null,
-  }),
-}));
-
-let mockDerivedStage = 1;
-jest.mock('../../../store/useProgramProgression', () => ({
-  useDerivedCurrentStage: (fallback: number) => mockDerivedStage ?? fallback,
-  useDerivedCurrentWeek: (fallback: number) => fallback,
-  useDaysUntilStage: () => null,
-}));
-
-function mockMakeStage(stageNumber: number) {
-  return {
-    id: stageNumber,
-    title: `Stage ${stageNumber}`,
-    subtitle: `Subtitle ${stageNumber}`,
-    stageNumber,
-    progress: 0,
-    color: '#aaa',
-    isUnlocked: stageNumber <= 2,
-    category: 'Test',
-    aspect: 'Aspect',
-    spiralDynamicsColor: 'Beige',
-    growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
-    relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description of free will.',
-    overviewUrl: '',
-    hotspots: [
-      { top: (10 - stageNumber) * 8 + 4, left: 4, width: 32, height: 6 },
-      { top: (10 - stageNumber) * 8 + 4, left: 34, width: 40, height: 6 },
-    ],
-  };
-}
-
-const mockStages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
-
-jest.mock('../services/stageService', () => ({
-  stageService: {
-    loadStages: jest.fn(),
-    beginAgain: jest.fn(),
-  },
-  isStageUnlocked: (
-    stage: { isUnlocked: boolean; stageNumber: number },
-    currentStage: number | null,
-  ) => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage),
-  isEndOfCycle: () => false,
-}));
-
-const buildMockStageState = () => ({
-  stages: mockStages,
-  stagesByNumber: Object.fromEntries(mockStages.map((s) => [s.stageNumber, s])),
-  stageOrder: mockStages.map((s) => s.stageNumber),
-  currentStage: 1,
-  loading: false,
-  error: null,
-  cycleNumber: 1,
-  setStages: jest.fn(),
-  setCurrentStage: jest.fn(),
-  setLoading: jest.fn(),
-  setError: jest.fn(),
-  updateStageProgress: jest.fn(),
-  setCycleNumber: jest.fn(),
-});
-
-jest.mock('../../../store/useStageStore', () => ({
-  useStageStore: jest.fn((selector) => {
-    const mockState = buildMockStageState();
-    return selector ? selector(mockState) : mockState;
-  }),
-  selectStages: (s: { stages: unknown }) => s.stages,
-  selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
-  selectStagesLoading: (s: { loading: unknown }) => s.loading,
-  selectStagesError: (s: { error: unknown }) => s.error,
-  selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
-  selectStageByNumber:
-    (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
-      n == null ? undefined : s.stagesByNumber[n],
-}));
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../hooks/useWheelBalance', () =>
+  jest.requireActual('./mapTestHarness').mockWheelBalanceModule(),
+);
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
 
 type TestNode = { props: Record<string, unknown> };
 
 describe('MapScreen wavelength explainer trigger', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
-    mockDerivedStage = 1;
-    mockWheelFullnessByStage = {};
+    resetMapMocks();
+    mockMapState.derivedStage = 1;
+    mockMapState.derivedWeek = null;
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
   });
 

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -1,0 +1,226 @@
+/* eslint-env jest */
+/* global jest */
+import type { StageData } from '../stageData';
+
+/**
+ * Shared Jest scaffold for the six MapScreen-driven suites. Each suite keeps its
+ * own ``jest.mock(...)`` calls (so it controls exactly which modules it mocks)
+ * and points every factory at a builder here via
+ * ``jest.requireActual('./mapTestHarness')`` — the factory then references only
+ * the ``jest`` global and a string literal, satisfying babel-plugin-jest-hoist
+ * regardless of import order. Per-test state lives on the shared ``mockMapState``
+ * singleton, which the suites mutate through their imported binding (the same
+ * cached module instance the factories resolve).
+ */
+
+/** Aggregated stage history, mirroring the ``/stages/{n}/history`` payload. */
+export interface StageHistoryData {
+  stage_number: number;
+  practices: Array<{
+    name: string;
+    sessions_completed: number;
+    total_minutes: number;
+    last_session: string | null;
+  }>;
+  habits: Array<{
+    name: string;
+    icon: string;
+    goals_achieved: Record<string, boolean>;
+    best_streak: number;
+    total_completions: number;
+  }>;
+}
+
+/** Build a realistic StageData; ``overrides`` owns the per-test seam. */
+export function mockMakeStage(stageNumber: number, overrides: Partial<StageData> = {}): StageData {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stageNumber,
+    progress: 0,
+    color: '#aaa',
+    isUnlocked: stageNumber <= 2,
+    category: 'Test',
+    aspect: 'Aspect',
+    spiralDynamicsColor: 'Beige',
+    growingUpStage: 'Growing',
+    divineGenderPolarity: 'Polarity',
+    relationshipToFreeWill: 'Free Will',
+    freeWillDescription: 'Description of free will.',
+    overviewUrl: '',
+    ...overrides,
+  };
+}
+
+/** Ten stages, highest-numbered first (the store's render order). */
+export function createDefaultStages(): StageData[] {
+  return Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+}
+
+type EndOfCycleMock = jest.Mock<boolean, [Record<number, { progress: number }>, number]>;
+
+/** Mutable per-test knobs the mock builders read lazily at call time. */
+export interface MapMockState {
+  stages: StageData[];
+  currentStage: number;
+  loading: boolean;
+  error: string | null;
+  cycleNumber: number;
+  derivedStage: number | null;
+  derivedWeek: number | null;
+  daysUntilStage: number | null;
+  wheelFullnessByStage: Record<number, number>;
+  wheelLoading: boolean;
+  wheelError: string | null;
+  isEndOfCycle: EndOfCycleMock;
+}
+
+function createDefaultState(): MapMockState {
+  return {
+    stages: createDefaultStages(),
+    currentStage: 1,
+    loading: false,
+    error: null,
+    cycleNumber: 1,
+    derivedStage: 1,
+    derivedWeek: 1,
+    daysUntilStage: null,
+    wheelFullnessByStage: {},
+    wheelLoading: false,
+    wheelError: null,
+    isEndOfCycle: jest.fn<boolean, [Record<number, { progress: number }>, number]>(() => false),
+  };
+}
+
+/** The shared, mutable state singleton every suite drives. */
+export const mockMapState: MapMockState = createDefaultState();
+
+/** Restore ``mockMapState`` to its defaults (fresh ``isEndOfCycle`` spy). */
+export function resetMapMockState(): void {
+  Object.assign(mockMapState, createDefaultState());
+}
+
+/** Navigation spy asserted by the suites; the navigation mock reads it. */
+export const mockNavigate = jest.fn();
+/** ``stageService.loadStages`` spy. */
+export const mockLoadStages = jest.fn();
+/** ``stageService.beginAgain`` spy. */
+export const mockBeginAgain = jest.fn();
+
+/** Reset state and clear the shared spies (call from ``beforeEach``). */
+export function resetMapMocks(): void {
+  resetMapMockState();
+  mockNavigate.mockClear();
+  mockLoadStages.mockClear();
+  mockBeginAgain.mockClear();
+}
+
+/** The single source of truth for the unlock rule, matching ``stageService``. */
+export const mockIsStageUnlocked = (
+  stage: { isUnlocked: boolean; stageNumber: number },
+  currentStage: number | null,
+): boolean => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage);
+
+/** Build the ``useStageStore`` state slice from the current ``mockMapState``. */
+export function buildMockStageState() {
+  const { stages, currentStage, loading, error, cycleNumber } = mockMapState;
+  return {
+    stages,
+    stagesByNumber: Object.fromEntries(stages.map((s) => [s.stageNumber, s])),
+    stageOrder: stages.map((s) => s.stageNumber),
+    currentStage,
+    loading,
+    error,
+    cycleNumber,
+    setStages: jest.fn(),
+    setCurrentStage: jest.fn(),
+    setLoading: jest.fn(),
+    setError: jest.fn(),
+    updateStageProgress: jest.fn(),
+    setCycleNumber: jest.fn(),
+  };
+}
+
+// --- Module-mock builders. Each returns the shape of one mocked module; the
+// suites wrap them in `jest.mock(path, () => requireActual(harness).builder())`.
+
+/** ``react-native/Libraries/Interaction/InteractionManager`` — runs callbacks now. */
+export function mockInteractionManagerModule() {
+  return {
+    runAfterInteractions: (cb: () => void) => {
+      cb();
+      return { then: () => {}, done: () => {}, cancel: () => {} };
+    },
+    createInteractionHandle: () => 1,
+    clearInteractionHandle: () => {},
+  };
+}
+
+/** ``navigation/hooks`` — surfaces the shared ``mockNavigate`` spy. */
+export function mockNavigationModule() {
+  return { useAppNavigation: () => ({ navigate: mockNavigate }) };
+}
+
+/** ``@react-navigation/bottom-tabs``. */
+export function mockBottomTabsModule() {
+  return { useBottomTabBarHeight: () => 0 };
+}
+
+/** ``react-native-safe-area-context``. */
+export function mockSafeAreaModule() {
+  return { useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }) };
+}
+
+/** ``hooks/useWheelBalance`` — driven by ``mockMapState.wheel*``. */
+export function mockWheelBalanceModule() {
+  return {
+    useWheelBalance: () => ({
+      fullnessByStage: mockMapState.wheelFullnessByStage,
+      loading: mockMapState.wheelLoading,
+      error: mockMapState.wheelError,
+    }),
+  };
+}
+
+/** ``store/useProgramProgression`` — ``null`` knobs fall back to the call-site default. */
+export function mockProgramProgressionModule() {
+  return {
+    useDerivedCurrentStage: (fallback: number) => mockMapState.derivedStage ?? fallback,
+    useDerivedCurrentWeek: (fallback: number) => mockMapState.derivedWeek ?? fallback,
+    useDaysUntilStage: () => mockMapState.daysUntilStage,
+  };
+}
+
+/** ``services/stageService`` — spies plus the shared unlock/end-of-cycle logic. */
+export function mockStageServiceModule() {
+  return {
+    stageService: {
+      loadStages: (...args: unknown[]) => mockLoadStages(...args),
+      beginAgain: (...args: unknown[]) => mockBeginAgain(...args),
+    },
+    isStageUnlocked: mockIsStageUnlocked,
+    isEndOfCycle: (stagesByNumber: Record<number, { progress: number }>, currentStage: number) =>
+      mockMapState.isEndOfCycle(stagesByNumber, currentStage),
+  };
+}
+
+type MockStageState = ReturnType<typeof buildMockStageState>;
+
+/** ``store/useStageStore`` — the hook plus every selector the suites consume. */
+export function mockStageStoreModule() {
+  return {
+    useStageStore: jest.fn((selector?: (state: MockStageState) => unknown) => {
+      const state = buildMockStageState();
+      return selector ? selector(state) : state;
+    }),
+    selectStages: (s: { stages: unknown }) => s.stages,
+    selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
+    selectStagesLoading: (s: { loading: unknown }) => s.loading,
+    selectStagesError: (s: { error: unknown }) => s.error,
+    selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
+    selectStageByNumber:
+      (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>
+        n == null ? undefined : s.stagesByNumber[n],
+  };
+}


### PR DESCRIPTION
## Summary

The six `MapScreen`-driven Jest suites each re-declared ~100 lines of identical
mock scaffold — the `mockMakeStage` factory, `buildMockStageState`, the
`useStageStore` mock and its selectors, the inline `isStageUnlocked`
reimplementation, the `StageHistoryData` shape, and the
`InteractionManager`/`bottom-tabs`/`safe-area`/`useWheelBalance` mocks — so any
store-shape or service change forced shotgun surgery across all six files.

This extracts a single `frontend/src/features/Map/__tests__/mapTestHarness.ts`
exporting the stage factory, a mutable `mockMapState` singleton,
`buildMockStageState`, `mockIsStageUnlocked`, the `StageHistoryData` type, and one
builder per mocked module. Each suite keeps its **own** `jest.mock()` calls
(preserving its exact set of mocked modules) and delegates each factory via
`jest.requireActual('./mapTestHarness').mockXModule()`.

- The delegating factory references only the `jest` global and a string literal,
  so it satisfies `babel-plugin-jest-hoist` **regardless of import order** and
  sidesteps the ESLint `import/order` (parent-before-sibling) constraint that
  rules out referencing a harness import from a hoisted factory.
- The harness is never itself mocked, so a suite's `import { mockMapState }` and
  the factory's `requireActual(...)` resolve to the same module-registry
  instance — per-test state stays shared.

Test-only: **no production code changes**. Every `it()` and its assertions are
preserved (43/3/8/7/4/4 across the six suites). The dead `stage.hotspots` field
is dropped because the component reads geometry from `mapLayout`, not the store
stage. Net −248 lines across the seven files.

## Test plan

- `./scripts/frontend/check-all.sh` — 4/4 green (typecheck, eslint, prettier,
  324 suites / 3274 tests).
- `npx jest src/features/Map` — 19 suites / 201 tests pass, identical to baseline.
- `npx jest --coverage` — thresholds hold: global branch 90.38%, statements
  96.63%, functions 95.56%, lines 97.56% (all ≥ 90).
- Gate 2.5 self-review (code-review-orchestrator): **CLEAN**, zero blocking
  findings.

Closes #1214