### PR TITLE
fix(storage): transient AsyncStorage read errors no longer delete the offline check-in queue

### DIFF
--- a/frontend/src/storage/__tests__/habitStorage.test.ts
+++ b/frontend/src/storage/__tests__/habitStorage.test.ts
@@ -138,12 +138,69 @@ describe('habitStorage', () => {
       const result = await loadHabits();
       expect(result).toBeNull();
     });
+
+    test('self-heals a non-array payload by clearing the key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({ not: 'an array' }));
+
+      const result = await loadHabits();
+      expect(result).toBeNull();
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/habits');
+    });
+
+    test('keeps stored habits on a transient read error (does not delete)', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('SQLite hiccup'));
+
+      const result = await loadHabits();
+      expect(result).toBeNull();
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+    });
   });
 
   describe('clearHabits', () => {
     test('removes habits from AsyncStorage', async () => {
       await clearHabits();
       expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/habits');
+    });
+  });
+
+  describe('loadPendingCheckIns', () => {
+    test('returns an empty queue when nothing is stored', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+      const result = await loadPendingCheckIns();
+      expect(result).toEqual([]);
+    });
+
+    test('returns the stored queue', async () => {
+      const queue = [{ goal_id: 1, did_complete: true, timestamp: 't1' }];
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(queue));
+
+      const result = await loadPendingCheckIns();
+      expect(result).toEqual(queue);
+    });
+
+    test('self-heals corrupt JSON by clearing the key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('not valid json{{{');
+
+      const result = await loadPendingCheckIns();
+      expect(result).toEqual([]);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/pending_checkins');
+    });
+
+    test('self-heals a non-array payload by clearing the key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({ not: 'an array' }));
+
+      const result = await loadPendingCheckIns();
+      expect(result).toEqual([]);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/pending_checkins');
+    });
+
+    test('keeps the offline queue on a transient read error (does not delete)', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('disk pressure'));
+
+      const result = await loadPendingCheckIns();
+      expect(result).toEqual([]);
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/storage/__tests__/notificationStorage.test.ts
+++ b/frontend/src/storage/__tests__/notificationStorage.test.ts
@@ -87,6 +87,29 @@ describe('notificationStorage', () => {
       const result = await loadNotificationIds(42);
       expect(result).toEqual([]);
     });
+
+    test('self-heals corrupt data by clearing the key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('bad json{');
+
+      await loadNotificationIds(42);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notifications/42');
+    });
+
+    test('self-heals a non-array payload by clearing the key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({ not: 'an array' }));
+
+      const result = await loadNotificationIds(42);
+      expect(result).toEqual([]);
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/notifications/42');
+    });
+
+    test('keeps stored IDs on a transient read error (does not delete)', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('SQLite hiccup'));
+
+      const result = await loadNotificationIds(42);
+      expect(result).toEqual([]);
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+    });
   });
 
   describe('clearNotificationIds', () => {
@@ -143,6 +166,14 @@ describe('notificationStorage', () => {
 
       const result = await loadAllNotificationMappings();
       expect(result).toEqual({ 1: ['a'] });
+    });
+
+    test('keeps the tracking list on a transient read error (does not delete)', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('disk pressure'));
+
+      const result = await loadAllNotificationMappings();
+      expect(result).toEqual({});
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/storage/habitStorage.ts
+++ b/frontend/src/storage/habitStorage.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
-import { resetCorruptKey } from './jsonStore';
+import { getJsonArray } from './jsonStore';
 import { serialize } from './serializedWrite';
 
 const STORAGE_KEY = '@adepthood/habits';
@@ -36,19 +36,9 @@ export async function saveHabits(habits: Habit[]): Promise<void> {
 }
 
 export async function loadHabits(): Promise<Habit[] | null> {
-  try {
-    const raw = await AsyncStorage.getItem(STORAGE_KEY);
-    if (raw === null) return null;
-    const parsed = JSON.parse(raw) as Habit[];
-    if (!Array.isArray(parsed)) {
-      await resetCorruptKey(STORAGE_KEY, new Error('expected array'));
-      return null;
-    }
-    return parsed.map(rehydrateHabit);
-  } catch (err: unknown) {
-    await resetCorruptKey(STORAGE_KEY, err);
-    return null;
-  }
+  const parsed = await getJsonArray<Habit>(STORAGE_KEY);
+  if (parsed === null) return null;
+  return parsed.map(rehydrateHabit);
 }
 
 export async function clearHabits(): Promise<void> {
@@ -86,19 +76,7 @@ export async function replacePendingCheckIns(checkIns: PendingCheckIn[]): Promis
 }
 
 export async function loadPendingCheckIns(): Promise<PendingCheckIn[]> {
-  try {
-    const raw = await AsyncStorage.getItem(PENDING_CHECKINS_KEY);
-    if (raw === null) return [];
-    const parsed = JSON.parse(raw) as PendingCheckIn[];
-    if (!Array.isArray(parsed)) {
-      await resetCorruptKey(PENDING_CHECKINS_KEY, new Error('expected array'));
-      return [];
-    }
-    return parsed;
-  } catch (err: unknown) {
-    await resetCorruptKey(PENDING_CHECKINS_KEY, err);
-    return [];
-  }
+  return (await getJsonArray<PendingCheckIn>(PENDING_CHECKINS_KEY)) ?? [];
 }
 
 /**

--- a/frontend/src/storage/jsonStore.ts
+++ b/frontend/src/storage/jsonStore.ts
@@ -13,3 +13,42 @@ export async function resetCorruptKey(key: string, err: unknown): Promise<void> 
     console.warn(`[storage] failed to clear corrupt key ${key}`, removeErr);
   }
 }
+
+/**
+ * Read a JSON array from AsyncStorage with fail-safe semantics, returning
+ * `null` when the value is absent or unreadable.
+ *
+ * The two failure modes are handled differently on purpose:
+ *
+ *   - A **transient** `getItem` rejection (Android SQLite hiccup, disk
+ *     pressure) leaves the stored data untouched — it returns `null`
+ *     WITHOUT calling `removeItem`, so a later read can still recover it.
+ *   - Genuinely **corrupt** JSON (parse failure or a non-array payload)
+ *     self-heals via `resetCorruptKey`, clearing the poisoned key so the
+ *     next launch starts clean.
+ *
+ * Conflating the two — wrapping both `getItem` and `JSON.parse` in one
+ * `try` whose `catch` clears the key — silently deletes good data on a
+ * momentary read blip, which is the bug this helper exists to prevent.
+ */
+export async function getJsonArray<T>(key: string): Promise<T[] | null> {
+  let raw: string | null;
+  try {
+    raw = await AsyncStorage.getItem(key);
+  } catch (err: unknown) {
+    console.warn(`[storage] transient read error for ${key}, keeping stored data`, err);
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      await resetCorruptKey(key, new Error('expected array'));
+      return null;
+    }
+    return parsed as T[];
+  } catch (err: unknown) {
+    await resetCorruptKey(key, err);
+    return null;
+  }
+}

--- a/frontend/src/storage/notificationStorage.ts
+++ b/frontend/src/storage/notificationStorage.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
-import { resetCorruptKey } from './jsonStore';
+import { getJsonArray } from './jsonStore';
 
 const KEY_PREFIX = '@adepthood/notifications';
 // expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
@@ -13,30 +13,13 @@ function keyFor(habitId: number): string {
   return `${KEY_PREFIX}/${habitId}`;
 }
 
-/**
- * BUG-FRONTEND-INFRA-011 — self-heal when AsyncStorage returns malformed JSON.
- */
-
 export async function saveNotificationIds(habitId: number, ids: string[]): Promise<void> {
   await AsyncStorage.setItem(keyFor(habitId), JSON.stringify(ids));
   await trackHabitId(habitId);
 }
 
 export async function loadNotificationIds(habitId: number): Promise<string[]> {
-  const key = keyFor(habitId);
-  try {
-    const raw = await AsyncStorage.getItem(key);
-    if (raw === null) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
-      await resetCorruptKey(key, new Error('expected array'));
-      return [];
-    }
-    return parsed as string[];
-  } catch (err: unknown) {
-    await resetCorruptKey(key, err);
-    return [];
-  }
+  return (await getJsonArray<string>(keyFor(habitId))) ?? [];
 }
 
 export async function clearNotificationIds(habitId: number): Promise<void> {
@@ -84,19 +67,7 @@ export async function loadPushToken(): Promise<string | null> {
 }
 
 async function loadTrackedHabitIds(): Promise<number[]> {
-  try {
-    const raw = await AsyncStorage.getItem(ALL_HABIT_IDS_KEY);
-    if (raw === null) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
-      await resetCorruptKey(ALL_HABIT_IDS_KEY, new Error('expected array'));
-      return [];
-    }
-    return parsed as number[];
-  } catch (err: unknown) {
-    await resetCorruptKey(ALL_HABIT_IDS_KEY, err);
-    return [];
-  }
+  return (await getJsonArray<number>(ALL_HABIT_IDS_KEY)) ?? [];
 }
 
 async function trackHabitId(habitId: number): Promise<void> {


### PR DESCRIPTION
## Summary

A **transient** AsyncStorage read failure (Android SQLite hiccup, disk pressure) was silently **deleting** the user's stored data. Four `load*` functions wrapped both `getItem` and `JSON.parse` in a single `try` whose `catch` called `resetCorruptKey(...)` (`AsyncStorage.removeItem`), so a momentary read rejection was treated identically to corrupt JSON and the key was wiped — most damagingly the offline check-in queue (`loadPendingCheckIns`), destroying unsynced completions.

This PR adds a `getJsonArray<T>(key)` helper to `frontend/src/storage/jsonStore.ts` that splits the two failure modes with fail-safe semantics:

- **Transient** `getItem` rejection → returns `null` **without** `removeItem` (data preserved for retry).
- **Corrupt** JSON (parse failure or non-array payload) → still self-heals via `resetCorruptKey`.

The four sites are rewritten to use it — `loadHabits`, `loadPendingCheckIns` (`habitStorage.ts`), `loadNotificationIds`, `loadTrackedHabitIds` (`notificationStorage.ts`) — collapsing four hand-rolled read-JSON-array blocks into one helper and generalizing the pattern already proven in `energyScaffoldingStorage.ts`. No write path or the `serialize()` lane is touched. Also removes a now-orphaned self-heal doc comment left behind in `notificationStorage.ts`.

## Test plan

- New tests (red before the fix): for each of the four functions, a transient `getItem` rejection returns the default and `AsyncStorage.removeItem` is **not** called.
- Retained/added corrupt-JSON + non-array self-heal tests (`removeItem` still called) — existing behavior preserved.
- `npx tsc --noEmit` — clean
- `npm run lint` (`--max-warnings=0`) — clean
- `npx jest --coverage` — 3282 passed; `habitStorage.ts` / `notificationStorage.ts` at 100%, `getJsonArray` branches fully covered
- `./scripts/frontend/check-all.sh` — exit 0

## Follow-ups (out of scope, noted by self-review)

- `recentPracticesStorage.ts` `loadRecentPractices` carries the same bug class but needs `sanitize()` + `[]`-on-non-array, so it isn't a drop-in for `getJsonArray`.
- `savePendingCheckIn`'s load-modify-write still overwrites the stored queue if the internal read fails transiently (pre-existing, not a regression); a distinct read-failure signal would let the append abort.

Closes #1270