### PR TITLE
refactor(habits): route the primary load path through toLocalHabit's sanitizers

### DIFF
--- a/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import { Text } from 'react-native';
 import renderer from 'react-test-renderer';
 
+import type * as ApiModule from '../../../api';
+
 const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
   id,
   name: `Habit ${id}`,
@@ -36,25 +38,31 @@ const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
 const buildApiHabits = (count: number) =>
   Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    listAll: jest.fn() as any,
-    create: jest.fn() as any,
-    update: jest.fn() as any,
-    delete: jest.fn() as any,
-    getStats: (jest.fn() as any).mockResolvedValue({
-      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-      values: [0, 0, 0, 0, 0, 0, 0],
-      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-      longest_streak: 0,
-      current_streak: 0,
-      total_completions: 0,
-      completion_rate: 0,
-      completion_dates: [],
-    }),
-  },
-  goalCompletions: { create: jest.fn() as any },
-}));
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      listAll: jest.fn() as any,
+      create: jest.fn() as any,
+      update: jest.fn() as any,
+      delete: jest.fn() as any,
+      getStats: (jest.fn() as any).mockResolvedValue({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+    },
+    goalCompletions: { create: jest.fn() as any },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token' }),

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -4,6 +4,7 @@ import { jest, describe, afterEach, it, expect } from '@jest/globals';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import type * as ApiModule from '../../../api';
 import { STAGE_COLORS } from '../../../design/tokens';
 import type { Habit } from '../Habits.types';
 import { HabitTile } from '../HabitTile';
@@ -37,25 +38,31 @@ const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
 const buildApiHabits = (count: number) =>
   Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    listAll: jest.fn() as any,
-    create: jest.fn() as any,
-    update: jest.fn() as any,
-    delete: jest.fn() as any,
-    getStats: (jest.fn() as any).mockResolvedValue({
-      day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-      values: [0, 0, 0, 0, 0, 0, 0],
-      completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-      longest_streak: 0,
-      current_streak: 0,
-      total_completions: 0,
-      completion_rate: 0,
-      completion_dates: [],
-    }),
-  },
-  goalCompletions: { create: jest.fn() as any },
-}));
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      listAll: jest.fn() as any,
+      create: jest.fn() as any,
+      update: jest.fn() as any,
+      delete: jest.fn() as any,
+      getStats: (jest.fn() as any).mockResolvedValue({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+    },
+    goalCompletions: { create: jest.fn() as any },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token' }),

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
+// Keep the real ``toLocalHabit`` mapper (the load path now delegates to it and
+// these tests assert its tier/notification sanitizing) while stubbing only the
+// network namespaces habitManager calls.
 jest.mock('../../../../api', () => ({
+  ...jest.requireActual<typeof ApiModule>('../../../../api'),
   habits: {
     listAll: jest.fn(() => Promise.resolve([])),
     create: jest.fn(() => Promise.resolve({})),
@@ -44,6 +48,7 @@ jest.mock('react-native', () => ({
   StyleSheet: { create: (s: Record<string, unknown>) => s },
 }));
 
+import type * as ApiModule from '../../../../api';
 import {
   habits as habitsApi,
   goalCompletions as goalCompletionsApi,
@@ -520,10 +525,13 @@ describe('habitManager', () => {
           start_date: '2025-01-01',
           energy_cost: 1,
           energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
           notification_times: null,
           notification_frequency: null,
           notification_days: null,
           milestone_notifications: false,
+          goals: [],
         },
       ] as never);
 
@@ -839,6 +847,111 @@ describe('habitManager', () => {
       expect(anchor!.getFullYear()).toBe(2026);
       expect(anchor!.getMonth()).toBe(1);
       expect(anchor!.getDate()).toBe(15);
+    });
+
+    it('narrows an unknown goal tier to the safe "clear" default instead of leaking the raw string', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 6,
+          name: 'Tier Test',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          revealed: true,
+          goals: [
+            {
+              id: 1,
+              title: 'Odd',
+              tier: 'bogus',
+              target: 1,
+              target_unit: 'units',
+              frequency: 1,
+              frequency_unit: 'per_day',
+              is_additive: true,
+            },
+          ],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits[0]!.goals[0]!.tier).toBe('clear');
+    });
+
+    it('drops an unknown notification_frequency instead of casting it through', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 7,
+          name: 'Notif Test',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          revealed: true,
+          notification_frequency: 'sometimes' as never,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits[0]!.notificationFrequency).toBeUndefined();
+    });
+
+    it('carries a numeric sort_order from the API onto the stored habit', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 8,
+          name: 'Ordered',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          revealed: true,
+          sort_order: 3,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits[0]!.sort_order).toBe(3);
+    });
+
+    it('defaults sort_order to null when the API omits it', async () => {
+      (loadHabits as jest.Mock).mockResolvedValueOnce(null as never);
+      (habitsApi.listAll as jest.Mock).mockResolvedValueOnce([
+        {
+          id: 9,
+          name: 'Unordered',
+          icon: '\u{1F9D8}',
+          start_date: '2025-01-01',
+          energy_cost: 1,
+          energy_return: 2,
+          stage: 'Beige',
+          streak: 0,
+          milestone_notifications: false,
+          revealed: true,
+          goals: [],
+        },
+      ] as never);
+
+      await habitManager.loadHabits();
+
+      expect(useHabitStore.getState().habits[0]!.sort_order).toBeNull();
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -15,6 +15,7 @@ import {
   goalCompletions as goalCompletionsApi,
   goalGroups as goalGroupsApi,
   goals as goalsApi,
+  toLocalHabit,
 } from '../../../api';
 import type {
   CheckInResult,
@@ -23,7 +24,6 @@ import type {
   HabitCreatePayload,
 } from '../../../api';
 import { formatApiError } from '../../../api/errorMessages';
-import { flattenGoalCompletions } from '../../../api/flattenGoalCompletions';
 import type { ToastConfig } from '../../../components/Toast';
 import { colors } from '../../../design/tokens';
 import {
@@ -111,40 +111,11 @@ const toApiPayload = (h: Habit): HabitCreatePayload => ({
   revealed: h.revealed ?? false,
 });
 
+// Delegate field mapping + tier/notification-frequency sanitizing to the
+// canonical ``toLocalHabit`` boundary; ``sort_order`` is the one Habits-only
+// field it does not carry, so preserve it via the spread override.
 const mapApiHabits = (apiHabits: Awaited<ReturnType<typeof habitsApi.listAll>>): Habit[] =>
-  apiHabits.map((h) => ({
-    id: h.id,
-    stage: h.stage ?? '',
-    name: h.name,
-    icon: h.icon,
-    streak: h.streak ?? 0,
-    energy_cost: h.energy_cost,
-    energy_return: h.energy_return,
-    start_date: new Date(h.start_date),
-    goals: (h.goals ?? []).map((g) => ({
-      id: g.id,
-      title: g.title,
-      tier: g.tier as 'low' | 'clear' | 'stretch',
-      target: g.target,
-      target_unit: g.target_unit,
-      frequency: g.frequency,
-      frequency_unit: g.frequency_unit,
-      is_additive: g.is_additive,
-      goal_group_id: g.goal_group_id ?? null,
-      days_of_week: g.days_of_week ?? undefined,
-    })),
-    // Shared with ``toLocalHabit`` -- single-source dedupe + Date rehydration.
-    completions: flattenGoalCompletions(h.goals ?? []),
-    // The server owns the unlock flag now; mirror it instead of forcing every
-    // fetched habit unlocked (which would defeat locked-by-default).
-    revealed: h.revealed,
-    notificationTimes: h.notification_times ?? undefined,
-    notificationFrequency:
-      (h.notification_frequency as Habit['notificationFrequency']) ?? undefined,
-    notificationDays: h.notification_days ?? undefined,
-    milestoneNotifications: h.milestone_notifications,
-    sort_order: h.sort_order ?? null,
-  }));
+  apiHabits.map((h) => ({ ...toLocalHabit(h), sort_order: h.sort_order ?? null }));
 
 // is_additive is propagated so single-tier flips can't leave the store half-additive (normalizeGoalTiers keys off low.is_additive).
 const normalizeGoalUnits = (goals: Goal[], updatedGoal: Goal): void => {


### PR DESCRIPTION
## Summary

`mapApiHabits` — the mapper on the primary `GET /habits` rehydration path that runs every session — was a field-for-field re-implementation of the exported `toLocalHabit`, but it force-cast the two fields `toLocalHabit` deliberately sanitizes:

- `g.tier as 'low' | 'clear' | 'stretch'` instead of `narrowTier(g.tier)` (unknown tier → safe `'clear'` default)
- `h.notification_frequency as Habit['notificationFrequency']` instead of the `isNotificationFrequency` guard (unknown frequency → `undefined`)

So the load path every session uses reintroduced exactly the failure the sanitizers were written to prevent. This collapses `mapApiHabits` onto the canonical mapper:

```ts
const mapApiHabits = (apiHabits) =>
  apiHabits.map((h) => ({ ...toLocalHabit(h), sort_order: h.sort_order ?? null }));
```

`sort_order` (the one Habits-only field `toLocalHabit` does not carry) is preserved via the spread override; every other field maps identically, and the now-orphaned `flattenGoalCompletions` import is removed. `toLocalHabit` itself, the goal/completion flattening, and the store shape are unchanged.

## Test plan

- New tests in `habitManager.test.ts` prove the load path now sanitizes: a `GET /habits` payload with an unknown `tier` (`'bogus'`) lands `'clear'` in the store; an unknown `notification_frequency` (`'sometimes'`) lands `undefined`; `sort_order` still carries through (numeric) and defaults to `null` when absent. The first two fail against the old force-cast body.
- The api-module mock in the three affected Habits test files now spreads `jest.requireActual` to preserve the real `toLocalHabit` (mirroring the existing HabitUtils mock idiom), since the load path depends on the real mapper.
- `./scripts/frontend/check-all.sh` green: ESLint + prettier + tsc + all 3547 Jest tests pass.

Closes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)