### PR TITLE
fix(frontend): seed journal persist refs on load so a failed re-tag reverts correctly

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -203,6 +203,11 @@ interface ClassificationPersist {
    * change has superseded it, else null.
    */
   changeClassification: (_tier: JournalClassification) => Promise<JournalClassification | null>;
+  /**
+   * Seed the last-persisted tier from a loaded entry so a failed re-tag reverts
+   * to the entry's real tier rather than the module default.
+   */
+  seedClassification: (_tier: JournalClassification) => void;
 }
 
 /**
@@ -234,7 +239,10 @@ function useClassificationPersist(
     },
     [entryIdRef],
   );
-  return { classificationRef, changeClassification };
+  const seedClassification = useCallback((tier: JournalClassification): void => {
+    classificationRef.current = tier;
+  }, []);
+  return { classificationRef, changeClassification, seedClassification };
 }
 
 interface ChordPersist {
@@ -245,6 +253,11 @@ interface ChordPersist {
    * later change has superseded it, else null.
    */
   changeChord: (_next: AspectChordValue) => Promise<AspectChordValue | null>;
+  /**
+   * Seed the last-persisted chord from a loaded entry so a failed re-tag reverts
+   * to the entry's real chord rather than the empty default.
+   */
+  seedChord: (_next: AspectChordValue) => void;
 }
 
 /**
@@ -279,7 +292,10 @@ function useChordPersist(entryIdRef: React.MutableRefObject<number | null>): Cho
     },
     [entryIdRef],
   );
-  return { chordRef, changeChord };
+  const seedChord = useCallback((next: AspectChordValue): void => {
+    chordRef.current = next;
+  }, []);
+  return { chordRef, changeChord, seedChord };
 }
 
 type TimerRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
@@ -415,6 +431,33 @@ function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) =
   );
 }
 
+/**
+ * Compose the tier + chord persisters: their refs (read by the writer), their
+ * seeders (for load), and error-surfacing change wrappers sharing the save hint.
+ */
+function usePersistControls(
+  entryIdRef: React.MutableRefObject<number | null>,
+  setSaveState: (_state: SaveState) => void,
+) {
+  const { classificationRef, changeClassification, seedClassification } =
+    useClassificationPersist(entryIdRef);
+  const { chordRef, changeChord, seedChord } = useChordPersist(entryIdRef);
+  const seedPersist = useCallback(
+    (tier: JournalClassification, chord: AspectChordValue): void => {
+      seedClassification(tier);
+      seedChord(chord);
+    },
+    [seedClassification, seedChord],
+  );
+  return {
+    classificationRef,
+    chordRef,
+    seedPersist,
+    persistClassification: useErrorSurfacingPersist(changeClassification, setSaveState),
+    persistChord: useErrorSurfacingPersist(changeChord, setSaveState),
+  };
+}
+
 /** Debounced create-then-update draft saver; tracks the save state. */
 function useDebouncedSave(
   routeEntryId: number | null,
@@ -432,8 +475,7 @@ function useDebouncedSave(
   // A weekly-prompt response is write-once; this guards against the debounce or
   // flush submitting it twice (the backend 409s on a duplicate week).
   const respondedRef = useRef(false);
-  const { classificationRef, changeClassification } = useClassificationPersist(entryIdRef);
-  const { chordRef, changeChord } = useChordPersist(entryIdRef);
+  const persist = usePersistControls(entryIdRef, setSaveState);
   // Refs so non-memoised inputs don't churn the save callbacks below.
   const onSavedRef = useRef(onSaved);
   const ctxRef = useRef(ctx);
@@ -451,8 +493,8 @@ function useDebouncedSave(
     {
       entryIdRef,
       respondedRef,
-      classificationRef,
-      chordRef,
+      classificationRef: persist.classificationRef,
+      chordRef: persist.chordRef,
       loadFailedRef,
       ctxRef,
       onSavedRef,
@@ -464,16 +506,13 @@ function useDebouncedSave(
   const setTyping = useCallback(() => setSaveState('typing'), []);
   const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
-  // A failed classification/chord PATCH surfaces the same error hint as a body save.
-  const persistClassification = useErrorSurfacingPersist(changeClassification, setSaveState);
-  const persistChord = useErrorSurfacingPersist(changeChord, setSaveState);
-
   return {
     saveState,
     save,
     flush,
-    changeClassification: persistClassification,
-    changeChord: persistChord,
+    changeClassification: persist.persistClassification,
+    changeChord: persist.persistChord,
+    seedPersist: persist.seedPersist,
   };
 }
 
@@ -521,6 +560,8 @@ interface EntryState {
   bodyRef: StrRef;
   /** Set (to {@link LOAD_ERROR_MESSAGE}) when loading an existing entry failed. */
   loadError: string | null;
+  /** Flips true once an existing entry's values have been applied to state. */
+  loaded: boolean;
 }
 
 /** The entry's editable state (title/body/status/tier) + one-time load-on-open. */
@@ -531,6 +572,7 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
   const [classification, setClassification] = useState<JournalClassification>(DEFAULT_TIER);
   const [chord, setChord] = useState<AspectChordValue>(EMPTY_CHORD);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
   // Refs mirror the latest text so the change handlers stay referentially stable.
   const titleRef = useRef(initialTitle);
   const bodyRef = useRef('');
@@ -550,6 +592,8 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
         primary: entry.primary_aspect ?? null,
         secondary: entry.secondary_aspect ?? null,
       });
+      // Signal the load so the persist refs can be seeded from these values.
+      setLoaded(true);
     }, []),
     useCallback(() => setLoadError(LOAD_ERROR_MESSAGE), []),
   );
@@ -568,6 +612,7 @@ function useEntryState(routeEntryId: number | null, initialTitle: string): Entry
     titleRef,
     bodyRef,
     loadError,
+    loaded,
   };
 }
 
@@ -607,6 +652,24 @@ function useChoiceHandlers(
   return { onChangeClassification, onChangeChord };
 }
 
+/**
+ * Seed the persist refs from a loaded entry exactly once, so a failed re-tag
+ * reverts to the entry's real tier/chord rather than the module default. The
+ * guard keeps later optimistic changes (which own the refs themselves) from
+ * being clobbered.
+ */
+function useSeedPersistOnLoad(
+  entry: Pick<EntryState, 'loaded' | 'classification' | 'chord'>,
+  seedPersist: (_tier: JournalClassification, _chord: AspectChordValue) => void,
+): void {
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !entry.loaded) return;
+    seededRef.current = true;
+    seedPersist(entry.classification, entry.chord);
+  }, [entry.loaded, entry.classification, entry.chord, seedPersist]);
+}
+
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
 function useJournalAutosave(
   routeEntryId: number | null,
@@ -617,13 +680,9 @@ function useJournalAutosave(
 ): AutosaveApi {
   const entry = useEntryState(routeEntryId, initialTitle);
   const { titleRef, bodyRef } = entry;
-  const { saveState, save, flush, changeClassification, changeChord } = useDebouncedSave(
-    routeEntryId,
-    delayMs,
-    ctx,
-    entry.loadError != null,
-    onSaved,
-  );
+  const { saveState, save, flush, changeClassification, changeChord, seedPersist } =
+    useDebouncedSave(routeEntryId, delayMs, ctx, entry.loadError != null, onSaved);
+  useSeedPersistOnLoad(entry, seedPersist);
 
   const { onChangeTitle, onChangeBody } = useFieldHandlers(
     titleRef,

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -135,6 +135,37 @@ describe('JournalEntryScreen — chord change PATCH failure', () => {
     }
   });
 
+  it('reverts to the loaded (tagged) chord, not the empty default, when the PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      // Loaded with a primary Aspect — a failed re-tag must fall back to the
+      // persisted chord (primary 3), not the empty default the ref started at.
+      mockGet.mockResolvedValue(entry({ id: 7, primary_aspect: 3, secondary_aspect: null }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      const page = within(getByTestId('journal-page'));
+      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getByTestId('journal-save-hint').props.children).toBe(ERROR_HINT);
+      const after = within(getByTestId('journal-page'));
+      // Reverted to the persisted chord (primary 3), not the empty default.
+      expect(after.getByTestId('aspect-primary-3').props.accessibilityState.selected).toBe(true);
+      expect(after.getByTestId('aspect-primary-5').props.accessibilityState.selected).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('keeps the new chord selected with no error hint when the PATCH succeeds', async () => {
     jest.useFakeTimers();
     try {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -304,6 +304,38 @@ describe('JournalEntryScreen — tier change PATCH failure', () => {
     }
   });
 
+  it('reverts to the loaded non-default tier (not the module default) when the PATCH rejects', async () => {
+    jest.useFakeTimers();
+    try {
+      // Loaded as intimate — a failed re-tag must fall back to the persisted
+      // intimate, never the personal default (which would read as less private).
+      mockGet.mockResolvedValue(entry({ id: 7, classification: 'intimate' }));
+      const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+      await waitFor(() => {
+        expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+      });
+      mockUpdate.mockClear();
+      mockUpdate.mockRejectedValueOnce(new Error('network'));
+
+      fireEvent.press(within(getByTestId('journal-page')).getByTestId('privacy-tier-public'));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const page = within(getByTestId('journal-page'));
+      expect(page.getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(
+        true,
+      );
+      expect(page.getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(
+        false,
+      );
+      expect(page.getByTestId('privacy-tier-public').props.accessibilityState.selected).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('keeps the new tier selected with no error hint when the PATCH succeeds', async () => {
     jest.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

`JournalEntryScreen`'s optimistic tier/chord persist hooks own a "last value" ref used for revert-on-failure, but that ref was **never seeded when an existing entry loads**. On a non-default entry, a failed classification/chord PATCH reverted the control to the module **default** (`personal` / empty chord) instead of the entry's real tier/chord. This is privacy-relevant — an `intimate` entry could silently display as `personal` after a network hiccup.

The fix seeds the persist refs from the loaded entry so revert-on-failure returns the last-persisted value:

- Expose `seedClassification`/`seedChord` from `useClassificationPersist`/`useChordPersist`.
- Extract `usePersistControls` composing both persisters + a combined `seedPersist(tier, chord)`.
- Add a `loaded` signal to `useEntryState` (set in the load callback).
- Add `useSeedPersistOnLoad`: a one-shot effect (guarded by `seededRef`) that seeds the refs from the loaded tier/chord exactly once, so later optimistic changes — which own the refs themselves — are never clobbered.

Create-time behavior, the debounced body-save, the AspectChordControl collapsed-display issue (#1216), and the persist-hook duplication refactor (#1217) are untouched.

Follow-up noted during review (out of scope): `changeClassification`/`changeChord` PATCH whenever `entryIdRef` is set but do not consult `loadFailedRef`, so a tap after a *failed* load could PATCH the real entry to an unseen default — worth a separate privacy-hardening issue.

## Test plan

- New: reverts to the loaded **non-default** tier (`intimate`), not the default, when the PATCH rejects (`JournalEntryScreenPrivacy.test.tsx`).
- New: reverts to the loaded **tagged** chord (primary 3), not the empty default, when the PATCH rejects (`JournalEntryScreenChord.test.tsx`).
- Both new tests fail against the pre-fix code (verified RED) and pass after.
- Existing default-tier revert test stays green.
- `./scripts/frontend/check-all.sh`: eslint (`--max-warnings=0`), prettier, tsc, and the full jest suite (3279 tests) all pass.

Closes #1261