### PR TITLE
refactor(habits): unify subtractive-polarity onto the any-non-additive rule

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -78,6 +78,19 @@ export const isGoalAchieved = (
   return goal.is_additive ? todayProgress >= targetValue : todayProgress <= targetValue;
 };
 
+/**
+ * A goal set is subtractive iff **any** goal is non-additive. This
+ * any-non-additive rule is the single shared source of habit polarity for the
+ * "Achieved" badge, the visual helpers (markers/progress/color), and the
+ * backend's `_subtractive_context`, so none of them can disagree. Probing a
+ * single tier let them diverge when the tiers were not perfectly consistent.
+ */
+export const goalsAreSubtractive = (goals: ReadonlyArray<Goal>): boolean =>
+  goals.some((g) => !g.is_additive);
+
+/** Habit-level polarity: delegates to {@link goalsAreSubtractive} over `habit.goals`. */
+export const isSubtractiveHabit = (habit: Habit): boolean => goalsAreSubtractive(habit.goals);
+
 /** LG/CG/SG on a unified 0-100 bar; missing-tier collapses to {0,0,0} as a failure signal. */
 export const getMarkerPositions = (
   lowGoal?: Goal,
@@ -92,7 +105,7 @@ export const getMarkerPositions = (
   const clearTarget = getGoalTarget(clearGoal);
   const stretchTarget = getGoalTarget(stretchGoal);
 
-  if (lowGoal.is_additive) {
+  if (!goalsAreSubtractive([lowGoal, clearGoal, stretchGoal])) {
     if (stretchTarget <= 0) return { low: 0, clear: 50, stretch: 100 };
     return {
       low: clampPercentage((lowTarget / stretchTarget) * 100),
@@ -207,11 +220,7 @@ export const getGoalTier = (habit: Habit, tz: string = DEFAULT_TIMEZONE): GoalTi
   }
 
   const todayProgress = calculateTodaysProgress(habit, tz);
-  // A habit is subtractive iff ANY of its goals is non-additive — the same rule
-  // the backend's _subtractive_context uses, so the "Achieved" badge and the
-  // server-computed streak can never disagree (#768). Probing a single tier let
-  // them diverge when the tiers were not perfectly consistent.
-  const isSubtractive = habit.goals.some((g) => !g.is_additive);
+  const isSubtractive = isSubtractiveHabit(habit);
   return isSubtractive
     ? resolveSubtractiveTier(todayProgress, lowGoal, clearGoal, stretchGoal)
     : resolveAdditiveTier(todayProgress, lowGoal, clearGoal, stretchGoal);
@@ -227,7 +236,7 @@ export const getProgressPercentage = (
   const stretchGoal = habit.goals.find((g) => g.tier === 'stretch') ?? currentGoal;
   const stretchTarget = getGoalTarget(stretchGoal);
 
-  if (currentGoal.is_additive) {
+  if (!isSubtractiveHabit(habit)) {
     if (stretchTarget <= 0) return 100;
     return clampPercentage((todayProgress / stretchTarget) * 100);
   }
@@ -260,7 +269,7 @@ export const getProgressBarColor = (
 
   const todayProgress = calculateTodaysProgress(habit, tz);
 
-  if (clearGoal.is_additive) {
+  if (!isSubtractiveHabit(habit)) {
     return todayProgress >= getGoalTarget(clearGoal) ? brightenColor(stageColor) : stageColor;
   }
 

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -17,6 +17,8 @@ import {
   isEarlyUnlocked,
   isGoalAchieved,
   isHabitLockedToday,
+  isSubtractiveHabit,
+  goalsAreSubtractive,
   logHabitUnits,
   calculateHabitStartDate,
   stageAtIndex,
@@ -1128,5 +1130,194 @@ describe('progress percentage, bar color, and clamp scenarios', () => {
       expect(typeof stageAtIndex(0)).toBe('string');
       expect(typeof stageAtIndex(STAGE_ORDER.length * 2)).toBe('string');
     });
+  });
+});
+
+describe('mixed-polarity goal set (any-non-additive rule)', () => {
+  const base = {
+    id: 1,
+    name: 'Test',
+    icon: '🔥',
+    stage: 'Beige',
+    streak: 0,
+    energy_cost: 0,
+    energy_return: 0,
+    start_date: new Date(),
+  } as const;
+
+  // Low is additive but clear/stretch are not: the single-tier probes each
+  // helper used to run (low for markers, currentGoal for progress, clear for
+  // bar color) disagree with each other on this set, while the any-non-additive
+  // rule resolves all of them to subtractive.
+  const mixedGoals: Goal[] = [
+    {
+      id: 1,
+      tier: 'low',
+      title: 'low',
+      target: 10,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+    {
+      id: 2,
+      tier: 'clear',
+      title: 'clear',
+      target: 5,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+    {
+      id: 3,
+      tier: 'stretch',
+      title: 'stretch',
+      target: 2,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: false,
+    },
+  ];
+  const [mixedLow, mixedClear, mixedStretch] = mixedGoals;
+
+  test('getMarkerPositions resolves a low-additive/clear-stretch-non-additive set as subtractive', () => {
+    const pos = getMarkerPositions(mixedLow, mixedClear, mixedStretch);
+    // (10-5)/(10-2) * 100 = 62.5, low-anchored scale.
+    expect(pos.low).toBe(0);
+    expect(pos.clear).toBeCloseTo(62.5, 1);
+    expect(pos.stretch).toBe(100);
+  });
+
+  test('getProgressPercentage resolves polarity from the goal set, not the passed-in currentGoal', () => {
+    const habit: Habit = {
+      ...base,
+      goals: mixedGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 6 }],
+    };
+    // Passing the additive-flagged low goal as currentGoal: the additive
+    // formula would clamp to 100; the subtractive formula (range 10-2=8,
+    // progress 6) gives 100 - ((6-2)/8)*100 = 50.
+    expect(getProgressPercentage(habit, mixedLow!, 'UTC')).toBe(50);
+  });
+
+  test('getProgressBarColor resolves polarity from the goal set even when the probed clear goal is additive', () => {
+    const additiveClearGoals: Goal[] = [
+      {
+        id: 1,
+        tier: 'low',
+        title: 'low',
+        target: 10,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+      {
+        id: 2,
+        tier: 'clear',
+        title: 'clear',
+        target: 5,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        id: 3,
+        tier: 'stretch',
+        title: 'stretch',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: false,
+      },
+    ];
+    const habit: Habit = {
+      ...base,
+      goals: additiveClearGoals,
+      completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 6 }],
+    };
+    // Progress (6) is >= clear target (5) so the additive branch would
+    // brighten; it is also > stretch target (2) so the subtractive branch
+    // reports plain stage color. The set is subtractive (low/stretch non-additive).
+    expect(getProgressBarColor(habit, 'UTC')).toBe(STAGE_COLORS.Beige);
+  });
+
+  test('getGoalTier and the three visual helpers agree on subtractive polarity for a mixed-polarity goal set', () => {
+    const habit: Habit = { ...base, goals: mixedGoals, completions: [] };
+    const { currentGoal, completedAllGoals } = getGoalTier(habit, 'UTC');
+    expect(completedAllGoals).toBe(true);
+    expect(currentGoal.tier).toBe('stretch');
+
+    const positions = getMarkerPositions(mixedLow, mixedClear, mixedStretch);
+    expect(positions.low).toBe(0);
+    expect(positions.clear).toBeCloseTo(62.5, 1);
+    expect(positions.stretch).toBe(100);
+
+    expect(getProgressPercentage(habit, currentGoal, 'UTC')).toBe(100);
+    expect(getProgressBarColor(habit, 'UTC')).toBe(brightenColor(STAGE_COLORS.Beige!));
+  });
+});
+
+describe('isSubtractiveHabit and goalsAreSubtractive (any-non-additive rule)', () => {
+  const additiveGoal: Goal = {
+    id: 1,
+    tier: 'low',
+    title: 'low',
+    target: 1,
+    target_unit: 'u',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: true,
+  };
+  const nonAdditiveGoal: Goal = {
+    id: 2,
+    tier: 'clear',
+    title: 'clear',
+    target: 1,
+    target_unit: 'u',
+    frequency: 1,
+    frequency_unit: 'per_day',
+    is_additive: false,
+  };
+
+  test('goalsAreSubtractive is false when every goal is additive', () => {
+    expect(goalsAreSubtractive([additiveGoal, { ...additiveGoal, id: 3, tier: 'stretch' }])).toBe(
+      false,
+    );
+  });
+
+  test('goalsAreSubtractive is true when one goal among additive goals is non-additive', () => {
+    expect(goalsAreSubtractive([additiveGoal, nonAdditiveGoal])).toBe(true);
+  });
+
+  test('goalsAreSubtractive is true when every goal is non-additive', () => {
+    expect(
+      goalsAreSubtractive([nonAdditiveGoal, { ...nonAdditiveGoal, id: 3, tier: 'stretch' }]),
+    ).toBe(true);
+  });
+
+  test('goalsAreSubtractive is false for an empty goal list', () => {
+    expect(goalsAreSubtractive([])).toBe(false);
+  });
+
+  test('isSubtractiveHabit delegates to goalsAreSubtractive over habit.goals', () => {
+    const habit: Habit = {
+      id: 1,
+      name: 'Test',
+      icon: '🔥',
+      stage: 'Beige',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date(),
+      goals: [additiveGoal, nonAdditiveGoal],
+      completions: [],
+    };
+    expect(isSubtractiveHabit(habit)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Finishes the #768 polarity fix. The question "is this habit subtractive?" was answered by probing a **different goal tier** in each of three helpers in `frontend/src/features/Habits/HabitUtils.ts`, while `getGoalTier` already used the canonical **any-non-additive** rule (matching the backend's `_subtractive_context`):

- `getMarkerPositions` probed the **low** tier
- `getProgressPercentage` probed the **current** tier
- `getProgressBarColor` probed the **clear** tier

If a habit's tiers ever diverged on `is_additive` (the precondition #768 was written for), the "Achieved" badge/streak and the star positions/progress %/bar color would compute on opposite polarities.

This PR extracts a single shared predicate — `goalsAreSubtractive(goals)` and its thin wrapper `isSubtractiveHabit(habit)` — and routes all four functions through it. `getMarkerPositions` keeps its exact signature (it passes its three tier goals to the core predicate), so no call sites change.

This is a pure refactor: no signatures or call sites changed, and the additive/subtractive math is untouched — only the branch selector is unified. For habits whose tiers had *inconsistent* polarity flags, the visual helpers' branch choice now agrees with the badge and backend (the intended completion of #768, not a regression); consistent-polarity behavior is bit-identical.

## Test plan

- Added mixed-polarity tests in `frontend/src/features/Habits/__tests__/HabitUtils.test.ts` proving the badge (`getGoalTier`), marker positions, progress %, and bar color all agree on subtractive treatment for a goal set where the probed tier disagreed with the any-non-additive rule (each was RED under the old single-tier probes).
- Added direct predicate unit tests for `isSubtractiveHabit` / `goalsAreSubtractive` (all-additive → false, one non-additive → true, all non-additive → true, empty → false).
- `./scripts/frontend/check-all.sh` green: jest 3422/3422, ESLint zero warnings, strict tsc, coverage ≥ 90%.

Closes #1253
Refs #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)