### PR TITLE
refactor(components): extract shared ErrorFallback from duplicated boundaries

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { colors, SPACING } from '../design/tokens';
 import { reportException } from '../observability/sentry';
+
+import { ErrorFallback } from './ErrorFallback';
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -58,29 +60,27 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     return (
       <View style={styles.container} testID="error-boundary">
         <ScrollView contentContainerStyle={styles.content}>
-          <Text style={styles.heading}>Something went wrong</Text>
-          <Text style={styles.guidance}>
-            Try closing and reopening the app. If this keeps happening, copy the details below and
-            send them to support so we can fix it.
-          </Text>
-          <Text style={styles.message}>{this.state.error.message}</Text>
-          {/* Issue #272: the verbatim JS stack leaks file paths and internal
-              function names — development builds only. Production users get
-              the message plus the copy-to-support guidance above. */}
-          {__DEV__ && this.state.error.stack ? (
-            <Text style={styles.stack} testID="error-boundary-stack">
-              {this.state.error.stack}
-            </Text>
-          ) : null}
-          <TouchableOpacity
-            accessibilityLabel="Try again"
-            accessibilityRole="button"
-            onPress={this.handleRetry}
-            style={styles.retry}
-            testID="error-boundary-retry"
+          <ErrorFallback
+            heading="Something went wrong"
+            onRetry={this.handleRetry}
+            retryAccessibilityLabel="Try again"
+            retryTestID="error-boundary-retry"
+            retryStyle={styles.retrySpacing}
           >
-            <Text style={styles.retryText}>Try again</Text>
-          </TouchableOpacity>
+            <Text style={styles.guidance}>
+              Try closing and reopening the app. If this keeps happening, copy the details below and
+              send them to support so we can fix it.
+            </Text>
+            <Text style={styles.message}>{this.state.error.message}</Text>
+            {/* Issue #272: the verbatim JS stack leaks file paths and internal
+                function names — development builds only. Production users get
+                the message plus the copy-to-support guidance above. */}
+            {__DEV__ && this.state.error.stack ? (
+              <Text style={styles.stack} testID="error-boundary-stack">
+                {this.state.error.stack}
+              </Text>
+            ) : null}
+          </ErrorFallback>
         </ScrollView>
       </View>
     );
@@ -94,12 +94,6 @@ const styles = StyleSheet.create({
   content: {
     padding: SPACING.xl,
     paddingTop: SPACING.xxl + SPACING.lg,
-  },
-  heading: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.danger,
-    marginBottom: SPACING.md,
   },
   guidance: {
     fontSize: 15,
@@ -117,16 +111,7 @@ const styles = StyleSheet.create({
     color: colors.text.secondaryAccessible,
     fontFamily: 'monospace',
   },
-  retry: {
-    alignSelf: 'flex-start',
+  retrySpacing: {
     marginTop: SPACING.xl,
-    backgroundColor: colors.primary,
-    paddingHorizontal: SPACING.lg,
-    paddingVertical: SPACING.sm,
-    borderRadius: 8,
-  },
-  retryText: {
-    color: colors.text.light,
-    fontWeight: '600',
   },
 });

--- a/frontend/src/components/ErrorFallback.tsx
+++ b/frontend/src/components/ErrorFallback.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+
+import { colors, SPACING } from '@/design/tokens';
+
+interface ErrorFallbackProps {
+  heading: string;
+  onRetry: () => void;
+  retryAccessibilityLabel: string;
+  retryTestID?: string;
+  retryStyle?: StyleProp<ViewStyle>;
+  children?: React.ReactNode;
+}
+
+/** Shared presentational fallback skeleton used by both error boundaries. */
+export function ErrorFallback({
+  heading,
+  onRetry,
+  retryAccessibilityLabel,
+  retryTestID,
+  retryStyle,
+  children,
+}: ErrorFallbackProps): React.JSX.Element {
+  return (
+    <>
+      <Text style={styles.heading}>{heading}</Text>
+      {children}
+      <TouchableOpacity
+        accessibilityLabel={retryAccessibilityLabel}
+        accessibilityRole="button"
+        onPress={onRetry}
+        style={retryStyle ? [styles.retry, retryStyle] : styles.retry}
+        testID={retryTestID}
+      >
+        <Text style={styles.retryText}>Try again</Text>
+      </TouchableOpacity>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.danger,
+    marginBottom: SPACING.md,
+  },
+  retry: {
+    alignSelf: 'flex-start',
+    backgroundColor: colors.primary,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.sm,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: colors.text.light,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/components/FeatureErrorBoundary.tsx
+++ b/frontend/src/components/FeatureErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { ErrorFallback } from './ErrorFallback';
 
 import { colors, SPACING } from '@/design/tokens';
 import { reportException } from '@/observability/sentry';
@@ -101,24 +103,21 @@ class FeatureErrorBoundaryClass extends React.Component<
     const { name } = this.props;
     return (
       <View style={styles.container} testID={`feature-error-${name.toLowerCase()}`}>
-        <Text style={styles.heading}>{name} hit a snag</Text>
-        <Text style={styles.body}>
-          Something went wrong while loading this section. The rest of the app is still usable.
-        </Text>
-        {/* Dev-only: a thrown error's message can carry internal detail (paths,
-            library internals). Unlike the top-level ErrorBoundary — which shows
-            the message in every build alongside a "copy to support" prompt — this
-            inline recovery card has no such affordance, so a production user has
-            no safe channel for the raw text. Hide it here. (audit-ux-05) */}
-        {__DEV__ && <Text style={styles.message}>{this.state.error.message}</Text>}
-        <TouchableOpacity
-          accessibilityLabel={`Retry loading ${name}`}
-          accessibilityRole="button"
-          onPress={this.handleReset}
-          style={styles.retry}
+        <ErrorFallback
+          heading={`${name} hit a snag`}
+          onRetry={this.handleReset}
+          retryAccessibilityLabel={`Retry loading ${name}`}
         >
-          <Text style={styles.retryText}>Try again</Text>
-        </TouchableOpacity>
+          <Text style={styles.body}>
+            Something went wrong while loading this section. The rest of the app is still usable.
+          </Text>
+          {/* Dev-only: a thrown error's message can carry internal detail (paths,
+              library internals). Unlike the top-level ErrorBoundary — which shows
+              the message in every build alongside a "copy to support" prompt — this
+              inline recovery card has no such affordance, so a production user has
+              no safe channel for the raw text. Hide it here. (audit-ux-05) */}
+          {__DEV__ && <Text style={styles.message}>{this.state.error.message}</Text>}
+        </ErrorFallback>
       </View>
     );
   }
@@ -154,12 +153,6 @@ const styles = StyleSheet.create({
     padding: SPACING.xl,
     justifyContent: 'center',
   },
-  heading: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.danger,
-    marginBottom: SPACING.md,
-  },
   body: {
     fontSize: 15,
     color: colors.text.primary,
@@ -170,16 +163,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: colors.text.secondary,
     marginBottom: SPACING.xl,
-  },
-  retry: {
-    alignSelf: 'flex-start',
-    backgroundColor: colors.primary,
-    paddingHorizontal: SPACING.lg,
-    paddingVertical: SPACING.sm,
-    borderRadius: 8,
-  },
-  retryText: {
-    color: colors.text.light,
-    fontWeight: '600',
   },
 });

--- a/frontend/src/components/__tests__/ErrorFallback.test.tsx
+++ b/frontend/src/components/__tests__/ErrorFallback.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { ErrorFallback } from '../ErrorFallback';
+
+describe('ErrorFallback', () => {
+  it('renders the given heading and the Try again button label', () => {
+    const { getByText } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+      />,
+    );
+    expect(getByText('Something went wrong')).toBeTruthy();
+    expect(getByText('Try again')).toBeTruthy();
+  });
+
+  it('renders children between the heading and the retry button', () => {
+    const { getByText } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+      >
+        <Text>marker</Text>
+      </ErrorFallback>,
+    );
+    expect(getByText('marker')).toBeTruthy();
+  });
+
+  it('calls onRetry exactly once when the button is pressed', () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={onRetry}
+        retryAccessibilityLabel="Try again"
+        retryTestID="error-boundary-retry"
+      />,
+    );
+    fireEvent.press(getByTestId('error-boundary-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes an accessible button role and the given accessibility label', () => {
+    const { getByLabelText } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+      />,
+    );
+    const button = getByLabelText('Try again');
+    expect(button.props.accessibilityRole).toBe('button');
+    expect(button.props.accessibilityLabel).toBe('Try again');
+  });
+
+  it('passes retryTestID through onto the button when provided', () => {
+    const { getByTestId } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+        retryTestID="error-boundary-retry"
+      />,
+    );
+    expect(getByTestId('error-boundary-retry')).toBeTruthy();
+  });
+
+  it('still renders without a retryTestID', () => {
+    const { getByText, queryByTestId } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+      />,
+    );
+    expect(getByText('Try again')).toBeTruthy();
+    expect(queryByTestId('error-boundary-retry')).toBeNull();
+  });
+
+  it('merges retryStyle onto the button style', () => {
+    const { getByTestId } = render(
+      <ErrorFallback
+        heading="Something went wrong"
+        onRetry={jest.fn()}
+        retryAccessibilityLabel="Try again"
+        retryTestID="error-boundary-retry"
+        retryStyle={{ marginTop: 20 }}
+      />,
+    );
+    const flattened = StyleSheet.flatten(getByTestId('error-boundary-retry').props.style);
+    expect(flattened).toMatchObject({ marginTop: 20 });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract a shared presentational `ErrorFallback` (heading + "Try again" button + the three duplicated `heading`/`retry`/`retryText` styles) from `ErrorBoundary` and `FeatureErrorBoundary`, so the fallback look-and-feel lives in exactly one place.
- Both boundaries now render `<ErrorFallback>` with their distinct middle content as children while keeping their own containers and their distinct `componentDidCatch` reporting contexts (`boundary: 'ErrorBoundary'` vs `boundary: 'FeatureErrorBoundary', name`).
- Behavior-preserving: `ErrorBoundary`'s extra retry top-margin is preserved via a local `retrySpacing` style + `retryStyle` prop; no change to testIDs, accessibility labels, dev/prod message/stack gating, retry-reset, navigation-focus subscription, or the `reportException` payload shape.

## Test plan
- New `frontend/src/components/__tests__/ErrorFallback.test.tsx` (7 tests): heading + label render, children slot, `onRetry` fires once, a11y role/label, `retryTestID` present/absent, and `retryStyle` merge (pins the marginTop-preservation mechanism).
- The existing `ErrorBoundary.test.tsx` and `FeatureErrorBoundary.test.tsx` suites pass unchanged (characterization safety net).
- `./scripts/frontend/check-all.sh` green: ESLint (zero-warning), prettier, `tsc --noEmit`, and the full jest suite (3523 tests, coverage ≥ 90%).
- Gate 2.5 code-review-orchestrator returned CLEAN.

Closes #1275
