### PR TITLE
feat(practice): wire expo-audio adapter into the ritual session

### DIFF
--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -23,7 +23,8 @@
  *     `useWeeklyProgress` callbacks so the bar reconciles with server truth.
  *   - Activate keep-awake while the engine is `running` (not for the whole
  *     active-card lifetime).
- *   - Inject the expo-haptics adapter so ritual cues emit tactile feedback.
+ *   - Inject the expo-haptics and expo-audio adapters so ritual cues emit
+ *     tactile feedback and audible bells.
  */
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -43,10 +44,12 @@ import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConf
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
 import { buildCardMeditationMetadata, pickCard } from '@/features/Practice/data/resolveCard';
 import { cardForDayIndex } from '@/features/Practice/data/tarot';
+import { createExpoAudioAdapter } from '@/features/Practice/engine/adapters/audio';
 import { createExpoHapticsAdapter } from '@/features/Practice/engine/adapters/haptics';
 import { scheduledCues } from '@/features/Practice/engine/cues';
 import { totalSteps, totalStepsPerRound } from '@/features/Practice/engine/tallied';
 import type {
+  AudioAdapter,
   CardMeditationConfig,
   EngineDeps,
   IntervalBellConfig,
@@ -98,6 +101,8 @@ export interface ActiveRitualSessionProps {
   onUserPracticeUpdated: (_next: UserPractice) => void;
   /** Open the journal-reflection composer (parent owns the navigator). */
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
+  /** Injectable audio adapter for tests; defaults to the bundled bell audio. */
+  audio?: AudioAdapter;
 }
 
 interface ActiveSession {
@@ -238,14 +243,19 @@ function useHarvestedMetadata(
   };
 }
 
-function useEngineDeps(tarotCardIndex: number): EngineDeps {
+function useEngineDeps(tarotCardIndex: number, injectedAudio?: AudioAdapter): EngineDeps {
   const [haptics] = useState(() => createExpoHapticsAdapter());
-  return useMemo(() => ({ startCardIndex: tarotCardIndex, haptics }), [tarotCardIndex, haptics]);
+  const [audio] = useState<AudioAdapter>(() => injectedAudio ?? createExpoAudioAdapter());
+  useEffect(() => () => audio.dispose?.(), [audio]);
+  return useMemo(
+    () => ({ startCardIndex: tarotCardIndex, haptics, audio }),
+    [tarotCardIndex, haptics, audio],
+  );
 }
 
 function useActiveSession(props: ActiveRitualSessionProps): ActiveSession {
   const tarotCardIndex = useTarotCardIndex(props);
-  const engineDeps = useEngineDeps(tarotCardIndex);
+  const engineDeps = useEngineDeps(tarotCardIndex, props.audio);
   const [state, controls] = useRitualEngine(props.effectiveConfig, engineDeps);
   useKeepAwakeWhileRunning(state.status);
   const window = useCompletionWindow(state.status);

--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.audio.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.audio.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { Audio } from 'expo-av';
+import React from 'react';
+
+import type { UserPractice } from '@/api';
+import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
+import type {
+  AudioAdapter,
+  MeditationTimerConfig,
+  ModeConfig,
+  RandomIntervalBellConfig,
+} from '@/features/Practice/engine/types';
+
+const userPractice: UserPractice = {
+  id: 10,
+  practice_id: 1,
+  stage_number: 1,
+  start_date: '2026-04-12',
+  end_date: null,
+};
+
+const meditationConfig: MeditationTimerConfig = {
+  mode: 'meditation_timer',
+  duration_minutes: 1,
+  halfway_bell: true,
+};
+
+const randomBellConfig: RandomIntervalBellConfig = {
+  mode: 'random_interval_bell',
+  duration_minutes: 1,
+  min_interval_seconds: 5,
+  max_interval_seconds: 10,
+  bell_tone: 'bowl',
+};
+
+function createAudioSpy(): AudioAdapter {
+  return {
+    play: jest.fn<AudioAdapter['play']>(),
+    dispose: jest.fn<NonNullable<AudioAdapter['dispose']>>(),
+  };
+}
+
+interface RenderOverrides {
+  config?: ModeConfig;
+  audio?: AudioAdapter;
+}
+
+function renderSession(overrides: RenderOverrides = {}) {
+  return render(
+    <ActiveRitualSession
+      userPractice={userPractice}
+      effectiveName="Breath Awareness"
+      effectiveConfig={overrides.config ?? meditationConfig}
+      userTimezone="UTC"
+      onSessionApply={jest.fn()}
+      onSessionRollback={jest.fn()}
+      onSessionCommitted={jest.fn()}
+      onUserPracticeUpdated={jest.fn()}
+      onWriteReflection={jest.fn()}
+      audio={overrides.audio}
+    />,
+  );
+}
+
+describe('ActiveRitualSession audio wiring', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    (Audio.Sound.createAsync as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('plays the start_bell cue through the injected audio adapter when the session starts', () => {
+    const spy = createAudioSpy();
+    const { getByTestId } = renderSession({ audio: spy });
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    expect(spy.play).toHaveBeenCalledWith('start_bell');
+  });
+
+  it('plays the halfway_bell then the end_bell exactly once each as the session progresses', () => {
+    const spy = createAudioSpy();
+    const { getByTestId } = renderSession({ audio: spy });
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+    const halfwayCalls = (spy.play as jest.Mock).mock.calls.filter(
+      ([kind]) => kind === 'halfway_bell',
+    );
+    expect(halfwayCalls).toHaveLength(1);
+
+    act(() => {
+      jest.advanceTimersByTime(30_000);
+    });
+    const endCalls = (spy.play as jest.Mock).mock.calls.filter(([kind]) => kind === 'end_bell');
+    expect(endCalls).toHaveLength(1);
+    expect(
+      (spy.play as jest.Mock).mock.calls.filter(([kind]) => kind === 'halfway_bell'),
+    ).toHaveLength(1);
+  });
+
+  it('falls back to the expo-av-backed adapter when no audio prop is given', () => {
+    const { getByTestId } = renderSession();
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    expect(Audio.Sound.createAsync).toHaveBeenCalled();
+  });
+
+  it('disposes the injected audio adapter exactly once on unmount', () => {
+    const spy = createAudioSpy();
+    const { unmount, getByTestId } = renderSession({ audio: spy });
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    expect(spy.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls the injected engine audio adapter for random_interval_bell (view owns its own bells)', () => {
+    const spy = createAudioSpy();
+    const { getByTestId } = renderSession({ config: randomBellConfig, audio: spy });
+
+    act(() => {
+      fireEvent.press(getByTestId('ritual-start'));
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(spy.play).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Inject a real audio adapter into the ritual session so engine-scheduled bells are audible. `ActiveRitualSession`'s `useEngineDeps` now resolves `createExpoAudioAdapter()` (created once, disposed on unmount) and includes it in the `EngineDeps` passed to `useRitualEngine`, mirroring the existing expo-haptics wiring. Previously the engine fell back to `NOOP_AUDIO`, so every scheduled `start_bell` / `halfway_bell` / `end_bell` / `interval_bell` played silently.
- Add an optional `audio?: AudioAdapter` prop so tests can inject a spy adapter (same pattern `RandomIntervalBellView` already uses).
- `random_interval_bell` is unaffected — it is `noCues` in the engine and self-schedules its own bells, so there is no double-play.

## Test plan
- New `ActiveRitualSession.audio.test.tsx` (RNTL): a `meditation_timer` session driven with a spy adapter calls `audio.play('start_bell')` on start and `audio.play('end_bell')` on completion, plays `halfway_bell` once, uses the expo-av adapter by default when no prop is passed, disposes on unmount, and never double-plays for `random_interval_bell`.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, `tsc --noEmit`, and Jest (333 suites / 3556 tests) all pass.

Closes #1388
Refs #1387
