### PR TITLE
fix(map): hyphenate right-column Aspect labels instead of shrink-to-fit truncation

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -29,6 +29,11 @@ const CENTER_FLEX = GRID_COLUMN_FLEX.center;
 const RIGHT_FLEX = GRID_COLUMN_FLEX.right;
 const CENTER = 'center';
 
+// Line height for the right-column aspect label, tuned to its fontSize 15 so
+// the up-to-two hyphenated lines stay compact and centered without pushing
+// neighboring rows.
+const RIGHT_LABEL_LINE_HEIGHT = 19;
+
 /**
  * Styles for the Map's spiral-of-becoming grid + the rich stage-detail modal.
  * The grid is token-only and laid out purely with flex; the modal keeps the
@@ -97,11 +102,13 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
 
-  // Right-column aspect label: a single line that auto-scales down to fit its
-  // cell width, so the text is never clipped or broken mid-word.
+  // Right-column aspect label: fixed serif size rendered on up to two
+  // pre-hyphenated lines, its line height kept compact so a two-line label
+  // stays vertically centered without pushing neighboring rows.
   rightLabelText: {
     fontFamily: editorialType.serif,
     fontSize: 15,
+    lineHeight: RIGHT_LABEL_LINE_HEIGHT,
     color: ink.primary,
   },
 

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -45,7 +45,7 @@ import {
   unlockTimeline,
 } from './journeyNarrative';
 import styles from './Map.styles';
-import { MAP_ROWS, RIGHT_LABEL_MIN_FONT_SCALE, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
+import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
@@ -314,13 +314,8 @@ const MapRowView = ({
         onCellLayout={onCellLayout}
       />
       <View style={styles.rightCell}>
-        <Text
-          style={styles.rightLabelText}
-          numberOfLines={1}
-          adjustsFontSizeToFit
-          minimumFontScale={RIGHT_LABEL_MIN_FONT_SCALE}
-        >
-          {row.rightLabel}
+        <Text style={styles.rightLabelText} numberOfLines={2}>
+          {row.rightLabelLines.join('\n')}
         </Text>
       </View>
     </View>

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -5,7 +5,7 @@ import { Image, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import styles from '../Map.styles';
-import { RIGHT_LABEL_MIN_FONT_SCALE } from '../mapLayout';
+import { MAP_ROWS } from '../mapLayout';
 import MapScreen from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
 import { BALANCE_COPY, emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
@@ -426,31 +426,44 @@ describe('MapScreen', () => {
     expect(tree.root.findByProps({ testID: 'you-are-here' })).toBeTruthy();
   });
 
+  // Right-column labels render as row.rightLabelLines joined by a newline in
+  // a single Text node (static hyphenation, not shrink-to-fit).
+  const findRightLabelNode = (
+    tree: ReturnType<typeof create>,
+    row: (typeof MAP_ROWS)[number],
+  ): TestNode => {
+    const expectedChildren = row.rightLabelLines.join('\n');
+    const matches = tree.root.findAll((n: TestNode) => n.props.children === expectedChildren);
+    const node = matches[0];
+    if (!node) {
+      throw new Error(`no right-label Text found for ${row.rightLabel}`);
+    }
+    return node;
+  };
+
   it('keeps all six Aspect labels present after the wave overlay renders', () => {
     const tree = create(<MapScreen />);
     fireGridLayout(tree);
-    const aspectLabels = ['Awareness', 'Being', 'Wisdom', 'Understanding', 'Love', 'Yes-And-Ness'];
-    for (const label of aspectLabels) {
-      expect(tree.root.findAll((n: TestNode) => n.props.children === label).length).toBeGreaterThan(
-        0,
-      );
+    for (const row of MAP_ROWS) {
+      expect(findRightLabelNode(tree, row)).toBeTruthy();
     }
   });
 
-  it('renders each right-column Aspect label as a single-line auto-fitting Text', () => {
+  it('renders each right-column Aspect label as a static two-line Text, no auto-fit', () => {
     const tree = create(<MapScreen />);
     fireGridLayout(tree);
-    const aspectLabels = ['Awareness', 'Being', 'Wisdom', 'Understanding', 'Love', 'Yes-And-Ness'];
-    for (const label of aspectLabels) {
-      const candidates = tree.root.findAll((n: TestNode) => n.props.children === label);
-      const autoFitting = candidates.some(
-        (n: TestNode) =>
-          n.props.numberOfLines === 1 &&
-          n.props.adjustsFontSizeToFit === true &&
-          n.props.minimumFontScale === RIGHT_LABEL_MIN_FONT_SCALE,
-      );
-      expect(autoFitting).toBe(true);
+    for (const row of MAP_ROWS) {
+      const node = findRightLabelNode(tree, row);
+      expect(node.props.numberOfLines).toBe(2);
+      expect(node.props.adjustsFontSizeToFit).toBeUndefined();
+      expect(node.props.minimumFontScale).toBeUndefined();
     }
+  });
+
+  it('still keys each right-column row by its rightLabel testID after hyphenation', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    expect(tree.root.findByProps({ testID: 'map-row-Understanding' })).toBeTruthy();
   });
 
   // --- right-cell edge padding ---

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,16 +1,21 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import {
-  GRID_COLUMN_FLEX,
-  MAP_ROWS,
-  MAP_TITLE_LINES,
-  RIGHT_LABEL_MIN_FONT_SCALE,
-  STAGE_DISPLAY,
-} from '../mapLayout';
+import { GRID_COLUMN_FLEX, MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from '../mapLayout';
 import { STAGE_COUNT } from '../stageData';
 
 const HEX_COLOR = /^#[\da-f]{6}$/i;
 const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
+const MAX_RIGHT_LABEL_LINE_LENGTH = 9;
+
+// Locate a row by its rightLabel, failing loudly (not with a false-positive
+// undefined) if the expected copy ever moves or is renamed.
+const findRowByLabel = (label: string) => {
+  const row = MAP_ROWS.find((r) => r.rightLabel === label);
+  if (!row) {
+    throw new Error(`no MAP_ROWS entry with rightLabel ${label}`);
+  }
+  return row;
+};
 
 describe('mapLayout', () => {
   it('defines display copy for every stage', () => {
@@ -43,9 +48,29 @@ describe('mapLayout', () => {
     expect(MAP_TITLE_LINES).toEqual(['EMPTINESS', 'UNITY']);
   });
 
-  it('keeps the right-label font-scale floor within the auto-fit range', () => {
-    expect(RIGHT_LABEL_MIN_FONT_SCALE).toBeGreaterThan(0);
-    expect(RIGHT_LABEL_MIN_FONT_SCALE).toBeLessThan(1);
+  it('gives every right-label at most two hyphenated lines, each within the cell width', () => {
+    MAP_ROWS.forEach((row) => {
+      expect(row.rightLabelLines.length).toBeGreaterThanOrEqual(1);
+      expect(row.rightLabelLines.length).toBeLessThanOrEqual(2);
+      row.rightLabelLines.forEach((line) => {
+        expect(line.length).toBeLessThanOrEqual(MAX_RIGHT_LABEL_LINE_LENGTH);
+      });
+    });
+  });
+
+  it('rejoins each rightLabelLines back to its rightLabel, ignoring hyphen placement', () => {
+    MAP_ROWS.forEach((row) => {
+      const rejoined = row.rightLabelLines.join('').replaceAll('-', '');
+      expect(rejoined).toBe(row.rightLabel.replaceAll('-', ''));
+    });
+  });
+
+  it('hyphenates Understanding as Under- / standing', () => {
+    expect(findRowByLabel('Understanding').rightLabelLines).toEqual(['Under-', 'standing']);
+  });
+
+  it('hyphenates Yes-And-Ness as Yes-And- / Ness', () => {
+    expect(findRowByLabel('Yes-And-Ness').rightLabelLines).toEqual(['Yes-And-', 'Ness']);
   });
 
   it('keeps the shared column-flex weights the wave geometry also depends on', () => {

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -18,14 +18,6 @@
 /** Flex weights of each stage row's three cells (left / center / right). */
 export const GRID_COLUMN_FLEX = { left: 2, center: 2, right: 1 } as const;
 
-/**
- * Minimum auto-fit font scale for the right-column aspect label. Worst case is
- * "Understanding" (13 glyphs) on a ~320pt screen, where the ~20% right band
- * leaves ~48pt of usable width; 0.55 lets that word shrink onto a single line
- * without ellipsis or a mid-word break.
- */
-export const RIGHT_LABEL_MIN_FONT_SCALE = 0.55;
-
 /** Static, design-specific copy + color for a single stage's left-column text. */
 export interface StageDisplay {
   stageNumber: number;
@@ -45,6 +37,8 @@ export interface StageDisplay {
 export interface MapRow {
   /** Aspect-of-wholeness label shown in the right column. */
   rightLabel: string;
+  /** Pre-hyphenated right-column label lines (<= 2), avoiding shrink-to-fit. */
+  rightLabelLines: readonly string[];
   /** Stage numbers contained in this row, ordered top → bottom. */
   stageNumbers: readonly number[];
 }
@@ -155,10 +149,10 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
  * "feminine" stage above a warm-color "masculine" stage.
  */
 export const MAP_ROWS: readonly MapRow[] = [
-  { rightLabel: 'Awareness', stageNumbers: [10] },
-  { rightLabel: 'Being', stageNumbers: [9] },
-  { rightLabel: 'Wisdom', stageNumbers: [8, 7] },
-  { rightLabel: 'Understanding', stageNumbers: [6, 5] },
-  { rightLabel: 'Love', stageNumbers: [4, 3] },
-  { rightLabel: 'Yes-And-Ness', stageNumbers: [2, 1] },
+  { rightLabel: 'Awareness', rightLabelLines: ['Awareness'], stageNumbers: [10] },
+  { rightLabel: 'Being', rightLabelLines: ['Being'], stageNumbers: [9] },
+  { rightLabel: 'Wisdom', rightLabelLines: ['Wisdom'], stageNumbers: [8, 7] },
+  { rightLabel: 'Understanding', rightLabelLines: ['Under-', 'standing'], stageNumbers: [6, 5] },
+  { rightLabel: 'Love', rightLabelLines: ['Love'], stageNumbers: [4, 3] },
+  { rightLabel: 'Yes-And-Ness', rightLabelLines: ['Yes-And-', 'Ness'], stageNumbers: [2, 1] },
 ];


### PR DESCRIPTION
## Summary

The Map right column truncated `Understan…` and `Yes-And-…` on real phones. The shrink-to-fit path introduced in #1224 (`numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={RIGHT_LABEL_MIN_FONT_SCALE}` = 0.55) hit its scale floor on the narrower-than-modeled right band and fell back to an ellipsis — shrink-to-fit degrades to truncation whenever the width model is off, and RN has no reliable cross-platform auto-hyphenation.

This replaces that approach with explicit, correctly-placed static hyphenation:

- `MapRow` gains `rightLabelLines: readonly string[]` — `Understanding` → `Under-` / `standing`, `Yes-And-Ness` → `Yes-And-` / `Ness` (breaks at its existing hyphen, no doubled hyphen). `Awareness`, `Being`, `Wisdom`, `Love` stay single-line at full size.
- The right-label `Text` renders `row.rightLabelLines.join('\n')` with `numberOfLines={2}` and a named `lineHeight` so two-line labels stay vertically centered without pushing neighboring rows.
- `RIGHT_LABEL_MIN_FONT_SCALE` and its docstring are removed from the codebase.
- Row `testID`s (`map-row-${rightLabel}`) and React keys are unchanged — rows stay keyed by `rightLabel`.

Diff is scoped strictly to the right-column label rendering (coordination with in-flight #1291 on MapScreen/Map.styles).

## Test plan

- `mapLayout.test.ts`: every `MAP_ROWS` entry exposes `rightLabelLines` (≤ 2 lines, ≤ 9 chars/line); hyphen-insensitive rejoin invariant back to `rightLabel`; exact lines for the two long labels.
- `MapScreen.test.tsx`: right-label `Text` no longer sets `adjustsFontSizeToFit`/`minimumFontScale`, renders both lines with `numberOfLines={2}`; `map-row-Understanding` testID still resolves.
- `cd frontend && npm test && npm run lint && npx tsc --noEmit` all pass; `scripts/frontend/check-all.sh` green (3284 tests).

Closes #1286
Refs #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)