### PR TITLE
feat(habits): paginated second habit set covering stages 11-20

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -30,6 +30,19 @@ export const stageAtIndex = (index: number): string =>
   STAGE_ORDER[index % STAGE_ORDER.length] ?? STAGE_ORDER[STAGE_ORDER.length - 1]!;
 
 /**
+ * 1-based inclusive stage bounds for a habits page/lap: page 0 → stages 1..10,
+ * page 1 → 11..20, and so on. Drives the pagination bar's stage-range label and
+ * the second-lap invite copy so both name the stretch of stages a page covers.
+ */
+export const stageRangeForPage = (
+  page: number,
+  pageSize: number,
+): { start: number; end: number } => ({
+  start: page * pageSize + 1,
+  end: (page + 1) * pageSize,
+});
+
+/**
  * Calculate the start date for a habit based on its order in the onboarding
  * flow. Habits 1–8 begin 21 days apart while habits 9–10 begin 42 days apart.
  *

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -39,6 +39,7 @@ import {
   calculateMissedDays,
   isHabitUnlocked,
   stageAtIndex,
+  stageRangeForPage,
 } from './HabitUtils';
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
@@ -440,12 +441,29 @@ interface PaginationBarProps {
   onPrev: () => void;
   onNext: () => void;
   scale: number;
+  stageStart?: number;
+  stageEnd?: number;
 }
 
-export const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: PaginationBarProps) => {
+export const PaginationBar = ({
+  page,
+  pageCount,
+  onPrev,
+  onNext,
+  scale,
+  stageStart,
+  stageEnd,
+}: PaginationBarProps) => {
   const canPrev = page > 0;
   const canNext = page < pageCount - 1;
   const textSize = { fontSize: spacing(1.75, scale) };
+  // The visible label names the stage range this page covers; the page position
+  // (redundant for sighted users who read the range) is folded into this same
+  // Text's accessibility label so screen readers announce where they are. The
+  // label lives on the Text — an accessibility element — rather than the
+  // container, whose own accessibleLabel would be swallowed by its focusable
+  // children.
+  const positionLabel = `Stages ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
   return (
     <View style={styles.paginationBar} testID="habits-pagination">
       <TouchableOpacity
@@ -459,8 +477,12 @@ export const PaginationBar = ({ page, pageCount, onPrev, onNext, scale }: Pagina
       >
         <Text style={[styles.paginationButtonText, textSize]}>Prev</Text>
       </TouchableOpacity>
-      <Text style={[styles.paginationLabel, textSize]}>
-        Page {page + 1} of {pageCount}
+      <Text
+        style={[styles.paginationLabel, textSize]}
+        testID="pagination-label"
+        accessibilityLabel={positionLabel}
+      >
+        Stages {stageStart}–{stageEnd}
       </Text>
       <TouchableOpacity
         testID="pagination-next"
@@ -566,8 +588,11 @@ const useHabitTileRenderer = (
       // default, opened only when the user chooses. Stage/calendar never gate it.
       const isLocked = !isHabitUnlocked(item);
       const globalIndex = pageOffset + index;
-      // index is page-relative, so each page restarts the Beige → Clear Light gradient.
-      const stageColor = STAGE_COLORS[stageAtIndex(index)]!;
+      // Anchor the tile color to its global position, not the page-relative one:
+      // the mod-wrap inside stageAtIndex (over STAGE_ORDER's length) is what
+      // restarts the Beige → Clear Light gradient on each lap, so a full first
+      // lap and the second lap paint identically without page math here.
+      const stageColor = STAGE_COLORS[stageAtIndex(globalIndex)]!;
       return (
         <HabitTile
           habit={item}
@@ -657,7 +682,62 @@ interface HabitsContentProps {
   onRetry: () => void;
   onAddHabit: () => void;
   pagination: PaginationBarProps | null;
+  /** Stage bounds for the current lap's empty state; omitted on the first-run page. */
+  emptyStageStart?: number;
+  emptyStageEnd?: number;
 }
+
+interface HabitsBodyProps {
+  showEmpty: boolean;
+  habits: Habit[];
+  columns: number;
+  gridGutter: number;
+  renderItem: (_info: { item: Habit; index: number }) => React.ReactElement;
+  onAddHabit: () => void;
+  pagination: PaginationBarProps | null;
+  emptyStageStart?: number;
+  emptyStageEnd?: number;
+}
+
+// Empty state and list swap on showEmpty, but the pagination bar renders
+// alongside either so a full lap's trailing invite page is never stranded
+// without a way back to the populated laps.
+const HabitsBody = ({
+  showEmpty,
+  habits,
+  columns,
+  gridGutter,
+  renderItem,
+  onAddHabit,
+  pagination,
+  emptyStageStart,
+  emptyStageEnd,
+}: HabitsBodyProps) => (
+  <>
+    {showEmpty && (
+      <HabitsEmptyState onAdd={onAddHabit} stageStart={emptyStageStart} stageEnd={emptyStageEnd} />
+    )}
+    {!showEmpty && (
+      <HabitList
+        habits={habits}
+        columns={columns}
+        gridGutter={gridGutter}
+        renderItem={renderItem}
+      />
+    )}
+    {pagination && (
+      <PaginationBar
+        page={pagination.page}
+        pageCount={pagination.pageCount}
+        onPrev={pagination.onPrev}
+        onNext={pagination.onNext}
+        scale={pagination.scale}
+        stageStart={pagination.stageStart}
+        stageEnd={pagination.stageEnd}
+      />
+    )}
+  </>
+);
 
 export const HabitsContent = ({
   habits,
@@ -669,6 +749,8 @@ export const HabitsContent = ({
   onRetry,
   onAddHabit,
   pagination,
+  emptyStageStart,
+  emptyStageEnd,
 }: HabitsContentProps) => {
   // First-run guidance; suppressed during loading/error (audit-ux-07).
   const showEmpty = !loading && !error && habits.length === 0;
@@ -676,26 +758,18 @@ export const HabitsContent = ({
     <>
       {error && <ErrorBanner error={error} onRetry={onRetry} />}
       {loading && <LoadingSpinner />}
-      {showEmpty && <HabitsEmptyState onAdd={onAddHabit} />}
-      {/* List co-renders under the error banner (unchanged); only loading/empty replace it. */}
-      {!loading && !showEmpty && (
-        <>
-          <HabitList
-            habits={habits}
-            columns={columns}
-            gridGutter={gridGutter}
-            renderItem={renderItem}
-          />
-          {pagination && (
-            <PaginationBar
-              page={pagination.page}
-              pageCount={pagination.pageCount}
-              onPrev={pagination.onPrev}
-              onNext={pagination.onNext}
-              scale={pagination.scale}
-            />
-          )}
-        </>
+      {!loading && (
+        <HabitsBody
+          showEmpty={showEmpty}
+          habits={habits}
+          columns={columns}
+          gridGutter={gridGutter}
+          renderItem={renderItem}
+          onAddHabit={onAddHabit}
+          pagination={pagination}
+          emptyStageStart={emptyStageStart}
+          emptyStageEnd={emptyStageEnd}
+        />
       )}
     </>
   );
@@ -708,6 +782,12 @@ const useHabitsScreenState = () => {
   const responsive = useResponsive();
   const { userTimezone } = useAuth();
   const pagination = usePagination(habitsReturn.habits.length, HABITS_PER_PAGE);
+  // Lap-aware empty-state copy applies only beyond the first page: page 0 keeps
+  // the plain first-run guidance, while a trailing invite page names its stages.
+  const isLapInvitePage = pagination.page > 0;
+  const lapRange = stageRangeForPage(pagination.page, HABITS_PER_PAGE);
+  const emptyStageStart = isLapInvitePage ? lapRange.start : undefined;
+  const emptyStageEnd = isLapInvitePage ? lapRange.end : undefined;
   const pageOffset = pagination.page * HABITS_PER_PAGE;
   const pagedHabits = useMemo(
     () => habitsReturn.habits.slice(pageOffset, pageOffset + HABITS_PER_PAGE),
@@ -742,6 +822,8 @@ const useHabitsScreenState = () => {
     responsive,
     pagination,
     pagedHabits,
+    emptyStageStart,
+    emptyStageEnd,
     handleSelectMode,
     renderHabitTile,
     handleAddHabit,
@@ -752,21 +834,51 @@ const useHabitsScreenState = () => {
 const buildPaginationProps = (
   pagination: ReturnType<typeof usePagination>,
   scale: number,
-): PaginationBarProps | null =>
-  pagination.pageCount > 1
-    ? {
-        page: pagination.page,
-        pageCount: pagination.pageCount,
-        onPrev: pagination.goPrev,
-        onNext: pagination.goNext,
-        scale,
-      }
-    : null;
+): PaginationBarProps | null => {
+  if (pagination.pageCount <= 1) return null;
+  const { start, end } = stageRangeForPage(pagination.page, HABITS_PER_PAGE);
+  return {
+    page: pagination.page,
+    pageCount: pagination.pageCount,
+    onPrev: pagination.goPrev,
+    onNext: pagination.goNext,
+    scale,
+    stageStart: start,
+    stageEnd: end,
+  };
+};
+
+interface HabitsContentSectionProps {
+  state: ReturnType<typeof useHabitsScreenState>;
+  columns: number;
+  gridGutter: number;
+  paginationProps: PaginationBarProps | null;
+}
+
+const HabitsContentSection = ({
+  state,
+  columns,
+  gridGutter,
+  paginationProps,
+}: HabitsContentSectionProps) => (
+  <HabitsContent
+    habits={state.pagedHabits}
+    loading={state.loading}
+    error={state.error}
+    columns={columns}
+    gridGutter={gridGutter}
+    renderItem={state.renderHabitTile}
+    onRetry={() => void state.actions.loadHabits()}
+    onAddHabit={() => state.modals.open('addHabit')}
+    pagination={paginationProps}
+    emptyStageStart={state.emptyStageStart}
+    emptyStageEnd={state.emptyStageEnd}
+  />
+);
 
 const HabitsScreen = () => {
   const state = useHabitsScreenState();
-  const { habits, loading, error, modals, actions, ui, responsive, pagination, pagedHabits } =
-    state;
+  const { habits, modals, actions, ui, responsive, pagination } = state;
   const { columns, gridGutter, scale, isLG, isXL } = responsive;
   const paginationProps = buildPaginationProps(pagination, scale);
   return (
@@ -783,16 +895,11 @@ const HabitsScreen = () => {
           onToggleReveal={state.handleToggleReveal}
         />
       </View>
-      <HabitsContent
-        habits={pagedHabits}
-        loading={loading}
-        error={error}
+      <HabitsContentSection
+        state={state}
         columns={columns}
         gridGutter={gridGutter}
-        renderItem={state.renderHabitTile}
-        onRetry={() => void actions.loadHabits()}
-        onAddHabit={() => modals.open('addHabit')}
-        pagination={paginationProps}
+        paginationProps={paginationProps}
       />
       <EnergyFooter
         showCTA={ui.showEnergyCTA}

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -21,6 +21,7 @@ import {
   logHabitUnits,
   calculateHabitStartDate,
   stageAtIndex,
+  stageRangeForPage,
   STAGE_ORDER,
   STAGE_DURATIONS_DAYS,
 } from '../HabitUtils';
@@ -1332,5 +1333,37 @@ describe('isSubtractiveHabit and goalsAreSubtractive (any-non-additive rule)', (
       completions: [],
     };
     expect(isSubtractiveHabit(habit)).toBe(true);
+  });
+});
+
+describe('stageRangeForPage', () => {
+  test('page 0 covers stages 1 through 10', () => {
+    expect(stageRangeForPage(0, 10)).toEqual({ start: 1, end: 10 });
+  });
+
+  test('page 1 covers stages 11 through 20 (second habit set)', () => {
+    expect(stageRangeForPage(1, 10)).toEqual({ start: 11, end: 20 });
+  });
+
+  test('page 2 covers stages 21 through 30', () => {
+    expect(stageRangeForPage(2, 10)).toEqual({ start: 21, end: 30 });
+  });
+
+  test('generalizes to a non-default pageSize', () => {
+    expect(stageRangeForPage(1, 5)).toEqual({ start: 6, end: 10 });
+  });
+});
+
+describe('stageAtIndex global anchoring contract for the second habit set', () => {
+  // HABITS_PER_PAGE equals STAGE_ORDER.length, so a global index into the
+  // second lap (10, 11, ...) must mod-wrap back to the start of the gradient
+  // -- the same anchor the first tile of page 2 needs to reuse Beige/Purple
+  // instead of continuing past Clear Light.
+  test('index 10 anchors to the first stage, matching the first tile of the second lap', () => {
+    expect(stageAtIndex(10)).toBe(STAGE_ORDER[0]);
+  });
+
+  test('index 11 anchors to the second stage, matching the second tile of the second lap', () => {
+    expect(stageAtIndex(11)).toBe(STAGE_ORDER[1]);
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsContent.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsContent.test.tsx
@@ -157,4 +157,56 @@ describe('HabitsContent', () => {
     );
     expect(queryByTestId('habits-pagination')).toBeNull();
   });
+
+  it('keeps the pagination bar visible on an empty second-lap invite page (stranded-page trap)', () => {
+    const { getByTestId } = render(
+      <HabitsContent
+        habits={[]}
+        loading={false}
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={{
+          page: 1,
+          pageCount: 2,
+          onPrev: jest.fn(),
+          onNext: jest.fn(),
+          scale: 1,
+          stageStart: 11,
+          stageEnd: 20,
+        }}
+      />,
+    );
+    expect(getByTestId('habits-empty-state')).toBeTruthy();
+    expect(getByTestId('habits-pagination')).toBeTruthy();
+  });
+
+  it('shows the stage range as the visible pagination label', () => {
+    const habits = [makeHabit(1)];
+    const { getByText } = render(
+      <HabitsContent
+        habits={habits}
+        loading={false}
+        error={null}
+        columns={1}
+        gridGutter={8}
+        renderItem={renderRow}
+        onRetry={jest.fn()}
+        onAddHabit={jest.fn()}
+        pagination={{
+          page: 0,
+          pageCount: 2,
+          onPrev: jest.fn(),
+          onNext: jest.fn(),
+          scale: 1,
+          stageStart: 1,
+          stageEnd: 10,
+        }}
+      />,
+    );
+    expect(getByText(/Stages\s*1[\s\S]*10/)).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsEmptyState.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmptyState.test.tsx
@@ -48,6 +48,23 @@ describe('HabitsEmptyState', () => {
   });
 });
 
+describe('HabitsEmptyState second-lap invite (stages 11-20)', () => {
+  it('renders range-aware copy naming the stage bounds when stageStart/stageEnd are supplied', () => {
+    const { getByTestId, getByText } = render(<HabitsEmptyState stageStart={11} stageEnd={20} />);
+    expect(getByTestId('habits-empty-state')).toBeTruthy();
+    expect(getByText(/11[\s\S]*20/)).toBeTruthy();
+  });
+
+  it('still renders the Add CTA and fires onAdd when lap-context props are supplied', () => {
+    const onAdd = jest.fn();
+    const { getByTestId } = render(
+      <HabitsEmptyState stageStart={11} stageEnd={20} onAdd={onAdd} />,
+    );
+    fireEvent.press(getByTestId('habits-empty-add'));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+});
+
 const sampleHabit = { id: 1, name: 'Meditate' } as unknown as Habit;
 const renderTile = () => (<></>) as unknown as React.ReactElement;
 const baseProps = {

--- a/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
@@ -111,6 +111,42 @@ describe('HabitsScreen chrome accessibility', () => {
       expect(getByLabelText('Previous page').props.accessibilityState).toEqual({ disabled: false });
       expect(getByLabelText('Next page').props.accessibilityState).toEqual({ disabled: false });
     });
+
+    it('shows the stage range as the visible label, moving the page position into the accessibility label', () => {
+      const { getByText, getByTestId } = render(
+        <PaginationBar
+          page={0}
+          pageCount={2}
+          onPrev={noop}
+          onNext={noop}
+          scale={1}
+          stageStart={1}
+          stageEnd={10}
+        />,
+      );
+      const rangeLabel = getByText(/Stages\s*1[\s\S]*10/);
+      expect(rangeLabel).toBeTruthy();
+      // The page position is announced on the visible range Text (an
+      // accessibility element), not the container whose label a screen reader
+      // would skip past its focusable children.
+      expect(rangeLabel.props.accessibilityLabel).toMatch(/page 1 of 2/i);
+      expect(getByTestId('habits-pagination')).toBeTruthy();
+    });
+
+    it('shows the second-lap stage range for page 2', () => {
+      const { getByText } = render(
+        <PaginationBar
+          page={1}
+          pageCount={2}
+          onPrev={noop}
+          onNext={noop}
+          scale={1}
+          stageStart={11}
+          stageEnd={20}
+        />,
+      );
+      expect(getByText(/Stages\s*11[\s\S]*20/)).toBeTruthy();
+    });
   });
 
   describe('EnergyCTA', () => {

--- a/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
@@ -1,0 +1,152 @@
+/* eslint-env jest */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Second habit set (stages 11-20): once a lap fills every slot, the screen
+// offers a trailing invite page into the next lap instead of stranding the
+// user on a full first page with no way forward.
+import { jest, describe, afterEach, it, expect } from '@jest/globals';
+import React from 'react';
+import { Text } from 'react-native';
+import renderer from 'react-test-renderer';
+
+const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
+  id,
+  name: `Habit ${id}`,
+  icon: '✨',
+  start_date: '2020-01-01',
+  energy_cost: 1,
+  energy_return: 2,
+  stage: 'Beige',
+  streak: 0,
+  goals: [
+    {
+      id: id * 100,
+      habit_id: id,
+      title: 'Clear',
+      tier: 'clear',
+      target: 1,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ],
+  ...overrides,
+});
+
+const buildApiHabits = (count: number) =>
+  Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
+
+jest.mock('../../../api', () => ({
+  habits: {
+    listAll: jest.fn() as any,
+    create: jest.fn() as any,
+    update: jest.fn() as any,
+    delete: jest.fn() as any,
+    getStats: (jest.fn() as any).mockResolvedValue({
+      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+      values: [0, 0, 0, 0, 0, 0, 0],
+      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+      longest_streak: 0,
+      current_streak: 0,
+      total_completions: 0,
+      completion_rate: 0,
+      completion_dates: [],
+    }),
+  },
+  goalCompletions: { create: jest.fn() as any },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactLib = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: any }) =>
+      ReactLib.createElement(ReactLib.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+const { habits: habitsApi } = require('../../../api');
+const HabitsScreen = require('../HabitsScreen').default;
+
+const renderScreen = async (apiHabits: ReturnType<typeof buildApiHabits>) => {
+  habitsApi.listAll.mockResolvedValue(apiHabits);
+  jest
+    .spyOn(require('react-native'), 'useWindowDimensions')
+    .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });
+  let testRenderer: any;
+  await renderer.act(async () => {
+    testRenderer = renderer.create(React.createElement(HabitsScreen));
+  });
+  await renderer.act(async () => {
+    await Promise.resolve();
+  });
+  return testRenderer;
+};
+
+const hasTestId = (tree: any, testID: string): boolean =>
+  tree.findAllByProps({ testID }).length > 0;
+
+const visibleTextMatches = (tree: any, pattern: RegExp): boolean =>
+  tree.findAllByType(Text).some((node: any) => {
+    const children = node.props.children;
+    const text = Array.isArray(children) ? children.join('') : String(children ?? '');
+    return pattern.test(text);
+  });
+
+describe('Habits screen second-lap pagination flow', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the stage-range pagination bar for a full first lap, invites into the second lap, and returns on Prev', async () => {
+    const testRenderer = await renderScreen(buildApiHabits(10));
+    const tree = testRenderer.root;
+
+    // A full first lap (10 habits) must show pagination, not just a bare list.
+    expect(hasTestId(tree, 'habits-pagination')).toBe(true);
+    expect(visibleTextMatches(tree, /Stages\s*1[\s\S]*10/)).toBe(true);
+
+    const nextButton = tree.findByProps({ testID: 'pagination-next' });
+    await renderer.act(async () => {
+      nextButton.props.onPress();
+    });
+
+    // The invite page: no second-lap habits yet, so the range-aware empty
+    // state renders, and the pagination bar stays visible (not stranded).
+    expect(hasTestId(tree, 'habits-empty-state')).toBe(true);
+    expect(hasTestId(tree, 'habits-pagination')).toBe(true);
+    expect(visibleTextMatches(tree, /Stages\s*11[\s\S]*20/)).toBe(true);
+
+    const prevButton = tree.findByProps({ testID: 'pagination-prev' });
+    await renderer.act(async () => {
+      prevButton.props.onPress();
+    });
+
+    // Back on the first lap: the list is showing again, not the empty state.
+    expect(hasTestId(tree, 'habits-list')).toBe(true);
+    expect(hasTestId(tree, 'habits-empty-state')).toBe(false);
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -7,6 +7,7 @@ import renderer from 'react-test-renderer';
 import { STAGE_COLORS } from '../../../design/tokens';
 import type { Habit } from '../Habits.types';
 import { HabitTile } from '../HabitTile';
+import type * as HabitUtilsModule from '../HabitUtils';
 
 const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
   id,
@@ -86,6 +87,14 @@ jest.mock('../components/StatsModal', () => ({
   __esModule: true,
   default: jest.fn(() => null),
 }));
+
+// Wrap the real stageAtIndex in a jest.fn so page-2 tests can assert which
+// index (page-relative vs global) HabitsScreen actually calls it with, while
+// every other test in this file still gets the real coloring behavior.
+jest.mock('../HabitUtils', () => {
+  const actual: typeof HabitUtilsModule = jest.requireActual('../HabitUtils');
+  return { ...actual, stageAtIndex: jest.fn(actual.stageAtIndex) };
+});
 
 const { habits: habitsApi } = require('../../../api');
 const HabitsScreen = require('../HabitsScreen').default;
@@ -192,7 +201,12 @@ describe('HabitsScreen position-based stage colors', () => {
     expect(tileBorderAt(tree, 9)).toBe(STAGE_COLORS['Clear Light']);
   });
 
-  it('restarts the Beige → Clear Light sequence on page 2', async () => {
+  it('re-anchors the Beige → Clear Light sequence on page 2 via the global-index mod-wrap', async () => {
+    // page 2 restarts the gradient because HABITS_PER_PAGE equals
+    // STAGE_ORDER.length, so global indices 10/11 mod-wrap back to 0/1 --
+    // pixel-identical to the old page-relative coloring, which is why this
+    // test cannot tell the two apart on its own (see the spy-based test below
+    // for the semantic assertion that the global index is what's used).
     const testRenderer = await renderScreen(buildApiHabits(12));
     const tree = testRenderer.root;
     expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
@@ -202,6 +216,20 @@ describe('HabitsScreen position-based stage colors', () => {
     });
     expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS.Beige);
     expect(tileBorderAt(tree, 1)).toBe(STAGE_COLORS.Purple);
+  });
+
+  it('calls stageAtIndex with global indices (10, 11), not page-relative ones, for page-2 tiles', async () => {
+    const { stageAtIndex: stageAtIndexMock } = require('../HabitUtils');
+    const testRenderer = await renderScreen(buildApiHabits(12));
+    const tree = testRenderer.root;
+    const nextButton = tree.findByProps({ testID: 'pagination-next' });
+    stageAtIndexMock.mockClear();
+    await renderer.act(async () => {
+      nextButton.props.onPress();
+    });
+    const calledWithIndices = stageAtIndexMock.mock.calls.map((args: unknown[]) => args[0]);
+    expect(calledWithIndices).toContain(10);
+    expect(calledWithIndices).toContain(11);
   });
 
   it('colors tiles by list position regardless of habit.stage', async () => {

--- a/frontend/src/features/Habits/__tests__/habitCounts.test.ts
+++ b/frontend/src/features/Habits/__tests__/habitCounts.test.ts
@@ -105,3 +105,29 @@ describe('unlockedHabits', () => {
     expect(unlockedHabits([])).toEqual([]);
   });
 });
+
+describe('second habit set (lap-agnostic counting)', () => {
+  // 15 habits spanning both laps: indices 0-9 are the first lap, 10-14 are
+  // the second. Revealed state and completions are mixed across the
+  // boundary so lap position cannot leak into either count.
+  const buildTwoLapHabits = (): Habit[] =>
+    Array.from({ length: 15 }, (_, i) =>
+      makeHabit({
+        id: i + 1,
+        revealed: i % 3 === 0, // revealed at 0, 3, 6, 9, 12 -- spans both laps
+        completions: i === 12 ? [{ id: `c-${i}`, timestamp: new Date(), completed_units: 1 }] : [],
+      }),
+    );
+
+  it('unlockedHabits returns exactly the revealed habits regardless of lap position', () => {
+    const habits = buildTwoLapHabits();
+    const unlocked = unlockedHabits(habits);
+    expect(unlocked.map((h) => h.id)).toEqual([1, 4, 7, 10, 13]);
+  });
+
+  it('countDoneToday counts a completion on a second-lap habit (index >= 10)', () => {
+    const habits = buildTwoLapHabits();
+    // Only index 12 (the 13th habit, second lap) has a today completion.
+    expect(countDoneToday(habits)).toBe(1);
+  });
+});

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -6,29 +6,62 @@ import { colors, radius, spacing, touchTarget } from '../../../design/tokens';
 interface HabitsEmptyStateProps {
   /** When provided, renders an "Add a habit" CTA wired to the add-habit modal. */
   onAdd?: () => void;
+  /** First stage of the current lap; with `stageEnd`, switches to lap-invite copy. */
+  stageStart?: number;
+  /** Last stage of the current lap; with `stageStart`, switches to lap-invite copy. */
+  stageEnd?: number;
 }
 
+interface EmptyStateCopy {
+  title: string;
+  subtitle: string;
+}
+
+const FIRST_RUN_COPY: EmptyStateCopy = {
+  title: 'No habits yet',
+  subtitle: 'Add your first habit to start building momentum. Small, daily actions compound.',
+};
+
+/**
+ * Copy for the empty state. With a stage range supplied (any lap past the
+ * first), it names the newly-open stages as a gentle, declinable invitation to
+ * start another set — never a nudge. Otherwise it keeps the first-run guidance.
+ */
+const selectCopy = (stageStart?: number, stageEnd?: number): EmptyStateCopy =>
+  stageStart !== undefined && stageEnd !== undefined
+    ? {
+        title: `Stages ${stageStart}–${stageEnd} are open`,
+        subtitle:
+          'Begin a new set whenever it feels right — no pressure either way, or simply keep tending the habits you already have.',
+      }
+    : FIRST_RUN_COPY;
+
 /** First-run fallback guiding a zero-habit user to add their first (audit-ux-07). */
-export const HabitsEmptyState = ({ onAdd }: HabitsEmptyStateProps): React.JSX.Element => (
-  <View style={styles.container} testID="habits-empty-state">
-    <Text style={styles.icon}>{'+'}</Text>
-    <Text style={styles.title}>No habits yet</Text>
-    <Text style={styles.subtitle}>
-      Add your first habit to start building momentum. Small, daily actions compound.
-    </Text>
-    {onAdd && (
-      <TouchableOpacity
-        onPress={onAdd}
-        accessibilityRole="button"
-        accessibilityLabel="Add a habit"
-        style={styles.cta}
-        testID="habits-empty-add"
-      >
-        <Text style={styles.ctaText}>Add a habit</Text>
-      </TouchableOpacity>
-    )}
-  </View>
-);
+export const HabitsEmptyState = ({
+  onAdd,
+  stageStart,
+  stageEnd,
+}: HabitsEmptyStateProps): React.JSX.Element => {
+  const { title, subtitle } = selectCopy(stageStart, stageEnd);
+  return (
+    <View style={styles.container} testID="habits-empty-state">
+      <Text style={styles.icon}>{'+'}</Text>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.subtitle}>{subtitle}</Text>
+      {onAdd && (
+        <TouchableOpacity
+          onPress={onAdd}
+          accessibilityRole="button"
+          accessibilityLabel="Add a habit"
+          style={styles.cta}
+          testID="habits-empty-add"
+        >
+          <Text style={styles.ctaText}>Add a habit</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {

--- a/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
@@ -78,3 +78,75 @@ describe('usePagination', () => {
     expect(result.current.page).toBe(1);
   });
 });
+
+// Second habit set (stages 11-20): a trailing invite page appears once every
+// slot on the current lap is filled, inviting the user into the next lap.
+describe('usePagination trailing invite page', () => {
+  it('adds a trailing invite page when count is an exact multiple of pageSize', () => {
+    expect(renderHook(() => usePagination(10, PAGE_SIZE)).result.current.pageCount).toBe(2);
+    expect(renderHook(() => usePagination(20, PAGE_SIZE)).result.current.pageCount).toBe(3);
+    expect(renderHook(() => usePagination(30, PAGE_SIZE)).result.current.pageCount).toBe(4);
+  });
+
+  it('does not add a spurious invite page for a partial last lap or an empty list', () => {
+    expect(renderHook(() => usePagination(15, PAGE_SIZE)).result.current.pageCount).toBe(2);
+    expect(renderHook(() => usePagination(0, PAGE_SIZE)).result.current.pageCount).toBe(1);
+  });
+
+  it('goNext can advance into the trailing invite page once the last content page is full', () => {
+    const { result } = renderHook(() => usePagination(10, PAGE_SIZE));
+    expect(result.current.page).toBe(0);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(1);
+  });
+
+  it('goLast retargets to the last content page, not the invite page, when count exactly fills whole pages', () => {
+    const ten = renderHook(() => usePagination(10, PAGE_SIZE));
+    expect(ten.result.current.pageCount).toBe(2);
+    act(() => ten.result.current.goLast());
+    expect(ten.result.current.page).toBe(0);
+
+    const twenty = renderHook(() => usePagination(20, PAGE_SIZE));
+    expect(twenty.result.current.pageCount).toBe(3);
+    act(() => twenty.result.current.goLast());
+    expect(twenty.result.current.page).toBe(1);
+  });
+
+  it('goLast still lands on the last content page for counts that do not exactly fill a page', () => {
+    const eleven = renderHook(() => usePagination(11, PAGE_SIZE));
+    act(() => eleven.result.current.goLast());
+    expect(eleven.result.current.page).toBe(1);
+
+    const twentyOne = renderHook(() => usePagination(21, PAGE_SIZE));
+    act(() => twentyOne.result.current.goLast());
+    expect(twentyOne.result.current.page).toBe(2);
+  });
+
+  it('growing from a partial page to an exact multiple adds the invite page, and goLast stays on the content page', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => usePagination(count, PAGE_SIZE),
+      { initialProps: { count: 9 } },
+    );
+    expect(result.current.pageCount).toBe(1);
+    rerender({ count: 10 });
+    expect(result.current.pageCount).toBe(2);
+    act(() => result.current.goLast());
+    expect(result.current.page).toBe(0);
+  });
+
+  it('a goLast captured before an append lands on the appended row, not the stale last page', () => {
+    // Reproduces the add flow: the screen captures goLast at count=10 (last
+    // content page 0), the append raises the count to 11 (new row on page 1),
+    // and only then does the captured callback run. It must target the row the
+    // user just created, so goLast reads the live count rather than the render
+    // it was created in.
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => usePagination(count, PAGE_SIZE),
+      { initialProps: { count: 10 } },
+    );
+    const capturedGoLast = result.current.goLast;
+    rerender({ count: 11 });
+    act(() => capturedGoLast());
+    expect(result.current.page).toBe(1);
+  });
+});

--- a/frontend/src/features/Habits/hooks/usePagination.ts
+++ b/frontend/src/features/Habits/hooks/usePagination.ts
@@ -1,16 +1,22 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 /**
  * Window a list into fixed-size pages. The setters never advance the internal
- * `page` above `pageCount - 1` (`goNext` caps it, `goLast` targets it, `goPrev`
- * only decreases), so `goPrev`/`goNext` always step relative to a valid index.
+ * `page` above `pageCount - 1` (`goNext` caps it, `goLast` targets the last
+ * content page, `goPrev` only decreases), so `goPrev`/`goNext` always step
+ * relative to a valid index.
  * The read site additionally clamps `page` to guard the one case the setters
  * cannot: `habitCount` shrinking beneath the stored index without a setter call
  * (e.g. items are removed) — resolving it on the next read without an extra
  * render.
  *
- * `goLast` jumps to the true last page (`pageCount - 1`). Use it after
- * appending a new item so the user lands on the page that contains it.
+ * When the last lap is completely full (`habitCount` is a positive exact
+ * multiple of `pageSize`) the count grows by one trailing **invite page**: an
+ * extra navigable empty page that lets the user start the next lap. `goNext`
+ * can step onto it, but `goLast` deliberately does not — it retargets to the
+ * last *content* page (the page holding the final item), so appending a new
+ * item lands the user on the row they just created rather than the empty
+ * invitation beyond it.
  */
 export interface PaginationState {
   /** Clamped current page (0-based). */
@@ -23,12 +29,25 @@ export interface PaginationState {
 }
 
 export const usePagination = (habitCount: number, pageSize: number): PaginationState => {
-  const pageCount = Math.max(1, Math.ceil(habitCount / pageSize));
+  const contentPages = Math.max(1, Math.ceil(habitCount / pageSize));
+  const hasInvitePage = habitCount > 0 && habitCount % pageSize === 0;
+  const pageCount = contentPages + (hasInvitePage ? 1 : 0);
   const [page, setPage] = useState(0);
+
+  // Track the live count in a ref so `goLast` reads it at call time rather than
+  // closing over a stale render. The add flow appends a habit and then calls
+  // `goLast` from a callback captured before the append re-rendered; without
+  // the ref that callback would target the pre-append last page and strand the
+  // user on the wrong lap instead of the row they just created.
+  const countRef = useRef(habitCount);
+  countRef.current = habitCount;
 
   const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
   const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
-  const goLast = useCallback(() => setPage(pageCount - 1), [pageCount]);
+  const goLast = useCallback(
+    () => setPage(Math.floor(Math.max(0, countRef.current - 1) / pageSize)),
+    [pageSize],
+  );
 
   return {
     page: Math.min(page, pageCount - 1),


### PR DESCRIPTION
## Summary

Surfaces the second lap of the Archetypal Wavelength (stages 11-20) as a reachable second page on the Habits screen, with room for arbitrarily many laps beyond it.

- `usePagination` grows one navigable **trailing invite page** whenever the last lap is exactly full (`count % pageSize === 0`), generalizing to any number of laps. `goLast` retargets to the last **content** page and reads a live-count ref, so appending a habit across a lap boundary lands the user on the row they just created instead of the empty invite beyond it.
- The `HabitsContent` pagination bar was lifted out of the empty-state branch so an empty invite page keeps its navigation (no stranded page).
- New pure `stageRangeForPage(page, pageSize)` helper feeds both the pagination affordance and the empty state. The affordance now names the lap in view (`Stages 11-20`) and folds the page position into that visible label's `accessibilityLabel` for screen readers.
- Tiles anchor their stage color to their **global** index through the shared `stageAtIndex` helper (no duplicated stage math); the mod-wrap restarts the Beige -> Clear Light gradient each lap.
- The empty second-lap page shows a declinable, non-pressuring invitation that names the newly open stages (NORTH-STAR tone); first-run copy is unchanged.
- Add/edit/delete parity on the second page is inherited from the shared habit list and actions. Counts, streaks, and energy stay lap-agnostic through the existing `isHabitUnlocked` predicate.

No backend/model/migration changes: stage is positional and ordering already persists via `sort_order`. `MAX_HABITS`, page size, and one-screen tile density are unchanged.

## Test plan

- `cd frontend && ./scripts/frontend/check-all.sh` — jest (3472 passing), tsc, eslint (`--max-warnings=0`), and prettier all green.
- New/extended Jest coverage: `usePagination` invite-page + `goLast` retarget incl. a stale-closure regression; `stageRangeForPage` math; global-index stage anchoring (spy-based, since the mod-wrap makes it pixel-identical); lap-aware empty-state copy; stranded-page co-render; stage-range pagination label + accessibility; lap-agnostic counts; and a screen-level second-lap navigation flow.

Closes #1333