### PR TITLE
feat(frontend): add soft grid rules to the Map table

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -34,6 +34,15 @@ const CENTER = 'center';
 // neighboring rows.
 const RIGHT_LABEL_LINE_HEIGHT = 19;
 
+// --- Soft grid rules -------------------------------------------------------
+// The Map is a table, and a table reads as one through its rules: gentle
+// horizontal lines between the aspect bands (and the stacked stages within
+// them) and vertical lines between the three columns. Drawn as the thinnest
+// hairline the platform can render, in the faint warm rule colour, so they
+// whisper the grid over the parchment rather than caging it.
+const GRID_LINE_COLOR = surface.hairline;
+const GRID_LINE_WIDTH = StyleSheet.hairlineWidth;
+
 /**
  * Styles for the Map's spiral-of-becoming grid + the rich stage-detail modal.
  * The grid is token-only and laid out purely with flex; the modal keeps the
@@ -75,14 +84,25 @@ const styles = StyleSheet.create({
   },
   leftCell: {
     flex: LEFT_FLEX,
+    borderRightWidth: GRID_LINE_WIDTH,
+    borderRightColor: GRID_LINE_COLOR,
   },
   centerCell: {
     flex: CENTER_FLEX,
+    borderRightWidth: GRID_LINE_WIDTH,
+    borderRightColor: GRID_LINE_COLOR,
   },
   rightCell: {
     flex: RIGHT_FLEX,
     justifyContent: CENTER,
     paddingHorizontal: spacing(1),
+  },
+  // Shared soft horizontal rule: a row boundary (applied to the group row) or a
+  // within-row stage boundary (applied to a stacked stage's cell). Both share
+  // the same faint hairline so the table's lines read as one gentle system.
+  horizontalDivider: {
+    borderTopWidth: GRID_LINE_WIDTH,
+    borderTopColor: GRID_LINE_COLOR,
   },
 
   // Left-column stage text block (also the tap target -0)

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -128,6 +128,8 @@ interface StageCellProps {
 interface StageTextBlockProps extends StageCellProps {
   /** Wheel-of-wholeness fullness (0..1) for this Aspect; drives emphasis + a11y. */
   fullness: number;
+  /** Draw the soft within-row rule above this stage (false for a row's top stage). */
+  showTopDivider: boolean;
 }
 
 // Left cell: colored stage text (the -0 tap target); wheel overlay adds emphasis opacity + a11y only.
@@ -137,11 +139,17 @@ const StageTextBlock = ({
   display,
   locked,
   fullness,
+  showTopDivider,
   onPress,
 }: StageTextBlockProps): React.JSX.Element => (
   <TouchableOpacity
     testID={`stage-hotspot-${display.stageNumber}-0`}
-    style={[styles.stageBlock, locked ? styles.locked : null, emphasisStyle(fullness)]}
+    style={[
+      styles.stageBlock,
+      showTopDivider ? styles.horizontalDivider : null,
+      locked ? styles.locked : null,
+      emphasisStyle(fullness),
+    ]}
     onPress={() => onPress(stage)}
     accessibilityRole="button"
     accessibilityLabel={stageNodeLabel(display, fullness)}
@@ -201,6 +209,8 @@ const CenterContent = ({
 interface StageCenterCellProps extends StageCellProps {
   /** Index of the row this cell sits in, for anchor measurement. */
   rowIndex: number;
+  /** Draw the soft within-row rule above this stage (false for a row's top stage). */
+  showTopDivider: boolean;
   /** Record this cell's measured row-relative center on layout. */
   onCellLayout: UseStageAnchorsResult['onCellLayout'];
 }
@@ -212,12 +222,14 @@ const StageCenterCell = ({
   isCurrent,
   onPress,
   rowIndex,
+  showTopDivider,
   onCellLayout,
 }: StageCenterCellProps): React.JSX.Element => (
   <TouchableOpacity
     testID={`stage-hotspot-${display.stageNumber}-1`}
     style={[
       styles.centerStageCell,
+      showTopDivider ? styles.horizontalDivider : null,
       isLeftReturning(display.stageNumber) ? styles.cellFeminine : styles.cellMasculine,
       locked ? styles.locked : null,
       isCurrent ? styles.cellCurrent : null,
@@ -274,7 +286,7 @@ const RowLeftColumn = ({
   onPress: (_stage: StageData) => void;
 }): React.JSX.Element => (
   <View style={styles.leftCell}>
-    {resolved.map(({ stage, display }) => (
+    {resolved.map(({ stage, display }, index) => (
       <StageTextBlock
         key={stage.stageNumber}
         stage={stage}
@@ -282,6 +294,9 @@ const RowLeftColumn = ({
         locked={!isStageUnlocked(stage, currentStage)}
         isCurrent={stage.stageNumber === currentStage}
         fullness={fullnessByStage[stage.stageNumber] ?? THIN_FULLNESS}
+        // A row's top stage sits on the row boundary the group row already
+        // rules; only the stacked stage(s) below it carry the within-row line.
+        showTopDivider={index > 0}
         onPress={onPress}
       />
     ))}
@@ -303,7 +318,7 @@ const RowCenterColumn = ({
   onCellLayout: UseStageAnchorsResult['onCellLayout'];
 }): React.JSX.Element => (
   <View style={styles.centerCell}>
-    {resolved.map(({ stage, display }) => (
+    {resolved.map(({ stage, display }, index) => (
       <StageCenterCell
         key={stage.stageNumber}
         stage={stage}
@@ -312,6 +327,9 @@ const RowCenterColumn = ({
         isCurrent={stage.stageNumber === currentStage}
         onPress={onPress}
         rowIndex={rowIndex}
+        // Match the left column: only stages stacked below a row's top stage
+        // carry the within-row rule, so left + center lines align.
+        showTopDivider={index > 0}
         onCellLayout={onCellLayout}
       />
     ))}
@@ -332,7 +350,13 @@ const MapRowView = ({
   const resolved = resolveRowStages(row, lookup);
   return (
     <View
-      style={[styles.groupRow, { flex: row.stageNumbers.length }]}
+      style={[
+        styles.groupRow,
+        { flex: row.stageNumbers.length },
+        // Full-width rule between aspect bands; the first row hugs the header,
+        // so it takes no top line (avoids a double rule under it).
+        rowIndex > 0 ? styles.horizontalDivider : null,
+      ]}
       testID={`map-row-${row.rightLabel}`}
       onLayout={(e) => onRowLayout(rowIndex, e)}
     >

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Image, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
-import { ink } from '../../../design/tokens';
+import { ink, surface } from '../../../design/tokens';
 import styles from '../Map.styles';
 import { MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
 import MapScreen from '../MapScreen';
@@ -706,6 +706,72 @@ describe('MapScreen left-column stage text color', () => {
       const node = tree.root.findByProps({ children: title });
       const flat = StyleSheet.flatten(node.props.style) as { color?: string };
       expect(flat.color).toBe(ink.muted);
+    }
+  });
+});
+
+// The Map is a table, and a table reads as one through its rules: gentle
+// horizontal lines between the aspect bands (and the stacked stages within
+// them) and vertical lines between the three columns. They are rendered as the
+// thinnest possible hairline in the faint warm rule colour so they whisper the
+// grid rather than caging it.
+describe('MapScreen soft grid lines', () => {
+  type BorderStyle = {
+    borderTopWidth?: number;
+    borderTopColor?: string;
+    borderRightWidth?: number;
+    borderRightColor?: string;
+  };
+
+  const topBorder = (tree: ReturnType<typeof create>, testID: string): BorderStyle =>
+    StyleSheet.flatten(tree.root.findByProps({ testID }).props.style) as BorderStyle;
+
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
+    );
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('draws soft vertical dividers between the three columns in the faint rule colour', () => {
+    expect(styles.leftCell.borderRightWidth).toBeGreaterThan(0);
+    expect(styles.leftCell.borderRightColor).toBe(surface.hairline);
+    expect(styles.centerCell.borderRightWidth).toBeGreaterThan(0);
+    expect(styles.centerCell.borderRightColor).toBe(surface.hairline);
+  });
+
+  it('renders the column dividers as the thinnest hairline so they read gently', () => {
+    expect(styles.leftCell.borderRightWidth).toBe(StyleSheet.hairlineWidth);
+    expect(styles.centerCell.borderRightWidth).toBe(StyleSheet.hairlineWidth);
+  });
+
+  it('draws a soft full-width horizontal rule above every aspect row except the first', () => {
+    const tree = create(<MapScreen />);
+    const awareness = topBorder(tree, 'map-row-Awareness');
+    const being = topBorder(tree, 'map-row-Being');
+    expect(awareness.borderTopWidth ?? 0).toBe(0);
+    expect(being.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+    expect(being.borderTopColor).toBe(surface.hairline);
+  });
+
+  it('divides stacked stages within a paired row with a soft line across left + center', () => {
+    const tree = create(<MapScreen />);
+    // The Yes-And-Ness row pairs stage 2 (top) over stage 1 (bottom). The top
+    // stage sits on the row boundary (drawn by the row itself), so only the
+    // bottom stage carries the within-row rule — across both its columns.
+    for (const column of [0, 1]) {
+      expect(topBorder(tree, `stage-hotspot-2-${column}`).borderTopWidth ?? 0).toBe(0);
+      const bottom = topBorder(tree, `stage-hotspot-1-${column}`);
+      expect(bottom.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(bottom.borderTopColor).toBe(surface.hairline);
+    }
+  });
+
+  it('never draws a rule above the topmost stage (no double line under the header)', () => {
+    const tree = create(<MapScreen />);
+    for (const column of [0, 1]) {
+      expect(topBorder(tree, `stage-hotspot-10-${column}`).borderTopWidth ?? 0).toBe(0);
     }
   });
 });


### PR DESCRIPTION
Render the aptitude Map's table lines: gentle horizontal rules between the
aspect bands (and between stacked stages within a band, across the left and
center columns) plus vertical rules between the three columns. Each is the
thinnest platform hairline in the faint warm rule colour, so the grid whispers
rather than cages the spiral. The topmost stage and first row take no top line,
avoiding a double rule under the journey header.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Afhxg9ikgSvfS3ixUQXVzZ