### PR TITLE
refactor(habits): extract a shared ModalHeader primitive across the Habits modals

### DIFF
--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -53,31 +53,6 @@ export const styles = StyleSheet.create({
     borderTopWidth: 5,
     ...SHADOWS.large,
   },
-  modalHeader: {
-    flexDirection: 'row',
-    justifyContent: JUSTIFY_SPACE_BETWEEN,
-    alignItems: 'center',
-    borderBottomWidth: 1,
-    borderColor: '#eee',
-    paddingBottom: SPACING.md,
-    marginBottom: SPACING.md,
-  },
-  modalTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    flex: 1,
-    color: COLORS.text.primary,
-  },
-  closeButton: {
-    padding: SPACING.xs,
-  },
-  closeButtonText: {
-    fontSize: 28,
-    lineHeight: 28,
-    fontWeight: '300',
-    color: COLORS.text.secondary,
-  },
-
   // ===== Goal Items =====
   saveButton: {
     paddingVertical: SPACING.xs,

--- a/frontend/src/features/Habits/components/AddHabitModal.tsx
+++ b/frontend/src/features/Habits/components/AddHabitModal.tsx
@@ -7,21 +7,13 @@ import type { AddHabitInput } from '../Habits.types';
 
 import { EnergyCostReturnEditor } from './EnergyCostReturnEditor';
 import HabitEmojiPicker from './HabitEmojiPicker';
+import ModalHeader from './ModalHeader';
 
 interface AddHabitModalProps {
   visible: boolean;
   onClose: () => void;
   onAdd: (_input: AddHabitInput) => void | Promise<void>;
 }
-
-const AddHabitHeader = ({ onClose }: { onClose: () => void }) => (
-  <View style={styles.modalHeader}>
-    <Text style={styles.modalTitle}>Add Habit</Text>
-    <TouchableOpacity onPress={onClose} style={styles.closeButton} testID="add-habit-close">
-      <Text style={styles.closeButtonText}>×</Text>
-    </TouchableOpacity>
-  </View>
-);
 
 interface NameRowProps {
   name: string;
@@ -174,7 +166,7 @@ export const AddHabitModal = ({ visible, onClose, onAdd }: AddHabitModalProps) =
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.modalOverlay}>
         <View style={styles.settingsModalContent} testID="add-habit-modal">
-          <AddHabitHeader onClose={onClose} />
+          <ModalHeader title="Add Habit" onClose={onClose} closeTestID="add-habit-close" />
           <NameRow name={f.name} setName={f.setName} />
           <IconRow
             icon={f.icon}

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -50,6 +50,7 @@ import {
 
 import ConfirmDialog from './ConfirmDialog';
 import HabitEmojiPicker from './HabitEmojiPicker';
+import ModalHeader from './ModalHeader';
 
 /** Height of the goal progress bar; tier star markers are centered on it. */
 const MODAL_BAR_HEIGHT = 12;
@@ -1038,8 +1039,7 @@ const GoalModalHeader = ({
   onToggleEdit,
 }: GoalModalHeaderProps) => (
   <>
-    <View style={styles.modalHeader}>
-      <Text style={styles.modalTitle}>{habit.name}</Text>
+    <ModalHeader title={habit.name} onClose={onClose}>
       <EditToggleButton isEditing={isEditing} onToggle={onToggleEdit} />
       <TouchableOpacity
         testID="goal-modal-icon-button"
@@ -1049,10 +1049,7 @@ const GoalModalHeader = ({
       >
         <Text style={styles.iconLarge}>{habit.icon}</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-        <Text style={styles.closeButtonText}>×</Text>
-      </TouchableOpacity>
-    </View>
+    </ModalHeader>
     {goalGroup && (
       <View testID="goal-group-badge" style={goalGroupBadgeStyles.container}>
         <Text style={goalGroupBadgeStyles.text}>

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -19,6 +19,7 @@ import type { Habit, HabitSettingsModalProps } from '../Habits.types';
 import ConfirmDialog from './ConfirmDialog';
 import { EnergyCostReturnEditor } from './EnergyCostReturnEditor';
 import HabitEmojiPicker from './HabitEmojiPicker';
+import ModalHeader from './ModalHeader';
 
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
   if (current === 'daily') return 'weekly';
@@ -484,15 +485,6 @@ const useSettingsHandlers = (
   };
 };
 
-const SettingsModalHeader = ({ onClose }: { onClose: () => void }) => (
-  <View style={styles.modalHeader}>
-    <Text style={styles.modalTitle}>Edit Habit</Text>
-    <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-      <Text style={styles.closeButtonText}>×</Text>
-    </TouchableOpacity>
-  </View>
-);
-
 interface SettingsBodyProps {
   editedHabit: Habit;
   showEmojiSelector: boolean;
@@ -518,7 +510,7 @@ const SettingsModalBody = ({
     <View
       style={[styles.settingsModalContent, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
     >
-      <SettingsModalHeader onClose={onClose} />
+      <ModalHeader title="Edit Habit" onClose={onClose} />
       <SettingsForm
         editedHabit={editedHabit}
         showEmojiSelector={showEmojiSelector}

--- a/frontend/src/features/Habits/components/ModalHeader.tsx
+++ b/frontend/src/features/Habits/components/ModalHeader.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { colors as COLORS, SPACING } from '../../../design/tokens';
+
+interface ModalHeaderProps {
+  title: React.ReactNode;
+  onClose: () => void;
+  closeTestID?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared title-plus-close header for Habits modals. Renders the modal title,
+ * any inline controls passed as children, and the trailing close button.
+ */
+const ModalHeader = ({ title, onClose, closeTestID, children }: ModalHeaderProps) => (
+  <View style={styles.modalHeader}>
+    <Text style={styles.modalTitle}>{title}</Text>
+    {children}
+    <TouchableOpacity onPress={onClose} style={styles.closeButton} testID={closeTestID}>
+      <Text style={styles.closeButtonText}>×</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+    paddingBottom: SPACING.md,
+    marginBottom: SPACING.md,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    flex: 1,
+    color: COLORS.text.primary,
+  },
+  closeButton: {
+    padding: SPACING.xs,
+  },
+  closeButtonText: {
+    fontSize: 28,
+    lineHeight: 28,
+    fontWeight: '300',
+    color: COLORS.text.secondary,
+  },
+});
+
+export default ModalHeader;

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -10,6 +10,8 @@ import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
 import { calculateHabitStartDate, stageAtIndex } from '../HabitUtils';
 
+import ModalHeader from './ModalHeader';
+
 // Lazy require so jest (which doesn't transform this ES-module package) can load this file.
 let DateTimePickerModal: ComponentType<Record<string, unknown>> = () => null;
 if (Platform.OS !== 'web') {
@@ -224,12 +226,7 @@ const ReorderBody = ({
   onSave,
 }: ReorderBodyProps) => (
   <View style={styles.reorderModalContent}>
-    <View style={styles.modalHeader}>
-      <Text style={styles.modalTitle}>Reorder Habits</Text>
-      <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-        <Text style={styles.closeButtonText}>×</Text>
-      </TouchableOpacity>
-    </View>
+    <ModalHeader title="Reorder Habits" onClose={onClose} />
     <ReorderDateButton
       startDate={startDate}
       onOpenPicker={onOpenPicker}

--- a/frontend/src/features/Habits/components/StatsModal.tsx
+++ b/frontend/src/features/Habits/components/StatsModal.tsx
@@ -8,6 +8,8 @@ import styles from '../Habits.styles';
 import type { HabitStatsData, StatsModalProps } from '../Habits.types';
 import { generateStatsForHabit } from '../HabitUtils';
 
+import ModalHeader from './ModalHeader';
+
 const FALLBACK_CHART_COLOR = 'rgba(134, 65, 244, 1)';
 const FALLBACK_CALENDAR_COLOR = '#50cebb';
 
@@ -166,21 +168,10 @@ const ChartTab = ({ title, children }: ChartTabProps) => (
   </View>
 );
 
-const StatsModalHeader = ({
-  habit,
-  onClose,
-}: {
-  habit: { name: string; icon: string };
-  onClose: () => void;
-}) => (
-  <View style={styles.modalHeader}>
-    <Text style={styles.modalTitle}>
-      {habit.name} Stats <Text style={styles.iconLarge}>{habit.icon}</Text>
-    </Text>
-    <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-      <Text style={styles.closeButtonText}>×</Text>
-    </TouchableOpacity>
-  </View>
+const StatsHeaderTitle = ({ habit }: { habit: { name: string; icon: string } }) => (
+  <>
+    {habit.name} Stats <Text style={styles.iconLarge}>{habit.icon}</Text>
+  </>
 );
 
 interface StatsContentProps {
@@ -200,7 +191,7 @@ const StatsContent = (props: StatsContentProps) => {
 
   return (
     <View style={[styles.statsModalContent, { borderTopColor: STAGE_COLORS[habit.stage] }]}>
-      <StatsModalHeader habit={habit} onClose={onClose} />
+      <ModalHeader title={<StatsHeaderTitle habit={habit} />} onClose={onClose} />
       <TabBar selectedTab={selectedTab} onSelect={onSelectTab} />
       <ScrollView style={styles.statsContainer}>
         {loading && (

--- a/frontend/src/features/Habits/components/__tests__/ModalHeader.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/ModalHeader.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+
+import ModalHeader from '../ModalHeader';
+
+describe('ModalHeader', () => {
+  it('renders a plain string title and the close glyph', () => {
+    const { getByText } = render(<ModalHeader title="Add Habit" onClose={jest.fn()} />);
+    expect(getByText('Add Habit')).toBeTruthy();
+    expect(getByText('×')).toBeTruthy();
+  });
+
+  it('calls onClose exactly once when the close button is pressed', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(<ModalHeader title="Add Habit" onClose={onClose} />);
+    fireEvent.press(getByText('×'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries a testID on the close button when provided, and omits it otherwise', () => {
+    const { getByTestId } = render(
+      <ModalHeader title="Add Habit" onClose={jest.fn()} closeTestID="modal-header-close" />,
+    );
+    expect(getByTestId('modal-header-close')).toBeTruthy();
+
+    const { queryByTestId } = render(<ModalHeader title="Add Habit" onClose={jest.fn()} />);
+    expect(queryByTestId('modal-header-close')).toBeNull();
+  });
+
+  it('renders a compound ReactNode title with a nested Text part', () => {
+    const { getByText } = render(
+      <ModalHeader
+        title={
+          <>
+            Morning Walk Stats <Text>ICON</Text>
+          </>
+        }
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByText('ICON')).toBeTruthy();
+    expect(getByText('Morning Walk Stats ICON')).toBeTruthy();
+  });
+
+  it('renders children between the title and the close button', () => {
+    const onExtraPress = jest.fn();
+    const { getByTestId } = render(
+      <ModalHeader title="Add Habit" onClose={jest.fn()}>
+        <TouchableOpacity testID="extra-control" onPress={onExtraPress}>
+          <Text>slot</Text>
+        </TouchableOpacity>
+      </ModalHeader>,
+    );
+    const extra = getByTestId('extra-control');
+    expect(extra).toBeTruthy();
+    fireEvent.press(extra);
+    expect(onExtraPress).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Every Habits modal hand-rolled the identical title-plus-close header shell (a `modalHeader` row wrapping a `modalTitle` and a close-`×` `TouchableOpacity`), duplicating the same markup and four style keys five times. This extracts one shared primitive and routes all five modals through it.

- Add `ModalHeader` (`frontend/src/features/Habits/components/ModalHeader.tsx`), a presentational primitive taking `title: ReactNode`, `onClose`, an optional `closeTestID`, and a `children` slot for inline controls rendered between the title and the close button. Its co-located `StyleSheet` owns the header-only style keys (`modalHeader`, `modalTitle`, `closeButton`, `closeButtonText`), copied verbatim from `Habits.styles`.
- Route `AddHabitModal`, `HabitSettingsModal`, `StatsModal`, `ReorderHabitsModal`, and `GoalModal` through it, deleting the four hand-rolled header components and the inline Reorder header. `StatsModal` supplies its compound title via a small `StatsHeaderTitle` node; `GoalModal` keeps its edit-toggle and icon controls in the `children` slot, with the goal-group badge and emoji picker staying outside the header.
- Remove the four now-dead header style keys from `Habits.styles`.

Behavior, appearance, and close-button wiring are unchanged. Preserved testIDs: `add-habit-close`, `goal-modal-icon-button`, `goal-group-badge`.

Note: #1305 (Candle & Ink Edit-Habit modal) is open backlog and untouched by any sibling PR; if it later restyles the shared header it will now do so in one place.

## Test plan

- New `ModalHeader.test.tsx` covers the string title + `×` glyph, single `onClose` on press, `closeTestID` present/absent, a compound ReactNode title, and the interactive `children` slot.
- Existing modal suites (`AddHabitModal`, `HabitSettingsModal`, `StatsModal`, `ReorderHabitsModal`, `GoalModal`, `GoalModal.goalGroup`) still pass unchanged — the regression net for behavior preservation.
- Gate 2 green: `./scripts/frontend/check-all.sh` (eslint zero-warnings, prettier, tsc strict, full jest 330 suites / 3496 tests) exits 0; coverage ≥90% holds.

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)