### PR TITLE
fix(backend): key goal-completion uniqueness on user-local day, not UTC day

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -87,12 +87,12 @@ _SQLITE_ALWAYS_INDEXES: tuple[str, ...] = (
 # reject.  Concurrency tests opt in to exercise the
 # ``IntegrityError -> idempotent`` path.
 _SQLITE_CONCURRENT_ONLY_INDEXES: tuple[str, ...] = (
-    # goal_completion: one row per (goal, user, calendar day).  Production
-    # uses ``((timestamp AT TIME ZONE 'UTC')::date)`` for IMMUTABLE-ness
-    # under a non-UTC server zone; SQLite stores ``timestamp`` as ISO
-    # text and ``date(timestamp)`` is sufficient at test scale.
+    # goal_completion: one row per (goal, user, user-local calendar day).
+    # Production keys uniqueness off the ``local_day`` column the check-in
+    # service writes, so the mirror indexes the same column rather than
+    # re-deriving a day from ``timestamp``.
     'CREATE UNIQUE INDEX IF NOT EXISTS "ix_goal_completion_unique_per_day_test" '
-    "ON goalcompletion (goal_id, user_id, date(timestamp))",
+    "ON goalcompletion (goal_id, user_id, local_day)",
 )
 
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -56,7 +56,7 @@ _RAW_SQL_MANAGED_INDEXES: frozenset[str] = frozenset(
         # 78b1620cafde aside, every index here is created via op.execute
         # because SQLAlchemy's Index() can't render the expression on SQLite.
         "ix_user_lower_email_unique",  # e8376b41c6a1: lower(email)
-        "ix_goal_completion_unique_per_day",  # d4e5f6a7b8c9: (timestamp AT TIME ZONE 'UTC')::date
+        "ix_goal_completion_unique_per_day",  # f7a8b9c0d1e3: (goal_id, user_id, local_day)
         "ix_goal_completion_goal_user_timestamp",  # d4e5f6a7b8c9: composite
         "ix_user_practice_active_stage",  # f6a7b8c9d0e1: partial unique
         "ix_habit_user_lower_name_unique",  # b5c6d7e8f9a0: lower(trim(name))
@@ -91,11 +91,7 @@ def _include_object(
     """
     if type_ == "index" and name in _RAW_SQL_MANAGED_INDEXES:
         return False
-    if (
-        type_ == "table"
-        and name is not None
-        and name.startswith(_MIGRATION_ARCHIVE_TABLE_PREFIX)
-    ):
+    if type_ == "table" and name is not None and name.startswith(_MIGRATION_ARCHIVE_TABLE_PREFIX):
         return False
     return True
 

--- a/backend/migrations/versions/d4e5f6a7b8c9_goal_completion_unique_per_day_and_index.py
+++ b/backend/migrations/versions/d4e5f6a7b8c9_goal_completion_unique_per_day_and_index.py
@@ -14,8 +14,12 @@ speed up streak computation queries.
 is only STABLE because it depends on the session timezone, and Postgres
 refuses to index non-IMMUTABLE expressions. Pinning the conversion to UTC
 with ``AT TIME ZONE 'UTC'`` yields a ``TIMESTAMP WITHOUT TIME ZONE`` whose
-``::date`` cast is IMMUTABLE. The app always writes ``datetime.now(UTC)``,
-so "one completion per UTC calendar day" matches the intended semantics.
+``::date`` cast is IMMUTABLE.
+
+Note: a later migration replaces this UTC-day index with one keyed off a
+``local_day`` column, because bucketing on the UTC date dropped legitimate
+completions for users east/west of UTC whose distinct local days shared a UTC
+calendar date.
 """
 
 from typing import Sequence, Union
@@ -39,10 +43,7 @@ def upgrade() -> None:
         "ON goalcompletion "
         "(goal_id, user_id, ((timestamp AT TIME ZONE 'UTC')::date))"
     )
-    op.execute(
-        f'CREATE INDEX "{_COMPOUND_INDEX}" '
-        "ON goalcompletion (goal_id, user_id, timestamp)"
-    )
+    op.execute(f'CREATE INDEX "{_COMPOUND_INDEX}" ON goalcompletion (goal_id, user_id, timestamp)')
 
 
 def downgrade() -> None:

--- a/backend/migrations/versions/f7a8b9c0d1e3_goal_completion_local_day.py
+++ b/backend/migrations/versions/f7a8b9c0d1e3_goal_completion_local_day.py
@@ -1,0 +1,127 @@
+"""goal_completion local_day column and local-day unique index
+
+Revision ID: f7a8b9c0d1e3
+Revises: e6f7a8b9c0d2
+Create Date: 2026-07-04 00:00:00.000000
+
+The check-in service enforces "one completion per goal per user-LOCAL day", but
+the previous unique index bucketed on ``((timestamp AT TIME ZONE 'UTC')::date)``
+-- one row per UTC calendar day. For a user east of UTC, two completions on
+distinct local days that happen to share a UTC date collided; the resulting
+``IntegrityError`` was swallowed and a legitimate completion silently dropped.
+
+This migration adds a ``local_day`` column populated by the service to the
+user-local target day, backfills it from existing rows, and swaps the UTC-day
+functional unique index for a plain ``(goal_id, user_id, local_day)`` index
+under the SAME name so the constraint moves to the correct granularity.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a8b9c0d1e3"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "e6f7a8b9c0d2"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_UNIQUE_PER_DAY_INDEX = "ix_goal_completion_unique_per_day"
+_ARCHIVE_TABLE = "_duplicates_goalcompletion"
+
+
+def _backfill_local_day() -> None:
+    """Populate ``local_day`` from each row's timestamp in the user's timezone.
+
+    On Postgres the conversion honours the owning user's recorded timezone
+    (defaulting to UTC) so historical rows land on the same local day the app
+    would now write. On SQLite -- the round-trip test target -- the old
+    conftest mirror bucketed on ``date(timestamp)``, so we reproduce that here
+    to keep the upgrade/downgrade round-trip lossless.
+    """
+    dialect = op.get_bind().dialect.name
+    if dialect == "postgresql":
+        op.execute(
+            "UPDATE goalcompletion "
+            "SET local_day = ((timestamp AT TIME ZONE COALESCE(u.timezone, 'UTC'))::date) "
+            'FROM "user" u '
+            "WHERE u.id = goalcompletion.user_id"
+        )
+    else:
+        op.execute("UPDATE goalcompletion SET local_day = date(timestamp)")
+
+
+def _archive_and_drop_local_day_duplicates() -> None:
+    """Archive, then delete, rows that duplicate a ``(goal_id, user_id, local_day)`` group.
+
+    Two rows can share a local day only when a boundary race wrote both before
+    the tightened constraint existed -- the app already treats them as one
+    completion. We keep the lowest ``id`` (first-wins, matching the app's
+    idempotency) and move the losers into ``_duplicates_goalcompletion`` so the
+    unique index can be created and the discarded rows are archived for audit
+    rather than silently dropped.
+    """
+    op.execute(
+        f"CREATE TABLE IF NOT EXISTS {_ARCHIVE_TABLE} AS SELECT * FROM goalcompletion WHERE false"
+    )
+    op.execute(
+        f"INSERT INTO {_ARCHIVE_TABLE} "
+        "SELECT * FROM goalcompletion gc "
+        "WHERE gc.id NOT IN ("
+        "  SELECT min(id) FROM goalcompletion "
+        "  GROUP BY goal_id, user_id, local_day"
+        ")"
+    )
+    op.execute(f"DELETE FROM goalcompletion WHERE id IN (SELECT id FROM {_ARCHIVE_TABLE})")
+
+
+def upgrade() -> None:
+    """Add ``local_day``, backfill + dedup, then swap in the local-day unique index."""
+    op.add_column("goalcompletion", sa.Column("local_day", sa.Date(), nullable=True))
+    _backfill_local_day()
+    _archive_and_drop_local_day_duplicates()
+    # Drop the old UTC-day index before the batch-mode NOT NULL tightening: on
+    # SQLite the batch step recreates the table, and it cannot carry over the
+    # old functional (expression) index. Postgres does a plain ALTER, so the
+    # drop order is immaterial there.
+    op.execute(f'DROP INDEX IF EXISTS "{_UNIQUE_PER_DAY_INDEX}"')
+    # Batch mode keeps the NOT NULL tightening SQLite-compatible for the
+    # round-trip test while emitting a plain ALTER on the Postgres target.
+    with op.batch_alter_table("goalcompletion") as batch_op:
+        batch_op.alter_column(
+            "local_day",
+            existing_type=sa.Date(),
+            existing_nullable=True,
+            nullable=False,
+        )
+    op.execute(
+        f'CREATE UNIQUE INDEX "{_UNIQUE_PER_DAY_INDEX}" '
+        "ON goalcompletion (goal_id, user_id, local_day)"
+    )
+
+
+def downgrade() -> None:
+    """Restore the UTC-day unique index and drop ``local_day``.
+
+    Re-tightening to one row per UTC calendar day can legitimately fail on
+    post-fix data that holds two local days sharing a UTC date -- that is
+    inherent to reverting this fix, not a bug in the downgrade. Rows archived
+    into ``_duplicates_goalcompletion`` during upgrade are NOT re-inserted; the
+    archive is for audit only.
+    """
+    op.execute(f'DROP INDEX IF EXISTS "{_UNIQUE_PER_DAY_INDEX}"')
+    # Batch mode keeps the column drop SQLite-compatible for the round-trip test.
+    with op.batch_alter_table("goalcompletion") as batch_op:
+        batch_op.drop_column("local_day")
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            f'CREATE UNIQUE INDEX "{_UNIQUE_PER_DAY_INDEX}" '
+            "ON goalcompletion "
+            "(goal_id, user_id, ((timestamp AT TIME ZONE 'UTC')::date))"
+        )
+    else:
+        op.execute(
+            f'CREATE UNIQUE INDEX "{_UNIQUE_PER_DAY_INDEX}" '
+            "ON goalcompletion (goal_id, user_id, date(timestamp))"
+        )

--- a/backend/src/models/goal_completion.py
+++ b/backend/src/models/goal_completion.py
@@ -1,7 +1,7 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Index
 from sqlmodel import Field, Relationship, SQLModel
 
 if TYPE_CHECKING:
@@ -18,6 +18,11 @@ class GoalCompletion(SQLModel, table=True):
     successful if total >= target.
     For subtractive goals, all logs in a day are summed, and the day is
     successful if total < target.
+
+    ``local_day`` is the user-local calendar day the completion belongs to and
+    is the per-user-day uniqueness key: the migration-owned unique index over
+    ``(goal_id, user_id, local_day)`` guarantees one completion per goal per
+    user-local day, independent of the row's UTC ``timestamp``.
     """
 
     # ``ix_goalcompletion_goal_user_ts`` is created by migration
@@ -36,6 +41,10 @@ class GoalCompletion(SQLModel, table=True):
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    local_day: date = Field(
+        default_factory=lambda: datetime.now(UTC).date(),
+        sa_column=Column(Date, nullable=False),
     )
     completed_units: float
     via_timer: bool = False

--- a/backend/src/services/checkin.py
+++ b/backend/src/services/checkin.py
@@ -56,6 +56,9 @@ class _CheckInJob:
     did_complete: bool
     old_streak: int
     new_streak: int
+    # The user-local calendar day the completion belongs to; stored on the row
+    # as the per-user-day uniqueness key.
+    target_day: date
     # Explicit completion time for a backfilled past day; ``None`` lets the
     # ``GoalCompletion`` model default (``datetime.now(UTC)``) stand.
     timestamp: datetime | None
@@ -178,7 +181,7 @@ def _completion_timestamp(completed_on: date | None, user_timezone: str) -> date
     ``None`` lets the model default (now) stand for a same-day log. For a
     backfilled day, anchors mid-day in the user's TZ so the value lands
     unambiguously inside that local calendar day regardless of DST shoulder
-    days, and buckets on it under the unique-per-day index.
+    days. Per-day uniqueness is keyed off ``local_day``, not this timestamp.
     """
     if completed_on is None:
         return None
@@ -207,6 +210,7 @@ async def _persist_and_build_response(session: AsyncSession, job: _CheckInJob) -
     completion = GoalCompletion(
         goal_id=job.goal_id,
         user_id=job.user_id,
+        local_day=job.target_day,
         completed_units=job.target if job.did_complete else 0,
     )
     if job.timestamp is not None:
@@ -328,6 +332,7 @@ async def record_goal_completion(
         did_complete=did_complete,
         old_streak=old_streak,
         new_streak=new_streak,
+        target_day=target_day,
         timestamp=_completion_timestamp(completed_on, ctx.user_timezone),
         subtractive=subtractive,
     )

--- a/backend/tests/test_goal_completions.py
+++ b/backend/tests/test_goal_completions.py
@@ -6,11 +6,12 @@ import asyncio
 import logging
 from datetime import UTC, date, datetime, timedelta
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlmodel import select
+from sqlmodel import col, select
 
 from domain.dates import today_in_tz
 from models.goal import Goal
@@ -958,3 +959,164 @@ async def test_subtractive_check_in_fails_loudly_on_duplicate_clear_tier(
     )
     assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
     assert resp.json()["detail"] == "duplicate_clear_tier_goals"
+
+
+# ── Local-day bucketing: distinct local days sharing a UTC calendar date ──
+
+
+async def _seed_karachi_swallowed_completion(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+    email: str,
+) -> tuple[dict[str, str], int, date]:
+    """Signup a Karachi user and seed a completion for today; return (headers, goal_id, today).
+
+    Row A sits at 00:30 local time, so its UTC instant falls on the prior UTC
+    calendar day -- reproducing the collision the old UTC-day unique index hits
+    when a backfill for the prior local day is submitted next.
+    """
+    signup_resp = await concurrent_async_client.post(
+        "/auth/signup",
+        json={
+            "email": email,
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": "Asia/Karachi",
+        },
+    )
+    headers = {"Authorization": f"Bearer {signup_resp.json()['token']}"}
+    user_id = signup_resp.json()["user_id"]
+    today = today_in_tz("Asia/Karachi")
+
+    async with concurrent_session_factory() as session:
+        habit = Habit(
+            name="Karachi habit",
+            icon="🕌",
+            start_date=date(2025, 1, 1),
+            energy_cost=1,
+            energy_return=1,
+            user_id=user_id,
+        )
+        session.add(habit)
+        await session.commit()
+        await session.refresh(habit)
+        goal = Goal(
+            habit_id=habit.id,
+            title="Daily sit",
+            tier="clear",
+            target=10.0,
+            target_unit="minutes",
+            frequency=1.0,
+            frequency_unit="per_day",
+            is_additive=True,
+        )
+        session.add(goal)
+        await session.commit()
+        await session.refresh(goal)
+        goal_id = goal.id
+
+        row_a_timestamp = datetime(
+            today.year, today.month, today.day, 0, 30, tzinfo=ZoneInfo("Asia/Karachi")
+        ).astimezone(UTC)
+        session.add(
+            GoalCompletion(
+                goal_id=goal_id,
+                user_id=user_id,
+                completed_units=goal.target,
+                timestamp=row_a_timestamp,
+                local_day=today,
+            )
+        )
+        await session.commit()
+
+    assert goal_id is not None
+    return headers, goal_id, today
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_karachi_backfill_on_distinct_local_day_is_not_swallowed(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Two Karachi completions on distinct local days sharing a UTC date both persist."""
+    headers, goal_id, today = await _seed_karachi_swallowed_completion(
+        concurrent_async_client, concurrent_session_factory, "karachigoal@example.com"
+    )
+    backfill_day = today - timedelta(days=1)
+
+    resp = await concurrent_async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal_id, "completed_on": backfill_day.isoformat()},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["reason_code"] == "streak_incremented"
+
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(GoalCompletion).where(GoalCompletion.goal_id == goal_id)
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_karachi_repeat_backfill_on_same_local_day_stays_idempotent(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Re-submitting the same Karachi backfill day still short-circuits as already_logged_today."""
+    headers, goal_id, today = await _seed_karachi_swallowed_completion(
+        concurrent_async_client, concurrent_session_factory, "karachirepeat@example.com"
+    )
+    backfill_day = today - timedelta(days=1)
+    payload = {"goal_id": goal_id, "completed_on": backfill_day.isoformat()}
+
+    first = await concurrent_async_client.post("/goal_completions/", json=payload, headers=headers)
+    assert first.status_code == HTTPStatus.OK
+
+    second = await concurrent_async_client.post("/goal_completions/", json=payload, headers=headers)
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["reason_code"] == "already_logged_today"
+
+    async with concurrent_session_factory() as session:
+        result = await session.execute(
+            select(GoalCompletion).where(GoalCompletion.goal_id == goal_id)
+        )
+        rows = list(result.scalars().all())
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_local_day_column_matches_target_day_for_backfill_and_same_day(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The persisted local_day column equals the intended user-local day, not the UTC day."""
+    headers, user_id = await _signup(async_client, "localday_user")
+    goal = await _seed_goal(db_session, user_id)
+    yesterday = today_in_tz("UTC") - timedelta(days=1)
+
+    backfill = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "completed_on": yesterday.isoformat()},
+        headers=headers,
+    )
+    assert backfill.status_code == HTTPStatus.OK
+
+    today_log = await async_client.post(
+        "/goal_completions/",
+        json={"goal_id": goal.id, "did_complete": True},
+        headers=headers,
+    )
+    assert today_log.status_code == HTTPStatus.OK
+
+    result = await db_session.execute(
+        select(GoalCompletion)
+        .where(GoalCompletion.goal_id == goal.id)
+        .order_by(col(GoalCompletion.timestamp))
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 2
+    assert rows[0].local_day == yesterday
+    assert rows[1].local_day == today_in_tz("UTC")

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1980,3 +1980,207 @@ def test_habit_revealed_migration_round_trip_on_sqlite(
     command.upgrade(cfg, _HABIT_REVEALED_REVISION)
     row_1_again = _habit_revealed_row(db_url, habit_id=1)
     assert bool(row_1_again["revealed"]) is True
+
+
+# -- goalcompletion.local_day column migration round-trip --------------------
+
+_LOCAL_DAY_BASE_REVISION = "e6f7a8b9c0d2"  # pragma: allowlist secret
+_LOCAL_DAY_REVISION = "f7a8b9c0d1e3"  # pragma: allowlist secret
+
+
+def _bootstrap_local_day_baseline(sync_url: str) -> None:
+    """Pre-create a minimal ``goalcompletion`` table (no ``local_day``) with two seeded rows.
+
+    Rows sit on two distinct calendar days so both the new local-day unique
+    index and the restored UTC-day index remain satisfiable across the
+    round-trip.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE user ( id INTEGER PRIMARY KEY, timezone VARCHAR(64))"))
+        conn.execute(text("INSERT INTO user (id, timezone) VALUES (1, 'UTC')"))
+        conn.execute(
+            text(
+                "CREATE TABLE goalcompletion ("
+                " id INTEGER PRIMARY KEY,"
+                " goal_id INTEGER NOT NULL,"
+                " user_id INTEGER NOT NULL,"
+                " timestamp DATETIME NOT NULL,"
+                " completed_units FLOAT NOT NULL,"
+                " via_timer BOOLEAN NOT NULL DEFAULT 0"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goalcompletion"
+                " (id, goal_id, user_id, timestamp, completed_units)"
+                " VALUES (1, 1, 1, '2025-03-01 10:00:00', 10.0)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goalcompletion"
+                " (id, goal_id, user_id, timestamp, completed_units)"
+                " VALUES (2, 1, 1, '2025-03-02 10:00:00', 10.0)"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_local_day(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before the local_day migration."""
+    db_path = tmp_path / "local_day_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_local_day_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _LOCAL_DAY_BASE_REVISION)
+    return cfg
+
+
+def _local_day_of(db_url: str, completion_id: int) -> dict[str, Any]:
+    """Fetch the ``id`` + ``local_day`` of one goalcompletion row."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text("SELECT id, local_day FROM goalcompletion WHERE id = :id"),
+                    {"id": completion_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_local_day_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_local_day: Config,
+) -> None:
+    """Round-trip the local_day migration: upgrade adds + backfills; downgrade drops.
+
+    Upgrade adds ``local_day`` and backfills it from ``date(timestamp)`` on
+    SQLite; downgrade drops the column; re-upgrade reproduces the backfill.
+    """
+    cfg = alembic_sqlite_config_local_day
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _LOCAL_DAY_REVISION)
+    cols = _columns_of(db_url, "goalcompletion")
+    assert "local_day" in cols
+    assert str(_local_day_of(db_url, completion_id=1)["local_day"]) == "2025-03-01"
+    assert str(_local_day_of(db_url, completion_id=2)["local_day"]) == "2025-03-02"
+
+    command.downgrade(cfg, _LOCAL_DAY_BASE_REVISION)
+    cols_after = _columns_of(db_url, "goalcompletion")
+    assert "local_day" not in cols_after
+
+    command.upgrade(cfg, _LOCAL_DAY_REVISION)
+    assert str(_local_day_of(db_url, completion_id=1)["local_day"]) == "2025-03-01"
+
+
+def _bootstrap_local_day_collision_baseline(sync_url: str) -> None:
+    """Seed two rows that share a calendar day so backfill makes them collide.
+
+    Both rows bucket to ``2025-03-01`` under ``date(timestamp)``, so the new
+    ``(goal_id, user_id, local_day)`` unique index cannot be created until the
+    dedup step archives one of them.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE user ( id INTEGER PRIMARY KEY, timezone VARCHAR(64))"))
+        conn.execute(text("INSERT INTO user (id, timezone) VALUES (1, 'UTC')"))
+        conn.execute(
+            text(
+                "CREATE TABLE goalcompletion ("
+                " id INTEGER PRIMARY KEY,"
+                " goal_id INTEGER NOT NULL,"
+                " user_id INTEGER NOT NULL,"
+                " timestamp DATETIME NOT NULL,"
+                " completed_units FLOAT NOT NULL,"
+                " via_timer BOOLEAN NOT NULL DEFAULT 0"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goalcompletion"
+                " (id, goal_id, user_id, timestamp, completed_units)"
+                " VALUES (1, 1, 1, '2025-03-01 08:00:00', 10.0)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goalcompletion"
+                " (id, goal_id, user_id, timestamp, completed_units)"
+                " VALUES (2, 1, 1, '2025-03-01 20:00:00', 5.0)"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_local_day_collision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config seeded with a same-local-day collision pair."""
+    db_path = tmp_path / "local_day_collision_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_local_day_collision_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _LOCAL_DAY_BASE_REVISION)
+    return cfg
+
+
+def _ids_from_query(db_url: str, query: str) -> list[int]:
+    """Return the sorted ``id`` values yielded by a literal SELECT ``query``."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text(query)).scalars().all()
+            return [int(value) for value in rows]
+    finally:
+        engine.dispose()
+
+
+def test_local_day_migration_archives_same_day_duplicate_on_sqlite(
+    alembic_sqlite_config_local_day_collision: Config,
+) -> None:
+    """A same-local-day collision keeps the min-id row and archives the loser, never dropping it.
+
+    This exercises the data-safety-critical dedup branch: the higher-id row must
+    move into ``_duplicates_goalcompletion`` (recoverable) rather than vanish,
+    and the surviving completion row must be the first-logged (lowest id).
+    """
+    cfg = alembic_sqlite_config_local_day_collision
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _LOCAL_DAY_REVISION)
+
+    assert _ids_from_query(db_url, "SELECT id FROM goalcompletion ORDER BY id") == [1]
+    assert _table_exists(db_url, "_duplicates_goalcompletion")
+    assert _ids_from_query(db_url, "SELECT id FROM _duplicates_goalcompletion ORDER BY id") == [2]


### PR DESCRIPTION
## Summary

Fixes silent completion loss for non-UTC users. The check-in service enforces
"one completion per goal per **user-local** day", but the DB uniqueness backstop
was a unique index bucketed on `((timestamp AT TIME ZONE 'UTC')::date)` — one row
per **UTC** calendar day. For a user east of UTC, two completions on distinct
local days that share a UTC date collided; the resulting `IntegrityError` was
swallowed by the idempotent-fallback path in `_try_persist_or_idempotent` and a
legitimate completion was **silently dropped**, breaking the streak.

The fix reconciles the backstop with the day the app already reasons about:

- Add a `local_day: date` column to `GoalCompletion`, written by the check-in
  service to the user-local `target_day`.
- Swap the UTC-day functional unique index for a plain
  `(goal_id, user_id, local_day)` index under the same name
  `ix_goal_completion_unique_per_day`.
- New Alembic migration `f7a8b9c0d1e3`: adds the column, backfills it
  timezone-aware on Postgres (`AT TIME ZONE user.timezone`) / `date(timestamp)`
  on SQLite, **archives** any boundary-race duplicate rows into
  `_duplicates_goalcompletion` (first-wins / lowest-id, matching app idempotency)
  before tightening, then swaps the index. Downgrade restores the UTC-day index.
- `_already_logged_on` (timestamp-window) and streak math (bucketed on
  `timestamp`) are intentionally unchanged — the bug was purely index
  granularity.
- The stale `d4e5f6a7b8c9` docstring claiming the app "always writes
  `datetime.now(UTC)`" as the uniqueness rationale is corrected.

## Test plan

- Full backend suite green (`2370 passed`), coverage 96.56% (≥90%),
  xenon rank A, radon MI ≥ B, interrogate 95.4% (≥85%).
- New regression tests in `tests/test_goal_completions.py`:
  - An `Asia/Karachi` (UTC+5) user logging two completions on distinct local
    days that share a UTC date now persists **both** rows (was swallowed as
    `already_logged_today`).
  - A same-local-day double-submit still idempotently no-ops (no second row).
  - The persisted `local_day` equals the intended user-local day for both the
    same-day and backfill paths.
- New migration round-trip tests in `tests/test_migrations.py`: upgrade
  backfills `local_day` + downgrade drops it + re-upgrade is clean; and a
  same-local-day collision case proves the loser row is **archived** into
  `_duplicates_goalcompletion` (not silently dropped) while the lowest-id
  survivor remains.

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)