### PR TITLE
style(map): darken left-column stage text; lighten UNITY/EMPTINESS watermarks and fit

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -172,7 +172,7 @@ const styles = StyleSheet.create({
   // 40px overlay): the serif ramp scales rather than overflowing the column.
   titleText: {
     ...editorialType.title,
-    color: ink.primary,
+    color: ink.muted,
     letterSpacing: 1,
     textAlign: CENTER,
   },

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -146,9 +146,9 @@ const StageTextBlock = ({
     accessibilityRole="button"
     accessibilityLabel={stageNodeLabel(display, fullness)}
   >
-    <Text style={[styles.personaText, { color: display.textColor }]}>{display.persona}</Text>
-    <Text style={[styles.lineText, { color: display.textColor }]}>{display.descriptor}</Text>
-    <Text style={[styles.lineText, { color: display.textColor }]}>{display.practice}</Text>
+    <Text style={[styles.personaText, { color: display.leftTextColor }]}>{display.persona}</Text>
+    <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.descriptor}</Text>
+    <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.practice}</Text>
     {locked ? <LockGlyph /> : null}
   </TouchableOpacity>
 );
@@ -186,7 +186,11 @@ const CenterContent = ({
 }): React.JSX.Element | null => {
   const title = TITLE_BY_STAGE[display.stageNumber];
   if (title) {
-    return <Text style={styles.titleText}>{title}</Text>;
+    return (
+      <Text style={styles.titleText} adjustsFontSizeToFit numberOfLines={1}>
+        {title}
+      </Text>
+    );
   }
   if (!display.arrowLabel) {
     return null;

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -4,8 +4,9 @@ import React from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
+import { ink } from '../../../design/tokens';
 import styles from '../Map.styles';
-import { MAP_ROWS } from '../mapLayout';
+import { MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
 import MapScreen from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
 import { emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
@@ -653,5 +654,58 @@ describe('MapScreen center-cell overlay layout', () => {
     const countdown = block.findByProps({ testID: 'stage-unlock-3' });
     const flat = StyleSheet.flatten(countdown.props.style) as { textAlign?: string };
     expect(flat.textAlign).toBe('left');
+  });
+});
+
+describe('MapScreen left-column stage text color', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
+    );
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  // Sample rows spanning the top, a paired middle row, and the two bottom rows.
+  const SAMPLE_STAGES = [10, 8, 3, 1];
+
+  const requireDisplay = (stageNumber: number) => {
+    const display = STAGE_DISPLAY[stageNumber];
+    if (!display) {
+      throw new Error(`no STAGE_DISPLAY entry for stage ${stageNumber}`);
+    }
+    return display;
+  };
+
+  it('renders persona, descriptor, and practice in the leftTextColor, not the wave textColor', () => {
+    const tree = create(<MapScreen />);
+    for (const stageNumber of SAMPLE_STAGES) {
+      const display = requireDisplay(stageNumber);
+      const hotspot = tree.root.findByProps({ testID: `stage-hotspot-${stageNumber}-0` });
+      for (const line of [display.persona, display.descriptor, display.practice]) {
+        const textNode = hotspot.findAll((n: TestNode) => n.props.children === line)[0];
+        const flat = StyleSheet.flatten(textNode.props.style) as { color?: string };
+        expect(flat.color).toBe(display.leftTextColor);
+        expect(flat.color).not.toBe(display.textColor);
+      }
+    }
+  });
+
+  it('shrinks the EMPTINESS / UNITY title watermark to fit on one line', () => {
+    const tree = create(<MapScreen />);
+    for (const title of ['EMPTINESS', 'UNITY']) {
+      const node = tree.root.findByProps({ children: title });
+      expect(node.props.adjustsFontSizeToFit).toBe(true);
+      expect(node.props.numberOfLines).toBe(1);
+    }
+  });
+
+  it('renders the EMPTINESS / UNITY title watermark in the muted ink, not the primary ink', () => {
+    const tree = create(<MapScreen />);
+    for (const title of ['EMPTINESS', 'UNITY']) {
+      const node = tree.root.findByProps({ children: title });
+      const flat = StyleSheet.flatten(node.props.style) as { color?: string };
+      expect(flat.color).toBe(ink.muted);
+    }
   });
 });

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect */
+import { ink, surface } from '../../../design/tokens';
 import {
   GRID_COLUMN_FLEX,
   labelCorner,
@@ -12,6 +13,36 @@ import { isLeftReturning, STAGE_COUNT } from '../stageData';
 const HEX_COLOR = /^#[\da-f]{6}$/i;
 const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
 const MAX_RIGHT_LABEL_LINE_LENGTH = 9;
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
+
+// Locate a stage's display copy, failing loudly (not with a false-positive
+// undefined) if a stage number is ever missing from STAGE_DISPLAY.
+const requireDisplay = (stageNumber: number) => {
+  const display = STAGE_DISPLAY[stageNumber];
+  if (!display) {
+    throw new Error(`no STAGE_DISPLAY entry for stage ${stageNumber}`);
+  }
+  return display;
+};
 
 // Locate a row by its rightLabel, failing loudly (not with a false-positive
 // undefined) if the expected copy ever moves or is renamed.
@@ -103,5 +134,34 @@ describe('mapLayout', () => {
       const expected = isLeftReturning(stageNumber) ? 'right' : 'left';
       expect(labelCorner(stageNumber)).toBe(expected);
     }
+  });
+});
+
+describe('left-column stage text color', () => {
+  it('gives every stage a valid left-column text hex color', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      expect(requireDisplay(stageNumber).leftTextColor).toMatch(HEX_COLOR);
+    });
+  });
+
+  it('meets WCAG AA for the left-column text on the canvas ground', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      const display = requireDisplay(stageNumber);
+      expect(contrast(display.leftTextColor, surface.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+  });
+
+  it('is strictly darker than the matching wave color', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      const display = requireDisplay(stageNumber);
+      expect(luminance(display.leftTextColor)).toBeLessThan(luminance(display.textColor));
+    });
+  });
+
+  it('is darker than the EMPTINESS / UNITY title watermark ink', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      const display = requireDisplay(stageNumber);
+      expect(luminance(display.leftTextColor)).toBeLessThan(luminance(ink.muted));
+    });
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -33,6 +33,15 @@ export interface StageDisplay {
   arrowLabel: string;
   /** Text color matching this stage's arrow in the artwork. */
   textColor: string;
+  /**
+   * Darker variant of ``textColor`` for the left-column stage text. Same hue as
+   * ``textColor`` with HSL lightness reduced until it clears WCAG AA 4.5:1
+   * (~6.5:1 with margin) on the Map's parchment ground (``surface.canvas``
+   * #faf6ef), landing strictly darker (lower relative luminance) than both its
+   * own ``textColor`` and the UNITY/EMPTINESS watermark ink. Precomputed — no
+   * runtime color math.
+   */
+  leftTextColor: string;
 }
 
 /** A horizontal band of the table: one aspect label over one or two stages. */
@@ -70,6 +79,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Cultivate Vipassana',
     arrowLabel: '',
     textColor: '#1a1a1a',
+    leftTextColor: '#141414',
   },
   9: {
     stageNumber: 9,
@@ -78,6 +88,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Cultivate Samatha Jhanas',
     arrowLabel: '',
     textColor: '#9a5a78',
+    leftTextColor: '#7d4961',
   },
   8: {
     stageNumber: 8,
@@ -86,6 +97,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Deep Intuition',
     arrowLabel: 'Nondual',
     textColor: '#6d92a6',
+    leftTextColor: '#415b6a',
   },
   7: {
     stageNumber: 7,
@@ -94,6 +106,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Blissy Meditation',
     arrowLabel: 'Systems',
     textColor: '#c9a43c',
+    leftTextColor: '#6b561e',
   },
   6: {
     stageNumber: 6,
@@ -102,6 +115,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Shadow Work',
     arrowLabel: 'Embodied',
     textColor: '#7cb273',
+    leftTextColor: '#3c6135',
   },
   5: {
     stageNumber: 5,
@@ -110,6 +124,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Wim Hof Method',
     arrowLabel: 'Intellectual',
     textColor: '#dc9a5b',
+    leftTextColor: '#804d1b',
   },
   4: {
     stageNumber: 4,
@@ -118,6 +133,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Metta Meditation',
     arrowLabel: 'Community',
     textColor: '#6f9bd4',
+    leftTextColor: '#2c5993',
   },
   3: {
     stageNumber: 3,
@@ -126,6 +142,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Confidence Meditation',
     arrowLabel: 'Self-Love',
     textColor: '#b14a3a',
+    leftTextColor: '#943e31',
   },
   2: {
     stageNumber: 2,
@@ -134,6 +151,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: 'Divination',
     arrowLabel: 'Receptivity',
     textColor: '#5d4e9e',
+    leftTextColor: '#5c4d9c',
   },
   1: {
     stageNumber: 1,
@@ -142,6 +160,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
     practice: '5-4-3-2-1 Technique',
     arrowLabel: 'Agency',
     textColor: '#cdb079',
+    leftTextColor: '#6b5428',
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes the Map screen's left-column legibility and the UNITY/EMPTINESS title watermarks per the founder's note ("the left hand of the graph a slightly darker color... UNITY and EMPTINESS a lighter color... not to overflow").

- **Darker left-column text:** each stage now carries a precomputed, hue-preserving `leftTextColor` in `mapLayout.ts`. The three left-column lines (persona / descriptor / practice) render it instead of the artwork `textColor`. Every value clears WCAG AA 4.5:1 on the parchment ground (`surface.canvas` #faf6ef) at ~6.5:1 and reads strictly darker than both its own `textColor` and the watermark ink. No runtime color math.
- **Wave untouched:** `textColor` is unchanged on every entry, so the helix strands and arrowheads (which read it) stay pixel-identical. `waveGeometry.ts` / `WaveOverlay.tsx` are not touched.
- **Lighter, non-overflowing watermark:** `titleText` lightens from `ink.primary` to `ink.muted`, and the UNITY/EMPTINESS `<Text>` gains `adjustsFontSizeToFit` + `numberOfLines={1}` so EMPTINESS fits at 320–430 pt without moving or wrapping.

## Test plan

- `mapLayout.test.ts`: new invariants — every stage exposes a valid `leftTextColor` hex, clears AA 4.5:1 on the canvas ground, and is strictly darker (lower relative luminance) than its own `textColor` and than the `ink.muted` watermark.
- `MapScreen.test.tsx`: left-column texts render `leftTextColor` (not `textColor`); UNITY/EMPTINESS carry `adjustsFontSizeToFit` + `numberOfLines={1}` and the `ink.muted` color.
- Full frontend `check-all.sh` green: tsc, eslint (0 warnings), jest 3272 passing + coverage.

Closes #1289
Refs #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)