### PR TITLE
test(map): strengthen coverage-theater assertions in Map history/layout/copy-intent tests

### DIFF
--- a/frontend/src/features/Map/__tests__/MapHistory.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapHistory.test.tsx
@@ -1,13 +1,33 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 import React from 'react';
-import { Image } from 'react-native';
+import { Image, StyleSheet, Text, type ViewStyle } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
 
 import type { StageHistoryData } from './mapTestHarness';
 import { resetMapMocks } from './mapTestHarness';
+
+import { colors } from '@/design/tokens';
+
+const UNACHIEVED_BADGE_BG = 'rgba(255,255,255,0.15)';
+
+/** Minimal shape of a react-test-renderer node used by the queries below. */
+interface TestNode {
+  type: unknown;
+  props: Record<string, unknown>;
+  findAll: (predicate: (node: TestNode) => boolean) => TestNode[];
+  findByProps: (props: Record<string, unknown>) => TestNode;
+}
+
+/** Joins a node's descendant Text children into one string for content assertions. */
+const collectText = (node: TestNode): string =>
+  node
+    .findAll((n) => n.type === Text)
+    .flatMap((n) => n.props.children)
+    .filter((child) => typeof child === 'string' || typeof child === 'number')
+    .join('');
 
 jest.mock('../../../navigation/hooks', () =>
   jest.requireActual('./mapTestHarness').mockNavigationModule(),
@@ -73,7 +93,8 @@ describe('MapScreen — Stage History', () => {
       tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
     });
     const section = tree.root.findByProps({ testID: 'history-section' });
-    expect(section).toBeTruthy();
+    expect(collectText(section)).toContain('Your Journey');
+    expect(section.findByProps({ testID: 'history-toggle' })).toBeTruthy();
   });
 
   it('does not show history section for locked stages', () => {
@@ -120,19 +141,20 @@ describe('MapScreen — Stage History', () => {
     const content = tree.root.findByProps({ testID: 'history-content' });
     expect(content).toBeTruthy();
 
-    // Practice items — findAll may return duplicates from deep traversal
+    // findAll may return duplicates from deep traversal; all refer to the same content.
     const practiceItems = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) => node.props.testID === 'practice-history-item',
+      (node: TestNode) => node.props.testID === 'practice-history-item',
     );
     expect(practiceItems.length).toBeGreaterThanOrEqual(1);
+    expect(collectText(practiceItems[0]!)).toContain('Breath of Fire');
+    expect(collectText(practiceItems[0]!)).toContain('12 sessions');
+    expect(collectText(practiceItems[0]!)).toContain('3 hrs');
 
-    // Habit items
     const habitItems = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) => node.props.testID === 'habit-history-item',
+      (node: TestNode) => node.props.testID === 'habit-history-item',
     );
     expect(habitItems.length).toBeGreaterThanOrEqual(1);
+    expect(collectText(habitItems[0]!)).toContain('Morning Exercise · 14d streak');
   });
 
   it('renders goal tier badges for habits', async () => {
@@ -146,14 +168,19 @@ describe('MapScreen — Stage History', () => {
       tree.root.findByProps({ testID: 'history-toggle' }).props.onPress();
     });
 
-    // Should have 3 goal badges (low, clear, stretch)
-    const badges = tree.root.findAll(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (node: any) =>
-        typeof node.props.testID === 'string' && node.props.testID.startsWith('goal-badge-'),
-    );
-    // Deep traversal may find duplicates; at minimum 3 unique tiers
-    expect(badges.length).toBeGreaterThanOrEqual(3);
+    const badgeBg = (tier: string): unknown => {
+      const nodes = tree.root.findAll(
+        (node: TestNode) => node.props.testID === `goal-badge-${tier}`,
+      );
+      expect(nodes.length).toBeGreaterThanOrEqual(1);
+      return StyleSheet.flatten(nodes[0]!.props.style as ViewStyle).backgroundColor;
+    };
+
+    expect(badgeBg('low')).toBe(colors.medal.bronze);
+    expect(badgeBg('clear')).toBe(colors.medal.silver);
+    const stretchBg = badgeBg('stretch');
+    expect(stretchBg).toBe(UNACHIEVED_BADGE_BG);
+    expect(stretchBg).not.toBe(colors.medal.gold);
   });
 
   it('lazy loads history data only when expanded', async () => {

--- a/frontend/src/features/Map/__tests__/copyIntentRule.test.ts
+++ b/frontend/src/features/Map/__tests__/copyIntentRule.test.ts
@@ -5,13 +5,31 @@ import { ranksOrShames } from './copyIntentRule';
 describe('ranksOrShames', () => {
   it.each([
     ["you're only at level 3"],
-    ['climb to unlock the next stage'],
+    ['you are at level 4'],
+    ["you're at stage 3 of 10"],
+    ['climb to unlock deeper practice'],
+    ['unlock the next tier of practice'],
+    ['reach the next to unlock more content'],
     ["you're behind"],
     ["don't fall behind"],
     ['catch up to the others'],
     ['leaderboard'],
-    ['keep your streak alive or lose it'],
+    ['you hold rank 5 this week'],
+    ['you are ranked among your peers'],
+    ['she is ahead of you now'],
+    ["you're inferior to them"],
+    ['they are further along than you'],
+    ['keep your streak this week'],
     ['you lost your streak'],
+    ["don't lose your streak today"],
+    ['keep the streak alive'],
+    ['you broke your streak yesterday'],
+    ["don't miss out on this moment"],
+    ["don't break the chain"],
+    ['this streak lasts forever'],
+    ['just keep going no matter what'],
+    ['you must complete this today'],
+    ["don't lose your momentum"],
   ])('returns true for ranking/shaming copy: %s', (copy) => {
     expect(ranksOrShames(copy)).toBe(true);
   });

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -3,7 +3,6 @@
 import { ink, surface } from '../../../design/tokens';
 import {
   fittedTitleFontSize,
-  GRID_COLUMN_FLEX,
   labelCorner,
   MAP_ROWS,
   MAP_TITLE_LINES,
@@ -12,6 +11,7 @@ import {
   TITLE_MIN_FONT_SIZE,
 } from '../mapLayout';
 import { isLeftReturning, STAGE_COUNT } from '../stageData';
+import { centerColumnBounds } from '../waveGeometry';
 
 const HEX_COLOR = /^#[\da-f]{6}$/i;
 const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
@@ -114,7 +114,16 @@ describe('mapLayout', () => {
   });
 
   it('keeps the shared column-flex weights the wave geometry also depends on', () => {
-    expect(GRID_COLUMN_FLEX).toEqual({ left: 2, center: 2, right: 1 });
+    // 2:2:1 ratio: center column matches the left gutter; right gutter is half that.
+    const width = 500;
+    const bounds = centerColumnBounds(width);
+    const centerWidth = bounds.right - bounds.left;
+    const rightGutter = width - bounds.right;
+
+    expect(bounds.left).toBeCloseTo(200);
+    expect(bounds.right).toBeCloseTo(400);
+    expect(bounds.left).toBeCloseTo(centerWidth);
+    expect(rightGutter).toBeCloseTo(centerWidth / 2);
   });
 
   it('renames stage 3 arrow label from Self-Interest to Self-Love', () => {


### PR DESCRIPTION
## Summary

De-slop for the Map test suite (issue #1259, Family 9 — coverage theater). Replaces count-only, existence-only, and literal change-detector assertions with exact-value and behavioral checks so a logic mutation fails. **No production code changes.**

- **MapHistory.test.tsx**
  - `renders practice and habit history items` now asserts the rendered practice name (`Breath of Fire`), formatted minutes (`12 sessions`, `3 hrs`), and the habit line `Morning Exercise · 14d streak` — not just node counts.
  - `renders goal tier badges` now resolves each `goal-badge-{tier}` node's `StyleSheet.flatten(...).backgroundColor` and asserts tier-specific achieved styling (low→bronze, clear→silver achieved; stretch→the dim unachieved overlay and *not* gold), catching an inverted-styling or wrong-tier mutation.
  - `shows history section for unlocked stages` replaces the hollow `findByProps + toBeTruthy` with assertions on the section's `Your Journey` title and its history toggle.
  - Drops the react-test-renderer `any`-casts (+ their `eslint-disable`) in favour of a local `TestNode` interface.
- **mapLayout.test.ts** — replaces the `GRID_COLUMN_FLEX` literal `toEqual` change-detector with a behavioral test driving `centerColumnBounds(500)`: it pins the 2:2:1 flex ratio via its layout consequence (left gutter equals center width; right gutter is half of it), so a flex-weight change fails.
- **copyIntentRule.test.ts** — extends the positive `it.each` so every `RANK_OR_SHAME_PATTERNS` entry is exercised, each with a string only its target pattern matches (verified against short-circuit subsumption).

Scope note: the stale `torusGeometry.test.ts` finding (#4) is out of scope — that file was deleted in #1291. Does not touch the #1215 or #1214 items.

## Follow-up (out of scope — production de-slop)

Two `RANK_OR_SHAME_PATTERNS` are dead by subsumption and cannot be uniquely exercised without a production change (`.some()` short-circuits on an earlier pattern): `fall(ing)? behind` is fully covered by the earlier `\bbehind\b`, and `don.?t lose your streak` by the later `don.?t lose`. Their test strings still assert the phrases are flagged, but the specific patterns are redundant — recommend a separate production de-slop to remove/reorder them.

## Test plan

- `cd frontend && npx jest src/features/Map/__tests__/{MapHistory,mapLayout,copyIntentRule}.test.ts` — 60 pass.
- `./scripts/frontend/check-all.sh` — 4/4 (tests 3514 pass, lint, typecheck, format all clean).
- Discrimination verified by temporary production mutations (reverted): inverting the goal-badge achieved styling and rendering a wrong practice name both turn the strengthened MapHistory tests RED; each strengthened assertion passes against unmutated production.

Closes #1259