### PR TITLE
fix(frontend): anchor journal habits tile denominator to stage-unlocked habits

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -593,6 +593,18 @@ export const isEarlyUnlocked = (habit: Habit): boolean => {
   return habit.revealed === true && new Date(habit.start_date).getTime() > Date.now();
 };
 
+/**
+ * A habit is unlocked once the user's current stage has reached its cumulative
+ * position — one habit unlocks per stage, so the habit at `index` is available
+ * when `index < currentStage`. It is also unlocked when manually revealed ahead
+ * of its start_date (early unlock), regardless of position.
+ */
+export const isHabitUnlockedAtStage = (
+  habit: Habit,
+  index: number,
+  currentStage: number,
+): boolean => index < currentStage || isEarlyUnlocked(habit);
+
 /** Locked today iff unrevealed AND its calendar-anchored `start_date` is still in the future; once that date arrives the habit unlocks regardless of a stale `revealed` flag (which only gates manual early-unlock). */
 export const isHabitLockedToday = (habit: Habit, now: number = Date.now()): boolean => {
   return habit.revealed === false && new Date(habit.start_date).getTime() > now;

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -594,16 +594,25 @@ export const isEarlyUnlocked = (habit: Habit): boolean => {
 };
 
 /**
- * A habit is unlocked once the user's current stage has reached its cumulative
- * position — one habit unlocks per stage, so the habit at `index` is available
- * when `index < currentStage`. It is also unlocked when manually revealed ahead
- * of its start_date (early unlock), regardless of position.
+ * A habit is unlocked once the user's current stage has reached the habit's own
+ * Spiral-Dynamics stage — the threshold is derived from `habit.stage` (its
+ * position in `STAGE_ORDER`, 1-based) so drag-and-drop reordering of the list
+ * never changes which habits are unlocked. When `habit.stage` is missing or
+ * unrecognized, we fall back to the list position (`index`), preserving the
+ * legacy `index < currentStage` behavior for stage-less habits. A habit is also
+ * unlocked when manually revealed ahead of its start_date (early unlock),
+ * regardless of stage.
  */
 export const isHabitUnlockedAtStage = (
   habit: Habit,
   index: number,
   currentStage: number,
-): boolean => index < currentStage || isEarlyUnlocked(habit);
+): boolean => {
+  if (isEarlyUnlocked(habit)) return true;
+  const stageIndex = STAGE_ORDER.indexOf(habit.stage);
+  const threshold = stageIndex >= 0 ? stageIndex + 1 : index + 1;
+  return threshold <= currentStage;
+};
 
 /** Locked today iff unrevealed AND its calendar-anchored `start_date` is still in the future; once that date arrives the habit unlocks regardless of a stale `revealed` flag (which only gates manual early-unlock). */
 export const isHabitLockedToday = (habit: Habit, now: number = Date.now()): boolean => {

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -17,6 +17,7 @@ import {
   isEarlyUnlocked,
   isGoalAchieved,
   isHabitLockedToday,
+  isHabitUnlockedAtStage,
   isSubtractiveHabit,
   goalsAreSubtractive,
   logHabitUnits,
@@ -973,6 +974,50 @@ describe('isHabitLockedToday', () => {
     expect(isHabitLockedToday(make({ revealed: false, start_date: iso('2000-01-01') }), NOW)).toBe(
       false,
     );
+  });
+});
+
+describe('isHabitUnlockedAtStage', () => {
+  const make = (overrides: Partial<Habit>): Habit =>
+    ({
+      id: 1,
+      name: 'H',
+      icon: '🔒',
+      stage: 'Purple',
+      streak: 0,
+      energy_cost: 0,
+      energy_return: 0,
+      start_date: new Date('2020-01-01T00:00:00Z'),
+      goals: [],
+      completions: [],
+      revealed: false,
+      ...overrides,
+    }) as Habit;
+
+  test('unlocked when index is below currentStage regardless of revealed/start_date', () => {
+    const habit = make({
+      revealed: false,
+      start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    });
+    expect(isHabitUnlockedAtStage(habit, 0, 3)).toBe(true);
+  });
+
+  test('locked when index is at or beyond currentStage for a plain locked habit', () => {
+    const habit = make({ revealed: false, start_date: new Date('2020-01-01T00:00:00Z') });
+    expect(isHabitUnlockedAtStage(habit, 5, 3)).toBe(false);
+  });
+
+  test('unlocked when index is at or beyond currentStage but the habit is early-unlocked', () => {
+    const habit = make({
+      revealed: true,
+      start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
+    });
+    expect(isHabitUnlockedAtStage(habit, 5, 3)).toBe(true);
+  });
+
+  test('locked at the exact boundary index === currentStage with no early unlock', () => {
+    const habit = make({ revealed: false, start_date: new Date('2020-01-01T00:00:00Z') });
+    expect(isHabitUnlockedAtStage(habit, 3, 3)).toBe(false);
   });
 });
 

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -994,29 +994,43 @@ describe('isHabitUnlockedAtStage', () => {
       ...overrides,
     }) as Habit;
 
-  test('unlocked when index is below currentStage regardless of revealed/start_date', () => {
-    const habit = make({
-      revealed: false,
-      start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
-    });
-    expect(isHabitUnlockedAtStage(habit, 0, 3)).toBe(true);
+  test('unlocked when the habit stage sits at or below currentStage', () => {
+    // Purple is the 2nd stage (STAGE_ORDER index 1 -> threshold 2).
+    const habit = make({ stage: 'Purple' });
+    expect(isHabitUnlockedAtStage(habit, 0, 2)).toBe(true);
   });
 
-  test('locked when index is at or beyond currentStage for a plain locked habit', () => {
-    const habit = make({ revealed: false, start_date: new Date('2020-01-01T00:00:00Z') });
-    expect(isHabitUnlockedAtStage(habit, 5, 3)).toBe(false);
+  test('locked when the habit stage sits above currentStage', () => {
+    // Red is the 3rd stage (threshold 3) and currentStage is 2.
+    const habit = make({ stage: 'Red' });
+    expect(isHabitUnlockedAtStage(habit, 0, 2)).toBe(false);
   });
 
-  test('unlocked when index is at or beyond currentStage but the habit is early-unlocked', () => {
+  test('unlock follows the habit stage, not list position, after a reorder', () => {
+    // A Red habit dragged to the top of the list (index 0) stays locked at
+    // currentStage 2, while the lower-stage habits below it stay unlocked.
+    const red = make({ stage: 'Red' });
+    const beige = make({ stage: 'Beige' });
+    const purple = make({ stage: 'Purple' });
+    expect(isHabitUnlockedAtStage(red, 0, 2)).toBe(false);
+    expect(isHabitUnlockedAtStage(beige, 1, 2)).toBe(true);
+    expect(isHabitUnlockedAtStage(purple, 2, 2)).toBe(true);
+  });
+
+  test('unlocked regardless of stage when the habit is early-unlocked', () => {
     const habit = make({
+      stage: 'Clear Light',
       revealed: true,
       start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
     });
-    expect(isHabitUnlockedAtStage(habit, 5, 3)).toBe(true);
+    expect(isHabitUnlockedAtStage(habit, 9, 1)).toBe(true);
   });
 
-  test('locked at the exact boundary index === currentStage with no early unlock', () => {
-    const habit = make({ revealed: false, start_date: new Date('2020-01-01T00:00:00Z') });
+  test('falls back to list position when the stage is unknown or missing', () => {
+    const habit = make({ stage: '' });
+    // index 0 -> threshold 1, unlocked at currentStage 1.
+    expect(isHabitUnlockedAtStage(habit, 0, 1)).toBe(true);
+    // index 3 -> threshold 4, locked at currentStage 3.
     expect(isHabitUnlockedAtStage(habit, 3, 3)).toBe(false);
   });
 });

--- a/frontend/src/features/Habits/__tests__/habitCounts.test.ts
+++ b/frontend/src/features/Habits/__tests__/habitCounts.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { jest, afterEach, describe, it, expect } from '@jest/globals';
 
-import { countDoneToday, unlockedToday } from '../habitCounts';
+import { countDoneToday, unlockedAtStage } from '../habitCounts';
 import type { Habit } from '../Habits.types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -64,41 +64,49 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe('unlockedToday', () => {
-  it('drops a habit that is unrevealed with a future start_date', () => {
-    const locked = makeHabit({
-      id: 2,
-      revealed: false,
-      start_date: new Date(Date.now() + 7 * DAY_MS),
-    });
-    expect(unlockedToday([locked])).toEqual([]);
+describe('unlockedAtStage', () => {
+  it('returns only the first habit at stage 1', () => {
+    const habit0 = makeHabit({ id: 10 });
+    const habit1 = makeHabit({ id: 11 });
+    expect(unlockedAtStage([habit0, habit1], 1)).toEqual([habit0]);
   });
 
-  it('keeps a revealed habit even with a future start_date', () => {
-    const unlocked = makeHabit({
-      id: 3,
-      revealed: true,
-      start_date: new Date(Date.now() + 7 * DAY_MS),
-    });
-    expect(unlockedToday([unlocked])).toEqual([unlocked]);
+  it('returns the first three habits at stage 3 regardless of revealed/start_date', () => {
+    const habits = [
+      makeHabit({ id: 20, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 21, revealed: false, start_date: new Date(Date.now() + 7 * DAY_MS) }),
+      makeHabit({ id: 22 }),
+    ];
+    expect(unlockedAtStage(habits, 3)).toEqual(habits);
   });
 
-  it('keeps an unrevealed habit whose start_date has already passed', () => {
-    const unlocked = makeHabit({
-      id: 4,
-      revealed: false,
-      start_date: new Date('2020-01-01T00:00:00Z'),
-    });
-    expect(unlockedToday([unlocked])).toEqual([unlocked]);
+  it('excludes a locked habit with a past start_date at an index beyond currentStage', () => {
+    const habits = [
+      makeHabit({ id: 30 }),
+      makeHabit({ id: 31 }),
+      makeHabit({ id: 32 }),
+      makeHabit({ id: 33 }),
+      makeHabit({ id: 34 }),
+      makeHabit({ id: 35, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+    ];
+    const result = unlockedAtStage(habits, 3);
+    expect(result).toEqual(habits.slice(0, 3));
+    expect(result).not.toContain(habits[5]);
   });
 
-  it('filters a mixed list down to only the unlocked habits', () => {
-    const locked = makeHabit({
-      id: 5,
-      revealed: false,
-      start_date: new Date(Date.now() + 7 * DAY_MS),
-    });
-    const unlocked = makeHabit({ id: 6, revealed: true });
-    expect(unlockedToday([locked, unlocked])).toEqual([unlocked]);
+  it('includes an early-unlocked habit at an index at or beyond currentStage', () => {
+    const habits = [
+      makeHabit({ id: 40 }),
+      makeHabit({
+        id: 41,
+        revealed: true,
+        start_date: new Date(Date.now() + 7 * DAY_MS),
+      }),
+    ];
+    expect(unlockedAtStage(habits, 1)).toEqual(habits);
+  });
+
+  it('returns an empty array for an empty habit list', () => {
+    expect(unlockedAtStage([], 3)).toEqual([]);
   });
 });

--- a/frontend/src/features/Habits/__tests__/habitCounts.test.ts
+++ b/frontend/src/features/Habits/__tests__/habitCounts.test.ts
@@ -65,40 +65,56 @@ afterEach(() => {
 });
 
 describe('unlockedAtStage', () => {
-  it('returns only the first habit at stage 1', () => {
-    const habit0 = makeHabit({ id: 10 });
-    const habit1 = makeHabit({ id: 11 });
+  it('returns only the first-stage habit at stage 1', () => {
+    const habit0 = makeHabit({ id: 10, stage: 'Beige' });
+    const habit1 = makeHabit({ id: 11, stage: 'Purple' });
     expect(unlockedAtStage([habit0, habit1], 1)).toEqual([habit0]);
   });
 
-  it('returns the first three habits at stage 3 regardless of revealed/start_date', () => {
+  it('returns the first three stages at stage 3 regardless of revealed/start_date', () => {
     const habits = [
-      makeHabit({ id: 20, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 21, revealed: false, start_date: new Date(Date.now() + 7 * DAY_MS) }),
-      makeHabit({ id: 22 }),
+      makeHabit({
+        id: 20,
+        stage: 'Beige',
+        revealed: false,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 21,
+        stage: 'Purple',
+        revealed: false,
+        start_date: new Date(Date.now() + 7 * DAY_MS),
+      }),
+      makeHabit({ id: 22, stage: 'Red' }),
     ];
     expect(unlockedAtStage(habits, 3)).toEqual(habits);
   });
 
-  it('excludes a locked habit with a past start_date at an index beyond currentStage', () => {
+  it('excludes a habit whose stage is above currentStage even with a past start_date', () => {
     const habits = [
-      makeHabit({ id: 30 }),
-      makeHabit({ id: 31 }),
-      makeHabit({ id: 32 }),
-      makeHabit({ id: 33 }),
-      makeHabit({ id: 34 }),
-      makeHabit({ id: 35, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 30, stage: 'Beige' }),
+      makeHabit({ id: 31, stage: 'Purple' }),
+      makeHabit({ id: 32, stage: 'Red' }),
+      makeHabit({ id: 33, stage: 'Blue' }),
+      makeHabit({ id: 34, stage: 'Orange' }),
+      makeHabit({
+        id: 35,
+        stage: 'Green',
+        revealed: false,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     ];
     const result = unlockedAtStage(habits, 3);
     expect(result).toEqual(habits.slice(0, 3));
     expect(result).not.toContain(habits[5]);
   });
 
-  it('includes an early-unlocked habit at an index at or beyond currentStage', () => {
+  it('includes an early-unlocked habit whose stage is at or above currentStage', () => {
     const habits = [
-      makeHabit({ id: 40 }),
+      makeHabit({ id: 40, stage: 'Beige' }),
       makeHabit({
         id: 41,
+        stage: 'Purple',
         revealed: true,
         start_date: new Date(Date.now() + 7 * DAY_MS),
       }),

--- a/frontend/src/features/Habits/habitCounts.ts
+++ b/frontend/src/features/Habits/habitCounts.ts
@@ -4,7 +4,7 @@
  * list they already subscribe to, rather than reading an imperative snapshot.
  */
 import type { Habit } from '@/features/Habits/Habits.types';
-import { isHabitLockedToday } from '@/features/Habits/HabitUtils';
+import { isHabitUnlockedAtStage } from '@/features/Habits/HabitUtils';
 import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
 
 /**
@@ -24,7 +24,11 @@ export function countDoneToday(habits: readonly Habit[], tz: string = DEFAULT_TI
   ).length;
 }
 
-/** The subset of habits that are unlocked today (dropping still-locked ones). */
-export function unlockedToday(habits: readonly Habit[]): Habit[] {
-  return habits.filter((h) => !isHabitLockedToday(h));
+/**
+ * The subset of habits unlocked at the user's current stage — the habit at each
+ * index unlocks once `currentStage` reaches its cumulative position, plus any
+ * habit manually revealed ahead of its start_date.
+ */
+export function unlockedAtStage(habits: readonly Habit[], currentStage: number): Habit[] {
+  return habits.filter((h, i) => isHabitUnlockedAtStage(h, i, currentStage));
 }

--- a/frontend/src/features/Habits/habitCounts.ts
+++ b/frontend/src/features/Habits/habitCounts.ts
@@ -25,9 +25,10 @@ export function countDoneToday(habits: readonly Habit[], tz: string = DEFAULT_TI
 }
 
 /**
- * The subset of habits unlocked at the user's current stage — the habit at each
- * index unlocks once `currentStage` reaches its cumulative position, plus any
- * habit manually revealed ahead of its start_date.
+ * The subset of habits unlocked at the user's current stage — a habit unlocks
+ * once `currentStage` reaches its own Spiral-Dynamics stage (list position is
+ * only a fallback for stage-less habits), plus any habit manually revealed
+ * ahead of its start_date. See {@link isHabitUnlockedAtStage}.
  */
 export function unlockedAtStage(habits: readonly Habit[], currentStage: number): Habit[] {
   return habits.filter((h, i) => isHabitUnlockedAtStage(h, i, currentStage));

--- a/frontend/src/features/Journal/HabitsStatTile.tsx
+++ b/frontend/src/features/Journal/HabitsStatTile.tsx
@@ -10,16 +10,31 @@ import React, { useEffect } from 'react';
 import StatTile from './StatTile';
 
 import { useAuth } from '@/context/AuthContext';
-import { countDoneToday, unlockedToday } from '@/features/Habits/habitCounts';
+import { countDoneToday, unlockedAtStage } from '@/features/Habits/habitCounts';
 import { habitManager } from '@/features/Habits/services/habitManager';
+import { stageService } from '@/features/Map/services/stageService';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { useHabitStore } from '@/store/useHabitStore';
+import {
+  selectCurrentStage,
+  selectStages,
+  selectStagesError,
+  selectStagesLoading,
+  useStageStore,
+} from '@/store/useStageStore';
 
 type HabitsTileNav = BottomTabNavigationProp<RootTabParamList>;
 
 const TITLE = "Today's habits";
 const OPEN_CUE = 'Open habits →';
 const ADD_CUE = 'Add a habit →';
+
+/**
+ * Stage to assume when stage loading has failed and left the store empty: one
+ * habit is always unlocked, so falling back to 1 (rather than a possibly-stale
+ * store value) keeps the denominator conservative.
+ */
+const FALLBACK_STAGE = 1;
 
 interface HabitsDescriptor {
   loading: boolean;
@@ -30,15 +45,16 @@ interface HabitsDescriptor {
 
 /**
  * Resolve the tile's stat line, cue, loading flag, and a11y label from plain
- * counts — pure so the loading branch reads the store's flag directly.
+ * counts. `loading` is the caller's precomputed "show skeleton" flag (habits or
+ * stages still resolving), so this stays pure and flat.
  */
-function describeHabits(
+export function describeHabits(
   loading: boolean,
   habitCount: number,
   unlockedCount: number,
   doneCount: number,
 ): HabitsDescriptor {
-  if (loading && habitCount === 0) {
+  if (loading) {
     return { loading: true, cue: OPEN_CUE, accessibilityLabel: `${TITLE}, loading. Open habits` };
   }
   if (habitCount === 0) {
@@ -50,6 +66,8 @@ function describeHabits(
     };
   }
   if (unlockedCount === 0) {
+    // Defensive: the current stage always floors at 1, so the first habit is
+    // unlocked whenever any exist. Kept as a guard for a zero-unlocked corpus.
     return {
       loading: false,
       stat: 'Unlocks soon',
@@ -68,16 +86,34 @@ function describeHabits(
 const HabitsStatTile = (): React.JSX.Element => {
   const navigation = useNavigation<HabitsTileNav>();
   const { userTimezone } = useAuth();
-  const loading = useHabitStore((state) => state.loading);
+  const habitsLoading = useHabitStore((state) => state.loading);
   const habits = useHabitStore((state) => state.habits);
+  const currentStage = useStageStore(selectCurrentStage);
+  const stages = useStageStore(selectStages);
+  const stagesLoading = useStageStore(selectStagesLoading);
+  const stagesError = useStageStore(selectStagesError);
 
   useEffect(() => {
     void habitManager.loadHabits(userTimezone);
   }, [userTimezone]);
 
-  const unlocked = unlockedToday(habits);
+  useEffect(() => {
+    if (stages.length === 0) void stageService.loadStages();
+  }, [stages.length]);
+
+  // Stages have not resolved yet — either nothing has errored, or a (re)load is
+  // in flight. Hold the skeleton so the tile never flashes a denominator
+  // computed against an empty stage list.
+  const stagesPending = stages.length === 0 && (stagesError === null || stagesLoading);
+  // A failed load leaves stages empty; trust the always-unlocked floor rather
+  // than a possibly-stale store `currentStage`.
+  const stagesFailed = stagesError !== null && stages.length === 0;
+  const effectiveStage = stagesFailed ? FALLBACK_STAGE : currentStage;
+
+  const unlocked = unlockedAtStage(habits, effectiveStage);
+  const showSkeleton = (habitsLoading && habits.length === 0) || stagesPending;
   const descriptor = describeHabits(
-    loading,
+    showSkeleton,
     habits.length,
     unlocked.length,
     countDoneToday(unlocked, userTimezone),

--- a/frontend/src/features/Journal/HabitsStatTile.tsx
+++ b/frontend/src/features/Journal/HabitsStatTile.tsx
@@ -46,7 +46,8 @@ interface HabitsDescriptor {
 /**
  * Resolve the tile's stat line, cue, loading flag, and a11y label from plain
  * counts. `loading` is the caller's precomputed "show skeleton" flag (habits or
- * stages still resolving), so this stays pure and flat.
+ * stages still resolving) — not the raw habit-store `loading` — so this stays
+ * pure and flat.
  */
 export function describeHabits(
   loading: boolean,

--- a/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
@@ -19,10 +19,19 @@ jest.mock('@/features/Habits/services/habitManager', () => ({
   },
 }));
 
-import HabitsStatTile from '../HabitsStatTile';
+const mockLoadStages = jest.fn();
+jest.mock('@/features/Map/services/stageService', () => ({
+  stageService: {
+    loadStages: (...args: unknown[]) => mockLoadStages(...args),
+  },
+}));
+
+import HabitsStatTile, { describeHabits } from '../HabitsStatTile';
 
 import type { Habit } from '@/features/Habits/Habits.types';
+import type { StageData } from '@/features/Map/stageData';
 import { useHabitStore } from '@/store/useHabitStore';
+import { useStageStore } from '@/store/useStageStore';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -41,14 +50,39 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   ...overrides,
 });
 
+const makeStage = (stageNumber: number): StageData => ({
+  id: stageNumber,
+  title: `Stage ${stageNumber}`,
+  subtitle: `Subtitle ${stageNumber}`,
+  stageNumber,
+  progress: 0,
+  color: '#aaa',
+  isUnlocked: true,
+  category: '',
+  aspect: '',
+  spiralDynamicsColor: '',
+  growingUpStage: '',
+  divineGenderPolarity: '',
+  relationshipToFreeWill: '',
+  freeWillDescription: '',
+  overviewUrl: '',
+});
+
 beforeEach(() => {
   mockNavigate.mockClear();
   mockLoadHabits.mockClear();
+  mockLoadStages.mockClear();
   useHabitStore.setState({
     loading: false,
     habits: [],
     habitsById: {},
     habitOrder: [],
+    error: null,
+  });
+  useStageStore.setState({
+    stages: [makeStage(1), makeStage(2), makeStage(3)],
+    currentStage: 3,
+    loading: false,
     error: null,
   });
 });
@@ -78,41 +112,114 @@ describe('HabitsStatTile', () => {
     expect(mockNavigate).toHaveBeenCalledWith('Habits');
   });
 
-  it('shows "Unlocks soon" when every habit is still locked', () => {
-    const lockedOne = makeHabit({
-      id: 2,
-      revealed: false,
-      start_date: new Date(Date.now() + 7 * DAY_MS),
-    });
-    const lockedTwo = makeHabit({
-      id: 3,
-      revealed: false,
-      start_date: new Date(Date.now() + 14 * DAY_MS),
-    });
-    useHabitStore.setState({ loading: false, habits: [lockedOne, lockedTwo] });
-    const { getByText, getByTestId } = render(<HabitsStatTile />);
-    expect(getByText('Unlocks soon')).toBeTruthy();
-    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
-    expect(label).toBe("Today's habits, unlocks soon. Open habits");
-  });
-
-  it('shows "1/2 done" when one of two unlocked habits was completed today', () => {
-    const done = makeHabit({
-      id: 4,
-      revealed: true,
-      completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
-    });
-    const notDone = makeHabit({ id: 5, revealed: true, completions: [] });
-    useHabitStore.setState({ loading: false, habits: [done, notDone] });
-    const { getByText, getByTestId } = render(<HabitsStatTile />);
-    expect(getByText('1/2 done')).toBeTruthy();
-    const label = getByTestId('journal-habits-tile').props.accessibilityLabel as string;
-    expect(label).toContain('1 of 2 done');
-  });
-
   it('calls habitManager.loadHabits with the user timezone on mount', () => {
     useHabitStore.setState({ loading: false, habits: [] });
     render(<HabitsStatTile />);
     expect(mockLoadHabits).toHaveBeenCalledWith('UTC');
+  });
+
+  it('anchors the denominator to currentStage, not the raw habit count', () => {
+    const habits = Array.from({ length: 7 }, (_, i) =>
+      makeHabit({ id: 100 + i, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+    );
+    useHabitStore.setState({ loading: false, habits });
+    useStageStore.setState({ currentStage: 3 });
+    const { getByText } = render(<HabitsStatTile />);
+    expect(getByText('0/3 done')).toBeTruthy();
+  });
+
+  it('shows "0/1 done" at stage 1 Beige with a single habit', () => {
+    const habits = [
+      makeHabit({ id: 200, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 201, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 202, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    useStageStore.setState({ currentStage: 1 });
+    const { getByText } = render(<HabitsStatTile />);
+    expect(getByText('0/1 done')).toBeTruthy();
+  });
+
+  it('shows "1/1 done" at stage 1 once the first habit is completed today', () => {
+    const habits = [
+      makeHabit({
+        id: 210,
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+      }),
+      makeHabit({ id: 211, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 212, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    useStageStore.setState({ currentStage: 1 });
+    const { getByText } = render(<HabitsStatTile />);
+    expect(getByText('1/1 done')).toBeTruthy();
+  });
+
+  it('never counts a locked habit with a past start_date toward the denominator', () => {
+    const habits = [
+      makeHabit({ id: 220, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 221, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 222, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 223, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    useStageStore.setState({ currentStage: 3 });
+    const { getByText } = render(<HabitsStatTile />);
+    expect(getByText('0/3 done')).toBeTruthy();
+  });
+
+  it('counts an early-unlocked habit at a high index toward the denominator', () => {
+    const habits = [
+      makeHabit({ id: 230, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 231, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 232, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 233,
+        revealed: true,
+        start_date: new Date(Date.now() + 30 * DAY_MS),
+      }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    useStageStore.setState({ currentStage: 1 });
+    const { getByText } = render(<HabitsStatTile />);
+    expect(getByText('0/2 done')).toBeTruthy();
+  });
+
+  it('shows the skeleton and self-hydrates stages on a cold entry with no stages loaded yet', () => {
+    useHabitStore.setState({ loading: false, habits: [makeHabit({ id: 300 })] });
+    useStageStore.setState({ stages: [], currentStage: 1, loading: false, error: null });
+    const { getByTestId } = render(<HabitsStatTile />);
+    expect(getByTestId('journal-habits-tile-skeleton')).toBeTruthy();
+    expect(mockLoadStages).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to currentStage 1 (ignoring a stale store value) and renders a determinate stat when stage loading errored', () => {
+    const habits = [
+      makeHabit({
+        id: 310,
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+      }),
+      makeHabit({ id: 311, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({ id: 312, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    // currentStage 5 is a stale value from a prior session; the error means it must not be trusted.
+    useStageStore.setState({ stages: [], currentStage: 5, loading: false, error: 'boom' });
+    const { getByText, queryByTestId } = render(<HabitsStatTile />);
+    expect(getByText('1/1 done')).toBeTruthy();
+    expect(queryByTestId('journal-habits-tile-skeleton')).toBeNull();
+  });
+});
+
+describe('describeHabits', () => {
+  it('returns the "Unlocks soon" stat and cue when there are habits but none unlocked yet', () => {
+    const result = describeHabits(false, 2, 0, 0);
+    expect(result.stat).toBe('Unlocks soon');
+    expect(result.cue).toBe('Open habits →');
+    expect(result.accessibilityLabel).toBe("Today's habits, unlocks soon. Open habits");
   });
 });

--- a/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
@@ -50,6 +50,10 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   ...overrides,
 });
 
+// Ascending Spiral-Dynamics stages so each habit's own stage (not its list
+// position) drives its unlock threshold — see isHabitUnlockedAtStage.
+const STAGES = ['Beige', 'Purple', 'Red', 'Blue', 'Orange', 'Green', 'Yellow'] as const;
+
 const makeStage = (stageNumber: number): StageData => ({
   id: stageNumber,
   title: `Stage ${stageNumber}`,
@@ -120,7 +124,12 @@ describe('HabitsStatTile', () => {
 
   it('anchors the denominator to currentStage, not the raw habit count', () => {
     const habits = Array.from({ length: 7 }, (_, i) =>
-      makeHabit({ id: 100 + i, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 100 + i,
+        stage: STAGES[i],
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     );
     useHabitStore.setState({ loading: false, habits });
     useStageStore.setState({ currentStage: 3 });
@@ -130,9 +139,24 @@ describe('HabitsStatTile', () => {
 
   it('shows "0/1 done" at stage 1 Beige with a single habit', () => {
     const habits = [
-      makeHabit({ id: 200, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 201, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 202, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 200,
+        stage: 'Beige',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 201,
+        stage: 'Purple',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 202,
+        stage: 'Red',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     ];
     useHabitStore.setState({ loading: false, habits });
     useStageStore.setState({ currentStage: 1 });
@@ -144,12 +168,23 @@ describe('HabitsStatTile', () => {
     const habits = [
       makeHabit({
         id: 210,
+        stage: 'Beige',
         revealed: true,
         start_date: new Date('2020-01-01T00:00:00Z'),
         completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
       }),
-      makeHabit({ id: 211, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 212, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 211,
+        stage: 'Purple',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 212,
+        stage: 'Red',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     ];
     useHabitStore.setState({ loading: false, habits });
     useStageStore.setState({ currentStage: 1 });
@@ -159,10 +194,31 @@ describe('HabitsStatTile', () => {
 
   it('never counts a locked habit with a past start_date toward the denominator', () => {
     const habits = [
-      makeHabit({ id: 220, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 221, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 222, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 223, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 220,
+        stage: 'Beige',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 221,
+        stage: 'Purple',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 222,
+        stage: 'Red',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      // Blue sits above currentStage 3, so a past start_date can't unlock it.
+      makeHabit({
+        id: 223,
+        stage: 'Blue',
+        revealed: false,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     ];
     useHabitStore.setState({ loading: false, habits });
     useStageStore.setState({ currentStage: 3 });
@@ -170,13 +226,30 @@ describe('HabitsStatTile', () => {
     expect(getByText('0/3 done')).toBeTruthy();
   });
 
-  it('counts an early-unlocked habit at a high index toward the denominator', () => {
+  it('counts an early-unlocked habit at a high stage toward the denominator', () => {
     const habits = [
-      makeHabit({ id: 230, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 231, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 232, revealed: false, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 230,
+        stage: 'Beige',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 231,
+        stage: 'Purple',
+        revealed: false,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 232,
+        stage: 'Red',
+        revealed: false,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      // Blue is above currentStage 1, so only its early-unlock reveal counts it.
       makeHabit({
         id: 233,
+        stage: 'Blue',
         revealed: true,
         start_date: new Date(Date.now() + 30 * DAY_MS),
       }),
@@ -199,12 +272,23 @@ describe('HabitsStatTile', () => {
     const habits = [
       makeHabit({
         id: 310,
+        stage: 'Beige',
         revealed: true,
         start_date: new Date('2020-01-01T00:00:00Z'),
         completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
       }),
-      makeHabit({ id: 311, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
-      makeHabit({ id: 312, revealed: true, start_date: new Date('2020-01-01T00:00:00Z') }),
+      makeHabit({
+        id: 311,
+        stage: 'Purple',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
+      makeHabit({
+        id: 312,
+        stage: 'Red',
+        revealed: true,
+        start_date: new Date('2020-01-01T00:00:00Z'),
+      }),
     ];
     useHabitStore.setState({ loading: false, habits });
     // currentStage 5 is a stale value from a prior session; the error means it must not be trusted.


### PR DESCRIPTION
## Summary

- The Journal "Today's habits" stat tile counted **locked** habits in its denominator because the unlock rule was calendar-anchored (`isHabitLockedToday`, keyed off `start_date`/`revealed`). Misanchored or past `start_date`s defeat that rule, inflating a partway-through user to `n/7`.
- Introduces a single stage-anchored predicate `isHabitUnlockedAtStage(habit, index, currentStage) = index < currentStage || isEarlyUnlocked(habit)` in `HabitUtils.ts`, and a matching `unlockedAtStage(habits, currentStage)` in `habitCounts.ts` replacing the removed `unlockedToday`. The tile now reads `currentStage` from `useStageStore` (self-hydrating stages on mount via `stageService.loadStages()`), so the denominator equals the stage-unlocked set: Beige (stage 1) → `0/1` or `1/1`; Red (stage 3) → `n/3`. Manually early-unlocked habits still count; locked habits never do, regardless of `start_date`/`revealed`.
- Cold Journal entry holds the loading skeleton until stages resolve (no wrong-denominator flash); a stage-load error falls back to stage 1 rather than a stale store value.

## Scope note

The Habits tab's own per-tile lock is calendar-anchored (`isHabitLockedToday` + the "Unlocks in N days" countdown) — a distinct, complementary visual reveal mechanic with its own large test suite. Reconciling it to the stage-anchored rule is intentionally out of scope for this P0 and is tracked as a follow-up (#1343).

## Test plan

- Added Jest coverage (RED-first): stage-1 and stage-3 denominators (`0/1`, `1/1`, `0/3`), the 7-habit inflated-denominator reproduction, locked habits with past `start_date` excluded, early-unlocked habit included, cold-entry skeleton + `loadStages` called once, and stage-load-error fallback. `unlockedAtStage` / `isHabitUnlockedAtStage` unit tests and the existing loading / no-habits / navigate / "Unlocks soon" branches.
- `./scripts/frontend/check-all.sh` passes (ESLint zero-warning, `tsc --noEmit` strict, prettier, full Jest suite 3433 tests green).

Closes #1318
Refs #1343
