### PR TITLE
fix(frontend): memoize magnifier lens content style

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -268,7 +268,8 @@ const useLensDrag = (params: LensDragParams): LensDragHandlers => {
  * pill's own center (see ``magnifierTransform`` for the derivation).
  */
 const magnifiedContentStyle = (
-  motion: LensMotion,
+  center: Animated.ValueXY,
+  frost: Animated.Value,
   frame: LensFrame,
   gridWidth: number,
   gridHeight: number,
@@ -281,7 +282,7 @@ const magnifiedContentStyle = (
     left: 0,
     width: gridWidth,
     height: gridHeight,
-    opacity: motion.frost.interpolate({
+    opacity: frost.interpolate({
       inputRange: [0, 1],
       outputRange: [1, MOTION_CONTENT_OPACITY],
     }),
@@ -289,13 +290,13 @@ const magnifiedContentStyle = (
       {
         translateX: Animated.add(
           new Animated.Value(t.kx),
-          Animated.multiply(motion.center.x, negativeScale),
+          Animated.multiply(center.x, negativeScale),
         ),
       },
       {
         translateY: Animated.add(
           new Animated.Value(t.ky),
-          Animated.multiply(motion.center.y, negativeScale),
+          Animated.multiply(center.y, negativeScale),
         ),
       },
       { scale: MAGNIFICATION },
@@ -317,9 +318,14 @@ const LensGlass = ({
   gridHeight: number;
   anchors: StageAnchors;
 }): React.JSX.Element => {
+  const contentStyle = useMemo(
+    () => magnifiedContentStyle(motion.center, motion.frost, frame, gridWidth, gridHeight),
+    [motion.center, motion.frost, frame, gridWidth, gridHeight],
+  );
+
   return (
     <View style={[styles.magnifierClip, { borderRadius: frame.radius }]} pointerEvents="none">
-      <Animated.View style={magnifiedContentStyle(motion, frame, gridWidth, gridHeight)}>
+      <Animated.View style={contentStyle}>
         <WaveOverlay
           width={gridWidth}
           height={gridHeight}


### PR DESCRIPTION
### Motivation
- Address review feedback and an ESLint hook warning by preventing the magnifier's animated transform graph from being recreated on unrelated renders. 
- Reduce unnecessary work during lens re-renders to keep motion smooth and deterministic under both reduced- and full-motion modes.

### Description
- Change `magnifiedContentStyle` to accept stable animated primitives (`center: Animated.ValueXY` and `frost: Animated.Value`) instead of the full `motion` object. 
- Memoize the magnified content style inside `LensGlass` with `useMemo`, keyed on `motion.center`, `motion.frost`, `frame`, and grid dimensions to satisfy hook linting and avoid re-allocating animated nodes. 
- Localized all edits to `frontend/src/features/Map/MagnifierLens.tsx` and preserved existing behavior and APIs for the rest of the component.

### Testing
- Ran `pre-commit run --all-files` and the pre-commit pipeline completed successfully (including lint/format/type checks). 
- Ran the targeted unit tests with `npm test -- --runInBand src/features/Map/__tests__/MagnifierLens.test.tsx` and all tests passed (`14 passed, 0 failed`). 
- Ran the frontend linter (`npm run lint -- --max-warnings=0`) and verified the previous hook warning was resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476c0d39ec83228edca5a451e1b03e)