### PR TITLE
fix(frontend): polish Map stage boxes and title fit

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -105,12 +105,21 @@ const styles = StyleSheet.create({
     borderTopColor: GRID_LINE_COLOR,
   },
 
-  // Left-column stage text block (also the tap target -0)
+  // Left-column stage text block (also the tap target -0). A row so a locked
+  // stage's padlock sits on the far left while the three text lines keep the
+  // box's full height, vertically centered — never a fourth stacked line.
   stageBlock: {
     flex: 1,
-    justifyContent: CENTER,
+    flexDirection: 'row',
+    alignItems: CENTER,
     paddingHorizontal: spacing(1),
     paddingVertical: spacing(0.5),
+  },
+  // The persona / descriptor / practice column fills the remaining width and
+  // centers its three lines across the block's height.
+  stageLines: {
+    flex: 1,
+    justifyContent: CENTER,
   },
   personaText: {
     fontWeight: '700',
@@ -188,6 +197,12 @@ const styles = StyleSheet.create({
     color: ink.soft,
     flexShrink: 1,
   },
+  // Measured wrapper for the EMPTINESS / UNITY watermark: stretches to the
+  // cell's inner width so the fitted font size is computed from real pixels.
+  titleFit: {
+    alignSelf: 'stretch',
+    alignItems: CENTER,
+  },
   // Responsive title carried in the top stage rows' own grid cells (no fixed
   // 40px overlay): the serif ramp scales rather than overflowing the column.
   titleText: {
@@ -213,6 +228,13 @@ const styles = StyleSheet.create({
   lockText: {
     fontSize: 14,
     color: ink.muted,
+  },
+  // Left-column padlock: pinned to the far left of the stage block's row,
+  // vertically centered by the row's alignItems.
+  lockLeft: {
+    fontSize: 14,
+    color: ink.muted,
+    marginRight: spacing(0.5),
   },
   // Locked stages read recessed
   locked: {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -45,12 +45,18 @@ import {
   unlockTimeline,
 } from './journeyNarrative';
 import styles from './Map.styles';
-import { labelCorner, MAP_ROWS, STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
+import {
+  fittedTitleFontSize,
+  labelCorner,
+  MAP_ROWS,
+  STAGE_DISPLAY,
+  TITLE_BY_STAGE,
+} from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
 import { WaveOverlay } from './WaveOverlay';
-import { emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from './wheelBalance';
+import { FULLNESS_ALIVE_THRESHOLD } from './wheelBalance';
 
 import { Button } from '@/components/Button';
 import { Celebration } from '@/components/feedback/Celebration';
@@ -132,7 +138,10 @@ interface StageTextBlockProps extends StageCellProps {
   showTopDivider: boolean;
 }
 
-// Left cell: colored stage text (the -0 tap target); wheel overlay adds emphasis opacity + a11y only.
+// Left cell: colored stage text (the -0 tap target); the wheel overlay adds
+// a11y only — unlocked stages always render at full opacity. A locked stage's
+// padlock sits inline on the far left, so the three text lines keep the full
+// height of the box and stay vertically centered.
 
 const StageTextBlock = ({
   stage,
@@ -148,16 +157,17 @@ const StageTextBlock = ({
       styles.stageBlock,
       showTopDivider ? styles.horizontalDivider : null,
       locked ? styles.locked : null,
-      emphasisStyle(fullness),
     ]}
     onPress={() => onPress(stage)}
     accessibilityRole="button"
     accessibilityLabel={stageNodeLabel(display, fullness)}
   >
-    <Text style={[styles.personaText, { color: display.leftTextColor }]}>{display.persona}</Text>
-    <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.descriptor}</Text>
-    <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.practice}</Text>
-    {locked ? <LockGlyph /> : null}
+    {locked ? <Text style={styles.lockLeft}>🔒</Text> : null}
+    <View style={styles.stageLines}>
+      <Text style={[styles.personaText, { color: display.leftTextColor }]}>{display.persona}</Text>
+      <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.descriptor}</Text>
+      <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.practice}</Text>
+    </View>
   </TouchableOpacity>
 );
 
@@ -183,6 +193,31 @@ const AspectLabelBlock = ({
   );
 };
 
+/**
+ * EMPTINESS / UNITY watermark sized to its measured cell width. The native
+ * ``adjustsFontSizeToFit`` (kept as a belt-and-braces net) is a no-op on
+ * react-native-web, so the deterministic ``fittedTitleFontSize`` does the real
+ * work of guaranteeing a single un-truncated, un-hyphenated line everywhere.
+ */
+const FittedTitle = ({ title }: { title: string }): React.JSX.Element => {
+  const [width, setWidth] = useState(0);
+  return (
+    <View
+      style={styles.titleFit}
+      testID={`title-fit-${title}`}
+      onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
+    >
+      <Text
+        style={[styles.titleText, { fontSize: fittedTitleFontSize(title, width) }]}
+        adjustsFontSizeToFit
+        numberOfLines={1}
+      >
+        {title}
+      </Text>
+    </View>
+  );
+};
+
 // Title rows (9, 10) keep their centered serif heading; every other stage shows
 // its corner-hugging Aspect-label block instead of a centered word.
 const CenterContent = ({
@@ -194,11 +229,7 @@ const CenterContent = ({
 }): React.JSX.Element | null => {
   const title = TITLE_BY_STAGE[display.stageNumber];
   if (title) {
-    return (
-      <Text style={styles.titleText} adjustsFontSizeToFit numberOfLines={1}>
-        {title}
-      </Text>
-    );
+    return <FittedTitle title={title} />;
   }
   if (!display.arrowLabel) {
     return null;

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -6,10 +6,10 @@ import { act, create } from 'react-test-renderer';
 
 import { ink, surface } from '../../../design/tokens';
 import styles from '../Map.styles';
-import { MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
+import { fittedTitleFontSize, MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
 import MapScreen from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
-import { emphasisStyle, FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
+import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
 import {
   mockBeginAgain,
@@ -191,32 +191,17 @@ describe('MapScreen', () => {
 
   // --- Wheel-of-wholeness balance tests ---
 
-  it('alive node (fullness >= threshold) renders with higher opacity than a thin node', () => {
-    // Stage 3 is alive; stage 1 is thin.
-    mockMapState.wheelFullnessByStage = { 3: FULLNESS_ALIVE_THRESHOLD, 1: 0.0 };
+  it('renders unlocked stages at full opacity even when the wheel reads thin', () => {
+    // Stage 1 is unlocked but reads thin — the balance must stay an a11y-only
+    // read, never a washed-out (greyed) stage block.
+    mockMapState.wheelFullnessByStage = { 1: 0.0 };
     const tree = create(<MapScreen />);
 
-    const aliveHotspot = tree.root.findByProps({ testID: 'stage-hotspot-3-0' });
-    const thinHotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
-
-    const aliveOpacity = emphasisStyle(FULLNESS_ALIVE_THRESHOLD).opacity;
-    const thinOpacity = emphasisStyle(0.0).opacity;
-
-    // The alive node must render with a visually distinct (higher) opacity.
-    expect(aliveOpacity).toBeGreaterThan(thinOpacity as number);
-
-    // The alive hotspot carries the alive-emphasis style; the thin does not.
-    const aliveStyles = (aliveHotspot.props.style as unknown[]).flat(10);
-    const thinStyles = (thinHotspot.props.style as unknown[]).flat(10);
-    const opacityOf = (styles: unknown[]) =>
-      styles.reduce<number | undefined>((acc, s) => {
-        if (s && typeof s === 'object' && 'opacity' in (s as object)) {
-          return (s as { opacity: number }).opacity;
-        }
-        return acc;
-      }, undefined);
-
-    expect(opacityOf(aliveStyles)).toBeGreaterThan(opacityOf(thinStyles) ?? 0);
+    const unlockedHotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
+    const flat = StyleSheet.flatten(unlockedHotspot.props.style as unknown[]) as {
+      opacity?: number;
+    };
+    expect(flat.opacity ?? 1).toBe(1);
   });
 
   it('alive node accessibilityLabel contains "reads full" suffix', () => {
@@ -597,6 +582,37 @@ describe('MapScreen center-cell overlay layout', () => {
     expect(flat.opacity).toBe(0.4);
   });
 
+  it('puts the left-column lock on the far left, not on a fourth stacked line', () => {
+    const tree = create(<MapScreen />);
+    const leftHotspot = tree.root.findByProps({ testID: 'stage-hotspot-8-0' });
+
+    // The block lays out as a row with its content vertically centered, so
+    // the padlock sits beside the three text lines, never below them.
+    const flat = StyleSheet.flatten(leftHotspot.props.style) as {
+      flexDirection?: string;
+      alignItems?: string;
+    };
+    expect(flat.flexDirection).toBe('row');
+    expect(flat.alignItems).toBe('center');
+
+    // The lock renders before the persona text (far left of the row).
+    const texts = leftHotspot
+      .findAll((node: TestNode) => typeof node.props.children === 'string')
+      .map((node: TestNode) => node.props.children as string);
+    const display = STAGE_DISPLAY[8];
+    expect(texts.indexOf('🔒')).toBeGreaterThanOrEqual(0);
+    expect(texts.indexOf('🔒')).toBeLessThan(texts.indexOf(display!.persona));
+  });
+
+  it('centers the three text lines of an unlocked left block across its height', () => {
+    const tree = create(<MapScreen />);
+    const leftHotspot = tree.root.findByProps({ testID: 'stage-hotspot-1-0' });
+    // No lock for an unlocked stage, and the text column centers vertically.
+    expect(leftHotspot.findAll(isLockIcon)).toHaveLength(0);
+    expect(styles.stageLines.justifyContent).toBe('center');
+    expect(styles.stageLines.flex).toBe(1);
+  });
+
   it('stacks the pill above the label and the countdown above the lock', () => {
     mockMapState.daysUntilStage = 42;
     const tree = create(<MapScreen />);
@@ -697,6 +713,24 @@ describe('MapScreen left-column stage text color', () => {
       const node = tree.root.findByProps({ children: title });
       expect(node.props.adjustsFontSizeToFit).toBe(true);
       expect(node.props.numberOfLines).toBe(1);
+    }
+  });
+
+  it('sizes the title watermark from its measured cell width (react-native-web fit)', () => {
+    // adjustsFontSizeToFit is a no-op on react-native-web, so the title must
+    // carry a deterministic fitted fontSize computed from the measured width.
+    const MEASURED_WIDTH = 140;
+    const tree = create(<MapScreen />);
+    for (const title of ['EMPTINESS', 'UNITY']) {
+      const wrapper = tree.root.findByProps({ testID: `title-fit-${title}` });
+      act(() => {
+        (wrapper.props.onLayout as (e: unknown) => void)({
+          nativeEvent: { layout: { width: MEASURED_WIDTH, height: 40 } },
+        });
+      });
+      const node = tree.root.findByProps({ children: title });
+      const flat = StyleSheet.flatten(node.props.style) as { fontSize?: number };
+      expect(flat.fontSize).toBe(fittedTitleFontSize(title, MEASURED_WIDTH));
     }
   });
 

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -2,11 +2,14 @@
 /* global describe, it, expect */
 import { ink, surface } from '../../../design/tokens';
 import {
+  fittedTitleFontSize,
   GRID_COLUMN_FLEX,
   labelCorner,
   MAP_ROWS,
   MAP_TITLE_LINES,
   STAGE_DISPLAY,
+  TITLE_MAX_FONT_SIZE,
+  TITLE_MIN_FONT_SIZE,
 } from '../mapLayout';
 import { isLeftReturning, STAGE_COUNT } from '../stageData';
 
@@ -133,6 +136,46 @@ describe('mapLayout', () => {
     for (let stageNumber = 1; stageNumber <= 8; stageNumber += 1) {
       const expected = isLeftReturning(stageNumber) ? 'right' : 'left';
       expect(labelCorner(stageNumber)).toBe(expected);
+    }
+  });
+});
+
+describe('fittedTitleFontSize', () => {
+  // The conservative glyph-advance estimate the fit is computed against; a
+  // fitted size is correct when estimated line width never exceeds the cell.
+  const GLYPH_EM_WIDTH = 0.72;
+  const LETTER_SPACING = 1;
+  const estimatedWidth = (title: string, fontSize: number): number =>
+    title.length * fontSize * GLYPH_EM_WIDTH + title.length * LETTER_SPACING;
+
+  it('renders at the ceiling before layout reports a width', () => {
+    expect(fittedTitleFontSize('EMPTINESS', 0)).toBe(TITLE_MAX_FONT_SIZE);
+  });
+
+  it('caps a short word in a wide cell at the type ramp ceiling', () => {
+    expect(fittedTitleFontSize('UNITY', 400)).toBe(TITLE_MAX_FONT_SIZE);
+  });
+
+  it('shrinks EMPTINESS so its estimated width fits a phone-width center cell', () => {
+    for (const width of [120, 140, 160, 200]) {
+      const size = fittedTitleFontSize('EMPTINESS', width);
+      expect(size).toBeLessThanOrEqual(TITLE_MAX_FONT_SIZE);
+      expect(estimatedWidth('EMPTINESS', size)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it('never shrinks below the legibility floor', () => {
+    expect(fittedTitleFontSize('EMPTINESS', 10)).toBe(TITLE_MIN_FONT_SIZE);
+  });
+
+  it('fits every configured title line, not just the current copy', () => {
+    const NARROW_CELL = 130;
+    for (const title of MAP_TITLE_LINES) {
+      const size = fittedTitleFontSize(title, NARROW_CELL);
+      expect(size).toBeGreaterThanOrEqual(TITLE_MIN_FONT_SIZE);
+      if (size > TITLE_MIN_FONT_SIZE) {
+        expect(estimatedWidth(title, size)).toBeLessThanOrEqual(NARROW_CELL);
+      }
     }
   });
 });

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -57,6 +57,37 @@ export interface MapRow {
 /** The serif title across the top of the spiral (top → bottom). */
 export const MAP_TITLE_LINES = ['EMPTINESS', 'UNITY'] as const;
 
+/** Ceiling for the title watermark — ``editorialType.title``'s 26px. */
+export const TITLE_MAX_FONT_SIZE = 26;
+
+/** Floor below which the watermark would stop reading as a title. */
+export const TITLE_MIN_FONT_SIZE = 12;
+
+/** Letter spacing (px) the title style renders with; part of the fit budget. */
+export const TITLE_LETTER_SPACING = 1;
+
+/**
+ * Conservative average advance width of an uppercase serif glyph, in ems.
+ * Deliberately generous (Georgia caps average ≈0.63em) so the estimate only
+ * ever errs toward a smaller, guaranteed-fitting size.
+ */
+const TITLE_GLYPH_EM_WIDTH = 0.72;
+
+/**
+ * Largest font size (capped at ``TITLE_MAX_FONT_SIZE``) at which ``title``
+ * fits ``width`` on a single line. The native ``adjustsFontSizeToFit`` is not
+ * implemented by react-native-web, so the watermark sizes itself from the
+ * measured cell width instead — EMPTINESS / UNITY must never truncate or
+ * hyphenate on any target. An unmeasured width (0) renders at the ceiling
+ * until layout reports.
+ */
+export const fittedTitleFontSize = (title: string, width: number): number => {
+  if (width <= 0 || title.length === 0) return TITLE_MAX_FONT_SIZE;
+  const glyphBudget = width - TITLE_LETTER_SPACING * title.length;
+  const fitted = Math.floor(glyphBudget / (title.length * TITLE_GLYPH_EM_WIDTH));
+  return Math.max(TITLE_MIN_FONT_SIZE, Math.min(TITLE_MAX_FONT_SIZE, fitted));
+};
+
 /**
  * The title line each top stage carries in its own grid row (no absolute
  * overlay): stage 10 reads EMPTINESS, stage 9 reads UNITY. Stages 1–8 have none.

--- a/frontend/src/features/Map/wheelBalance.ts
+++ b/frontend/src/features/Map/wheelBalance.ts
@@ -1,13 +1,9 @@
-/** Wheel-of-wholeness balance overlay: each Aspect reads thin/alive, a wheel not a ladder. */
+/**
+ * Wheel-of-wholeness balance overlay: each Aspect reads thin/alive, a wheel
+ * not a ladder. The read is carried through accessibility labels only —
+ * unlocked stages always render at full opacity, so the Map never looks
+ * washed out when the wheel reads thin (or hasn't loaded yet).
+ */
 
 /** Fullness at or above which an Aspect reads as "alive" rather than "thin". */
 export const FULLNESS_ALIVE_THRESHOLD = 0.5;
-
-/** Opacity emphasis dial (not a token): thin nodes are muted, alive nodes fully opaque. */
-const THIN_OPACITY = 0.55;
-const ALIVE_OPACITY = 1;
-
-/** Opacity fragment for a node: fuller Aspect reads more present (alive vs thin). */
-export function emphasisStyle(fullness: number): { opacity: number } {
-  return { opacity: fullness >= FULLNESS_ALIVE_THRESHOLD ? ALIVE_OPACITY : THIN_OPACITY };
-}


### PR DESCRIPTION
- Move a locked stage's padlock inline to the far left of its
  left-column box so persona/descriptor/practice stay three lines,
  vertically centered across the box height
- Drop the wheel-balance opacity dimming that greyed out unlocked
  stages; the thin/alive read stays as an accessibility label
- Size the EMPTINESS/UNITY watermark from its measured cell width so
  it never truncates or hyphenates (adjustsFontSizeToFit is a no-op
  on react-native-web)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AEZgf58u6Sj2XfTC2F8SEh