### PR TITLE
fix(journal): revert dismiss by re-inserting the row, not a stale snapshot

### DIFF
--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -206,4 +206,38 @@ describe('useResonance — suggestions', () => {
     expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 2]); // reverted
     expect(result.current.error).toBeTruthy();
   });
+
+  it('a suggestion generated mid-dismiss survives a failed dismiss', async () => {
+    mockSugList.mockResolvedValue({ items: [suggestion({ id: 1 })] });
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(1));
+
+    let rejectDismiss: (_e: unknown) => void = () => {};
+    mockDismiss.mockReturnValue(
+      new Promise<CompletionSuggestion>((_resolve, reject) => {
+        rejectDismiss = reject;
+      }),
+    );
+    let dismissPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      dismissPromise = result.current.dismissSuggestion(1);
+    });
+    expect(result.current.suggestions).toHaveLength(0);
+
+    mockGenerate.mockResolvedValue(
+      resonancePayload({ suggestions: [suggestion({ id: 2, anchor_start: 20 })] }),
+    );
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toContain(2);
+
+    await act(async () => {
+      rejectDismiss(new ApiError(500, 'boom'));
+      await dismissPromise;
+    });
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 2]);
+    expect(result.current.error).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -188,16 +188,19 @@ interface DismissDeps {
 /** Dismiss a suggestion: per-id guarded; optimistic remove, revert on error. */
 async function runDismiss(
   id: number,
-  snapshot: CompletionSuggestion[],
+  current: CompletionSuggestion[],
   deps: DismissDeps,
 ): Promise<void> {
   if (deps.pendingIdsRef.current.has(id)) return;
   deps.pendingIdsRef.current.add(id);
-  deps.setSuggestions(snapshot.filter((s) => s.id !== id)); // optimistic
+  const dismissed = current.find((s) => s.id === id);
+  deps.setSuggestions((prev) => prev.filter((s) => s.id !== id)); // optimistic
   try {
     await completionSuggestions.dismiss(id);
   } catch (err) {
-    deps.setSuggestions(snapshot); // revert
+    if (dismissed) {
+      deps.setSuggestions((prev) => mergeByIdSorted([dismissed], prev)); // revert
+    }
     deps.setError(formatApiError(err));
   } finally {
     deps.pendingIdsRef.current.delete(id);


### PR DESCRIPTION
## Summary
- `runDismiss` reverted a failed dismiss with `setSuggestions(snapshot)`, replacing state with the array captured at dismiss time — silently clobbering any suggestion that landed between the snapshot capture and the revert (e.g. one generated, and charged for, during an in-flight dismiss).
- Both the optimistic remove and the error-revert now use functional updaters: the dismissed row is captured synchronously, then re-inserted into the *current* state via `mergeByIdSorted([dismissed], prev)` so concurrent additions survive and a fresher copy of the same id wins.
- The per-id dismiss guard, the accept path, and the generate pass are unchanged.

## Test plan
- Added a regression test that puts a dismiss in flight (row optimistically removed), runs a generate pass that adds a new suggestion mid-dismiss, then fails the dismiss — asserting the generated suggestion survives the revert. It fails against the old snapshot-restore logic and passes with the fix.
- `./scripts/frontend/check-all.sh` green: ESLint (select=ALL, zero warnings), `tsc --noEmit`, Jest 3450 tests + coverage all pass.

Closes #1263
