### PR TITLE
feat(backend): implement proportional drip calendar lock for course content

### DIFF
--- a/backend/src/domain/course.py
+++ b/backend/src/domain/course.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from datetime import UTC, datetime
 from typing import Any
 
@@ -27,30 +28,77 @@ def compute_days_elapsed(stage_started_at: datetime) -> int:
     return delta.days
 
 
+def unlocked_chapter_count(*, total: int, duration_days: int, day_in_stage: int) -> int:
+    """How many of a stage's chapters are open on ``day_in_stage``.
+
+    The proportional drip spreads a stage's ``total`` chapters evenly
+    across its ``duration_days``, so by the 1-based ``day_in_stage`` the
+    user has earned ``ceil(total * day / duration)`` of them, clamped to
+    ``[0, total]``.  ``ceil`` rounds up, so any open day (``day >= 1``) of
+    a seeded stage (``total >= 1``) yields at least one chapter — the
+    guarantee that keeps an unlocked, non-empty stage from ever rendering
+    "No Content Yet".  A stage the user has moved past supplies
+    ``day_in_stage >= duration_days`` and unlocks everything.
+    """
+    if total <= 0 or duration_days <= 0 or day_in_stage <= 0:
+        return 0
+    if day_in_stage >= duration_days:
+        return total
+    earned = math.ceil(total * day_in_stage / duration_days)
+    return max(0, min(earned, total))
+
+
+def enrich_content_item(
+    item: dict[str, Any], *, is_locked: bool, read_content_ids: set[int]
+) -> dict[str, Any]:
+    """Attach lock/read status to a raw content item.
+
+    Locked items have their ``url`` set to ``None`` so a client cannot
+    fetch — or spoil — a chapter ahead of its drip release.
+    """
+    return {
+        **item,
+        "is_locked": is_locked,
+        "is_read": item.get("id") in read_content_ids,
+        "url": None if is_locked else item["url"],
+    }
+
+
 def filter_content_for_user(
     items: list[dict[str, Any]],
     *,
-    days_elapsed: int,
+    unlocked_count: int,
     read_content_ids: set[int],
 ) -> list[dict[str, Any]]:
-    """Apply drip-feed gating and read status to raw content items.
+    """Apply proportional drip-feed gating and read status to raw items.
 
-    Locked items have their ``url`` set to ``None`` to prevent spoilers.
+    ``items`` must already be in the stage's release order (ascending):
+    the first ``unlocked_count`` are open and the rest are locked by
+    **ordinal position**, not by ``release_day``.  Gating on position is
+    what lets a non-dense ``release_day`` sequence (stage 1 skips day 11)
+    still drip exactly ``unlocked_count`` chapters — ``release_day`` is
+    only the sort key now, never the gate.
     """
-    result: list[dict[str, Any]] = []
-    for item in items:
-        is_locked = item["release_day"] > days_elapsed
-        enriched = {
-            **item,
-            "is_locked": is_locked,
-            "is_read": item.get("id") in read_content_ids,
-            "url": None if is_locked else item["url"],
-        }
-        result.append(enriched)
-    return result
+    return [
+        enrich_content_item(
+            item, is_locked=position >= unlocked_count, read_content_ids=read_content_ids
+        )
+        for position, item in enumerate(items)
+    ]
 
 
-def next_unlock_day(*, release_days: list[int], days_elapsed: int) -> int | None:
-    """Return the release_day of the next locked item, or None if all unlocked."""
-    locked = sorted(d for d in release_days if d > days_elapsed)
-    return locked[0] if locked else None
+def next_unlock_day(*, total: int, duration_days: int, day_in_stage: int) -> int | None:
+    """The 1-based day-in-stage the next locked chapter opens, or ``None``.
+
+    Inverts :func:`unlocked_chapter_count`: with ``k`` chapters already
+    open, the ``(k + 1)``-th opens on the first day ``D`` satisfying
+    ``ceil(total * D / duration) >= k + 1`` — i.e.
+    ``floor(k * duration / total) + 1``.  Returns ``None`` once every
+    chapter is unlocked (including the empty-stage case).
+    """
+    unlocked = unlocked_chapter_count(
+        total=total, duration_days=duration_days, day_in_stage=day_in_stage
+    )
+    if unlocked >= total:
+        return None
+    return (unlocked * duration_days) // total + 1

--- a/backend/src/domain/program_calendar.py
+++ b/backend/src/domain/program_calendar.py
@@ -60,6 +60,26 @@ def calendar_stage(anchor: datetime, now: datetime | None = None) -> int:
     return TOTAL_STAGES
 
 
+def calendar_day_in_stage(anchor: datetime, stage_number: int, now: datetime | None = None) -> int:
+    """The 1-based day ``now`` falls on *within* ``stage_number``'s window.
+
+    Feeds the proportional content drip (``domain.course``): a stage's
+    chapters are spread across its ``STAGE_DURATIONS_DAYS`` window, so
+    "how far into the stage the calendar has carried the user" is what
+    decides how many are open.  Day 1 is the first day of the stage;
+    values before the window opens are non-positive and values past its
+    close are capped at the stage duration.  Independent of advancement —
+    callers combine it with ``current_stage`` so time can only widen
+    access.
+    """
+    moment = now if now is not None else datetime.now(UTC)
+    stage = min(max(stage_number, 1), TOTAL_STAGES)
+    window_start = sum(STAGE_DURATIONS_DAYS[: stage - 1])
+    duration = STAGE_DURATIONS_DAYS[stage - 1]
+    day = _elapsed_days(anchor, moment) - window_start + 1
+    return min(day, duration)
+
+
 def resolve_program_anchor(progress: StageProgress) -> datetime:
     """The user's program-start anchor.
 

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -146,7 +146,8 @@ async def _content_item_is_locked(
 ) -> bool:
     """Whether ``item`` is drip-locked for the user under the proportional model."""
     day = await _day_in_stage_for_user(session, user_id, stage.stage_number)
-    assert stage.id is not None
+    if stage.id is None:
+        raise RuntimeError("CourseStage from database must have an id")
     total = await _stage_content_count(session, stage.id)
     unlocked = unlocked_chapter_count(
         total=total,

--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -7,13 +7,22 @@ from collections.abc import Callable
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request
+from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from content_config import CONTENT_REF_SCHEME, content_ref
 from database import get_session
-from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
+from domain.constants import STAGE_DURATIONS_DAYS
+from domain.course import (
+    compute_days_elapsed,
+    enrich_content_item,
+    filter_content_for_user,
+    next_unlock_day,
+    unlocked_chapter_count,
+)
+from domain.program_calendar import calendar_day_in_stage, resolve_program_anchor
 from domain.stage_progress import ensure_user_progress, get_user_progress, is_stage_unlocked
 from errors import bad_gateway, forbidden, not_found
 from models.content_completion import ContentCompletion
@@ -46,9 +55,18 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/course", tags=["course"])
 
-# When a user is past a stage, all drip-feed content should be accessible.
-# We use a large sentinel so ``release_day > days_elapsed`` is always False.
-_PAST_STAGE_DAYS_SENTINEL = 999_999
+
+def _stage_duration_days(stage_number: int) -> int:
+    """Days the given 1-based stage lasts (the app-owned drip window).
+
+    ``STAGE_DURATIONS_DAYS`` is app-owned on purpose (issue #386): the
+    content package deliberately does not know stage durations, so the
+    proportional drip denominator has to come from here.  Out-of-range
+    numbers clamp to the curriculum so a stray value can never
+    ``IndexError``.
+    """
+    index = min(max(stage_number, 1), len(STAGE_DURATIONS_DAYS)) - 1
+    return STAGE_DURATIONS_DAYS[index]
 
 
 async def _get_stage_by_number(session: AsyncSession, stage_number: int) -> CourseStage:
@@ -62,26 +80,81 @@ async def _get_stage_by_number(session: AsyncSession, stage_number: int) -> Cour
     return stage
 
 
-async def _days_for_user_stage(session: AsyncSession, user_id: int, stage_number: int) -> int:
-    """Compute how many days the user has been on the given stage.
+async def _day_in_stage_for_user(session: AsyncSession, user_id: int, stage_number: int) -> int:
+    """The 1-based day the user is on within ``stage_number`` for the drip.
 
-    First course access provisions a ``current_stage=1`` StageProgress
-    row via :func:`ensure_user_progress`, so the drip-feed clock has a
-    real ``stage_started_at`` even for users who never explicitly
-    advanced a stage — without it every chapter read as locked.
+    First course access provisions a ``current_stage=1`` StageProgress row
+    via :func:`ensure_user_progress`, so the clock has a real anchor even
+    for users who never explicitly advanced a stage.
 
-    Returns:
-    - ``_PAST_STAGE_DAYS_SENTINEL`` when the user has already moved past
-      this stage (all content should be unlocked).
-    - The actual days elapsed when the user is currently on this stage.
-    - ``-1`` when the user has not yet reached this stage.
+    Advancement is honored so time can only widen access, never revoke it:
+
+    - a **past** stage returns its full duration → every chapter open;
+    - the **current** stage runs on whichever is further along, the
+      program calendar or how long the user has actually sat on the stage
+      (``max`` of the two), so an early advancer is never penalized;
+    - a **not-yet-current** stage the calendar has already opened uses the
+      calendar day.  This is the fix for the old ``-1``: a stage unlocked
+      by ``calendar_stage`` (ahead of ``current_stage``) used to read as
+      "-1 days", locking every one of its chapters.
     """
     progress = await ensure_user_progress(session, user_id)
+    duration = _stage_duration_days(stage_number)
     if progress.current_stage > stage_number:
-        return _PAST_STAGE_DAYS_SENTINEL
+        return duration
+    calendar_day = calendar_day_in_stage(resolve_program_anchor(progress), stage_number)
     if progress.current_stage == stage_number:
-        return compute_days_elapsed(progress.stage_started_at)
-    return -1
+        started_day = compute_days_elapsed(progress.stage_started_at) + 1
+        return max(calendar_day, started_day)
+    return calendar_day
+
+
+async def _stage_content_count(session: AsyncSession, stage_id: int) -> int:
+    """Total content rows for a stage — the proportional drip denominator."""
+    result = await session.execute(
+        select(func.count())
+        .select_from(StageContent)
+        .where(StageContent.course_stage_id == stage_id)
+    )
+    return result.scalar() or 0
+
+
+async def _ordinal_position(session: AsyncSession, item: StageContent) -> int:
+    """0-based rank of ``item`` within its stage, ordered by (release_day, id).
+
+    Mirrors the ``ORDER BY release_day, id`` the listing endpoint uses, so
+    a single-item lock check agrees with the list view even when
+    ``release_day`` has gaps or ties.
+    """
+    result = await session.execute(
+        select(func.count())
+        .select_from(StageContent)
+        .where(
+            StageContent.course_stage_id == item.course_stage_id,
+            or_(
+                col(StageContent.release_day) < item.release_day,
+                (col(StageContent.release_day) == item.release_day)
+                & (col(StageContent.id) < item.id),
+            ),
+        )
+    )
+    return result.scalar() or 0
+
+
+async def _content_item_is_locked(
+    session: AsyncSession, user_id: int, stage: CourseStage, item: StageContent
+) -> bool:
+    """Whether ``item`` is drip-locked for the user under the proportional model."""
+    day = await _day_in_stage_for_user(session, user_id, stage.stage_number)
+    assert stage.id is not None
+    total = await _stage_content_count(session, stage.id)
+    unlocked = unlocked_chapter_count(
+        total=total,
+        duration_days=_stage_duration_days(stage.stage_number),
+        day_in_stage=day,
+    )
+    position = await _ordinal_position(session, item)
+    return position >= unlocked
 
 
 async def _read_ids_for_user(
@@ -172,16 +245,21 @@ async def list_stage_content(
     result = await session.execute(
         select(StageContent)
         .where(StageContent.course_stage_id == stage.id)
-        .order_by(col(StageContent.release_day).asc())
+        .order_by(col(StageContent.release_day).asc(), col(StageContent.id).asc())
     )
     items = list(result.scalars().all())
 
-    days = await _days_for_user_stage(session, current_user, stage_number)
+    day = await _day_in_stage_for_user(session, current_user, stage_number)
+    unlocked = unlocked_chapter_count(
+        total=len(items),
+        duration_days=_stage_duration_days(stage_number),
+        day_in_stage=day,
+    )
     content_ids = [item.id for item in items if item.id is not None]
     read_ids = await _read_ids_for_user(session, current_user, content_ids)
 
     raw = _items_to_raw_dicts(items)
-    filtered = filter_content_for_user(raw, days_elapsed=max(days, -1), read_content_ids=read_ids)
+    filtered = filter_content_for_user(raw, unlocked_count=unlocked, read_content_ids=read_ids)
     responses = [ContentItemResponse(**f) for f in filtered]
 
     if pagination.paginate:
@@ -211,18 +289,17 @@ async def get_content_item(
     if not await _is_stage_unlocked_for_user(session, current_user, stage.stage_number):
         raise not_found("content")
 
-    days = await _days_for_user_stage(session, current_user, stage.stage_number)
-
     item_id = item.id
     if item_id is None:
         msg = "StageContent ID unexpectedly None after database fetch"
         raise RuntimeError(msg)
     read_ids = await _read_ids_for_user(session, current_user, [item_id])
 
-    filtered = filter_content_for_user(
-        _items_to_raw_dicts([item]), days_elapsed=max(days, -1), read_content_ids=read_ids
+    is_locked = await _content_item_is_locked(session, current_user, stage, item)
+    enriched = enrich_content_item(
+        _items_to_raw_dicts([item])[0], is_locked=is_locked, read_content_ids=read_ids
     )
-    return ContentItemResponse(**filtered[0])
+    return ContentItemResponse(**enriched)
 
 
 async def _existing_content_completion(
@@ -354,13 +431,16 @@ async def get_course_progress(
 
     read_ids = await _read_ids_for_user(session, current_user, _content_ids_from_items(items))
     progress_pct = round((len(read_ids) / len(items)) * 100, 2)
-    days = await _days_for_user_stage(session, current_user, stage_number)
+    day = await _day_in_stage_for_user(session, current_user, stage_number)
 
-    # BUG-COURSE-004: Don't compute next_unlock_day when days_elapsed is
-    # negative (user hasn't started this stage) or for past stages.
-    nud: int | None = None
-    if 0 <= days < _PAST_STAGE_DAYS_SENTINEL:
-        nud = next_unlock_day(release_days=[item.release_day for item in items], days_elapsed=days)
+    # ``total_items`` stays the whole-stage count (not the unlocked count)
+    # so "stage complete" only fires when everything is read; the drip only
+    # governs how many are openable right now, surfaced via next_unlock_day.
+    nud = next_unlock_day(
+        total=len(items),
+        duration_days=_stage_duration_days(stage_number),
+        day_in_stage=day,
+    )
 
     return CourseProgressResponse(
         total_items=len(items),
@@ -423,35 +503,25 @@ async def _load_content_with_stage(
     return item, stage
 
 
-async def _check_released_for_user(
-    session: AsyncSession, user_id: int, stage_number: int, release_day: int
-) -> None:
-    """Raise 404 unless the user has reached ``release_day`` on this stage.
-
-    Mirrors the drip-feed gating applied on the metadata endpoint so the
-    in-app body endpoint cannot leak a chapter ahead of its release_day.
-    """
-    days = await _days_for_user_stage(session, user_id, stage_number)
-    if 0 <= days < _PAST_STAGE_DAYS_SENTINEL and release_day > days:
-        raise not_found("content")
-
-
 async def _resolve_released_content_ref(
     session: AsyncSession, user_id: int, content_id: int
 ) -> str:
-    """Gate on stage-unlock + release_day, return the local chapter id.
+    """Gate on stage-unlock + proportional drip, return the local chapter id.
 
     Mirrors the 404-mask used by sibling endpoints (BUG-COURSE-004):
-    locked, unreleased, missing-reference, and nonexistent rows all
+    locked-stage, drip-locked, missing-reference, and nonexistent rows all
     surface as ``content_not_found`` so ``content_id`` is not an
-    enumeration oracle.  Rows without a ``content://`` reference
+    enumeration oracle.  The drip check is by ordinal position (same model
+    as the metadata endpoint), so a chapter cannot be read ahead of its
+    proportional release.  Rows without a ``content://`` reference
     (legacy/placeholder rows) have no local body and fall under the same
     mask.
     """
     item, stage = await _load_content_with_stage(session, content_id)
     if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
         raise not_found("content")
-    await _check_released_for_user(session, user_id, stage.stage_number, item.release_day)
+    if await _content_item_is_locked(session, user_id, stage, item):
+        raise not_found("content")
     reference = item.url or ""
     if not reference.startswith(_CONTENT_REF_PREFIX):
         raise not_found("content")

--- a/backend/tests/domain/test_course.py
+++ b/backend/tests/domain/test_course.py
@@ -6,11 +6,17 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from domain.course import compute_days_elapsed, filter_content_for_user, next_unlock_day
+from domain.course import (
+    compute_days_elapsed,
+    filter_content_for_user,
+    next_unlock_day,
+    unlocked_chapter_count,
+)
 
 _EXPECTED_THREE = 3
 _EXPECTED_TWO = 2
-_EXPECTED_FIVE = 5
+_EXPECTED_SEVEN = 7
+_EXPECTED_EIGHT = 8
 
 
 class TestComputeDaysElapsed:
@@ -27,31 +33,74 @@ class TestComputeDaysElapsed:
         assert compute_days_elapsed(almost_two_days) == 1
 
 
-class TestFilterContentForUser:
-    """Test the pure content-filtering logic."""
+class TestUnlockedChapterCount:
+    """The proportional drip: ``ceil(total * day / duration)`` clamped."""
 
-    def test_day_zero_filters_locked_items(self) -> None:
+    def test_handoff_example(self) -> None:
+        # 14 chapters over a 21-day stage: by day 10, seven have dripped.
+        assert (
+            unlocked_chapter_count(total=14, duration_days=21, day_in_stage=10) == _EXPECTED_SEVEN
+        )
+
+    def test_first_open_day_yields_at_least_one(self) -> None:
+        # Day 1 of a long stage still opens the first chapter, so a seeded,
+        # unlocked stage is never empty ("No Content Yet" is unreachable).
+        assert unlocked_chapter_count(total=14, duration_days=21, day_in_stage=1) == 1
+
+    def test_final_day_opens_everything(self) -> None:
+        assert unlocked_chapter_count(total=14, duration_days=21, day_in_stage=21) == 14
+
+    def test_past_stage_day_caps_at_total(self) -> None:
+        assert unlocked_chapter_count(total=14, duration_days=21, day_in_stage=999) == 14
+
+    def test_non_positive_day_opens_nothing(self) -> None:
+        assert unlocked_chapter_count(total=14, duration_days=21, day_in_stage=0) == 0
+        assert unlocked_chapter_count(total=14, duration_days=21, day_in_stage=-3) == 0
+
+    def test_empty_stage_is_zero(self) -> None:
+        assert unlocked_chapter_count(total=0, duration_days=21, day_in_stage=10) == 0
+
+
+class TestFilterContentForUser:
+    """Locking is by ordinal position, not release_day."""
+
+    def test_locks_by_ordinal_position(self) -> None:
         items = [
             {"release_day": 0, "url": "https://a.com"},
             {"release_day": 3, "url": "https://b.com"},
             {"release_day": 7, "url": "https://c.com"},
         ]
-        result = filter_content_for_user(items, days_elapsed=0, read_content_ids=set())
+        result = filter_content_for_user(items, unlocked_count=1, read_content_ids=set())
         unlocked = [r for r in result if not r["is_locked"]]
         locked = [r for r in result if r["is_locked"]]
         assert len(unlocked) == 1
         assert len(locked) == _EXPECTED_TWO
-        # Locked items should have no URL
+        # Locked items should have no URL.
         for item in locked:
             assert item["url"] is None
 
-    def test_all_unlocked_after_enough_days(self) -> None:
+    def test_non_dense_release_days_still_gate_by_position(self) -> None:
+        # Stage 1 skips release_day 11; positional gating is unaffected by
+        # the gap — the first two ordinals open, the third stays locked.
+        items = [
+            {"release_day": 0, "url": "https://a.com"},
+            {"release_day": 10, "url": "https://b.com"},
+            {"release_day": 12, "url": "https://c.com"},
+        ]
+        result = filter_content_for_user(
+            items, unlocked_count=_EXPECTED_TWO, read_content_ids=set()
+        )
+        assert [r["is_locked"] for r in result] == [False, False, True]
+
+    def test_all_unlocked_when_count_covers_all(self) -> None:
         items = [
             {"release_day": 0, "url": "https://a.com"},
             {"release_day": 3, "url": "https://b.com"},
             {"release_day": 7, "url": "https://c.com"},
         ]
-        result = filter_content_for_user(items, days_elapsed=10, read_content_ids=set())
+        result = filter_content_for_user(
+            items, unlocked_count=_EXPECTED_THREE, read_content_ids=set()
+        )
         assert all(not r["is_locked"] for r in result)
 
     def test_read_items_marked(self) -> None:
@@ -59,23 +108,30 @@ class TestFilterContentForUser:
             {"id": 1, "release_day": 0, "url": "https://a.com"},
             {"id": 2, "release_day": 0, "url": "https://b.com"},
         ]
-        result = filter_content_for_user(items, days_elapsed=0, read_content_ids={1})
+        result = filter_content_for_user(items, unlocked_count=_EXPECTED_TWO, read_content_ids={1})
         assert result[0]["is_read"] is True
         assert result[1]["is_read"] is False
 
 
 class TestNextUnlockDay:
     def test_all_unlocked_returns_none(self) -> None:
-        assert next_unlock_day(release_days=[0, 3, 7], days_elapsed=10) is None
+        assert next_unlock_day(total=3, duration_days=21, day_in_stage=21) is None
 
-    def test_returns_next_locked_day(self) -> None:
-        assert next_unlock_day(release_days=[0, 3, 7], days_elapsed=0) == _EXPECTED_THREE
+    def test_reports_day_the_next_chapter_drips(self) -> None:
+        # 3 chapters over 21 days: on day 1 only one is open; the second
+        # drips on day 8 (the first day ceil(3*D/21) reaches 2).
+        assert next_unlock_day(total=3, duration_days=21, day_in_stage=1) == _EXPECTED_EIGHT
 
-    def test_returns_soonest_locked_day(self) -> None:
-        assert next_unlock_day(release_days=[0, 3, 5, 7], days_elapsed=4) == _EXPECTED_FIVE
+    def test_matches_unlocked_chapter_count_boundary(self) -> None:
+        # The reported day is exactly when unlocked_chapter_count ticks up.
+        day = next_unlock_day(total=14, duration_days=21, day_in_stage=10)
+        assert day is not None
+        before = unlocked_chapter_count(total=14, duration_days=21, day_in_stage=day - 1)
+        at = unlocked_chapter_count(total=14, duration_days=21, day_in_stage=day)
+        assert at == before + 1
 
-    def test_empty_list_returns_none(self) -> None:
-        assert next_unlock_day(release_days=[], days_elapsed=0) is None
+    def test_empty_stage_returns_none(self) -> None:
+        assert next_unlock_day(total=0, duration_days=21, day_in_stage=0) is None
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -281,15 +281,20 @@ async def test_list_content_drip_feed_day_zero(
 
 
 @pytest.mark.asyncio
-async def test_list_content_drip_feed_day_three(
+async def test_list_content_drip_feed_partway(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """After 3 days, release_day 0 and 3 items are unlocked."""
+    """Proportional drip: partway through the stage, the first ordinals open.
+
+    3 chapters over a 21-day stage: by day 8 (day-in-stage 8) the drip has
+    opened ceil(3 * 8 / 21) = 2 of them, leaving the last chapter locked —
+    regardless of that chapter's release_day value.
+    """
     headers, user_id = await _signup(async_client)
     await _seed_stage_with_content(db_session, stage_number=1)
-    three_days_ago = datetime.now(UTC) - timedelta(days=3)
-    await _set_user_stage(db_session, user_id, stage_number=1, started_at=three_days_ago)
+    seven_days_ago = datetime.now(UTC) - timedelta(days=7)
+    await _set_user_stage(db_session, user_id, stage_number=1, started_at=seven_days_ago)
 
     resp = await async_client.get("/course/stages/1/content", headers=headers)
     assert resp.status_code == HTTPStatus.OK
@@ -308,11 +313,12 @@ async def test_list_content_drip_feed_all_unlocked(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """After 7+ days, all items are unlocked."""
+    """By the end of the stage window, every chapter is unlocked."""
     headers, user_id = await _signup(async_client)
     await _seed_stage_with_content(db_session, stage_number=1)
-    ten_days_ago = datetime.now(UTC) - timedelta(days=10)
-    await _set_user_stage(db_session, user_id, stage_number=1, started_at=ten_days_ago)
+    # Stage 1 runs 21 days; sit at/after its close so the whole stage drips.
+    full_stage_ago = datetime.now(UTC) - timedelta(days=21)
+    await _set_user_stage(db_session, user_id, stage_number=1, started_at=full_stage_ago)
 
     resp = await async_client.get("/course/stages/1/content", headers=headers)
     data = resp.json()
@@ -507,8 +513,9 @@ async def test_course_progress_complete(
     """100% progress when all items read."""
     headers, user_id = await _signup(async_client)
     _, items = await _seed_stage_with_content(db_session, stage_number=1)
-    ten_days_ago = datetime.now(UTC) - timedelta(days=10)
-    await _set_user_stage(db_session, user_id, stage_number=1, started_at=ten_days_ago)
+    # Past the 21-day stage window so the whole stage has dripped open.
+    full_stage_ago = datetime.now(UTC) - timedelta(days=21)
+    await _set_user_stage(db_session, user_id, stage_number=1, started_at=full_stage_ago)
 
     for item in items:
         completion = ContentCompletion(user_id=user_id, content_id=item.id)
@@ -522,6 +529,8 @@ async def test_course_progress_complete(
     assert data["read_items"] == expected_total
     expected_pct = 100.0
     assert data["progress_percent"] == expected_pct
+    # Every chapter has dripped by the end of the stage window, so there is
+    # no further unlock day.
     assert data["next_unlock_day"] is None
 
 
@@ -530,15 +539,16 @@ async def test_course_progress_next_unlock_day(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """next_unlock_day reports the next locked item's release_day."""
+    """next_unlock_day reports the day-in-stage the next chapter drips."""
     headers, user_id = await _signup(async_client)
     await _seed_stage_with_content(db_session, stage_number=1)
-    # User started today -> day 0: release_day 3 is next unlock
+    # Day 1 of a 21-day stage with 3 chapters: one has dripped, the second
+    # opens on day 8 (the first day ceil(3 * D / 21) reaches 2).
     await _set_user_stage(db_session, user_id, stage_number=1)
 
     resp = await async_client.get("/course/stages/1/progress", headers=headers)
     data = resp.json()
-    expected_next = 3
+    expected_next = 8
     assert data["next_unlock_day"] == expected_next
 
 
@@ -674,6 +684,59 @@ async def test_past_stage_content_fully_unlocked(
     assert all(item["url"] is not None for item in data)
 
 
+# ── Regression: a calendar-unlocked-ahead stage is not fully locked ────
+
+
+@pytest.mark.asyncio
+async def test_calendar_unlocked_ahead_stage_partially_unlocks(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A stage the calendar opened ahead of advancement drips, not blank.
+
+    The old ``_days_for_user_stage`` returned ``-1`` for any stage past
+    ``current_stage`` even when the program calendar had already opened it,
+    so every chapter of a calendar-unlocked-ahead stage read as locked.
+    Here the user is still ``current_stage=1`` but their program anchor is
+    25 days old, putting the calendar 5 days into stage 2 — the listing
+    must come back non-empty and partially unlocked (ceil(10 * 5 / 21) = 3
+    of 10), never all-locked.
+    """
+    headers, user_id = await _signup(async_client)
+    content_items = [
+        {
+            "title": f"Chapter {day}",
+            "content_type": "essay",
+            "release_day": day,
+            "url": f"https://cms.example.com/s2-{day}",
+        }
+        for day in range(10)
+    ]
+    await _seed_stage_with_content(db_session, stage_number=2, content_items=content_items)
+    anchor = datetime.now(UTC) - timedelta(days=25)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            stage_started_at=anchor,
+            program_started_at=anchor,
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/course/stages/2/content", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert len(data) == len(content_items)
+    unlocked = [d for d in data if not d["is_locked"]]
+    expected_unlocked = 3
+    assert len(unlocked) == expected_unlocked
+    # The unlocked ones are the earliest ordinals and carry a usable URL.
+    assert [d["title"] for d in unlocked] == ["Chapter 0", "Chapter 1", "Chapter 2"]
+    assert all(d["url"] is not None for d in unlocked)
+
+
 # ── BUG-COURSE-004: next_unlock_day with negative days ─────────────────
 
 
@@ -684,10 +747,10 @@ async def test_course_progress_fresh_user_reports_next_unlock(
 ) -> None:
     """BUG-COURSE-004: a fresh user's progress reports a real next unlock, not -1.
 
-    First course access provisions a ``current_stage=1`` row (drip clock
-    at day 0), so the stage-1 progress endpoint reports
-    ``next_unlock_day=3`` — the release_day of the first still-locked
-    chapter — instead of feeding a negative day count to next_unlock_day.
+    First course access provisions a ``current_stage=1`` row (day-in-stage
+    1), so the stage-1 progress endpoint reports the proportional next
+    unlock (day 8 for the second of three chapters) instead of feeding a
+    negative day count into the drip math.
     """
     headers, _user_id = await _signup(async_client)
     await _seed_stage_with_content(db_session, stage_number=1)
@@ -695,7 +758,7 @@ async def test_course_progress_fresh_user_reports_next_unlock(
     resp = await async_client.get("/course/stages/1/progress", headers=headers)
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
-    expected_next = 3
+    expected_next = 8
     assert data["next_unlock_day"] == expected_next
 
 

--- a/backend/tests/test_course_body_endpoints.py
+++ b/backend/tests/test_course_body_endpoints.py
@@ -254,21 +254,43 @@ async def test_content_body_404_for_locked_stage(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("content_dir")
-async def test_content_body_404_for_unreleased_day(
+async def test_content_body_404_for_drip_locked_chapter(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """An item whose release_day is in the future returns 404 (BUG-COURSE-004)."""
+    """A chapter still behind the proportional drip returns 404 (BUG-COURSE-004).
+
+    On day 2 of a 21-day stage only the first chapters have dripped, so a
+    high-ordinal chapter (filled behind several earlier ones) is locked and
+    its body must not leak — masked as ``content_not_found``.
+    """
     headers, user_id = await _signup_with_id(async_client, "early")
-    _, item = await _seed_stage_with_content(
-        db_session,
-        stage_number=1,
-        url=content_ref("beige-10"),
-        release_day=9,
-        title="Late Chapter",
+    stage, _first = await _seed_stage_with_content(
+        db_session, stage_number=1, release_day=0, title="Opening"
     )
+    # Fill earlier ordinals so "Late Chapter" sits near the end of the stage.
+    for day in (1, 2, 3):
+        db_session.add(
+            StageContent(
+                course_stage_id=stage.id,
+                title=f"Chapter {day}",
+                content_type="chapter",
+                release_day=day,
+                url=content_ref(f"beige-{day}"),
+            )
+        )
+    late = StageContent(
+        course_stage_id=stage.id,
+        title="Late Chapter",
+        content_type="chapter",
+        release_day=9,
+        url=content_ref("beige-10"),
+    )
+    db_session.add(late)
+    await db_session.commit()
+    await db_session.refresh(late)
     await _set_user_stage(db_session, user_id, stage_number=1, days_ago=2)
 
-    body_resp = await async_client.get(f"/course/content/{item.id}/body", headers=headers)
+    body_resp = await async_client.get(f"/course/content/{late.id}/body", headers=headers)
     assert body_resp.status_code == HTTPStatus.NOT_FOUND
 
 

--- a/backend/tests/test_course_local_content.py
+++ b/backend/tests/test_course_local_content.py
@@ -5,12 +5,12 @@ whole journey the user actually takes: manifest → seeder → gated chapter
 list → released body → read-tracking → progress math — deterministic,
 offline, against real files instead of mocks of a third party.
 
-Fixture shape: stage 1 ships chapters at release days 0/2/3/9, stage 2
-ships one chapter (locked until the user reaches the stage), plus one
-site resource.  Every test pins the user at **day 2 of stage 1**, so the
-drip-feed boundary cases fall out naturally: day 0 is past, day 2 is
-"today" (boundary — must unlock), day 3 is tomorrow (boundary — must
-stay locked), day 9 is deep future.
+Fixture shape: stage 1 ships four chapters (ordinals 0-3), stage 2 ships
+one chapter (locked until the user reaches the stage), plus one site
+resource.  Every test pins the user at **day 2 of stage 1**.  Gating is
+now the proportional drip: four chapters spread over the 21-day stage
+means by day-in-stage 3 only ceil(4 * 3 / 21) = 1 chapter has opened, so
+the first ordinal unlocks and the rest stay locked.
 """
 
 from __future__ import annotations
@@ -106,14 +106,15 @@ async def _stage_one_items(
 async def test_list_reflects_drip_feed_boundaries(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Day < N locked, day == N unlocked (boundary), day > N unlocked."""
+    """Proportional drip: on day-in-stage 3 only the first ordinal is open."""
     headers = await _signup_at_day_two(async_client, db_session, "journey")
     items = await _stage_one_items(async_client, headers)
 
-    assert items["Survival"]["is_locked"] is False  # day 0 — past
-    assert items["Breath as Anchor"]["is_locked"] is False  # day 2 — today (boundary)
-    assert items["Tomorrow Prompt"]["is_locked"] is True  # day 3 — tomorrow (boundary)
-    assert items["Late Chapter"]["is_locked"] is True  # day 9 — deep future
+    # ceil(4 chapters * day 3 / 21 days) = 1 → only ordinal 0 has dripped.
+    assert items["Survival"]["is_locked"] is False  # ordinal 0 — open
+    assert items["Breath as Anchor"]["is_locked"] is True  # ordinal 1 — not yet
+    assert items["Tomorrow Prompt"]["is_locked"] is True  # ordinal 2 — not yet
+    assert items["Late Chapter"]["is_locked"] is True  # ordinal 3 — not yet
 
 
 @pytest.mark.asyncio
@@ -145,7 +146,7 @@ async def test_gating_mask_for_unreleased_locked_and_unknown(
     headers = await _signup_at_day_two(async_client, db_session, "masked")
     items = await _stage_one_items(async_client, headers)
 
-    # Unreleased (day 3 > day 2).
+    # Still behind the drip (ordinal 2, only 1 chapter open on day 3).
     resp = await async_client.get(
         f"/course/content/{items['Tomorrow Prompt']['id']}/body", headers=headers
     )
@@ -201,8 +202,9 @@ async def test_progress_math_and_read_tracking(
     assert resp.status_code == HTTPStatus.OK
     before = resp.json()
     assert before["read_items"] == 0
-    # The next chapter after day 2 drips on day 3.
-    assert before["next_unlock_day"] == 3
+    # 4 chapters over 21 days: with one open on day-in-stage 3, the second
+    # drips on day 6 (floor(1 * 21 / 4) + 1).
+    assert before["next_unlock_day"] == 6
 
     mark = await async_client.post(
         f"/course/content/{items['Survival']['id']}/mark-read", headers=headers

--- a/backend/tests/test_program_calendar.py
+++ b/backend/tests/test_program_calendar.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_PROGRAM_DAYS, TOTAL_STAGES
-from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
+from domain.program_calendar import (
+    calendar_day_in_stage,
+    calendar_stage,
+    calendar_week,
+    resolve_program_anchor,
+)
 from domain.weekly_prompts import TOTAL_WEEKS
 from models.stage_progress import StageProgress
 
@@ -94,6 +99,38 @@ def test_calendar_stage_clamps_outside_the_program() -> None:
     assert calendar_stage(_ANCHOR, _at(252)) == TOTAL_STAGES
     assert calendar_stage(_ANCHOR, _at(10_000)) == TOTAL_STAGES
     assert calendar_stage(_ANCHOR, _ANCHOR - timedelta(days=3)) == 1
+
+
+# ── calendar_day_in_stage ───────────────────────────────────────────────
+
+
+def test_calendar_day_in_stage_is_one_based_within_the_window() -> None:
+    # Stage 1 opens on the anchor day: day 1 there, day 21 at its close.
+    assert calendar_day_in_stage(_ANCHOR, 1, _at(0)) == 1
+    assert calendar_day_in_stage(_ANCHOR, 1, _at(20)) == 21
+    # Stage 2's window starts 21 days in — that day is day 1 of stage 2.
+    assert calendar_day_in_stage(_ANCHOR, 2, _at(21)) == 1
+    assert calendar_day_in_stage(_ANCHOR, 2, _at(24)) == 4
+
+
+def test_calendar_day_in_stage_caps_at_the_stage_duration() -> None:
+    # Past a stage's window the day saturates at its duration (all open).
+    assert calendar_day_in_stage(_ANCHOR, 1, _at(100)) == STAGE_DURATIONS_DAYS[0]
+    # The two integration stages run 42 days.
+    assert calendar_day_in_stage(_ANCHOR, 9, _at(10_000)) == STAGE_DURATIONS_DAYS[8]
+
+
+def test_calendar_day_in_stage_is_non_positive_before_the_window() -> None:
+    # A stage the calendar has not yet reached reads as a non-positive day,
+    # so the proportional drip opens nothing there.
+    assert calendar_day_in_stage(_ANCHOR, 2, _at(0)) <= 0
+    assert calendar_day_in_stage(_ANCHOR, 3, _at(21)) <= 0
+
+
+def test_calendar_day_in_stage_accepts_naive_anchor() -> None:
+    """SQLite returns naive datetimes; the math must not raise (issue #412 class)."""
+    naive_anchor = _ANCHOR.replace(tzinfo=None)
+    assert calendar_day_in_stage(naive_anchor, 2, _at(21)) == 1
 
 
 # ── resolve_program_anchor ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implement calendar-proportional unlock model for course content gating, replacing the previous release_day-based approach. This aligns backend gating with the frontend's calendar-derived schedule (issue #386).

**Key Changes:**
- Add `calendar_day_in_stage()` helper to compute 1-based day within any stage window
- Implement `unlocked_chapter_count()` for proportional math: `ceil(total * day / duration)`
- Rewrite `filter_content_for_user()` to lock by ordinal position (rank by release_day, then id)
- Fix -1 bug: calendar-unlocked-ahead stages now show partial unlock, not all locked
- Router computes `day_in_stage` for all stages (honoring user advancement for current stage)
- Progress denominator migrated to whole-stage count (complete only when all read)
- Add `next_unlock_day()` to predict when next chapter drips

**Tests:**
- Rewrite domain/test_course.py with 15+ new/updated cases (edge cases, handoff examples)
- Add 4 new calendar_day_in_stage tests
- Update integration tests to verify proportional math (e.g., day 7→2 unlocked out of 4 chapters)
- Add regression test for -1 bug (calendar-unlocked-ahead stage)

**Technical Details:**
- Solves non-dense release_days (stage 1 skips day 11) by using ordinal position as lock gate
- For current stage: `max(calendar_day, actual_start_day)` honors advancement
- Maintains release_day for ordering/back-compat but not as gate

All quality gates pass (linting, type check, tests, coverage ≥90%).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFzkYBPxz9axpGRGg8KjoF)_