### PR TITLE
feat(map): corner-hug aspect labels with their unlock estimate; rename Self-Love

### DIFF
--- a/frontend/src/api/__tests__/wheel-api.test.ts
+++ b/frontend/src/api/__tests__/wheel-api.test.ts
@@ -21,7 +21,7 @@ const VALID_WHEEL: WheelBalance = {
   aspects: [
     { stage_number: 1, aspect: 'Agency', fullness: 0.1 },
     { stage_number: 2, aspect: 'Receptivity', fullness: 0.2 },
-    { stage_number: 3, aspect: 'Self-Interest', fullness: 0.85 },
+    { stage_number: 3, aspect: 'Self-Love', fullness: 0.85 },
     { stage_number: 4, aspect: 'Community', fullness: 0.0 },
     { stage_number: 5, aspect: 'Intellectual', fullness: 0.5 },
     { stage_number: 6, aspect: 'Embodied', fullness: 0.6 },
@@ -47,7 +47,7 @@ describe('wheel.get', () => {
     expect(result.aspects).toHaveLength(10);
     expect(result.aspects[2]?.stage_number).toBe(3);
     expect(result.aspects[2]?.fullness).toBe(0.85);
-    expect(result.aspects[2]?.aspect).toBe('Self-Interest');
+    expect(result.aspects[2]?.aspect).toBe('Self-Love');
   });
 
   test('surfaces a 401 as ApiError with status 401', async () => {

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -151,17 +151,21 @@ const styles = StyleSheet.create({
     color: colors.text.light,
     letterSpacing: 0.5,
   },
-  centerLabelRow: {
-    flexDirection: 'row',
-    alignItems: CENTER,
-    justifyContent: CENTER,
-    gap: spacing(0.5),
+  // Aspect-label block hugging a center-cell corner (opposite the wave's
+  // return pole). ``alignSelf`` escapes the cell's centering so the word +
+  // its unlock estimate group against the edge, in flow (no absolute overlay).
+  labelBlockLeft: {
+    alignSelf: 'flex-start',
+    alignItems: 'flex-start',
+  },
+  labelBlockRight: {
+    alignSelf: 'flex-end',
+    alignItems: 'flex-end',
   },
   arrowLabelText: {
     fontWeight: '700',
     fontSize: 12,
     color: ink.soft,
-    textAlign: CENTER,
     flexShrink: 1,
   },
   // Responsive title carried in the top stage rows' own grid cells (no fixed
@@ -194,17 +198,21 @@ const styles = StyleSheet.create({
   locked: {
     opacity: 0.4,
   },
-  // Unlock timeline stacked beneath the lock glyph ("Unlocks in N days").
-  // ``alignSelf: 'stretch'`` restores the full-width box the old absolute
-  // ``left: 0, right: 0`` gave, so ``textAlign: CENTER`` still centers the
-  // longer multi-line unlock-condition copy across the whole cell.
+  // Unlock estimate ("Unlocks in N days") grouped under the Aspect word inside
+  // the corner-hugging label block. Its text aligns to the same corner as the
+  // block via the left/right variants below, so the copy reads away from the
+  // wave strand rather than spanning and centering across the cell.
   unlockTimeline: {
-    alignSelf: 'stretch',
     marginTop: spacing(0.25),
     fontSize: 9,
     color: ink.muted,
-    textAlign: CENTER,
     paddingHorizontal: spacing(0.25),
+  },
+  unlockTimelineLeft: {
+    textAlign: 'left',
+  },
+  unlockTimelineRight: {
+    textAlign: 'right',
   },
 
   // --- Stage-completion celebration banner ----------------------------------

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -45,7 +45,7 @@ import {
   unlockTimeline,
 } from './journeyNarrative';
 import styles from './Map.styles';
-import { MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
+import { labelCorner, MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
@@ -86,15 +86,26 @@ const LockGlyph = (): React.JSX.Element => (
   </View>
 );
 
+/** Aspect label / unlock estimate corner within a center cell. */
+type LabelCorner = 'left' | 'right';
+
 /**
  * "Unlocks in N days" / unlock-condition copy for a locked stage, computed from
  * the existing calendar drip (no new backend). Falls back to the condition when
- * no program anchor is set.
+ * no program anchor is set. Its text aligns to the block's corner so the copy
+ * reads away from the wave strand.
  */
-const UnlockTimeline = ({ stageNumber }: { stageNumber: number }): React.JSX.Element => {
+const UnlockTimeline = ({
+  stageNumber,
+  corner,
+}: {
+  stageNumber: number;
+  corner: LabelCorner;
+}): React.JSX.Element => {
   const daysUntil = useDaysUntilStage(stageNumber);
+  const alignStyle = corner === 'left' ? styles.unlockTimelineLeft : styles.unlockTimelineRight;
   return (
-    <Text style={styles.unlockTimeline} testID={`stage-unlock-${stageNumber}`}>
+    <Text style={[styles.unlockTimeline, alignStyle]} testID={`stage-unlock-${stageNumber}`}>
       {unlockTimeline(daysUntil)}
     </Text>
   );
@@ -145,19 +156,42 @@ const StageTextBlock = ({
 // --- Center cell: label/title, lock, badge (the -1 tap); the wave overlay now
 // carries the directional/polarity read behind these cells ----------------
 
-const CenterContent = ({ display }: { display: StageDisplay }): React.JSX.Element => {
-  const title = TITLE_BY_STAGE[display.stageNumber];
+// Corner-hugging Aspect-label block: the arrow word plus, when locked, its
+// unlock estimate, grouped against the corner opposite the wave's return pole.
+const AspectLabelBlock = ({
+  display,
+  locked,
+}: {
+  display: StageDisplay;
+  locked: boolean;
+}): React.JSX.Element => {
+  const corner = labelCorner(display.stageNumber);
+  const blockStyle = corner === 'left' ? styles.labelBlockLeft : styles.labelBlockRight;
   return (
-    <>
-      {title ? (
-        <Text style={styles.titleText}>{title}</Text>
-      ) : display.arrowLabel ? (
-        <View style={styles.centerLabelRow}>
-          <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
-        </View>
-      ) : null}
-    </>
+    <View style={blockStyle} testID={`aspect-label-${display.stageNumber}`}>
+      <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
+      {locked ? <UnlockTimeline stageNumber={display.stageNumber} corner={corner} /> : null}
+    </View>
   );
+};
+
+// Title rows (9, 10) keep their centered serif heading; every other stage shows
+// its corner-hugging Aspect-label block instead of a centered word.
+const CenterContent = ({
+  display,
+  locked,
+}: {
+  display: StageDisplay;
+  locked: boolean;
+}): React.JSX.Element | null => {
+  const title = TITLE_BY_STAGE[display.stageNumber];
+  if (title) {
+    return <Text style={styles.titleText}>{title}</Text>;
+  }
+  if (!display.arrowLabel) {
+    return null;
+  }
+  return <AspectLabelBlock display={display} locked={locked} />;
 };
 
 interface StageCenterCellProps extends StageCellProps {
@@ -190,9 +224,8 @@ const StageCenterCell = ({
     accessibilityLabel={`${stage.title} - ${stage.subtitle}`}
   >
     {isCurrent ? <YouAreHereMarker /> : null}
-    <CenterContent display={display} />
+    <CenterContent display={display} locked={locked} />
     {locked ? <LockGlyph /> : null}
-    {locked ? <UnlockTimeline stageNumber={display.stageNumber} /> : null}
     {stage.progress >= FULL_PROGRESS ? (
       <View style={styles.completedBadge} testID={`stage-complete-${stage.stageNumber}`}>
         <Text style={styles.completedBadgeText}>✓</Text>

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -576,11 +576,7 @@ describe('MapScreen center-cell overlay layout', () => {
     }
   });
 
-  it('unlock countdown spans the full cell width so its centered copy stays centered', () => {
-    // Restores the full-width box the old ``left: 0, right: 0`` absolute
-    // positioning gave: without ``alignSelf: 'stretch'`` an in-flow Text
-    // shrink-wraps to its widest wrapped line and ``textAlign: 'center'``
-    // becomes a no-op for the multi-line unlock-condition copy.
+  it('unlock countdown hugs its corner instead of spanning and centering', () => {
     mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
     const countdown = tree.root.findByProps({ testID: 'stage-unlock-8' });
@@ -588,8 +584,9 @@ describe('MapScreen center-cell overlay layout', () => {
       alignSelf?: string;
       textAlign?: string;
     };
-    expect(flat.alignSelf).toBe('stretch');
-    expect(flat.textAlign).toBe('center');
+    expect(flat.textAlign).toBe('right');
+    expect(flat.textAlign).not.toBe('center');
+    expect(flat.alignSelf).not.toBe('stretch');
   });
 
   it('locked stages keep the recessed opacity treatment', () => {
@@ -599,7 +596,7 @@ describe('MapScreen center-cell overlay layout', () => {
     expect(flat.opacity).toBe(0.4);
   });
 
-  it('stacks the pill above the label and the countdown below the lock', () => {
+  it('stacks the pill above the label and the countdown above the lock', () => {
     mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
     const textOrder = (testID: string): string[] =>
@@ -613,10 +610,48 @@ describe('MapScreen center-cell overlay layout', () => {
     expect(currentText.indexOf('YOU ARE HERE')).toBeLessThan(currentText.indexOf('Agency'));
     expect(currentText.indexOf('YOU ARE HERE')).toBeGreaterThanOrEqual(0);
 
-    // Locked stage 8: the lock renders before the countdown copy.
+    // Locked stage 8: the countdown copy now renders before the lock glyph.
     const lockedText = textOrder('stage-hotspot-8-1');
     const countdownIndex = lockedText.findIndex((text) => text.startsWith('Unlocks'));
-    expect(lockedText.indexOf('🔒')).toBeGreaterThanOrEqual(0);
-    expect(lockedText.indexOf('🔒')).toBeLessThan(countdownIndex);
+    expect(countdownIndex).toBeGreaterThanOrEqual(0);
+    expect(countdownIndex).toBeLessThan(lockedText.indexOf('🔒'));
+  });
+
+  it('groups stage 1 (Agency) label in the left corner, unlocked with no countdown', () => {
+    const tree = create(<MapScreen />);
+    const block = tree.root.findByProps({ testID: 'aspect-label-1' });
+    const flat = StyleSheet.flatten(block.props.style) as { alignSelf?: string };
+    expect(flat.alignSelf).toBe('flex-start');
+    expect(block.findAll((node: TestNode) => node.props.testID === 'stage-unlock-1')).toHaveLength(
+      0,
+    );
+  });
+
+  it('groups stage 2 (Receptivity) label in the right corner, unlocked', () => {
+    const tree = create(<MapScreen />);
+    const block = tree.root.findByProps({ testID: 'aspect-label-2' });
+    const flat = StyleSheet.flatten(block.props.style) as { alignSelf?: string };
+    expect(flat.alignSelf).toBe('flex-end');
+  });
+
+  it('nests the locked stage 8 (Nondual) countdown inside its right-corner block', () => {
+    mockMapState.daysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    const block = tree.root.findByProps({ testID: 'aspect-label-8' });
+    const countdown = block.findByProps({ testID: 'stage-unlock-8' });
+    expect(countdown).toBeTruthy();
+    const flat = StyleSheet.flatten(countdown.props.style) as { textAlign?: string };
+    expect(flat.textAlign).toBe('right');
+  });
+
+  it('nests the locked stage 3 (Self-Love) countdown inside its left-corner block', () => {
+    mockMapState.daysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    const block = tree.root.findByProps({ testID: 'aspect-label-3' });
+    const label = block.findAll((node: TestNode) => node.props.children === 'Self-Love');
+    expect(label.length).toBeGreaterThan(0);
+    const countdown = block.findByProps({ testID: 'stage-unlock-3' });
+    const flat = StyleSheet.flatten(countdown.props.style) as { textAlign?: string };
+    expect(flat.textAlign).toBe('left');
   });
 });

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,7 +1,13 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { GRID_COLUMN_FLEX, MAP_ROWS, MAP_TITLE_LINES, STAGE_DISPLAY } from '../mapLayout';
-import { STAGE_COUNT } from '../stageData';
+import {
+  GRID_COLUMN_FLEX,
+  labelCorner,
+  MAP_ROWS,
+  MAP_TITLE_LINES,
+  STAGE_DISPLAY,
+} from '../mapLayout';
+import { isLeftReturning, STAGE_COUNT } from '../stageData';
 
 const HEX_COLOR = /^#[\da-f]{6}$/i;
 const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
@@ -75,5 +81,27 @@ describe('mapLayout', () => {
 
   it('keeps the shared column-flex weights the wave geometry also depends on', () => {
     expect(GRID_COLUMN_FLEX).toEqual({ left: 2, center: 2, right: 1 });
+  });
+
+  it('renames stage 3 arrow label from Self-Interest to Self-Love', () => {
+    expect(STAGE_DISPLAY[3]?.arrowLabel).toBe('Self-Love');
+  });
+
+  it('hugs odd stages left and even stages right', () => {
+    expect(labelCorner(1)).toBe('left');
+    expect(labelCorner(2)).toBe('right');
+    expect(labelCorner(3)).toBe('left');
+    expect(labelCorner(4)).toBe('right');
+    expect(labelCorner(5)).toBe('left');
+    expect(labelCorner(6)).toBe('right');
+    expect(labelCorner(7)).toBe('left');
+    expect(labelCorner(8)).toBe('right');
+  });
+
+  it('always hugs the corner opposite the wave return pole', () => {
+    for (let stageNumber = 1; stageNumber <= 8; stageNumber += 1) {
+      const expected = isLeftReturning(stageNumber) ? 'right' : 'left';
+      expect(labelCorner(stageNumber)).toBe(expected);
+    }
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -15,6 +15,8 @@
  * match the supplied spiral PNG rather than the app-wide spiral-dynamics swatches.
  */
 
+import { isLeftReturning } from './stageData';
+
 /** Flex weights of each stage row's three cells (left / center / right). */
 export const GRID_COLUMN_FLEX = { left: 2, center: 2, right: 1 } as const;
 
@@ -122,7 +124,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     persona: 'Dominator',
     descriptor: 'Power',
     practice: 'Confidence Meditation',
-    arrowLabel: 'Self-Interest',
+    arrowLabel: 'Self-Love',
     textColor: '#b14a3a',
   },
   2: {
@@ -156,3 +158,12 @@ export const MAP_ROWS: readonly MapRow[] = [
   { rightLabel: 'Love', rightLabelLines: ['Love'], stageNumbers: [4, 3] },
   { rightLabel: 'Yes-And-Ness', rightLabelLines: ['Yes-And-', 'Ness'], stageNumbers: [2, 1] },
 ];
+
+/**
+ * Which corner of the center panel a stage's Aspect label hugs. The label sits
+ * on the corner opposite the wave's return pole, so the word never lands under
+ * the strand: even (left-returning) stages hug the right corner, odd stages the
+ * left. Title stages (9, 10) carry no arrow label and never call this.
+ */
+export const labelCorner = (stageNumber: number): 'left' | 'right' =>
+  isLeftReturning(stageNumber) ? 'right' : 'left';


### PR DESCRIPTION
## Summary

The Map's center-column Aspect words (Agency, Receptivity, Self-Love, Community, Intellectual, Embodied, Systems, Nondual) were horizontally centered in their cells — exactly where the sine-wave helix strands converge — so the wave drew through the words, and each locked stage's "Unlocks in N days" estimate rendered as a detached, centered sibling under the lock glyph.

This change groups each Aspect word with its unlock estimate into one in-flow block that hugs **alternating corners** of the center panel: **left for odd stages** (Agency 1, Self-Love 3, Intellectual 5, Systems 7) and **right for even stages** (Receptivity 2, Community 4, Embodied 6, Nondual 8) — always the corner **opposite the wave's return pole**, so no word lands under a strand. The unlock estimate is pulled along with its title word and aligns to the same corner. Title rows (stages 9/10: EMPTINESS / UNITY) are untouched.

Stage 3's Aspect is also renamed from **Self-Interest** to **Self-Love**, aligning the Map with the existing backend copy (the curriculum already uses the `Self-Love` subtitle).

### Implementation
- `mapLayout.ts` — new pure `labelCorner(stageNumber)` helper (`isLeftReturning(n) ? 'right' : 'left'`, i.e. opposite the wave pole); stage-3 `arrowLabel` renamed to `Self-Love`.
- `MapScreen.tsx` — `CenterContent` refactored into pure title-vs-label-block rendering; new `AspectLabelBlock` (one `aspect-label-<n>` testID) groups the word and, when locked, the corner-aware `UnlockTimeline` nested inside it.
- `Map.styles.ts` — `labelBlockLeft` / `labelBlockRight` corner styles; the unlock estimate now aligns to its corner instead of stretching/centering; orphaned `centerLabelRow` removed. Candle & Ink tokens only.

## Test plan

- `mapLayout.test.ts` — asserts the full stage 1–8 `labelCorner` mapping (odd→left, even→right), the opposite-of-pole property, and `STAGE_DISPLAY[3].arrowLabel === 'Self-Love'`.
- `MapScreen.test.tsx` — new tests for a left stage (Agency) and right stage (Receptivity) carrying the corner-alignment style; a locked stage's `stage-unlock-<n>` rendering **inside** its `aspect-label-<n>` block with corner-matched text alignment; the countdown now ordered above the lock. Rewrote two tests whose old assertions (stretch/center, lock-before-countdown) the new behavior supersedes. Tap targets, a11y labels, `you-are-here`, completed badge, and connectors stay green.
- `wheel-api.test.ts` — fixture vocabulary updated to `Self-Love` for a clean repo-wide grep of the retired string.
- Full `scripts/frontend/check-all.sh` green: ESLint (0 warnings), prettier, strict tsc, and the entire Jest suite (3265 tests).

Closes #1288
Refs #1284