### PR TITLE
refactor(store): remove dead loading/error state from useDepthPreferencesStore

### DIFF
--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -37,8 +37,6 @@ type MockStoreState = {
   enable_practices: boolean;
   enable_course: boolean;
   enable_sangha: boolean;
-  loading: boolean;
-  error: string | null;
 };
 
 const DEFAULT_STORE_STATE: MockStoreState = {
@@ -46,8 +44,6 @@ const DEFAULT_STORE_STATE: MockStoreState = {
   enable_practices: true,
   enable_course: true,
   enable_sangha: true,
-  loading: false,
-  error: null,
 };
 
 let mockStoreState: MockStoreState = { ...DEFAULT_STORE_STATE };
@@ -66,8 +62,6 @@ jest.mock('@/store/useDepthPreferencesStore', () => ({
   selectEnablePractices: (s: MockStoreState): boolean => s.enable_practices,
   selectEnableCourse: (s: MockStoreState): boolean => s.enable_course,
   selectEnableSangha: (s: MockStoreState): boolean => s.enable_sangha,
-  selectDepthPreferencesLoading: (s: MockStoreState): boolean => s.loading,
-  selectDepthPreferencesError: (s: MockStoreState): string | null => s.error,
   get load() {
     return mockLoad;
   },

--- a/frontend/src/store/__tests__/useDepthPreferencesStore.test.ts
+++ b/frontend/src/store/__tests__/useDepthPreferencesStore.test.ts
@@ -51,7 +51,7 @@ describe('useDepthPreferencesStore', () => {
     });
   });
 
-  it('initial state is all-on with loading false and error null', () => {
+  it('initial state is all-on', () => {
     const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
     const state = useDepthPreferencesStore.getState();
 
@@ -59,11 +59,9 @@ describe('useDepthPreferencesStore', () => {
     expect(state.enable_practices).toBe(true);
     expect(state.enable_course).toBe(true);
     expect(state.enable_sangha).toBe(true);
-    expect(state.loading).toBe(false);
-    expect(state.error).toBeNull();
   });
 
-  it('load() sets loading true during fetch then stores returned booleans', async () => {
+  it('load() stores the returned booleans', async () => {
     const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
 
     const serverResponse = {
@@ -72,32 +70,17 @@ describe('useDepthPreferencesStore', () => {
       enable_course: true,
       enable_sangha: false,
     };
-
-    // Single mock: captures mid-flight loading state AND resolves the response
-    let midFlightLoading: boolean | undefined;
-    mockApi.depthPreferences.get.mockImplementationOnce(
-      () =>
-        new Promise<DepthPreferences>((resolve) => {
-          // Record loading state synchronously before the promise settles
-          midFlightLoading = useDepthPreferencesStore.getState().loading;
-          resolve(serverResponse);
-        }),
-    );
+    mockApi.depthPreferences.get.mockResolvedValueOnce(serverResponse);
 
     await act(async () => {
       await useDepthPreferencesStore.getState().load('tok');
     });
-
-    // loading was true mid-flight
-    expect(midFlightLoading).toBe(true);
 
     const state = useDepthPreferencesStore.getState();
     expect(state.enable_habits).toBe(true);
     expect(state.enable_practices).toBe(false);
     expect(state.enable_course).toBe(true);
     expect(state.enable_sangha).toBe(false);
-    expect(state.loading).toBe(false);
-    expect(state.error).toBeNull();
   });
 
   it('load() calls depthPreferences.get with the supplied token', async () => {
@@ -163,38 +146,36 @@ describe('useDepthPreferencesStore', () => {
     expect(useDepthPreferencesStore.getState().enable_sangha).toBe(false);
   });
 
-  it('load() error sets error string, restores loading to false, leaves defaults intact', async () => {
+  it('load() failure resolves quietly and leaves the flags intact', async () => {
     const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
 
     mockApi.depthPreferences.get.mockRejectedValueOnce(new Error('network failure'));
 
     await act(async () => {
-      await useDepthPreferencesStore.getState().load('tok');
+      await expect(useDepthPreferencesStore.getState().load('tok')).resolves.toBeUndefined();
     });
 
     const state = useDepthPreferencesStore.getState();
-    expect(typeof state.error).toBe('string');
-    expect(state.error).not.toBeNull();
-    expect(state.loading).toBe(false);
-    // Defaults remain all-on
+    // A failed read must not flip a ring — defaults remain all-on.
     expect(state.enable_habits).toBe(true);
     expect(state.enable_practices).toBe(true);
     expect(state.enable_course).toBe(true);
     expect(state.enable_sangha).toBe(true);
   });
 
-  it('update() error sets error string and restores loading to false', async () => {
+  it('update() failure resolves quietly and leaves the flags intact', async () => {
     const { useDepthPreferencesStore } = require('../useDepthPreferencesStore');
 
     mockApi.depthPreferences.update.mockRejectedValueOnce(new Error('server error'));
 
     await act(async () => {
-      await useDepthPreferencesStore.getState().update({ enable_habits: false }, 'tok');
+      await expect(
+        useDepthPreferencesStore.getState().update({ enable_habits: false }, 'tok'),
+      ).resolves.toBeUndefined();
     });
 
-    const state = useDepthPreferencesStore.getState();
-    expect(typeof state.error).toBe('string');
-    expect(state.loading).toBe(false);
+    // A failed update must not flip a ring.
+    expect(useDepthPreferencesStore.getState().enable_habits).toBe(true);
   });
 
   it('reset() returns state to the all-on defaults', () => {
@@ -207,8 +188,6 @@ describe('useDepthPreferencesStore', () => {
         enable_practices: false,
         enable_course: false,
         enable_sangha: false,
-        loading: true,
-        error: 'some error',
       });
     });
 
@@ -221,8 +200,6 @@ describe('useDepthPreferencesStore', () => {
     expect(state.enable_practices).toBe(true);
     expect(state.enable_course).toBe(true);
     expect(state.enable_sangha).toBe(true);
-    expect(state.loading).toBe(false);
-    expect(state.error).toBeNull();
   });
 
   it('selectors return their slices from state', () => {
@@ -232,8 +209,6 @@ describe('useDepthPreferencesStore', () => {
       selectEnablePractices,
       selectEnableCourse,
       selectEnableSangha,
-      selectDepthPreferencesLoading,
-      selectDepthPreferencesError,
     } = require('../useDepthPreferencesStore');
 
     act(() => {
@@ -242,8 +217,6 @@ describe('useDepthPreferencesStore', () => {
         enable_practices: false,
         enable_course: true,
         enable_sangha: false,
-        loading: true,
-        error: 'oops',
       });
     });
 
@@ -252,8 +225,6 @@ describe('useDepthPreferencesStore', () => {
     expect(selectEnablePractices(state)).toBe(false);
     expect(selectEnableCourse(state)).toBe(true);
     expect(selectEnableSangha(state)).toBe(false);
-    expect(selectDepthPreferencesLoading(state)).toBe(true);
-    expect(selectDepthPreferencesError(state)).toBe('oops');
   });
 
   it('registers its reset with the shared store registry', () => {

--- a/frontend/src/store/useDepthPreferencesStore.ts
+++ b/frontend/src/store/useDepthPreferencesStore.ts
@@ -13,16 +13,13 @@ import { registerStoreReset } from './registry';
  * Unlike an optimistic toggle, ``update`` waits for the server's echoed full
  * state before mutating: the four flags interact (a backend rule may force a
  * dependent ring off), so the authoritative post-update snapshot is the only
- * safe thing to store. A failed call leaves the current flags untouched and
- * surfaces a string ``error`` for the UI to render.
+ * safe thing to store. A failed call leaves the current flags untouched.
  */
 export interface DepthPreferencesStoreState {
   enable_habits: boolean;
   enable_practices: boolean;
   enable_course: boolean;
   enable_sangha: boolean;
-  loading: boolean;
-  error: string | null;
 
   /** Fetch the current ring toggles and replace local state with the result. */
   load: (_token?: string) => Promise<void>;
@@ -37,8 +34,6 @@ const INITIAL_STATE = {
   enable_practices: true,
   enable_course: true,
   enable_sangha: true,
-  loading: false,
-  error: null as string | null,
 };
 
 /** Narrow the four toggle flags out of a full API response. */
@@ -49,32 +44,25 @@ const toToggles = (prefs: DepthPreferences) => ({
   enable_sangha: prefs.enable_sangha,
 });
 
-/** Human-readable message for an unknown rejection value. */
-const messageFor = (err: unknown): string =>
-  err instanceof Error ? err.message : 'Failed to load depth preferences';
-
 export const useDepthPreferencesStore = create<DepthPreferencesStoreState>((set) => ({
   ...INITIAL_STATE,
 
   load: async (token) => {
-    set({ loading: true, error: null });
     try {
       const prefs = await depthPreferences.get(token);
-      set({ ...toToggles(prefs), loading: false });
-    } catch (err: unknown) {
+      set({ ...toToggles(prefs) });
+    } catch {
       // Leave the existing flags intact — a failed read must not flip a ring.
-      set({ loading: false, error: messageFor(err) });
     }
   },
 
   update: async (partial, token) => {
-    set({ loading: true, error: null });
     try {
       const prefs = await depthPreferences.update(partial, token);
       // Non-optimistic: state comes only from the server's echoed full snapshot.
-      set({ ...toToggles(prefs), loading: false });
-    } catch (err: unknown) {
-      set({ loading: false, error: messageFor(err) });
+      set({ ...toToggles(prefs) });
+    } catch {
+      // Leave the existing flags intact — a failed update must not flip a ring.
     }
   },
 
@@ -114,7 +102,3 @@ export const selectEnableCourse = (state: DepthPreferencesStoreState): boolean =
   state.enable_course;
 export const selectEnableSangha = (state: DepthPreferencesStoreState): boolean =>
   state.enable_sangha;
-export const selectDepthPreferencesLoading = (state: DepthPreferencesStoreState): boolean =>
-  state.loading;
-export const selectDepthPreferencesError = (state: DepthPreferencesStoreState): string | null =>
-  state.error;


### PR DESCRIPTION
## Summary
De-slop of `useDepthPreferencesStore`: removes a dead loading/error state machine and a mis-worded, never-surfaced error message.

- Remove the `loading`/`error` state fields, their setters, and the `selectDepthPreferencesLoading`/`selectDepthPreferencesError` selectors. Verified zero production consumers via tree-wide grep — the three real consumers (`BottomTabs.tsx`, `Settings/ChooseDepthsSection.tsx`, `Journal/StatTileRow.tsx`) only read the four `selectEnable*` slices.
- Drop the now-dead `messageFor` helper, whose `'Failed to load depth preferences'` fallback was reused on the `update` catch path (a load-verb message on an update failure) and never rendered by any UI.
- Correct the store docstring, which claimed it "surfaces a string `error` for the UI to render" — no UI renders it.
- `load`/`update` keep their prior observable behavior (resolve on failure, flags untouched); the two failure tests now characterize this directly (`.resolves.toBeUndefined()` + flags-intact) instead of asserting the dead `error` string.

## Test plan
- `./scripts/frontend/check-all.sh` green (ESLint, prettier, tsc, Jest): 331 suites / 3523 tests pass.
- All pre-commit hooks pass; coverage of the surviving `selectEnable*` slices and load/update/reset behavior preserved.
- Gate 2.5 code-review-orchestrator verdict: CLEAN, no blockers.

Closes #1277