### PR TITLE
feat(habits): lock habits by default with user-controlled unlock

### DIFF
--- a/backend/migrations/versions/e6f7a8b9c0d2_add_habit_revealed.py
+++ b/backend/migrations/versions/e6f7a8b9c0d2_add_habit_revealed.py
@@ -1,0 +1,57 @@
+"""Add habit.revealed unlock flag.
+
+Revision ID: e6f7a8b9c0d2
+Revises: d3e4f5a6b7c8
+Create Date: 2026-07-03 00:00:00.000000
+
+Adds ``revealed`` to ``habit``: the single source of truth for whether a habit
+is unlocked (``revealed is True`` == unlocked). ``upgrade`` adds it NOT NULL
+with a temporary ``server_default=false`` so existing rows can be inserted,
+then backfills every EXISTING row to ``true`` — accounts predating the
+locked-by-default model keep their habits unlocked — and finally drops the DB
+server default so the app owns the default via the model's ``Field`` default
+(keeping ``alembic check`` drift-free). Only NEW/seeded habits created after
+this migration start locked. ``downgrade`` drops the column.
+
+The column is added and the default dropped inside ``batch_alter_table`` so the
+SQLite round-trip test stays compatible with the Postgres prod target.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e6f7a8b9c0d2"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d3e4f5a6b7c8"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``revealed`` (NOT NULL), backfill existing rows to unlocked, drop the default."""
+    # Add with a server_default so the NOT NULL column can be added to a table
+    # that already has rows, then backfill each existing habit to unlocked.
+    op.add_column(
+        "habit",
+        sa.Column("revealed", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute("UPDATE habit SET revealed = true")
+    # Drop the DB-level server_default (the app owns the default via the model's
+    # Field default, keeping ``alembic check`` drift-free). Batch mode keeps the
+    # ALTER SQLite-compatible for the round-trip test.
+    with op.batch_alter_table("habit") as batch_op:
+        batch_op.alter_column(
+            "revealed",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    """Drop the revealed column."""
+    # Batch mode keeps the downgrade SQLite-compatible.
+    with op.batch_alter_table("habit") as batch_op:
+        batch_op.drop_column("revealed")

--- a/backend/src/models/habit.py
+++ b/backend/src/models/habit.py
@@ -12,7 +12,15 @@ if TYPE_CHECKING:
 
 
 class Habit(SQLModel, table=True):
-    """Tracks a user's habit and related goals."""
+    """Tracks a user's habit and related goals.
+
+    ``revealed`` is the single source of truth for whether a habit is unlocked
+    ("unlocked" == ``revealed is True`` in product terms). New and seeded
+    habits default to locked; the user opts each one in. Re-locking (flipping
+    ``revealed`` back to ``False``) preserves logged completions — those live
+    on the habit's goals, never on this flag — so a re-locked habit keeps its
+    history for when the user unlocks it again.
+    """
 
     id: int | None = Field(default=None, primary_key=True)
     name: str = Field(max_length=255)
@@ -32,6 +40,7 @@ class Habit(SQLModel, table=True):
     sort_order: int | None = None
     stage: str = Field(default="", max_length=100)
     streak: int = 0
+    revealed: bool = Field(default=False)
     user: "User" = Relationship(back_populates="habits")
     goals: list["Goal"] = Relationship(
         back_populates="habit",

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -41,6 +41,7 @@ class Habit(OwnedResourcePublic):
     sort_order: int | None = None
     stage: str = ""
     streak: int = 0
+    revealed: bool = False
 
 
 class HabitWithGoals(Habit):
@@ -67,3 +68,4 @@ class HabitCreate(BaseModel):
     milestone_notifications: bool = False
     sort_order: int | None = None
     stage: str = Field(default="", max_length=HABIT_STAGE_MAX_LENGTH)
+    revealed: bool = False

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -743,6 +743,88 @@ async def test_cross_tenant_completions_survive_a_commit_after_get(
     assert persisted.user_id == 999_999
 
 
+# ── Locked-by-default / manual unlock persistence ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_habit_without_revealed_defaults_to_locked(async_client: AsyncClient) -> None:
+    """POST /habits/ omitting ``revealed`` locks the new habit by default."""
+    headers = await _signup(async_client, "locked_default")
+    resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["revealed"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_habit_with_revealed_true_stays_unlocked(async_client: AsyncClient) -> None:
+    """POST /habits/ with ``revealed: true`` persists unlocked.
+
+    A stuck-user recovery re-push (``recoverStuckHabits``) replays the
+    client's cached habits, including an already-unlocked one; the server
+    must not silently re-lock it.
+    """
+    headers = await _signup(async_client, "recovery_repush")
+    resp = await async_client.post("/habits/", json=sample_payload(revealed=True), headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["revealed"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_habit_revealed_persists(async_client: AsyncClient) -> None:
+    """PUT revealed:true, then GET, round-trips the unlock flag."""
+    headers = await _signup(async_client, "persist_reveal")
+    create_resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    habit_id = create_resp.json()["id"]
+
+    put_resp = await async_client.put(
+        f"/habits/{habit_id}", json=sample_payload(revealed=True), headers=headers
+    )
+    assert put_resp.status_code == HTTPStatus.OK
+
+    get_resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    assert get_resp.status_code == HTTPStatus.OK
+    assert get_resp.json()["revealed"] is True
+
+
+@pytest.mark.asyncio
+async def test_relock_preserves_completions(async_client: AsyncClient) -> None:
+    """Re-locking a habit (PUT revealed:false) must not drop its logged completions."""
+    headers = await _signup(async_client, "relock_preserve")
+    create_resp = await async_client.post(
+        "/habits/", json=sample_payload(revealed=True), headers=headers
+    )
+    habit_id = create_resp.json()["id"]
+    goal_id = next(g["id"] for g in create_resp.json()["goals"] if g["tier"] == "clear")
+
+    log_resp = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal_id, "did_complete": True},
+        headers=headers,
+    )
+    assert log_resp.status_code == HTTPStatus.OK
+
+    put_resp = await async_client.put(
+        f"/habits/{habit_id}", json=sample_payload(revealed=False), headers=headers
+    )
+    assert put_resp.status_code == HTTPStatus.OK
+    assert put_resp.json()["revealed"] is False
+
+    stats_resp = await async_client.get(f"/habits/{habit_id}/stats", headers=headers)
+    assert stats_resp.status_code == HTTPStatus.OK
+    assert stats_resp.json()["total_completions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_habits_includes_revealed(async_client: AsyncClient) -> None:
+    """GET /habits/ list items include the ``revealed`` unlock flag."""
+    headers = await _signup(async_client, "list_revealed")
+    await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    resp = await async_client.get("/habits/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    [habit] = resp.json()
+    assert habit["revealed"] is False
+
+
 @pytest.mark.asyncio
 async def test_subtractive_habit_no_logs_streaks_from_start_date_via_list(
     async_client: AsyncClient, db_session: AsyncSession

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1846,3 +1846,137 @@ def test_journal_chord_migration_round_trip_on_sqlite(
     cols_final = _columns_of(db_url, "journalentry")
     assert "primary_aspect" in cols_final
     assert "secondary_aspect" in cols_final
+
+
+# -- habit.revealed column migration round-trip ------------------------------
+
+# down_revision is d3e4f5a6b7c8 (the highest_stage_reached migration, the
+# current chain head at authoring time).
+_HABIT_REVEALED_BASE_REVISION = "d3e4f5a6b7c8"  # pragma: allowlist secret
+# The implementer must replace this with the real revision ID they author.
+_HABIT_REVEALED_REVISION = "e6f7a8b9c0d2"  # pragma: allowlist secret
+
+
+def _bootstrap_habit_revealed_baseline(sync_url: str) -> None:
+    """Pre-create a minimal ``habit`` table (no ``revealed`` column) with two seeded rows.
+
+    Mirrors the schema in place just before the revealed-column migration,
+    without pulling in every preceding migration. Two pre-existing rows let
+    the "upgrade backfills every existing row to True" assertion cover more
+    than a single row.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'revealed@example.com')"))
+        conn.execute(
+            text(
+                "CREATE TABLE habit ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " name VARCHAR(255) NOT NULL,"
+                " icon VARCHAR(100) NOT NULL,"
+                " start_date DATE NOT NULL,"
+                " energy_cost INTEGER NOT NULL,"
+                " energy_return INTEGER NOT NULL,"
+                " stage VARCHAR(100) NOT NULL DEFAULT '',"
+                " streak INTEGER NOT NULL DEFAULT 0"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO habit"
+                " (id, user_id, name, icon, start_date, energy_cost, energy_return)"
+                " VALUES (1, 1, 'Existing Habit', 'leaf', '2025-01-01', 1, 2)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO habit"
+                " (id, user_id, name, icon, start_date, energy_cost, energy_return)"
+                " VALUES (2, 1, 'Second Habit', 'drop', '2025-02-01', 1, 2)"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_habit_revealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before the habit.revealed migration."""
+    db_path = tmp_path / "habit_revealed_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_habit_revealed_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _HABIT_REVEALED_BASE_REVISION)
+    return cfg
+
+
+def _habit_revealed_row(db_url: str, habit_id: int) -> dict[str, Any]:
+    """Fetch a ``habit`` row including the new ``revealed`` column."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text("SELECT id, revealed FROM habit WHERE id = :id"),
+                    {"id": habit_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_habit_revealed_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_habit_revealed: Config,
+) -> None:
+    """Round-trip the habit.revealed migration: upgrade adds + backfills; downgrade drops.
+
+    Phase 1: upgrade adds ``revealed`` NOT NULL and backfills every EXISTING
+    row to ``true`` -- accounts that pre-date the locked-by-default model keep
+    their habits unlocked; only NEW/seeded habits created after this migration
+    start locked (that default lives in the model/schema, not this backfill).
+    Phase 2: downgrade drops the column.
+    Phase 3: re-upgrade reproduces the same backfill (idempotent).
+
+    This test fails until the implementer authors the migration and sets
+    ``_HABIT_REVEALED_REVISION`` to its real revision ID.
+    """
+    cfg = alembic_sqlite_config_habit_revealed
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds the column and backfills both seeded rows to True.
+    command.upgrade(cfg, _HABIT_REVEALED_REVISION)
+    cols = _columns_of(db_url, "habit")
+    assert "revealed" in cols
+    row_1 = _habit_revealed_row(db_url, habit_id=1)
+    assert bool(row_1["revealed"]) is True
+    row_2 = _habit_revealed_row(db_url, habit_id=2)
+    assert bool(row_2["revealed"]) is True
+
+    # Phase 2: downgrade drops the revealed column.
+    command.downgrade(cfg, _HABIT_REVEALED_BASE_REVISION)
+    cols_after = _columns_of(db_url, "habit")
+    assert "revealed" not in cols_after
+
+    # Phase 3: re-upgrade -- backfill must reproduce the same values.
+    command.upgrade(cfg, _HABIT_REVEALED_REVISION)
+    row_1_again = _habit_revealed_row(db_url, habit_id=1)
+    assert bool(row_1_again["revealed"]) is True

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -801,6 +801,9 @@ export interface ApiHabit {
   sort_order?: number | null;
   stage: string;
   streak: number;
+  // Persisted unlock flag (revealed === unlocked). Optional so fixtures/payloads
+  // predating the column still typecheck; the live backend always sends it.
+  revealed?: boolean;
 }
 
 export interface ApiHabitWithGoals extends ApiHabit {
@@ -830,6 +833,7 @@ export interface HabitCreatePayload {
   milestone_notifications?: boolean;
   sort_order?: number | null;
   stage?: string;
+  revealed?: boolean;
 }
 
 /**
@@ -884,6 +888,7 @@ export function toLocalHabit(apiHabit: ApiHabitWithGoals): LocalHabit {
       days_of_week: g.days_of_week ?? undefined,
     })),
     completions: flattenGoalCompletions(apiHabit.goals),
+    revealed: apiHabit.revealed,
     notificationTimes: apiHabit.notification_times ?? undefined,
     notificationFrequency: isNotificationFrequency(apiHabit.notification_frequency)
       ? apiHabit.notification_frequency

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -196,6 +196,10 @@ export const habitSchema = z.object({
   sort_order: z.number().int().nullish(),
   stage: z.string(),
   streak: z.number().int(),
+  // Persisted unlock flag (revealed === unlocked). Optional on the wire so
+  // payloads captured before the column shipped still validate; the live
+  // backend always sends it.
+  revealed: z.boolean().optional(),
 });
 
 export const habitWithGoalsSchema = habitSchema.extend({

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -13,7 +13,7 @@ import {
   touchTarget,
 } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
-import { DEFAULT_TIMEZONE, MS_PER_DAY } from '../../utils/dateUtils';
+import { DEFAULT_TIMEZONE } from '../../utils/dateUtils';
 
 import ConfirmDialog from './components/ConfirmDialog';
 import { MAX_HABITS } from './constants';
@@ -27,7 +27,6 @@ import {
   getMarkerPositions,
   getProgressBarColor,
   isGoalAchieved,
-  isEarlyUnlocked,
   calculateTodaysProgress,
 } from './HabitUtils';
 import { longPressGestureStyle } from './longPressGestureStyle';
@@ -414,17 +413,10 @@ const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
 const LOCKED_BACKGROUND = '#e8e8e8';
 const LOCKED_OPACITY = 0.4;
 
-const calculateDaysUntilUnlock = (startDate: Date): number => {
-  const now = new Date();
-  const start = new Date(startDate);
-  return Math.max(0, Math.ceil((start.getTime() - now.getTime()) / MS_PER_DAY));
-};
-
-const getUnlockLabel = (habit: Habit): string => {
-  const days = calculateDaysUntilUnlock(habit.start_date);
-  if (days > 0) return `Unlocks in ${days} day${days === 1 ? '' : 's'}`;
-  return `Stage ${habit.stage} · Locked`;
-};
+// The calendar no longer participates in unlock — a locked habit is a standing
+// invitation the user accepts by tapping, never a timer that counts down. So
+// the label is a static "Stage X · Locked" regardless of start_date.
+const getUnlockLabel = (habit: Habit): string => `Stage ${habit.stage} · Locked`;
 
 interface LockedTileProps {
   habit: Habit;
@@ -467,12 +459,15 @@ const LockedTileButton = ({
   scale,
   gridGutter,
   tileMinHeight,
-  onLongPress,
-}: Omit<LockedTileProps, 'onUnlockHabit'> & { onLongPress?: () => void }) => (
+  onUnlock,
+}: Omit<LockedTileProps, 'onUnlockHabit'> & { onUnlock?: () => void }) => (
   <TouchableOpacity
     testID="habit-tile"
     accessibilityLabel={`${habit.name} locked`}
-    onLongPress={onLongPress}
+    // A locked tile's only affordance is the unlock invitation — both a tap and
+    // a long-press open the same confirm dialog. No goal editor / stats behind it.
+    onPress={onUnlock}
+    onLongPress={onUnlock}
     style={getLockedTileStyle(stageColor, scale, gridGutter, tileMinHeight)}
   >
     <View testID="habit-header" style={{ flexDirection: 'row', alignItems: 'center' }}>
@@ -495,15 +490,14 @@ const LockedTileButton = ({
 
 const LockedTile = ({ onUnlockHabit, ...rest }: LockedTileProps) => {
   const [showUnlockConfirm, setShowUnlockConfirm] = useState(false);
-  const handleLongPress = onUnlockHabit ? () => setShowUnlockConfirm(true) : undefined;
-  const dateStr = new Date(rest.habit.start_date).toLocaleDateString();
+  const handleUnlock = onUnlockHabit ? () => setShowUnlockConfirm(true) : undefined;
   return (
     <>
-      <LockedTileButton {...rest} onLongPress={handleLongPress} />
+      <LockedTileButton {...rest} onUnlock={handleUnlock} />
       <ConfirmDialog
         visible={showUnlockConfirm}
-        title="Unlock Early?"
-        message={`Unlock "${rest.habit.name}" early? The recommended start date is ${dateStr}.`}
+        title={`Unlock "${rest.habit.name}"?`}
+        message="This habit is yours to begin whenever you choose. Unlock it now, or leave it locked and come back to it later."
         testID="unlock-habit-confirm"
         cancelTestID="unlock-habit-cancel"
         confirmTestID="unlock-habit-confirm-button"
@@ -529,7 +523,6 @@ interface UnlockedTileProps {
 
 const buildUnlockedTileStyle = (
   stageColor: string,
-  earlyUnlocked: boolean,
   scale: number,
   gridGutter: number,
   tileMinHeight: number,
@@ -537,7 +530,6 @@ const buildUnlockedTileStyle = (
   flex: 1 as const,
   borderWidth: TILE_BORDER_WIDTH,
   borderColor: stageColor,
-  borderStyle: (earlyUnlocked ? 'dashed' : undefined) as 'dashed' | undefined,
   paddingVertical: spacing(tileDensity.paddingV, scale),
   paddingHorizontal: spacing(1, scale),
   margin: gridGutter / 2,
@@ -566,12 +558,11 @@ const UnlockedTile = ({
   const streakText =
     `${habit.streak} days${hasCompletedGoal ? ' — Achieved Today!' : ''}`.toUpperCase();
   const barHeight = Math.max(8, spacing(2, scale));
-  const earlyUnlocked = isEarlyUnlocked(habit);
 
   return (
     <TouchableOpacity
       testID="habit-tile"
-      style={buildUnlockedTileStyle(stageColor, earlyUnlocked, scale, gridGutter, tileMinHeight)}
+      style={buildUnlockedTileStyle(stageColor, scale, gridGutter, tileMinHeight)}
       onPress={onOpenGoals}
       onLongPress={onLongPress}
     >

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -588,33 +588,12 @@ export const calculateNetEnergy = (cost: number, returnValue: number): number =>
   return returnValue - cost;
 };
 
-/** A habit is "early unlocked" if it has been manually revealed before its start_date. */
-export const isEarlyUnlocked = (habit: Habit): boolean => {
-  return habit.revealed === true && new Date(habit.start_date).getTime() > Date.now();
-};
-
 /**
- * A habit is unlocked once the user's current stage has reached the habit's own
- * Spiral-Dynamics stage — the threshold is derived from `habit.stage` (its
- * position in `STAGE_ORDER`, 1-based) so drag-and-drop reordering of the list
- * never changes which habits are unlocked. When `habit.stage` is missing or
- * unrecognized, we fall back to the list position (`index`), preserving the
- * legacy `index < currentStage` behavior for stage-less habits. A habit is also
- * unlocked when manually revealed ahead of its start_date (early unlock),
- * regardless of stage.
+ * A habit is UNLOCKED iff `revealed === true` — the single source of truth for
+ * the lock state. Habits are locked by default (new and seeded); the user opts
+ * each one in. Neither the Spiral-Dynamics stage nor the calendar `start_date`
+ * participates: nothing auto-unlocks over time, so a future or past start_date
+ * never changes the result. Re-locking flips `revealed` back to `false` while
+ * preserving the habit's logged completions.
  */
-export const isHabitUnlockedAtStage = (
-  habit: Habit,
-  index: number,
-  currentStage: number,
-): boolean => {
-  if (isEarlyUnlocked(habit)) return true;
-  const stageIndex = STAGE_ORDER.indexOf(habit.stage);
-  const threshold = stageIndex >= 0 ? stageIndex + 1 : index + 1;
-  return threshold <= currentStage;
-};
-
-/** Locked today iff unrevealed AND its calendar-anchored `start_date` is still in the future; once that date arrives the habit unlocks regardless of a stale `revealed` flag (which only gates manual early-unlock). */
-export const isHabitLockedToday = (habit: Habit, now: number = Date.now()): boolean => {
-  return habit.revealed === false && new Date(habit.start_date).getTime() > now;
-};
+export const isHabitUnlocked = (habit: Habit): boolean => habit.revealed === true;

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -205,7 +205,7 @@ export interface HabitsActions {
   iconPress: (_index: number) => void;
   emojiSelect: (_emoji: string) => void;
   revealAllHabits: () => void;
-  lockUnstartedHabits: () => void;
+  lockUntouchedHabits: () => void;
   unlockHabit: (_habitId: number) => void;
 }
 

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -20,6 +20,7 @@ import { STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
+import ConfirmDialog from './components/ConfirmDialog';
 import GoalModal from './components/GoalModal';
 import HabitEmojiPicker from './components/HabitEmojiPicker';
 import { HabitsEmptyState } from './components/HabitsEmptyState';
@@ -36,7 +37,7 @@ import {
   generateStatsForHabit,
   toLocalHabitStats,
   calculateMissedDays,
-  isHabitLockedToday,
+  isHabitUnlocked,
   stageAtIndex,
 } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
@@ -143,7 +144,15 @@ const OverflowMenuList = ({
   onToggleReveal,
 }: OverflowMenuListProps) => {
   const RevealIcon = allRevealed ? Lock : Unlock;
-  const revealLabel = allRevealed ? 'Lock Unstarted Habits' : 'Reveal All Habits';
+  // Locking re-locks only untouched habits; the toggle label reflects that
+  // it acts on unstarted habits. Unlocking-all is destructive enough (it
+  // bypasses every per-tile confirm) to warrant its own confirmation.
+  const revealLabel = allRevealed ? 'Lock Unstarted Habits' : 'Unlock All Habits';
+  const [showUnlockAllConfirm, setShowUnlockAllConfirm] = useState(false);
+  const handleRevealPress = () => {
+    if (allRevealed) onToggleReveal();
+    else setShowUnlockAllConfirm(true);
+  };
   return (
     <View testID="overflow-menu" style={[styles.mobileMenu, { top: spacing(4, scale), right: 0 }]}>
       {MENU_ITEMS.map((item) => (
@@ -159,8 +168,22 @@ const OverflowMenuList = ({
         key="reveal-toggle"
         icon={<RevealIcon size={spacing(2, scale)} style={iconMargin} />}
         label={revealLabel}
-        onPress={onToggleReveal}
+        onPress={handleRevealPress}
         scale={scale}
+      />
+      <ConfirmDialog
+        visible={showUnlockAllConfirm}
+        title="Unlock all habits?"
+        message="This opens every locked habit at once. You can always re-lock the ones you haven't started."
+        testID="unlock-all-confirm"
+        cancelTestID="unlock-all-cancel"
+        confirmTestID="unlock-all-confirm-button"
+        confirmLabel="Unlock All"
+        onCancel={() => setShowUnlockAllConfirm(false)}
+        onConfirm={() => {
+          setShowUnlockAllConfirm(false);
+          onToggleReveal();
+        }}
       />
     </View>
   );
@@ -539,8 +562,9 @@ const useHabitTileRenderer = (
   const { unlockHabit } = actions;
   const renderHabitTile = useCallback(
     ({ item, index }: { item: Habit; index: number }) => {
-      // Calendar-driven: unlocks when the anchored start_date arrives, not on the stale `revealed` flag — keeps Habits in lockstep with Map/Practice/Course.
-      const isLocked = isHabitLockedToday(item);
+      // Unlock is governed solely by the persisted ``revealed`` flag — locked by
+      // default, opened only when the user chooses. Stage/calendar never gate it.
+      const isLocked = !isHabitUnlocked(item);
       const globalIndex = pageOffset + index;
       // index is page-relative, so each page restarts the Beige → Clear Light gradient.
       const stageColor = STAGE_COLORS[stageAtIndex(index)]!;
@@ -611,10 +635,10 @@ const useToggleReveal = (
   actions: ReturnType<typeof useHabits>['actions'],
   closeAll: () => void,
 ) => {
-  const allRevealed = habits.every((h) => h.revealed !== false);
+  const allRevealed = habits.every(isHabitUnlocked);
   const handleToggleReveal = useCallback(() => {
     if (allRevealed) {
-      actions.lockUnstartedHabits();
+      actions.lockUntouchedHabits();
     } else {
       actions.revealAllHabits();
     }

--- a/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileLocked.test.tsx
@@ -100,7 +100,9 @@ describe('HabitTile locked state', () => {
     expect(hasStreakText).toBe(false);
   });
 
-  it('shows "Unlocks in X days" countdown for future start dates', () => {
+  it('never shows an "Unlocks in N days" countdown, even for a future start_date', () => {
+    // The calendar no longer drives unlock at all -- a day-count countdown
+    // would misleadingly imply this habit unlocks itself over time.
     const habit = makeHabit({ start_date: new Date('2026-04-13T00:00:00Z') });
 
     const component = renderer.create(
@@ -108,32 +110,20 @@ describe('HabitTile locked state', () => {
     );
 
     const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
-    expect(unlockLabel.props.children).toBe('Unlocks in 7 days');
+    expect(unlockLabel.props.children).not.toMatch(/Unlocks in \d+ day/);
   });
 
-  it('shows singular "day" for 1 day remaining', () => {
-    const habit = makeHabit({ start_date: new Date('2026-04-07T12:00:00Z') });
+  it('renders a locked tile for revealed: false even when start_date is in the PAST, with no countdown label and "Stage X · Locked" copy regardless of date', () => {
+    const future = makeHabit({ stage: 'Purple', start_date: new Date('2026-04-13T00:00:00Z') });
+    const past = makeHabit({ stage: 'Purple', start_date: new Date('2026-04-01T00:00:00Z') });
 
-    const component = renderer.create(
-      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
-    );
-
-    const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
-    expect(unlockLabel.props.children).toBe('Unlocks in 1 day');
-  });
-
-  it('shows "Stage X · Locked" when start date has passed', () => {
-    const habit = makeHabit({
-      stage: 'Purple',
-      start_date: new Date('2026-04-01T00:00:00Z'),
-    });
-
-    const component = renderer.create(
-      <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
-    );
-
-    const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
-    expect(unlockLabel.props.children).toBe('Stage Purple · Locked');
+    for (const habit of [future, past]) {
+      const component = renderer.create(
+        <HabitTile habit={habit} locked onOpenGoals={() => {}} onLongPress={() => {}} />,
+      );
+      const unlockLabel = component.root.findByProps({ testID: 'unlock-label' });
+      expect(unlockLabel.props.children).toBe('Stage Purple · Locked');
+    }
   });
 
   it('does not render progress bar for locked tiles', () => {

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -14,10 +14,8 @@ import {
   calculateTodaysProgress,
   getProgressBarColor,
   clampPercentage,
-  isEarlyUnlocked,
   isGoalAchieved,
-  isHabitLockedToday,
-  isHabitUnlockedAtStage,
+  isHabitUnlocked,
   isSubtractiveHabit,
   goalsAreSubtractive,
   logHabitUnits,
@@ -778,8 +776,8 @@ describe('calculateNetEnergy', () => {
   });
 });
 
-describe('isEarlyUnlocked', () => {
-  const earlyUnlockedBase = {
+describe('isHabitUnlocked', () => {
+  const base = {
     id: 1,
     name: 'H',
     icon: '\u{1F512}',
@@ -791,31 +789,49 @@ describe('isEarlyUnlocked', () => {
     completions: [],
   };
 
-  test('true when manually revealed ahead of its start_date', () => {
+  test('true when revealed is true, regardless of a future start_date', () => {
     const habit: Habit = {
-      ...earlyUnlockedBase,
+      ...base,
       revealed: true,
       start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
     };
-    expect(isEarlyUnlocked(habit)).toBe(true);
+    expect(isHabitUnlocked(habit)).toBe(true);
   });
 
-  test('false when the start_date has already passed', () => {
+  test('true when revealed is true, regardless of a past start_date', () => {
     const habit: Habit = {
-      ...earlyUnlockedBase,
+      ...base,
       revealed: true,
       start_date: new Date(Date.now() - 1000 * 60 * 60 * 24),
     };
-    expect(isEarlyUnlocked(habit)).toBe(false);
+    expect(isHabitUnlocked(habit)).toBe(true);
   });
 
-  test('false when not revealed, regardless of start_date', () => {
+  test('false when revealed is false, even with a past start_date', () => {
     const habit: Habit = {
-      ...earlyUnlockedBase,
+      ...base,
+      revealed: false,
+      start_date: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    };
+    expect(isHabitUnlocked(habit)).toBe(false);
+  });
+
+  test('false when revealed is false, regardless of a future start_date', () => {
+    const habit: Habit = {
+      ...base,
       revealed: false,
       start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
     };
-    expect(isEarlyUnlocked(habit)).toBe(false);
+    expect(isHabitUnlocked(habit)).toBe(false);
+  });
+
+  test('false when revealed is undefined', () => {
+    const habit: Habit = {
+      ...base,
+      revealed: undefined,
+      start_date: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    };
+    expect(isHabitUnlocked(habit)).toBe(false);
   });
 });
 
@@ -923,61 +939,7 @@ describe('getGoalTier subtractive total-failure branch', () => {
   });
 });
 
-describe('isHabitLockedToday', () => {
-  const NOW = new Date('2026-04-06T12:00:00Z').getTime();
-  const make = (overrides: Partial<Habit>): Habit =>
-    ({
-      id: 1,
-      name: 'H',
-      icon: '🔒',
-      stage: 'Purple',
-      streak: 0,
-      energy_cost: 0,
-      energy_return: 0,
-      start_date: new Date('2026-04-06T00:00:00Z'),
-      goals: [],
-      completions: [],
-      ...overrides,
-    }) as Habit;
-
-  test('locked when unrevealed and start_date is still in the future', () => {
-    const habit = make({ revealed: false, start_date: new Date('2026-05-01T00:00:00Z') });
-    expect(isHabitLockedToday(habit, NOW)).toBe(true);
-  });
-
-  test('unlocked once the calendar reaches its start_date, even if revealed is stale-false', () => {
-    // The Purple habit: start_date has passed but the server flag was never
-    // flipped. The calendar (start_date <= today) must win so the screen
-    // tracks the same stage the Map/Practice show.
-    const habit = make({ revealed: false, start_date: new Date('2026-04-01T00:00:00Z') });
-    expect(isHabitLockedToday(habit, NOW)).toBe(false);
-  });
-
-  test('unlocked when manually revealed ahead of its start_date', () => {
-    const habit = make({ revealed: true, start_date: new Date('2026-05-01T00:00:00Z') });
-    expect(isHabitLockedToday(habit, NOW)).toBe(false);
-  });
-
-  test('unrevealed (undefined) future habit is treated as unlocked, matching prior contract', () => {
-    const habit = make({ revealed: undefined, start_date: new Date('2026-05-01T00:00:00Z') });
-    expect(isHabitLockedToday(habit, NOW)).toBe(false);
-  });
-
-  test('accepts ISO string start dates (server payloads arrive unparsed)', () => {
-    // The API delivers ``start_date`` as an ISO string before it is mapped to
-    // a Date, so the helper must tolerate both. Cast through ``unknown`` since
-    // the Habit type declares the post-parse ``Date``.
-    const iso = (value: string) => value as unknown as Date;
-    expect(isHabitLockedToday(make({ revealed: false, start_date: iso('2999-01-01') }), NOW)).toBe(
-      true,
-    );
-    expect(isHabitLockedToday(make({ revealed: false, start_date: iso('2000-01-01') }), NOW)).toBe(
-      false,
-    );
-  });
-});
-
-describe('isHabitUnlockedAtStage', () => {
+describe('isHabitUnlocked (stage/calendar no longer participate)', () => {
   const make = (overrides: Partial<Habit>): Habit =>
     ({
       id: 1,
@@ -994,44 +956,36 @@ describe('isHabitUnlockedAtStage', () => {
       ...overrides,
     }) as Habit;
 
-  test('unlocked when the habit stage sits at or below currentStage', () => {
-    // Purple is the 2nd stage (STAGE_ORDER index 1 -> threshold 2).
-    const habit = make({ stage: 'Purple' });
-    expect(isHabitUnlockedAtStage(habit, 0, 2)).toBe(true);
+  test('a high-stage habit stays locked even with a past start_date, unless revealed', () => {
+    // Under the old stage/calendar model this Clear Light habit (10th stage)
+    // would have unlocked once its start_date passed. Now only `revealed`
+    // decides, so it stays locked.
+    const habit = make({ stage: 'Clear Light', start_date: new Date('2000-01-01T00:00:00Z') });
+    expect(isHabitUnlocked(habit)).toBe(false);
   });
 
-  test('locked when the habit stage sits above currentStage', () => {
-    // Red is the 3rd stage (threshold 3) and currentStage is 2.
-    const habit = make({ stage: 'Red' });
-    expect(isHabitUnlockedAtStage(habit, 0, 2)).toBe(false);
+  test('a Beige (first-stage) habit stays locked with revealed: false', () => {
+    const habit = make({ stage: 'Beige' });
+    expect(isHabitUnlocked(habit)).toBe(false);
   });
 
-  test('unlock follows the habit stage, not list position, after a reorder', () => {
-    // A Red habit dragged to the top of the list (index 0) stays locked at
-    // currentStage 2, while the lower-stage habits below it stay unlocked.
-    const red = make({ stage: 'Red' });
-    const beige = make({ stage: 'Beige' });
-    const purple = make({ stage: 'Purple' });
-    expect(isHabitUnlockedAtStage(red, 0, 2)).toBe(false);
-    expect(isHabitUnlockedAtStage(beige, 1, 2)).toBe(true);
-    expect(isHabitUnlockedAtStage(purple, 2, 2)).toBe(true);
-  });
-
-  test('unlocked regardless of stage when the habit is early-unlocked', () => {
+  test('unlocked once revealed: true, regardless of stage or start_date', () => {
     const habit = make({
       stage: 'Clear Light',
       revealed: true,
       start_date: new Date(Date.now() + 1000 * 60 * 60 * 24),
     });
-    expect(isHabitUnlockedAtStage(habit, 9, 1)).toBe(true);
+    expect(isHabitUnlocked(habit)).toBe(true);
   });
 
-  test('falls back to list position when the stage is unknown or missing', () => {
-    const habit = make({ stage: '' });
-    // index 0 -> threshold 1, unlocked at currentStage 1.
-    expect(isHabitUnlockedAtStage(habit, 0, 1)).toBe(true);
-    // index 3 -> threshold 4, locked at currentStage 3.
-    expect(isHabitUnlockedAtStage(habit, 3, 3)).toBe(false);
+  test('accepts ISO string start dates without affecting the result (server payloads arrive unparsed)', () => {
+    // The API delivers ``start_date`` as an ISO string before it is mapped to
+    // a Date, so the helper must tolerate both without letting the date value
+    // change the unlock outcome. Cast through ``unknown`` since the Habit type
+    // declares the post-parse ``Date``.
+    const iso = (value: string) => value as unknown as Date;
+    expect(isHabitUnlocked(make({ revealed: false, start_date: iso('2000-01-01') }))).toBe(false);
+    expect(isHabitUnlocked(make({ revealed: true, start_date: iso('2999-01-01') }))).toBe(true);
   });
 });
 

--- a/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
@@ -62,8 +62,9 @@ describe('HabitsScreen chrome accessibility', () => {
       for (const name of ['Quick Log', 'Stats', 'Edit', 'Add Habit', 'Energy Scaffolding']) {
         expect(getByRole('button', { name })).toBeTruthy();
       }
-      // The reveal toggle reflects the current allRevealed state in its label.
-      expect(getByRole('button', { name: 'Reveal All Habits' })).toBeTruthy();
+      // The reveal toggle reflects the current allRevealed state in its label
+      // (renamed from "Reveal All" to the plainer "Unlock All").
+      expect(getByRole('button', { name: 'Unlock All Habits' })).toBeTruthy();
     });
 
     it('switches the reveal-toggle label when all habits are revealed', () => {

--- a/frontend/src/features/Habits/__tests__/ManualUnlock.test.tsx
+++ b/frontend/src/features/Habits/__tests__/ManualUnlock.test.tsx
@@ -5,7 +5,6 @@ import renderer from 'react-test-renderer';
 
 import type { Habit } from '../Habits.types';
 import { HabitTile } from '../HabitTile';
-import { isEarlyUnlocked } from '../HabitUtils';
 
 const makeGoals = () => [
   {
@@ -61,54 +60,31 @@ const makeFutureHabit = (overrides: Partial<Habit> = {}): Habit => ({
   ...overrides,
 });
 
-describe('isEarlyUnlocked', () => {
-  it('returns true when revealed is true but start_date is in the future', () => {
-    const habit = makeFutureHabit({ revealed: true });
-    expect(isEarlyUnlocked(habit)).toBe(true);
-  });
-
-  it('returns false when revealed is true and start_date is in the past', () => {
-    const habit = makePastHabit({ revealed: true });
-    expect(isEarlyUnlocked(habit)).toBe(false);
-  });
-
-  it('returns false when revealed is false', () => {
-    const habit = makeFutureHabit({ revealed: false });
-    expect(isEarlyUnlocked(habit)).toBe(false);
-  });
-
-  it('returns false when revealed is undefined', () => {
-    const habit = makeFutureHabit({ revealed: undefined });
-    expect(isEarlyUnlocked(habit)).toBe(false);
-  });
-});
-
-describe('HabitTile early-unlock visual indicator', () => {
-  it('renders with dotted border when early unlocked', () => {
-    const habit = makeFutureHabit({ revealed: true });
-    const component = renderer.create(
-      <HabitTile habit={habit} onOpenGoals={() => {}} onLongPress={() => {}} />,
-    );
-    const tile = component.root.findByProps({ testID: 'habit-tile' });
-    expect(tile.props.style.borderStyle).toBe('dashed');
-  });
-
-  it('renders with solid border when naturally unlocked', () => {
-    const habit = makePastHabit({ revealed: true });
-    const component = renderer.create(
-      <HabitTile habit={habit} onOpenGoals={() => {}} onLongPress={() => {}} />,
-    );
-    const tile = component.root.findByProps({ testID: 'habit-tile' });
-    expect(tile.props.style.borderStyle).toBeUndefined();
+describe('HabitTile unlocked visual style (no early/natural distinction)', () => {
+  // The old model drew a dashed border for a "manually early-unlocked"
+  // habit (revealed ahead of its calendar start_date) versus a solid border
+  // for one "naturally" reached by the calendar. Since the calendar no
+  // longer participates in unlock at all, every revealed habit is unlocked
+  // the same way — there is nothing left to distinguish visually.
+  it('renders with a solid border for any revealed habit, regardless of start_date', () => {
+    const future = makeFutureHabit({ revealed: true });
+    const past = makePastHabit({ revealed: true });
+    for (const habit of [future, past]) {
+      const component = renderer.create(
+        <HabitTile habit={habit} onOpenGoals={() => {}} onLongPress={() => {}} />,
+      );
+      const tile = component.root.findByProps({ testID: 'habit-tile' });
+      expect(tile.props.style.borderStyle).toBeUndefined();
+    }
   });
 });
 
 describe('HabitTile locked tile long-press', () => {
   // ConfirmDialog (#786) replaces Alert.alert, which is a no-op on RN Web mobile.
-  const mentionsHabit = (component: ReturnType<typeof renderer.create>, name: string): boolean =>
+  const mentionsText = (component: ReturnType<typeof renderer.create>, text: string): boolean =>
     component.root.findAll(
       (n: { props: { children?: unknown } }) =>
-        typeof n.props.children === 'string' && n.props.children.includes(name),
+        typeof n.props.children === 'string' && n.props.children.includes(text),
     ).length > 0;
 
   it('shows unlock confirmation on long-press of a locked (unrevealed) tile', () => {
@@ -124,12 +100,14 @@ describe('HabitTile locked tile long-press', () => {
     // The rendered dialog appears (not a silently-dropped Alert) and names the habit.
     expect(component.root.findByProps({ testID: 'unlock-habit-confirm' })).toBeTruthy();
     expect(component.root.findByProps({ testID: 'unlock-habit-confirm-button' })).toBeTruthy();
-    expect(mentionsHabit(component, 'Future Habit')).toBe(true);
+    expect(mentionsText(component, 'Future Habit')).toBe(true);
   });
 
-  it('calls onUnlockHabit when unlock is confirmed', () => {
+  it('confirms unlock with non-"early" copy for a habit whose stage sits far ahead of any current stage', () => {
     const onUnlockHabit = jest.fn();
-    const habit = makeFutureHabit({ revealed: false });
+    // A Clear Light (final-stage) habit unlocking out of order — the calendar
+    // and stage gates are both gone, so nothing blocks the manual unlock.
+    const habit = makeFutureHabit({ revealed: false, stage: 'Clear Light' });
     const component = renderer.create(
       <HabitTile habit={habit} locked onUnlockHabit={onUnlockHabit} />,
     );
@@ -137,6 +115,12 @@ describe('HabitTile locked tile long-press', () => {
     renderer.act(() => {
       tile.props.onLongPress();
     });
+    // New tone: a plain "Unlock \"<name>\"?" question, no "early" framing and
+    // no mention of a "recommended start date" (the calendar no longer unlocks).
+    expect(mentionsText(component, `Unlock "${habit.name}"?`)).toBe(true);
+    expect(mentionsText(component, 'Early')).toBe(false);
+    expect(mentionsText(component, 'recommended start date')).toBe(false);
+
     const confirmButton = component.root.findByProps({ testID: 'unlock-habit-confirm-button' });
     renderer.act(() => {
       confirmButton.props.onPress();
@@ -159,7 +143,7 @@ describe('HabitTile locked tile long-press', () => {
   });
 });
 
-describe('Reveal All / Lock Unstarted actions', () => {
+describe('Reveal All / Lock Untouched actions', () => {
   it('revealAllHabits sets all habits to revealed: true', () => {
     const habits: Habit[] = [
       makePastHabit({ id: 1, revealed: true }),
@@ -170,19 +154,21 @@ describe('Reveal All / Lock Unstarted actions', () => {
     expect(result.every((h) => h.revealed)).toBe(true);
   });
 
-  it('lockUnstartedHabits resets future habits to revealed: false', () => {
-    const now = Date.now();
-    const habits: Habit[] = [
-      makePastHabit({ id: 1, revealed: true }),
-      makeFutureHabit({ id: 2, revealed: true }),
-      makeFutureHabit({ id: 3, revealed: true }),
-    ];
+  it('lockUntouchedHabits re-locks only habits with zero completions, regardless of start_date', () => {
+    const untouchedPast = makePastHabit({ id: 1, revealed: true, completions: [] });
+    const touchedFuture = makeFutureHabit({
+      id: 2,
+      revealed: true,
+      completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+    });
+    const untouchedFuture = makeFutureHabit({ id: 3, revealed: true, completions: [] });
+    const habits: Habit[] = [untouchedPast, touchedFuture, untouchedFuture];
     const result = habits.map((h) => ({
       ...h,
-      revealed: new Date(h.start_date).getTime() <= now,
+      revealed: (h.completions?.length ?? 0) > 0,
     }));
-    expect(result[0]?.revealed).toBe(true);
-    expect(result[1]?.revealed).toBe(false);
+    expect(result[0]?.revealed).toBe(false);
+    expect(result[1]?.revealed).toBe(true);
     expect(result[2]?.revealed).toBe(false);
   });
 });

--- a/frontend/src/features/Habits/__tests__/UnlockAll.test.tsx
+++ b/frontend/src/features/Habits/__tests__/UnlockAll.test.tsx
@@ -1,0 +1,104 @@
+// Unlocking every habit at once is destructive enough (it bypasses every
+// individual long-press confirm) that it needs its own confirmation dialog
+// before the toggle action fires — distinct from the per-habit unlock
+// confirm on a locked tile.
+//
+// Mirrors the isolated-component convention in HabitsScreenA11y.test.tsx:
+// render OverflowMenu directly with explicit props rather than mounting the
+// whole screen + API layer.
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'token' })),
+}));
+jest.mock('../components/AddHabitModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/GoalModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/HabitSettingsModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/MissedDaysModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/OnboardingModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/ReorderHabitsModal', () => ({ __esModule: true, default: () => null }));
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: () => null }));
+
+import { OverflowMenu } from '../HabitsScreen';
+
+const noop = (..._args: unknown[]): void => {};
+
+const baseProps = {
+  scale: 1,
+  onToggle: noop,
+  onSelectMode: noop,
+  onOpenOnboarding: noop,
+  onOpenAddHabit: noop,
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('OverflowMenu unlock-all confirm flow', () => {
+  it('labels the toggle "Unlock All Habits" (not "Reveal All Habits") when nothing is unlocked', () => {
+    const { getByRole } = render(
+      <OverflowMenu {...baseProps} menuVisible allRevealed={false} onToggleReveal={jest.fn()} />,
+    );
+    expect(getByRole('button', { name: 'Unlock All Habits' })).toBeTruthy();
+  });
+
+  it('pressing "Unlock All Habits" opens a confirm dialog instead of firing the toggle immediately', () => {
+    const onToggleReveal = jest.fn();
+    const { getByRole, getByTestId } = render(
+      <OverflowMenu
+        {...baseProps}
+        menuVisible
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+      />,
+    );
+
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+
+    expect(getByTestId('unlock-all-confirm')).toBeTruthy();
+    expect(getByTestId('unlock-all-confirm-button')).toBeTruthy();
+    expect(onToggleReveal).not.toHaveBeenCalled();
+  });
+
+  it('confirming the dialog invokes the unlock-all action exactly once', () => {
+    const onToggleReveal = jest.fn();
+    const { getByRole, getByTestId } = render(
+      <OverflowMenu
+        {...baseProps}
+        menuVisible
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+      />,
+    );
+
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+    fireEvent.press(getByTestId('unlock-all-confirm-button'));
+
+    expect(onToggleReveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelling does NOT invoke the unlock-all action', () => {
+    const onToggleReveal = jest.fn();
+    const { getByRole, getByTestId, queryByTestId } = render(
+      <OverflowMenu
+        {...baseProps}
+        menuVisible
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+      />,
+    );
+
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+    fireEvent.press(getByTestId('unlock-all-cancel'));
+
+    expect(onToggleReveal).not.toHaveBeenCalled();
+    expect(queryByTestId('unlock-all-confirm')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/__tests__/habitCounts.test.ts
+++ b/frontend/src/features/Habits/__tests__/habitCounts.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { jest, afterEach, describe, it, expect } from '@jest/globals';
 
-import { countDoneToday, unlockedAtStage } from '../habitCounts';
+import { countDoneToday, unlockedHabits } from '../habitCounts';
 import type { Habit } from '../Habits.types';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -64,65 +64,44 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe('unlockedAtStage', () => {
-  it('returns only the first-stage habit at stage 1', () => {
-    const habit0 = makeHabit({ id: 10, stage: 'Beige' });
-    const habit1 = makeHabit({ id: 11, stage: 'Purple' });
-    expect(unlockedAtStage([habit0, habit1], 1)).toEqual([habit0]);
+describe('unlockedHabits', () => {
+  it('returns only the revealed habit out of two', () => {
+    const habit0 = makeHabit({ id: 10, revealed: true });
+    const habit1 = makeHabit({ id: 11, revealed: false });
+    expect(unlockedHabits([habit0, habit1])).toEqual([habit0]);
   });
 
-  it('returns the first three stages at stage 3 regardless of revealed/start_date', () => {
-    const habits = [
-      makeHabit({
-        id: 20,
-        stage: 'Beige',
-        revealed: false,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 21,
-        stage: 'Purple',
-        revealed: false,
-        start_date: new Date(Date.now() + 7 * DAY_MS),
-      }),
-      makeHabit({ id: 22, stage: 'Red' }),
-    ];
-    expect(unlockedAtStage(habits, 3)).toEqual(habits);
+  it('returns only the middle habit for an out-of-order revealed set', () => {
+    const habit0 = makeHabit({ id: 20, revealed: false });
+    const habit1 = makeHabit({ id: 21, revealed: true });
+    const habit2 = makeHabit({ id: 22, revealed: false });
+    expect(unlockedHabits([habit0, habit1, habit2])).toEqual([habit1]);
   });
 
-  it('excludes a habit whose stage is above currentStage even with a past start_date', () => {
+  it('ignores stage and start_date entirely — only revealed matters', () => {
     const habits = [
-      makeHabit({ id: 30, stage: 'Beige' }),
-      makeHabit({ id: 31, stage: 'Purple' }),
-      makeHabit({ id: 32, stage: 'Red' }),
-      makeHabit({ id: 33, stage: 'Blue' }),
-      makeHabit({ id: 34, stage: 'Orange' }),
       makeHabit({
-        id: 35,
-        stage: 'Green',
-        revealed: false,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-    ];
-    const result = unlockedAtStage(habits, 3);
-    expect(result).toEqual(habits.slice(0, 3));
-    expect(result).not.toContain(habits[5]);
-  });
-
-  it('includes an early-unlocked habit whose stage is at or above currentStage', () => {
-    const habits = [
-      makeHabit({ id: 40, stage: 'Beige' }),
-      makeHabit({
-        id: 41,
-        stage: 'Purple',
+        id: 30,
+        stage: 'Clear Light',
         revealed: true,
         start_date: new Date(Date.now() + 7 * DAY_MS),
       }),
+      makeHabit({
+        id: 31,
+        stage: 'Beige',
+        revealed: false,
+        start_date: new Date('2000-01-01T00:00:00Z'),
+      }),
     ];
-    expect(unlockedAtStage(habits, 1)).toEqual(habits);
+    expect(unlockedHabits(habits)).toEqual([habits[0]]);
+  });
+
+  it('returns an empty array when no habit is revealed', () => {
+    const habits = [makeHabit({ id: 40, revealed: false }), makeHabit({ id: 41, revealed: false })];
+    expect(unlockedHabits(habits)).toEqual([]);
   });
 
   it('returns an empty array for an empty habit list', () => {
-    expect(unlockedAtStage([], 3)).toEqual([]);
+    expect(unlockedHabits([])).toEqual([]);
   });
 });

--- a/frontend/src/features/Habits/habitCounts.ts
+++ b/frontend/src/features/Habits/habitCounts.ts
@@ -4,7 +4,7 @@
  * list they already subscribe to, rather than reading an imperative snapshot.
  */
 import type { Habit } from '@/features/Habits/Habits.types';
-import { isHabitUnlockedAtStage } from '@/features/Habits/HabitUtils';
+import { isHabitUnlocked } from '@/features/Habits/HabitUtils';
 import { DEFAULT_TIMEZONE, dayKeyInTZ } from '@/utils/dateUtils';
 
 /**
@@ -25,11 +25,11 @@ export function countDoneToday(habits: readonly Habit[], tz: string = DEFAULT_TI
 }
 
 /**
- * The subset of habits unlocked at the user's current stage — a habit unlocks
- * once `currentStage` reaches its own Spiral-Dynamics stage (list position is
- * only a fallback for stage-less habits), plus any habit manually revealed
- * ahead of its start_date. See {@link isHabitUnlockedAtStage}.
+ * The subset of unlocked habits — those the user has revealed. Unlock is
+ * governed solely by `revealed` (see {@link isHabitUnlocked}); neither the
+ * Spiral-Dynamics stage nor the calendar `start_date` participates, so no
+ * current-stage argument is needed.
  */
-export function unlockedAtStage(habits: readonly Habit[], currentStage: number): Habit[] {
-  return habits.filter((h, i) => isHabitUnlockedAtStage(h, i, currentStage));
+export function unlockedHabits(habits: readonly Habit[]): Habit[] {
+  return habits.filter((h) => isHabitUnlocked(h));
 }

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -169,7 +169,7 @@ export const useHabitActions = (
       iconPress,
       emojiSelect,
       revealAllHabits: habitManager.revealAllHabits,
-      lockUnstartedHabits: habitManager.lockUnstartedHabits,
+      lockUntouchedHabits: habitManager.lockUntouchedHabits,
       unlockHabit: habitManager.unlockHabit,
     }),
     [logUnit, iconPress, emojiSelect, onboardingSave, tz],

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -142,6 +142,45 @@ describe('habitManager', () => {
       expect(useHabitStore.getState().habits.length).toBeGreaterThan(0);
     });
 
+    it('FALLBACK_HABITS (offline demo seed) stay unlocked so the degraded state is interactable', async () => {
+      // The locked-by-default rule targets real onboarding-seeded and
+      // user-created habits. FALLBACK_HABITS is a placeholder demo shown only
+      // when the server is unreachable and no cache exists; locking it would
+      // render every tile behind the padlock during an outage, with no real
+      // data to unlock. It stays revealed so the offline demo remains usable.
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([] as never);
+
+      await habitManager.loadHabits();
+
+      const habits = useHabitStore.getState().habits;
+      expect(habits.length).toBeGreaterThan(0);
+      expect(habits.every((h) => h.revealed === true)).toBe(true);
+    });
+
+    it('mapApiHabits reads the revealed flag from the API response instead of hardcoding true', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 5,
+          name: 'Stretch',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          revealed: false,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits[0]!.revealed).toBe(false);
+    });
+
     it('does NOT seed FALLBACK_HABITS when the live store already has habits', async () => {
       // Cache empty + API empty + live store has habits → leave them alone.
       const userBuilt: Habit[] = [makeHabit({ id: 1, name: 'My Habit' })];
@@ -1051,6 +1090,18 @@ describe('habitManager', () => {
 
       expect(habitsApi.update).not.toHaveBeenCalled();
     });
+
+    it('includes the revealed flag in the PUT payload so the lock state round-trips', () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, revealed: true })] });
+      const updated = { ...makeHabit(), revealed: false };
+
+      habitManager.updateHabit(updated);
+
+      expect(habitsApi.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ revealed: false }),
+      );
+    });
   });
 
   describe('deleteHabit', () => {
@@ -1092,6 +1143,22 @@ describe('habitManager', () => {
       await habitManager.addHabit({ name: 'First', icon: '1️⃣' });
       const { habits } = useHabitStore.getState();
       expect(habits[habits.length - 1]!.stage).toBe('Beige');
+    });
+
+    it('buildAddedHabit defaults the new habit to locked', () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, name: 'Existing' })] });
+      let resolveCreate: (() => void) | undefined;
+      (habitsApi.create as jest.Mock).mockImplementationOnce(
+        () => new Promise<unknown>((r) => (resolveCreate = () => r({}))),
+      );
+
+      const inFlight = habitManager.addHabit({ name: 'Brand New', icon: '🆕' });
+
+      const optimistic = useHabitStore.getState().habits;
+      expect(optimistic[1]!.revealed).toBe(false);
+
+      resolveCreate?.();
+      return inFlight;
     });
 
     it('posts the new habit to the server and reloads to pick up server ids', async () => {
@@ -1418,6 +1485,34 @@ describe('habitManager', () => {
       expect(showToast).toHaveBeenCalled();
     });
 
+    it('buildOnboardingHabits defaults every habit to locked, regardless of stage', async () => {
+      const newHabits: OnboardingHabit[] = [
+        {
+          id: 'a',
+          name: 'Meditate',
+          icon: '\u{1F9D8}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Beige',
+          start_date: new Date('2025-01-01'),
+        },
+        {
+          id: 'b',
+          name: 'Journal',
+          icon: '\u{1F4D3}',
+          energy_cost: 1,
+          energy_return: 3,
+          stage: 'Purple',
+          start_date: new Date('2025-01-22'),
+        },
+      ];
+
+      await habitManager.onboardingSave(newHabits, jest.fn());
+
+      const habits = useHabitStore.getState().habits;
+      expect(habits.every((h) => h.revealed === false)).toBe(true);
+    });
+
     it('anchors the universal program calendar to the earliest habit start date', async () => {
       useProgramStore.getState().hydrateProgramStartDate(null);
       const newHabits: OnboardingHabit[] = [
@@ -1527,34 +1622,72 @@ describe('habitManager', () => {
   });
 
   describe('reveal helpers', () => {
-    it('revealAllHabits flips every habit to revealed=true', () => {
+    it('revealAllHabits flips every habit to revealed=true and PUTs each to the API', async () => {
       useHabitStore.setState({
         habits: [makeHabit({ id: 1, revealed: false }), makeHabit({ id: 2, revealed: false })],
       });
 
       habitManager.revealAllHabits();
+      await Promise.resolve();
 
       expect(useHabitStore.getState().habits.every((h) => h.revealed === true)).toBe(true);
+      expect(habitsApi.update).toHaveBeenCalledWith(1, expect.objectContaining({ revealed: true }));
+      expect(habitsApi.update).toHaveBeenCalledWith(2, expect.objectContaining({ revealed: true }));
     });
 
-    it('lockUnstartedHabits reveals only habits whose start_date is in the past', () => {
-      const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
-      const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    it('revealAllHabits rolls every habit back to its pre-unlock state when a PUT rejects', async () => {
+      useHabitStore.setState({
+        habits: [makeHabit({ id: 1, revealed: false }), makeHabit({ id: 2, revealed: false })],
+      });
+      (habitsApi.update as jest.Mock).mockRejectedValueOnce(new Error('offline') as never);
+
+      habitManager.revealAllHabits();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const habits = useHabitStore.getState().habits;
+      expect(habits.every((h) => h.revealed === false)).toBe(true);
+    });
+
+    it('lockUntouchedHabits re-locks only habits with zero logged completions', () => {
       useHabitStore.setState({
         habits: [
-          makeHabit({ id: 1, start_date: past, revealed: true }),
-          makeHabit({ id: 2, start_date: future, revealed: true }),
+          makeHabit({ id: 1, revealed: true, completions: [] }),
+          makeHabit({
+            id: 2,
+            revealed: true,
+            completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+          }),
         ],
       });
 
-      habitManager.lockUnstartedHabits();
+      habitManager.lockUntouchedHabits();
 
       const habits = useHabitStore.getState().habits;
-      expect(habits[0]!.revealed).toBe(true);
-      expect(habits[1]!.revealed).toBe(false);
+      expect(habits[0]!.revealed).toBe(false);
+      expect(habits[1]!.revealed).toBe(true);
     });
 
-    it('unlockHabit reveals a single habit by id', () => {
+    it('lockUntouchedHabits leaves a zero-completion habit locked even with a past start_date', () => {
+      // The old ``lockUnstartedHabits`` kept a past-start_date habit revealed;
+      // the new re-lock affordance keys ONLY off completions, so a
+      // never-touched habit re-locks regardless of its calendar date.
+      useHabitStore.setState({
+        habits: [
+          makeHabit({
+            id: 1,
+            revealed: true,
+            start_date: new Date(Date.now() - 1000 * 60 * 60 * 24),
+            completions: [],
+          }),
+        ],
+      });
+
+      habitManager.lockUntouchedHabits();
+
+      expect(useHabitStore.getState().habits[0]!.revealed).toBe(false);
+    });
+
+    it('unlockHabit reveals a single habit by id and PUTs it to the API', () => {
       useHabitStore.setState({
         habits: [makeHabit({ id: 1, revealed: false }), makeHabit({ id: 2, revealed: false })],
       });
@@ -1564,6 +1697,18 @@ describe('habitManager', () => {
       const habits = useHabitStore.getState().habits;
       expect(habits[0]!.revealed).toBe(true);
       expect(habits[1]!.revealed).toBe(false);
+      expect(habitsApi.update).toHaveBeenCalledWith(1, expect.objectContaining({ revealed: true }));
+    });
+
+    it('unlockHabit rolls the store back when the API rejects', async () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, revealed: false })] });
+      (habitsApi.update as jest.Mock).mockRejectedValueOnce(new Error('offline') as never);
+
+      habitManager.unlockHabit(1);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(useHabitStore.getState().habits[0]!.revealed).toBe(false);
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -49,6 +49,10 @@ import { updateHabitNotifications, cancelForHabit } from '../hooks/useHabitNotif
 
 export type ShowToast = (_config: ToastConfig) => void;
 
+// The offline/demo seed is shown only when the server is unreachable and no
+// cache exists. Unlike server-seeded habits (locked by default), these demo
+// tiles stay revealed so the offline experience is explorable rather than a
+// wall of locked tiles.
 const FALLBACK_HABITS: Habit[] = HABIT_DEFAULTS.map((habit) => ({
   ...habit,
   revealed: true,
@@ -102,6 +106,9 @@ const toApiPayload = (h: Habit): HabitCreatePayload => ({
   // insertion order with the original onboarding stage label.
   sort_order: h.sort_order ?? null,
   stage: h.stage,
+  // ``revealed`` is the persisted unlock flag; default locked when absent so a
+  // client that never set it does not accidentally unlock the row server-side.
+  revealed: h.revealed ?? false,
 });
 
 const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.listAll>>): Habit[] =>
@@ -128,7 +135,9 @@ const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.listAll>>):
     })),
     // Shared with ``toLocalHabit`` -- single-source dedupe + Date rehydration.
     completions: flattenGoalCompletions(h.goals ?? []),
-    revealed: true,
+    // The server owns the unlock flag now; mirror it instead of forcing every
+    // fetched habit unlocked (which would defeat locked-by-default).
+    revealed: h.revealed,
     notificationTimes: h.notification_times ?? undefined,
     notificationFrequency:
       (h.notification_frequency as Habit['notificationFrequency']) ?? undefined,
@@ -262,7 +271,7 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
     ...habit,
     id: index + 1,
     streak: 0,
-    revealed: habit.stage === 'Beige',
+    revealed: false,
     completions: [] as Habit['completions'],
     goals: GOAL_TIERS.map((t, ti) => ({
       id: index * 3 + ti + 1,
@@ -299,7 +308,7 @@ const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => 
       target: t.target,
     })),
     completions: [],
-    revealed: true,
+    revealed: false,
     sort_order: existingCount,
   };
 };
@@ -663,6 +672,31 @@ const revertOnFailure = (prev: Habit[], fallback: string): ((err: unknown) => vo
     void persistHabits(prev);
     Alert.alert("Couldn't sync", formatApiError(err, { fallback }));
   };
+};
+
+/**
+ * Optimistically apply a new unlock (``revealed``) state and PUT each affected
+ * row to the API. Shared by the bulk reveal/re-lock affordances and the
+ * single-habit unlock so all three persist the flag server-side rather than
+ * only in the store. Fans the PUTs out via ``Promise.all`` so a single
+ * rejection triggers one deterministic rollback to ``prev`` (mirrors
+ * ``saveHabitOrder``), restoring both the store and the on-disk snapshot.
+ */
+const syncRevealState = (next: Habit[], failureMessage: string): void => {
+  const prev = getHabits();
+  const revealedBefore = new Map(prev.map((h) => [h.id, h.revealed]));
+  setHabits(next);
+  void persistHabits(next);
+  const updates: Array<Promise<unknown>> = [];
+  for (const habit of next) {
+    if (habit.id == null) continue;
+    // Only PUT rows whose unlock flag actually flipped, so a single unlock
+    // does not rewrite every untouched row.
+    if (habit.revealed === revealedBefore.get(habit.id)) continue;
+    updates.push(habitsApi.update(habit.id, toApiPayload(habit)));
+  }
+  if (updates.length === 0) return;
+  Promise.all(updates).catch(revertOnFailure(prev, failureMessage));
 };
 
 /**
@@ -1065,24 +1099,36 @@ export const habitManager = {
 
   revealAllHabits: (): void => {
     const next = getHabits().map((h) => ({ ...h, revealed: true }));
-    setHabits(next);
-    void persistHabits(next);
+    syncRevealState(
+      next,
+      "We couldn't unlock every habit. Your previous state was restored — check your connection and try again.",
+    );
   },
 
-  lockUnstartedHabits: (): void => {
-    const now = Date.now();
+  /**
+   * Re-lock affordance: flips every UNTOUCHED habit (zero logged completions)
+   * back to locked, leaving any habit the user has already logged against
+   * unlocked. Re-locking is an allowed, declinable bulk action; it only hides
+   * the tile — the underlying completions are preserved, so unlocking again
+   * restores full history. Keys strictly off completions, never the calendar.
+   */
+  lockUntouchedHabits: (): void => {
     const next = getHabits().map((h) => ({
       ...h,
-      revealed: new Date(h.start_date).getTime() <= now,
+      revealed: (h.completions?.length ?? 0) > 0,
     }));
-    setHabits(next);
-    void persistHabits(next);
+    syncRevealState(
+      next,
+      "We couldn't re-lock those habits. Your previous state was restored — check your connection and try again.",
+    );
   },
 
   unlockHabit: (habitId: number): void => {
     const next = getHabits().map((h) => (h.id === habitId ? { ...h, revealed: true } : h));
-    setHabits(next);
-    void persistHabits(next);
+    syncRevealState(
+      next,
+      "We couldn't unlock that habit. Your previous state was restored — check your connection and try again.",
+    );
   },
 
   /**

--- a/frontend/src/features/Journal/HabitsStatTile.tsx
+++ b/frontend/src/features/Journal/HabitsStatTile.tsx
@@ -10,31 +10,16 @@ import React, { useEffect } from 'react';
 import StatTile from './StatTile';
 
 import { useAuth } from '@/context/AuthContext';
-import { countDoneToday, unlockedAtStage } from '@/features/Habits/habitCounts';
+import { countDoneToday, unlockedHabits } from '@/features/Habits/habitCounts';
 import { habitManager } from '@/features/Habits/services/habitManager';
-import { stageService } from '@/features/Map/services/stageService';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { useHabitStore } from '@/store/useHabitStore';
-import {
-  selectCurrentStage,
-  selectStages,
-  selectStagesError,
-  selectStagesLoading,
-  useStageStore,
-} from '@/store/useStageStore';
 
 type HabitsTileNav = BottomTabNavigationProp<RootTabParamList>;
 
 const TITLE = "Today's habits";
 const OPEN_CUE = 'Open habits →';
 const ADD_CUE = 'Add a habit →';
-
-/**
- * Stage to assume when stage loading has failed and left the store empty: one
- * habit is always unlocked, so falling back to 1 (rather than a possibly-stale
- * store value) keeps the denominator conservative.
- */
-const FALLBACK_STAGE = 1;
 
 interface HabitsDescriptor {
   loading: boolean;
@@ -45,9 +30,9 @@ interface HabitsDescriptor {
 
 /**
  * Resolve the tile's stat line, cue, loading flag, and a11y label from plain
- * counts. `loading` is the caller's precomputed "show skeleton" flag (habits or
- * stages still resolving) — not the raw habit-store `loading` — so this stays
- * pure and flat.
+ * counts. `loading` is the caller's precomputed "show skeleton" flag (habits
+ * still resolving) — not the raw habit-store `loading` — so this stays pure and
+ * flat.
  */
 export function describeHabits(
   loading: boolean,
@@ -67,13 +52,13 @@ export function describeHabits(
     };
   }
   if (unlockedCount === 0) {
-    // Defensive: the current stage always floors at 1, so the first habit is
-    // unlocked whenever any exist. Kept as a guard for a zero-unlocked corpus.
+    // Habits are locked by default now; with a corpus but nothing unlocked,
+    // invite the user to open one rather than implying a timed auto-unlock.
     return {
       loading: false,
-      stat: 'Unlocks soon',
+      stat: 'Unlock a habit to begin',
       cue: OPEN_CUE,
-      accessibilityLabel: `${TITLE}, unlocks soon. Open habits`,
+      accessibilityLabel: `${TITLE}, unlock a habit to begin. Open habits`,
     };
   }
   return {
@@ -89,30 +74,15 @@ const HabitsStatTile = (): React.JSX.Element => {
   const { userTimezone } = useAuth();
   const habitsLoading = useHabitStore((state) => state.loading);
   const habits = useHabitStore((state) => state.habits);
-  const currentStage = useStageStore(selectCurrentStage);
-  const stages = useStageStore(selectStages);
-  const stagesLoading = useStageStore(selectStagesLoading);
-  const stagesError = useStageStore(selectStagesError);
 
   useEffect(() => {
     void habitManager.loadHabits(userTimezone);
   }, [userTimezone]);
 
-  useEffect(() => {
-    if (stages.length === 0) void stageService.loadStages();
-  }, [stages.length]);
-
-  // Stages have not resolved yet — either nothing has errored, or a (re)load is
-  // in flight. Hold the skeleton so the tile never flashes a denominator
-  // computed against an empty stage list.
-  const stagesPending = stages.length === 0 && (stagesError === null || stagesLoading);
-  // A failed load leaves stages empty; trust the always-unlocked floor rather
-  // than a possibly-stale store `currentStage`.
-  const stagesFailed = stagesError !== null && stages.length === 0;
-  const effectiveStage = stagesFailed ? FALLBACK_STAGE : currentStage;
-
-  const unlocked = unlockedAtStage(habits, effectiveStage);
-  const showSkeleton = (habitsLoading && habits.length === 0) || stagesPending;
+  // Unlock is governed solely by the persisted ``revealed`` flag, so the
+  // denominator no longer depends on the user's current stage.
+  const unlocked = unlockedHabits(habits);
+  const showSkeleton = habitsLoading && habits.length === 0;
   const descriptor = describeHabits(
     showSkeleton,
     habits.length,

--- a/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
+++ b/frontend/src/features/Journal/__tests__/HabitsStatTile.test.tsx
@@ -33,8 +33,6 @@ import type { StageData } from '@/features/Map/stageData';
 import { useHabitStore } from '@/store/useHabitStore';
 import { useStageStore } from '@/store/useStageStore';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
 const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   id: 1,
   stage: 'Beige',
@@ -49,10 +47,6 @@ const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
   revealed: true,
   ...overrides,
 });
-
-// Ascending Spiral-Dynamics stages so each habit's own stage (not its list
-// position) drives its unlock threshold — see isHabitUnlockedAtStage.
-const STAGES = ['Beige', 'Purple', 'Red', 'Blue', 'Orange', 'Green', 'Yellow'] as const;
 
 const makeStage = (stageNumber: number): StageData => ({
   id: stageNumber,
@@ -83,6 +77,9 @@ beforeEach(() => {
     habitOrder: [],
     error: null,
   });
+  // Seeded so the (currently still present) stage-store gate never blocks
+  // these tests on its own skeleton — the denominator itself must not
+  // depend on this value.
   useStageStore.setState({
     stages: [makeStage(1), makeStage(2), makeStage(3)],
     currentStage: 3,
@@ -122,38 +119,14 @@ describe('HabitsStatTile', () => {
     expect(mockLoadHabits).toHaveBeenCalledWith('UTC');
   });
 
-  it('anchors the denominator to currentStage, not the raw habit count', () => {
-    const habits = Array.from({ length: 7 }, (_, i) =>
-      makeHabit({
-        id: 100 + i,
-        stage: STAGES[i],
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-    );
-    useHabitStore.setState({ loading: false, habits });
-    useStageStore.setState({ currentStage: 3 });
-    const { getByText } = render(<HabitsStatTile />);
-    expect(getByText('0/3 done')).toBeTruthy();
-  });
-
-  it('shows "0/1 done" at stage 1 Beige with a single habit', () => {
+  it('counts a manually-unlocked habit toward the denominator regardless of its stage', () => {
+    // Blue is well above currentStage 1 -- under the old stage-gated model
+    // this habit would stay excluded from the denominator. Under the new
+    // model only `revealed` decides, so it counts.
     const habits = [
       makeHabit({
-        id: 200,
-        stage: 'Beige',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 201,
-        stage: 'Purple',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 202,
-        stage: 'Red',
+        id: 500,
+        stage: 'Blue',
         revealed: true,
         start_date: new Date('2020-01-01T00:00:00Z'),
       }),
@@ -164,146 +137,60 @@ describe('HabitsStatTile', () => {
     expect(getByText('0/1 done')).toBeTruthy();
   });
 
-  it('shows "1/1 done" at stage 1 once the first habit is completed today', () => {
+  it('excludes a locked (revealed: false) habit from the denominator even at a low stage', () => {
+    // Beige is the very first stage -- under the old stage-gated model this
+    // habit would already count regardless of `revealed`. The new model
+    // requires an explicit manual unlock.
     const habits = [
       makeHabit({
-        id: 210,
+        id: 501,
         stage: 'Beige',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
-      }),
-      makeHabit({
-        id: 211,
-        stage: 'Purple',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 212,
-        stage: 'Red',
-        revealed: true,
+        revealed: false,
         start_date: new Date('2020-01-01T00:00:00Z'),
       }),
     ];
     useHabitStore.setState({ loading: false, habits });
-    useStageStore.setState({ currentStage: 1 });
+    useStageStore.setState({ currentStage: 5 });
+    const { queryByText } = render(<HabitsStatTile />);
+    expect(queryByText(/\/1 done/)).toBeNull();
+  });
+
+  it('counts done-today progress only against manually-unlocked habits', () => {
+    const habits = [
+      makeHabit({
+        id: 510,
+        stage: 'Beige',
+        revealed: true,
+        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+      }),
+      makeHabit({ id: 511, stage: 'Purple', revealed: false }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
     const { getByText } = render(<HabitsStatTile />);
     expect(getByText('1/1 done')).toBeTruthy();
   });
 
-  it('never counts a locked habit with a past start_date toward the denominator', () => {
+  it('shows a manual-unlock invitation instead of "Unlocks soon" for a zero-unlocked corpus', () => {
+    // Both habits sit at the highest stages so the OLD stage-gated model
+    // would also report zero-unlocked here -- isolating this test to the
+    // copy itself, not the count.
     const habits = [
-      makeHabit({
-        id: 220,
-        stage: 'Beige',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 221,
-        stage: 'Purple',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 222,
-        stage: 'Red',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      // Blue sits above currentStage 3, so a past start_date can't unlock it.
-      makeHabit({
-        id: 223,
-        stage: 'Blue',
-        revealed: false,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-    ];
-    useHabitStore.setState({ loading: false, habits });
-    useStageStore.setState({ currentStage: 3 });
-    const { getByText } = render(<HabitsStatTile />);
-    expect(getByText('0/3 done')).toBeTruthy();
-  });
-
-  it('counts an early-unlocked habit at a high stage toward the denominator', () => {
-    const habits = [
-      makeHabit({
-        id: 230,
-        stage: 'Beige',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 231,
-        stage: 'Purple',
-        revealed: false,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 232,
-        stage: 'Red',
-        revealed: false,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      // Blue is above currentStage 1, so only its early-unlock reveal counts it.
-      makeHabit({
-        id: 233,
-        stage: 'Blue',
-        revealed: true,
-        start_date: new Date(Date.now() + 30 * DAY_MS),
-      }),
+      makeHabit({ id: 520, stage: 'Ultraviolet', revealed: false }),
+      makeHabit({ id: 521, stage: 'Clear Light', revealed: false }),
     ];
     useHabitStore.setState({ loading: false, habits });
     useStageStore.setState({ currentStage: 1 });
-    const { getByText } = render(<HabitsStatTile />);
-    expect(getByText('0/2 done')).toBeTruthy();
-  });
-
-  it('shows the skeleton and self-hydrates stages on a cold entry with no stages loaded yet', () => {
-    useHabitStore.setState({ loading: false, habits: [makeHabit({ id: 300 })] });
-    useStageStore.setState({ stages: [], currentStage: 1, loading: false, error: null });
-    const { getByTestId } = render(<HabitsStatTile />);
-    expect(getByTestId('journal-habits-tile-skeleton')).toBeTruthy();
-    expect(mockLoadStages).toHaveBeenCalledTimes(1);
-  });
-
-  it('falls back to currentStage 1 (ignoring a stale store value) and renders a determinate stat when stage loading errored', () => {
-    const habits = [
-      makeHabit({
-        id: 310,
-        stage: 'Beige',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
-      }),
-      makeHabit({
-        id: 311,
-        stage: 'Purple',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-      makeHabit({
-        id: 312,
-        stage: 'Red',
-        revealed: true,
-        start_date: new Date('2020-01-01T00:00:00Z'),
-      }),
-    ];
-    useHabitStore.setState({ loading: false, habits });
-    // currentStage 5 is a stale value from a prior session; the error means it must not be trusted.
-    useStageStore.setState({ stages: [], currentStage: 5, loading: false, error: 'boom' });
-    const { getByText, queryByTestId } = render(<HabitsStatTile />);
-    expect(getByText('1/1 done')).toBeTruthy();
-    expect(queryByTestId('journal-habits-tile-skeleton')).toBeNull();
+    const { getByText, queryByText } = render(<HabitsStatTile />);
+    expect(queryByText('Unlocks soon')).toBeNull();
+    expect(getByText('Unlock a habit to begin')).toBeTruthy();
   });
 });
 
 describe('describeHabits', () => {
-  it('returns the "Unlocks soon" stat and cue when there are habits but none unlocked yet', () => {
+  it('returns the manual-unlock invitation stat and cue when there are habits but none unlocked yet', () => {
     const result = describeHabits(false, 2, 0, 0);
-    expect(result.stat).toBe('Unlocks soon');
+    expect(result.stat).toBe('Unlock a habit to begin');
     expect(result.cue).toBe('Open habits →');
-    expect(result.accessibilityLabel).toBe("Today's habits, unlocks soon. Open habits");
+    expect(result.accessibilityLabel).toBe("Today's habits, unlock a habit to begin. Open habits");
   });
 });


### PR DESCRIPTION
## Summary

- Habit locking is now an explicit user choice: `revealed` is the single persisted source of truth for unlock state. New and seeded habits default **locked**; the user unlocks each habit in any order regardless of stage, or unlocks the whole set at once behind a declinable confirm. Stage and the calendar `start_date` no longer auto-unlock anything.
- Adds a backend `revealed` boolean column (Alembic migration `e6f7a8b9c0d2`) threaded through the habit read/create schemas and the frontend API layer, so unlock state persists on the server and survives reload. The migration **backfills existing rows to unlocked** so current users are not jarringly re-locked on deploy; only newly created/seeded habits lock by default.
- Unifies onto a single `isHabitUnlocked` predicate and deletes the divergent `isHabitLockedToday` / `isHabitUnlockedAtStage` / `isEarlyUnlocked` paths. The Journal "Today's habits" tile now counts the user-unlocked set and no longer depends on the stage store.

### Decisions (documented in code + here)
- **Re-locking is allowed** as a bulk affordance ("Lock Unstarted Habits") that re-locks only *untouched* habits (zero logged completions). Re-locking preserves completions — they live on the habit's goals, never on the `revealed` flag — so unlocking again restores full history. Locked habits stay non-completable and are excluded from daily counts.
- The offline/no-cache demo seed (`FALLBACK_HABITS`) intentionally stays unlocked so the degraded state is explorable; it is neither onboarding-seeded nor user-created.

## Test plan
- Backend: `./scripts/backend/check-all.sh` green (ruff, ruff-format, mypy, bandit, pip-audit, radon, pytest — 2365 passed, 96.47% coverage) plus `xenon --max-absolute A --max-modules A --max-average A src/` and interrogate (88.9%). New tests cover default-locked on create, explicit unlock, PUT persistence round-trip, re-lock preserving completions, list inclusion, and a migration round-trip (upgrade backfill + downgrade).
- Frontend: `./scripts/frontend/check-all.sh` green (ESLint, Prettier, `tsc --noEmit`, Jest — 3438 passed). New/updated tests cover `isHabitUnlocked`, out-of-order `unlockedHabits`, locked-by-default builders, `mapApiHabits`/`toApiPayload` round-trip, PUT-synced unlock/unlock-all/lock-untouched with rollback, the unlock-all confirm dialog, the Journal tile reflecting manual unlocks, and locked tiles showing no calendar countdown.

Closes #1332
Refs #1343

This redesign subsumes #1343: the calendar-anchored "Unlocks in N days" reveal countdown is removed, and unlock is now purely user-driven, so the countdown-vs-stage reconciliation it tracked no longer applies.
