### PR TITLE
fix(course): stabilize ChapterReader body-fetch effect key

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -164,6 +164,25 @@ function fetchBody(source: ChapterReaderSource): Promise<ContentBody> {
   }
 }
 
+/**
+ * Stable primitive identity for a source.  Callers construct ``source`` as a
+ * fresh inline literal on every render, so keying the fetch effect on the
+ * object by reference re-runs it — and flashes the body back to a spinner — on
+ * every parent re-render (e.g. mark-as-read).  Reducing the source to its
+ * discriminants lets the effect fire only when the chapter actually changes,
+ * and does so inside the hook so no caller can reintroduce the defect.
+ */
+function sourceKey(source: ChapterReaderSource): string {
+  switch (source.kind) {
+    case 'content':
+      return `content:${source.id}`;
+    case 'resource':
+      return `resource:${source.slug}`;
+    case 'intro':
+      return `intro:${source.stageNumber}`;
+  }
+}
+
 function useContentBody(source: ChapterReaderSource): {
   body: ContentBody | null;
   loading: boolean;
@@ -175,6 +194,11 @@ function useContentBody(source: ChapterReaderSource): {
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const isMountedRef = useRef(true);
+  // Hold the latest ``source`` so the fetch effect can read it without taking
+  // the (referentially unstable) object as a dependency — see ``sourceKey``.
+  const sourceRef = useRef(source);
+  sourceRef.current = source;
+  const fetchKey = sourceKey(source);
 
   useEffect(
     () => () => {
@@ -192,7 +216,7 @@ function useContentBody(source: ChapterReaderSource): {
     // (set by ``AuthContext`` at sign-in), so the bearer header is
     // attached automatically.  Same pattern as ``stagesApi.listAll()``
     // and the other "no explicit token" callers in the codebase.
-    const promise = fetchBody(source);
+    const promise = fetchBody(sourceRef.current);
 
     promise
       .then((result) => {
@@ -207,7 +231,7 @@ function useContentBody(source: ChapterReaderSource): {
         if (!isMountedRef.current) return;
         setLoading(false);
       });
-  }, [source, refreshKey]);
+  }, [fetchKey, refreshKey]);
 
   const retry = useCallback(() => setRefreshKey((n) => n + 1), []);
   return { body, loading, error, retry };

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -183,6 +183,29 @@ describe('ContentViewer', () => {
     expect(queryByTestId('reflect-button')).toBeNull();
   });
 
+  it('does not refetch the body when marking as read', async () => {
+    const item = makeItem();
+    const { getByTestId, queryByTestId, findByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+    await findByTestId('reader-markdown');
+    expect(courseApi.contentBody).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('mark-read-button'));
+    });
+    await waitFor(() => {
+      expect(onMarkRead).toHaveBeenCalledTimes(1);
+    });
+
+    // The mark-as-read re-render passes a fresh ``source`` literal; the reader
+    // must key its fetch on the primitive identity, so the body is fetched once
+    // across the whole cycle and never flashes back to the loading spinner.
+    expect(courseApi.contentBody).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('reader-loading')).toBeNull();
+    expect(queryByTestId('reader-markdown')).not.toBeNull();
+  });
+
   it('surfaces a retry UI when the content body fails to load', async () => {
     courseApi.contentBody.mockRejectedValueOnce({ detail: 'content_unavailable' });
     const item = makeItem();


### PR DESCRIPTION
## Summary

`ChapterReader`'s body-fetch effect keyed on the `source` **object** by reference (`useEffect(..., [source, refreshKey])`), but all three call sites (`ContentViewer`, and the resource/intro branches in `CourseScreen`) pass a **fresh inline object literal** each render. Any parent re-render produced a new `source` reference, re-running the effect — a spurious full-body refetch plus a visible content → spinner → content flicker. This fired on the primary happy path: tapping **Mark as Read** re-renders `ContentViewer`, yielding a new `source` literal and a redundant `course.contentBody` call.

Fix: reduce `source` to a stable primitive `sourceKey` over its discriminants (`content:id` / `resource:slug` / `intro:stageNumber`) and depend on that; the effect reads the latest source via a `sourceRef` updated during render. The effect now fires only when the chapter actually changes. Fixed **inside the hook** so no call site can reintroduce the defect. Resource-mode (#1153) and intro-mode are preserved — both `sourceKey` and `fetchBody` exhaustively handle all three union arms.

No `eslint-disable`/`ts-ignore` was needed (exhaustive-deps stays clean: the effect's only reactive triggers are `fetchKey` and `refreshKey`).

## Test plan

- New RNTL regression test in `ContentViewer.test.tsx`: render `ContentViewer`, wait for `reader-markdown`, press `mark-read-button`, and assert `course.contentBody` was called **exactly once** across the cycle, with no `reader-loading` spinner flash and `reader-markdown` still mounted. (Fails pre-fix with 2 calls; passes post-fix.)
- `npx tsc --noEmit` — clean
- `npm run lint` (eslint on changed files) — clean
- `./scripts/frontend/check-all.sh` — all 4 checks pass, full suite 3276 tests green, coverage gates hold

Closes #1256