### PR TITLE
refactor(habits): make useHabitActions return a referentially stable object

### DIFF
--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -373,5 +373,78 @@ describe('useHabitActions.addHabit', () => {
   });
 });
 
+describe('useHabitActions — referential stability', () => {
+  let stableShowToast: jest.Mock;
+
+  beforeEach(() => {
+    stableShowToast = jest.fn();
+  });
+
+  const renderActionsStable = () =>
+    renderHook(() => {
+      const ui = useHabitUI();
+      const actions = useHabitActions(ui, stableShowToast, 'UTC');
+      return { ui, actions };
+    });
+
+  it('keeps the same actions reference across an unrelated re-render', async () => {
+    const { result, rerender } = renderActionsStable();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const first = result.current.actions;
+    rerender({});
+
+    expect(result.current.actions).toBe(first);
+  });
+
+  it('keeps the same actions reference when emojiHabitIndex changes', async () => {
+    const { result } = renderActionsStable();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const first = result.current.actions;
+    act(() => {
+      result.current.actions.iconPress(0);
+    });
+
+    expect(result.current.actions).toBe(first);
+  });
+
+  it('emojiSelect commits against the emoji-picker target set on a later render', async () => {
+    useHabitStore.setState({ habits: [makeHabit()] });
+    const { result } = renderActionsStable();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const emojiSelect = result.current.actions.emojiSelect;
+    act(() => {
+      result.current.actions.iconPress(0);
+    });
+    act(() => {
+      emojiSelect('X');
+    });
+
+    expect(useHabitStore.getState().habits[0]!.icon).toBe('X');
+    expect(result.current.ui.emojiHabitIndex).toBeNull();
+  });
+
+  it('keeps logUnit and onboardingSave stable across a re-render', async () => {
+    const { result, rerender } = renderActionsStable();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const { logUnit, onboardingSave } = result.current.actions;
+    rerender({});
+
+    expect(result.current.actions.logUnit).toBe(logUnit);
+    expect(result.current.actions.onboardingSave).toBe(onboardingSave);
+  });
+});
+
 // Quiet React's "unused import" concerns when `act` covers the renders.
 void React;

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { ApiError, ApiValidationError } from '../../../api';
 import { formatApiError } from '../../../api/errorMessages';
@@ -103,7 +103,7 @@ const useLogUnitMutation = (
   showToast: ShowToast,
   tz: string,
 ): ((_habitId: number, _amount: number, _date?: Date) => void) => {
-  const mutation = useOptimisticMutation<LogUnitContext, unknown>({
+  const { mutate } = useOptimisticMutation<LogUnitContext, unknown>({
     apply: (ctx) => habitManager.applyLogUnitContext(ctx),
     commit: (ctx) => habitManager.commitLogUnitContext(ctx),
     rollback: (ctx, err) => handleLogUnitFailure(ctx, err, showToast, tz),
@@ -119,9 +119,9 @@ const useLogUnitMutation = (
       // Fire-and-forget: rollback runs inside the hook before the re-throw
       // and has already surfaced the failure to the user via ``showToast``,
       // so swallow the rejection here to keep UI handlers tidy.
-      mutation.mutate(ctx).catch(() => {});
+      mutate(ctx).catch(() => {});
     },
-    [mutation, tz],
+    [mutate, tz],
   );
 };
 
@@ -137,14 +137,22 @@ export const useHabitActions = (
 ): HabitsActions => {
   const logUnit = useLogUnitMutation(showToast, tz);
 
-  const iconPress = useCallback((index: number) => ui.setEmojiHabitIndex(index), [ui]);
+  const { setEmojiHabitIndex } = ui;
+
+  const iconPress = useCallback((index: number) => setEmojiHabitIndex(index), [setEmojiHabitIndex]);
+
+  // Latest-ref keeps emojiSelect referentially stable while it reads the
+  // current picker target at call time.
+  const emojiHabitIndexRef = useRef(ui.emojiHabitIndex);
+  emojiHabitIndexRef.current = ui.emojiHabitIndex;
 
   const emojiSelect = useCallback(
     (emoji: string) => {
-      if (ui.emojiHabitIndex !== null) habitManager.setEmojiForHabit(ui.emojiHabitIndex, emoji);
-      ui.setEmojiHabitIndex(null);
+      const index = emojiHabitIndexRef.current;
+      if (index !== null) habitManager.setEmojiForHabit(index, emoji);
+      setEmojiHabitIndex(null);
     },
-    [ui],
+    [setEmojiHabitIndex],
   );
 
   const onboardingSave = useCallback(


### PR DESCRIPTION
## Summary
- `useHabitActions` now returns a genuinely stable `HabitsActions` object across renders with unchanged `showToast`/`tz`, so its "stable for memoized children" docstring is finally true.
- Fixed both instability sources: `iconPress`/`emojiSelect` now depend on the stable `useState` setter (destructured to dodge the exhaustive-deps this-binding warning) with a latest-value ref for the changing emoji-picker index, and `logUnit` depends on the stable `mutate` callback instead of the fresh `{ mutate, pending }` container `useOptimisticMutation` returns each render.
- Identity-only change — no behavior change to any action.

## Test plan
- Added a `useHabitActions — referential stability` describe block: `actions` identity is preserved across a plain rerender and across an `emojiHabitIndex` state change; `emojiSelect` captured before the picker target is set still commits against the current target (latest-ref guard); `logUnit`/`onboardingSave` keep identity across rerender.
- `npx jest src/features/Habits/hooks/__tests__/useHabitActions.test.tsx` — 15/15 pass.
- `./scripts/frontend/check-all.sh` — green (332 suites / 3551 tests, ESLint zero-warning, `tsc --noEmit` clean, coverage >=90%).

Closes #1352
