### PR TITLE
refactor(backend): remove dead calendar start-date gate from energy planner

### DIFF
--- a/backend/src/domain/energy.py
+++ b/backend/src/domain/energy.py
@@ -13,7 +13,6 @@ class Habit:
     name: str
     energy_cost: int
     energy_return: int
-    start_date: date | None = None
 
     @property
     def net_energy(self) -> int:
@@ -57,8 +56,6 @@ def generate_plan(habits: Sequence[Habit], start_date: date) -> tuple[EnergyPlan
     for offset in range(PLAN_DURATION_DAYS):
         habit = habits[offset % len(habits)]
         plan_date = start_date + timedelta(days=offset)
-        if habit.start_date is not None and habit.start_date > plan_date:
-            continue
         items.append(EnergyPlanItem(habit_id=habit.id, date=plan_date))
         net_energy += habit.net_energy
     plan = EnergyPlan(items=items, net_energy=net_energy)

--- a/backend/tests/domain/test_energy.py
+++ b/backend/tests/domain/test_energy.py
@@ -1,3 +1,4 @@
+import dataclasses
 from datetime import date
 
 from domain.energy import PLAN_DURATION_DAYS, EnergyPlanItem, Habit, generate_plan
@@ -21,3 +22,8 @@ def test_generate_plan_creates_21_day_schedule() -> None:
     expected_net = habits[0].net_energy * 11 + habits[1].net_energy * 10
     assert plan.net_energy == expected_net
     assert plan.items[0] == EnergyPlanItem(habit_id=1, date=start)
+
+
+def test_habit_has_no_calendar_start_date_field() -> None:
+    """The planner's Habit carries no calendar gate; unlock is user-driven."""
+    assert "start_date" not in {field.name for field in dataclasses.fields(Habit)}


### PR DESCRIPTION
## Summary

- Removes the dead calendar `start_date` gate from the energy planner. The domain `Habit` dataclass carried an optional `start_date` field and `generate_plan` gated scheduling on it (`if habit.start_date is not None and habit.start_date > plan_date: continue`), but the only production caller — `services.energy._build_domain_habits` — never set the field, so the gate could never fire. A future-dated habit was scheduled from day 0 anyway.
- This closes the field-vs-gate inconsistency the de-slop scan flagged: the model requires `start_date`, yet the planner both declared and read a field it never received.

## Decision

Chose the removal path (not wiring the field through). The habit-locking redesign made unlock purely user-driven via a persisted `revealed` flag and removed all calendar `start_date`-anchored gating; the product principle is "you choose your depth" — calendar timing is an invitation, not a gate. The energy planner is fed an explicit, user-chosen list of habit IDs, so re-introducing a calendar skip would resurrect exactly the gating that was deliberately removed. Removing the dead field + gate is the consistent, correct call.

`generate_plan`'s `start_date` **parameter** is deliberately kept — it is the plan's start anchor (named consistently with `EnergyPlanRequest.start_date` across the energy stack), not the per-habit calendar field. Only the domain `Habit.start_date` field and its gate were removed.

## Test plan

- Added a structural regression test (`test_habit_has_no_calendar_start_date_field`) asserting the domain `Habit` no longer carries a `start_date` field — the strongest durable guard against anyone resurrecting the calendar gate. Written RED first (failed on the field's presence), GREEN after removal.
- `./scripts/backend/check-all.sh` green — 2380 passed, 2 skipped, 96.58% coverage, 7/7 quality checks (ruff, ruff-format, mypy, bandit, pip-audit, radon, pytest).
- `xenon --max-absolute A --max-modules A --max-average A src/` exit 0; `radon mi src/domain/energy.py` = A. Complexity strictly decreased (a branch removed).
- Existing planner behavior (`test_generate_plan_creates_21_day_schedule`) and the full energy service/integration/API suites still pass.

Closes #1355
