### PR TITLE
fix(welcome): update stale 'Today' onboarding copy after Today tab removal

### DIFF
--- a/frontend/src/components/feedback/EmptyState.tsx
+++ b/frontend/src/components/feedback/EmptyState.tsx
@@ -40,7 +40,7 @@ interface EmptyStateProps {
    * settle so it doesn't read as floating over the content beneath it.
    *
    * Defaults to ``false``: the full-screen centered/opaque behavior the
-   * Today / Course / Journal / Practice screens rely on is preserved untouched.
+   * Course / Journal / Practice screens rely on is preserved untouched.
    */
   inline?: boolean;
   testID?: string;

--- a/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/feedback/__tests__/EmptyState.test.tsx
@@ -49,7 +49,7 @@ describe('EmptyState', () => {
     const flat = StyleSheet.flatten(
       getByTestId('es-default').props.style as Parameters<typeof StyleSheet.flatten>[0],
     ) as { flex?: number; justifyContent?: string; backgroundColor?: string };
-    // These must never regress — Today/Course/Journal/Practice screens depend on them.
+    // These must never regress — Course/Journal/Practice screens depend on them.
     expect(flat.flex).toBe(1);
     expect(flat.justifyContent).toBe('center');
     expect(flat.backgroundColor).toBe(surface.canvas);

--- a/frontend/src/features/Journal/JournalHero.styles.ts
+++ b/frontend/src/features/Journal/JournalHero.styles.ts
@@ -4,7 +4,7 @@ import { SPACING, editorialType, onShowcase, touchTarget } from '@/design/tokens
 
 const EYEBROW_TRACKING = 1;
 
-/** Token-only styles for the journal showcase hero, mirroring the Today hub. */
+/** Token-only styles for the journal showcase hero. */
 export const journalHeroStyles = StyleSheet.create({
   eyebrow: {
     ...editorialType.caption,

--- a/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
+++ b/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
@@ -162,3 +162,18 @@ describe('WelcomeScreen — onboarding privacy note (issue #897)', () => {
     expect(onBegin).toHaveBeenCalledTimes(1);
   });
 });
+
+// The Today tab was removed; the Journal shelf is now the daily home.
+describe('WelcomeScreen — final panel names the Journal as the daily home', () => {
+  const finalBody = WELCOME_PANELS[WELCOME_PANELS.length - 1]?.body ?? '';
+
+  it('names the Journal as the daily home', () => {
+    expect(finalBody).toMatch(/land on your Journal/);
+    expect(finalBody).toMatch(/daily home/);
+  });
+
+  it('no panel points new users at the removed Today tab', () => {
+    expect(WELCOME_PANELS.every((p) => !/land on Today/.test(p.body))).toBe(true);
+    expect(WELCOME_PANELS.every((p) => !/Today, your daily home/.test(p.body))).toBe(true);
+  });
+});

--- a/frontend/src/features/Welcome/welcomeContent.ts
+++ b/frontend/src/features/Welcome/welcomeContent.ts
@@ -54,6 +54,6 @@ export const WELCOME_PANELS: readonly WelcomePanel[] = [
   {
     eyebrow: 'Ready',
     title: 'Let’s begin',
-    body: 'Press Begin to land on Today, your daily home. From the Habits tab you can plant your first habits whenever you’re ready.',
+    body: 'Press Begin to land on your Journal, your daily home. From the Habits tab you can plant your first habits whenever you’re ready.',
   },
 ] as const;

--- a/frontend/src/store/useContractionSignalStore.ts
+++ b/frontend/src/store/useContractionSignalStore.ts
@@ -9,7 +9,7 @@ import type { ContractionReflection } from '@/api';
 
 /**
  * Shared contraction-signal store. The journal resonance pass feeds it each
- * observed contraction; the Today seam reads ``active`` to decide whether the
+ * observed contraction; the Journal shelf reads ``active`` to decide whether the
  * declinable Return offer may surface. Latest pass wins, so a healthy or
  * simple-ease-off pass retracts a prior offer signal.
  */


### PR DESCRIPTION
## Summary
Fast-follow to #1172, which removed the Today tab/screen and moved the Return + invitation surfaces onto the Journal shelf. User-facing onboarding copy still pointed new users at the vanished tab.

- `welcomeContent.ts` — final "Ready" panel now reads "Press Begin to land on your **Journal**, your daily home" (Candle & Ink declinable-invitation voice), replacing "land on Today, your daily home."
- Cleared the stale Today-tab references the acceptance-criteria grep sweep surfaces in code comments: the `JournalHero.styles.ts` "mirroring the Today hub" note, the `useContractionSignalStore.ts` "Today seam" docstring (now "Journal shelf"), and the `EmptyState.tsx` screen list (dropped the vestigial "Today").
- Added a regression guard on the final welcome panel (names the Journal as the daily home; asserts no panel points at the removed Today tab).

Remaining `grep -ri "today" frontend/src --include='*.ts*'` hits are legitimate day-references (date math, "Today's habits" stat tile, "saved today", "Achieved Today", "Psychology Today directory", GoalModal/DatePicker date labels, the journal hero date eyebrow, program-progression date params) — not tab references.

## Test plan
- New `WelcomeScreen.test.tsx` guard: RED before the copy change, GREEN after.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 3291 jest tests pass).

Closes #1247
Refs #1172