### PR TITLE
Smooth map magnifier swipe settling

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -103,12 +103,16 @@ interface DragOrigin {
   velocityY: number;
 }
 
-/** Run one glide: ease the center over, then clear the frost on arrival. */
+/** Centers are identical when a parent focus update asks for the glide already in flight. */
+const sameLensCenter = (a: LensCenter | null, b: LensCenter): boolean =>
+  a !== null && a.x === b.x && a.y === b.y;
+
 const runGlide = (
   center: Animated.ValueXY,
   frost: Animated.Value,
   target: LensCenter,
   distance: number,
+  onDone: () => void,
 ): void => {
   Animated.timing(center, {
     toValue: target,
@@ -123,6 +127,7 @@ const runGlide = (
         useNativeDriver: false,
       }).start();
     }
+    onDone();
   });
 };
 
@@ -147,6 +152,7 @@ const useLensMotion = (
   const center = centerRef.current;
   const frost = useRef(new Animated.Value(0)).current;
   const dragging = useRef(false);
+  const activeGlideTarget = useRef<LensCenter | null>(null);
 
   useEffect(() => {
     const id = center.addListener((value) => {
@@ -161,14 +167,20 @@ const useLensMotion = (
 
   const glideTo = useCallback(
     (target: LensCenter) => {
+      if (sameLensCenter(activeGlideTarget.current, target)) return;
+
       if (reducedMotion) {
+        activeGlideTarget.current = null;
         center.setValue(target);
         frost.setValue(0);
         return;
       }
+      activeGlideTarget.current = target;
       const distance = Math.hypot(target.x - lastCenter.current.x, target.y - lastCenter.current.y);
       raiseFrost();
-      runGlide(center, frost, target, distance);
+      runGlide(center, frost, target, distance, () => {
+        activeGlideTarget.current = null;
+      });
     },
     [center, frost, raiseFrost, reducedMotion],
   );
@@ -303,6 +315,9 @@ const useLensDrag = (params: LensDragParams): LensDragHandlers => {
     onResponderTerminationRequest: () => false,
     onResponderGrant: (event) => {
       motion.dragging.current = false;
+      motion.center.stopAnimation((value: LensCenter) => {
+        motion.lastCenter.current = value;
+      });
       dragOrigin.current = newDragOrigin(event, motion.lastCenter.current);
     },
     onResponderMove: handleMove,

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 import React from 'react';
+import { Animated } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import { lensCenterForStage, lensFrame } from '../magnifierGeometry';
@@ -245,6 +246,54 @@ describe('MagnifierLens', () => {
       });
       expect(tree.root.findByProps({ testID: 'magnifier-frost' })).toBeTruthy();
     } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('starts one uninterrupted settling glide after a swipe changes stages', () => {
+    reducedMotionState.value = false;
+    jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
+
+    const Harness = (): React.JSX.Element => {
+      const [focusedStage, setFocusedStage] = React.useState(1);
+      return (
+        <MagnifierLens
+          gridWidth={GRID_WIDTH}
+          gridHeight={GRID_HEIGHT}
+          anchors={{}}
+          focusedStage={focusedStage}
+          currentStage={1}
+          onSettleStage={setFocusedStage}
+          onOpenStage={jest.fn()}
+        />
+      );
+    };
+
+    try {
+      let tree!: ReturnType<typeof create>;
+      act(() => {
+        tree = create(<Harness />);
+        jest.advanceTimersByTime(2000); // let the mount glide finish
+      });
+      timing.mockClear();
+
+      const lens = lensNode(tree);
+      const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
+      const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+      act(() => {
+        lens.props.onResponderGrant(touch(150, start.y, 0));
+        lens.props.onResponderMove(touch(150, stage3Y, 100));
+        lens.props.onResponderRelease(touch(150, stage3Y, 100));
+      });
+
+      const centerGlides = timing.mock.calls.filter(([, config]) => {
+        const toValue = (config as { toValue?: unknown }).toValue;
+        return typeof toValue === 'object' && toValue !== null && 'x' in toValue && 'y' in toValue;
+      });
+      expect(centerGlides).toHaveLength(1);
+    } finally {
+      timing.mockRestore();
       jest.useRealTimers();
     }
   });


### PR DESCRIPTION
### Motivation
- The magnifier pill on the Map was stuttering when given a swipe because each intermediate stage it passed could restart a settle animation, producing a jerky experience instead of a single smooth coast.  
- Fix should preserve existing drag-to-explore, tap-to-open, and settle semantics while making swipe coasts fluid.  

### Description
- Added an `activeGlideTarget` guard and `sameLensCenter` helper to `frontend/src/features/Map/MagnifierLens.tsx` so a parent-driven focused-stage update that matches an in-flight glide does not restart the same glide.  
- Switched `runGlide` to accept an `onDone` callback and ensure the active target is cleared only when a glide truly finishes.  
- On responder grant, stopped any in-flight `Animated` center animation and captured the current animated position so a new drag does not fight a prior glide.  
- Added a regression test `starts one uninterrupted settling glide after a swipe changes stages` to `frontend/src/features/Map/__tests__/MagnifierLens.test.tsx` which asserts a single center glide is started for a stage-changing swipe.  

### Testing
- Ran the new unit test file with `cd frontend && npm test -- --runTestsByPath src/features/Map/__tests__/MagnifierLens.test.tsx --runInBand` and observed all tests in that file pass.  
- Executed linting and typecheck via `cd frontend && npm run lint -- src/features/Map/MagnifierLens.tsx src/features/Map/__tests__/MagnifierLens.test.tsx && npx tsc --noEmit` with no failures.  
- Iterated `pre-commit` hooks until clean and ran `pre-commit run --all-files`; all hooks (including frontend eslint, prettier, typecheck, and tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4821229e7c83229f102182ab6cf15e)