### PR TITLE
fix(frontend): bring the Edit Habit settings modal into the Candle & Ink design language

### DIFF
--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -1,11 +1,16 @@
 import { Platform, StyleSheet, type ViewStyle } from 'react-native';
 
 import {
+  accent,
   colors as COLORS,
+  fonts,
+  ink,
   shadows as SHADOWS,
   SPACING,
   BORDER_RADIUS,
   surface,
+  surfaceShadow,
+  touchTarget,
 } from '../../design/tokens';
 
 const JUSTIFY_SPACE_BETWEEN = 'space-between' as const;
@@ -53,31 +58,24 @@ export const styles = StyleSheet.create({
     borderTopWidth: 5,
     ...SHADOWS.large,
   },
-  // ===== Goal Items =====
-  saveButton: {
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.sm,
-    backgroundColor: COLORS.success,
-    borderRadius: BORDER_RADIUS.xs,
-  },
-  saveButtonText: {
-    color: COLORS.text.light,
-    fontWeight: '600',
-  },
-
   // ===== Days Selector =====
   dayOption: {
-    backgroundColor: COLORS.background.accent,
+    backgroundColor: surface.sunken,
+    borderWidth: 1,
+    borderColor: surface.hairline,
     padding: SPACING.sm,
     borderRadius: BORDER_RADIUS.xs,
     margin: 2,
   },
   selectedDayOption: {
-    backgroundColor: '#aed581',
+    backgroundColor: accent.primary,
   },
   dayOptionText: {
     fontSize: 12,
-    color: COLORS.text.primary,
+    color: ink.primary,
+  },
+  dayOptionTextSelected: {
+    color: accent.onPrimary,
   },
 
   // ===== Action Buttons =====
@@ -125,13 +123,22 @@ export const styles = StyleSheet.create({
     borderTopWidth: 5,
     ...SHADOWS.large,
   },
+  editModalCard: {
+    width: '90%',
+    maxHeight: '90%',
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.xl,
+    padding: SPACING.lg,
+    borderTopWidth: 5,
+    ...surfaceShadow.raised,
+  },
   settingsContainer: {
     marginTop: SPACING.md,
   },
   settingGroup: {
     marginVertical: SPACING.md,
     borderBottomWidth: 1,
-    borderColor: '#eee',
+    borderColor: surface.hairline,
     paddingBottom: SPACING.md,
   },
   settingRow: {
@@ -146,15 +153,27 @@ export const styles = StyleSheet.create({
     flex: 1,
     color: COLORS.text.primary,
   },
+  editSettingLabel: {
+    fontWeight: '600',
+    fontSize: 15,
+    flex: 1,
+    color: ink.primary,
+    fontFamily: fonts.sans,
+  },
   settingValue: {
     fontSize: 15,
-    color: COLORS.text.secondary,
+    color: ink.soft,
+    fontFamily: fonts.sans,
   },
   settingInput: {
     borderWidth: 1,
     borderColor: '#ccc',
     padding: SPACING.sm,
     borderRadius: BORDER_RADIUS.xs,
+    flex: 1,
+    marginLeft: SPACING.md,
+  },
+  settingFieldFlex: {
     flex: 1,
     marginLeft: SPACING.md,
   },
@@ -166,22 +185,6 @@ export const styles = StyleSheet.create({
   iconButtonText: {
     color: COLORS.secondary,
     fontWeight: '500',
-  },
-
-  // ===== Reorder Button =====
-  reorderButton: {
-    backgroundColor: COLORS.primary,
-    paddingVertical: SPACING.md,
-    paddingHorizontal: SPACING.lg,
-    borderRadius: BORDER_RADIUS.xs,
-    marginVertical: SPACING.md,
-    alignItems: 'center',
-    ...SHADOWS.medium,
-  },
-  reorderButtonText: {
-    color: COLORS.text.light,
-    fontWeight: '600',
-    fontSize: 16,
   },
 
   // ===== Energy Container =====
@@ -238,28 +241,31 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
   },
   timeButton: {
-    backgroundColor: COLORS.secondary,
+    backgroundColor: surface.sunken,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.xs,
-    ...SHADOWS.small,
+    justifyContent: 'center',
   },
   timeButtonText: {
-    color: COLORS.text.light,
+    color: ink.primary,
+    fontFamily: fonts.sans,
     fontSize: 16,
   },
   addTimeButton: {
-    backgroundColor: COLORS.success,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    backgroundColor: accent.primary,
+    width: touchTarget.minimum,
+    height: touchTarget.minimum,
+    borderRadius: 22,
     justifyContent: 'center',
     alignItems: 'center',
     marginLeft: SPACING.sm,
-    ...SHADOWS.small,
   },
   addTimeButtonText: {
-    color: COLORS.text.light,
+    color: accent.onPrimary,
     fontSize: 20,
     fontWeight: 'bold',
   },
@@ -270,7 +276,7 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: JUSTIFY_SPACE_BETWEEN,
     alignItems: 'center',
-    backgroundColor: COLORS.background.accent,
+    backgroundColor: surface.sunken,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.xs,
@@ -278,34 +284,39 @@ export const styles = StyleSheet.create({
   },
   timeText: {
     fontSize: 16,
-    color: COLORS.text.primary,
+    color: ink.primary,
+    fontFamily: fonts.sans,
   },
   removeTimeButton: {
     width: 24,
     height: 24,
     borderRadius: 12,
-    backgroundColor: COLORS.danger,
+    backgroundColor: COLORS.destructive.background,
     justifyContent: 'center',
     alignItems: 'center',
   },
   removeTimeButtonText: {
-    color: COLORS.text.light,
+    color: COLORS.destructive.text,
     fontSize: 16,
     fontWeight: 'bold',
   },
 
   // ===== Days Button =====
   daysButton: {
-    backgroundColor: COLORS.secondary,
+    backgroundColor: surface.sunken,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.xs,
     flex: 1,
     marginLeft: SPACING.md,
-    ...SHADOWS.small,
+    justifyContent: 'center',
   },
   daysButtonText: {
-    color: COLORS.text.light,
+    color: ink.primary,
+    fontFamily: fonts.sans,
     fontSize: 14,
   },
   daysPicker: {
@@ -320,32 +331,39 @@ export const styles = StyleSheet.create({
     marginVertical: SPACING.lg,
   },
   deleteButton: {
-    backgroundColor: COLORS.danger,
+    backgroundColor: surface.raised,
+    borderWidth: 1,
+    borderColor: COLORS.destructive.border,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.md,
     paddingHorizontal: SPACING.lg,
     borderRadius: BORDER_RADIUS.xs,
     marginTop: SPACING.md,
     alignItems: 'center',
-    ...SHADOWS.medium,
+    justifyContent: 'center',
   },
   deleteButtonText: {
-    color: COLORS.text.light,
+    color: COLORS.destructive.text,
     fontSize: 16,
     fontWeight: 'bold',
   },
 
   // ===== Frequency Button =====
   frequencyButton: {
-    backgroundColor: COLORS.secondary,
+    backgroundColor: surface.sunken,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.xs,
     flex: 1,
     marginLeft: SPACING.md,
-    ...SHADOWS.small,
+    justifyContent: 'center',
   },
   frequencyButtonText: {
-    color: COLORS.text.light,
+    color: ink.primary,
+    fontFamily: fonts.sans,
     fontSize: 16,
   },
 
@@ -427,10 +445,10 @@ export const styles = StyleSheet.create({
   reorderModalContent: {
     width: '90%',
     height: '85%',
-    backgroundColor: COLORS.background.card,
+    backgroundColor: surface.raised,
     borderRadius: BORDER_RADIUS.xl,
     padding: SPACING.lg,
-    ...SHADOWS.large,
+    ...surfaceShadow.raised,
   },
   datePickerContainer: {
     flexDirection: 'row',
@@ -441,22 +459,27 @@ export const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginRight: SPACING.md,
-    color: COLORS.text.primary,
+    color: ink.primary,
+    fontFamily: fonts.sans,
   },
   datePickerButton: {
-    backgroundColor: COLORS.secondary,
+    backgroundColor: surface.sunken,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.md,
     borderRadius: BORDER_RADIUS.xs,
-    ...SHADOWS.small,
+    justifyContent: 'center',
   },
   datePickerButtonText: {
-    color: COLORS.text.light,
+    color: ink.primary,
+    fontFamily: fonts.sans,
     fontSize: 16,
   },
   reorderInstructions: {
     fontSize: 14,
-    color: COLORS.text.secondary,
+    color: ink.muted,
     marginBottom: SPACING.lg,
     textAlign: 'center',
     fontStyle: 'italic',
@@ -468,12 +491,12 @@ export const styles = StyleSheet.create({
   reorderItem: {
     padding: SPACING.lg,
     borderBottomWidth: 1,
-    borderColor: '#eee',
-    backgroundColor: COLORS.background.card,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
   },
   reorderItemActive: {
-    backgroundColor: COLORS.background.accent,
-    ...SHADOWS.medium,
+    backgroundColor: surface.sunken,
+    ...surfaceShadow.card,
   },
   reorderItemContent: {
     flexDirection: 'row',
@@ -483,24 +506,12 @@ export const styles = StyleSheet.create({
   reorderItemText: {
     fontSize: 16,
     fontWeight: '500',
-    color: COLORS.text.primary,
+    color: ink.primary,
+    fontFamily: fonts.sans,
   },
   reorderItemDate: {
     fontSize: 14,
-    color: COLORS.text.secondary,
-  },
-  saveOrderButton: {
-    backgroundColor: COLORS.success,
-    paddingVertical: SPACING.md,
-    borderRadius: BORDER_RADIUS.xs,
-    marginTop: SPACING.lg,
-    alignItems: 'center',
-    ...SHADOWS.medium,
-  },
-  saveOrderButtonText: {
-    color: COLORS.text.light,
-    fontSize: 16,
-    fontWeight: 'bold',
+    color: ink.soft,
   },
 
   // ===== Missed Days Modal =====

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -1,17 +1,10 @@
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  Modal,
-  TextInput,
-  Platform,
-  ScrollView,
-  Switch,
-} from 'react-native';
+import { View, Text, TouchableOpacity, Modal, Platform, ScrollView, Switch } from 'react-native';
 
-import { STAGE_COLORS } from '../../../design/tokens';
+import { Button } from '../../../components/Button';
+import { TextField } from '../../../components/TextField';
+import { STAGE_COLORS, SPACING } from '../../../design/tokens';
 import { DAYS_OF_WEEK } from '../constants';
 import styles from '../Habits.styles';
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
@@ -63,7 +56,9 @@ const DayPickerGrid = ({
         style={[styles.dayOption, days.includes(day) && styles.selectedDayOption]}
         onPress={() => onToggleDay(day)}
       >
-        <Text style={styles.dayOptionText}>{day.substring(0, 3)}</Text>
+        <Text style={[styles.dayOptionText, days.includes(day) && styles.dayOptionTextSelected]}>
+          {day.substring(0, 3)}
+        </Text>
       </TouchableOpacity>
     ))}
   </View>
@@ -81,8 +76,9 @@ const NotifFrequencySection = ({
 }: NotifFrequencyProps) => (
   <>
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Frequency:</Text>
+      <Text style={styles.editSettingLabel}>Frequency:</Text>
       <TouchableOpacity
+        testID="habit-settings-frequency"
         style={styles.frequencyButton}
         onPress={() =>
           onChange('notificationFrequency', cycleFrequency(habit.notificationFrequency))
@@ -93,7 +89,7 @@ const NotifFrequencySection = ({
     </View>
     {habit.notificationFrequency === 'custom' && (
       <View style={styles.settingRow}>
-        <Text style={styles.settingLabel}>Days:</Text>
+        <Text style={styles.editSettingLabel}>Days:</Text>
         <TouchableOpacity
           style={styles.daysButton}
           onPress={() => setShowDaysPicker(!showDaysPicker)}
@@ -155,7 +151,7 @@ const NotifTimeSection = ({
 }: NotifTimeProps) => (
   <>
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Time:</Text>
+      <Text style={styles.editSettingLabel}>Time:</Text>
       <View style={styles.timeInputContainer}>
         <TouchableOpacity style={styles.timeButton} onPress={() => setShowTimePicker(true)}>
           <Text style={styles.timeButtonText}>{notificationTime}</Text>
@@ -186,7 +182,7 @@ const NotifToggleRow = ({
   onChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
 }) => (
   <View style={styles.settingRow}>
-    <Text style={styles.settingLabel}>Notifications:</Text>
+    <Text style={styles.editSettingLabel}>Notifications:</Text>
     <Switch
       value={isEnabled}
       onValueChange={(value) => onChange('notificationFrequency', value ? 'daily' : 'off')}
@@ -230,7 +226,7 @@ const NotificationSettings = ({
       </>
     )}
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Milestone Notifications:</Text>
+      <Text style={styles.editSettingLabel}>Milestone Notifications:</Text>
       <Switch
         value={habit.milestoneNotifications || false}
         onValueChange={(value) => onChange('milestoneNotifications', value)}
@@ -278,15 +274,15 @@ const BasicFields = ({
 }: BasicFieldsProps) => (
   <>
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Name:</Text>
-      <TextInput
-        style={styles.settingInput}
+      <Text style={styles.editSettingLabel}>Name:</Text>
+      <TextField
         value={editedHabit.name}
         onChangeText={(text) => handleChange('name', text)}
+        style={styles.settingFieldFlex}
       />
     </View>
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Icon:</Text>
+      <Text style={styles.editSettingLabel}>Icon:</Text>
       <TouchableOpacity onPress={() => setShowEmojiSelector(!showEmojiSelector)}>
         <Text style={styles.currentIcon}>{editedHabit.icon}</Text>
       </TouchableOpacity>
@@ -300,12 +296,16 @@ const BasicFields = ({
       onClose={() => setShowEmojiSelector(false)}
     />
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Stage:</Text>
+      <Text style={styles.editSettingLabel}>Stage:</Text>
       <Text style={styles.settingValue}>{editedHabit.stage}</Text>
     </View>
-    <TouchableOpacity style={styles.reorderButton} onPress={() => onOpenReorderModal(allHabits)}>
-      <Text style={styles.reorderButtonText}>Reorder Habits</Text>
-    </TouchableOpacity>
+    <Button
+      label="Reorder Habits"
+      variant="secondary"
+      onPress={() => onOpenReorderModal(allHabits)}
+      testID="habit-settings-reorder"
+      style={{ marginVertical: SPACING.md }}
+    />
   </>
 );
 
@@ -318,7 +318,7 @@ const EnergyAndDateSection = ({
 }) => (
   <>
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Energy Rating:</Text>
+      <Text style={styles.editSettingLabel}>Energy Rating:</Text>
     </View>
     <EnergyCostReturnEditor
       cost={editedHabit.energy_cost}
@@ -327,7 +327,7 @@ const EnergyAndDateSection = ({
       onCommitReturn={(value) => handleChange('energy_return', value)}
     />
     <View style={styles.settingRow}>
-      <Text style={styles.settingLabel}>Start Date:</Text>
+      <Text style={styles.editSettingLabel}>Start Date:</Text>
       <DateTimePicker
         value={new Date(editedHabit.start_date)}
         mode="date"
@@ -340,10 +340,8 @@ const EnergyAndDateSection = ({
 
 const FormActionButtons = ({ onSave, onDelete }: { onSave: () => void; onDelete: () => void }) => (
   <View style={styles.buttonGroup}>
-    <TouchableOpacity style={styles.saveButton} onPress={onSave}>
-      <Text style={styles.saveButtonText}>Save Changes</Text>
-    </TouchableOpacity>
-    <TouchableOpacity style={styles.deleteButton} onPress={onDelete}>
+    <Button label="Save Changes" variant="primary" onPress={onSave} testID="habit-settings-save" />
+    <TouchableOpacity testID="habit-settings-delete" style={styles.deleteButton} onPress={onDelete}>
       <Text style={styles.deleteButtonText}>Delete Habit</Text>
     </TouchableOpacity>
   </View>
@@ -508,7 +506,8 @@ const SettingsModalBody = ({
 }: SettingsBodyProps) => (
   <View style={styles.modalOverlay}>
     <View
-      style={[styles.settingsModalContent, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
+      testID="habit-settings-card"
+      style={[styles.editModalCard, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
     >
       <ModalHeader title="Edit Habit" onClose={onClose} />
       <SettingsForm

--- a/frontend/src/features/Habits/components/ModalHeader.tsx
+++ b/frontend/src/features/Habits/components/ModalHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { colors as COLORS, SPACING } from '../../../design/tokens';
+import { editorialType, ink, SPACING, surface } from '../../../design/tokens';
 
 interface ModalHeaderProps {
   title: React.ReactNode;
@@ -30,15 +30,14 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     borderBottomWidth: 1,
-    borderColor: '#eee',
+    borderColor: surface.hairline,
     paddingBottom: SPACING.md,
     marginBottom: SPACING.md,
   },
   modalTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
+    ...editorialType.title,
+    color: ink.primary,
     flex: 1,
-    color: COLORS.text.primary,
   },
   closeButton: {
     padding: SPACING.xs,
@@ -47,7 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 28,
     lineHeight: 28,
     fontWeight: '300',
-    color: COLORS.text.secondary,
+    color: ink.soft,
   },
 });
 

--- a/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
+++ b/frontend/src/features/Habits/components/ReorderHabitsModal.tsx
@@ -3,8 +3,9 @@ import type { ComponentType } from 'react';
 import { Modal, Platform, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
+import { Button } from '../../../components/Button';
 import { parseISODate, toISODate } from '../../../components/DatePicker';
-import { STAGE_COLORS } from '../../../design/tokens';
+import { colors, STAGE_COLORS, SPACING } from '../../../design/tokens';
 import { useProgramStore } from '../../../store/useProgramStore';
 import styles from '../Habits.styles';
 import type { Habit, ReorderHabitsModalProps } from '../Habits.types';
@@ -40,7 +41,7 @@ interface ReorderItemProps {
 
 const ReorderHabitItem = ({ item, index, drag, isActive }: ReorderItemProps) => {
   const stage = stageAtIndex(index);
-  const color = STAGE_COLORS[stage] ?? '#ccc';
+  const color = STAGE_COLORS[stage] ?? colors.neutral;
   return (
     <TouchableOpacity
       onLongPress={drag}
@@ -225,7 +226,7 @@ const ReorderBody = ({
   onDragEnd,
   onSave,
 }: ReorderBodyProps) => (
-  <View style={styles.reorderModalContent}>
+  <View testID="reorder-modal-card" style={styles.reorderModalContent}>
     <ModalHeader title="Reorder Habits" onClose={onClose} />
     <ReorderDateButton
       startDate={startDate}
@@ -236,9 +237,13 @@ const ReorderBody = ({
       Drag habits to reorder. Habits 1-8 start 21 days apart, habits 9-10 start 42 days apart.
     </Text>
     <ReorderList orderedHabits={orderedHabits} onDragEnd={onDragEnd} />
-    <TouchableOpacity style={styles.saveOrderButton} onPress={onSave}>
-      <Text style={styles.saveOrderButtonText}>Save Order</Text>
-    </TouchableOpacity>
+    <Button
+      label="Save Order"
+      variant="primary"
+      onPress={onSave}
+      testID="reorder-save-order"
+      style={{ marginTop: SPACING.lg, alignSelf: 'stretch' }}
+    />
   </View>
 );
 

--- a/frontend/src/features/Habits/components/__tests__/HabitEditModalsTokens.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitEditModalsTokens.test.tsx
@@ -1,0 +1,241 @@
+/* eslint-env jest */
+// Candle & Ink token guards for the Habit edit modals: settings card + reorder card shadows, CTA/pill colors, and header/label type, pinned to their semantic token values against the legacy values.
+
+import { describe, expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import type { Habit, HabitSettingsModalProps } from '../../Habits.types';
+import { HabitSettingsModal } from '../HabitSettingsModal';
+import ReorderHabitsModal from '../ReorderHabitsModal';
+
+import { accent, colors, fonts, ink, shadows, surface, surfaceShadow } from '@/design/tokens';
+
+jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children: React.ReactNode }) => children,
+  Gesture: {
+    LongPress: () => ({ minDuration: () => ({ onStart: () => ({}) }) }),
+    Pan: () => ({ onBegin: () => ({}) }),
+    Race: () => ({}),
+  },
+}));
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: { View: require('react-native').View },
+  View: require('react-native').View,
+}));
+jest.mock('react-native-modal-datetime-picker', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const baseHabit: Habit = {
+  id: 42,
+  stage: 'Beige',
+  name: 'Morning walk',
+  icon: '🚶',
+  streak: 3,
+  energy_cost: 3,
+  energy_return: 5,
+  start_date: new Date('2026-01-01T00:00:00.000Z'),
+  goals: [],
+  notificationFrequency: 'daily',
+  notificationTimes: [],
+  notificationDays: [],
+  milestoneNotifications: false,
+};
+
+const renderSettingsModal = (overrides: Partial<HabitSettingsModalProps> = {}) =>
+  render(
+    <HabitSettingsModal
+      visible
+      habit={baseHabit}
+      onClose={jest.fn()}
+      onUpdate={jest.fn()}
+      onDelete={jest.fn()}
+      onOpenReorderModal={jest.fn()}
+      allHabits={[baseHabit]}
+      {...overrides}
+    />,
+  );
+
+const makeHabit = (id: number, stage: string, name: string): Habit => ({
+  id,
+  stage,
+  name,
+  icon: '⭐',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 1,
+  start_date: new Date('2026-01-01'),
+  goals: [],
+});
+
+const HABITS: Habit[] = [makeHabit(1, 'Beige', 'A'), makeHabit(2, 'Purple', 'B')];
+
+const renderReorderModal = () =>
+  render(
+    <ReorderHabitsModal visible habits={HABITS} onClose={jest.fn()} onSaveOrder={jest.fn()} />,
+  );
+
+// Shared flatten helper (same pattern as CreatePracticeWizardTokens.test.tsx).
+const flatten = (style: unknown): Record<string, unknown> =>
+  StyleSheet.flatten(style as never) as Record<string, unknown>;
+
+// Guard 1: settings card shadowRadius resolves to surfaceShadow.raised (18), not legacy shadows.large (4).
+describe('Candle & Ink token guard — settings card shadow (habit-settings-card)', () => {
+  it('settings card shadowRadius resolves to surfaceShadow.raised', () => {
+    const { getByTestId } = renderSettingsModal();
+    const card = getByTestId('habit-settings-card');
+    expect(flatten(card.props.style).shadowRadius).toBe(surfaceShadow.raised.shadowRadius);
+  });
+
+  it('settings card shadowRadius does NOT use the legacy shadows.large value', () => {
+    const { getByTestId } = renderSettingsModal();
+    const card = getByTestId('habit-settings-card');
+    expect(flatten(card.props.style).shadowRadius).not.toBe(shadows.large.shadowRadius);
+  });
+});
+
+// Guard 2: reorder card shadowRadius resolves to surfaceShadow.raised (18), not legacy shadows.large (4).
+describe('Candle & Ink token guard — reorder card shadow (reorder-modal-card)', () => {
+  it('reorder card shadowRadius resolves to surfaceShadow.raised', () => {
+    const { getByTestId } = renderReorderModal();
+    const card = getByTestId('reorder-modal-card');
+    expect(flatten(card.props.style).shadowRadius).toBe(surfaceShadow.raised.shadowRadius);
+  });
+
+  it('reorder card shadowRadius does NOT use the legacy shadows.large value', () => {
+    const { getByTestId } = renderReorderModal();
+    const card = getByTestId('reorder-modal-card');
+    expect(flatten(card.props.style).shadowRadius).not.toBe(shadows.large.shadowRadius);
+  });
+});
+
+// Guard 3: Save Changes background resolves to accent.primary, not legacy colors.success.
+describe('Candle & Ink token guard — settings save CTA (habit-settings-save)', () => {
+  it('save button background resolves to accent.primary', () => {
+    const { getByTestId } = renderSettingsModal();
+    const save = getByTestId('habit-settings-save');
+    expect(flatten(save.props.style).backgroundColor).toBe(accent.primary);
+  });
+
+  it('save button does NOT use the legacy colors.success', () => {
+    const { getByTestId } = renderSettingsModal();
+    const save = getByTestId('habit-settings-save');
+    expect(flatten(save.props.style).backgroundColor).not.toBe(colors.success);
+  });
+});
+
+// Guard 4: Save Order background resolves to accent.primary, not legacy colors.success.
+describe('Candle & Ink token guard — reorder save CTA (reorder-save-order)', () => {
+  it('save order button background resolves to accent.primary', () => {
+    const { getByTestId } = renderReorderModal();
+    const save = getByTestId('reorder-save-order');
+    expect(flatten(save.props.style).backgroundColor).toBe(accent.primary);
+  });
+
+  it('save order button does NOT use the legacy colors.success', () => {
+    const { getByTestId } = renderReorderModal();
+    const save = getByTestId('reorder-save-order');
+    expect(flatten(save.props.style).backgroundColor).not.toBe(colors.success);
+  });
+});
+
+// Guard 5: Reorder Habits pill border resolves to accent.primary, not legacy colors.primary solid fill.
+describe('Candle & Ink token guard — reorder-habits action (habit-settings-reorder)', () => {
+  it('reorder button border resolves to accent.primary', () => {
+    const { getByTestId } = renderSettingsModal();
+    const reorder = getByTestId('habit-settings-reorder');
+    expect(flatten(reorder.props.style).borderColor).toBe(accent.primary);
+  });
+
+  it('reorder button does NOT use the legacy colors.primary solid fill', () => {
+    const { getByTestId } = renderSettingsModal();
+    const reorder = getByTestId('habit-settings-reorder');
+    expect(flatten(reorder.props.style).backgroundColor).not.toBe(colors.primary);
+  });
+});
+
+// Guard 6: Delete Habit pill border resolves to colors.destructive.border, not legacy colors.danger solid fill.
+describe('Candle & Ink token guard — delete-habit action (habit-settings-delete)', () => {
+  it('delete button border resolves to colors.destructive.border', () => {
+    const { getByTestId } = renderSettingsModal();
+    const del = getByTestId('habit-settings-delete');
+    expect(flatten(del.props.style).borderColor).toBe(colors.destructive.border);
+  });
+
+  it('delete button does NOT use the legacy colors.danger solid fill', () => {
+    const { getByTestId } = renderSettingsModal();
+    const del = getByTestId('habit-settings-delete');
+    expect(flatten(del.props.style).backgroundColor).not.toBe(colors.danger);
+  });
+});
+
+// Guard 7: frequency pill background resolves to surface.sunken, not legacy colors.secondary.
+describe('Candle & Ink token guard — frequency pill (habit-settings-frequency)', () => {
+  it('frequency pill background resolves to surface.sunken', () => {
+    const { getByTestId } = renderSettingsModal();
+    const pill = getByTestId('habit-settings-frequency');
+    expect(flatten(pill.props.style).backgroundColor).toBe(surface.sunken);
+  });
+
+  it('frequency pill does NOT use the legacy colors.secondary', () => {
+    const { getByTestId } = renderSettingsModal();
+    const pill = getByTestId('habit-settings-frequency');
+    expect(flatten(pill.props.style).backgroundColor).not.toBe(colors.secondary);
+  });
+});
+
+// Guard 8: settings header resolves to fonts.serif, not fonts.sans.
+describe('Candle & Ink token guard — settings header serif (Edit Habit)', () => {
+  it('header resolves to fonts.serif', () => {
+    const { getByText } = renderSettingsModal();
+    const header = getByText('Edit Habit');
+    expect(flatten(header.props.style).fontFamily).toBe(fonts.serif);
+  });
+
+  it('header does NOT use fonts.sans', () => {
+    const { getByText } = renderSettingsModal();
+    const header = getByText('Edit Habit');
+    expect(flatten(header.props.style).fontFamily).not.toBe(fonts.sans);
+  });
+});
+
+// Guard 9: reorder header resolves to fonts.serif, not fonts.sans.
+describe('Candle & Ink token guard — reorder header serif (Reorder Habits)', () => {
+  it('header resolves to fonts.serif', () => {
+    const { getByText } = renderReorderModal();
+    const header = getByText('Reorder Habits');
+    expect(flatten(header.props.style).fontFamily).toBe(fonts.serif);
+  });
+
+  it('header does NOT use fonts.sans', () => {
+    const { getByText } = renderReorderModal();
+    const header = getByText('Reorder Habits');
+    expect(flatten(header.props.style).fontFamily).not.toBe(fonts.sans);
+  });
+});
+
+// Guard 10: the "Name:" field label resolves to ink.primary, not legacy colors.text.primary.
+describe('Candle & Ink token guard — Name label ink (Name:)', () => {
+  it('label color resolves to ink.primary', () => {
+    const { getByText } = renderSettingsModal();
+    const label = getByText('Name:');
+    expect(flatten(label.props.style).color).toBe(ink.primary);
+  });
+
+  it('label does NOT use the legacy colors.text.primary', () => {
+    const { getByText } = renderSettingsModal();
+    const label = getByText('Name:');
+    expect(flatten(label.props.style).color).not.toBe(colors.text.primary);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the **Edit Habit settings modal** and its child **Reorder Habits modal** (plus the shared `ModalHeader`) into the "Candle & Ink" warm-editorial language, so tapping into a habit's settings no longer drops the user onto a stark-white sheet with legacy grey/olive/near-black chrome. The modals now read as the same product as the Habits grid behind them and the redesigned Today / Practice surfaces.

- Migrates the touched style sections in `Habits.styles.ts` off legacy `colors.*` + cool shadows onto the static semantic layer (`surface` / `ink` / `accent` / `surfaceShadow` / `fonts.serif`), and swaps bespoke buttons/input to the shared #801 `Button` / `TextField` primitives.
- **Reskin only:** every `testID`, accessibility label, text string, and interaction is unchanged; the two existing behavior-contract test files pass unedited. All interactive targets are ≥ 44 dp (the add-time control grew 36 → 44).

### Before → after (what tokens replaced what)

| Element | Before (legacy) | After (Candle & Ink) |
|---|---|---|
| Modal sheet | `colors.background.card` + cool `shadows.large` | `surface.raised` + `surfaceShadow.raised` |
| Title ("Edit Habit" / "Reorder Habits") | plain-sans `fontSize:20` bold | serif `editorialType.title` on `ink.primary` |
| Labels / values / instructions | `colors.text.*` greys | `ink.primary` / `ink.soft` / `ink.muted` + `fonts.sans` |
| Save Changes / Save Order | bespoke `colors.success` (olive) buttons | shared `Button` primary — terracotta `accent.primary` |
| Reorder Habits | bespoke `colors.primary` (near-black) button | shared `Button` secondary (warm outline) |
| Delete Habit | heavy full-width `colors.danger` fill | destructive outline — `surface.raised` + `colors.destructive.border` / `.text` |
| Frequency / Time / Days / Date pills | `colors.secondary` (olive) fills | quiet `surface.sunken` wells + `surface.hairline` borders |
| Add-time `+` | `colors.success` circle, 36 dp | `accent.primary` circle, 44 dp |
| Day-grid selected | raw hex `#aed581` | `accent.primary` fill + `accent.onPrimary` text |
| Name input | bespoke `#ccc`-border `TextInput` | shared `TextField` primitive |

Shared style keys still consumed by `AddHabitModal` (`settingLabel` / `settingInput` / `settingsModalContent`) are left untouched — the settings modal re-points to new scoped keys — so sibling modals do not regress. Restyling the shared `ModalHeader` intentionally brings all five Habits-modal headers into the serif language (a consistency win; covered by `ModalHeader.test.tsx`).

**Deliberate scoping note:** dark-mode-via-`useTheme()` (#804 tokens) is left unadopted here, matching every other feature surface — no feature currently consumes `useTheme()` for styling, and the static-light #801 primitives this issue mandates reusing cannot honor a runtime theme. App-wide dark adoption (including theming the primitives) is a separate follow-up. This PR delivers the visible fix and mirrors the #932 practice-authoring migration precedent exactly.

## Test plan

- New `HabitEditModalsTokens.test.tsx`: 20 token-guard pins (positive + negative per key control), mirroring `CreatePracticeWizardTokens.test.tsx` — card shadow geometry, Save/Reorder/Delete/Save-Order/pill token values, serif header, ink label.
- The unedited `HabitSettingsModal.test.tsx` + `ReorderHabitsModal.test.tsx` (42 behavior assertions) and the ModalHeader/AddHabit/Goal/Stats sibling suites all pass — proving behavior is unchanged.
- `./scripts/frontend/check-all.sh` exits 0 (ESLint zero-warning, Prettier, `tsc --noEmit`, all 3543 Jest tests).

Closes #1305
