### PR TITLE
fix(frontend): fail-closed logout so a failed clearToken can't resurrect the session

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -9,7 +9,14 @@ import {
   type AuthResponse,
   type UnauthorizedReason,
 } from '@/api';
-import { clearToken, loadToken, saveToken } from '@/storage/authStorage';
+import {
+  clearLogoutPending,
+  clearToken,
+  isLogoutPending,
+  loadToken,
+  markLogoutPending,
+  saveToken,
+} from '@/storage/authStorage';
 import { clearHabits, clearPendingCheckIns } from '@/storage/habitStorage';
 import { clearLlmApiKey } from '@/storage/llmKeyStorage';
 import { clearAllNotificationData } from '@/storage/notificationStorage';
@@ -164,6 +171,35 @@ async function wipeUserState(): Promise<void> {
 }
 
 /**
+ * Best-effort ``clearToken`` shared by every teardown path. Returns ``true``
+ * when the delete succeeded and ``false`` when it rejected (warned inside), so
+ * the caller can decide whether to arm the BUG-FE-STATE-001 logout-pending
+ * marker.
+ */
+async function clearTokenSafely(label: string): Promise<boolean> {
+  try {
+    await clearToken();
+    return true;
+  } catch (err: unknown) {
+    console.warn(`clearToken failed in ${label}`, err);
+    return false;
+  }
+}
+
+/**
+ * BUG-FE-STATE-001: a logout/401 clear that failed left the JWT on disk to
+ * resurrect on cold start. Arm the logout-pending marker (best-effort) so the
+ * next bootstrap retries the delete before hydrating.
+ */
+async function armLogoutPending(label: string): Promise<void> {
+  try {
+    await markLogoutPending();
+  } catch (err: unknown) {
+    console.warn(`markLogoutPending failed in ${label}`, err);
+  }
+}
+
+/**
  * BUG-AUTH-005 / BUG-NAV-001: the storage write must complete before we drop
  * the token from state; otherwise a crash between the two leaves a stale
  * token in secure storage that hydrates on next launch. When the API layer
@@ -181,10 +217,8 @@ async function clearTokenForReauth(
   mutators: AuthMutators,
   reason: UnauthorizedReason,
 ): Promise<void> {
-  try {
-    await clearToken();
-  } catch (err: unknown) {
-    console.warn('clearToken failed in onUnauthorized', err);
+  if (!(await clearTokenSafely('onUnauthorized'))) {
+    await armLogoutPending('onUnauthorized');
   }
   mutators.setToken(null);
   mutators.setAuthStatus((prev) => {
@@ -263,32 +297,53 @@ function useApiCallbacks(
 }
 
 /**
- * Load token from storage on mount, discarding expired tokens. Terminates
- * in either ``'authenticated'`` or ``'anonymous'`` — ``'loading'`` is a
- * one-shot state, so later effects must not rewind it (BUG-NAV-002).
+ * BUG-FE-STATE-001: a prior logout/401 armed the marker because ``clearToken``
+ * failed, stranding the JWT on disk. Retry the delete now; disarm the marker
+ * only if the retry succeeds so a still-failing store is tried again next
+ * launch. Either way the session lands ``'anonymous'``.
  */
+async function drainPendingLogout(mutators: AuthMutators): Promise<void> {
+  if (await clearTokenSafely('bootstrap')) {
+    try {
+      await clearLogoutPending();
+    } catch (err: unknown) {
+      console.warn('clearLogoutPending failed on bootstrap', err);
+    }
+  }
+  mutators.setAuthStatus('anonymous');
+}
+
+/**
+ * Cold-start bootstrap: honor a pending logout before hydrating, then load the
+ * stored token and discard it if expired. Terminates in ``'authenticated'`` or
+ * ``'anonymous'`` — ``'loading'`` is one-shot, so later effects must not rewind
+ * it (BUG-NAV-002).
+ */
+async function bootstrapStoredToken(mutators: AuthMutators): Promise<void> {
+  if (await isLogoutPending()) {
+    await drainPendingLogout(mutators);
+    return;
+  }
+  const stored = await loadToken();
+  if (stored && !isTokenExpired(stored)) {
+    mutators.setToken(stored);
+    mutators.setAuthStatus('authenticated');
+    return;
+  }
+  if (stored) {
+    // Expired token: discard without arming the marker — the user did not ask
+    // to log out, so a failed clear should not force a wipe next launch.
+    await clearTokenSafely('bootstrap discard expired');
+  }
+  mutators.setAuthStatus('anonymous');
+}
+
 function useLoadStoredToken(mutators: AuthMutators): void {
   useEffect(() => {
-    loadToken()
-      .then(async (stored) => {
-        if (stored && !isTokenExpired(stored)) {
-          mutators.setToken(stored);
-          mutators.setAuthStatus('authenticated');
-          return;
-        }
-        if (stored) {
-          try {
-            await clearToken();
-          } catch (err: unknown) {
-            console.warn('clearToken failed discarding expired stored token', err);
-          }
-        }
-        mutators.setAuthStatus('anonymous');
-      })
-      .catch((err: unknown) => {
-        console.warn('loadToken failed on bootstrap', err);
-        mutators.setAuthStatus('anonymous');
-      });
+    bootstrapStoredToken(mutators).catch((err: unknown) => {
+      console.warn('loadToken failed on bootstrap', err);
+      mutators.setAuthStatus('anonymous');
+    });
   }, [mutators]);
 }
 
@@ -313,6 +368,13 @@ interface AuthActions {
  */
 async function applyAuthResponse(response: AuthResponse, mutators: AuthMutators): Promise<void> {
   await saveToken(response.token);
+  // BUG-FE-STATE-001: a fresh auth supersedes any stale pending-logout marker;
+  // a clear failure here must not break login / signup / password-reset.
+  try {
+    await clearLogoutPending();
+  } catch (err: unknown) {
+    console.warn('clearLogoutPending failed in applyAuthResponse', err);
+  }
   mutators.setToken(response.token);
   mutators.setUserTimezone(response.timezone ?? 'UTC');
   mutators.setAuthStatus('authenticated');
@@ -354,10 +416,8 @@ async function signupWithDeviceTimezone(email: string, password: string): Promis
  * duplicated across two callbacks.
  */
 async function tearDownSession(mutators: AuthMutators, where: string): Promise<void> {
-  try {
-    await clearToken();
-  } catch (err: unknown) {
-    console.warn(`clearToken failed in ${where}`, err);
+  if (!(await clearTokenSafely(where))) {
+    await armLogoutPending(where);
   }
   await wipeUserState();
   mutators.setToken(null);

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -29,6 +29,9 @@ jest.mock('@/storage/authStorage', () => ({
   saveToken: jest.fn(() => Promise.resolve()),
   loadToken: jest.fn(() => Promise.resolve(null)),
   clearToken: jest.fn(() => Promise.resolve()),
+  markLogoutPending: jest.fn(() => Promise.resolve()),
+  isLogoutPending: jest.fn(() => Promise.resolve(false)),
+  clearLogoutPending: jest.fn(() => Promise.resolve()),
 }));
 
 // Mock token utilities
@@ -40,13 +43,23 @@ jest.mock('@/utils/token', () => ({
 }));
 
 import { auth, setOnTokenRefreshed, setOnUnauthorized, setTokenGetter } from '@/api';
-import { saveToken, loadToken, clearToken } from '@/storage/authStorage';
+import {
+  saveToken,
+  loadToken,
+  clearToken,
+  markLogoutPending,
+  isLogoutPending,
+  clearLogoutPending,
+} from '@/storage/authStorage';
 import { isTokenExpired, shouldRefreshToken } from '@/utils/token';
 
 const mockAuth = auth as jest.Mocked<typeof auth>;
 const mockLoadToken = loadToken as jest.MockedFunction<typeof loadToken>;
 const mockSaveToken = saveToken as jest.MockedFunction<typeof saveToken>;
 const mockClearToken = clearToken as jest.MockedFunction<typeof clearToken>;
+const mockMarkLogoutPending = markLogoutPending as jest.MockedFunction<typeof markLogoutPending>;
+const mockIsLogoutPending = isLogoutPending as jest.MockedFunction<typeof isLogoutPending>;
+const mockClearLogoutPending = clearLogoutPending as jest.MockedFunction<typeof clearLogoutPending>;
 const mockSetTokenGetter = setTokenGetter as jest.MockedFunction<typeof setTokenGetter>;
 const mockSetOnTokenRefreshed = setOnTokenRefreshed as jest.MockedFunction<
   typeof setOnTokenRefreshed
@@ -65,6 +78,7 @@ beforeEach(() => {
   mockLoadToken.mockResolvedValue(null);
   mockIsTokenExpired.mockReturnValue(false);
   mockShouldRefreshToken.mockReturnValue(false);
+  mockIsLogoutPending.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -904,6 +918,119 @@ describe('AuthContext', () => {
       expect(result.current.authStatus).toBe('anonymous');
       expect(result.current.token).toBeNull();
       expect(mockSaveToken).not.toHaveBeenCalled();
+    });
+  });
+
+  // BUG-FE-STATE-001 follow-up: a failed clearToken() on logout/401 left the JWT on disk, resurrecting on cold start.
+  describe('logout-pending marker survives a failed clearToken (BUG-FE-STATE-001)', () => {
+    it('arms the marker when logout fails to clear, then wipes the stale token on next launch', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('SecureStore unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const launch1 = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(launch1.result.current.token).toBe('existing-jwt'));
+
+      await act(async () => {
+        await launch1.result.current.logout();
+      });
+
+      expect(mockMarkLogoutPending).toHaveBeenCalled();
+      expect(launch1.result.current.authStatus).toBe('anonymous');
+      launch1.unmount();
+
+      mockIsLogoutPending.mockResolvedValueOnce(true);
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      const launch2 = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(launch2.result.current.authStatus).toBe('anonymous'));
+      expect(launch2.result.current.token).toBeNull();
+      expect(mockClearToken).toHaveBeenCalledTimes(2);
+      expect(mockClearLogoutPending).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('arms the marker when a 401 reauth fails to clear, then lands anonymous on next launch', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('SecureStore unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const launch1 = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(launch1.result.current.authStatus).toBe('authenticated'));
+
+      const unauthorized = mockSetOnUnauthorized.mock.calls.at(-1)?.[0];
+      await act(async () => {
+        unauthorized?.('session_expired');
+      });
+
+      await waitFor(() => expect(launch1.result.current.authStatus).toBe('reauth-required'));
+      expect(mockMarkLogoutPending).toHaveBeenCalled();
+      launch1.unmount();
+
+      mockIsLogoutPending.mockResolvedValueOnce(true);
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      const launch2 = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(launch2.result.current.authStatus).toBe('anonymous'));
+      expect(launch2.result.current.token).toBeNull();
+      expect(mockClearLogoutPending).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('keeps the marker armed when the bootstrap re-clear also fails', async () => {
+      mockIsLogoutPending.mockResolvedValueOnce(true);
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('still unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+      expect(result.current.token).toBeNull();
+      expect(mockClearLogoutPending).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('login success clears the logout-pending marker', async () => {
+      mockAuth.login.mockResolvedValue({ token: 'new-jwt', user_id: 1 });
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+
+      await act(async () => {
+        await result.current.login('user@test.com', 'password123');
+      });
+
+      expect(mockClearLogoutPending).toHaveBeenCalled();
+      expect(result.current.authStatus).toBe('authenticated');
+    });
+
+    it('still lands authenticated when clearing the logout-pending marker rejects', async () => {
+      mockAuth.login.mockResolvedValue({ token: 'new-jwt', user_id: 1 });
+      mockClearLogoutPending.mockRejectedValueOnce(new Error('disk full'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+
+      await act(async () => {
+        await result.current.login('user@test.com', 'password123');
+      });
+
+      expect(result.current.authStatus).toBe('authenticated');
+      expect(result.current.token).toBe('new-jwt');
+      warnSpy.mockRestore();
+    });
+
+    it('does not arm the marker when discarding an expired stored token fails to clear', async () => {
+      mockLoadToken.mockResolvedValue('expired-jwt');
+      mockIsTokenExpired.mockReturnValue(true);
+      mockClearToken.mockRejectedValueOnce(new Error('locked'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('anonymous'));
+      expect(mockMarkLogoutPending).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 });

--- a/frontend/src/storage/__tests__/authStorage.test.ts
+++ b/frontend/src/storage/__tests__/authStorage.test.ts
@@ -3,6 +3,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
+import { clearLogoutPending, isLogoutPending, markLogoutPending } from '../authStorage';
 import type * as AuthStorageModule from '../authStorage';
 
 const platformRef = { value: 'ios' as 'ios' | 'android' | 'web' };
@@ -115,5 +116,38 @@ describe('authStorage (web)', () => {
     await expect(saveToken('')).rejects.toBeInstanceOf(EmptyAuthTokenError);
     await expect(saveToken('   ')).rejects.toBeInstanceOf(EmptyAuthTokenError);
     expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+// BUG-FE-STATE-001: independent of the SecureStore JWT, always AsyncStorage-backed.
+describe('authStorage logout-pending marker (BUG-FE-STATE-001)', () => {
+  const LOGOUT_PENDING_KEY = '@adepthood/logout_pending';
+
+  test('markLogoutPending writes the pending flag', async () => {
+    await markLogoutPending();
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(LOGOUT_PENDING_KEY, 'true');
+  });
+
+  test('isLogoutPending returns false when unset', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+    expect(await isLogoutPending()).toBe(false);
+  });
+
+  test('isLogoutPending returns true once marked', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+    expect(await isLogoutPending()).toBe(true);
+  });
+
+  test('isLogoutPending swallows storage errors as false', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'));
+    expect(await isLogoutPending()).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('clearLogoutPending removes the pending flag', async () => {
+    await clearLogoutPending();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(LOGOUT_PENDING_KEY);
   });
 });

--- a/frontend/src/storage/authStorage.ts
+++ b/frontend/src/storage/authStorage.ts
@@ -104,3 +104,31 @@ export async function clearToken(): Promise<void> {
   }
   await SecureStore.deleteItemAsync(TOKEN_KEY);
 }
+
+// BUG-FE-STATE-001: a logout-pending marker, always AsyncStorage-backed on
+// both platforms. It is deliberately independent of the SecureStore JWT store
+// so a SecureStore delete outage can't also strand the marker on native; it
+// holds no secret, so it adds no BUG-FE-AUTH-007 XSS surface.
+const LOGOUT_PENDING_KEY = '@adepthood/logout_pending';
+const FLAG_TRUE = 'true';
+
+/** Arm the marker so a failed ``clearToken`` is retried on the next launch. */
+export async function markLogoutPending(): Promise<void> {
+  await AsyncStorage.setItem(LOGOUT_PENDING_KEY, FLAG_TRUE);
+}
+
+/** Read the marker; non-throwing so a transient read blip never logs out a legit user. */
+export async function isLogoutPending(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(LOGOUT_PENDING_KEY);
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[authStorage] failed to read logout-pending marker', err);
+    return false;
+  }
+}
+
+/** Disarm the marker once the stale token clears or a fresh auth supersedes it. */
+export async function clearLogoutPending(): Promise<void> {
+  await AsyncStorage.removeItem(LOGOUT_PENDING_KEY);
+}


### PR DESCRIPTION
## Summary
Logout (`tearDownSession`) and 401 re-auth (`clearTokenForReauth`) called `await clearToken()` in a try/catch and, when the SecureStore delete **rejected**, only logged a warning before going `anonymous`/`reauth-required` — leaving the JWT on disk. On the next cold start, `useLoadStoredToken` re-hydrated any non-expired stored token unconditionally, silently signing the logged-out user back in (a shared-device session-handover). Taxonomy Family 0 (swallowed exception on a write path) + Family 10 (session not fully cleared).

This makes session termination **fail-closed**:
- New AsyncStorage **logout-pending marker** (`@adepthood/logout_pending`), deliberately independent of the SecureStore that holds the JWT, so a SecureStore delete outage cannot also strand the marker on native. It holds no secret, so it adds no `BUG-FE-AUTH-007` XSS surface.
- On a **failed** `clearToken()` in `tearDownSession`/`clearTokenForReauth`, the marker is armed (best-effort). In-memory outcome is unchanged: logout → `anonymous`, 401 → `reauth-required`/`anonymous` per reason (the `BUG-FE-STATE-001` contract is preserved).
- **Bootstrap** (`bootstrapStoredToken`) checks the marker *before* `loadToken()`: if armed, it force re-clears the token and lands `anonymous` **without hydrating**, disarming the marker only if the re-clear succeeds (so a still-failing store retries every launch and always settles `anonymous`).
- `applyAuthResponse` clears the marker on fresh login/signup/password-reset, so a stale marker can't log out a freshly-authenticated user.
- The three identical `try { await clearToken() } catch` blocks collapse into one `clearTokenSafely(label)` helper.

The expired-token discard path intentionally does **not** arm the marker (an expired token can't resurrect a session anyway, and the user didn't ask to log out).

### Accepted tradeoff
`isLogoutPending()` is non-throwing (a read error → `false`) so a transient AsyncStorage blip never boots a legitimate authenticated user to login on every cold start. The residual fail-open window requires a rare triple-conjunction (prior `clearToken` failed → marker armed → marker read blips → stale token still on disk); biasing the read toward `true`/throw would harm the common case far more. Flagged for conscious sign-off.

## Test plan
- `frontend/src/context/__tests__/AuthContext.test.tsx` — new two-launch tests: marker armed on failed logout clear (AC-1) and failed 401 reauth clear (AC-2); next-launch bootstrap re-clears and disarms; marker stays armed when the re-clear also fails; fresh login clears the marker (and still lands `authenticated` if the clear rejects); expired-token discard failure does **not** arm the marker (scope pin). Existing `still transitions to anonymous when clearToken rejects` + reauth analogue untouched (AC-3).
- `frontend/src/storage/__tests__/authStorage.test.ts` — marker round-trip on both platforms + `isLogoutPending` returns `false` (and warns) on read error.
- `./scripts/frontend/check-all.sh` green: eslint, prettier, tsc, jest (3289 tests) all pass.

Closes #1267