### PR TITLE
fix(journal): gate tier/chord PATCH on failed entry load

### DIFF
--- a/frontend/src/components/RadioOption.tsx
+++ b/frontend/src/components/RadioOption.tsx
@@ -8,6 +8,8 @@ export interface RadioOptionProps {
   onPress: () => void;
   testID: string;
   accessibilityHint?: string;
+  /** When true, the option is announced as disabled to assistive tech. */
+  disabled?: boolean;
   style: StyleProp<ViewStyle>;
   selectedStyle: StyleProp<ViewStyle>;
   labelStyle: StyleProp<TextStyle>;
@@ -31,6 +33,7 @@ export function RadioOption({
   onPress,
   testID,
   accessibilityHint,
+  disabled = false,
   style,
   selectedStyle,
   labelStyle,
@@ -43,7 +46,7 @@ export function RadioOption({
       accessibilityRole="radio"
       accessibilityLabel={label}
       accessibilityHint={accessibilityHint}
-      accessibilityState={{ selected }}
+      accessibilityState={{ selected, disabled }}
       testID={testID}
     >
       <Text style={[labelStyle, selected && selectedLabelStyle]}>{label}</Text>

--- a/frontend/src/components/__tests__/RadioOption.test.tsx
+++ b/frontend/src/components/__tests__/RadioOption.test.tsx
@@ -45,7 +45,10 @@ describe('RadioOption', () => {
         selectedLabelStyle={selectedLabelStyle}
       />,
     );
-    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({ selected: true });
+    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({
+      selected: true,
+      disabled: false,
+    });
   });
 
   it('reflects selected=false in accessibilityState', () => {
@@ -61,7 +64,30 @@ describe('RadioOption', () => {
         selectedLabelStyle={selectedLabelStyle}
       />,
     );
-    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({ selected: false });
+    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({
+      selected: false,
+      disabled: false,
+    });
+  });
+
+  it('announces disabled in accessibilityState when disabled', () => {
+    const { getByTestId } = render(
+      <RadioOption
+        label="Morning"
+        selected={false}
+        disabled
+        onPress={jest.fn()}
+        testID="opt-morning"
+        style={baseStyle}
+        selectedStyle={selectedStyle}
+        labelStyle={baseLabelStyle}
+        selectedLabelStyle={selectedLabelStyle}
+      />,
+    );
+    expect(getByTestId('opt-morning').props.accessibilityState).toEqual({
+      selected: false,
+      disabled: true,
+    });
   });
 
   it('fires onPress exactly once when pressed', () => {

--- a/frontend/src/features/Journal/AspectChordControl.tsx
+++ b/frontend/src/features/Journal/AspectChordControl.tsx
@@ -46,6 +46,8 @@ export interface AspectChordControlProps {
   value?: AspectChordValue;
   /** Called with the next chord whenever a chip or the clear affordance fires. */
   onChange: (_next: AspectChordValue) => void;
+  /** When true, the trigger won't expand and changes are inert (failed load). */
+  disabled?: boolean;
 }
 
 interface AspectChipRowProps {
@@ -82,7 +84,13 @@ function AspectChipRow({
 }
 
 /** The collapsed state: a single warm trigger that reveals the chooser. */
-function CollapsedTrigger({ onExpand }: { onExpand: () => void }): React.JSX.Element {
+function CollapsedTrigger({
+  onExpand,
+  disabled,
+}: {
+  onExpand: () => void;
+  disabled: boolean;
+}): React.JSX.Element {
   return (
     <View style={styles.aspectChordControl}>
       <TouchableOpacity
@@ -90,6 +98,7 @@ function CollapsedTrigger({ onExpand }: { onExpand: () => void }): React.JSX.Ele
         onPress={onExpand}
         accessibilityRole="button"
         accessibilityLabel={TRIGGER_LABEL}
+        accessibilityState={{ disabled }}
         testID="aspect-chord-trigger"
       >
         <Text style={styles.aspectChordTriggerLabel}>{TRIGGER_LABEL}</Text>
@@ -102,7 +111,7 @@ function CollapsedTrigger({ onExpand }: { onExpand: () => void }): React.JSX.Ele
 function ExpandedChooser({
   value,
   onChange,
-}: Required<AspectChordControlProps>): React.JSX.Element {
+}: Required<Pick<AspectChordControlProps, 'value' | 'onChange'>>): React.JSX.Element {
   const primary = value.primary;
   return (
     <View style={styles.aspectChordControl} accessibilityLabel="Aspect chord">
@@ -144,6 +153,7 @@ function ExpandedChooser({
 function AspectChordControl({
   value = EMPTY_CHORD,
   onChange,
+  disabled = false,
 }: AspectChordControlProps): React.JSX.Element {
   // Derive expansion from the value so a loaded (pre-tagged) entry opens on its
   // chips instead of the "optional" trigger — even when the chord arrives after
@@ -151,12 +161,17 @@ function AspectChordControl({
   const [userExpanded, setUserExpanded] = useState(false);
   const expanded = userExpanded || value.primary !== null;
   if (!expanded) {
-    return <CollapsedTrigger onExpand={() => setUserExpanded(true)} />;
+    // A disabled control (failed load) never reveals its chips on tap.
+    const onExpand = (): void => {
+      if (!disabled) setUserExpanded(true);
+    };
+    return <CollapsedTrigger onExpand={onExpand} disabled={disabled} />;
   }
   // Latch the control open once the writer acts inside it, so pressing Clear on
   // an edit-loaded chord leaves them on the chips to re-pick rather than snapping
-  // back to the collapsed "optional" trigger mid-edit.
+  // back to the collapsed "optional" trigger mid-edit. Inert while disabled.
   const handleChange = (next: AspectChordValue): void => {
+    if (disabled) return;
     setUserExpanded(true);
     onChange(next);
   };

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -217,10 +217,14 @@ interface ClassificationPersist {
  */
 function useClassificationPersist(
   entryIdRef: React.MutableRefObject<number | null>,
+  loadFailedRef: React.MutableRefObject<boolean>,
 ): ClassificationPersist {
   const classificationRef = useRef<JournalClassification>(DEFAULT_TIER);
   const changeClassification = useCallback(
     async (tier: JournalClassification): Promise<JournalClassification | null> => {
+      // Never PATCH against an entry that failed to load — the ref is stale and a
+      // write here could silently downgrade the stored (unseen) privacy tier.
+      if (loadFailedRef.current) return null;
       const previous = classificationRef.current;
       classificationRef.current = tier;
       // Create-time: the ref rides the next journal.create, nothing to PATCH yet.
@@ -237,7 +241,7 @@ function useClassificationPersist(
         return previous;
       }
     },
-    [entryIdRef],
+    [entryIdRef, loadFailedRef],
   );
   const seedClassification = useCallback((tier: JournalClassification): void => {
     classificationRef.current = tier;
@@ -267,10 +271,16 @@ interface ChordPersist {
  * A failed PATCH resolves to the prior chord so the control reverts to the
  * truth, mirroring the sibling privacy-tier control's revert-on-failure path.
  */
-function useChordPersist(entryIdRef: React.MutableRefObject<number | null>): ChordPersist {
+function useChordPersist(
+  entryIdRef: React.MutableRefObject<number | null>,
+  loadFailedRef: React.MutableRefObject<boolean>,
+): ChordPersist {
   const chordRef = useRef<AspectChordValue>(EMPTY_CHORD);
   const changeChord = useCallback(
     async (next: AspectChordValue): Promise<AspectChordValue | null> => {
+      // Never PATCH against an entry that failed to load — the ref is stale and a
+      // write here could overwrite the stored (unseen) chord.
+      if (loadFailedRef.current) return null;
       const previous = chordRef.current;
       chordRef.current = next;
       // Create-time: the ref rides the next journal.create, nothing to PATCH yet.
@@ -290,7 +300,7 @@ function useChordPersist(entryIdRef: React.MutableRefObject<number | null>): Cho
         return previous;
       }
     },
-    [entryIdRef],
+    [entryIdRef, loadFailedRef],
   );
   const seedChord = useCallback((next: AspectChordValue): void => {
     chordRef.current = next;
@@ -438,10 +448,13 @@ function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) =
 function usePersistControls(
   entryIdRef: React.MutableRefObject<number | null>,
   setSaveState: (_state: SaveState) => void,
+  loadFailedRef: React.MutableRefObject<boolean>,
 ) {
-  const { classificationRef, changeClassification, seedClassification } =
-    useClassificationPersist(entryIdRef);
-  const { chordRef, changeChord, seedChord } = useChordPersist(entryIdRef);
+  const { classificationRef, changeClassification, seedClassification } = useClassificationPersist(
+    entryIdRef,
+    loadFailedRef,
+  );
+  const { chordRef, changeChord, seedChord } = useChordPersist(entryIdRef, loadFailedRef);
   const seedPersist = useCallback(
     (tier: JournalClassification, chord: AspectChordValue): void => {
       seedClassification(tier);
@@ -475,13 +488,14 @@ function useDebouncedSave(
   // A weekly-prompt response is write-once; this guards against the debounce or
   // flush submitting it twice (the backend 409s on a duplicate week).
   const respondedRef = useRef(false);
-  const persist = usePersistControls(entryIdRef, setSaveState);
   // Refs so non-memoised inputs don't churn the save callbacks below.
   const onSavedRef = useRef(onSaved);
   const ctxRef = useRef(ctx);
   // A failed load leaves entryIdRef pointing at the real, unloaded entry with a
-  // blank body — so any save here would overwrite it. Gate on the latest flag.
+  // blank body — so any save (or tier/chord PATCH) here would overwrite it. Gate
+  // on the latest flag; declared before the persisters so they can read it too.
   const loadFailedRef = useRef(loadFailed);
+  const persist = usePersistControls(entryIdRef, setSaveState, loadFailedRef);
   useEffect(() => {
     onSavedRef.current = onSaved;
     ctxRef.current = ctx;
@@ -730,6 +744,8 @@ interface WritingColumnProps {
   onChangeChord: (_next: AspectChordValue) => void;
   onFinish?: () => void;
   bodyPlaceholder?: string;
+  /** Disables the tier + chord controls while an entry's load has failed. */
+  controlsDisabled: boolean;
 }
 
 /** Quiet control to mark a draft finished. */
@@ -745,28 +761,41 @@ function FinishControl({ onFinish }: { onFinish: () => void }) {
   );
 }
 
-/** The scrollable writing column (title + growing body + save hint). */
-function WritingColumn({
-  title,
-  body,
-  saveState,
+/** The privacy-tier + Aspect-chord choosers, both gated off when load failed. */
+function EntryTagControls({
   classification,
   chord,
-  onChangeTitle,
-  onChangeBody,
   onChangeClassification,
   onChangeChord,
-  onFinish,
-  bodyPlaceholder = 'Begin writing…',
-}: WritingColumnProps) {
+  controlsDisabled,
+}: Pick<
+  WritingColumnProps,
+  'classification' | 'chord' | 'onChangeClassification' | 'onChangeChord' | 'controlsDisabled'
+>) {
   return (
-    <ScrollView
-      style={styles.writingColumn}
-      contentContainerStyle={styles.writingColumnContent}
-      keyboardShouldPersistTaps="handled"
-    >
-      <PrivacyTierControl value={classification} onChange={onChangeClassification} />
-      <AspectChordControl value={chord} onChange={onChangeChord} />
+    <>
+      <PrivacyTierControl
+        value={classification}
+        onChange={onChangeClassification}
+        disabled={controlsDisabled}
+      />
+      <AspectChordControl value={chord} onChange={onChangeChord} disabled={controlsDisabled} />
+    </>
+  );
+}
+
+/** The title + growing body inputs (the raw editable text of the entry). */
+function WritingFields({
+  title,
+  body,
+  onChangeTitle,
+  onChangeBody,
+  bodyPlaceholder,
+}: Pick<WritingColumnProps, 'title' | 'body' | 'onChangeTitle' | 'onChangeBody'> & {
+  bodyPlaceholder: string;
+}) {
+  return (
+    <>
       <TextInput
         style={styles.titleInput}
         value={title}
@@ -790,6 +819,45 @@ function WritingColumn({
         scrollEnabled={false}
         accessibilityLabel="Entry body"
         testID="journal-body-input"
+      />
+    </>
+  );
+}
+
+/** The scrollable writing column (title + growing body + save hint). */
+function WritingColumn({
+  title,
+  body,
+  saveState,
+  classification,
+  chord,
+  onChangeTitle,
+  onChangeBody,
+  onChangeClassification,
+  onChangeChord,
+  onFinish,
+  bodyPlaceholder = 'Begin writing…',
+  controlsDisabled,
+}: WritingColumnProps) {
+  return (
+    <ScrollView
+      style={styles.writingColumn}
+      contentContainerStyle={styles.writingColumnContent}
+      keyboardShouldPersistTaps="handled"
+    >
+      <EntryTagControls
+        classification={classification}
+        chord={chord}
+        onChangeClassification={onChangeClassification}
+        onChangeChord={onChangeChord}
+        controlsDisabled={controlsDisabled}
+      />
+      <WritingFields
+        title={title}
+        body={body}
+        onChangeTitle={onChangeTitle}
+        onChangeBody={onChangeBody}
+        bodyPlaceholder={bodyPlaceholder}
       />
       <Text style={styles.savedHint} testID="journal-save-hint">
         {savedHintLabel(saveState)}
@@ -1105,6 +1173,8 @@ type Controller = ReturnType<typeof useJournalEntryController>;
 function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
   const { title, body, saveState, classification, chord } = ctl.autosave;
   const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
+  // A failed load leaves the controls bound to an unseen entry, so disable them.
+  const controlsDisabled = ctl.autosave.loadError != null;
   return editMode ? (
     <WritingColumn
       title={title}
@@ -1118,6 +1188,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       onChangeChord={ctl.autosave.onChangeChord}
       onFinish={canFinish ? markFinished : undefined}
       bodyPlaceholder={bodyPlaceholder}
+      controlsDisabled={controlsDisabled}
     />
   ) : (
     <ReadColumn

--- a/frontend/src/features/Journal/PrivacyTierControl.tsx
+++ b/frontend/src/features/Journal/PrivacyTierControl.tsx
@@ -46,6 +46,8 @@ export interface PrivacyTierControlProps {
   value?: PrivacyTier;
   /** Called with the chosen tier when an option is pressed. */
   onChange: (_tier: PrivacyTier) => void;
+  /** When true, taps are inert — used while an entry's load has failed. */
+  disabled?: boolean;
 }
 
 /**
@@ -55,6 +57,7 @@ export interface PrivacyTierControlProps {
 function PrivacyTierControl({
   value = DEFAULT_TIER,
   onChange,
+  disabled = false,
 }: PrivacyTierControlProps): React.JSX.Element {
   return (
     <View style={styles.privacyTierControl}>
@@ -64,7 +67,10 @@ function PrivacyTierControl({
             key={option.tier}
             label={option.label}
             selected={option.tier === value}
-            onPress={() => onChange(option.tier)}
+            onPress={() => {
+              if (!disabled) onChange(option.tier);
+            }}
+            disabled={disabled}
             testID={`privacy-tier-${option.tier}`}
             accessibilityHint={option.hint}
             style={styles.privacyTierOption}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
@@ -128,4 +128,45 @@ describe('JournalEntryScreen load error', () => {
       jest.useRealTimers();
     }
   });
+
+  it('does not PATCH the privacy tier when the user taps a tier after a failed load', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+    const { getByTestId, findByTestId } = renderScreen({ entryId: 7 });
+    await findByTestId('journal-load-error');
+    fireEvent.press(getByTestId('privacy-tier-public'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not PATCH the chord when the user taps the chord control after a failed load', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+    const { getByTestId, findByTestId, queryByTestId } = renderScreen({ entryId: 7 });
+    await findByTestId('journal-load-error');
+    fireEvent.press(getByTestId('aspect-chord-trigger'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(queryByTestId('aspect-primary-5')).toBeNull();
+  });
+
+  // Regression pin; full successful-load PATCH matrix lives in JournalEntryScreenPrivacy.test.tsx
+  it('still PATCHes the tier normally after a successful load (gate does not over-block)', async () => {
+    mockGet.mockResolvedValue(entry({ id: 7, classification: 'intimate' }));
+    const { getByTestId } = renderScreen({ entryId: 7 }, { autosaveDelayMs: 100 });
+    await waitFor(() => {
+      expect(getByTestId('journal-body-input').props.value).toBeTruthy();
+    });
+    mockUpdate.mockClear();
+    fireEvent.press(getByTestId('privacy-tier-personal'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ classification: 'personal' }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

When an existing journal entry **fails to load**, the privacy-tier and Aspect-chord controls render defaults while `entryIdRef` still points at the real, unseen entry. Previously a tap then fired `journal.update` PATCHing that entry to a value chosen against unseen state — a privacy-relevant clobber that could silently downgrade an `intimate` tier without the user seeing what it was.

The fix gates both control paths on the existing failed-load flag, two layers deep:

- **UI honesty (primary):** `PrivacyTierControl` and `AspectChordControl` gain an optional `disabled` prop. While `loadError != null` the controls are inert — the tier radios no-op, the chord trigger won't expand or reveal its chips — and the disabled state is announced to assistive tech via `accessibilityState` (`RadioOption` + the chord trigger).
- **Persist gate (defense-in-depth):** `changeClassification`/`changeChord` early-return before any `journal.update` when `loadFailedRef.current` is true, mirroring the existing body-autosave gate in `useSaveRunner`.

A successful load re-enables both paths, so re-classification and re-tagging still PATCH normally (pinned by a regression test). `WritingColumn` was refactored (extracted `EntryTagControls` + `WritingFields`) to stay within the max-lines-per-function budget.

## Test plan

- Added failing-first tests in `JournalEntryScreenLoadError.test.tsx`: after a failed load, tapping a privacy tier fires no PATCH; tapping the chord trigger fires no PATCH and does not reveal its chips; and (regression) a tier PATCH still works after a successful load.
- Updated `RadioOption.test.tsx` for the new honest `accessibilityState.disabled` field and added a disabled-announcement case.
- `./scripts/frontend/check-all.sh` green locally: 3443 tests pass, ESLint, Prettier, and TypeScript all clean.

Closes #1283