### PR TITLE
fix(map): decelerate the magnifier settle so a swipe coasts instead of jerking

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -89,7 +89,7 @@ interface LensMotion {
   lastCenter: React.MutableRefObject<LensCenter>;
   /** True while a finger owns the lens; the glide effect defers to it. */
   dragging: React.MutableRefObject<boolean>;
-  glideTo: (_target: LensCenter) => void;
+  glideTo: (_target: LensCenter, _decelerate?: boolean) => void;
   raiseFrost: () => void;
 }
 
@@ -107,17 +107,28 @@ interface DragOrigin {
 const sameLensCenter = (a: LensCenter | null, b: LensCenter): boolean =>
   a !== null && a.x === b.x && a.y === b.y;
 
+/** A tap or focus change starts from rest, so its glide eases in and out — gather, glide, slow. */
+const FOCUS_EASING = Easing.inOut(Easing.cubic);
+
+/**
+ * A released swipe already carries the finger's speed, so its settle only
+ * decelerates: easing *out* keeps that momentum and slides to a slowing stop,
+ * never braking to zero and re-accelerating (the jerk of an ease-in restart).
+ */
+const SETTLE_EASING = Easing.out(Easing.cubic);
+
 const runGlide = (
   center: Animated.ValueXY,
   frost: Animated.Value,
   target: LensCenter,
   distance: number,
+  easing: (_value: number) => number,
   onDone: () => void,
 ): void => {
   Animated.timing(center, {
     toValue: target,
     duration: glideDurationMs(distance),
-    easing: Easing.inOut(Easing.cubic),
+    easing,
     useNativeDriver: false,
   }).start(({ finished }) => {
     if (finished) {
@@ -166,7 +177,7 @@ const useLensMotion = (
   }, [frost]);
 
   const glideTo = useCallback(
-    (target: LensCenter) => {
+    (target: LensCenter, decelerate = false) => {
       if (sameLensCenter(activeGlideTarget.current, target)) return;
 
       if (reducedMotion) {
@@ -178,7 +189,7 @@ const useLensMotion = (
       activeGlideTarget.current = target;
       const distance = Math.hypot(target.x - lastCenter.current.x, target.y - lastCenter.current.y);
       raiseFrost();
-      runGlide(center, frost, target, distance, () => {
+      runGlide(center, frost, target, distance, decelerate ? SETTLE_EASING : FOCUS_EASING, () => {
         activeGlideTarget.current = null;
       });
     },
@@ -273,7 +284,7 @@ const settleDraggedLens = (params: LensDragParams, dragOrigin: DragOrigin): void
     gridHeight,
     anchors,
   );
-  motion.glideTo(params.restingCenter(settled));
+  motion.glideTo(params.restingCenter(settled), true);
   if (settled !== params.focusedStage) params.onSettleStage(settled);
 };
 

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -57,6 +57,32 @@ const touch = (pageX: number, pageY: number, timestamp = 0) => ({
   nativeEvent: { pageX, pageY, timestamp },
 });
 
+/** A settle/glide `Animated.timing` config: an easing curve over an XY target. */
+interface CenterGlideConfig {
+  toValue: { x: number; y: number };
+  easing: (_t: number) => number;
+}
+
+/** Pull the center-driving `Animated.timing` configs (XY toValue) from a spy. */
+const centerGlideConfigs = (timing: jest.SpyInstance): CenterGlideConfig[] =>
+  timing.mock.calls
+    .map(([, config]) => config as CenterGlideConfig)
+    .filter(
+      (config) =>
+        typeof config?.toValue === 'object' &&
+        config.toValue !== null &&
+        'x' in config.toValue &&
+        'y' in config.toValue,
+    );
+
+/** The single center glide a settle/focus change is expected to start. */
+const soleCenterGlide = (timing: jest.SpyInstance): CenterGlideConfig => {
+  const [glide, ...rest] = centerGlideConfigs(timing);
+  expect(rest).toHaveLength(0);
+  if (!glide) throw new Error('expected exactly one center glide');
+  return glide;
+};
+
 /** Drive a full grant → move → release drag on the lens. */
 const drag = (
   tree: ReturnType<typeof create>,
@@ -317,6 +343,103 @@ describe('MagnifierLens', () => {
       });
       expect(onSettleStage).toHaveBeenCalledWith(3);
     } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('coasts to a stop after a fast swipe: the settle decelerates, never restarting from rest', () => {
+    reducedMotionState.value = false;
+    jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
+    try {
+      const { tree } = renderLens({ focusedStage: 1 });
+      act(() => {
+        jest.advanceTimersByTime(2000); // let the mount glide finish
+      });
+      timing.mockClear();
+
+      const lens = lensNode(tree);
+      const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
+      const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+      act(() => {
+        lens.props.onResponderGrant(touch(150, start.y, 0));
+        lens.props.onResponderMove(touch(150, stage3Y + 28, 80));
+        lens.props.onResponderMove(touch(150, stage3Y, 100));
+        lens.props.onResponderRelease(touch(150, stage3Y, 100));
+      });
+
+      const settle = soleCenterGlide(timing);
+      // Ease-out spends most of its travel early, then slows to the stage: the
+      // lens keeps the finger's speed and decelerates. An ease-in-out settle
+      // would sit near zero here (a dead stop before re-accelerating) — the jerk.
+      expect(settle.easing(0.1)).toBeGreaterThan(0.2);
+    } finally {
+      timing.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('locks exactly on a stage after a swipe: the settle target is that stage anchor', () => {
+    reducedMotionState.value = false;
+    jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
+    try {
+      const { tree, onSettleStage } = renderLens({ focusedStage: 1 });
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      timing.mockClear();
+
+      const lens = lensNode(tree);
+      const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
+      const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
+      act(() => {
+        lens.props.onResponderGrant(touch(150, start.y, 0));
+        lens.props.onResponderMove(touch(150, stage3Y + 28, 80));
+        lens.props.onResponderMove(touch(150, stage3Y, 100));
+        lens.props.onResponderRelease(touch(150, stage3Y, 100));
+      });
+
+      expect(onSettleStage).toHaveBeenCalledWith(6);
+      const settle = soleCenterGlide(timing);
+      expect(settle.toValue.y).toBeCloseTo(stageWavePoint(6).y * GRID_HEIGHT);
+    } finally {
+      timing.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('a stage-focus glide still gathers speed from rest (ease-in-out, not a snap)', () => {
+    reducedMotionState.value = false;
+    jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
+    try {
+      const { tree } = renderLens({ focusedStage: 1 });
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      timing.mockClear();
+
+      act(() => {
+        tree.update(
+          <MagnifierLens
+            gridWidth={GRID_WIDTH}
+            gridHeight={GRID_HEIGHT}
+            anchors={{}}
+            focusedStage={6}
+            currentStage={1}
+            onSettleStage={jest.fn()}
+            onOpenStage={jest.fn()}
+          />,
+        );
+      });
+
+      const glide = soleCenterGlide(timing);
+      // A tap/focus change starts from a standstill, so it must ease in — near
+      // zero early travel — rather than lurching off at full speed.
+      expect(glide.easing(0.1)).toBeLessThan(0.05);
+    } finally {
+      timing.mockRestore();
       jest.useRealTimers();
     }
   });


### PR DESCRIPTION
## Summary

The Map's magnifying-glass pill jerked on a fast swipe — it braked to a dead stop and re-accelerated toward its snap target, reading as a lurch that locked onto stages mid-fling. PR #1312 added a redundant-glide guard but never touched the settle animation, so the hitch survived.

**Root cause:** the release settle glided with `Easing.inOut(Easing.cubic)`, which *starts from zero velocity*. After a fast finger swipe the pill was already moving quickly, so easing *in* from a standstill created a visible velocity discontinuity — the jerk.

**Fix:** thread a `decelerate` flag through `glideTo` / `runGlide`. The release path now eases **out** (`Easing.out(Easing.cubic)`) — it keeps the finger's speed and slides to a slowing stop — while stage-tap and focus-change glides keep easing in-out (they start from rest, so they should gather speed). The settle *target* is unchanged, so the pill still lands exactly on a stage as momentum runs out.

Behaviors preserved (pinned by tests): final lock lands exactly on a stage, slow-drag unchanged, tap/click unchanged.

## Test plan

TDD — failing-first tests written before the fix:
- `coasts to a stop after a fast swipe: the settle decelerates, never restarting from rest` — asserts the settle easing samples high early (`easing(0.1) > 0.2`, ease-out coast) instead of near-zero (`0.004`, the ease-in hitch). **Failed** under the old code, passes now.
- `locks exactly on a stage after a swipe: the settle target is that stage anchor` — settle `toValue.y` lands exactly on the stage-6 anchor; `onSettleStage(6)`.
- `a stage-focus glide still gathers speed from rest (ease-in-out, not a snap)` — guards that tap/focus glides keep `easing(0.1) < 0.05`, so the fix doesn't over-reach.
- Existing drag / tap / rail-lock / one-uninterrupted-glide tests unchanged and green.

`./scripts/frontend/check-all.sh` fully green (eslint, prettier, tsc, jest + 90% coverage); `pre-commit run --all-files` green on commit. No bypasses.

Closes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)