### PR TITLE
refactor(storage): extract shared secure-string store factory

### DIFF
--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -6,7 +6,10 @@ sanitization, JWT signing, rate limiting, CORS) — those are in `backend/`.
 
 ## Auth token persistence
 
-**File:** `src/storage/authStorage.ts`
+**File:** `src/storage/secureStringStore.ts` (the shared factory that owns
+the web `localStorage` branch). The auth token and BYOK LLM key reach it
+through two thin wrappers: `src/storage/authStorage.ts` and
+`src/storage/llmKeyStorage.ts`.
 **Bug ID:** BUG-FE-AUTH-007
 **Status:** Accepted risk on web; migration tracked.
 
@@ -21,9 +24,9 @@ sanitization, JWT signing, rate limiting, CORS) — those are in `backend/`.
 
 `expo-secure-store` v55 has no web implementation (its web bundle is
 literally `export default {}`), so calling `SecureStore.setItemAsync` on
-web throws `TypeError`. The platform branch in `authStorage.ts` exists to
-prevent that crash; the alternative would be the auth flow failing
-end-to-end on every web load.
+web throws `TypeError`. The platform branch in `secureStringStore.ts`
+exists to prevent that crash; the alternative would be the auth flow
+failing end-to-end on every web load.
 
 ### The XSS-window risk
 
@@ -36,14 +39,20 @@ the probability of XSS but do not bound the impact once it happens.
 ### What we do today to compensate
 
 1. The JS path that uses `localStorage` is isolated to a single file
-   (`src/storage/authStorage.ts`) and a single platform branch
-   (`Platform.OS === 'web'`). No other module reaches into
+   (`src/storage/secureStringStore.ts`) and a single platform branch
+   (`Platform.OS === 'web'`). `authStorage.ts` and `llmKeyStorage.ts`
+   are thin wrappers over that factory; they do not reach into
+   `localStorage` themselves, and no other module reaches into
    `localStorage` for the token.
-2. The file carries a header comment block describing the risk so any
-   diff that touches it shows the warning in PR review.
-3. The web branch carries a per-line `BUG-FE-AUTH-007` reference so
-   `git grep BUG-FE-AUTH-007` finds every accepted-risk site in one
-   command.
+2. The factory file carries a header comment block describing the risk
+   so any diff that touches it shows the warning in PR review.
+3. The web branch in the factory carries a per-line `BUG-FE-AUTH-007`
+   reference, and the `authStorage.ts` wrapper repeats it at its
+   factory-instantiation site, so `git grep BUG-FE-AUTH-007` finds
+   every token accepted-risk site in one command. The `llmKeyStorage.ts`
+   wrapper carries its own `BUG-FE-STORAGE-001` marker at its
+   instantiation site (its `localStorage` writes ride the same
+   factory branch), so a full audit greps both IDs.
 
 ### The migration plan
 
@@ -71,10 +80,12 @@ reviewed default.
 - **Adding new web persistence code** that puts secrets, tokens, or
   user-identifying data in `localStorage`, `sessionStorage`,
   `IndexedDB`, or any global JS-readable surface, without coming through
-  `authStorage.ts` (or reading this doc and updating it).
-- **Removing the `BUG-FE-AUTH-007` markers** in `authStorage.ts`
-  without simultaneously deleting the `isWeb` branch and replacing it
-  with a cookie-based flow.
+  the shared `secureStringStore.ts` factory (or reading this doc and
+  updating it).
+- **Removing the `BUG-FE-AUTH-007` markers** in `secureStringStore.ts`
+  (or the pointer markers at the `authStorage.ts` / `llmKeyStorage.ts`
+  factory-instantiation sites) without simultaneously deleting the
+  `isWeb` branch and replacing it with a cookie-based flow.
 - **Loosening Content-Security-Policy** in a way that adds new XSS
   surface without compensating for the elevated-impact fact above.
 

--- a/frontend/src/storage/__tests__/secureStringStore.test.ts
+++ b/frontend/src/storage/__tests__/secureStringStore.test.ts
@@ -1,0 +1,134 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+
+import type * as SecureStringStoreModule from '../secureStringStore';
+
+const platformRef = { value: 'ios' as 'ios' | 'android' | 'web' };
+
+jest.mock('react-native', () => ({
+  Platform: {
+    get OS() {
+      return platformRef.value;
+    },
+  },
+}));
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+const TEST_KEY = 'test_secure_key';
+
+class TestEmptyError extends Error {}
+
+function loadSecureStringStore(): typeof SecureStringStoreModule {
+  let mod: typeof SecureStringStoreModule | undefined;
+  jest.isolateModules(() => {
+    mod = require('../secureStringStore') as typeof SecureStringStoreModule;
+  });
+  if (!mod) throw new Error('failed to load secureStringStore');
+  return mod;
+}
+
+function makeStore() {
+  const { createSecureStringStore } = loadSecureStringStore();
+  return createSecureStringStore(TEST_KEY, TestEmptyError);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createSecureStringStore (native)', () => {
+  beforeEach(() => {
+    platformRef.value = 'ios';
+  });
+
+  test('save routes to SecureStore on native', async () => {
+    const store = makeStore();
+    await store.save('some-value');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(TEST_KEY, 'some-value');
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  test('load reads from SecureStore on native', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce('some-value');
+    const store = makeStore();
+    await expect(store.load()).resolves.toBe('some-value');
+    expect(mockAsyncStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  test('clear removes from SecureStore on native', async () => {
+    const store = makeStore();
+    await store.clear();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(TEST_KEY);
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSecureStringStore (web)', () => {
+  beforeEach(() => {
+    platformRef.value = 'web';
+  });
+
+  test('save routes to AsyncStorage on web', async () => {
+    const store = makeStore();
+    await store.save('some-value');
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(TEST_KEY, 'some-value');
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('load reads from AsyncStorage on web', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('some-value');
+    const store = makeStore();
+    await expect(store.load()).resolves.toBe('some-value');
+    expect(mockSecureStore.getItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('clear removes from AsyncStorage on web', async () => {
+    const store = makeStore();
+    await store.clear();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(TEST_KEY);
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('save trims whitespace before storing', async () => {
+    const store = makeStore();
+    await store.save('  val \n');
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(TEST_KEY, 'val');
+  });
+
+  test('save rejects empty / whitespace-only input with the passed error ctor', async () => {
+    const store = makeStore();
+    await expect(store.save('')).rejects.toBeInstanceOf(TestEmptyError);
+    await expect(store.save('   ')).rejects.toBeInstanceOf(TestEmptyError);
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  test('load returns null passthrough when the underlying store returns null', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+    const store = makeStore();
+    await expect(store.load()).resolves.toBeNull();
+  });
+
+  test('load propagates rejection when the underlying store rejects', async () => {
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('read boom'));
+    const store = makeStore();
+    await expect(store.load()).rejects.toThrow('read boom');
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/storage/authStorage.ts
+++ b/frontend/src/storage/authStorage.ts
@@ -1,66 +1,19 @@
 /**
- * Auth token persistence — native keychain on iOS/Android, localStorage on web.
+ * Auth token persistence — a thin wrapper over the shared secure-string store.
  *
- * SECURITY NOTE — BUG-FE-AUTH-007 (web XSS-window risk).
- * --------------------------------------------------------
- * On the web platform this module persists the JWT in ``localStorage``
- * (via ``AsyncStorage``).  ``localStorage`` is fully readable by any
- * JavaScript that runs on the same origin — including injected XSS — so a
- * single successful XSS exploit on the web build yields full account
- * takeover (the attacker copies the token and replays it from anywhere
- * until the user logs out or it expires).  This is a deliberate, audited
- * tradeoff:
- *
- *   * ``expo-secure-store`` v55 ships no web implementation (its web
- *     module is literally ``export default {}``), so the secure path
- *     simply does not exist on web.
- *   * The native build is unaffected: iOS uses Keychain, Android uses
- *     Keystore, both isolated from RN JS context.
- *   * The proper long-term fix is moving the web build to an
- *     httpOnly + SameSite=Strict session cookie issued by the backend so
- *     the JWT never touches JS at all.  That requires backend cookie/CSRF
- *     wiring and a session refresh endpoint and is tracked as a separate
- *     post-MVP epic.
- *
- * Mitigations IN this file — KEEP these together so a future contributor
- * who removes one immediately sees the others:
- *
- *   1. ``isWeb`` branches keep the localStorage path strictly OFF on
- *      native (where Keychain works).
- *   2. Each web call site carries an inline ``BUG-FE-AUTH-007`` marker
- *      comment so ``git grep BUG-FE-AUTH-007`` enumerates every
- *      accepted-risk site for audit.  Any new web persistence path that
- *      bypasses this file is grounds for review rejection (see
- *      ``frontend/SECURITY.md``).
- *   3. ``frontend/SECURITY.md`` documents the threat model and the
- *      migration plan; reviewers should reject changes that move web
- *      tokens *out* of ``AsyncStorage`` into something even more
- *      JS-readable (e.g. a global window prop) without raising the
- *      concern there.
- *
- * DO NOT remove this comment block when refactoring this file.  If the
- * web build moves to cookies, delete the ``isWeb`` branch entirely; do
- * not silently switch to a different JS-readable store.
+ * The native-Keychain / web-localStorage fallback, the trim/reject-empty guard,
+ * and the web XSS-window tradeoff (BUG-FE-AUTH-007) all live in
+ * ``secureStringStore.ts`` — read that file's header for the security rationale
+ * and the httpOnly-cookie migration plan before touching the web path.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
-import { Platform } from 'react-native';
+
+import { createSecureStringStore } from './secureStringStore';
 
 // expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys,
 // so we cannot use the `@adepthood/...` namespace prefix here.
 const TOKEN_KEY = 'adepthood_auth_token';
-
-// ``expo-secure-store`` v55 has no web implementation — its web module is
-// literally ``export default {}``, so calling ``SecureStore.setItemAsync``
-// throws ``TypeError: … is not a function`` and every auth attempt in the
-// Expo Web build fails with the generic signup fallback copy. On web we
-// fall back to ``AsyncStorage`` (which resolves to ``localStorage``) so
-// the flow works end-to-end. Native keeps using Keychain/Keystore.
-//
-// SECURITY: see the file-header note above for the XSS risk this fallback
-// accepts and the long-term migration plan (httpOnly session cookie).
-const isWeb = Platform.OS === 'web';
 
 export class EmptyAuthTokenError extends Error {
   constructor() {
@@ -69,40 +22,21 @@ export class EmptyAuthTokenError extends Error {
   }
 }
 
+// BUG-FE-AUTH-007: the auth token's web-fallback accepted-risk site. The
+// localStorage persistence physically lives in secureStringStore.ts; this
+// marker keeps ``git grep BUG-FE-AUTH-007`` pointing at the auth store.
+const tokenStore = createSecureStringStore(TOKEN_KEY, EmptyAuthTokenError);
+
 export async function saveToken(token: string): Promise<void> {
-  // BUG-FE-STORAGE-004: trim and reject empty / whitespace-only tokens
-  // at the boundary.  Without this, an accidental save (e.g. a stale
-  // ``''`` returned by a malformed refresh response that slipped past
-  // the Zod gate -- BUG-API-007 closed it, this is defence in depth)
-  // would silently clear the previous valid token and bounce the user
-  // to the login screen.
-  const trimmed = token.trim();
-  if (!trimmed) throw new EmptyAuthTokenError();
-  if (isWeb) {
-    // BUG-FE-AUTH-007: web persists to localStorage — XSS risk accepted
-    // until the backend httpOnly-cookie session migration ships.  See the
-    // file-header note for context.  Reviewers: any new web persistence
-    // path here MUST go through the same ``isWeb`` branch (or be replaced
-    // by a cookie-based session).
-    await AsyncStorage.setItem(TOKEN_KEY, trimmed);
-    return;
-  }
-  await SecureStore.setItemAsync(TOKEN_KEY, trimmed);
+  await tokenStore.save(token);
 }
 
 export async function loadToken(): Promise<string | null> {
-  // BUG-FE-AUTH-007: web reads from localStorage — see the file-header note.
-  if (isWeb) return AsyncStorage.getItem(TOKEN_KEY);
-  return SecureStore.getItemAsync(TOKEN_KEY);
+  return tokenStore.load();
 }
 
 export async function clearToken(): Promise<void> {
-  if (isWeb) {
-    // BUG-FE-AUTH-007: web clears localStorage — see the file-header note.
-    await AsyncStorage.removeItem(TOKEN_KEY);
-    return;
-  }
-  await SecureStore.deleteItemAsync(TOKEN_KEY);
+  await tokenStore.clear();
 }
 
 // BUG-FE-STATE-001: a logout-pending marker, always AsyncStorage-backed on

--- a/frontend/src/storage/llmKeyStorage.ts
+++ b/frontend/src/storage/llmKeyStorage.ts
@@ -1,31 +1,19 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import * as SecureStore from 'expo-secure-store';
-import { Platform } from 'react-native';
-
 /**
- * Storage layer for the user's BYOK (Bring Your Own Key) LLM API key.
+ * Storage layer for the user's BYOK (Bring Your Own Key) LLM API key — a thin
+ * wrapper over the shared secure-string store.
  *
  * The key is stored **only** on the device -- never uploaded to our backend
- * database -- so a server-side breach cannot leak user-owned LLM keys
- * (issue #185).
+ * database -- so a server-side breach cannot leak user-owned LLM keys.
  *
- * Native uses ``expo-secure-store`` (Keychain / Keystore).  Web has no
- * SecureStore implementation in expo-secure-store v55, so a call there
- * throws ``TypeError: ... is not a function`` and the BYOK settings
- * screen crashes for every Expo Web user (BUG-FE-STORAGE-001).  The
- * web branch falls back to ``AsyncStorage`` (which resolves to
- * ``localStorage``) -- the same XSS-window risk already documented for
- * the auth token, and the same long-term migration plan applies.
- *
- * BUG-FE-STORAGE-004: empty / whitespace keys are rejected at the
- * boundary so an accidental save (e.g. paste of trailing newline) does
- * NOT clear the previous key without warning, and so the BotMason
- * router never receives a 401-guaranteed empty Bearer header.
+ * The native-Keychain / web-localStorage fallback, the trim/reject-empty guard,
+ * and the web XSS-window tradeoff all live in ``secureStringStore.ts``; read
+ * that file's header for the security rationale before touching the web path.
  */
+
+import { createSecureStringStore } from './secureStringStore';
+
 // expo-secure-store only allows alphanumerics plus `.`, `-`, `_` in keys.
 const LLM_API_KEY_STORAGE_KEY = 'adepthood_llm_api_key'; // pragma: allowlist secret
-
-const isWeb = Platform.OS === 'web';
 
 export class EmptyApiKeyError extends Error {
   constructor() {
@@ -34,34 +22,19 @@ export class EmptyApiKeyError extends Error {
   }
 }
 
+// BUG-FE-STORAGE-001: the BYOK key's web-fallback accepted-risk site. Web has
+// no SecureStore implementation, so persistence falls back to localStorage
+// inside secureStringStore.ts; this marker keeps that site grep-able here.
+const apiKeyStore = createSecureStringStore(LLM_API_KEY_STORAGE_KEY, EmptyApiKeyError);
+
 export async function saveLlmApiKey(apiKey: string): Promise<void> {
-  // BUG-FE-STORAGE-004: trim whitespace at the boundary so the stored
-  // value is canonical and a paste of "  sk-...  " does not silently
-  // produce a 401 on the next BotMason call.  Empty / whitespace-only
-  // input is rejected explicitly -- callers (the Settings screen)
-  // surface this as an inline form error.
-  const trimmed = apiKey.trim();
-  if (!trimmed) throw new EmptyApiKeyError();
-  if (isWeb) {
-    // BUG-FE-STORAGE-001: web has no SecureStore implementation; fall
-    // back to AsyncStorage (localStorage) so the BYOK settings screen
-    // does not crash on Expo Web.  Same XSS-window tradeoff as the
-    // auth token; see ``authStorage.ts`` for the long-term migration.
-    await AsyncStorage.setItem(LLM_API_KEY_STORAGE_KEY, trimmed);
-    return;
-  }
-  await SecureStore.setItemAsync(LLM_API_KEY_STORAGE_KEY, trimmed);
+  await apiKeyStore.save(apiKey);
 }
 
 export async function loadLlmApiKey(): Promise<string | null> {
-  if (isWeb) return AsyncStorage.getItem(LLM_API_KEY_STORAGE_KEY);
-  return SecureStore.getItemAsync(LLM_API_KEY_STORAGE_KEY);
+  return apiKeyStore.load();
 }
 
 export async function clearLlmApiKey(): Promise<void> {
-  if (isWeb) {
-    await AsyncStorage.removeItem(LLM_API_KEY_STORAGE_KEY);
-    return;
-  }
-  await SecureStore.deleteItemAsync(LLM_API_KEY_STORAGE_KEY);
+  await apiKeyStore.clear();
 }

--- a/frontend/src/storage/secureStringStore.ts
+++ b/frontend/src/storage/secureStringStore.ts
@@ -1,0 +1,115 @@
+/**
+ * Secure single-string store — native keychain on iOS/Android, localStorage
+ * on web. Shared factory behind the auth-token and BYOK LLM-key stores; each
+ * previously carried a byte-identical copy of this SecureStore/AsyncStorage
+ * fallback, trim/reject-empty guard, and dedicated Empty*Error.
+ *
+ * SECURITY NOTE — BUG-FE-AUTH-007 (web XSS-window risk).
+ * --------------------------------------------------------
+ * On the web platform this module persists the secret in ``localStorage``
+ * (via ``AsyncStorage``).  ``localStorage`` is fully readable by any
+ * JavaScript that runs on the same origin — including injected XSS — so a
+ * single successful XSS exploit on the web build can exfiltrate the stored
+ * secret (e.g. the JWT copied and replayed from anywhere until the user logs
+ * out or it expires).  This is a deliberate, audited tradeoff:
+ *
+ *   * ``expo-secure-store`` v55 ships no web implementation (its web
+ *     module is literally ``export default {}``), so the secure path
+ *     simply does not exist on web.
+ *   * The native build is unaffected: iOS uses Keychain, Android uses
+ *     Keystore, both isolated from RN JS context.
+ *   * The proper long-term fix is moving the web build to an
+ *     httpOnly + SameSite=Strict session cookie issued by the backend so
+ *     the JWT never touches JS at all.  That requires backend cookie/CSRF
+ *     wiring and a session refresh endpoint and is tracked as a separate
+ *     post-MVP epic.
+ *
+ * Mitigations IN this file — KEEP these together so a future contributor
+ * who removes one immediately sees the others:
+ *
+ *   1. The ``isWeb`` branch keeps the localStorage path strictly OFF on
+ *      native (where Keychain works).
+ *   2. Each web call site carries an inline ``BUG-FE-AUTH-007`` marker
+ *      comment so ``git grep BUG-FE-AUTH-007`` enumerates every
+ *      accepted-risk site for audit.  Any new web persistence path that
+ *      bypasses this file is grounds for review rejection (see
+ *      ``frontend/SECURITY.md``).
+ *   3. ``frontend/SECURITY.md`` documents the threat model and the
+ *      migration plan; reviewers should reject changes that move web
+ *      secrets *out* of ``AsyncStorage`` into something even more
+ *      JS-readable (e.g. a global window prop) without raising the
+ *      concern there.
+ *
+ * DO NOT remove this comment block when refactoring this file.  If the
+ * web build moves to cookies, delete the ``isWeb`` branch entirely; do
+ * not silently switch to a different JS-readable store.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+// ``expo-secure-store`` v55 has no web implementation — its web module is
+// literally ``export default {}``, so calling ``SecureStore.setItemAsync``
+// throws ``TypeError: … is not a function``. On web we fall back to
+// ``AsyncStorage`` (which resolves to ``localStorage``) so the flow works
+// end-to-end; native keeps using Keychain/Keystore. Evaluated once at module
+// scope to match the original per-store semantics.
+//
+// SECURITY: see the file-header note above for the XSS risk this fallback
+// accepts and the long-term migration plan (httpOnly session cookie).
+const isWeb = Platform.OS === 'web';
+
+/** A device-local store for a single trimmed, non-empty secret string. */
+export interface SecureStringStore {
+  save(value: string): Promise<void>;
+  load(): Promise<string | null>;
+  clear(): Promise<void>;
+}
+
+/**
+ * Build a {@link SecureStringStore} for ``storageKey``, throwing an instance of
+ * ``EmptyErrorCtor`` when asked to save empty / whitespace-only input.
+ */
+export function createSecureStringStore(
+  storageKey: string,
+  EmptyErrorCtor: new () => Error,
+): SecureStringStore {
+  return {
+    async save(value: string): Promise<void> {
+      // BUG-FE-STORAGE-004: trim and reject empty / whitespace-only input at
+      // the boundary. Without this, an accidental save (e.g. a stale ``''`` or
+      // a paste of ``"  sk-...  "``) would silently clear the previous valid
+      // value — bouncing the user to login, or producing a 401-guaranteed
+      // empty Bearer header on the next call. Defence in depth at the store.
+      const trimmed = value.trim();
+      if (!trimmed) throw new EmptyErrorCtor();
+      if (isWeb) {
+        // BUG-FE-AUTH-007: web persists to localStorage — XSS risk accepted
+        // until the backend httpOnly-cookie session migration ships. See the
+        // file-header note. Reviewers: any new web persistence path MUST go
+        // through this same ``isWeb`` branch (or be replaced by a cookie).
+        await AsyncStorage.setItem(storageKey, trimmed);
+        return;
+      }
+      await SecureStore.setItemAsync(storageKey, trimmed);
+    },
+
+    async load(): Promise<string | null> {
+      // BUG-FE-AUTH-007: web reads from localStorage — see the file-header
+      // note. No try/catch: a read rejection propagates unchanged so callers
+      // (and the store's own consumers) see the true failure.
+      if (isWeb) return AsyncStorage.getItem(storageKey);
+      return SecureStore.getItemAsync(storageKey);
+    },
+
+    async clear(): Promise<void> {
+      if (isWeb) {
+        // BUG-FE-AUTH-007: web clears localStorage — see the file-header note.
+        await AsyncStorage.removeItem(storageKey);
+        return;
+      }
+      await SecureStore.deleteItemAsync(storageKey);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

`authStorage.ts` and `llmKeyStorage.ts` were the same secure-string store — "SecureStore on native, AsyncStorage fallback on web, trim + reject-empty, dedicated `Empty*Error`" — implemented twice modulo the key constant, error class, and param name (de-slop Family 3 duplication).

This extracts one factory and re-implements both modules as thin wrappers, with no public-API or behavior change:

- **New `frontend/src/storage/secureStringStore.ts`** — `createSecureStringStore(storageKey, EmptyErrorCtor)` returning `{ save, load, clear }`. It is the single home of the `isWeb` branch, the trim/reject-empty guard, and the canonical BUG-FE-AUTH-007 web-XSS-tradeoff header. `load` propagates read rejections unchanged (no swallow / self-heal).
- **`authStorage.ts`** — thin wrapper keeping `EmptyAuthTokenError` and `saveToken`/`loadToken`/`clearToken`; the logout-pending marker block is untouched.
- **`llmKeyStorage.ts`** — thin wrapper keeping `EmptyApiKeyError` and `saveLlmApiKey`/`loadLlmApiKey`/`clearLlmApiKey`; the `adepthood_llm_api_key` key (with its `// pragma: allowlist secret`) is preserved verbatim.
- **`frontend/SECURITY.md`** — updated to name `secureStringStore.ts` as the file that owns the web-`localStorage` branch and the accepted-risk markers, keeping the `git grep BUG-FE-AUTH-007` / `BUG-FE-STORAGE-001` audit invariant accurate.

Public exports, error types, storage keys, and the web-fallback security posture are byte-for-byte preserved. The existing `authStorage.test.ts` and `llmKeyStorage.test.ts` characterization suites are unchanged and stay green.

## Test plan

- New `frontend/src/storage/__tests__/secureStringStore.test.ts` pins native routing, web routing, trim, empty-reject via the passed error ctor, null passthrough, and no-swallow-on-read (rejection propagation) for the factory.
- `./scripts/frontend/check-all.sh` green: ESLint, prettier, `tsc --noEmit`, and the full Jest suite (327 suites / 3460 tests, including all three storage suites).

Closes #1276