### PR TITLE
refactor(components): drop DatePicker's silently-ignored props and duplicate slot

### DIFF
--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -18,8 +18,6 @@ export interface DatePickerProps {
   maxDate?: string;
   disabledDate?: (_date: Date) => boolean;
   locale?: string;
-  mode?: 'scaffoldingStart' | 'courseStart';
-  stageColor?: string;
 }
 
 export const toISODate = (date: Date): string => {
@@ -39,7 +37,7 @@ export const parseISODate = (iso: string): Date => {
   return new Date(y, m - 1, d);
 };
 
-export const formatDisplayDate = (date: Date, locale = 'en-US'): string =>
+const formatDisplayDate = (date: Date, locale = 'en-US'): string =>
   date.toLocaleDateString(locale, {
     weekday: 'short',
     month: 'short',
@@ -105,7 +103,7 @@ const validateDate = (
   return null;
 };
 
-export const getLocalToday = (): Date => {
+const getLocalToday = (): Date => {
   const now = new Date();
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 };
@@ -118,7 +116,7 @@ export const getNextMonday = (): Date => {
   return local;
 };
 
-export const getFirstOfNextMonth = (): Date => {
+const getFirstOfNextMonth = (): Date => {
   const d = new Date();
   d.setMonth(d.getMonth() + 1, 1);
   return d;
@@ -343,18 +341,6 @@ const makeHandleChangeText = (
   };
 };
 
-interface NativePickerSlotProps {
-  value: string;
-  minDate?: string;
-  maxDate?: string;
-  pickerVisible: boolean;
-  setPickerVisible: (_v: boolean) => void;
-  commitDate: (_d: Date) => void;
-}
-
-const NativePickerSlot: React.FC<NativePickerSlotProps> = (props) =>
-  Platform.OS === 'web' ? null : <NativePicker {...props} />;
-
 const DatePicker: React.FC<DatePickerProps> = ({
   value,
   onChange,
@@ -388,14 +374,16 @@ const DatePicker: React.FC<DatePickerProps> = ({
         commitDate={commitDate}
       />
       {error && <Text accessibilityRole="alert">{error}</Text>}
-      <NativePickerSlot
-        value={value}
-        minDate={minDate}
-        maxDate={maxDate}
-        pickerVisible={pickerVisible}
-        setPickerVisible={setPickerVisible}
-        commitDate={commitDate}
-      />
+      {Platform.OS !== 'web' && (
+        <NativePicker
+          value={value}
+          minDate={minDate}
+          maxDate={maxDate}
+          pickerVisible={pickerVisible}
+          setPickerVisible={setPickerVisible}
+          commitDate={commitDate}
+        />
+      )}
       <QuickDateButtons
         onSelectDate={commitDate}
         minDate={minDate}

--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -388,7 +388,6 @@ const ReorderHeader = ({ startDate, onDateChange, postReveal }: ReorderHeaderPro
       <DatePicker
         value={toISODate(startDate)}
         minDate={toISODate(new Date())}
-        mode="scaffoldingStart"
         onChange={onDateChange}
       />
     </View>


### PR DESCRIPTION
## Summary

De-slop of `frontend/src/components/DatePicker.tsx`. Verified each claim against current `main` before acting (the missed-days work landed a second, comprehensive test file since the scan ran):

- **Removed the silently-ignored props.** `DatePickerProps` declared `mode?: 'scaffoldingStart' | 'courseStart'` and `stageColor?: string`, but the component never destructured or read them (no `...rest`) — the caller's intent was provably discarded. Both props are gone, and the sole call site (`OnboardingModal.tsx`) no longer passes `mode="scaffoldingStart"`. Per the issue's decision-needed note, the theming was never built, so this removes the dead surface rather than wiring speculative behavior.
- **Narrowed truly-dead exports.** `formatDisplayDate`, `getLocalToday`, and `getFirstOfNextMonth` had zero references anywhere and are now module-private. `parseDateInput`, `isDateWithinRange`, and `getNextMonday` are **kept exported** — they have a legitimate unit-test consumer (`frontend/__tests__/DatePicker.test.tsx`); forcing those pure-function tests through the UI would degrade test quality, not reduce cruft. `toISODate`/`parseISODate` stay exported (imported by other modules).
- **Collapsed the duplicate interface.** `NativePickerSlotProps` was field-identical to `NativePickerProps`, and `NativePickerSlot` was a one-line pass-through. Both are deleted; `<NativePicker>` now renders directly behind an inline `Platform.OS !== 'web'` guard. That guard is load-bearing — a test asserts the modal element is not mounted on web — so it is preserved rather than dropped.

### Scope adaptation
The issue also listed "add text-parser tests." Against current `main`, `frontend/__tests__/DatePicker.test.tsx` **already** covers the parser via `onChangeText` for every requested branch — valid MDY (`9/1/25`, `9/1/2025`), two-digit-year normalization, month-name (`Aug 5`), strict ISO, and the exact `Use the format YYYY-MM-DD` error branch. Adding a second batch would duplicate coverage in a de-slop PR, so no new tests were added.

## Test plan

- `./scripts/frontend/check-all.sh` (eslint + prettier + tsc + jest) — green: 330 suites / 3516 tests pass.
- `DatePicker.tsx` coverage: 100% lines / 92.77% branches.
- Grep-verified no surviving caller passes `mode`/`stageColor` to `DatePicker` and no module imports the three now-private helpers.

Closes #1274