### PR TITLE
fix(security): re-normalize to NFC after stripping in sanitize_user_text

### DIFF
--- a/backend/src/security/text_sanitize.py
+++ b/backend/src/security/text_sanitize.py
@@ -117,7 +117,11 @@ def sanitize_user_text(
     4. Strip leading and trailing whitespace.  This happens **after** the
        control-char strip so a string like ``"  \x00  hello  "`` becomes
        ``"hello"`` rather than ``" hello "``.
-    5. Enforce the length cap.
+    5. Re-normalize to NFC.  Stripping a zero-width joiner that sat between a
+       base character and a combining mark can leave the result decomposed, so
+       a second normalize restores canonical form and keeps the helper
+       idempotent.
+    6. Enforce the length cap.
 
     The helper is pure (no side effects) and idempotent — applying it twice
     is the same as applying it once, which lets routers and services both
@@ -127,8 +131,9 @@ def sanitize_user_text(
         TypeError: if ``text`` is not a ``str``.  The fail-fast TypeError keeps
             ``None`` and other non-strings from being silently coerced.
         TextTooLongError: when the *sanitized* length exceeds ``max_len``.
-            Length is measured after stripping so a payload that fits inside
-            the cap purely because of stripped padding is still accepted.
+            Length is measured on the final normalized output, after stripping,
+            so a payload that fits inside the cap purely because of stripped
+            padding is still accepted.
     """
     if not isinstance(text, str):
         msg = f"sanitize_user_text expected str, got {type(text).__name__}"
@@ -137,6 +142,7 @@ def sanitize_user_text(
     cleaned = _CONTROL_CHARS.sub("", cleaned)
     cleaned = _ZERO_WIDTH.sub("", cleaned)
     cleaned = cleaned.strip()
+    cleaned = unicodedata.normalize("NFC", cleaned)
     if len(cleaned) > max_len:
         msg = f"text exceeds {max_len} chars after sanitization"
         raise TextTooLongError(msg)

--- a/backend/tests/security/test_text_sanitize.py
+++ b/backend/tests/security/test_text_sanitize.py
@@ -43,6 +43,7 @@ WORD_JOINER = "\u2060"
 INVISIBLE_TIMES = "\u2062"
 INVISIBLE_PLUS = "\u2064"
 BOM = "\ufeff"
+COMBINING_ACUTE = "\u0301"  # combining acute accent
 
 # Unicode Tags block (U+E0000-U+E007F) -- invisible ASCII-smuggling channel.
 # Range bounds as named constants so the smuggling helper below carries no
@@ -261,6 +262,34 @@ class TestUnicodeNormalization:
         assert unicodedata.is_normalized("NFC", result)
         assert "́" not in result
         assert "̈" not in result
+
+    def test_zwj_interrupted_combining_sequence_composes_to_nfc(self) -> None:
+        """A ZWJ between base and combining mark must not block NFC composition.
+
+        Input is "e" + ZWJ + combining acute.  ZWJ has to be stripped before
+        NFC normalization runs, otherwise the joiner blocks composition and
+        the result stays as the two-codepoint decomposed form instead of the
+        single precomposed "e" with an acute accent.
+        """
+        raw = "e" + ZWJ + COMBINING_ACUTE
+        expected = unicodedata.normalize("NFC", "e" + COMBINING_ACUTE)
+        result = sanitize_user_text(raw)
+        assert result == expected
+        assert len(result) == 1
+        assert unicodedata.is_normalized("NFC", result)
+
+    def test_zwj_interrupted_combining_sequence_idempotent(self) -> None:
+        """Sanitizing the ZWJ-interrupted combining sequence twice is stable."""
+        raw = "e" + ZWJ + COMBINING_ACUTE
+        once = sanitize_user_text(raw)
+        twice = sanitize_user_text(once)
+        assert once == twice
+
+    def test_zwj_interrupted_combining_sequence_output_is_nfc(self) -> None:
+        """The sanitized output of the ZWJ-interrupted sequence is itself NFC."""
+        raw = "e" + ZWJ + COMBINING_ACUTE
+        result = sanitize_user_text(raw)
+        assert result == unicodedata.normalize("NFC", result)
 
 
 class TestWhitespaceHandling:


### PR DESCRIPTION
## Summary
- `sanitize_user_text` NFC-normalized *before* stripping zero-width codepoints, so removing a zero-width joiner (U+200D) that sat between a base character and a combining mark left the output decomposed and non-canonical — breaking both the module's documented NFC-canonical-form guarantee and its idempotency guarantee (`f(f(x)) != f(x)`).
- Add a final `unicodedata.normalize("NFC", cleaned)` after the control/zero-width strips and `strip()` so the returned value is always canonical NFC and the helper is idempotent for arbitrary input. Canonical composition never emits control or zero-width chars, so the trailing normalize cannot re-introduce any stripped codepoint class.
- Update the function docstring's numbered Steps (new step 5 = re-normalize; cap becomes step 6) and the `TextTooLongError` length note so docs match the implementation exactly.

## Test plan
- Added three regression tests in `TestUnicodeNormalization` (`backend/tests/security/test_text_sanitize.py`) for input `"e" + ZWJ + U+0301`: asserting NFC composition to `"é"` (single U+00E9), idempotency, and the `out == NFC(out)` invariant. Confirmed all three fail RED against the pre-fix code and pass GREEN after.
- `python -m pytest tests/security/test_text_sanitize.py` — 53 passed.
- `./scripts/backend/check-all.sh` — all 7 quality checks pass; 2393 passed / 2 skipped; total coverage 96.62%, `text_sanitize.py` at 100%.
- `xenon` (A) and `radon mi` (A) / `radon cc` (A) on the touched module.
- `pre-commit` on the touched files — all hooks pass.

Closes #1384
