### PR TITLE
fix(journal): guard useShelf load against stale-response race

### DIFF
--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -8,7 +8,7 @@
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Animated, SectionList, Text, TouchableOpacity, View } from 'react-native';
 import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 
@@ -135,21 +135,26 @@ function useShelf(): ShelfState {
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestSeq = useRef(0);
 
   const load = useCallback(async (search: string | undefined, offset: number) => {
+    // Only the newest in-flight request may settle; stale ones are dropped.
+    const requestId = (requestSeq.current += 1);
+    const isLatest = () => requestId === requestSeq.current;
     setLoading(true);
     setError(null);
     try {
       const page = await journal.list({ search, limit: PAGE_SIZE, offset });
+      if (!isLatest()) return;
       setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
       setTotal(page.total);
       setHasMore(page.has_more);
     } catch (err) {
       // Surface the failure so a cold-start network error isn't mistaken for an
       // empty shelf; the current items (if any) stay in place for retry.
-      setError(formatApiError(err));
+      if (isLatest()) setError(formatApiError(err));
     } finally {
-      setLoading(false);
+      if (isLatest()) setLoading(false);
     }
   }, []);
 

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -319,6 +319,48 @@ describe('JournalShelfScreen', () => {
     expect(queryByTestId('journal-shelf-empty')).toBeNull();
   });
 
+  it('does not let a stale mount response overwrite a newer search result', async () => {
+    let resolveMount: (_value: JournalListResponse) => void = () => undefined;
+    const mountPromise = new Promise<JournalListResponse>((resolve) => {
+      resolveMount = resolve;
+    });
+    mockList.mockImplementation((p) =>
+      p?.search === 'willow' ? Promise.resolve(page([entry(2)])) : mountPromise,
+    );
+    const { getByTestId, queryByTestId } = render(<JournalShelfScreen />);
+
+    fireEvent.changeText(getByTestId('shelf-search'), 'willow');
+    await waitFor(() => expect(queryByTestId('journal-shelf-card-2')).toBeTruthy());
+    expect(queryByTestId('journal-shelf-card-1')).toBeNull();
+
+    resolveMount(page([entry(1), entry(2)]));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-shelf-card-1')).toBeNull();
+  });
+
+  it('does not let a stale mount failure clobber a newer search-empty result', async () => {
+    let rejectMount: (_reason: unknown) => void = () => undefined;
+    const mountPromise = new Promise<JournalListResponse>((_resolve, reject) => {
+      rejectMount = reject;
+    });
+    mockList.mockImplementation((p) =>
+      p?.search === 'willow' ? Promise.resolve(page([])) : mountPromise,
+    );
+    const { getByTestId, findByTestId, queryByTestId } = render(<JournalShelfScreen />);
+
+    fireEvent.changeText(getByTestId('shelf-search'), 'willow');
+    await findByTestId('journal-shelf-no-results');
+
+    rejectMount(new Error('network down'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-shelf-error')).toBeNull();
+    expect(queryByTestId('journal-shelf-no-results')).toBeTruthy();
+  });
+
   it('appends the next page when more are available', async () => {
     mockList.mockResolvedValueOnce(page([entry(1), entry(2)], true));
     const { findByTestId, getByTestId } = render(<JournalShelfScreen />);


### PR DESCRIPTION
## Summary

`useShelf.load` (the journal shelf loader in `JournalShelfScreen.tsx`) fires from three independent triggers — the mount effect (unfiltered), `onSearch`, and `loadMore` — and previously committed its results **unconditionally**. A slower earlier request could resolve *after* a newer one and overwrite it (last-write-wins). In practice the unfiltered mount load could land after a search load, leaving the shelf showing the full list while the search box still held a query.

The fix adds a monotonic request-id ref (`requestSeq`) captured per call. Only the latest request may commit `items`/`total`/`hasMore`, set the error, or clear the `loading` flag. This generalizes the existing ref-sentinel idiom already used by the co-located `usePrompt` and by `useResonance` to a loader with three overlapping call sites. Paging semantics, the search min-length gate (`isSearchable`), and the count source are unchanged.

## Test plan

Two regression tests added to `JournalShelfScreen.test.tsx`, both RED before the fix:
- **Stale success:** the mount `journal.list` is held on a deferred promise while a search resolves with filtered items; resolving the mount page *late* must not resurrect the unfiltered entries.
- **Stale failure:** a late-*rejecting* mount request must not replace a legitimate no-results state with an error banner (guards the catch path).

Verified locally: all 3516 frontend tests pass, `tsc --noEmit` clean, `eslint --max-warnings=0` clean, `scripts/frontend/check-all.sh` exits 0.

Closes #1262