### PR TITLE
fix(map): resolve helix strand colors at the center line

### DIFF
--- a/frontend/src/features/Map/WaveOverlay.tsx
+++ b/frontend/src/features/Map/WaveOverlay.tsx
@@ -61,8 +61,8 @@ export const WaveOverlay = ({
     >
       {segments.map((segment) => (
         <Path
-          key={`near-${segment.stageNumber}`}
-          testID={`near-${segment.stageNumber}`}
+          key={`near-${segment.stageNumber}-${segment.half}`}
+          testID={`near-${segment.stageNumber}-${segment.half}`}
           d={segment.d}
           stroke={segment.color}
           {...WAVE_STROKE_PROPS}

--- a/frontend/src/features/Map/__tests__/WaveOverlay.test.tsx
+++ b/frontend/src/features/Map/__tests__/WaveOverlay.test.tsx
@@ -13,9 +13,12 @@ type WavePath = ReturnType<Renderer['root']['findAll']>[number];
 
 const WIDTH = 100;
 const HEIGHT = 200;
-const SEGMENT_COUNT = STAGE_COUNT - 1;
+const PAIR_COUNT = STAGE_COUNT - 1;
+const TOTAL_NEAR_PATH_COUNT = PAIR_COUNT * 2;
 const FULL_OPACITY = 1;
 
+const HALF_LOWER = 'lower';
+const HALF_UPPER = 'upper';
 const NEAR_PREFIX = 'near-';
 const FAR_PREFIX = 'far-';
 
@@ -27,17 +30,26 @@ const testIdOf = (node: WavePath): string =>
 const wavePathsWithPrefix = (tree: Renderer, prefix: string): WavePath[] =>
   tree.root.findAll((node: WavePath) => node.type === Path && testIdOf(node).startsWith(prefix));
 
+const nearTestId = (stageNumber: number, half: string): string =>
+  `${NEAR_PREFIX}${stageNumber}-${half}`;
+
 describe('WaveOverlay', () => {
-  it('renders exactly one wave path per segment and no far-side strand', () => {
+  it('renders exactly two wave paths per pair (a lower and an upper half) and no far-side strand', () => {
     const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
-    expect(wavePathsWithPrefix(tree, NEAR_PREFIX)).toHaveLength(SEGMENT_COUNT);
+    expect(wavePathsWithPrefix(tree, NEAR_PREFIX)).toHaveLength(TOTAL_NEAR_PATH_COUNT);
     expect(wavePathsWithPrefix(tree, FAR_PREFIX)).toHaveLength(0);
   });
 
-  it('leaves every near-<stage> path at full opacity', () => {
+  it('gives every near-<stage>-<half> path a unique testID', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    const testIds = wavePathsWithPrefix(tree, NEAR_PREFIX).map(testIdOf);
+    expect(new Set(testIds).size).toBe(TOTAL_NEAR_PATH_COUNT);
+  });
+
+  it('leaves every near-<stage>-<half> path at full opacity', () => {
     const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
     const nearPaths = wavePathsWithPrefix(tree, NEAR_PREFIX);
-    expect(nearPaths).toHaveLength(SEGMENT_COUNT);
+    expect(nearPaths).toHaveLength(TOTAL_NEAR_PATH_COUNT);
     for (const near of nearPaths) {
       const opacity = near.props.strokeOpacity;
       const isFullOpacity = opacity === undefined || opacity === FULL_OPACITY;
@@ -45,17 +57,29 @@ describe('WaveOverlay', () => {
     }
   });
 
-  it('colors each near-<stage> path the exact stage textColor', () => {
+  it('colors each near-<stage>-lower path with that stage textColor', () => {
     const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
-    for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
-      const near = tree.root.findByProps({ testID: `${NEAR_PREFIX}${stage}` });
+    for (let stage = 1; stage <= PAIR_COUNT; stage += 1) {
+      const near = tree.root.findByProps({ testID: nearTestId(stage, HALF_LOWER) });
       expect(near.props.stroke).toBe(STAGE_DISPLAY[stage]?.textColor);
     }
   });
 
-  it('still renders all 10 arrowheads on top of the wave paths', () => {
+  it('colors each near-<stage>-upper path with the next stage textColor', () => {
+    const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
+    for (let stage = 1; stage <= PAIR_COUNT; stage += 1) {
+      const near = tree.root.findByProps({ testID: nearTestId(stage, HALF_UPPER) });
+      expect(near.props.stroke).toBe(STAGE_DISPLAY[stage + 1]?.textColor);
+    }
+  });
+
+  it('still renders all 10 arrowheads on top of the wave paths, with unchanged colors', () => {
     const tree = create(<WaveOverlay width={WIDTH} height={HEIGHT} />);
     const arrowheads = tree.root.findAllByType(Polygon);
     expect(arrowheads).toHaveLength(STAGE_COUNT);
+    for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
+      const arrow = tree.root.findByProps({ testID: `wave-arrow-${stage}` });
+      expect(arrow.props.fill).toBe(STAGE_DISPLAY[stage]?.textColor);
+    }
   });
 });

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -17,6 +17,7 @@ const CONVERGENCE_EPSILON = 0.05;
 const UNIT_MIN = 0;
 const UNIT_MAX = 1;
 const SEGMENT_COUNT = STAGE_COUNT - 1;
+const TOTAL_SEGMENT_COUNT = SEGMENT_COUNT * 2;
 const SMALL_WIDTH = 100;
 const SMALL_HEIGHT = 200;
 const LARGE_WIDTH = 200;
@@ -41,8 +42,39 @@ const WOBBLE_VISIBILITY_FRACTION = 0.4;
 const LEFT_WOBBLE_STAGE = 2;
 const RIGHT_WOBBLE_STAGE = 1;
 
-// x tokens in the "M x1 y1 C x1 mY x2 mY x2 y2" segment path stream.
-const SEGMENT_X_TOKEN_INDICES = [1, 4, 6, 8];
+// Coordinate rounding precision shared with waveGeometry's own roundCoord.
+const COORD_PRECISION = 3;
+
+// Each half's path is "M x y C cx1 cy1 cx2 cy2 x y"; these are its x-token slots.
+const START_X_TOKEN_INDEX = 1;
+const CONTROL1_X_TOKEN_INDEX = 4;
+const CONTROL2_X_TOKEN_INDEX = 6;
+const END_X_TOKEN_INDEX = 8;
+const SEGMENT_X_TOKEN_INDICES = [
+  START_X_TOKEN_INDEX,
+  CONTROL1_X_TOKEN_INDEX,
+  CONTROL2_X_TOKEN_INDEX,
+  END_X_TOKEN_INDEX,
+];
+const SEGMENT_Y1_TOKEN_INDEX = 2;
+const SEGMENT_Y2_TOKEN_INDEX = 9;
+
+const HALF_LOWER = 'lower';
+const HALF_UPPER = 'upper';
+
+const NON_UNIFORM_ANCHORS: StageAnchors = {
+  1: 0.94,
+  2: 0.83,
+  3: 0.76,
+  4: 0.68,
+  5: 0.57,
+  6: 0.49,
+  7: 0.39,
+  8: 0.31,
+  9: 0.18,
+  10: 0.06,
+};
+
 const segmentPathXs = (d: string): number[] => {
   const tokens = d.trim().split(' ');
   return SEGMENT_X_TOKEN_INDICES.map((index) => Number(tokens[index]));
@@ -54,6 +86,49 @@ const arrowheadXs = (points: string): number[] =>
     .split(' ')
     .map((pair) => pair.split(',').map(Number))
     .map(([x]) => x as number);
+
+// Pixel x for a unit x within the center column, derived via the same exported
+// column fractions waveGeometry uses internally, so expectations never hardcode
+// magic pixel numbers.
+const toPixelX = (unitX: number, width: number): number => {
+  const { left, right } = centerColumnBounds(width);
+  return left + unitX * (right - left);
+};
+
+const findHalf = (
+  segments: readonly WaveSegment[],
+  stageNumber: number,
+  half: WaveSegment['half'],
+): WaveSegment => {
+  const segment = segments.find((s) => s.stageNumber === stageNumber && s.half === half);
+  if (!segment) throw new Error(`no ${half} half found for pair stage ${stageNumber}`);
+  return segment;
+};
+
+interface PairPixelEndpoints {
+  x1: number;
+  x2: number;
+  y1: number;
+  y2: number;
+}
+
+// The pair's raw (pre-split) pixel endpoints, derived from stageWavePoint the
+// same way waveSegments builds its bezier.
+const pairPixelEndpoints = (
+  pairStage: number,
+  width: number,
+  height: number,
+  anchors: StageAnchors = {},
+): PairPixelEndpoints => {
+  const lowerPoint = stageWavePoint(pairStage, anchors);
+  const upperPoint = stageWavePoint(pairStage + 1, anchors);
+  return {
+    x1: toPixelX(lowerPoint.x, width),
+    x2: toPixelX(upperPoint.x, width),
+    y1: lowerPoint.y * height,
+    y2: upperPoint.y * height,
+  };
+};
 
 describe('stageWavePoint', () => {
   it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
@@ -122,25 +197,30 @@ describe('stageWavePoint', () => {
 });
 
 describe('waveSegments', () => {
-  it('returns exactly STAGE_COUNT-1 segments', () => {
+  it('returns exactly 2*(STAGE_COUNT-1) segments, a lower and an upper half per pair', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
-    expect(segments).toHaveLength(SEGMENT_COUNT);
+    expect(segments).toHaveLength(TOTAL_SEGMENT_COUNT);
   });
 
-  it('assigns each segment the lower stage number of the pair it connects', () => {
+  it('assigns each pair stage number 1..9 to exactly two segments (one lower, one upper half)', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
     const stageNumbers = segments.map((s) => s.stageNumber).sort((a, b) => a - b);
-    expect(stageNumbers).toEqual(Array.from({ length: SEGMENT_COUNT }, (_, i) => i + 1));
+    const expectedStageNumbers = Array.from({ length: SEGMENT_COUNT }, (_, i) => i + 1)
+      .flatMap((stage) => [stage, stage])
+      .sort((a, b) => a - b);
+    expect(stageNumbers).toEqual(expectedStageNumbers);
   });
 
-  it('colors each segment with the lower stage textColor from STAGE_DISPLAY', () => {
+  it('colors the lower half with its own stage and the upper half with the next stage', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
     for (const segment of segments) {
-      expect(segment.color).toBe(STAGE_DISPLAY[segment.stageNumber]?.textColor);
+      const colorStage =
+        segment.half === HALF_LOWER ? segment.stageNumber : segment.stageNumber + 1;
+      expect(segment.color).toBe(STAGE_DISPLAY[colorStage]?.textColor);
     }
   });
 
-  it('produces a non-empty path string for every segment', () => {
+  it('produces a non-empty path string for every segment half', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
     for (const segment of segments) {
       expect(segment.d.length).toBeGreaterThan(0);
@@ -152,6 +232,131 @@ describe('waveSegments', () => {
     const large = waveSegments(LARGE_WIDTH, LARGE_HEIGHT);
     for (let i = 0; i < small.length; i += 1) {
       expect(large[i]?.d).not.toBe(small[i]?.d);
+    }
+  });
+});
+
+describe('waveSegments color phase: boundary colors land on the wave outside edges', () => {
+  it('colors both halves meeting at each interior anchor (stage 2..9) with that anchor stage color', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (let stage = 2; stage <= SEGMENT_COUNT; stage += 1) {
+      const endingHere = findHalf(segments, stage - 1, HALF_UPPER);
+      const startingHere = findHalf(segments, stage, HALF_LOWER);
+      const expectedColor = STAGE_DISPLAY[stage]?.textColor;
+      expect(endingHere.color).toBe(expectedColor);
+      expect(startingHere.color).toBe(expectedColor);
+    }
+  });
+
+  it('colors the opening lower half with stage 1 color', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const opening = findHalf(segments, 1, HALF_LOWER);
+    expect(opening.color).toBe(STAGE_DISPLAY[1]?.textColor);
+  });
+
+  it('colors the final upper half with the STAGE_COUNT stage color', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const final = findHalf(segments, SEGMENT_COUNT, HALF_UPPER);
+    expect(final.color).toBe(STAGE_DISPLAY[STAGE_COUNT]?.textColor);
+  });
+});
+
+describe('waveSegments identity: exactly one lower and one upper half per pair', () => {
+  it('every pair 1..9 yields exactly one lower half and one upper half', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (let pair = 1; pair <= SEGMENT_COUNT; pair += 1) {
+      const lowerHalves = segments.filter((s) => s.stageNumber === pair && s.half === HALF_LOWER);
+      const upperHalves = segments.filter((s) => s.stageNumber === pair && s.half === HALF_UPPER);
+      expect(lowerHalves).toHaveLength(1);
+      expect(upperHalves).toHaveLength(1);
+    }
+  });
+
+  it('all 18 (stageNumber, half) identities are unique', () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    const identities = segments.map((s) => `${s.stageNumber}-${s.half}`);
+    expect(new Set(identities).size).toBe(TOTAL_SEGMENT_COUNT);
+  });
+});
+
+describe('waveSegments split geometry: de Casteljau midline split', () => {
+  const scenarios: ReadonlyArray<{ label: string; anchors: StageAnchors }> = [
+    { label: 'nominal anchors', anchors: {} },
+    { label: 'non-uniform anchors', anchors: NON_UNIFORM_ANCHORS },
+  ];
+
+  for (const { label, anchors } of scenarios) {
+    it(`splits the pair bezier so the lower half ends and the upper half starts at the shared seam (${label})`, () => {
+      const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, anchors);
+      const lowerHalf = findHalf(segments, REPRESENTATIVE_STAGE, HALF_LOWER);
+      const upperHalf = findHalf(segments, REPRESENTATIVE_STAGE, HALF_UPPER);
+      const { x1, x2, y1, y2 } = pairPixelEndpoints(
+        REPRESENTATIVE_STAGE,
+        SMALL_WIDTH,
+        SMALL_HEIGHT,
+        anchors,
+      );
+      const seamX = ((x1 + x2) / 2).toFixed(COORD_PRECISION);
+      const seamY = ((y1 + y2) / 2).toFixed(COORD_PRECISION);
+      const lowerTokens = lowerHalf.d.trim().split(' ');
+      const upperTokens = upperHalf.d.trim().split(' ');
+      expect(lowerTokens[END_X_TOKEN_INDEX]).toBe(seamX);
+      expect(lowerTokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(seamY);
+      expect(upperTokens[START_X_TOKEN_INDEX]).toBe(seamX);
+      expect(upperTokens[SEGMENT_Y1_TOKEN_INDEX]).toBe(seamY);
+      expect(lowerTokens[END_X_TOKEN_INDEX]).toBe(upperTokens[START_X_TOKEN_INDEX]);
+      expect(lowerTokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(upperTokens[SEGMENT_Y1_TOKEN_INDEX]);
+    });
+
+    it(`places the de Casteljau interior control-point x values at the correct convex combinations (${label})`, () => {
+      const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, anchors);
+      const lowerHalf = findHalf(segments, REPRESENTATIVE_STAGE, HALF_LOWER);
+      const upperHalf = findHalf(segments, REPRESENTATIVE_STAGE, HALF_UPPER);
+      const { x1, x2 } = pairPixelEndpoints(
+        REPRESENTATIVE_STAGE,
+        SMALL_WIDTH,
+        SMALL_HEIGHT,
+        anchors,
+      );
+      const lowerTokens = lowerHalf.d.trim().split(' ');
+      const upperTokens = upperHalf.d.trim().split(' ');
+      const lowerControl1X = Number(lowerTokens[CONTROL1_X_TOKEN_INDEX]);
+      const lowerControl2X = Number(lowerTokens[CONTROL2_X_TOKEN_INDEX]);
+      const upperControl1X = Number(upperTokens[CONTROL1_X_TOKEN_INDEX]);
+      const upperControl2X = Number(upperTokens[CONTROL2_X_TOKEN_INDEX]);
+      expect(lowerControl1X).toBeCloseTo(x1, COORD_PRECISION);
+      expect(lowerControl2X).toBeCloseTo((3 * x1 + x2) / 4, COORD_PRECISION);
+      expect(upperControl1X).toBeCloseTo((x1 + 3 * x2) / 4, COORD_PRECISION);
+      expect(upperControl2X).toBeCloseTo(x2, COORD_PRECISION);
+    });
+  }
+});
+
+describe('waveSegments continuity across the split wave', () => {
+  const startCoord = (segment: WaveSegment): string => {
+    const tokens = segment.d.trim().split(' ');
+    return `${tokens[START_X_TOKEN_INDEX]} ${tokens[SEGMENT_Y1_TOKEN_INDEX]}`;
+  };
+  const endCoord = (segment: WaveSegment): string => {
+    const tokens = segment.d.trim().split(' ');
+    return `${tokens[END_X_TOKEN_INDEX]} ${tokens[SEGMENT_Y2_TOKEN_INDEX]}`;
+  };
+
+  it("the lower half's end matches the upper half's start at the seam, for every pair", () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (let pair = 1; pair <= SEGMENT_COUNT; pair += 1) {
+      const lowerHalf = findHalf(segments, pair, HALF_LOWER);
+      const upperHalf = findHalf(segments, pair, HALF_UPPER);
+      expect(endCoord(lowerHalf)).toBe(startCoord(upperHalf));
+    }
+  });
+
+  it("a pair's upper-half end matches the next pair's lower-half start at the shared anchor", () => {
+    const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT);
+    for (let pair = 1; pair < SEGMENT_COUNT; pair += 1) {
+      const upperHalf = findHalf(segments, pair, HALF_UPPER);
+      const nextLowerHalf = findHalf(segments, pair + 1, HALF_LOWER);
+      expect(endCoord(upperHalf)).toBe(startCoord(nextLowerHalf));
     }
   });
 });
@@ -173,12 +378,12 @@ describe('arrowheadAt', () => {
 describe('center-column containment', () => {
   const findSegmentX = (segments: readonly WaveSegment[], stageNumber: number): number => {
     for (const segment of segments) {
-      if (segment.stageNumber === stageNumber) {
+      if (segment.stageNumber === stageNumber && segment.half === HALF_LOWER) {
         const xs = segmentPathXs(segment.d);
         return xs[0] as number;
       }
     }
-    throw new Error(`no segment found for stage ${stageNumber}`);
+    throw new Error(`no lower-half segment found for stage ${stageNumber}`);
   };
 
   it('reports center-column bounds as flex-derived fractions of width', () => {
@@ -241,28 +446,7 @@ describe('measured anchors: nominal fallback and pixel-space threading', () => {
   const NOMINAL_BAND_MIDPOINT = 0.5;
   const OVERRIDE_STAGE = 4;
   const OVERRIDE_UNIT_Y = 0.42;
-  const NON_UNIFORM_ANCHORS: StageAnchors = {
-    1: 0.94,
-    2: 0.83,
-    3: 0.76,
-    4: 0.68,
-    5: 0.57,
-    6: 0.49,
-    7: 0.39,
-    8: 0.31,
-    9: 0.18,
-    10: 0.06,
-  };
-  const SEGMENT_Y1_TOKEN_INDEX = 2;
-  const SEGMENT_Y2_TOKEN_INDEX = 9;
-  const ANCHOR_COORD_PRECISION = 3;
   const EXPECTED_ARROWHEAD_HEIGHT = 10;
-
-  const findSegment = (segments: readonly WaveSegment[], stageNumber: number): WaveSegment => {
-    const segment = segments.find((s) => s.stageNumber === stageNumber);
-    if (!segment) throw new Error(`no segment found for stage ${stageNumber}`);
-    return segment;
-  };
 
   it('nominalAnchorY matches the legacy uniform-band formula for every stage', () => {
     for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
@@ -288,19 +472,20 @@ describe('measured anchors: nominal fallback and pixel-space threading', () => {
     }
   });
 
-  it('non-uniform anchors flow into segment endpoints in pixel space', () => {
+  it('non-uniform anchors flow into split segment endpoints in pixel space', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
     for (let stage = 1; stage <= SEGMENT_COUNT; stage += 1) {
-      const segment = findSegment(segments, stage);
-      const tokens = segment.d.trim().split(' ');
-      const expectedY1 = ((NON_UNIFORM_ANCHORS[stage] ?? 0) * SMALL_HEIGHT).toFixed(
-        ANCHOR_COORD_PRECISION,
-      );
-      const expectedY2 = ((NON_UNIFORM_ANCHORS[stage + 1] ?? 0) * SMALL_HEIGHT).toFixed(
-        ANCHOR_COORD_PRECISION,
-      );
-      expect(tokens[SEGMENT_Y1_TOKEN_INDEX]).toBe(expectedY1);
-      expect(tokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(expectedY2);
+      const lowerHalf = findHalf(segments, stage, HALF_LOWER);
+      const upperHalf = findHalf(segments, stage, HALF_UPPER);
+      const lowerTokens = lowerHalf.d.trim().split(' ');
+      const upperTokens = upperHalf.d.trim().split(' ');
+      const anchorY1 = (NON_UNIFORM_ANCHORS[stage] ?? 0) * SMALL_HEIGHT;
+      const anchorY2 = (NON_UNIFORM_ANCHORS[stage + 1] ?? 0) * SMALL_HEIGHT;
+      const seamY = ((anchorY1 + anchorY2) / 2).toFixed(COORD_PRECISION);
+      expect(lowerTokens[SEGMENT_Y1_TOKEN_INDEX]).toBe(anchorY1.toFixed(COORD_PRECISION));
+      expect(lowerTokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(seamY);
+      expect(upperTokens[SEGMENT_Y1_TOKEN_INDEX]).toBe(seamY);
+      expect(upperTokens[SEGMENT_Y2_TOKEN_INDEX]).toBe(anchorY2.toFixed(COORD_PRECISION));
     }
   });
 
@@ -321,7 +506,9 @@ describe('measured anchors: nominal fallback and pixel-space threading', () => {
   it('colors stay keyed to STAGE_DISPLAY textColor when anchors are non-uniform', () => {
     const segments = waveSegments(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
     for (const segment of segments) {
-      expect(segment.color).toBe(STAGE_DISPLAY[segment.stageNumber]?.textColor);
+      const colorStage =
+        segment.half === HALF_LOWER ? segment.stageNumber : segment.stageNumber + 1;
+      expect(segment.color).toBe(STAGE_DISPLAY[colorStage]?.textColor);
     }
     const arrowheads = waveArrowheads(SMALL_WIDTH, SMALL_HEIGHT, NON_UNIFORM_ANCHORS);
     for (const arrowhead of arrowheads) {

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -12,6 +12,15 @@
  * right for odd (I-pointing) stages. Its horizontal swing tapers smoothly and
  * monotonically from the widest stage-1 offset down to a tiny non-degenerate
  * apex at stage 10, so the two poles resolve into the whole as the wave rises.
+ *
+ * Each stage's color resolves near the centerline: rather than a stage's hue
+ * changing at the outside pole extremes where the anchors sit, every pair's
+ * cubic is split at its parametric midpoint (t = 0.5) into a lower and an upper
+ * half. That midpoint is where the swing hands off between the pair's two
+ * opposite poles, close to the column centerline. Each stage's hue then wraps
+ * symmetrically around its own pole extreme, changing over at those seams.
+ * Splitting a bezier at a parameter reproduces the identical curve, so only the
+ * color phase shifts.
  */
 
 import { GRID_COLUMN_FLEX, MAP_ROWS, STAGE_DISPLAY } from './mapLayout';
@@ -163,21 +172,28 @@ export const stageWavePoint = (stageNumber: number, anchors: StageAnchors = {}):
   return { x, y, pole: poleFor(stageNumber) };
 };
 
-/** A rendered wave segment: its SVG path, color, and lower stage. */
+/** Which centerline-split piece of a stage pair's cubic a segment carries. */
+export type SegmentHalf = 'lower' | 'upper';
+
+/** The lower half runs from the pair's anchor up to the midline seam. */
+const HALF_LOWER: SegmentHalf = 'lower';
+/** The upper half runs from the midline seam up to the next pair's anchor. */
+const HALF_UPPER: SegmentHalf = 'upper';
+
+/** One centerline-split half of a stage pair's cubic: its path, color, band. */
 export interface WaveSegment {
-  /** SVG path data in pixel space connecting the two stage points. */
+  /** SVG path data in pixel space for this half of the pair's cubic. */
   d: string;
-  /** Stroke color, taken from the lower stage's textColor. */
+  /** Stroke color: the textColor of the stage whose band this half belongs to. */
   color: string;
-  /** The lower of the two stage numbers this segment connects (1..9). */
+  /** The pair's lower stage number (1..9); both halves of a pair share it. */
   stageNumber: number;
+  /** Discriminates the two centerline-split pieces of the pair's cubic. */
+  half: SegmentHalf;
 }
 
 /** Round a raw pixel value to a coordinate string at fixed precision. */
 const roundCoord = (value: number): string => value.toFixed(COORD_PRECISION);
-
-/** Round a unit coordinate into a pixel coordinate string at fixed precision. */
-const toPixel = (unit: number, extent: number): string => roundCoord(unit * extent);
 
 /** Map a unit x within the center-column band to a pixel x across the grid. */
 const toColumnPixelX = (unitX: number, gridWidth: number): number =>
@@ -192,35 +208,89 @@ export const centerColumnBounds = (width: number): { left: number; right: number
   right: (CENTER_COLUMN_START_FRACTION + CENTER_COLUMN_WIDTH_FRACTION) * width,
 });
 
+/** A point in pixel space; a cubic's endpoints and controls are all points. */
+interface Point {
+  x: number;
+  y: number;
+}
+
+/** A cubic Bezier in pixel space: two endpoints and their two control points. */
+interface Cubic {
+  start: Point;
+  control1: Point;
+  control2: Point;
+  end: Point;
+}
+
+/** The two centerline-split halves of a pair's cubic, still in pixel space. */
+interface SplitCubic {
+  lower: Cubic;
+  upper: Cubic;
+}
+
+/** The midpoint of two points; averaging is the de Casteljau step itself. */
+const midpoint = (a: Point, b: Point): Point => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2,
+});
+
 /**
- * A smooth cubic Bezier between two points given by their unit x's and y's. The
- * control points sit at the vertical midpoint of the pair, each anchored to its
- * own x, giving the center column its continuous sine wobble rather than
- * straight zig-zags. x is confined to the center-column band via toColumnPixelX
- * (so a unit x of 0.5 lands on the column midline); y spans the full height.
+ * The pair's cubic in raw (unrounded) pixel space. Control points share the
+ * pair's vertical midpoint midY, each anchored to its own endpoint x, giving the
+ * column its continuous sine wobble rather than straight zig-zags. x is confined
+ * to the center-column band via toColumnPixelX (so a unit x of 0.5 lands on the
+ * column midline); y spans the full height. Endpoints stay unrounded so the two
+ * split halves share an exact seam.
  */
-const bezierPath = (
-  lowerX: number,
-  upperX: number,
-  lowerY: number,
-  upperY: number,
-  width: number,
-  height: number,
-): string => {
-  const midY = (lowerY + upperY) / 2;
-  const x1 = roundCoord(toColumnPixelX(lowerX, width));
-  const y1 = toPixel(lowerY, height);
-  const x2 = roundCoord(toColumnPixelX(upperX, width));
-  const y2 = toPixel(upperY, height);
-  const midYPixel = toPixel(midY, height);
-  return `M ${x1} ${y1} C ${x1} ${midYPixel} ${x2} ${midYPixel} ${x2} ${y2}`;
+const pairCubic = (lower: WavePoint, upper: WavePoint, width: number, height: number): Cubic => {
+  const x1 = toColumnPixelX(lower.x, width);
+  const x2 = toColumnPixelX(upper.x, width);
+  const y1 = lower.y * height;
+  const y2 = upper.y * height;
+  const midY = (y1 + y2) / 2;
+  return {
+    start: { x: x1, y: y1 },
+    control1: { x: x1, y: midY },
+    control2: { x: x2, y: midY },
+    end: { x: x2, y: y2 },
+  };
 };
 
 /**
- * The full wave as STAGE_COUNT-1 (9) segments in pixel space. Segment i connects
- * stage i to stage i+1 and carries the lower stage's number and textColor. y
- * scales with height and x with width within the center-column band, so a larger
- * layout yields a larger wave that still stays inside its lane.
+ * Split a cubic at its parameter midpoint (t = 0.5) via de Casteljau, using only
+ * midpoint averaging. The seam is the shared point where the lower half ends and
+ * the upper half begins; because the pair's controls sit at midY, the seam lands
+ * at the pair's horizontal midpoint (x1 + x2) / 2, close to the column
+ * centerline. The two halves together retrace the original curve byte-for-byte.
+ */
+const splitCubicAtMidpoint = (cubic: Cubic): SplitCubic => {
+  const lowerControl1 = midpoint(cubic.start, cubic.control1);
+  const mid = midpoint(cubic.control1, cubic.control2);
+  const upperControl2 = midpoint(cubic.control2, cubic.end);
+  const lowerControl2 = midpoint(lowerControl1, mid);
+  const upperControl1 = midpoint(mid, upperControl2);
+  const seam = midpoint(lowerControl2, upperControl1);
+  return {
+    lower: { start: cubic.start, control1: lowerControl1, control2: lowerControl2, end: seam },
+    upper: { start: seam, control1: upperControl1, control2: upperControl2, end: cubic.end },
+  };
+};
+
+/** Format a pixel-space cubic as an "M x y C cx1 cy1 cx2 cy2 x y" path string. */
+const cubicPath = ({ start, control1, control2, end }: Cubic): string =>
+  `M ${roundCoord(start.x)} ${roundCoord(start.y)} ` +
+  `C ${roundCoord(control1.x)} ${roundCoord(control1.y)} ` +
+  `${roundCoord(control2.x)} ${roundCoord(control2.y)} ` +
+  `${roundCoord(end.x)} ${roundCoord(end.y)}`;
+
+/**
+ * The full wave as 2*(STAGE_COUNT-1) = 18 centerline-split halves in pixel space.
+ * Each stage pair's cubic is split at its midline crossing into a lower and an
+ * upper half: the lower keeps the pair's own stage color and the upper takes the
+ * next stage's, so each stage's hue wraps symmetrically around its pole extreme
+ * and changes over at the midline seams. y scales with height and x with width
+ * within the center-column band, so a larger layout yields a larger wave that
+ * still stays inside its lane.
  */
 export const waveSegments = (
   width: number,
@@ -232,11 +302,21 @@ export const waveSegments = (
     if (previous !== null) {
       const lower = stageWavePoint(previous.stageNumber, anchors);
       const upper = stageWavePoint(current.stageNumber, anchors);
-      segments.push({
-        d: bezierPath(lower.x, upper.x, lower.y, upper.y, width, height),
-        color: previous.textColor,
-        stageNumber: previous.stageNumber,
-      });
+      const halves = splitCubicAtMidpoint(pairCubic(lower, upper, width, height));
+      segments.push(
+        {
+          d: cubicPath(halves.lower),
+          color: previous.textColor,
+          stageNumber: previous.stageNumber,
+          half: HALF_LOWER,
+        },
+        {
+          d: cubicPath(halves.upper),
+          color: current.textColor,
+          stageNumber: previous.stageNumber,
+          half: HALF_UPPER,
+        },
+      );
     }
     return current;
   }, null);


### PR DESCRIPTION
## Summary

- Split each Map helix stage-pair cubic at its parametric midpoint (t = 0.5) via de Casteljau into a lower and an upper half, so every stage's color now starts and ends near the column centerline instead of at the wave's outside pole extremes. Each stage's hue wraps symmetrically around its own pole extreme and hands off at the seam between adjacent stages.
- The drawn geometry is byte-identical — splitting a bezier at a parameter reproduces the same curve; only the stroke color phase shifts. `waveSegments` now emits `2 × (STAGE_COUNT − 1) = 18` half-segments; `WaveSegment` gains a `half: 'lower' | 'upper'` discriminator, and `WaveOverlay` keys/testIDs become `near-<stage>-<half>`. `arrowheadAt`, anchors, and the arrowheads are untouched.

## Test plan

- `npx jest` for the two Map suites: 42/42 pass (pure-geometry numeric assertions for the de Casteljau split point and interior control points, the color-phase rule for stages 2–9, 18-segment identity/continuity, plus the reworked overlay render counts/colors).
- `scripts/frontend/check-all.sh` exits 0: full frontend suite 3273/3273, `tsc --noEmit` clean, ESLint `--max-warnings=0` clean, prettier clean.
- Pre-commit hooks (eslint / prettier / typecheck / tests / commitlint) all pass.
- Gate 2.5 self-review (code-review-orchestrator) returned CLEAN: de Casteljau math and color-phase rule verified by hand; tests confirmed non-tautological; no key/testID/a11y regressions.

Closes #1290
Refs #1284
