### PR TITLE
refactor(api): drop dead default-export aggregate and 9 unused schema aliases

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2454,32 +2454,3 @@ export const depthPreferences = {
     });
   },
 };
-
-// Energy plan client
-export default {
-  habits,
-  goalCompletions,
-  goalGroups,
-  goals,
-  journal,
-  prompts,
-  stages,
-  course,
-  practices,
-  practiceShare,
-  practiceRecipes,
-  practiceTags,
-  userPractices,
-  frequency,
-  practiceSessions,
-  auth,
-  users,
-  depthPreferences,
-  wheel,
-  setTokenGetter,
-  setOnUnauthorized,
-  setOnTokenRefreshed,
-  setLlmApiKeyGetter,
-  setNetworkOnlineGetter,
-  LLM_API_KEY_HEADER,
-};

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -101,9 +101,6 @@ export const loginAuthResponseSchema = authResponseSchema.extend({
   user_id: z.number().int().positive(),
 });
 
-export type AuthResponseT = z.infer<typeof authResponseSchema>;
-export type LoginAuthResponseT = z.infer<typeof loginAuthResponseSchema>;
-
 /**
  * Response for ``PUT /users/me/timezone`` (issue #261): the IANA zone the
  * server now has on record for the caller.  Validated at the boundary so a
@@ -206,10 +203,6 @@ export const habitWithGoalsSchema = habitSchema.extend({
   goals: z.array(goalSchema),
 });
 
-export type HabitSchemaT = z.infer<typeof habitSchema>;
-export type HabitWithGoalsSchemaT = z.infer<typeof habitWithGoalsSchema>;
-export type GoalSchemaT = z.infer<typeof goalSchema>;
-
 /** One weekly prompt + the user's response state (mirrors backend ``PromptDetail``). */
 export const promptDetailSchema = z.object({
   week_number: z.number().int(),
@@ -229,8 +222,6 @@ export const promptListResponseSchema = z.object({
   total: z.number().int().nullable(),
   has_more: z.boolean(),
 });
-
-export type PromptListResponseSchemaT = z.infer<typeof promptListResponseSchema>;
 
 export const journalTagSchema = z.enum([
   'freeform',
@@ -280,8 +271,6 @@ export const journalListResponseSchema = z.object({
   total: z.number().int(),
   has_more: z.boolean(),
 });
-
-export type JournalListResponseSchemaT = z.infer<typeof journalListResponseSchema>;
 
 // ---------------------------------------------------------------------------
 // Per-item schemas for paginated endpoints (replacing loosePageSchema casts).
@@ -593,7 +582,6 @@ export const mettaReturnStateSchema = z.object({
   offer_dismissed: z.boolean(),
 });
 
-export type MettaFocusT = z.infer<typeof mettaFocusSchema>;
 export type ReturnWeekT = z.infer<typeof returnWeekSchema>;
 export type ReturnArcT = z.infer<typeof returnArcSchema>;
 export type MettaReturnStateT = z.infer<typeof mettaReturnStateSchema>;
@@ -696,7 +684,6 @@ export type CareResourceT = z.infer<typeof careResourceSchema>;
 export type CareResponseT = z.infer<typeof careResponseSchema>;
 export type ContractionVariantT = z.infer<typeof contractionVariantSchema>;
 export type ContractionReflectionT = z.infer<typeof contractionReflectionSchema>;
-export type ResonanceResponseT = z.infer<typeof resonanceResponseSchema>;
 
 // ---------------------------------------------------------------------------
 // Depth preferences (you-choose-your-depth ring toggles)


### PR DESCRIPTION
## Summary

Pure dead-code removal in `frontend/src/api/` (de-slopify Family 3 — Dispensables). No behavior change; the underlying Zod schemas are all retained.

- Removed the unreferenced `export default { ... }` aggregate object at the end of `frontend/src/api/index.ts`. Nothing imported the api module as a default (verified: zero `import x from '@/api'`/`./api` default imports anywhere), and the object had drifted out of sync with the named exports (it omitted `resonance`, `completionSuggestions`, `invitations`, `mettaReturn`, `ApiError`, …), making it a latent trap. The stale `// Energy plan client` comment that mislabeled it was removed with the block.
- Removed nine unused `export type ...T = z.infer<...>` aliases from `frontend/src/api/schemas.ts`: `AuthResponseT`, `LoginAuthResponseT`, `HabitSchemaT`, `HabitWithGoalsSchemaT`, `GoalSchemaT`, `PromptListResponseSchemaT`, `JournalListResponseSchemaT`, `MettaFocusT`, `ResonanceResponseT`. Each had zero references anywhere in `frontend/` (including tests) on the current tree.

Verified no schema was orphaned: every underlying schema whose alias was removed is still referenced by production code (`mettaFocusSchema` is composed into `returnWeekSchema`/`returnArcSchema`; the rest are used by their respective API clients and validation). The parallel `*T` aliases that *are* imported (`ReturnWeekT`, `ContractionVariantT`, `StageProgressRecordT`, …) were left untouched. Net: 42 deletions, 0 additions, across only these two files.

## Test plan

- `./scripts/frontend/check-all.sh` green: type-check (`tsc --noEmit`), ESLint, Prettier, and the full Jest suite (330 suites, 3516 tests) all pass.
- All pre-commit hooks pass.
- Gate 2.5 self-review (code-review-orchestrator): verdict CLEAN — reference sweep confirmed zero inbound edges for every deleted symbol, no orphaned schemas, no stray whitespace/comments.

Closes #1271