### PR TITLE
fix(habits): repair corrupted optimistic rollback in updateGoal

### DIFF
--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -61,7 +61,7 @@ import { useHabitStore } from '../../../../store/useHabitStore';
 import { useProgramStore } from '../../../../store/useProgramStore';
 import { dayKeyInTZ } from '../../../../utils/dateUtils';
 import type { Goal, Habit, OnboardingHabit } from '../../Habits.types';
-import { habitManager } from '../habitManager';
+import { applyGoalUpdate, habitManager } from '../habitManager';
 
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   id: 1,
@@ -957,6 +957,55 @@ describe('habitManager', () => {
         const goal = goals.find((g) => g.tier === tier)!;
         expect(goal.is_additive).toBe(false);
       }
+    });
+
+    it('does not mutate the goal objects of its input array', () => {
+      // The optimistic snapshot in ``updateGoal`` shares goal object refs with
+      // the ``prev`` rollback array; an in-place normalize would silently
+      // corrupt the tiers the user never edited before the PUT even resolves.
+      const habit = makeHabit();
+      const low = habit.goals.find((g) => g.tier === 'low')!;
+      const stretch = habit.goals.find((g) => g.tier === 'stretch')!;
+
+      const editedClear: Goal = {
+        ...habit.goals.find((g) => g.tier === 'clear')!,
+        target: 10,
+        target_unit: 'minutes',
+      };
+
+      applyGoalUpdate([habit], 1, editedClear);
+
+      expect(low.target_unit).toBe('units');
+      expect(low.target).toBe(1);
+      expect(stretch.target_unit).toBe('units');
+      expect(stretch.target).toBe(3);
+    });
+
+    it('rolls every tier back to its pre-edit state when the PUT rejects', async () => {
+      const original = makeHabit();
+      useHabitStore.setState({ habits: [original] });
+      (goalsApi.update as jest.Mock).mockRejectedValueOnce(new Error('offline') as never);
+
+      const editedClear: Goal = {
+        ...original.goals.find((g) => g.tier === 'clear')!,
+        target: 10,
+        target_unit: 'minutes',
+      };
+
+      habitManager.updateGoal(1, editedClear);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const { goals } = useHabitStore.getState().habits[0]!;
+      const byTier = (tier: string): Goal => goals.find((g) => g.tier === tier)!;
+      // Every tier — including the untouched low + stretch — restores to the
+      // exact pre-edit snapshot, not the corrupted optimistic values.
+      expect(byTier('low').target_unit).toBe('units');
+      expect(byTier('low').target).toBe(1);
+      expect(byTier('clear').target_unit).toBe('units');
+      expect(byTier('clear').target).toBe(2);
+      expect(byTier('stretch').target_unit).toBe('units');
+      expect(byTier('stretch').target).toBe(3);
     });
 
     it('skips the network call for synthetic goals with no id', async () => {

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -171,7 +171,10 @@ const normalizeGoalTiers = (goals: Goal[], updatedGoal: Goal): void => {
 export const applyGoalUpdate = (habits: Habit[], habitId: number, updatedGoal: Goal): Habit[] =>
   habits.map((h) => {
     if (h.id !== habitId) return h;
-    const goals = h.goals.map((goal) => (goal.id === updatedGoal.id ? updatedGoal : goal));
+    // Copy every goal before normalizing — the caller's ``prev`` rollback
+    // snapshot shares these object refs, so mutating in place would corrupt
+    // the untouched tiers of the pre-edit state.
+    const goals = h.goals.map((goal) => ({ ...(goal.id === updatedGoal.id ? updatedGoal : goal) }));
     normalizeGoalTiers(goals, updatedGoal);
     return { ...h, goals };
   });


### PR DESCRIPTION
## Summary

`habitManager.updateGoal` takes an optimistic snapshot `const prev = getHabits()` and, on a server rejection, restores it via `revertOnFailure(prev)`. But `applyGoalUpdate` mutated the **non-edited** tier goal objects in place, and those objects were shared by reference with `prev`. So the "immutable" rollback snapshot was silently corrupted before the PUT even resolved, and rolling back restored the failed-write state on the tiers the user never touched (e.g. Low and Stretch flip to `minutes` and Stretch's target gets clamped up while only Clear was edited).

The fix shallow-copies each goal (`{ ...goal }`) before `normalizeGoalTiers` runs, so the pre-edit snapshot's goal objects are never touched — the same immutable idiom the sibling `updateGoalUnits` already uses. The normalize/clamp helpers only assign top-level scalar fields, so a shallow spread fully isolates the store copy; the copy also closes a second latent path where `updatedGoal` itself was being mutated.

## Test plan

- New unit test: `applyGoalUpdate` does not mutate the goal objects of its input array (Low/Stretch keep `units` + original targets).
- New integration test: after a rejected `updateGoal` PUT, all three tiers (edited and non-edited) restore to their exact pre-edit `target`/`target_unit` values.
- Both tests fail without the fix (verified RED) and pass with it.
- Full frontend suite green: 3277 tests pass; tsc, ESLint, prettier, coverage all clean via `scripts/frontend/check-all.sh`.

Closes #1250