### PR TITLE
fix(ci): re-apply and verify the dependencies label on Dependabot bridge issues

### DIFF
--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -173,15 +173,28 @@ jobs:
             # A re-run cannot re-reach this check (the PR body now links the
             # issue, so `body_links_issue` short-circuits), so both branches
             # point to the same one-time manual fix: add the label by hand.
-            local labels
+            local labels label_error=""
             if ! labels="$(gh issue view "$issue_num" --repo "$REPO" \
               --json labels --jq '.labels[].name')"; then
-              echo "::error::Could not verify the label on issue #$issue_num (transient GitHub API error); the re-apply may have succeeded — if the issue is missing the label, add it once: gh issue edit $issue_num --add-label dependencies" >&2
-              exit 1
+              label_error="Could not verify the label on issue #$issue_num (transient GitHub API error); the re-apply may have succeeded — if the issue is missing the label, add it once: gh issue edit $issue_num --add-label dependencies"
+            elif ! printf '%s\n' "$labels" | grep -qx dependencies; then
+              label_error="The 'dependencies' label is absent on issue #$issue_num after re-apply (the token likely lacks Issues/triage permission); add it once by hand: gh issue edit $issue_num --add-label dependencies"
             fi
-            if ! printf '%s\n' "$labels" | grep -qx dependencies; then
-              echo "::error::The 'dependencies' label is absent on issue #$issue_num after re-apply (the token likely lacks Issues/triage permission); add it once by hand: gh issue edit $issue_num --add-label dependencies" >&2
-              exit 1
+
+            # Failure handling differs by path. The single-PR event path fails
+            # loud and immediate (exit 1). The reconciler processes a whole
+            # batch, so one PR's label-verify failure must NOT skip every later
+            # PR: record the diagnosis and let the caller continue, then fail
+            # the run once at the end. The issue is filed and its PR is already
+            # linked, so `body_links_issue` short-circuits any re-run — no
+            # duplicate is ever minted while the label is added by hand.
+            if [ -n "$label_error" ]; then
+              if [ "$EVENT_NAME" = "pull_request_target" ]; then
+                echo "::error::$label_error" >&2
+                exit 1
+              fi
+              reconcile_failures+=("$label_error")
+              echo "Label-verify failed for issue #$issue_num — recorded; continuing the batch." >&2
             fi
           }
 
@@ -202,6 +215,11 @@ jobs:
           count="$(printf '%s' "$prs" | jq 'length')"
           echo "Found $count open Dependabot PR(s)."
 
+          # Collects label-verify diagnoses across the batch so one PR's
+          # failure never skips the rest; the run fails once at the end if any
+          # were recorded.
+          reconcile_failures=()
+
           # Iterate without piping into a subshell so set -e propagates.
           for i in $(seq 0 $((count - 1))); do
             num="$(printf '%s' "$prs" | jq -r ".[$i].number")"
@@ -213,5 +231,17 @@ jobs:
             fi
             bridge_pr "$num" "$ttl"
           done
+
+          # Surface every deferred label-verify failure at once and fail the
+          # run, so the batch completes but a permission gap or persistent API
+          # flake is never silently swallowed. Each issue is filed and its PR
+          # linked, so the only manual step is adding the missing label(s).
+          if [ "${#reconcile_failures[@]}" -gt 0 ]; then
+            echo "::error::${#reconcile_failures[@]} bridged PR(s) could not have their 'dependencies' label verified; add the label(s) by hand (details below)." >&2
+            for failure in "${reconcile_failures[@]}"; do
+              echo "::error::$failure" >&2
+            done
+            exit 1
+          fi
 
           echo "Reconciler complete."

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -143,6 +143,20 @@ jobs:
 
             echo "Filed issue #$issue_num for PR #$pr."
 
+            # The REST create endpoint silently drops labels when the token
+            # lacks push/triage access — which would break the marker dedup
+            # above (it filters on the `dependencies` label). Re-apply the
+            # label with a dedicated call (that endpoint errors instead of
+            # dropping) and verify it stuck, so a permission gap fails loudly
+            # rather than filing an unlabeled, dedup-invisible issue.
+            gh issue edit "$issue_num" --repo "$REPO" \
+              --add-label dependencies || true
+            if ! gh issue view "$issue_num" --repo "$REPO" --json labels \
+              --jq '.labels[].name' | grep -qx dependencies; then
+              echo "::error::Could not apply the 'dependencies' label to issue #$issue_num; check the token's Issues/triage permissions." >&2
+              exit 1
+            fi
+
             # Append `Closes #<issue>` so the Dependabot PR becomes Ralph's
             # in-flight PR and auto-closes the issue on merge into main.
             gh pr edit "$pr" --repo "$REPO" \

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -161,21 +161,26 @@ jobs:
             # label with a dedicated call (that endpoint errors instead of
             # dropping) and verify it stuck, so a permission gap fails loudly
             # rather than leaving an unlabeled, picker-invisible issue.
+            # Swallow this call's own error: the read-back verification below is
+            # the authoritative diagnosis, so a failure here would be redundant.
             gh issue edit "$issue_num" --repo "$REPO" \
               --add-label dependencies || true
 
             # Verify the label stuck. Capture the read call's own success
-            # separately from the label match so the two failure modes stay
-            # distinct: a failed read is a transient API flake (retry), while a
-            # successful read that omits the label is a real permission gap.
+            # separately from the label match so the two failure modes keep
+            # distinct diagnoses: a failed read is a transient API flake, while
+            # a successful read that omits the label is a real permission gap.
+            # A re-run cannot re-reach this check (the PR body now links the
+            # issue, so `body_links_issue` short-circuits), so both branches
+            # point to the same one-time manual fix: add the label by hand.
             local labels
             if ! labels="$(gh issue view "$issue_num" --repo "$REPO" \
               --json labels --jq '.labels[].name')"; then
-              echo "::error::Could not verify labels on issue #$issue_num (transient GitHub API error); re-run the reconciler to retry." >&2
+              echo "::error::Could not verify the label on issue #$issue_num (transient GitHub API error); the re-apply may have succeeded — if the issue is missing the label, add it once: gh issue edit $issue_num --add-label dependencies" >&2
               exit 1
             fi
             if ! printf '%s\n' "$labels" | grep -qx dependencies; then
-              echo "::error::The 'dependencies' label is absent on issue #$issue_num after re-apply; check the token's Issues/triage permissions." >&2
+              echo "::error::The 'dependencies' label is absent on issue #$issue_num after re-apply (the token likely lacks Issues/triage permission); add it once by hand: gh issue edit $issue_num --add-label dependencies" >&2
               exit 1
             fi
           }

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -163,9 +163,19 @@ jobs:
             # rather than leaving an unlabeled, picker-invisible issue.
             gh issue edit "$issue_num" --repo "$REPO" \
               --add-label dependencies || true
-            if ! gh issue view "$issue_num" --repo "$REPO" --json labels \
-              --jq '.labels[].name' | grep -qx dependencies; then
-              echo "::error::Could not apply the 'dependencies' label to issue #$issue_num; check the token's Issues/triage permissions." >&2
+
+            # Verify the label stuck. Capture the read call's own success
+            # separately from the label match so the two failure modes stay
+            # distinct: a failed read is a transient API flake (retry), while a
+            # successful read that omits the label is a real permission gap.
+            local labels
+            if ! labels="$(gh issue view "$issue_num" --repo "$REPO" \
+              --json labels --jq '.labels[].name')"; then
+              echo "::error::Could not verify labels on issue #$issue_num (transient GitHub API error); re-run the reconciler to retry." >&2
+              exit 1
+            fi
+            if ! printf '%s\n' "$labels" | grep -qx dependencies; then
+              echo "::error::The 'dependencies' label is absent on issue #$issue_num after re-apply; check the token's Issues/triage permissions." >&2
               exit 1
             fi
           }

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -143,12 +143,24 @@ jobs:
 
             echo "Filed issue #$issue_num for PR #$pr."
 
+            # Append `Closes #<issue>` so the Dependabot PR becomes Ralph's
+            # in-flight PR and auto-closes the issue on merge into main. Do this
+            # BEFORE the label check below so that a persistent permission gap
+            # surfaces the error once instead of minting a fresh orphaned issue
+            # on every trigger: once the PR body links the issue,
+            # `body_links_issue` (which reads the PR body, not the label)
+            # short-circuits all subsequent runs.
+            gh pr edit "$pr" --repo "$REPO" \
+              --body "$(printf '%s\n\nCloses #%s' "$pr_body" "$issue_num")"
+
+            echo "Linked PR #$pr → issue #$issue_num via Closes."
+
             # The REST create endpoint silently drops labels when the token
             # lacks push/triage access — which would break the marker dedup
             # above (it filters on the `dependencies` label). Re-apply the
             # label with a dedicated call (that endpoint errors instead of
             # dropping) and verify it stuck, so a permission gap fails loudly
-            # rather than filing an unlabeled, dedup-invisible issue.
+            # rather than leaving an unlabeled, picker-invisible issue.
             gh issue edit "$issue_num" --repo "$REPO" \
               --add-label dependencies || true
             if ! gh issue view "$issue_num" --repo "$REPO" --json labels \
@@ -156,13 +168,6 @@ jobs:
               echo "::error::Could not apply the 'dependencies' label to issue #$issue_num; check the token's Issues/triage permissions." >&2
               exit 1
             fi
-
-            # Append `Closes #<issue>` so the Dependabot PR becomes Ralph's
-            # in-flight PR and auto-closes the issue on merge into main.
-            gh pr edit "$pr" --repo "$REPO" \
-              --body "$(printf '%s\n\nCloses #%s' "$pr_body" "$issue_num")"
-
-            echo "Linked PR #$pr → issue #$issue_num via Closes."
           }
 
           if [ "$EVENT_NAME" = "pull_request_target" ]; then


### PR DESCRIPTION
## Summary

The Dependabot→Ralph bridge (`.github/workflows/dependabot-to-ralph-issue.yml`) files a `dependencies`-labeled issue for each open Dependabot PR and dedups re-runs via a hidden marker that it looks up with `gh issue list --label dependencies`. In practice, issues filed after the bug was opened (#978, #998) arrived with `labels: []`.

Root cause: the GitHub REST *issue-create* endpoint silently drops `labels` when the token lacks push/triage access. `gh issue create --label dependencies` therefore produced an unlabeled issue, which is invisible to the marker dedup — so a later reconciler run re-files a duplicate (breaking idempotency).

Fix: after creating the issue, re-apply the label with a dedicated `gh issue edit --add-label dependencies` call (that endpoint errors instead of silently dropping) and then verify the label is actually present, failing the run loudly (`exit 1` with an `::error::` hint) if it isn't. The verification separates its two failure modes: a failed `gh issue view` read is reported as a transient API flake (re-run to retry), while a successful read that omits the label is reported as a token permission gap. This guarantees either the label is set (dedup works) or the run fails visibly — eliminating the silently-unlabeled, dedup-invisible state.

The change touches only the reconciler's `bridge_pr` helper; no untrusted event data is newly inlined into the `run:` block, so the `pull_request_target` injection defense is unchanged.

## Known limitation

The label re-apply/verify is loud-once, not self-healing. `Closes #<issue>` is appended to the PR body *before* the label check, so once that line lands, `body_links_issue` short-circuits every subsequent reconciler run for that PR. If the very first run's label re-apply fails the verification and exits, that failure surfaces once (via the `::error::` annotation) but is never retried automatically — the issue stays unlabeled and picker-invisible. Recovery is a one-time manual `gh issue edit <issue> --add-label dependencies`. This is an accepted trade-off: linking the PR before the label check is deliberate (it prevents a fresh orphaned issue being minted on every trigger), and a persistent permission gap is a configuration problem a retry loop would not fix.

## Test plan

- Pure GitHub Actions workflow YAML with embedded bash — no unit-test harness exists for the embedded script, so validated statically:
  - `pre-commit run --files .github/workflows/dependabot-to-ralph-issue.yml` — check-yaml + detect-secrets + commitlint pass.
  - `actionlint` — no new findings (the single pre-existing SC2016 info on the intentional `contract='...{PR}...'` placeholder line is unchanged).
- Reasoned through `set -euo pipefail` behavior: `grep -qx` whole-line match avoids sibling-label false positives; capturing the `gh issue view` exit status separately keeps a read flake from being misreported as a permission gap; re-adding an already-present label is an idempotent no-op.

Closes #994