### PR TITLE
fix(habits): compute missed-days modal dates in the user's timezone, not UTC

### DIFF
--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -6,7 +6,9 @@ import { brightenColor, colors, STAGE_COLORS, STAGE_ORDER } from '../../design/t
 import {
   DEFAULT_TIMEZONE,
   MS_PER_DAY,
+  addDaysInTZ,
   dayKeyInTZ,
+  dayKeyToInstant,
   streakFromCompletions,
   subtractiveLongestStreakFromCompletions,
   subtractiveStreakFromCompletions,
@@ -297,12 +299,9 @@ const emptyStats = (): HabitStatsData => ({
 });
 
 /**
- * UTC day key kept for legacy call sites that have not yet threaded a TZ
- * parameter (e.g. `logHabitUnits`, `calculateMissedDays`).  These are
- * called from optimistic-update paths that operate on `Date` objects
- * that have no notion of user TZ; UTC bucketing matches the historical
- * behavior, and Wave 4 (frontend feature screens) will migrate them as
- * part of its `useOptimisticMutation` work.
+ * UTC day key for `logHabitUnits`, whose optimistic-update path operates on
+ * bare `Date` objects with no notion of user TZ. UTC bucketing matches the
+ * historical de-dupe behavior for logging a completion once per calendar day.
  */
 const utcDayKey = (d: Date): string => dayKeyInTZ(d, DEFAULT_TIMEZONE);
 
@@ -528,35 +527,40 @@ export const toLocalHabitStats = (api: ApiHabitStats): HabitStatsData => ({
   completionDates: api.completion_dates,
 });
 
+// A gap needs at least a first and a last day to bound it.
+const MIN_KEYS_TO_BOUND_GAP = 2;
+// Day step used when walking the range between first and last completion.
+const NEXT_DAY_OFFSET = 1;
+
 /**
- * Calculate days without completions between the first and last completion.
+ * Calculate days without completions between the first and last completion,
+ * bucketing each completion into the user's local day via `dayKeyInTZ`.
+ *
+ * Walking the gap purely on `YYYY-MM-DD` day keys (which sort and compare
+ * lexicographically in chronological order) keeps the arithmetic in one
+ * timezone, so consecutive local days that straddle the UTC boundary no
+ * longer register a phantom missed day.
  */
-export const calculateMissedDays = (habit: Habit): Date[] => {
+export const calculateMissedDays = (habit: Habit, tz: string = DEFAULT_TIMEZONE): Date[] => {
   const completions = habit.completions;
   if (!completions || completions.length === 0) return [];
 
-  const completedDates = new Set<string>();
+  const completedKeys = new Set<string>();
   for (const c of completions) {
-    completedDates.add(utcDayKey(new Date(c.timestamp)));
+    completedKeys.add(dayKeyInTZ(c.timestamp, tz));
   }
+  if (completedKeys.size < MIN_KEYS_TO_BOUND_GAP) return [];
 
-  const sorted = Array.from(completedDates)
-    .map((s) => new Date(s + 'T00:00:00Z'))
-    .sort((a, b) => a.getTime() - b.getTime());
-
-  if (sorted.length < 2) return [];
+  const sortedKeys = Array.from(completedKeys).sort();
+  const lastKey = sortedKeys[sortedKeys.length - 1]!;
 
   const missed: Date[] = [];
-  const first = sorted[0]!;
-  const last = sorted[sorted.length - 1]!;
-  const cursor = new Date(first);
-  cursor.setDate(cursor.getDate() + 1);
-
-  while (cursor < last) {
-    if (!completedDates.has(utcDayKey(cursor))) {
-      missed.push(new Date(cursor));
+  let cursorKey = addDaysInTZ(sortedKeys[0]!, NEXT_DAY_OFFSET, tz);
+  while (cursorKey < lastKey) {
+    if (!completedKeys.has(cursorKey)) {
+      missed.push(dayKeyToInstant(cursorKey, tz));
     }
-    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    cursorKey = addDaysInTZ(cursorKey, NEXT_DAY_OFFSET, tz);
   }
 
   return missed;

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -247,40 +247,44 @@ interface HabitModalsProps {
 export const missedDaysFor = (
   open: boolean,
   habit: Habit | null,
-): ReturnType<typeof calculateMissedDays> => (open && habit ? calculateMissedDays(habit) : []);
+  tz?: string,
+): ReturnType<typeof calculateMissedDays> => (open && habit ? calculateMissedDays(habit, tz) : []);
 
 const HabitDataModals = ({
   modals,
   selectedHabit,
   habitStats,
   actions,
-}: Omit<HabitModalsProps, 'habits' | 'onAddHabit'>) => (
-  <>
-    <GoalModal
-      visible={modals.goal}
-      habit={selectedHabit}
-      onClose={() => modals.close('goal')}
-      onUpdateGoal={actions.updateGoal}
-      onUpdateGoalUnits={actions.updateGoalUnits}
-      onLogUnit={actions.logUnit}
-      onUpdateHabit={actions.updateHabit}
-    />
-    <StatsModal
-      visible={modals.stats}
-      habit={selectedHabit}
-      stats={habitStats}
-      onClose={() => modals.close('stats')}
-    />
-    <MissedDaysModal
-      visible={modals.missedDays}
-      habit={selectedHabit}
-      missedDays={missedDaysFor(modals.missedDays, selectedHabit)}
-      onClose={() => modals.close('missedDays')}
-      onBackfill={actions.backfillMissedDays}
-      onNewStartDate={actions.setNewStartDate}
-    />
-  </>
-);
+}: Omit<HabitModalsProps, 'habits' | 'onAddHabit'>) => {
+  const { userTimezone } = useAuth();
+  return (
+    <>
+      <GoalModal
+        visible={modals.goal}
+        habit={selectedHabit}
+        onClose={() => modals.close('goal')}
+        onUpdateGoal={actions.updateGoal}
+        onUpdateGoalUnits={actions.updateGoalUnits}
+        onLogUnit={actions.logUnit}
+        onUpdateHabit={actions.updateHabit}
+      />
+      <StatsModal
+        visible={modals.stats}
+        habit={selectedHabit}
+        stats={habitStats}
+        onClose={() => modals.close('stats')}
+      />
+      <MissedDaysModal
+        visible={modals.missedDays}
+        habit={selectedHabit}
+        missedDays={missedDaysFor(modals.missedDays, selectedHabit, userTimezone)}
+        onClose={() => modals.close('missedDays')}
+        onBackfill={actions.backfillMissedDays}
+        onNewStartDate={actions.setNewStartDate}
+      />
+    </>
+  );
+};
 
 const HabitWriteModals = ({
   modals,

--- a/frontend/src/features/Habits/__tests__/HabitStats.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitStats.test.ts
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 /* global describe, test, expect, jest */
+import { dayKeyInTZ } from '../../../utils/dateUtils';
 import type { Habit, Goal } from '../Habits.types';
 import { generateStatsForHabit, toLocalHabitStats, calculateMissedDays } from '../HabitUtils';
 
@@ -432,5 +433,61 @@ describe('calculateMissedDays', () => {
     const missed = calculateMissedDays(habit);
     expect(missed).toHaveLength(1);
     expect(missed[0]!.toISOString().slice(0, 10)).toBe('2024-01-02');
+  });
+
+  test('does not flag a missed day for consecutive local days that straddle the UTC boundary', () => {
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [
+        // Jan 1 08:00 PST
+        { id: 'c-1', timestamp: new Date('2026-01-01T16:00:00.000Z'), completed_units: 1 },
+        // Jan 2 23:00 PST
+        { id: 'c-2', timestamp: new Date('2026-01-03T07:00:00.000Z'), completed_units: 1 },
+      ],
+    };
+    const missed = calculateMissedDays(habit, 'America/Los_Angeles');
+    expect(missed).toEqual([]);
+  });
+
+  test('buckets by UTC by default (unchanged legacy behavior)', () => {
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [
+        { id: 'c-1', timestamp: new Date('2026-01-01T16:00:00.000Z'), completed_units: 1 },
+        { id: 'c-2', timestamp: new Date('2026-01-03T07:00:00.000Z'), completed_units: 1 },
+      ],
+    };
+    const missed = calculateMissedDays(habit);
+    expect(missed).toHaveLength(1);
+    expect(missed[0]!.toISOString().slice(0, 10)).toBe('2026-01-02');
+  });
+
+  test('emits missed days that re-bucket to the same local day when backfilled', () => {
+    const tz = 'America/Los_Angeles';
+    const habit: Habit = {
+      ...baseHabit,
+      completions: [
+        // Jan 1 08:00 PST, then a three-day gap to Jan 5 08:00 PST.
+        { id: 'c-1', timestamp: new Date('2026-01-01T16:00:00.000Z'), completed_units: 1 },
+        { id: 'c-2', timestamp: new Date('2026-01-05T16:00:00.000Z'), completed_units: 1 },
+      ],
+    };
+    const missed = calculateMissedDays(habit, tz);
+    expect(missed.map((d) => dayKeyInTZ(d, tz))).toEqual([
+      '2026-01-02',
+      '2026-01-03',
+      '2026-01-04',
+    ]);
+
+    // Backfilling those instants and re-detecting must leave no gap: the
+    // emitted Date has to land on the same local day it represents.
+    const backfilled: Habit = {
+      ...habit,
+      completions: [
+        ...habit.completions!,
+        ...missed.map((d, i) => ({ id: `b-${i}`, timestamp: d, completed_units: 1 })),
+      ],
+    };
+    expect(calculateMissedDays(backfilled, tz)).toEqual([]);
   });
 });

--- a/frontend/src/features/Habits/components/MissedDaysModal.tsx
+++ b/frontend/src/features/Habits/components/MissedDaysModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Modal, Text, TouchableOpacity, View } from 'react-native';
 import { Calendar, type DateData } from 'react-native-calendars';
 
+import { parseISODate, toISODate } from '../../../components/DatePicker';
 import { STAGE_COLORS } from '../../../design/tokens';
 import styles from '../Habits.styles';
 import type { MissedDaysModalProps } from '../Habits.types';
@@ -66,7 +67,7 @@ const useResetFlow = (
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showCalendar, setShowCalendar] = useState(false);
   const onPick = (date: DateData) => {
-    const picked = new Date(date.dateString);
+    const picked = parseISODate(date.dateString);
     setSelectedDate(picked);
     setPendingDate(picked);
   };
@@ -105,7 +106,7 @@ const MissedDaysBody = ({
     }
   };
 
-  const selectedDateString = reset.selectedDate.toISOString().split('T')[0]!;
+  const selectedDateString = toISODate(reset.selectedDate);
 
   return (
     <View style={styles.missedDaysContent}>

--- a/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/MissedDaysModal.test.tsx
@@ -29,6 +29,7 @@ jest.mock('react-native-calendars', () => {
   return { Calendar };
 });
 
+import * as DatePicker from '../../../../components/DatePicker';
 import type { Habit, MissedDaysModalProps } from '../../Habits.types';
 import { MissedDaysModal, ResetConfirmation } from '../MissedDaysModal';
 
@@ -226,5 +227,25 @@ describe('MissedDaysModal reset-start-date flow', () => {
     expect(habitId).toBe(7);
     expect(newDate.toISOString().slice(0, 10)).toBe('2026-08-10');
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Jest pins TZ=UTC, where `new Date('2026-08-10')` and the tz-safe
+  // `parseISODate('2026-08-10')` coincide, so a numeric day assertion cannot
+  // distinguish the bug. Instead verify the pick is routed through the
+  // tz-safe parser (local midnight) rather than the UTC-parsing `new Date`.
+  it('persists the tapped day via the timezone-safe parser, not UTC new Date', () => {
+    const spy = jest.spyOn(DatePicker, 'parseISODate');
+    try {
+      const { getByText, getByTestId, onNewStartDate } = renderMissedDaysModal();
+      fireEvent.press(getByText('Set new start date'));
+      fireEvent.press(getByTestId('calendar-mock-day'));
+      fireEvent.press(getByTestId('reset-confirm-yes'));
+
+      expect(spy).toHaveBeenCalledWith('2026-08-10');
+      const [, newDate] = onNewStartDate.mock.calls[0] as [number, Date];
+      expect(newDate.getTime()).toBe(DatePicker.parseISODate('2026-08-10').getTime());
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/frontend/src/utils/__tests__/dateUtils.test.ts
+++ b/frontend/src/utils/__tests__/dateUtils.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TIMEZONE,
   addDaysInTZ,
   dayKeyInTZ,
+  dayKeyToInstant,
   dayLabel,
   detectDeviceTimezone,
   streakFromCompletions,
@@ -363,6 +364,36 @@ describe('subtractiveLongestStreakFromCompletions', () => {
         TODAY,
       ),
     ).toBe(0);
+  });
+});
+
+describe('dayKeyToInstant', () => {
+  it('round-trips through dayKeyInTZ for a negative-offset zone', () => {
+    const tz = 'America/Los_Angeles';
+    const instant = dayKeyToInstant('2026-01-02', tz);
+    expect(dayKeyInTZ(instant, tz)).toBe('2026-01-02');
+  });
+
+  it('round-trips through dayKeyInTZ for a far-eastern zone', () => {
+    const tz = 'Pacific/Kiritimati';
+    const instant = dayKeyToInstant('2026-06-15', tz);
+    expect(dayKeyInTZ(instant, tz)).toBe('2026-06-15');
+  });
+
+  it('round-trips across a DST spring-forward boundary', () => {
+    const tz = 'America/Los_Angeles';
+    const instant = dayKeyToInstant('2026-03-08', tz);
+    expect(dayKeyInTZ(instant, tz)).toBe('2026-03-08');
+  });
+
+  it('anchors at UTC midday for UTC itself', () => {
+    const instant = dayKeyToInstant('2026-01-02', 'UTC');
+    expect(instant.toISOString()).toBe('2026-01-02T12:00:00.000Z');
+  });
+
+  it('falls back to UTC midnight for a malformed day key', () => {
+    const instant = dayKeyToInstant('not-a-date', 'America/Los_Angeles');
+    expect(Number.isNaN(instant.getTime())).toBe(true);
   });
 });
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -155,6 +155,71 @@ export const addDaysInTZ = (dayKey: string, days: number, _tz: string): string =
   return shifted.toISOString().slice(0, 10);
 };
 
+/** Wall-clock hour used to anchor a day-key instant clear of DST shoulders. */
+const NOON_HOUR = 12;
+
+/**
+ * The zone's UTC offset (local minus UTC) in milliseconds at `instant`,
+ * derived from the formatted wall-clock parts. DST-correct for that instant.
+ */
+const zoneOffsetMs = (instant: Date, tz: string): number => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(instant);
+  const field: Record<string, number> = {};
+  for (const part of parts) {
+    if (part.type !== 'literal') field[part.type] = Number.parseInt(part.value, 10);
+  }
+  // Intl can render midnight as hour 24; normalise it to 0.
+  const hour = field.hour === 24 ? 0 : field.hour!;
+  const wallAsUTC = Date.UTC(
+    field.year!,
+    field.month! - 1,
+    field.day!,
+    hour,
+    field.minute!,
+    field.second!,
+  );
+  return wallAsUTC - instant.getTime();
+};
+
+/**
+ * Convert a `YYYY-MM-DD` day key into a UTC instant that falls on that day in
+ * `tz`, anchored at local noon.
+ *
+ * The inverse of `dayKeyInTZ`: `dayKeyInTZ(dayKeyToInstant(k, tz), tz) === k`
+ * for every real zone offset (UTC-12..UTC+14). Anchoring at local noon (rather
+ * than the naive `${k}T00:00:00Z`, which lands on the previous day for
+ * negative-offset zones and the next day for far-eastern ones) keeps the
+ * instant unambiguously inside the target calendar day and clear of DST
+ * shoulders. Use it when a day key must round-trip through a `Date` that later
+ * gets re-bucketed in the same zone (e.g. persisted completion timestamps).
+ */
+export const dayKeyToInstant = (dayKey: string, tz: string): Date => {
+  const [year, month, day] = dayKey.split('-').map((part) => Number.parseInt(part, 10));
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    Number.isNaN(year) ||
+    Number.isNaN(month) ||
+    Number.isNaN(day)
+  ) {
+    return new Date(`${dayKey}T00:00:00Z`);
+  }
+  const zone = resolveZone(tz);
+  const wallNoonAsUTC = Date.UTC(year, month - 1, day, NOON_HOUR, 0, 0);
+  const offsetMs = zoneOffsetMs(new Date(wallNoonAsUTC), zone);
+  return new Date(wallNoonAsUTC - offsetMs);
+};
+
 /**
  * Compute the user's current streak from completion timestamps.
  *


### PR DESCRIPTION
## Summary

The Habits Missed-Days flow handled calendar dates in UTC on two write paths, so any user west of UTC (all of the Americas) could:

- **Reset a habit's start date to the day *before* the one they tapped** — `MissedDaysModal` parsed the picked `YYYY-MM-DD` string with `new Date(str)` (UTC midnight).
- **Be offered a backfill for a day they did not miss** — `calculateMissedDays` bucketed completions by UTC day, so two completions on consecutive *local* days that straddle the UTC boundary produced a phantom missed day that flowed straight to the backfill write path.

This routes the modal's date math through the repo's centralized TZ-aware helpers instead of hand-rolled UTC conversions:

- `MissedDaysModal.tsx`: pick via `parseISODate` (local midnight, mirroring sibling `ReorderHabitsModal`); derive the calendar-highlight key with `toISODate` so it doesn't regress to the prior day once the pick is local.
- `HabitUtils.ts` `calculateMissedDays(habit, tz)`: bucket completions with `dayKeyInTZ` and walk the gap on `YYYY-MM-DD` day keys via `addDaysInTZ`; the user's zone is threaded from `HabitsScreen` (`missedDaysFor` + the `MissedDaysModal` call site only — the list/pagination region is untouched).
- New `dateUtils.dayKeyToInstant(dayKey, tz)`: the inverse of `dayKeyInTZ`, anchoring at local noon so an emitted missed-day `Date` re-buckets onto the same local day when backfilled — instead of a UTC-midnight instant that lands a day early for negative-offset zones (and clear of DST shoulders / UTC+12..+14).
- Narrowed the stale `utcDayKey` docstring now that only `logHabitUnits` uses it.

## Test plan

- New unit tests (`HabitStats.test.ts`): two completions on consecutive local days straddling the UTC boundary yield **zero** missed days under `America/Los_Angeles`; UTC-default behavior is pinned unchanged; and an identify → backfill → re-identify round-trip yields `[]` (proves emitted instants re-bucket to the correct local day).
- New unit tests (`dateUtils.test.ts`): `dayKeyToInstant` round-trips through `dayKeyInTZ` for negative-offset, far-eastern (Kiritimati), DST-transition, and UTC zones.
- New component test (`MissedDaysModal.test.tsx`): the calendar pick is routed through the TZ-safe `parseISODate` seam rather than UTC-parsing `new Date` (jest pins `TZ=UTC`, where a numeric-day assertion cannot distinguish the two, so this asserts the seam).
- Full `scripts/frontend/check-all.sh` green: 328 suites / 3468 tests, ESLint, tsc, prettier, coverage.

Closes #1350