### PR TITLE
fix(frontend): reveal a loaded Aspect chord instead of hiding it on edit

### DIFF
--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -153,7 +153,14 @@ function AspectChordControl({
   if (!expanded) {
     return <CollapsedTrigger onExpand={() => setUserExpanded(true)} />;
   }
-  return <ExpandedChooser value={value} onChange={onChange} />;
+  // Latch the control open once the writer acts inside it, so pressing Clear on
+  // an edit-loaded chord leaves them on the chips to re-pick rather than snapping
+  // back to the collapsed "optional" trigger mid-edit.
+  const handleChange = (next: AspectChordValue): void => {
+    setUserExpanded(true);
+    onChange(next);
+  };
+  return <ExpandedChooser value={value} onChange={handleChange} />;
 }
 
 export default AspectChordControl;

--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -145,9 +145,13 @@ function AspectChordControl({
   value = EMPTY_CHORD,
   onChange,
 }: AspectChordControlProps): React.JSX.Element {
-  const [expanded, setExpanded] = useState(false);
+  // Derive expansion from the value so a loaded (pre-tagged) entry opens on its
+  // chips instead of the "optional" trigger — even when the chord arrives after
+  // mount, as it does on the edit screen. The user's own tap latches it open too.
+  const [userExpanded, setUserExpanded] = useState(false);
+  const expanded = userExpanded || value.primary !== null;
   if (!expanded) {
-    return <CollapsedTrigger onExpand={() => setExpanded(true)} />;
+    return <CollapsedTrigger onExpand={() => setUserExpanded(true)} />;
   }
   return <ExpandedChooser value={value} onChange={onChange} />;
 }

--- a/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
@@ -156,4 +156,18 @@ describe('AspectChordControl — clear affordance', () => {
     fireEvent.press(getByTestId('aspect-chord-clear'));
     expect(onChange).toHaveBeenCalledWith({ primary: null, secondary: null });
   });
+
+  it('stays expanded after clearing an edit-loaded chord (no snap back to the trigger)', () => {
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <AspectChordControl value={{ primary: 3, secondary: null }} onChange={onChange} />,
+    );
+    // Opened expanded via the loaded value, without ever tapping the trigger.
+    fireEvent.press(getByTestId('aspect-chord-clear'));
+    // Host clears the chord and re-renders; the control must remain open so the
+    // writer can immediately re-pick instead of being bounced mid-edit.
+    rerender(<AspectChordControl value={{ primary: null, secondary: null }} onChange={onChange} />);
+    expect(getByTestId('aspect-primary-1')).toBeTruthy();
+    expect(queryByTestId('aspect-chord-trigger')).toBeNull();
+  });
 });

--- a/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/AspectChordControl.test.tsx
@@ -39,6 +39,35 @@ describe('AspectChordControl — collapsed by default', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Loaded value (editing a pre-tagged entry)
+// ---------------------------------------------------------------------------
+
+describe('AspectChordControl — loaded value', () => {
+  it('opens expanded showing the selected primary chip when value.primary is set', () => {
+    const { getByTestId, queryByTestId } = renderControl({ primary: 3, secondary: null });
+    expect(getByTestId('aspect-primary-3')).toBeTruthy();
+    expect(queryByTestId('aspect-chord-trigger')).toBeNull();
+  });
+
+  it('never fires onChange on mount for a pre-tagged value', () => {
+    const onChange = jest.fn();
+    renderControl({ primary: 3, secondary: null }, onChange);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('expands to reveal the loaded chip when the value arrives after mount (edit load)', () => {
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId, rerender } = render(
+      <AspectChordControl value={{ primary: null, secondary: null }} onChange={onChange} />,
+    );
+    expect(getByTestId('aspect-chord-trigger')).toBeTruthy();
+    rerender(<AspectChordControl value={{ primary: 3, secondary: null }} onChange={onChange} />);
+    expect(getByTestId('aspect-primary-3')).toBeTruthy();
+    expect(queryByTestId('aspect-chord-trigger')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Expanding reveals primary chips
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -148,8 +148,7 @@ describe('JournalEntryScreen — chord change PATCH failure', () => {
       mockUpdate.mockClear();
       mockUpdate.mockRejectedValueOnce(new Error('network'));
 
-      const page = within(getByTestId('journal-page'));
-      fireEvent.press(page.getByTestId('aspect-chord-trigger'));
+      // A tagged entry loads expanded on its chips, so no trigger tap is needed.
       fireEvent.press(within(getByTestId('journal-page')).getByTestId('aspect-primary-5'));
 
       await act(async () => {


### PR DESCRIPTION
## Summary
`AspectChordControl` always mounted collapsed behind the "Name an Aspect (optional)" trigger, ignoring its `value`. When the writer opened an already-tagged entry, the loaded chord was hidden and the trigger falsely read "optional" — telling the user no Aspect was set when one already was (a wrong-value + misleading-label bug).

The control now derives expansion from the value: `const expanded = userExpanded || value.primary !== null`. A loaded chord opens expanded on its chips — reactively, so it works even when the chord arrives *after* mount as it does on the edit screen (`JournalEntryScreen` seeds the chord asynchronously). An untagged or new entry stays collapsed until the writer taps the trigger, and the user's tap latches expansion independently. No `useEffect` needed; expansion is derived during render.

## Test plan
- New `AspectChordControl` cases: a static loaded value shows its selected chip (not the "optional" trigger); no `onChange` fires on mount for a pre-tagged value; and — the case a naive `useState(initial)` fix would miss — a value arriving after mount (edit-load via `rerender`) expands to reveal the loaded chip.
- Empty-value default unchanged: still collapsed, no chips, no `onChange` on mount.
- Updated one pre-existing `JournalEntryScreenChord` test that pressed the now-obsolete trigger for a tagged entry (it loads expanded now).
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 3281 tests); coverage thresholds hold.

Closes #1216