### PR TITLE
fix(security): strip the Unicode Tags block in sanitize_user_text

### DIFF
--- a/backend/src/security/text_sanitize.py
+++ b/backend/src/security/text_sanitize.py
@@ -16,10 +16,13 @@ The helper strips three classes of input:
   ``\t`` / ``\n`` / ``\r`` are kept because journal entries legitimately
   contain newlines and tabs.
 * **DEL** (``0x7F``) — invisible, easily smuggled past visual review.
-* **Zero-width and bidirectional override codepoints** (``U+200B``-``U+200F``,
-  ``U+202A``-``U+202E``, ``U+2060``-``U+206F``, ``U+FEFF``) — invisible
-  characters used for visual spoofing (Trojan Source) and ``RIGHT-TO-LEFT
-  OVERRIDE`` attacks that flip rendered text direction.
+* **Zero-width, bidirectional-override, and Tags-block codepoints**
+  (``U+200B``-``U+200F``, ``U+202A``-``U+202E``, ``U+2060``-``U+206F``,
+  ``U+FEFF``, ``U+E0000``-``U+E007F``) — invisible characters used for visual
+  spoofing (Trojan Source) and ``RIGHT-TO-LEFT OVERRIDE`` attacks that flip
+  rendered text direction.  The Unicode Tags block (``U+E0000``-``U+E007F``)
+  is an invisible ASCII-smuggling / prompt-injection channel that would
+  otherwise reach the LLM prompt sink verbatim.
 
 It also normalises to NFC so combining-character variants (e.g. ``e`` plus
 combining-acute vs. precomposed ``é``) hash and compare identically downstream.
@@ -63,6 +66,10 @@ _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 #   * U+2060-U+206F — word joiner, function application, invisible math ops,
 #     and four reserved deprecated formatting codes.
 #   * U+FEFF — BOM / zero-width no-break space when not at file start.
+#   * U+E0000-U+E007F — Unicode Tags block: invisible supplementary-plane
+#     codepoints that tag-encode ASCII, an invisible smuggling channel to the
+#     LLM prompt sink.  Bounded at U+E007F so the variation-selector
+#     supplement (U+E0100+) survives.
 #
 # The pattern is built from codepoint constants so the source file itself
 # contains no invisible characters (Trojan-Source defense).  Ranges expand to
@@ -72,6 +79,7 @@ _ZERO_WIDTH_RANGES = (
     (0x200B, 0x200F),
     (0x202A, 0x202E),
     (0x2060, 0x206F),
+    (0xE0000, 0xE007F),
 )
 _ZERO_WIDTH_SINGLES = (0xFEFF,)
 _ZERO_WIDTH = re.compile(

--- a/backend/tests/security/test_text_sanitize.py
+++ b/backend/tests/security/test_text_sanitize.py
@@ -44,6 +44,24 @@ INVISIBLE_TIMES = "\u2062"
 INVISIBLE_PLUS = "\u2064"
 BOM = "\ufeff"
 
+# Unicode Tags block (U+E0000-U+E007F) -- invisible ASCII-smuggling channel.
+# Range bounds as named constants so the smuggling helper below carries no
+# magic numbers.
+TAG_BLOCK_START = 0xE0000
+TAG_BLOCK_END = 0xE007F
+TAG = "\U000e0000"  # TAG -- range start
+TAG_LANGUAGE = "\U000e0001"  # LANGUAGE TAG
+TAG_A = "\U000e0041"  # tag-encoded ASCII "A"
+TAG_B = "\U000e0042"  # tag-encoded ASCII "B"
+CANCEL_TAG = "\U000e007f"  # CANCEL TAG -- range end
+VS17 = "\U000e0100"  # first variation-selector-supplement codepoint, one past the tag block
+IVS_BASE = "\u4e2d"  # CJK base char paired with VS17 in the scope-guard test
+
+
+def _tag_encode(word: str) -> str:
+    """Encode an ASCII word as invisible Unicode Tags-block codepoints."""
+    return "".join(chr(TAG_BLOCK_START + ord(char)) for char in word)
+
 
 class TestPreservesLegitimateContent:
     """Legitimate user text -- including HTML-ish characters -- survives intact."""
@@ -171,6 +189,52 @@ class TestStripsZeroWidthAndDirectionalOverrides:
     def test_bom_stripped(self) -> None:
         """U+FEFF (BOM / zero-width no-break space) goes when embedded."""
         assert sanitize_user_text(f"hello{BOM}world") == "helloworld"
+
+
+class TestStripsUnicodeTagsBlock:
+    """Unicode Tags block (U+E0000-U+E007F) is invisible ASCII-smuggling."""
+
+    def test_invisible_tag_encoded_directive_stripped(self) -> None:
+        """A tag-encoded invisible "IGNORE" payload is removed; visible text survives."""
+        payload = "hello" + _tag_encode("IGNORE")
+        cleaned = sanitize_user_text(payload)
+        assert cleaned == "hello"
+        assert not any(TAG_BLOCK_START <= ord(char) <= TAG_BLOCK_END for char in cleaned)
+
+    def test_acceptance_example_stripped(self) -> None:
+        """Matches the literal acceptance example: tag-encoded "AB" disappears."""
+        assert sanitize_user_text("hello" + TAG_A + TAG_B) == "hello"
+
+    def test_tag_range_start_stripped(self) -> None:
+        """U+E0000 (TAG), the range start, is removed."""
+        assert sanitize_user_text(f"a{TAG}b") == "ab"
+
+    def test_language_tag_stripped(self) -> None:
+        """U+E0001 (LANGUAGE TAG) is removed."""
+        assert sanitize_user_text(f"a{TAG_LANGUAGE}b") == "ab"
+
+    def test_cancel_tag_range_end_stripped(self) -> None:
+        """U+E007F (CANCEL TAG), the range end, is removed."""
+        assert sanitize_user_text(f"a{CANCEL_TAG}b") == "ab"
+
+    def test_variation_selector_supplement_preserved(self) -> None:
+        """U+E0100 (VS17), one past the tag block, must survive -- pins the upper edge."""
+        text = IVS_BASE + VS17
+        result = sanitize_user_text(text)
+        assert result == unicodedata.normalize("NFC", text)
+        assert VS17 in result
+
+    def test_idempotent_with_tag_block_payload(self) -> None:
+        """Sanitizing twice equals sanitizing once, even with tag-block chars present."""
+        raw = "start" + TAG_LANGUAGE + "middle" + CANCEL_TAG + "end"
+        once = sanitize_user_text(raw)
+        twice = sanitize_user_text(once)
+        assert once == twice
+
+    def test_tag_block_stripped_before_length_cap(self) -> None:
+        """Tag chars are stripped before the max_len cap, like the control-strip cap test."""
+        with_tags = "a" * 100 + TAG_LANGUAGE * 50
+        assert sanitize_user_text(with_tags, max_len=100) == "a" * 100
 
 
 class TestUnicodeNormalization:


### PR DESCRIPTION
## Summary

`sanitize_user_text` — the insertion-time trust boundary that the module
docstring positions as the fix for stored-XSS and prompt-injection — stripped
zero-width, bidi-override, and C0-control codepoints but omitted the **Unicode
Tags block (U+E0000–U+E007F)**. That block renders invisibly yet decodes as
ASCII to an LLM (each ASCII char has an invisible tag-block counterpart), so
hidden instructions passed through untouched into the LLM prompt built by
`services/botmason.py` — the canonical modern invisible-ASCII-smuggling /
prompt-injection channel.

This adds `(0xE0000, 0xE007F)` to `_ZERO_WIDTH_RANGES`, folding the Tags block
into the existing invisible-codepoint strip pass. The range is built from
`chr(lo)`/`chr(hi)` so no literal invisible characters enter the source
(Trojan-Source-safe). The upper bound is pinned at **U+E007F** so the
variation-selector supplement (U+E0100+) survives — a characterization test
locks that edge. NFC normalization, C0-control handling, the length cap, and
the idempotency contract are unchanged.

## Test plan

New `TestStripsUnicodeTagsBlock` (8 tests) in
`backend/tests/security/test_text_sanitize.py`, all using `\U` escapes (no
literal invisibles):

- Tag-encoded invisible directive interleaved with visible text is stripped;
  the visible portion survives (`sanitize_user_text("hello\U000e0041\U000e0042") == "hello"`).
- Boundary tests at both edges: U+E0000 (range start), U+E0001 (LANGUAGE TAG),
  and U+E007F (CANCEL TAG, range end) are stripped.
- Scope guard (characterization): U+E0100 (variation-selector supplement, one
  past the range) is **preserved** — pins the upper edge against over-widening.
- Idempotency holds over a tag-laden payload; tag chars are stripped before the
  `max_len` cap.
- Existing 42 tests unchanged (NFC / C0 / DEL / length-cap / emoji + U+FE0F
  survival all still green).

Gate 2: `./scripts/backend/check-all.sh` passes (2379 passed, coverage 96.47%,
`text_sanitize.py` at 100%); xenon and radon A-grade on the module.

Closes #1354