### PR TITLE
refactor(habits): consolidate the five divergent stage-at-index computations into one helper

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -20,6 +20,16 @@ export { STAGE_ORDER };
 export { STAGE_DURATIONS_DAYS };
 
 /**
+ * Map a habit's zero-based list index to its Spiral-Dynamics stage. Wraps with
+ * `% STAGE_ORDER.length` so positions past the tenth cycle back to Beige, and
+ * falls back to the final stage when the index cannot resolve — the single
+ * source of truth for the index-based stage coloring shared by the Habits
+ * screen, the reorder modals, and the onboarding flow.
+ */
+export const stageAtIndex = (index: number): string =>
+  STAGE_ORDER[index % STAGE_ORDER.length] ?? STAGE_ORDER[STAGE_ORDER.length - 1]!;
+
+/**
  * Calculate the start date for a habit based on its order in the onboarding
  * flow. Habits 1–8 begin 21 days apart while habits 9–10 begin 42 days apart.
  *

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { habits as habitsApi } from '../../api';
 import { useAuth } from '../../context/AuthContext';
-import { STAGE_COLORS, STAGE_ORDER, spacing } from '../../design/tokens';
+import { STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
@@ -37,6 +37,7 @@ import {
   toLocalHabitStats,
   calculateMissedDays,
   isHabitLockedToday,
+  stageAtIndex,
 } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
@@ -542,7 +543,7 @@ const useHabitTileRenderer = (
       const isLocked = isHabitLockedToday(item);
       const globalIndex = pageOffset + index;
       // index is page-relative, so each page restarts the Beige → Clear Light gradient.
-      const stageColor = STAGE_COLORS[STAGE_ORDER[index % STAGE_ORDER.length]!]!;
+      const stageColor = STAGE_COLORS[stageAtIndex(index)]!;
       return (
         <HabitTile
           habit={item}

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -19,6 +19,8 @@ import {
   isHabitLockedToday,
   logHabitUnits,
   calculateHabitStartDate,
+  stageAtIndex,
+  STAGE_ORDER,
   STAGE_DURATIONS_DAYS,
 } from '../HabitUtils';
 
@@ -1108,5 +1110,23 @@ describe('progress percentage, bar color, and clamp scenarios', () => {
   test('clamps percentage values between 0 and 100', () => {
     expect(clampPercentage(150)).toBe(100);
     expect(clampPercentage(-20)).toBe(0);
+  });
+
+  describe('stageAtIndex', () => {
+    test('returns the stage at each in-range index', () => {
+      for (let i = 0; i < STAGE_ORDER.length; i++) {
+        expect(stageAtIndex(i)).toBe(STAGE_ORDER[i]);
+      }
+    });
+
+    test('wraps deterministically at the array length', () => {
+      expect(stageAtIndex(STAGE_ORDER.length)).toBe(STAGE_ORDER[0]);
+      expect(stageAtIndex(STAGE_ORDER.length + 3)).toBe(STAGE_ORDER[3]);
+    });
+
+    test('always returns a defined stage string', () => {
+      expect(typeof stageAtIndex(0)).toBe('string');
+      expect(typeof stageAtIndex(STAGE_ORDER.length * 2)).toBe('string');
+    });
   });
 });

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -25,7 +25,7 @@ import { colors, STAGE_COLORS } from '../../../design/tokens';
 import { MAX_HABITS } from '../constants';
 import styles from '../Habits.styles';
 import type { OnboardingHabit, OnboardingModalProps } from '../Habits.types';
-import { STAGE_ORDER, calculateHabitStartDate, calculateNetEnergy } from '../HabitUtils';
+import { calculateHabitStartDate, calculateNetEnergy, stageAtIndex } from '../HabitUtils';
 
 import { ConfirmDialog } from './ConfirmDialog';
 import HabitEmojiPicker from './HabitEmojiPicker';
@@ -61,7 +61,7 @@ const assignDatesAndStages = (habits: OnboardingHabit[], startDate: Date): Onboa
   habits.map((habit, index) => ({
     ...habit,
     start_date: calculateHabitStartDate(startDate, index),
-    stage: STAGE_ORDER[index] ?? 'Clear Light',
+    stage: stageAtIndex(index),
   }));
 
 interface HabitChipProps {
@@ -127,8 +127,7 @@ interface ReorderItemProps {
 }
 
 const ReorderItem = ({ item, index, drag, isActive, onEditIcon }: ReorderItemProps) => {
-  const stage = (STAGE_ORDER[index] ??
-    STAGE_ORDER[STAGE_ORDER.length - 1]) as keyof typeof STAGE_COLORS;
+  const stage = stageAtIndex(index);
   const color = STAGE_COLORS[stage] || '#ccc';
   const startDrag = Gesture.Pan().onBegin(() => drag());
 

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -8,7 +8,7 @@ import { STAGE_COLORS } from '../../../design/tokens';
 import { useProgramStore } from '../../../store/useProgramStore';
 import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
-import { STAGE_ORDER, calculateHabitStartDate } from '../HabitUtils';
+import { calculateHabitStartDate, stageAtIndex } from '../HabitUtils';
 
 // Lazy require so jest (which doesn't transform this ES-module package) can load this file.
 let DateTimePickerModal: ComponentType<Record<string, unknown>> = () => null;
@@ -29,10 +29,6 @@ const updateStartDates = (habits: Habit[], startDate: Date): Habit[] =>
     start_date: calculateHabitStartDate(startDate, index),
   }));
 
-/** Stage at this position; matches HabitsScreen's index-based coloring. */
-const stageAtPosition = (index: number): string =>
-  STAGE_ORDER[index % STAGE_ORDER.length] ?? 'Clear Light';
-
 interface ReorderItemProps {
   item: Habit;
   index: number;
@@ -41,7 +37,7 @@ interface ReorderItemProps {
 }
 
 const ReorderHabitItem = ({ item, index, drag, isActive }: ReorderItemProps) => {
-  const stage = stageAtPosition(index);
+  const stage = stageAtIndex(index);
   const color = STAGE_COLORS[stage] ?? '#ccc';
   return (
     <TouchableOpacity

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -25,7 +25,7 @@ import type {
 import { formatApiError } from '../../../api/errorMessages';
 import { flattenGoalCompletions } from '../../../api/flattenGoalCompletions';
 import type { ToastConfig } from '../../../components/Toast';
-import { colors, STAGE_ORDER } from '../../../design/tokens';
+import { colors } from '../../../design/tokens';
 import {
   saveHabits as persistHabits,
   loadHabits as loadCachedHabits,
@@ -38,7 +38,13 @@ import { useProgramStore } from '../../../store/useProgramStore';
 import { dayKeyInTZ, detectDeviceTimezone, todayInUserTZ } from '../../../utils/dateUtils';
 import { HABIT_DEFAULTS } from '../HabitDefaults';
 import type { AddHabitInput, Goal, Habit, OnboardingHabit } from '../Habits.types';
-import { getGoalTier, getGoalTarget, calculateTodaysProgress, logHabitUnits } from '../HabitUtils';
+import {
+  getGoalTier,
+  getGoalTarget,
+  calculateTodaysProgress,
+  logHabitUnits,
+  stageAtIndex,
+} from '../HabitUtils';
 import { updateHabitNotifications, cancelForHabit } from '../hooks/useHabitNotifications';
 
 export type ShowToast = (_config: ToastConfig) => void;
@@ -274,7 +280,7 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
  * server round-trip succeeds and `loadHabits` rehydrates from the API.
  */
 const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => {
-  const stage = STAGE_ORDER[existingCount % STAGE_ORDER.length] ?? 'Clear Light';
+  const stage = stageAtIndex(existingCount);
   const tempId = -Date.now();
   return {
     id: tempId,


### PR DESCRIPTION
## Summary

The single concept "map a habit's list index to its Spiral-Dynamics stage" was inlined at **five** sites with **two divergent variants** (with vs without the `% STAGE_ORDER.length` modulo) and **three different overflow fallbacks** (`!`, `?? 'Clear Light'`, `?? STAGE_ORDER[last]`), kept in sync by hand.

This introduces one shared `stageAtIndex(index: number): string` helper in `HabitUtils.ts` using the modulo-and-fallback form once, and routes all five call sites through it:

- `HabitsScreen.tsx` (tile stage color)
- `services/habitManager.ts` (`buildAddedHabit`)
- `components/ReorderHabitsModal.tsx` (deleted its local `stageAtPosition` copy)
- `components/OnboardingModal.tsx` — `assignDatesAndStages` and `ReorderItem`

Behavior is unchanged for indices 0-9. The two `OnboardingModal` sites previously omitted the modulo; adding it is a deliberate no-op for real inputs (`MAX_HABITS === STAGE_ORDER.length === 10`, so `index` never exceeds 9) and makes indices ≥ 10 wrap deterministically instead of relying on that hidden coupling. Stage ordering, colors, and `MAX_HABITS` are untouched.

After this change, `grep 'STAGE_ORDER\['` across the feature returns only the helper's definition.

## Test plan

- Added characterization unit tests for `stageAtIndex` in `__tests__/HabitUtils.test.ts`: every in-range index, wrap boundary (`length` → `[0]`, `length + 3` → `[3]`), and the always-returns-a-string guarantee.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 3413 tests, coverage ≥ 90%).
- Full Habits suite (585 tests) unchanged and passing; no existing tests modified.

Closes #1252