### PR TITLE
fix(habits): fit the full 10-tile habit set on one phone screen

### DIFF
--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -362,6 +362,12 @@ export const touchTarget = {
   minimum: 44,
 } as const;
 
+/** Habit-tile density in spacing UNITS (fed to `spacing(n, scale)`), not px. */
+export const tileDensity = { paddingV: 0.5, barGap: 0.5 } as const;
+
+/** React Navigation's default bottom tab-bar content height; bump if the tab bar is restyled taller. */
+export const BOTTOM_TAB_BAR_CONTENT_HEIGHT = 49;
+
 /** WCAG-AA on the white modal card: #555 = 7.22:1 on #ffffff (AAA normal). */
 export const CHART_AXIS_LABEL_COLOR = '#555555';
 

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -1,7 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { colors, STAGE_COLORS, spacing, surface } from '../../design/tokens';
+import {
+  BOTTOM_TAB_BAR_CONTENT_HEIGHT,
+  colors,
+  SPACING,
+  STAGE_COLORS,
+  spacing,
+  surface,
+  tileDensity,
+  touchTarget,
+} from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 import { DEFAULT_TIMEZONE, MS_PER_DAY } from '../../utils/dateUtils';
 
@@ -168,10 +178,24 @@ const TOTAL_HABITS = MAX_HABITS;
 /** Tile border thickness so the aptitude/stage color reads clearly at a glance. */
 export const TILE_BORDER_WIDTH = 3;
 
+// Empirical vertical budget reserved for the screen chrome the hook cannot
+// measure directly: the top action bar, the SafeAreaView container padding, a
+// footer/pagination allowance, and one grid gutter. Kept flat so the hook stays
+// A-grade. When a footer or pagination bar is visible the small remainder falls
+// to the FlatList scroll (the documented short-viewport degrade).
+const habitGridChrome = (scale: number, gridGutter: number): number =>
+  2 * spacing(1, scale) + spacing(3, scale) + 2 * spacing(1, scale) + SPACING.sm + gridGutter;
+
 export const useTileLayout = () => {
   const { width, height, columns, scale, gridGutter } = useResponsive();
+  const insets = useSafeAreaInsets();
   const rows = columns === 2 ? TOTAL_HABITS / columns : TOTAL_HABITS;
-  const tileMinHeight = height / rows - 2 * spacing(1, scale) - gridGutter;
+  const chrome = habitGridChrome(scale, gridGutter);
+  const bottomBarReserve = BOTTOM_TAB_BAR_CONTENT_HEIGHT + insets.bottom;
+  const availableHeight = height - insets.top - bottomBarReserve - chrome;
+  const rowPitch = availableHeight / rows;
+  // Floor to whole pixels so the reserved stack never rounds above the viewport.
+  const tileMinHeight = Math.max(touchTarget.minimum, Math.floor(rowPitch - gridGutter));
   const tileWidth = width / columns;
   const iconInline = columns === 1 || tileWidth < 400;
   return { columns, scale, gridGutter, tileMinHeight, iconInline };
@@ -303,7 +327,7 @@ const ProgressBar = ({
   const borderR = barHeight / 2;
 
   return (
-    <View style={{ marginTop: spacing(1, scale) }}>
+    <View style={{ marginTop: spacing(tileDensity.barGap, scale) }}>
       <View style={{ height: barHeight, position: 'relative' }}>
         <View
           style={{
@@ -420,7 +444,8 @@ const getLockedTileStyle = (
   flex: 1 as const,
   borderWidth: TILE_BORDER_WIDTH,
   borderColor: stageColor,
-  padding: spacing(1, scale),
+  paddingVertical: spacing(tileDensity.paddingV, scale),
+  paddingHorizontal: spacing(1, scale),
   margin: gridGutter / 2,
   minHeight: tileMinHeight,
   borderRadius: spacing(1, scale),
@@ -513,7 +538,8 @@ const buildUnlockedTileStyle = (
   borderWidth: TILE_BORDER_WIDTH,
   borderColor: stageColor,
   borderStyle: (earlyUnlocked ? 'dashed' : undefined) as 'dashed' | undefined,
-  padding: spacing(1, scale),
+  paddingVertical: spacing(tileDensity.paddingV, scale),
+  paddingHorizontal: spacing(1, scale),
   margin: gridGutter / 2,
   minHeight: tileMinHeight,
   borderRadius: spacing(1, scale),

--- a/frontend/src/features/Habits/__tests__/HabitTileFit.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileFit.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+import renderer from 'react-test-renderer';
+
+import {
+  spacing,
+  SPACING,
+  touchTarget,
+  tileDensity,
+  BOTTOM_TAB_BAR_CONTENT_HEIGHT,
+} from '../../../design/tokens';
+import type { Habit } from '../Habits.types';
+import { useTileLayout, HabitTile } from '../HabitTile';
+
+const TOTAL_HABITS = 10;
+
+interface Insets {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+const mockWindowDimensions = (width: number, height: number): void => {
+  jest
+    .spyOn(require('react-native'), 'useWindowDimensions')
+    .mockReturnValue({ width, height, scale: 1, fontScale: 1 });
+};
+
+// Probe renders the hook's return into testID'd Text so tests can read it back.
+const TileLayoutProbe = (): React.JSX.Element => {
+  const { tileMinHeight, gridGutter, scale } = useTileLayout();
+  return (
+    <>
+      <Text testID="probe-tile-min-height">{tileMinHeight}</Text>
+      <Text testID="probe-grid-gutter">{gridGutter}</Text>
+      <Text testID="probe-scale">{scale}</Text>
+    </>
+  );
+};
+
+interface TileLayoutSnapshot {
+  tileMinHeight: number;
+  gridGutter: number;
+  scale: number;
+}
+
+const renderTileLayout = (insets: Insets): TileLayoutSnapshot => {
+  const { getByTestId } = render(
+    <SafeAreaInsetsContext.Provider value={insets}>
+      <TileLayoutProbe />
+    </SafeAreaInsetsContext.Provider>,
+  );
+  const tileMinHeight = Number(getByTestId('probe-tile-min-height').props.children);
+  const gridGutter = Number(getByTestId('probe-grid-gutter').props.children);
+  const scale = Number(getByTestId('probe-scale').props.children);
+  return { tileMinHeight, gridGutter, scale };
+};
+
+// Mirrors the icon-row/header-row/section-gap chrome the implementation reserves per screen.
+const computeChrome = (scale: number, gridGutter: number): number =>
+  2 * spacing(1, scale) + spacing(3, scale) + 2 * spacing(1, scale) + SPACING.sm + gridGutter;
+
+describe('useTileLayout fit invariant', () => {
+  it('keeps the full 10-tile stack within the viewport height budget', () => {
+    mockWindowDimensions(390, 844);
+    const insets: Insets = { top: 47, bottom: 34, left: 0, right: 0 };
+    const { tileMinHeight, gridGutter, scale } = renderTileLayout(insets);
+
+    expect(tileMinHeight).toBeGreaterThanOrEqual(touchTarget.minimum);
+    // Concrete expected density at the target profile: a chrome-model drift or a
+    // token change breaks this independently of the reconstructed budget below.
+    const EXPECTED_TILE_MIN_HEIGHT = 57;
+    expect(tileMinHeight).toBe(EXPECTED_TILE_MIN_HEIGHT);
+
+    const chrome = computeChrome(scale, gridGutter);
+    const bottomBarReserve = BOTTOM_TAB_BAR_CONTENT_HEIGHT + insets.bottom;
+    const stackHeight = TOTAL_HABITS * (tileMinHeight + gridGutter);
+    const totalHeight = stackHeight + insets.top + bottomBarReserve + chrome;
+
+    expect(totalHeight).toBeLessThanOrEqual(844);
+  });
+
+  it('clamps tileMinHeight to the touch-target floor on a short viewport', () => {
+    mockWindowDimensions(390, 500);
+    const insets: Insets = { top: 20, bottom: 0, left: 0, right: 0 };
+    const { tileMinHeight } = renderTileLayout(insets);
+
+    expect(tileMinHeight).toBe(touchTarget.minimum);
+  });
+});
+
+describe('HabitTile density pass', () => {
+  const width = 390;
+  const height = 844;
+  const scale = 0.9;
+
+  const baseHabit: Habit = {
+    id: 1,
+    stage: 'Beige',
+    name: 'Meditate',
+    icon: 'star',
+    streak: 3,
+    energy_cost: 1,
+    energy_return: 1,
+    start_date: new Date(Date.now() - 86400000),
+    goals: [
+      {
+        title: 'Low',
+        tier: 'low',
+        target: 1,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        title: 'Clear',
+        tier: 'clear',
+        target: 2,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+      {
+        title: 'Stretch',
+        tier: 'stretch',
+        target: 3,
+        target_unit: 'u',
+        frequency: 1,
+        frequency_unit: 'per_day',
+        is_additive: true,
+      },
+    ],
+    completions: [],
+  };
+
+  beforeEach(() => {
+    mockWindowDimensions(width, height);
+  });
+
+  it('applies the reduced padding density on an unlocked tile', () => {
+    const testRenderer = renderer.create(<HabitTile habit={baseHabit} tz="UTC" />);
+    const tile = testRenderer.root.findByProps({ testID: 'habit-tile' });
+    const style = StyleSheet.flatten(tile.props.style);
+    expect(style.paddingVertical).toBe(spacing(tileDensity.paddingV, scale));
+    expect(style.paddingHorizontal).toBe(spacing(1, scale));
+  });
+
+  it('applies the reduced padding density on a locked tile', () => {
+    const testRenderer = renderer.create(<HabitTile habit={baseHabit} locked tz="UTC" />);
+    const tile = testRenderer.root.findByProps({ testID: 'habit-tile' });
+    const style = StyleSheet.flatten(tile.props.style);
+    expect(style.paddingVertical).toBe(spacing(tileDensity.paddingV, scale));
+    expect(style.paddingHorizontal).toBe(spacing(1, scale));
+  });
+
+  it('pins the habit name font size unchanged by the density pass', () => {
+    const { getByText } = render(<HabitTile habit={baseHabit} tz="UTC" />);
+    const nameNode = getByText(baseHabit.name);
+    const nameStyleFlat = StyleSheet.flatten(nameNode.props.style);
+    expect(nameStyleFlat.fontSize).toBe(spacing(2, scale));
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest, describe, afterEach, it, expect } from '@jest/globals';
 
-import { brightenColor, STAGE_COLORS } from '../../../design/tokens';
+import { brightenColor, STAGE_COLORS, SPACING } from '../../../design/tokens';
 
 const renderer = require('react-test-renderer');
 
@@ -62,14 +62,19 @@ const widths = [320, 390, 600, 900, 1200];
 
 const colorValues = Object.values(STAGE_COLORS);
 
+// Proves SOME reserve exists beyond the raw per-row split; the realistic budget lives in HabitTileFit.test.tsx.
+const CHROME_RESERVE = SPACING.sm;
+
 const assertTileLayout = (tile: any, height: number, expectedColumns: number): void => {
   const style = Array.isArray(tile.props.style)
     ? tile.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
     : tile.props.style;
 
-  const tileHeight = (style.minHeight ?? 0) + 2 * (style.padding ?? 0) + 2 * (style.margin ?? 0);
+  const verticalPadding = style.paddingVertical ?? style.padding ?? 0;
+  const tileHeight = (style.minHeight ?? 0) + 2 * verticalPadding + 2 * (style.margin ?? 0);
 
-  const maxTileHeight = (height * expectedColumns) / 10;
+  const rows = expectedColumns === 2 ? 5 : 10;
+  const maxTileHeight = (height - CHROME_RESERVE) / rows;
   expect(tileHeight).toBeLessThanOrEqual(maxTileHeight);
   if (expectedColumns === 2) {
     expect(style.flex).toBe(1);


### PR DESCRIPTION
## Summary

- The Habits screen sized each tile by dividing the **full window height** by the
  row count, ignoring safe-area insets, the bottom tab bar, and the screen's own
  chrome — so a full set of 10 tiles overflowed the fold (only 8 fit). `useTileLayout`
  now sizes tiles from the height that actually **remains** after `useSafeAreaInsets()`,
  the bottom tab bar (`BOTTOM_TAB_BAR_CONTENT_HEIGHT`), and an empirical chrome budget,
  clamps tile height at the 44pt touch-target floor, and floors to whole pixels. On a
  390×844 profile all 10 tiles + chrome now fit with no scroll (tiles ≈57pt tall).
- A density pass tightens tile vertical padding and the progress-bar gap via new named
  tokens (`tileDensity`) — no magic numbers, no font/icon/bar-height changes, so type
  and tap targets stay at design-system minimums.

## Degrade behavior (small screens)

On viewports too short to fit 10 tiles at the 44pt floor, `tileMinHeight` clamps to
`touchTarget.minimum` (44) and the existing FlatList scrolls the small remainder —
**deliberate minimal scroll**, never sub-44pt tap targets and never shrunk type. Nothing
is hidden. Note: the `EnergyCTA` footer is `position: absolute` and overlays the grid
today (pre-existing, unchanged); when a footer/pagination bar is visible the "fit all 10
without scrolling" guarantee holds via that same minimal-scroll degrade.
`BOTTOM_TAB_BAR_CONTENT_HEIGHT` mirrors React Navigation's default (colors-only override
in `BottomTabs.tsx`); it must move if the tab bar is ever restyled taller.

## Test plan

- New `HabitTileFit.test.tsx`: probes `useTileLayout` at 390×844 with realistic insets
  (47/34) — asserts the 10-tile stack + insets + tab bar + chrome fits 844 **and** pins
  the concrete tile height (57); a short-viewport case (390×500) asserts the 44pt clamp;
  density assertions pin the `paddingVertical`/`paddingHorizontal` split (unlocked +
  locked) and pin the habit-name font size unchanged.
- Strengthened `HabitsResponsive.test.tsx` `assertTileLayout` to account for
  `paddingVertical` and assert a real chrome-and-inset budget (was a tautological
  `height/rows`).
- Full frontend `check-all.sh` green: ESLint zero-warning, prettier, `tsc --noEmit`
  strict, 3427 jest tests (599 Habits) pass. Gate 2.5 code-review: CLEAN.

Closes #1334
