### PR TITLE
fix: suppress browser long-press selection on habits

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -19,6 +19,7 @@ import {
   isEarlyUnlocked,
   calculateTodaysProgress,
 } from './HabitUtils';
+import { longPressGestureStyle } from './longPressGestureStyle';
 import {
   TierMarkerOverlay,
   type MarkerInteraction,
@@ -416,6 +417,7 @@ const getLockedTileStyle = (
   borderRadius: spacing(1, scale),
   backgroundColor: LOCKED_BACKGROUND,
   opacity: LOCKED_OPACITY,
+  ...longPressGestureStyle,
 });
 
 const LOCKED_NAME_STYLE = {
@@ -507,6 +509,7 @@ const buildUnlockedTileStyle = (
   minHeight: tileMinHeight,
   borderRadius: spacing(1, scale),
   backgroundColor: surface.canvas,
+  ...longPressGestureStyle,
 });
 
 const UnlockedTile = ({

--- a/frontend/src/features/Habits/TierMarkerOverlay.tsx
+++ b/frontend/src/features/Habits/TierMarkerOverlay.tsx
@@ -5,6 +5,7 @@ import { TierStar } from '../../components/TierStar';
 
 import { centeredTranslateX, tooltipBoxStyle, type TierType } from './goalMarker';
 import { clampPercentage, getTierColor } from './HabitUtils';
+import { longPressGestureStyle } from './longPressGestureStyle';
 
 /**
  * One tier marker's render spec: which tier, where it sits on the bar
@@ -45,6 +46,7 @@ const markerContainerStyle = (
     transform: [{ translateX: centeredTranslateX(clamped, starSize) }],
     zIndex,
     alignItems: 'center',
+    ...longPressGestureStyle,
   };
 };
 

--- a/frontend/src/features/Habits/__tests__/HabitTileInteractions.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileInteractions.test.tsx
@@ -6,6 +6,7 @@ import renderer from 'react-test-renderer';
 
 import { HabitTile } from '../HabitTile';
 import type { Habit } from '../Habits.types';
+import { buildLongPressGestureStyle } from '../longPressGestureStyle';
 
 describe('HabitTile interactions', () => {
   it('dims tiles with future start dates and responds to icon press', () => {
@@ -66,5 +67,21 @@ describe('HabitTile interactions', () => {
       icon.props.onPress();
     });
     expect(onIconPress).toHaveBeenCalled();
+  });
+});
+
+describe('habit long-press browser gesture suppression', () => {
+  it('disables web text selection and callouts so Safari long-press can log progress', () => {
+    expect(buildLongPressGestureStyle('web')).toMatchObject({
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
+      WebkitTouchCallout: 'none',
+      touchAction: 'manipulation',
+    });
+  });
+
+  it('leaves native platforms unchanged', () => {
+    expect(buildLongPressGestureStyle('ios')).toEqual({});
+    expect(buildLongPressGestureStyle('android')).toEqual({});
   });
 });

--- a/frontend/src/features/Habits/longPressGestureStyle.ts
+++ b/frontend/src/features/Habits/longPressGestureStyle.ts
@@ -1,0 +1,27 @@
+import { Platform, type ViewStyle } from 'react-native';
+
+type LongPressPlatform = typeof Platform.OS;
+
+export type WebLongPressStyle = ViewStyle & {
+  userSelect?: 'none';
+  WebkitUserSelect?: 'none';
+  WebkitTouchCallout?: 'none';
+  touchAction?: 'manipulation';
+};
+
+/**
+ * Browser defaults turn long-press into text selection and callouts (the iOS
+ * Safari loupe is the painful one). Habit stars use long-press as the primary
+ * progress-logging gesture, so web targets opt out of those browser gestures.
+ */
+export const buildLongPressGestureStyle = (platform: LongPressPlatform): WebLongPressStyle =>
+  platform === 'web'
+    ? {
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+        WebkitTouchCallout: 'none',
+        touchAction: 'manipulation',
+      }
+    : {};
+
+export const longPressGestureStyle = buildLongPressGestureStyle(Platform.OS);


### PR DESCRIPTION
### Motivation
- Mobile browsers (notably iOS Safari) convert long-press into text selection / a magnifying callout which prevents habit-star long-presses from reliably logging progress, so the habits UI must opt out of those browser gestures on web builds.

### Description
- Add `frontend/src/features/Habits/longPressGestureStyle.ts` which exports `buildLongPressGestureStyle` and `longPressGestureStyle` (a `WebLongPressStyle` that sets `userSelect: 'none'`, `WebkitUserSelect: 'none'`, `WebkitTouchCallout: 'none'`, and `touchAction: 'manipulation'` on web and is a no-op on native).
- Apply the web-only suppression to habit tiles by spreading `...longPressGestureStyle` into the locked and unlocked tile style objects in `HabitTile.tsx` and into the marker container style in `TierMarkerOverlay.tsx` so both tile-level and star-level long-press targets are not intercepted by the browser.
- Add a focused test in `__tests__/HabitTileInteractions.test.tsx` that asserts `buildLongPressGestureStyle('web')` returns the expected properties and that native platforms return `{}`; update imports and formatting to keep linting/typechecks clean.

### Testing
- Ran `npm test -- --runTestsByPath src/features/Habits/__tests__/HabitTileInteractions.test.tsx`, and the test suite passed (3 tests passing).
- Ran the frontend linter/formatters via `npm run lint` and `npx prettier` for the affected files, and lint/typecheck/format steps passed for the changed files.
- Ran repository hooks via `pre-commit run --all-files`, which completed successfully for the project checks that run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a476cd5143c83229e351c599a334efa)