### PR TITLE
feat(frontend): long-press a tier star to animate-fill and log units

### DIFF
--- a/frontend/src/features/Habits/__tests__/markerGesture.test.ts
+++ b/frontend/src/features/Habits/__tests__/markerGesture.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { createMarkerGesture, type MarkerGestureCallbacks } from '../markerGesture';
+import { DRAG_SLOP_PX, STAR_LONG_PRESS_MS } from '../starFill';
+
+const makeCallbacks = (): jest.Mocked<MarkerGestureCallbacks> => ({
+  onFillStart: jest.fn(),
+  onFillRelease: jest.fn(),
+  onDragMove: jest.fn(),
+  onDragRelease: jest.fn(),
+});
+
+describe('createMarkerGesture', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('starts a fill after the long-press threshold and releases it on release', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    expect(cb.onFillStart).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+    expect(cb.onFillStart).toHaveBeenCalledTimes(1);
+
+    gesture.release();
+    expect(cb.onFillRelease).toHaveBeenCalledTimes(1);
+    expect(cb.onDragMove).not.toHaveBeenCalled();
+    expect(cb.onDragRelease).not.toHaveBeenCalled();
+  });
+
+  it('ignores sub-slop jitter so a slightly wobbly hold still fills', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    gesture.move(DRAG_SLOP_PX - 1);
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+
+    expect(cb.onFillStart).toHaveBeenCalledTimes(1);
+    expect(cb.onDragMove).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending fill and drags once movement crosses the slop', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    gesture.move(DRAG_SLOP_PX + 4);
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS * 2);
+
+    expect(cb.onFillStart).not.toHaveBeenCalled();
+    expect(cb.onDragMove).toHaveBeenCalledWith(DRAG_SLOP_PX + 4);
+
+    gesture.release();
+    expect(cb.onDragRelease).toHaveBeenCalledTimes(1);
+    expect(cb.onFillRelease).not.toHaveBeenCalled();
+  });
+
+  it('keeps forwarding small moves once dragging has started', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    gesture.move(DRAG_SLOP_PX + 2);
+    gesture.move(1);
+
+    expect(cb.onDragMove).toHaveBeenCalledTimes(2);
+    expect(cb.onDragMove).toHaveBeenLastCalledWith(1);
+  });
+
+  it('ignores moves while the fill owns the gesture', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+    gesture.move(50);
+
+    expect(cb.onDragMove).not.toHaveBeenCalled();
+  });
+
+  it('treats a quick tap as a drag release (existing confirm behavior)', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    gesture.release();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS * 2);
+
+    expect(cb.onDragRelease).toHaveBeenCalledTimes(1);
+    expect(cb.onFillStart).not.toHaveBeenCalled();
+    expect(cb.onFillRelease).not.toHaveBeenCalled();
+  });
+
+  it('releases an active fill on terminate without confirming a drag', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+    gesture.terminate();
+
+    expect(cb.onFillRelease).toHaveBeenCalledTimes(1);
+    expect(cb.onDragRelease).not.toHaveBeenCalled();
+  });
+
+  it('disarms the pending fill on terminate before the threshold', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    gesture.terminate();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS * 2);
+
+    expect(cb.onFillStart).not.toHaveBeenCalled();
+    expect(cb.onFillRelease).not.toHaveBeenCalled();
+    expect(cb.onDragRelease).not.toHaveBeenCalled();
+  });
+
+  it('supports a fresh gesture after a completed one', () => {
+    const cb = makeCallbacks();
+    const gesture = createMarkerGesture(cb);
+
+    gesture.grant();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+    gesture.release();
+
+    gesture.grant();
+    jest.advanceTimersByTime(STAR_LONG_PRESS_MS);
+    expect(cb.onFillStart).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/features/Habits/__tests__/starFill.test.ts
+++ b/frontend/src/features/Habits/__tests__/starFill.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { Goal, Habit } from '../Habits.types';
+import { FULL_SWEEP_MS, MIN_SWEEP_MS, computeStarFillPlan, sweepDurationMs } from '../starFill';
+
+const TZ = 'UTC';
+
+const makeGoal = (tier: 'low' | 'clear' | 'stretch', overrides: Partial<Goal> = {}): Goal => ({
+  id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  title: `${tier} goal`,
+  tier,
+  target: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  target_unit: 'units',
+  frequency: 1,
+  frequency_unit: 'per_day',
+  is_additive: true,
+  ...overrides,
+});
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 42,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: '🧘',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 2,
+  start_date: new Date('2025-01-01'),
+  goals: [makeGoal('low'), makeGoal('clear'), makeGoal('stretch')],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+const withTodayUnits = (units: number, overrides: Partial<Habit> = {}): Habit =>
+  makeHabit({
+    completions: [{ id: 't-1', timestamp: new Date(), completed_units: units }],
+    ...overrides,
+  });
+
+const subtractiveGoals = (): Goal[] => [
+  makeGoal('low', { target: 25, is_additive: false }),
+  makeGoal('clear', { target: 6, is_additive: false }),
+  makeGoal('stretch', { target: 0, is_additive: false }),
+];
+
+describe('computeStarFillPlan — additive habits', () => {
+  it('plans a full sweep to the stretch star from an empty bar', () => {
+    const plan = computeStarFillPlan(makeHabit(), 'stretch', TZ);
+    expect(plan).toEqual({
+      habitId: 42,
+      tier: 'stretch',
+      fromPercent: 0,
+      toPercent: 100,
+      deltaUnits: 3,
+      durationMs: FULL_SWEEP_MS,
+    });
+  });
+
+  it('plans a proportional hop to the low star from an empty bar', () => {
+    const plan = computeStarFillPlan(makeHabit(), 'low', TZ);
+    expect(plan?.deltaUnits).toBe(1);
+    expect(plan?.fromPercent).toBe(0);
+    expect(plan?.toPercent).toBeCloseTo(33.33, 1);
+    expect(plan?.durationMs).toBeCloseTo(FULL_SWEEP_MS / 3, 0);
+  });
+
+  it('logs only the remaining units when the bar starts mid-way', () => {
+    const plan = computeStarFillPlan(withTodayUnits(2), 'stretch', TZ);
+    expect(plan?.deltaUnits).toBe(1);
+    expect(plan?.fromPercent).toBeCloseTo(66.67, 1);
+    expect(plan?.toPercent).toBe(100);
+  });
+
+  it('plans a leftward (negative-delta) move when progress is past the pressed star', () => {
+    const plan = computeStarFillPlan(withTodayUnits(2), 'low', TZ);
+    expect(plan?.deltaUnits).toBe(-1);
+    expect(plan?.fromPercent).toBeCloseTo(66.67, 1);
+    expect(plan?.toPercent).toBeCloseTo(33.33, 1);
+  });
+
+  it('returns null when today already sits exactly on the pressed star', () => {
+    expect(computeStarFillPlan(withTodayUnits(2), 'clear', TZ)).toBeNull();
+  });
+
+  it('normalizes per-week targets to their daily equivalent', () => {
+    const habit = makeHabit({
+      goals: [
+        makeGoal('low', { target: 7, frequency_unit: 'per_week' }),
+        makeGoal('clear', { target: 14, frequency_unit: 'per_week' }),
+        makeGoal('stretch', { target: 21, frequency_unit: 'per_week' }),
+      ],
+    });
+    const plan = computeStarFillPlan(habit, 'low', TZ);
+    expect(plan?.deltaUnits).toBeCloseTo(1, 5);
+  });
+});
+
+describe('computeStarFillPlan — subtractive habits', () => {
+  it('plans a full drain to the low (loosest limit) star from a clean day', () => {
+    const habit = makeHabit({ goals: subtractiveGoals() });
+    const plan = computeStarFillPlan(habit, 'low', TZ);
+    expect(plan).toEqual({
+      habitId: 42,
+      tier: 'low',
+      fromPercent: 100,
+      toPercent: 0,
+      deltaUnits: 25,
+      durationMs: FULL_SWEEP_MS,
+    });
+  });
+
+  it('plans a partial drain to the clear star from a clean day', () => {
+    const habit = makeHabit({ goals: subtractiveGoals() });
+    const plan = computeStarFillPlan(habit, 'clear', TZ);
+    expect(plan?.deltaUnits).toBe(6);
+    expect(plan?.toPercent).toBeCloseTo(76, 1);
+  });
+
+  it('plans a rightward refill (negative delta) back to the stretch star after transgressions', () => {
+    const habit = withTodayUnits(10, { goals: subtractiveGoals() });
+    const plan = computeStarFillPlan(habit, 'stretch', TZ);
+    expect(plan?.deltaUnits).toBe(-10);
+    expect(plan?.fromPercent).toBeCloseTo(60, 1);
+    expect(plan?.toPercent).toBe(100);
+  });
+});
+
+describe('computeStarFillPlan — guards', () => {
+  it('returns null when the habit has no id (synthetic onboarding state)', () => {
+    const habit = makeHabit({ id: undefined as unknown as number });
+    expect(computeStarFillPlan(habit, 'stretch', TZ)).toBeNull();
+  });
+
+  it('returns null when any tier goal is missing', () => {
+    const habit = makeHabit({ goals: [makeGoal('low'), makeGoal('clear')] });
+    expect(computeStarFillPlan(habit, 'low', TZ)).toBeNull();
+  });
+});
+
+describe('sweepDurationMs', () => {
+  it('scales linearly with the distance travelled', () => {
+    expect(sweepDurationMs(0, 100)).toBe(FULL_SWEEP_MS);
+    expect(sweepDurationMs(100, 0)).toBe(FULL_SWEEP_MS);
+    expect(sweepDurationMs(25, 75)).toBe(FULL_SWEEP_MS / 2);
+  });
+
+  it('never drops below the visibility floor for short hops', () => {
+    expect(sweepDurationMs(50, 51)).toBe(MIN_SWEEP_MS);
+    expect(sweepDurationMs(50, 50)).toBe(MIN_SWEEP_MS);
+  });
+});

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -39,6 +39,9 @@ import {
   getGoalTarget,
   isGoalAchieved,
 } from '../HabitUtils';
+import { useStarFill, type StarFill, type StarFillControls } from '../hooks/useStarFill';
+import { createMarkerGesture } from '../markerGesture';
+import { STAR_LONG_PRESS_MS } from '../starFill';
 import {
   TierMarkerOverlay,
   type MarkerInteraction,
@@ -78,6 +81,7 @@ interface GoalProgressBarProps {
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
   onLayout: (_e: LayoutChangeEvent) => void;
+  starFill: StarFillControls;
 }
 
 interface ProgressFillProps {
@@ -106,19 +110,26 @@ const GoalProgressBar = ({
   tooltip,
   setTooltip,
   onLayout,
+  starFill,
 }: GoalProgressBarProps) => {
   const { scale } = useResponsive();
   const starSize = spacing(2, scale);
 
-  // Stretch markers open their tooltip on tap; low/clear are draggable, so they
-  // wrap a plain View and forward their pan handlers instead.
+  // Stretch markers open their tooltip on tap and fill-to-star on long press;
+  // low/clear are draggable, so they wrap a plain View and forward their pan
+  // handlers (whose gesture machine arbitrates long-press vs drag) instead.
   const resolveModalInteraction = (m: ModalMarkerSpec): MarkerInteraction =>
     m.tier === 'stretch'
       ? {
           Wrapper: TouchableOpacity,
           interactionProps: {
             onPressIn: () => setTooltip('stretch'),
-            onPressOut: () => setTooltip(null),
+            onPressOut: () => {
+              setTooltip(null);
+              starFill.release();
+            },
+            onLongPress: () => starFill.begin('stretch'),
+            delayLongPress: STAR_LONG_PRESS_MS,
           },
         }
       : { Wrapper: View, interactionProps: { ...m.panHandlers } };
@@ -860,23 +871,42 @@ function useMarkerPanResponders(
   setClearMarker: (_v: number) => void,
   setTooltip: (_v: null | 'low' | 'clear' | 'stretch') => void,
   onConfirm: (_tier: 'low' | 'clear', _pct: number) => void,
+  starFill: React.MutableRefObject<StarFillControls>,
 ) {
-  const createPanResponder = (tier: 'low' | 'clear') =>
-    PanResponder.create({
+  const dragTo = (tier: 'low' | 'clear', dx: number) => {
+    const init = tier === 'low' ? tiers.markers.low : tiers.markers.clear;
+    const pct = (((init / 100) * barWidth.current + dx) / barWidth.current) * 100;
+    if (tier === 'low') setLowMarker(Math.min(clampPercentage(pct), clearMarker - 5));
+    else setClearMarker(Math.max(clampPercentage(pct), lowMarker + 5));
+  };
+
+  const createPanResponder = (tier: 'low' | 'clear') => {
+    // The machine arbitrates the marker's two gestures: a held press becomes
+    // a fill-to-star (routed through the ref so the once-created responder
+    // always reaches the current hook instance), movement becomes the drag.
+    const gesture = createMarkerGesture({
+      onFillStart: () => starFill.current.begin(tier),
+      onFillRelease: () => starFill.current.release(),
+      onDragMove: (dx) => dragTo(tier, dx),
+      onDragRelease: () => onConfirm(tier, tier === 'low' ? lowMarker : clearMarker),
+    });
+    return PanResponder.create({
       onStartShouldSetPanResponder: () => true,
-      onPanResponderGrant: () => setTooltip(tier),
-      onPanResponderMove: (_, gesture) => {
-        const init = tier === 'low' ? tiers.markers.low : tiers.markers.clear;
-        const pct = (((init / 100) * barWidth.current + gesture.dx) / barWidth.current) * 100;
-        if (tier === 'low') setLowMarker(Math.min(clampPercentage(pct), clearMarker - 5));
-        else setClearMarker(Math.max(clampPercentage(pct), lowMarker + 5));
+      onPanResponderGrant: () => {
+        setTooltip(tier);
+        gesture.grant();
       },
+      onPanResponderMove: (_, g) => gesture.move(g.dx),
       onPanResponderRelease: () => {
         setTooltip(null);
-        onConfirm(tier, tier === 'low' ? lowMarker : clearMarker);
+        gesture.release();
       },
-      onPanResponderTerminate: () => setTooltip(null),
+      onPanResponderTerminate: () => {
+        setTooltip(null);
+        gesture.terminate();
+      },
     });
+  };
 
   const lowPan = useRef(createPanResponder('low')).current;
   const clearPan = useRef(createPanResponder('clear')).current;
@@ -910,6 +940,7 @@ function useGoalConfirm(
 const useGoalMarkers = (
   habit: GoalModalProps['habit'],
   onUpdateGoal: GoalModalProps['onUpdateGoal'],
+  starFill: React.MutableRefObject<StarFillControls>,
 ) => {
   const barWidth = useRef(0);
   const [lowMarker, setLowMarker] = useState(0);
@@ -942,6 +973,7 @@ const useGoalMarkers = (
     setClearMarker,
     setTooltip,
     onConfirm,
+    starFill,
   );
 
   return {
@@ -1066,6 +1098,7 @@ const buildProgressBarProps = (
   habit: NonNullable<GoalModalProps['habit']>,
   m: ReturnType<typeof useGoalMarkers>,
   tz: string,
+  fill: StarFill,
 ): GoalProgressBarProps => {
   // ``met`` is only computed when the goal exists — an absent tier has nothing to achieve.
   const markers: ModalMarkerSpec[] = [
@@ -1098,12 +1131,15 @@ const buildProgressBarProps = (
   ];
 
   return {
-    progressPercentage: modalProgressPercentage(habit, m, tz),
+    // While a fill or revert is running the animated frame wins; otherwise
+    // the bar renders the canonical prop-derived percent.
+    progressPercentage: fill.displayPercent ?? modalProgressPercentage(habit, m, tz),
     progressBarColor: getProgressBarColor(habit, tz),
     markers,
     tooltip: m.tooltip,
     setTooltip: m.setTooltip,
     onLayout: m.handleBarLayout,
+    starFill: fill,
   };
 };
 
@@ -1145,6 +1181,31 @@ const GoalEditConfirmDialog = ({
   />
 );
 
+/**
+ * Bind the marker layer to the star-fill animation. The pan responders are
+ * created once, so they reach the star-fill hook through a ref that is
+ * re-pointed at the current instance after every render.
+ */
+const useMarkersWithStarFill = (
+  habit: NonNullable<GoalModalProps['habit']>,
+  onUpdateGoal: GoalModalProps['onUpdateGoal'],
+  onLogUnit: GoalModalProps['onLogUnit'],
+  tz: string,
+) => {
+  const starFillRef = useRef<StarFillControls>({ begin: () => {}, release: () => {} });
+  const m = useGoalMarkers(habit, onUpdateGoal, starFillRef);
+  const fill = useStarFill({
+    habit,
+    tz,
+    progressPercent: modalProgressPercentage(habit, m, tz),
+    onLogUnit,
+  });
+  useEffect(() => {
+    starFillRef.current = fill;
+  });
+  return { m, fill };
+};
+
 const GoalModalBody = ({
   habit,
   onClose,
@@ -1156,8 +1217,8 @@ const GoalModalBody = ({
   const [showEmojiSelector, setShowEmojiSelector] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const goalGroup = useGoalGroup(habit);
-  const m = useGoalMarkers(habit, onUpdateGoal);
   const { userTimezone } = useAuth();
+  const { m, fill } = useMarkersWithStarFill(habit, onUpdateGoal, onLogUnit, userTimezone);
   const log = useLogState(habit, onLogUnit);
 
   return (
@@ -1173,7 +1234,7 @@ const GoalModalBody = ({
         onToggleEdit={() => setIsEditing((prev) => !prev)}
       />
       {/* Progress bar stays visible; the pencil only collapses the editor. */}
-      <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone)} />
+      <GoalProgressBar {...buildProgressBarProps(habit, m, userTimezone, fill)} />
       {isEditing && (
         <View testID="goal-modal-edit-region">
           <GoalTargetEditor

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.starLongPress.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.starLongPress.test.tsx
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('../../../../api', () => ({
+  __esModule: true,
+  goalGroups: {
+    get: jest.fn(() => Promise.resolve(null)),
+  },
+}));
+
+jest.mock('../../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+import type { Goal, Habit } from '../../Habits.types';
+import { FULL_SWEEP_MS, STAR_LONG_PRESS_MS } from '../../starFill';
+import { GoalModal } from '../GoalModal';
+
+const makeGoal = (tier: 'low' | 'clear' | 'stretch', overrides: Partial<Goal> = {}): Goal => ({
+  id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  title: `${tier} goal`,
+  tier,
+  target: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  target_unit: 'units',
+  frequency: 1,
+  frequency_unit: 'per_day',
+  is_additive: true,
+  ...overrides,
+});
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 42,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: '🧘',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 2,
+  start_date: new Date('2025-01-01'),
+  goals: [makeGoal('low'), makeGoal('clear'), makeGoal('stretch')],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+const subtractiveHabit = (overrides: Partial<Habit> = {}): Habit =>
+  makeHabit({
+    goals: [
+      makeGoal('low', { target: 25, is_additive: false }),
+      makeGoal('clear', { target: 6, is_additive: false }),
+      makeGoal('stretch', { target: 0, is_additive: false }),
+    ],
+    ...overrides,
+  });
+
+const buildProps = (
+  habit: Habit,
+): React.ComponentProps<typeof GoalModal> & { onLogUnit: jest.Mock } => ({
+  visible: true,
+  habit,
+  onClose: jest.fn(),
+  onUpdateGoal: jest.fn(),
+  onUpdateGoalUnits: jest.fn(),
+  onLogUnit: jest.fn(),
+  onUpdateHabit: jest.fn(),
+});
+
+const renderModal = (habit: Habit) => {
+  const props = buildProps(habit);
+  const utils = render(<GoalModal {...props} />);
+  return { ...utils, props };
+};
+
+const advance = (ms: number): void => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+const fillWidth = (getByTestId: (_id: string) => { props: { style: { width: string } } }): number =>
+  parseFloat(getByTestId('modal-progress-fill').props.style.width);
+
+/**
+ * Minimal single-touch history accepted by PanResponder's centroid math, so
+ * tests can drive the pan-wrapped low/clear markers through the responder
+ * protocol (grant → release) without a real gesture system.
+ */
+const touchHistory = (pageX: number, timeStamp: number) => ({
+  numberActiveTouches: 1,
+  indexOfSingleActiveTouch: 0,
+  mostRecentTimeStamp: timeStamp,
+  touchBank: [
+    {
+      touchActive: true,
+      startPageX: pageX,
+      startPageY: 0,
+      startTimeStamp: timeStamp,
+      currentPageX: pageX,
+      currentPageY: 0,
+      currentTimeStamp: timeStamp,
+      previousPageX: pageX,
+      previousPageY: 0,
+      previousTimeStamp: timeStamp,
+    },
+  ],
+});
+
+const grantMarker = (marker: unknown): void => {
+  fireEvent(marker as never, 'responderGrant', {
+    touchHistory: touchHistory(0, 1),
+    nativeEvent: {},
+  });
+};
+
+const releaseMarker = (marker: unknown): void => {
+  fireEvent(marker as never, 'responderRelease', {
+    touchHistory: touchHistory(0, 2),
+    nativeEvent: {},
+  });
+};
+
+describe('GoalModal star long-press fill', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-03T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fills to the stretch star and logs the full delta from an empty bar', () => {
+    const { getByTestId, props } = renderModal(makeHabit());
+
+    fireEvent(getByTestId('modal-marker-stretch'), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledTimes(1);
+    expect(props.onLogUnit).toHaveBeenCalledWith(42, 3);
+    expect(fillWidth(getByTestId as never)).toBe(100);
+  });
+
+  it('logs only the remaining units when the bar starts mid-way', () => {
+    const habit = makeHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 1 }],
+    });
+    const { getByTestId, props } = renderModal(habit);
+
+    fireEvent(getByTestId('modal-marker-stretch'), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(42, 2);
+  });
+
+  it('animates the width progressively while the star is held', () => {
+    const { getByTestId, props } = renderModal(makeHabit());
+
+    fireEvent(getByTestId('modal-marker-stretch'), 'longPress');
+    advance(FULL_SWEEP_MS / 2);
+
+    const midway = fillWidth(getByTestId as never);
+    expect(midway).toBeGreaterThan(0);
+    expect(midway).toBeLessThan(100);
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+  });
+
+  it('reverts to the starting position without logging when released early', () => {
+    const { getByTestId, props } = renderModal(makeHabit());
+
+    const marker = getByTestId('modal-marker-stretch');
+    fireEvent(marker, 'longPress');
+    advance(FULL_SWEEP_MS / 3);
+    fireEvent(marker, 'pressOut');
+    advance(FULL_SWEEP_MS * 2);
+
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+    expect(fillWidth(getByTestId as never)).toBe(0);
+  });
+
+  it('does nothing when today already sits exactly on the pressed star', () => {
+    const habit = makeHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 3 }],
+    });
+    const { getByTestId, props } = renderModal(habit);
+
+    fireEvent(getByTestId('modal-marker-stretch'), 'longPress');
+    advance(FULL_SWEEP_MS * 2);
+
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+    expect(fillWidth(getByTestId as never)).toBe(100);
+  });
+
+  it('drains a subtractive habit bar to the pressed limit star and logs the consumed units', () => {
+    const { getByTestId, props } = renderModal(subtractiveHabit());
+    const lowMarker = getByTestId('modal-marker-low');
+
+    grantMarker(lowMarker);
+    advance(STAR_LONG_PRESS_MS);
+    advance(FULL_SWEEP_MS / 2);
+    const midway = fillWidth(getByTestId as never);
+    expect(midway).toBeLessThan(100);
+    expect(midway).toBeGreaterThan(0);
+
+    advance(FULL_SWEEP_MS / 2 + 100);
+    expect(props.onLogUnit).toHaveBeenCalledTimes(1);
+    expect(props.onLogUnit).toHaveBeenCalledWith(42, 25);
+    expect(fillWidth(getByTestId as never)).toBe(0);
+  });
+
+  it('refills a subtractive bar toward the stretch star by logging a negative correction', () => {
+    const habit = subtractiveHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 10 }],
+    });
+    const { getByTestId, props } = renderModal(habit);
+
+    fireEvent(getByTestId('modal-marker-stretch'), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(42, -10);
+    expect(fillWidth(getByTestId as never)).toBe(100);
+  });
+
+  it('moves an additive bar leftward with a negative log when past the pressed star', () => {
+    const habit = makeHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 2 }],
+    });
+    const { getByTestId, props } = renderModal(habit);
+    const lowMarker = getByTestId('modal-marker-low');
+
+    grantMarker(lowMarker);
+    advance(STAR_LONG_PRESS_MS + FULL_SWEEP_MS);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(42, -1);
+  });
+
+  it('does not open the drag-edit confirm after a long-press fill completes', () => {
+    const { getByTestId, queryByTestId, props } = renderModal(subtractiveHabit());
+    const lowMarker = getByTestId('modal-marker-low');
+
+    grantMarker(lowMarker);
+    advance(STAR_LONG_PRESS_MS + FULL_SWEEP_MS + 100);
+    releaseMarker(lowMarker);
+
+    expect(props.onLogUnit).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('goal-edit-confirm')).toBeNull();
+    expect(props.onUpdateGoal).not.toHaveBeenCalled();
+  });
+
+  it('reverts a pan-marker fill without logging when released before the star', () => {
+    const { getByTestId, queryByTestId, props } = renderModal(subtractiveHabit());
+    const lowMarker = getByTestId('modal-marker-low');
+
+    grantMarker(lowMarker);
+    advance(STAR_LONG_PRESS_MS + FULL_SWEEP_MS / 3);
+    releaseMarker(lowMarker);
+    advance(FULL_SWEEP_MS * 2);
+
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+    expect(queryByTestId('goal-edit-confirm')).toBeNull();
+    expect(fillWidth(getByTestId as never)).toBe(100);
+  });
+
+  it('still opens the drag-edit confirm on a quick tap of a draggable star', () => {
+    const { getByTestId, props } = renderModal(makeHabit());
+    const lowMarker = getByTestId('modal-marker-low');
+
+    grantMarker(lowMarker);
+    advance(STAR_LONG_PRESS_MS / 4);
+    releaseMarker(lowMarker);
+
+    expect(getByTestId('goal-edit-confirm')).toBeTruthy();
+    advance(FULL_SWEEP_MS * 2);
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Habits/hooks/useStarFill.ts
+++ b/frontend/src/features/Habits/hooks/useStarFill.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react';
+import { Animated, Easing } from 'react-native';
+
+import type { TierType } from '../goalMarker';
+import type { GoalModalProps, Habit } from '../Habits.types';
+import { computeStarFillPlan, sweepDurationMs, type StarFillPlan } from '../starFill';
+
+/**
+ * The star-fill animation for the goal modal's progress bar: `begin(tier)`
+ * sweeps the bar from its current position toward the pressed star and logs
+ * the plan's delta on arrival; `release()` before arrival sweeps back to the
+ * starting position and logs nothing.
+ */
+
+/** The two entry points the gesture layer drives. */
+export interface StarFillControls {
+  begin: (_tier: TierType) => void;
+  release: () => void;
+}
+
+export interface StarFill extends StarFillControls {
+  /** Percent to render while a fill/revert runs; `null` = show the static percent. */
+  displayPercent: number | null;
+}
+
+interface UseStarFillArgs {
+  habit: Habit;
+  tz: string;
+  /** The bar's static (prop-derived) percent, owned by the caller. */
+  progressPercent: number;
+  onLogUnit: GoalModalProps['onLogUnit'];
+}
+
+/** One linear constant-speed leg of the sweep; `onEnd` gets Animated's `finished`. */
+const sweep = (
+  anim: Animated.Value,
+  toValue: number,
+  duration: number,
+  onEnd: (_finished: boolean) => void,
+): void => {
+  Animated.timing(anim, {
+    toValue,
+    duration,
+    easing: Easing.linear,
+    // Width is a layout prop — the native driver cannot animate it.
+    useNativeDriver: false,
+  }).start(({ finished }) => onEnd(finished));
+};
+
+/**
+ * Drive the fill with a JS Animated value whose listener mirrors each frame
+ * into React state, keeping the bar's `width` a plain percent string (the
+ * shape the static render and its tests already rely on). The active plan
+ * lives in a ref so the pan responders — created once — always act on the
+ * current gesture rather than a stale closure.
+ */
+export const useStarFill = ({
+  habit,
+  tz,
+  progressPercent,
+  onLogUnit,
+}: UseStarFillArgs): StarFill => {
+  const anim = useRef(new Animated.Value(0)).current;
+  const [displayPercent, setDisplayPercent] = useState<number | null>(null);
+  const activeRef = useRef<StarFillPlan | null>(null);
+
+  useEffect(() => {
+    const id = anim.addListener(({ value }) => setDisplayPercent(value));
+    return () => anim.removeListener(id);
+  }, [anim]);
+
+  // After a committed fill, the frozen frame equals the marker percent the
+  // logged units produce; once the static percent catches up (the parent
+  // habit re-renders), hand the bar back to the prop so it can never go stale.
+  useEffect(() => {
+    if (activeRef.current === null) setDisplayPercent(null);
+  }, [progressPercent]);
+
+  const begin = (tier: TierType): void => {
+    if (activeRef.current !== null) return;
+    const plan = computeStarFillPlan(habit, tier, tz);
+    if (plan === null) return;
+    activeRef.current = plan;
+    setDisplayPercent(plan.fromPercent);
+    anim.setValue(plan.fromPercent);
+    sweep(anim, plan.toPercent, plan.durationMs, (finished) => {
+      // An interrupted sweep (release/restart) is cleaned up by its interruptor.
+      if (!finished || activeRef.current !== plan) return;
+      activeRef.current = null;
+      onLogUnit(plan.habitId, plan.deltaUnits);
+    });
+  };
+
+  const release = (): void => {
+    const plan = activeRef.current;
+    if (plan === null) return; // no fill in flight (or it already committed)
+    activeRef.current = null;
+    anim.stopAnimation((current) => {
+      sweep(anim, plan.fromPercent, sweepDurationMs(current, plan.fromPercent), (finished) => {
+        if (finished && activeRef.current === null) setDisplayPercent(null);
+      });
+    });
+  };
+
+  return { displayPercent, begin, release };
+};

--- a/frontend/src/features/Habits/markerGesture.ts
+++ b/frontend/src/features/Habits/markerGesture.ts
@@ -1,0 +1,75 @@
+import { DRAG_SLOP_PX, STAR_LONG_PRESS_MS } from './starFill';
+
+/**
+ * Arbitration between the two gestures a draggable tier marker supports:
+ * hold-in-place long-presses become a fill-to-star, while movement past the
+ * slop becomes the pre-existing drag-to-edit. The machine is plain JS (no
+ * PanResponder types) so the decision logic stays unit-testable with fake
+ * timers, and the modal's pan responders reduce to thin adapters.
+ */
+
+export interface MarkerGestureCallbacks {
+  /** The press survived the long-press threshold without dragging. */
+  onFillStart: () => void;
+  /** The finger lifted (or the responder terminated) during an active fill. */
+  onFillRelease: () => void;
+  /** Movement crossed the slop — forward the pan dx to the drag handler. */
+  onDragMove: (_dx: number) => void;
+  /** A non-fill gesture ended — taps and drags both confirm, as before. */
+  onDragRelease: () => void;
+}
+
+export interface MarkerGesture {
+  grant: () => void;
+  move: (_dx: number) => void;
+  release: () => void;
+  terminate: () => void;
+}
+
+type Mode = 'idle' | 'pending' | 'filling' | 'dragging';
+
+/** Create the per-marker gesture arbiter; one instance lives per pan responder. */
+export const createMarkerGesture = (callbacks: MarkerGestureCallbacks): MarkerGesture => {
+  let mode: Mode = 'idle';
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const disarm = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const grant = (): void => {
+    mode = 'pending';
+    timer = setTimeout(() => {
+      timer = null;
+      mode = 'filling';
+      callbacks.onFillStart();
+    }, STAR_LONG_PRESS_MS);
+  };
+
+  const move = (dx: number): void => {
+    if (mode === 'filling') return; // the fill owns the gesture; no drag
+    if (mode === 'pending' && Math.abs(dx) < DRAG_SLOP_PX) return; // finger jitter
+    disarm();
+    mode = 'dragging';
+    callbacks.onDragMove(dx);
+  };
+
+  const end = (confirmDrag: boolean): void => {
+    disarm();
+    const wasFilling = mode === 'filling';
+    mode = 'idle';
+    if (wasFilling) callbacks.onFillRelease();
+    else if (confirmDrag) callbacks.onDragRelease();
+  };
+
+  return {
+    grant,
+    move,
+    release: () => end(true),
+    // Termination never confirmed a drag before the fill existed either.
+    terminate: () => end(false),
+  };
+};

--- a/frontend/src/features/Habits/starFill.ts
+++ b/frontend/src/features/Habits/starFill.ts
@@ -1,0 +1,94 @@
+import type { TierType } from './goalMarker';
+import type { Goal, Habit } from './Habits.types';
+import {
+  calculateTodaysProgress,
+  getGoalTarget,
+  getMarkerPositions,
+  getProgressPercentage,
+} from './HabitUtils';
+
+/**
+ * Long-press-to-fill: holding a tier star on the goal modal's progress bar
+ * animates the fill toward that star and, on arrival, logs exactly the units
+ * needed for today's progress to land on that tier's target. This module owns
+ * the pure math — which direction the bar moves, how many units get logged,
+ * and how long the sweep takes — so the animation hook and gesture layer stay
+ * thin and the invariants stay unit-testable.
+ */
+
+/** Hold time before a pressed star arms the fill animation. */
+export const STAR_LONG_PRESS_MS = 400;
+
+/** Time for the fill to sweep the full 0–100 bar; shorter hops scale down linearly. */
+export const FULL_SWEEP_MS = 1500;
+
+/** Duration floor so short hops still read as motion rather than a blink. */
+export const MIN_SWEEP_MS = 250;
+
+/** Movement beyond this many px turns a pending star long-press into a drag. */
+export const DRAG_SLOP_PX = 8;
+
+/** |delta| below this is "already on the star" — float dust from per-week targets. */
+const DELTA_EPSILON = 1e-9;
+
+const FULL_BAR_PERCENT = 100;
+
+/**
+ * Everything one star fill needs: where the bar starts (`fromPercent`, the
+ * revert target on early release), where it lands (`toPercent`, the star's
+ * marker position), the units to log on arrival (`deltaUnits`, negative when
+ * the bar must move away from the tier's achieved side), and the sweep time.
+ */
+export interface StarFillPlan {
+  habitId: number;
+  tier: TierType;
+  fromPercent: number;
+  toPercent: number;
+  deltaUnits: number;
+  durationMs: number;
+}
+
+/** Constant-speed sweep: proportional to distance, floored for visibility. */
+export const sweepDurationMs = (fromPercent: number, toPercent: number): number =>
+  Math.max(MIN_SWEEP_MS, (Math.abs(toPercent - fromPercent) / FULL_BAR_PERCENT) * FULL_SWEEP_MS);
+
+const findTier = (habit: Habit, tier: TierType): Goal | undefined =>
+  habit.goals.find((g) => g.tier === tier);
+
+/**
+ * Plan the fill for a long-pressed tier star, or `null` when there is nothing
+ * to do (missing tiers, id-less onboarding habit, or today's progress already
+ * sits on the star).
+ *
+ * `deltaUnits` is the daily-equivalent gap between the tier's target and
+ * today's logged units, so it works in every direction: positive fills an
+ * additive bar rightward or drains a subtractive one leftward (consuming
+ * allowance), negative walks either bar back toward the star. The percents
+ * come from the same canonical helpers the bar renders with, so the animation
+ * always lands exactly where the star is drawn.
+ */
+export const computeStarFillPlan = (
+  habit: Habit,
+  tier: TierType,
+  tz: string,
+): StarFillPlan | null => {
+  const lowGoal = findTier(habit, 'low');
+  const clearGoal = findTier(habit, 'clear');
+  const stretchGoal = findTier(habit, 'stretch');
+  const tierGoal = findTier(habit, tier);
+  if (habit.id == null || !lowGoal || !clearGoal || !stretchGoal || !tierGoal) return null;
+
+  const deltaUnits = getGoalTarget(tierGoal) - calculateTodaysProgress(habit, tz);
+  if (Math.abs(deltaUnits) < DELTA_EPSILON) return null;
+
+  const fromPercent = getProgressPercentage(habit, stretchGoal, tz);
+  const toPercent = getMarkerPositions(lowGoal, clearGoal, stretchGoal)[tier];
+  return {
+    habitId: habit.id,
+    tier,
+    fromPercent,
+    toPercent,
+    deltaUnits,
+    durationMs: sweepDurationMs(fromPercent, toPercent),
+  };
+};


### PR DESCRIPTION
Holding any tier star (4-, 5-, or 10-point) on the goal modal's progress
bar now sweeps the fill toward that star at constant speed and, on
arrival, logs exactly the units needed for today's progress to land on
that tier's target. Releasing before the star sweeps the bar back to its
starting position and logs nothing.

The delta is the daily-equivalent gap between the tier target and
today's logged units, so the gesture works from any starting point and
in every direction: it fills an additive bar rightward, drains a
subtractive bar (e.g. No Sugar) leftward as allowance is consumed, and
logs a negative correction when the bar must move back toward a star.

- starFill.ts: pure fill plan (direction, delta, duration) from the
  same canonical helpers the bar renders with, so the sweep always
  lands exactly on the drawn star
- markerGesture.ts: per-marker state machine arbitrating hold-to-fill
  vs the pre-existing drag-to-edit on the pan-wrapped low/clear stars
  (sub-slop jitter still fills; movement past the slop still drags)
- useStarFill.ts: Animated-driven sweep whose listener mirrors frames
  into state, keeping the fill width a plain percent string
- GoalModal: stretch star gains onLongPress; low/clear pan responders
  route grant/move/release through the gesture machine

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A82VCZb1BDsT9QC9KS5cMJ