### PR TITLE
fix(backend): stop BotMason generate_response from masking internal bugs as provider errors

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -18,7 +18,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
-from fastapi import HTTPException
+import anthropic
+import httpx
+import openai
 
 from domain.care import MEDICATION_GUARDRAIL
 from errors import bad_request, payment_required
@@ -148,13 +150,26 @@ _INJECTION_PATTERNS = re.compile(
 class LLMProviderError(RuntimeError):
     """A provider/config failure that callers should degrade gracefully on.
 
-    Raised by :func:`generate_response` for any provider, network, SDK, or
+    Raised by :func:`generate_response` for a provider, network, SDK, or
     LLM-config failure — giving the caller a single, SDK-agnostic type to catch
     (it never needs to know which provider SDK is installed). Subclasses
-    ``RuntimeError`` for back-compat, but callers catch *this* type specifically
-    so an unrelated internal ``RuntimeError`` (a genuine bug) still propagates
-    instead of being masked as provider degradation.
+    ``RuntimeError`` for back-compat, but only genuine provider/transport/config
+    failures normalize to this type. An unrelated internal bug (a ``TypeError``,
+    ``KeyError``, or unrelated ``RuntimeError``) is NOT wrapped: it propagates
+    unchanged so the real defect surfaces instead of masquerading as provider
+    degradation.
     """
+
+
+# Genuine provider/transport failures normalized to LLMProviderError; OSError
+# covers ConnectionError/TimeoutError and mirrors what ``_is_retryable`` treats
+# as transient, while the two SDK base classes give an SDK-agnostic catch.
+_PROVIDER_ERROR_TYPES: tuple[type[Exception], ...] = (
+    anthropic.AnthropicError,
+    httpx.HTTPError,
+    openai.OpenAIError,
+    OSError,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -310,8 +325,8 @@ def get_system_prompt() -> str:
     back to the built-in default prompt.
 
     Raises:
-        RuntimeError: If the file path resolves outside the allowed directory
-            or exceeds the maximum file size.
+        LLMProviderError: If the file path resolves outside the allowed
+            directory or exceeds the maximum file size.
     """
     prompt_config = os.getenv("BOTMASON_SYSTEM_PROMPT", "")
     if not prompt_config:
@@ -324,7 +339,7 @@ def get_system_prompt() -> str:
             prompt_path.relative_to(_ALLOWED_PROMPT_DIR.resolve())
         except ValueError:
             msg = f"BOTMASON_SYSTEM_PROMPT path must be within {_ALLOWED_PROMPT_DIR}"
-            raise RuntimeError(msg) from None
+            raise LLMProviderError(msg) from None
 
         file_size = prompt_path.stat().st_size
         if file_size > _MAX_PROMPT_FILE_SIZE:
@@ -332,7 +347,7 @@ def get_system_prompt() -> str:
                 f"BOTMASON_SYSTEM_PROMPT file exceeds maximum size "
                 f"({file_size} > {_MAX_PROMPT_FILE_SIZE} bytes)"
             )
-            raise RuntimeError(msg)
+            raise LLMProviderError(msg)
 
         return prompt_path.read_text().strip()
 
@@ -501,7 +516,7 @@ def _get_model(provider: str) -> str:
             "add it to the PROVIDER_REGISTRY entry in services.botmason only "
             "after a pricing row exists in services.llm_pricing."
         )
-        raise RuntimeError(msg)
+        raise LLMProviderError(msg)
     return requested
 
 
@@ -605,9 +620,11 @@ async def generate_response(
     Returns an :class:`LLMResponse` carrying both the generated text and the
     token counts needed to log usage downstream.
     """
-    # Any provider/config/SDK failure is normalised to LLMProviderError so the
-    # chat layer can catch one SDK-agnostic type; HTTPException (BYOK key / quota
-    # errors) is a client error and passes through unchanged.
+    # Provider/network/SDK/config failures normalize to LLMProviderError so the
+    # chat layer can catch one SDK-agnostic type. A genuine internal bug
+    # (TypeError/KeyError/unrelated RuntimeError) is not in the tuple, so it
+    # propagates unwrapped and surfaces as the real defect; HTTPException (BYOK
+    # key / quota client errors) likewise passes through unchanged.
     try:
         resolved_prompt = system_prompt or get_system_prompt()
         provider = _provider_for_request(api_key)
@@ -623,9 +640,7 @@ async def generate_response(
         result: LLMResponse = await caller(
             user_message, conversation_history, resolved_prompt, api_key
         )
-    except (HTTPException, LLMProviderError):
-        raise
-    except Exception as exc:
+    except _PROVIDER_ERROR_TYPES as exc:
         raise LLMProviderError(str(exc)) from exc
     return result
 
@@ -651,7 +666,12 @@ def _stub_response(user_message: str) -> LLMResponse:
 
 
 def _import_optional(module_name: str, provider_label: str) -> ModuleType:
-    """Import an optional SDK, raising a clear error if not installed."""
+    """Import an optional SDK, raising LLMProviderError if not installed.
+
+    openai and anthropic are pinned production dependencies, so this guard is
+    defensive. The dynamically imported :class:`ModuleType` is the mypy-strict
+    seam for the provider clients — keep it rather than inlining typed SDK calls.
+    """
     try:
         return importlib.import_module(module_name)
     except ImportError as exc:
@@ -659,7 +679,7 @@ def _import_optional(module_name: str, provider_label: str) -> ModuleType:
             f"{module_name} package is required for the {provider_label} provider. "
             f"Install it with: pip install {module_name}"
         )
-        raise RuntimeError(msg) from exc
+        raise LLMProviderError(msg) from exc
 
 
 def _get_llm_api_key() -> str:
@@ -670,7 +690,7 @@ def _get_llm_api_key() -> str:
     api_key = os.getenv("LLM_API_KEY", "")
     if not api_key:
         msg = "LLM_API_KEY environment variable must be set for non-stub providers"
-        raise RuntimeError(msg)
+        raise LLMProviderError(msg)
     return api_key
 
 

--- a/backend/tests/services/test_botmason_wrapping.py
+++ b/backend/tests/services/test_botmason_wrapping.py
@@ -19,18 +19,26 @@ system prompt and an operator-supplied ``BOTMASON_SYSTEM_PROMPT``.
 from __future__ import annotations
 
 import re
+from unittest.mock import AsyncMock, patch
 
+import httpx
+import openai
 import pytest
+from fastapi import HTTPException
 
+import services.botmason as botmason_mod
 from domain.care import MEDICATION_GUARDRAIL
 from services.botmason import (
     _DEFAULT_SYSTEM_PROMPT,
+    LLMProviderError,
     _augment_system_prompt,
     _build_anthropic_messages,
     _build_messages,
     _get_model,
+    _import_optional,
     _make_nonce,
     _wrap_user_input,
+    generate_response,
 )
 
 # Regex for a 16-hex-char nonce as produced by ``_make_nonce``.
@@ -386,3 +394,140 @@ class TestMedicationGuardrailInSystemPrompt:
         assert MEDICATION_GUARDRAIL in augmented_system
         # Sanity: no system role leaks into the Anthropic messages list.
         assert all(m["role"] in {"user", "assistant"} for m in _messages)
+
+
+_TEST_OPENAI_KEY = "sk-abcdef1234567890abcdef1234567890"  # pragma: allowlist secret
+
+
+def _configure_openai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", _TEST_OPENAI_KEY)
+
+
+class TestGenerateResponseExceptionContract:
+    """``generate_response`` unwraps genuine bugs but still normalizes provider failures."""
+
+    @pytest.mark.asyncio
+    async def test_type_error_propagates_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ``TypeError`` bug in the call path must surface as itself, not LLMProviderError."""
+        _configure_openai_env(monkeypatch)
+        broken_call = AsyncMock(side_effect=TypeError("injected bug"))
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(TypeError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert not isinstance(excinfo.value, LLMProviderError)
+
+    @pytest.mark.asyncio
+    async def test_key_error_propagates_unwrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ``KeyError`` bug in the call path must surface as itself, not LLMProviderError."""
+        _configure_openai_env(monkeypatch)
+        broken_call = AsyncMock(side_effect=KeyError("missing_field"))
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(KeyError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert not isinstance(excinfo.value, LLMProviderError)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_runtime_error_propagates_unwrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare ``RuntimeError`` bug must surface as itself, not LLMProviderError.
+
+        This pins the exact boundary the narrowed taxonomy hinges on: reverting
+        to a blanket catch (or listing ``RuntimeError`` in the provider tuple)
+        would mask this genuine bug as provider degradation.
+        """
+        _configure_openai_env(monkeypatch)
+        broken_call = AsyncMock(side_effect=RuntimeError("boom"))
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert not isinstance(excinfo.value, LLMProviderError)
+
+    @pytest.mark.asyncio
+    async def test_openai_connection_error_wraps_to_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real SDK connection error still normalizes to LLMProviderError."""
+        _configure_openai_env(monkeypatch)
+        request = httpx.Request("POST", "https://api.openai.com")
+        original = openai.APIConnectionError(request=request)
+        broken_call = AsyncMock(side_effect=original)
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(LLMProviderError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert excinfo.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_os_error_wraps_to_provider_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A transport-level ``OSError`` still normalizes to LLMProviderError."""
+        _configure_openai_env(monkeypatch)
+        original = OSError("network down")
+        broken_call = AsyncMock(side_effect=original)
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(LLMProviderError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert excinfo.value.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_http_exception_passes_through_unwrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A client-facing ``HTTPException`` must propagate as itself, never wrapped."""
+        _configure_openai_env(monkeypatch)
+        broken_call = AsyncMock(side_effect=HTTPException(status_code=402, detail="x"))
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(HTTPException) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert excinfo.value.status_code == 402
+
+    @pytest.mark.asyncio
+    async def test_existing_provider_error_is_not_double_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A provider error raised deeper in the stack must propagate as the same instance."""
+        _configure_openai_env(monkeypatch)
+        original = LLMProviderError("orig")
+        broken_call = AsyncMock(side_effect=original)
+        with (
+            patch.object(botmason_mod, "_call_openai", broken_call),
+            pytest.raises(LLMProviderError) as excinfo,
+        ):
+            await generate_response("hi", [])
+        assert excinfo.value is original
+        assert excinfo.value.args[0] == "orig"
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises_llm_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing ``LLM_API_KEY`` normalizes to LLMProviderError, not a bare RuntimeError."""
+        monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        with pytest.raises(LLMProviderError, match="LLM_API_KEY"):
+            await generate_response("hi", [])
+
+    def test_import_optional_missing_sdk_raises_llm_provider_error(self) -> None:
+        """An uninstalled optional SDK normalizes to LLMProviderError, not a bare RuntimeError."""
+        with pytest.raises(LLMProviderError):
+            _import_optional("nonexistent_sdk_xyz_zzqq", "Test")
+
+    def test_get_model_bad_model_raises_llm_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unvetted ``LLM_MODEL`` normalizes to LLMProviderError, not a bare RuntimeError."""
+        monkeypatch.setenv("LLM_MODEL", "gpt-99-turbo-megamax")
+        with pytest.raises(LLMProviderError):
+            _get_model("openai")


### PR DESCRIPTION
## Summary

`generate_response` in `services/botmason.py` wrapped every exception in a blanket `except Exception -> LLMProviderError`, so a genuine internal bug (a `TypeError` from an unexpected SDK response shape, a `KeyError` from `globals()[spec.call_name]`, an unrelated `RuntimeError`) was flattened to a provider failure and silently degraded by callers (`routers/journal.py` returns `[]` or a 502) — directly contradicting `LLMProviderError`'s own docstring guarantee that a real defect still propagates.

This change:
- Narrows the catch to an explicit taxonomy of genuine provider/transport failures: `(anthropic.AnthropicError, httpx.HTTPError, openai.OpenAIError, OSError)`. `OSError` covers `ConnectionError`/`TimeoutError` and mirrors what `_is_retryable` treats as transient; the two SDK base classes give an SDK-agnostic catch. Exception class names verified against the installed, hard-pinned versions (anthropic 0.116.0, openai 2.44.0).
- Lets everything else — `TypeError`, `KeyError`, unrelated `RuntimeError`, etc. — propagate unwrapped so the real defect surfaces instead of masquerading as provider degradation.
- Migrates the four config helpers (`get_system_prompt`, `_get_model`, `_import_optional`, `_get_llm_api_key`) from bare `RuntimeError` to `LLMProviderError` so genuine config failures still normalize as the docstring promises. Back-compatible: `LLMProviderError` subclasses `RuntimeError`, so every existing `except RuntimeError` / `pytest.raises(RuntimeError, ...)` still matches.
- Removes the now-redundant `except (HTTPException, LLMProviderError): raise` arm (neither is in the tuple, so both propagate naturally) and the now-unused `HTTPException` import.
- Aligns the `LLMProviderError` and helper docstrings with the real contract.

## Test plan

New `TestGenerateResponseExceptionContract` class in `backend/tests/services/test_botmason_wrapping.py` pins the boundary:
- Injected internal bugs (`TypeError`, `KeyError`, unrelated `RuntimeError`) propagate unwrapped and are not `LLMProviderError`.
- Real provider/transport failures (`openai.APIConnectionError`, `OSError`) still normalize to `LLMProviderError` with `__cause__` preserved.
- `HTTPException` passes through unwrapped; a pre-existing `LLMProviderError` propagates as the same instance (no double-wrap).
- Config failures (missing `LLM_API_KEY`, bad `LLM_MODEL`, missing optional SDK) normalize to `LLMProviderError` specifically.
- Existing `RuntimeError`-matching tests are unchanged and still pass (back-compat).

Local verification: `./scripts/backend/check-all.sh` 7/7, coverage 96.6%, xenon A-grade (`src/` exit 0), radon MI A, ruff + mypy clean, all 2389 tests pass.

Closes #1357