### PR TITLE
fix(map): lock magnifier to vertical rail

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -23,6 +23,7 @@ import {
   clampLensCenter,
   DRAG_TAP_SLOP,
   glideDurationMs,
+  inertialStageTarget,
   lensCaption,
   lensCenterForStage,
   lensFrame,
@@ -97,6 +98,9 @@ interface DragOrigin {
   touchX: number;
   touchY: number;
   center: LensCenter;
+  lastY: number;
+  lastTime: number | null;
+  velocityY: number;
 }
 
 /** Run one glide: ease the center over, then clear the frost on arrival. */
@@ -205,6 +209,62 @@ interface LensDragHandlers {
   onResponderTerminate: () => void;
 }
 
+const newDragOrigin = (event: GestureResponderEvent, center: LensCenter): DragOrigin => ({
+  touchX: event.nativeEvent.pageX,
+  touchY: event.nativeEvent.pageY,
+  center: { ...center },
+  lastY: center.y,
+  lastTime: event.nativeEvent.timestamp ?? null,
+  velocityY: 0,
+});
+
+const rememberVerticalVelocity = (
+  origin: React.MutableRefObject<DragOrigin>,
+  nextY: number,
+  eventTime: number | undefined,
+): void => {
+  if (typeof eventTime === 'number' && origin.current.lastTime !== null) {
+    const dt = eventTime - origin.current.lastTime;
+    if (dt > 0) origin.current.velocityY = (nextY - origin.current.lastY) / dt;
+    origin.current.lastTime = eventTime;
+  }
+  origin.current.lastY = nextY;
+};
+
+const settleStageWithMomentum = (
+  centerY: number,
+  velocityY: number,
+  gridHeight: number,
+  anchors: StageAnchors,
+): number => inertialStageTarget(centerY, velocityY, gridHeight, anchors);
+
+const dragCenterOnRail = (
+  event: GestureResponderEvent,
+  origin: DragOrigin,
+  frame: LensFrame,
+  gridWidth: number,
+  gridHeight: number,
+): LensCenter =>
+  clampLensCenter(
+    { x: origin.center.x, y: origin.center.y + event.nativeEvent.pageY - origin.touchY },
+    frame,
+    gridWidth,
+    gridHeight,
+  );
+
+const settleDraggedLens = (params: LensDragParams, dragOrigin: DragOrigin): void => {
+  const { motion, gridHeight, anchors } = params;
+  motion.dragging.current = false;
+  const settled = settleStageWithMomentum(
+    motion.lastCenter.current.y,
+    dragOrigin.velocityY,
+    gridHeight,
+    anchors,
+  );
+  motion.glideTo(params.restingCenter(settled));
+  if (settled !== params.focusedStage) params.onSettleStage(settled);
+};
+
 /**
  * Drag the lens with a plain responder: releases within ``DRAG_TAP_SLOP`` are
  * taps (open the stage); real drags track the finger, re-caption the stage
@@ -212,43 +272,38 @@ interface LensDragHandlers {
  */
 const useLensDrag = (params: LensDragParams): LensDragHandlers => {
   const { motion, frame, gridWidth, gridHeight, anchors } = params;
-  const dragOrigin = useRef<DragOrigin>({ touchX: 0, touchY: 0, center: { x: 0, y: 0 } });
+  const dragOrigin = useRef<DragOrigin>({
+    touchX: 0,
+    touchY: 0,
+    center: { x: 0, y: 0 },
+    lastY: 0,
+    lastTime: null,
+    velocityY: 0,
+  });
 
   const handleMove = (event: GestureResponderEvent): void => {
     const dx = event.nativeEvent.pageX - dragOrigin.current.touchX;
     const dy = event.nativeEvent.pageY - dragOrigin.current.touchY;
+    const eventTime = event.nativeEvent.timestamp;
     if (!motion.dragging.current) {
       if (Math.hypot(dx, dy) < DRAG_TAP_SLOP) return;
       motion.dragging.current = true;
       if (!params.reducedMotion) motion.raiseFrost();
     }
-    const next = clampLensCenter(
-      { x: dragOrigin.current.center.x + dx, y: dragOrigin.current.center.y + dy },
-      frame,
-      gridWidth,
-      gridHeight,
-    );
+    const next = dragCenterOnRail(event, dragOrigin.current, frame, gridWidth, gridHeight);
+    rememberVerticalVelocity(dragOrigin, next.y, eventTime);
     motion.center.setValue(next);
     params.onHoverStage(nearestStage(next.y, gridHeight, anchors));
   };
 
-  const settleDrag = (): void => {
-    motion.dragging.current = false;
-    const settled = nearestStage(motion.lastCenter.current.y, gridHeight, anchors);
-    motion.glideTo(params.restingCenter(settled));
-    if (settled !== params.focusedStage) params.onSettleStage(settled);
-  };
+  const settleDrag = (): void => settleDraggedLens(params, dragOrigin.current);
 
   return {
     onStartShouldSetResponder: () => true,
     onResponderTerminationRequest: () => false,
     onResponderGrant: (event) => {
       motion.dragging.current = false;
-      dragOrigin.current = {
-        touchX: event.nativeEvent.pageX,
-        touchY: event.nativeEvent.pageY,
-        center: { ...motion.lastCenter.current },
-      };
+      dragOrigin.current = newDragOrigin(event, motion.lastCenter.current);
     },
     onResponderMove: handleMove,
     onResponderRelease: () => {

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
-import { lensCenterForStage } from '../magnifierGeometry';
+import { lensCenterForStage, lensFrame } from '../magnifierGeometry';
 import MagnifierLens from '../MagnifierLens';
 import { stageWavePoint } from '../waveGeometry';
 
@@ -52,7 +52,9 @@ const headlineText = (tree: ReturnType<typeof create>): string =>
   tree.root.findByProps({ testID: 'magnifier-headline' }).props.children as string;
 
 /** Synthetic responder touch event at a page position. */
-const touch = (pageX: number, pageY: number) => ({ nativeEvent: { pageX, pageY } });
+const touch = (pageX: number, pageY: number, timestamp = 0) => ({
+  nativeEvent: { pageX, pageY, timestamp },
+});
 
 /** Drive a full grant → move → release drag on the lens. */
 const drag = (
@@ -135,6 +137,36 @@ describe('MagnifierLens', () => {
     const lens = lensNode(tree);
     expect(lens.props.onStartShouldSetResponder()).toBe(true);
     expect(lens.props.onResponderTerminationRequest()).toBe(false);
+  });
+
+  it('locks horizontal dragging to the center-column rail', () => {
+    const { tree } = renderLens({ focusedStage: 1 });
+    const lens = lensNode(tree);
+    const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
+    const stage2Y = stageWavePoint(2).y * GRID_HEIGHT;
+    act(() => {
+      lens.props.onResponderGrant(touch(150, start.y, 0));
+      lens.props.onResponderMove(touch(260, stage2Y, 100));
+    });
+    const style = lensNode(tree).props.style[2];
+    expect(style.transform[0].translateX.__getValue()).toBeCloseTo(
+      start.x - lensFrame(GRID_WIDTH, GRID_HEIGHT).width / 2,
+    );
+    expect(headlineText(tree)).toBe('Receptivity');
+  });
+
+  it('uses release velocity to coast a fast swipe farther than the finger position', () => {
+    const { tree, onSettleStage } = renderLens({ focusedStage: 1 });
+    const lens = lensNode(tree);
+    const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
+    const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+    act(() => {
+      lens.props.onResponderGrant(touch(150, start.y, 0));
+      lens.props.onResponderMove(touch(150, stage3Y + 28, 80));
+      lens.props.onResponderMove(touch(150, stage3Y, 100));
+      lens.props.onResponderRelease(touch(150, stage3Y, 100));
+    });
+    expect(onSettleStage).toHaveBeenCalledWith(6);
   });
 
   it('drag past the slop settles on the nearest stage instead of tapping', () => {

--- a/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
@@ -6,6 +6,7 @@ import {
   contentOffset,
   DRAG_TAP_SLOP,
   glideDurationMs,
+  inertialStageTarget,
   lensCaption,
   lensCenterForStage,
   lensFrame,
@@ -118,6 +119,25 @@ describe('nearestStage', () => {
   it('clamps to the arc extremes above and below the strand', () => {
     expect(nearestStage(-100, GRID_HEIGHT)).toBe(STAGE_COUNT);
     expect(nearestStage(GRID_HEIGHT + 100, GRID_HEIGHT)).toBe(1);
+  });
+});
+
+describe('inertialStageTarget', () => {
+  it('projects a fast upward swipe several stages along the vertical track', () => {
+    const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+    expect(inertialStageTarget(stage3Y, -1.4, GRID_HEIGHT)).toBe(6);
+  });
+
+  it('keeps slow releases at the nearest stage', () => {
+    const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+    expect(inertialStageTarget(stage3Y, -0.05, GRID_HEIGHT)).toBe(3);
+  });
+
+  it('clamps projected momentum to the map ends', () => {
+    const stage9Y = stageWavePoint(9).y * GRID_HEIGHT;
+    expect(inertialStageTarget(stage9Y, -4, GRID_HEIGHT)).toBe(STAGE_COUNT);
+    const stage2Y = stageWavePoint(2).y * GRID_HEIGHT;
+    expect(inertialStageTarget(stage2Y, 4, GRID_HEIGHT)).toBe(1);
   });
 });
 

--- a/frontend/src/features/Map/magnifierGeometry.ts
+++ b/frontend/src/features/Map/magnifierGeometry.ts
@@ -49,6 +49,9 @@ const GLIDE_MAX_MS = 900;
 /** Additional glide time per pixel of travel between resting points. */
 const GLIDE_MS_PER_PX = 1.1;
 
+/** Momentum look-ahead window: fast swipes project a few stage bands forward. */
+const INERTIA_PROJECTION_MS = 120;
+
 /** Clamp ``value`` into [min, max]; min wins when the range is degenerate. */
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
@@ -128,6 +131,18 @@ export const nearestStage = (
   }
   return best;
 };
+
+/**
+ * Choose the stage a released swipe should coast toward. ``velocityY`` is in
+ * px/ms (positive downward), so projecting the release point forward keeps the
+ * lens on its vertical rail while making faster swipes coast across more rows.
+ */
+export const inertialStageTarget = (
+  centerY: number,
+  velocityY: number,
+  gridHeight: number,
+  anchors: StageAnchors = {},
+): number => nearestStage(centerY + velocityY * INERTIA_PROJECTION_MS, gridHeight, anchors);
 
 /**
  * Constants of the magnified-content mapping. A full-size copy of the grid


### PR DESCRIPTION
### Motivation
- The magnifier lens must be constrained to the center-column vertical rail so it only slides up and down instead of being dragged freely across the map, while preserving tap-to-open and stage-tap semantics.  
- Add a simple, responsive inertial swipe behavior so fast vertical swipes coast multiple stages and slow releases still snap to the nearest stage.

### Description
- Constrain drag math to the vertical rail by keeping the lens's X fixed during drags and computing Y from the finger delta in `MagnifierLens.tsx` (introduced `dragCenterOnRail` and related helpers).  
- Track recent vertical motion and compute a momentum-projected release target using a new `inertialStageTarget` helper in `magnifierGeometry.ts` (with a short `INERTIA_PROJECTION_MS` lookahead), and use that target when settling a drag.  
- Factor helper functions in `MagnifierLens.tsx`: `newDragOrigin`, `rememberVerticalVelocity`, `settleDraggedLens` to keep the responder logic small and testable, and keep existing hover/tap behavior intact.  
- Add unit tests covering inertial projection and rail-locked dragging in `__tests__/magnifierGeometry.test.ts` and `__tests__/MagnifierLens.test.tsx`.

### Testing
- Wrote tests first for the new behavior and then implemented the change (TDD): added `inertialStageTarget` tests and lens drag/velocity tests and verified they reproduce the intended behavior.  
- Ran targeted unit tests: `npm test -- --runTestsByPath src/features/Map/__tests__/MagnifierLens.test.tsx src/features/Map/__tests__/magnifierGeometry.test.ts --runInBand` and observed all Map-related tests pass.  
- Ran the repository pre-commit pipeline: `pre-commit run --all-files`, which ran formatter/linter/typecheck and the frontend test suite; all automated checks passed (ESLint, Prettier, typecheck, and frontend tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d73955548322a34e745f27910192)