### PR TITLE
feat(frontend): cap content to a shared max screen width on all screens; fix Map's forced Understanding hyphen + Android Awareness line-break

### DIFF
--- a/frontend/src/components/layout/ContentContainer.tsx
+++ b/frontend/src/components/layout/ContentContainer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import { contentLayout } from '@/design/tokens';
+
+interface ContentContainerProps {
+  children: React.ReactNode;
+  /** Extra style merged onto the shared content-capped container. */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * The shared content-width cap: a full-width box centered and capped at
+ * ``contentLayout.maxWidth`` so screen bodies settle on the same comfortable
+ * reading measure on tablets and wide web instead of stretching edge-to-edge.
+ * It uses ``flexGrow`` (not ``flex``) so it fills a definite-height parent while
+ * still collapsing to its content height inside a ScrollView's content
+ * container — a plain ``flex: 1`` there would resolve to zero height on native.
+ * Callers wrap their scroll/flow body in this; a caller ``style`` is merged on
+ * top without dropping the cap.
+ */
+export const ContentContainer = ({
+  children,
+  style,
+  testID = 'content-container',
+}: ContentContainerProps): React.JSX.Element => (
+  <View style={[styles.container, style]} testID={testID}>
+    {children}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    width: '100%',
+    maxWidth: contentLayout.maxWidth,
+    alignSelf: 'center',
+  },
+});
+
+export default ContentContainer;

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
+import { ContentContainer } from './ContentContainer';
+
 import { rhythm, surface } from '@/design/tokens';
 
 interface ScreenScaffoldProps {
@@ -31,13 +33,13 @@ export const ScreenScaffold = ({
         contentContainerStyle={[styles.content, style]}
         testID={testID}
       >
-        {children}
+        <ContentContainer>{children}</ContentContainer>
       </ScrollView>
     );
   }
   return (
     <View style={[styles.ground, styles.content, style]} testID={testID}>
-      {children}
+      <ContentContainer>{children}</ContentContainer>
     </View>
   );
 };

--- a/frontend/src/components/layout/__tests__/ContentContainer.test.tsx
+++ b/frontend/src/components/layout/__tests__/ContentContainer.test.tsx
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+import { ContentContainer } from '../ContentContainer';
+
+import { contentLayout } from '@/design/tokens';
+
+describe('ContentContainer', () => {
+  it('renders its children', () => {
+    const { getByText } = render(
+      <ContentContainer>
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+  });
+
+  it('defaults to the shared content-container testID', () => {
+    const { getByTestId } = render(
+      <ContentContainer>
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    expect(getByTestId('content-container')).toBeTruthy();
+  });
+
+  it('accepts a caller-supplied testID', () => {
+    const { getByTestId } = render(
+      <ContentContainer testID="custom-container">
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    expect(getByTestId('custom-container')).toBeTruthy();
+  });
+
+  it('fills a phone-width screen with a grow-flexed, full-width box centered and capped at the shared content max-width', () => {
+    const { getByTestId } = render(
+      <ContentContainer>
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flexGrow).toBe(1);
+    expect(flat.flex).toBeUndefined();
+    expect(flat.width).toBe('100%');
+    expect(flat.maxWidth).toBe(contentLayout.maxWidth);
+    expect(flat.alignSelf).toBe('center');
+  });
+
+  it('merges a caller-supplied style onto the default container style without losing the cap', () => {
+    const { getByTestId } = render(
+      <ContentContainer style={{ backgroundColor: 'red' }}>
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.backgroundColor).toBe('red');
+    expect(flat.maxWidth).toBe(contentLayout.maxWidth);
+    expect(flat.alignSelf).toBe('center');
+  });
+});

--- a/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { render } from '@testing-library/react-native';
+import { render, within } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
 
@@ -26,5 +26,25 @@ describe('ScreenScaffold', () => {
       </ScreenScaffold>,
     );
     expect(getByText('scrolled')).toBeTruthy();
+  });
+
+  it('wraps children in the shared content-capped container in the plain (non-scroll) mode', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold>
+        <Text testID="scaffold-child">hello</Text>
+      </ScreenScaffold>,
+    );
+    const container = getByTestId('content-container');
+    expect(within(container).getByTestId('scaffold-child')).toBeTruthy();
+  });
+
+  it('wraps children in the shared content-capped container in scroll mode too', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll>
+        <Text testID="scaffold-scroll-child">scrolled</Text>
+      </ScreenScaffold>,
+    );
+    const container = getByTestId('content-container');
+    expect(within(container).getByTestId('scaffold-scroll-child')).toBeTruthy();
   });
 });

--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -7,6 +7,8 @@ import {
   STAGE_ORDER,
   brightenColor,
   colors,
+  contentLayout,
+  journalLayout,
   radius,
   resolveStageColor,
   shadows,
@@ -273,6 +275,15 @@ describe('design tokens', () => {
       expect(type(700).body.fontSize).toBe(17);
       expect(type(1000).body.fontSize).toBe(18);
       expect(type(1300).body.fontSize).toBe(19);
+    });
+  });
+
+  describe('contentLayout', () => {
+    it('caps shared screen content at the journal page width plus its margin column, never a bare literal', () => {
+      expect(contentLayout.maxWidth).toBe(
+        journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
+      );
+      expect(contentLayout.maxWidth).toBe(900);
     });
   });
 });

--- a/frontend/src/design/__tests__/useResponsive.test.ts
+++ b/frontend/src/design/__tests__/useResponsive.test.ts
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+/* global describe, it, expect, afterEach, jest */
+import { renderHook } from '@testing-library/react-native';
+
+import { contentLayout } from '../tokens';
+import useResponsive from '../useResponsive';
+
+const mockWindowDimensions = (width: number, height: number): void => {
+  jest
+    .spyOn(require('react-native'), 'useWindowDimensions')
+    .mockReturnValue({ width, height, scale: 1, fontScale: 1 });
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useResponsive contentWidth', () => {
+  it('passes the raw width through unchanged on a phone-width viewport (below the content cap)', () => {
+    mockWindowDimensions(390, 844);
+    const { result } = renderHook(() => useResponsive());
+    expect(result.current.contentWidth).toBe(390);
+  });
+
+  it('is a no-op exactly at the content cap boundary', () => {
+    mockWindowDimensions(contentLayout.maxWidth, 900);
+    const { result } = renderHook(() => useResponsive());
+    expect(result.current.contentWidth).toBe(contentLayout.maxWidth);
+  });
+
+  it('caps contentWidth at contentLayout.maxWidth on an ultra-wide viewport', () => {
+    mockWindowDimensions(1600, 900);
+    const { result } = renderHook(() => useResponsive());
+    expect(result.current.contentWidth).toBe(contentLayout.maxWidth);
+    // The raw width is still reported unclamped for callers that need it.
+    expect(result.current.width).toBe(1600);
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -423,6 +423,17 @@ export const journalLayout = {
 } as const;
 
 /**
+ * Shared reading-measure cap for full-width app screens. Derived from the
+ * journal page's writing column plus its margin-notes gutter so every scaffolded
+ * surface settles on the same comfortable measure on tablets and wide web,
+ * instead of stretching content edge-to-edge. Kept as a derivation (not a bare
+ * literal) so the cap tracks the journal metrics it is anchored to.
+ */
+export const contentLayout = {
+  maxWidth: journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
+} as const;
+
+/**
  * Warm, long-form serif typography for the journal surface. Uses the platform
  * serif stack (no bundled font asset): Georgia on iOS, the system ``serif``
  * family on Android, and a CSS-style stack on web. Line-heights are generous

--- a/frontend/src/design/useResponsive.ts
+++ b/frontend/src/design/useResponsive.ts
@@ -1,6 +1,6 @@
 import { useWindowDimensions } from 'react-native';
 
-import { breakpoints, spacing } from './tokens';
+import { breakpoints, contentLayout, spacing } from './tokens';
 
 const SCALE_XS = 0.85;
 const SCALE_SM = 0.9;
@@ -43,6 +43,10 @@ export const useResponsive = () => {
 
   return {
     width,
+    // Raw width clamped to the shared content cap, so callers can size layout
+    // off the same measure the ContentContainer renders content at on wide
+    // viewports. Callers needing the true viewport still read ``width``.
+    contentWidth: Math.min(width, contentLayout.maxWidth),
     height,
     isXS: breakpointKey === 'xs',
     isSM: breakpointKey === 'sm',

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../api';
 import { Celebration } from '../../components/feedback/Celebration';
 import { EmptyState } from '../../components/feedback/EmptyState';
+import { ContentContainer } from '../../components/layout/ContentContainer';
 import { EditorialSection } from '../../components/layout/EditorialSection';
 import { ScreenHeader } from '../../components/layout/ScreenHeader';
 import { ShowcaseCard } from '../../components/layout/ShowcaseCard';
@@ -497,20 +498,22 @@ const CourseScreen = (): React.JSX.Element => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <View style={styles.headerBand}>
-        <ScreenHeader eyebrow={COURSE_EYEBROW} title={COURSE_TITLE} />
-      </View>
-      <StageSelector
-        stages={allStages}
-        selectedStage={selectedStage}
-        onSelectStage={handleStageSelect}
-      />
-      <StagePanel
-        selectedStage={selectedStage}
-        selectedStageData={selectedStageData}
-        stageContent={stageContent}
-        viewer={viewer}
-      />
+      <ContentContainer>
+        <View style={styles.headerBand}>
+          <ScreenHeader eyebrow={COURSE_EYEBROW} title={COURSE_TITLE} />
+        </View>
+        <StageSelector
+          stages={allStages}
+          selectedStage={selectedStage}
+          onSelectStage={handleStageSelect}
+        />
+        <StagePanel
+          selectedStage={selectedStage}
+          selectedStageData={selectedStageData}
+          stageContent={stageContent}
+          viewer={viewer}
+        />
+      </ContentContainer>
     </SafeAreaView>
   );
 };

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -189,6 +189,16 @@ describe('CourseScreen', () => {
     });
   });
 
+  it('renders the stage selector and content list inside the shared content-capped container', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    const container = getByTestId('content-container');
+    expect(within(container).getByTestId('stage-selector')).toBeTruthy();
+    expect(within(container).getByTestId('content-list')).toBeTruthy();
+  });
+
   it('selects completed_count + 1 as the default stage (backend-truth mirror)', async () => {
     // BUG-FE-COURSE-001: stage 1 is complete, stage 2 is in progress →
     // default selection is the first unfinished stage, not the highest

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -186,7 +186,7 @@ const habitGridChrome = (scale: number, gridGutter: number): number =>
   2 * spacing(1, scale) + spacing(3, scale) + 2 * spacing(1, scale) + SPACING.sm + gridGutter;
 
 export const useTileLayout = () => {
-  const { width, height, columns, scale, gridGutter } = useResponsive();
+  const { contentWidth, height, columns, scale, gridGutter } = useResponsive();
   const insets = useSafeAreaInsets();
   const rows = columns === 2 ? TOTAL_HABITS / columns : TOTAL_HABITS;
   const chrome = habitGridChrome(scale, gridGutter);
@@ -195,7 +195,10 @@ export const useTileLayout = () => {
   const rowPitch = availableHeight / rows;
   // Floor to whole pixels so the reserved stack never rounds above the viewport.
   const tileMinHeight = Math.max(touchTarget.minimum, Math.floor(rowPitch - gridGutter));
-  const tileWidth = width / columns;
+  // Size tiles off the content-capped width so a wide viewport lays them out at
+  // the same measure the shared ContentContainer renders the grid at, rather
+  // than off the raw (uncapped) window width.
+  const tileWidth = contentWidth / columns;
   const iconInline = columns === 1 || tileWidth < 400;
   return { columns, scale, gridGutter, tileMinHeight, iconInline };
 };

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -45,6 +45,8 @@ import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
 import { usePagination } from './hooks/usePagination';
 
+import { ContentContainer } from '@/components/layout/ContentContainer';
+
 /** Habits per page — the ceiling that fills the screen 1-up on mobile and 2x5 on landscape/desktop. */
 const HABITS_PER_PAGE = MAX_HABITS;
 
@@ -887,40 +889,42 @@ const HabitsScreen = () => {
   const paginationProps = buildPaginationProps(pagination, scale);
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(isLG || isXL ? 2 : 1, scale) }]}>
-      <View style={styles.topBar}>
-        <OverflowMenu
-          scale={scale}
-          menuVisible={modals.menu}
-          onToggle={modals.toggleMenu}
-          onSelectMode={state.handleSelectMode}
-          onOpenOnboarding={() => modals.open('onboarding')}
-          onOpenAddHabit={() => modals.open('addHabit')}
-          allRevealed={state.allRevealed}
-          onToggleReveal={state.handleToggleReveal}
+      <ContentContainer>
+        <View style={styles.topBar}>
+          <OverflowMenu
+            scale={scale}
+            menuVisible={modals.menu}
+            onToggle={modals.toggleMenu}
+            onSelectMode={state.handleSelectMode}
+            onOpenOnboarding={() => modals.open('onboarding')}
+            onOpenAddHabit={() => modals.open('addHabit')}
+            allRevealed={state.allRevealed}
+            onToggleReveal={state.handleToggleReveal}
+          />
+        </View>
+        <HabitsContentSection
+          state={state}
+          columns={columns}
+          gridGutter={gridGutter}
+          paginationProps={paginationProps}
         />
-      </View>
-      <HabitsContentSection
-        state={state}
-        columns={columns}
-        gridGutter={gridGutter}
-        paginationProps={paginationProps}
-      />
-      <EnergyFooter
-        showCTA={ui.showEnergyCTA}
-        showArchive={ui.showArchiveMessage}
-        mode={state.mode}
-        onOpen={() => modals.open('onboarding')}
-        onArchive={ui.archiveEnergyCTA}
-        onExitMode={() => state.setMode('normal')}
-      />
-      <HabitModals
-        modals={modals}
-        selectedHabit={state.selectedHabit}
-        habitStats={state.habitStats}
-        habits={habits}
-        actions={actions}
-        onAddHabit={state.handleAddHabit}
-      />
+        <EnergyFooter
+          showCTA={ui.showEnergyCTA}
+          showArchive={ui.showArchiveMessage}
+          mode={state.mode}
+          onOpen={() => modals.open('onboarding')}
+          onArchive={ui.archiveEnergyCTA}
+          onExitMode={() => state.setMode('normal')}
+        />
+        <HabitModals
+          modals={modals}
+          selectedHabit={state.selectedHabit}
+          habitStats={state.habitStats}
+          habits={habits}
+          actions={actions}
+          onAddHabit={state.handleAddHabit}
+        />
+      </ContentContainer>
     </SafeAreaView>
   );
 };

--- a/frontend/src/features/Habits/__tests__/HabitTileContentWidth.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileContentWidth.test.tsx
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+/* global describe, it, expect, jest */
+import { renderHook } from '@testing-library/react-native';
+import React from 'react';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+
+import useResponsive from '../../../design/useResponsive';
+import { useTileLayout } from '../HabitTile';
+
+jest.mock('../../../design/useResponsive', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedUseResponsive = jest.mocked(useResponsive);
+
+const wrapper = ({ children }: { children: React.ReactNode }): React.JSX.Element => (
+  <SafeAreaInsetsContext.Provider value={{ top: 0, bottom: 0, left: 0, right: 0 }}>
+    {children}
+  </SafeAreaInsetsContext.Provider>
+);
+
+describe('useTileLayout content-width clamp', () => {
+  it('derives iconInline from the capped contentWidth, not the raw window width, on an ultra-wide viewport', () => {
+    // A raw width far beyond the shared content cap would keep a 2-column
+    // tile comfortably above the 400px icon-inline threshold if the hook
+    // used it directly; the capped contentWidth (well below the cap) must
+    // drive the calculation instead.
+    const NARROW_CAPPED_WIDTH = 300;
+    mockedUseResponsive.mockReturnValue({
+      width: 4000,
+      contentWidth: NARROW_CAPPED_WIDTH,
+      height: 900,
+      columns: 2,
+      scale: 1,
+      gridGutter: 8,
+      // Breakpoint flags are part of the hook's return contract but unused by
+      // useTileLayout; set consistent with the raw (ultra-wide) width.
+      isXS: false,
+      isSM: false,
+      isMD: false,
+      isLG: false,
+      isXL: true,
+    });
+
+    const { result } = renderHook(() => useTileLayout(), { wrapper });
+
+    expect(result.current.iconInline).toBe(true);
+  });
+
+  it('keeps iconInline false off a wide contentWidth even when the raw window width alone would read narrow', () => {
+    // The inverse case: a small raw width (which alone would cross below the
+    // 400px threshold and force the compact inline layout) paired with a wide
+    // contentWidth. The hook must key off contentWidth, not width.
+    const NARROW_RAW_WIDTH = 100;
+    const WIDE_CAPPED_WIDTH = 900;
+    mockedUseResponsive.mockReturnValue({
+      width: NARROW_RAW_WIDTH,
+      contentWidth: WIDE_CAPPED_WIDTH,
+      height: 900,
+      columns: 2,
+      scale: 1,
+      gridGutter: 8,
+      // Breakpoint flags are part of the hook's return contract but unused by
+      // useTileLayout; set consistent with the raw (narrow) width.
+      isXS: true,
+      isSM: false,
+      isMD: false,
+      isLG: false,
+      isXL: false,
+    });
+
+    const { result } = renderHook(() => useTileLayout(), { wrapper });
+
+    expect(result.current.iconInline).toBe(false);
+  });
+});

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -358,4 +358,18 @@ describe('HabitsScreen responsive layout', () => {
     expect(hasMenuItem).toBe(true);
     jest.useRealTimers();
   });
+
+  it('renders the habits list inside the shared content-capped container', async () => {
+    jest
+      .spyOn(require('react-native'), 'useWindowDimensions')
+      .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
+
+    let testRenderer: any;
+    await renderer.act(async () => {
+      testRenderer = renderer.create(<HabitsScreen />);
+    });
+
+    const container = testRenderer.root.findByProps({ testID: 'content-container' });
+    expect(container.findByProps({ testID: 'habits-list' })).toBeTruthy();
+  });
 });

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -29,11 +29,6 @@ const CENTER_FLEX = GRID_COLUMN_FLEX.center;
 const RIGHT_FLEX = GRID_COLUMN_FLEX.right;
 const CENTER = 'center';
 
-// Line height for the right-column aspect label, tuned to its fontSize 15 so
-// the up-to-two hyphenated lines stay compact and centered without pushing
-// neighboring rows.
-const RIGHT_LABEL_LINE_HEIGHT = 19;
-
 // --- Soft grid rules -------------------------------------------------------
 // The Map is a table, and a table reads as one through its rules: gentle
 // horizontal lines between the aspect bands (and the stacked stages within
@@ -131,13 +126,12 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
 
-  // Right-column aspect label: fixed serif size rendered on up to two
-  // pre-hyphenated lines, its line height kept compact so a two-line label
-  // stays vertically centered without pushing neighboring rows.
+  // Right-column aspect label: serif face and ink only. Font size and line
+  // height are computed per-fit at render time (fitRightLabel + the shared
+  // line-height ratio), so a long word shrinks to one line rather than being
+  // pinned to a fixed size.
   rightLabelText: {
     fontFamily: editorialType.serif,
-    fontSize: 15,
-    lineHeight: RIGHT_LABEL_LINE_HEIGHT,
     color: ink.primary,
   },
 

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -47,9 +47,11 @@ import {
 import { MagnifierLens } from './MagnifierLens';
 import styles from './Map.styles';
 import {
+  fitRightLabel,
   fittedTitleFontSize,
   labelCorner,
   MAP_ROWS,
+  RIGHT_LABEL_LINE_HEIGHT_RATIO,
   STAGE_DISPLAY,
   TITLE_BY_STAGE,
 } from './mapLayout';
@@ -61,6 +63,7 @@ import { FULLNESS_ALIVE_THRESHOLD } from './wheelBalance';
 
 import { Button } from '@/components/Button';
 import { Celebration } from '@/components/feedback/Celebration';
+import { ContentContainer } from '@/components/layout/ContentContainer';
 import { colors } from '@/design/tokens';
 
 /** Lookup of stage number → StageData for resolving row/arrow content. */
@@ -208,6 +211,37 @@ const FittedTitle = ({ title }: { title: string }): React.JSX.Element => {
       >
         {title}
       </Text>
+    </View>
+  );
+};
+
+/**
+ * Right-column aspect label sized to its measured cell width, mirroring the
+ * ``FittedTitle`` idiom. The full word is preferred on one un-hyphenated line,
+ * shrinking to fit; only a word too long for the floor size falls back to the
+ * row's pre-hyphenated lines. The Android break props are unconditional (no-ops
+ * on iOS/web) so the platform never inserts its own mid-word break.
+ */
+const FittedRightLabel = ({ row }: { row: MapRow }): React.JSX.Element => {
+  const [width, setWidth] = useState(0);
+  const { lines, fontSize } = fitRightLabel(row.rightLabel, row.rightLabelLines, width);
+  const lineHeight = fontSize * RIGHT_LABEL_LINE_HEIGHT_RATIO;
+  return (
+    <View
+      testID={`right-label-fit-${row.rightLabel}`}
+      onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
+    >
+      {lines.map((line) => (
+        <Text
+          key={line}
+          style={[styles.rightLabelText, { fontSize, lineHeight }]}
+          numberOfLines={1}
+          android_hyphenationFrequency="none"
+          textBreakStrategy="simple"
+        >
+          {line}
+        </Text>
+      ))}
     </View>
   );
 };
@@ -394,9 +428,7 @@ const MapRowView = ({
         onCellLayout={onCellLayout}
       />
       <View style={styles.rightCell}>
-        <Text style={styles.rightLabelText} numberOfLines={2}>
-          {row.rightLabelLines.join('\n')}
-        </Text>
+        <FittedRightLabel row={row} />
       </View>
     </View>
   );
@@ -1075,31 +1107,34 @@ interface MapContentProps {
 /** The rendered Map: spiral grid + magnifier lens + banners + stage modal. */
 const MapContent = (props: MapContentProps): React.JSX.Element => (
   <View style={styles.container}>
+    {/* The parchment backdrop stays full-bleed; only the spiral content caps. */}
     <MapBackdrop />
-    <JourneyHeader currentStage={props.currentStage} cycleNumber={props.cycleNumber} />
-    <MapGrid
-      lookup={props.lookup}
-      fullnessByStage={props.fullnessByStage}
-      currentStage={props.currentStage}
-      focusedStage={props.focusedStage}
-      onSelectStage={props.onSelectStage}
-      onSettleStage={props.onSettleStage}
-      onOpenStage={props.onOpenStage}
-    />
-    {props.showBeginAgain && (
-      <BeginAgainBlock onBeginAgain={props.onBeginAgain} beginning={props.beginning} />
-    )}
-    {props.showRefreshError && <MapRefreshErrorBanner onRetry={props.onRefresh} />}
-    <CelebrationBanner
-      active={props.celebration.active}
-      message={props.celebration.message}
-      onDismiss={props.celebration.dismiss}
-    />
-    <StageDetailModal
-      activeStage={props.activeStage}
-      onClose={props.onCloseModal}
-      onNavigate={props.onNavigate}
-    />
+    <ContentContainer>
+      <JourneyHeader currentStage={props.currentStage} cycleNumber={props.cycleNumber} />
+      <MapGrid
+        lookup={props.lookup}
+        fullnessByStage={props.fullnessByStage}
+        currentStage={props.currentStage}
+        focusedStage={props.focusedStage}
+        onSelectStage={props.onSelectStage}
+        onSettleStage={props.onSettleStage}
+        onOpenStage={props.onOpenStage}
+      />
+      {props.showBeginAgain && (
+        <BeginAgainBlock onBeginAgain={props.onBeginAgain} beginning={props.beginning} />
+      )}
+      {props.showRefreshError && <MapRefreshErrorBanner onRetry={props.onRefresh} />}
+      <CelebrationBanner
+        active={props.celebration.active}
+        message={props.celebration.message}
+        onDismiss={props.celebration.dismiss}
+      />
+      <StageDetailModal
+        activeStage={props.activeStage}
+        onClose={props.onCloseModal}
+        onNavigate={props.onNavigate}
+      />
+    </ContentContainer>
   </View>
 );
 

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -6,7 +6,15 @@ import { act, create } from 'react-test-renderer';
 
 import { ink, surface } from '../../../design/tokens';
 import styles from '../Map.styles';
-import { fittedTitleFontSize, MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
+import {
+  fitRightLabel,
+  fittedTitleFontSize,
+  MAP_ROWS,
+  RIGHT_LABEL_LINE_HEIGHT_RATIO,
+  RIGHT_LABEL_MAX_FONT_SIZE,
+  RIGHT_LABEL_MIN_FONT_SIZE,
+  STAGE_DISPLAY,
+} from '../mapLayout';
 import MapScreen from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
 import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
@@ -456,37 +464,71 @@ describe('MapScreen', () => {
     expect(tree.root.findByProps({ testID: 'you-are-here' })).toBeTruthy();
   });
 
-  // Right-column labels render as row.rightLabelLines joined by a newline in
-  // a single Text node (static hyphenation, not shrink-to-fit).
-  const findRightLabelNode = (
+  // Right-column labels now fit their own measured cell width, mirroring the
+  // EMPTINESS/UNITY FittedTitle idiom: a measured wrapper (`right-label-fit-*`)
+  // drives a `fitRightLabel` computation, rather than a static pre-hyphenated
+  // two-line Text.
+  const rightLabelFitTestId = (label: string): string => `right-label-fit-${label}`;
+
+  const fireRightLabelLayout = (
     tree: ReturnType<typeof create>,
-    row: (typeof MAP_ROWS)[number],
-  ): TestNode => {
-    const expectedChildren = row.rightLabelLines.join('\n');
-    const matches = tree.root.findAll((n: TestNode) => n.props.children === expectedChildren);
-    const node = matches[0];
-    if (!node) {
-      throw new Error(`no right-label Text found for ${row.rightLabel}`);
-    }
-    return node;
+    label: string,
+    width: number,
+  ): void => {
+    act(() => {
+      (
+        tree.root.findByProps({ testID: rightLabelFitTestId(label) }).props.onLayout as (
+          _e: unknown,
+        ) => void
+      )({ nativeEvent: { layout: { width, height: 20 } } });
+    });
   };
 
-  it('keeps all six Aspect labels present after the wave overlay renders', () => {
+  it('renders a fitted right-label wrapper for all six Aspect rows after the wave overlay renders', () => {
     const tree = create(<MapScreen />);
     fireGridLayout(tree);
     for (const row of MAP_ROWS) {
-      expect(findRightLabelNode(tree, row)).toBeTruthy();
+      expect(tree.root.findByProps({ testID: rightLabelFitTestId(row.rightLabel) })).toBeTruthy();
     }
   });
 
-  it('renders each right-column Aspect label as a static two-line Text, no auto-fit', () => {
+  it('renders Understanding as one un-hyphenated line in a wide right cell', () => {
+    const WIDE_CELL = 180;
+    const tree = create(<MapScreen />);
+    fireRightLabelLayout(tree, 'Understanding', WIDE_CELL);
+    const node = tree.root.findByProps({ children: 'Understanding' });
+    expect(node.props.numberOfLines).toBe(1);
+    const flat = StyleSheet.flatten(node.props.style) as { fontSize?: number };
+    expect(flat.fontSize).toBe(RIGHT_LABEL_MAX_FONT_SIZE);
+  });
+
+  it('shrinks Awareness to a single fitted line with a reduced, ratio-consistent fontSize in a narrow right cell', () => {
+    const NARROW_CELL = 56;
+    const tree = create(<MapScreen />);
+    fireRightLabelLayout(tree, 'Awareness', NARROW_CELL);
+    const node = tree.root.findByProps({ children: 'Awareness' });
+    expect(node.props.numberOfLines).toBe(1);
+    const flat = StyleSheet.flatten(node.props.style) as {
+      fontSize?: number;
+      lineHeight?: number;
+    };
+    const expected = fitRightLabel('Awareness', ['Awareness'], NARROW_CELL);
+    expect(flat.fontSize).toBe(expected.fontSize);
+    expect(flat.fontSize).toBeLessThan(RIGHT_LABEL_MAX_FONT_SIZE);
+    expect(flat.fontSize).toBeGreaterThanOrEqual(RIGHT_LABEL_MIN_FONT_SIZE);
+    expect(flat.lineHeight).toBeCloseTo((flat.fontSize as number) * RIGHT_LABEL_LINE_HEIGHT_RATIO);
+  });
+
+  it('always carries android_hyphenationFrequency="none" and textBreakStrategy="simple", unconditionally', () => {
+    // Before any right-label wrapper has reported a measured width, every row
+    // renders its full label as one line (fitRightLabel's width<=0 case) — a
+    // single stable target per row, independent of hyphenation strategy.
     const tree = create(<MapScreen />);
     fireGridLayout(tree);
     for (const row of MAP_ROWS) {
-      const node = findRightLabelNode(tree, row);
-      expect(node.props.numberOfLines).toBe(2);
-      expect(node.props.adjustsFontSizeToFit).toBeUndefined();
-      expect(node.props.minimumFontScale).toBeUndefined();
+      const node = tree.root.findByProps({ children: row.rightLabel });
+      expect(node.props.android_hyphenationFrequency).toBe('none');
+      expect(node.props.textBreakStrategy).toBe('simple');
     }
   });
 
@@ -501,6 +543,11 @@ describe('MapScreen', () => {
   it('gives the right cell symmetric horizontal padding (no left-only padding)', () => {
     expect(styles.rightCell.paddingHorizontal).toBeTruthy();
     expect('paddingLeft' in styles.rightCell).toBe(false);
+  });
+
+  it('drops the hardcoded fontSize/lineHeight from the base rightLabelText style (both are now computed per-fit)', () => {
+    expect('fontSize' in styles.rightLabelText).toBe(false);
+    expect('lineHeight' in styles.rightLabelText).toBe(false);
   });
 
   it('renders the wave overlay independent of MAP_BACKGROUND_URI (MapBackdrop is a no-op)', () => {
@@ -900,5 +947,21 @@ describe('MapScreen soft grid lines', () => {
     for (const column of [0, 1]) {
       expect(topBorder(tree, `stage-hotspot-10-${column}`).borderTopWidth ?? 0).toBe(0);
     }
+  });
+});
+
+describe('MapScreen content-width cap', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
+    );
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('renders the map grid inside the shared content-capped container', () => {
+    const tree = create(<MapScreen />);
+    const container = tree.root.findByProps({ testID: 'content-container' });
+    expect(container.findByProps({ testID: 'map-grid' })).toBeTruthy();
   });
 });

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -2,10 +2,14 @@
 /* global describe, it, expect */
 import { ink, surface } from '../../../design/tokens';
 import {
+  fitRightLabel,
   fittedTitleFontSize,
   labelCorner,
   MAP_ROWS,
   MAP_TITLE_LINES,
+  RIGHT_LABEL_GLYPH_EM_WIDTH,
+  RIGHT_LABEL_MAX_FONT_SIZE,
+  RIGHT_LABEL_MIN_FONT_SIZE,
   STAGE_DISPLAY,
   TITLE_MAX_FONT_SIZE,
   TITLE_MIN_FONT_SIZE,
@@ -88,13 +92,18 @@ describe('mapLayout', () => {
     expect(MAP_TITLE_LINES).toEqual(['EMPTINESS', 'UNITY']);
   });
 
-  it('gives every right-label at most two hyphenated lines, each within the cell width', () => {
+  it('gives every two-line right-label fallback two hyphenated lines, each within the cell width', () => {
+    // Single-line fallbacks (the common case) carry the full, un-truncated
+    // word instead: fitRightLabel shrinks its font size to fit at render
+    // time, so they are not bound by the old fixed-width hyphenation budget.
     MAP_ROWS.forEach((row) => {
       expect(row.rightLabelLines.length).toBeGreaterThanOrEqual(1);
       expect(row.rightLabelLines.length).toBeLessThanOrEqual(2);
-      row.rightLabelLines.forEach((line) => {
-        expect(line.length).toBeLessThanOrEqual(MAX_RIGHT_LABEL_LINE_LENGTH);
-      });
+      if (row.rightLabelLines.length === 2) {
+        row.rightLabelLines.forEach((line) => {
+          expect(line.length).toBeLessThanOrEqual(MAX_RIGHT_LABEL_LINE_LENGTH);
+        });
+      }
     });
   });
 
@@ -105,8 +114,10 @@ describe('mapLayout', () => {
     });
   });
 
-  it('hyphenates Understanding as Under- / standing', () => {
-    expect(findRowByLabel('Understanding').rightLabelLines).toEqual(['Under-', 'standing']);
+  it('keeps Understanding as a single un-hyphenated fallback line (fitRightLabel shrinks it to fit)', () => {
+    const lines = findRowByLabel('Understanding').rightLabelLines;
+    expect(lines).toEqual(['Understanding']);
+    lines.forEach((line) => expect(line).not.toContain('-'));
   });
 
   it('hyphenates Yes-And-Ness as Yes-And- / Ness', () => {
@@ -186,6 +197,63 @@ describe('fittedTitleFontSize', () => {
         expect(estimatedWidth(title, size)).toBeLessThanOrEqual(NARROW_CELL);
       }
     }
+  });
+});
+
+describe('fitRightLabel', () => {
+  const UNDERSTANDING_FALLBACK = ['Under-', 'standing'] as const;
+  const YES_AND_NESS_FALLBACK = ['Yes-And-', 'Ness'] as const;
+  const WIDE_CELL = 180;
+  const NARROW_PHONE_CELL = 56;
+
+  // Same conservative advance-width idiom fittedTitleFontSize's own tests use,
+  // scoped to the right label's own glyph budget.
+  const estimatedLineWidth = (line: string, fontSize: number): number =>
+    line.length * fontSize * RIGHT_LABEL_GLYPH_EM_WIDTH;
+
+  it('renders the full label on one un-hyphenated line at the ceiling before layout reports a width', () => {
+    const result = fitRightLabel('Understanding', UNDERSTANDING_FALLBACK, 0);
+    expect(result).toEqual({ lines: ['Understanding'], fontSize: RIGHT_LABEL_MAX_FONT_SIZE });
+  });
+
+  it('keeps Understanding on one line at the ceiling size in a wide cell', () => {
+    const result = fitRightLabel('Understanding', UNDERSTANDING_FALLBACK, WIDE_CELL);
+    expect(result).toEqual({ lines: ['Understanding'], fontSize: RIGHT_LABEL_MAX_FONT_SIZE });
+  });
+
+  it('keeps every returned line within the measured cell width whenever the size shrinks below the ceiling', () => {
+    for (const width of [40, 56, 70, 90, 120, 150]) {
+      const result = fitRightLabel('Understanding', UNDERSTANDING_FALLBACK, width);
+      if (result.fontSize > RIGHT_LABEL_MIN_FONT_SIZE) {
+        result.lines.forEach((line) => {
+          expect(estimatedLineWidth(line, result.fontSize)).toBeLessThanOrEqual(width);
+        });
+      }
+    }
+  });
+
+  it('clamps fontSize to the configured floor and ceiling for every width, including non-positive ones', () => {
+    for (const width of [-10, 0, 20, 56, 90, 180, 500]) {
+      const result = fitRightLabel('Understanding', UNDERSTANDING_FALLBACK, width);
+      expect(result.fontSize).toBeGreaterThanOrEqual(RIGHT_LABEL_MIN_FONT_SIZE);
+      expect(result.fontSize).toBeLessThanOrEqual(RIGHT_LABEL_MAX_FONT_SIZE);
+    }
+  });
+
+  it('shrinks Awareness to fit a narrow phone cell on one line without splitting the word', () => {
+    const result = fitRightLabel('Awareness', ['Awareness'], NARROW_PHONE_CELL);
+    expect(result.lines).toEqual(['Awareness']);
+    expect(result.fontSize).toBeGreaterThanOrEqual(RIGHT_LABEL_MIN_FONT_SIZE);
+    expect(result.fontSize).toBeLessThan(RIGHT_LABEL_MAX_FONT_SIZE);
+  });
+
+  it('falls back to the pre-hyphenated Yes-And-Ness lines instead of inserting a new hyphen', () => {
+    const NARROW_WIDTH = 40;
+    const result = fitRightLabel('Yes-And-Ness', YES_AND_NESS_FALLBACK, NARROW_WIDTH);
+    expect(result.lines).toEqual(['Yes-And-', 'Ness']);
+    // Exactly the label's own two hyphens survive — none inserted elsewhere.
+    const hyphenCount = (result.lines.join('').match(/-/g) ?? []).length;
+    expect(hyphenCount).toBe(2);
   });
 });
 

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -88,6 +88,61 @@ export const fittedTitleFontSize = (title: string, width: number): number => {
   return Math.max(TITLE_MIN_FONT_SIZE, Math.min(TITLE_MAX_FONT_SIZE, fitted));
 };
 
+/** Ceiling for a right-column aspect label — the legacy fixed size (15px). */
+export const RIGHT_LABEL_MAX_FONT_SIZE = 15;
+
+/** Floor below which an aspect label would stop reading as a label. */
+export const RIGHT_LABEL_MIN_FONT_SIZE = 9;
+
+/**
+ * Conservative average advance width of a mixed-case serif glyph, in ems.
+ * Deliberately generous (err toward smaller) so the single-line fit only ever
+ * settles on a guaranteed-fitting size for the lowercase-heavy aspect words.
+ */
+export const RIGHT_LABEL_GLYPH_EM_WIDTH = 0.62;
+
+/** Line-height multiple the aspect label renders at — the legacy 19/15 rhythm. */
+export const RIGHT_LABEL_LINE_HEIGHT_RATIO = 19 / RIGHT_LABEL_MAX_FONT_SIZE;
+
+/** Largest size (<= ceiling) at which ``line`` fits ``width`` on one line. */
+const fittedLabelLineFontSize = (line: string, width: number): number => {
+  if (width <= 0 || line.length === 0) return RIGHT_LABEL_MAX_FONT_SIZE;
+  const fitted = Math.floor(width / (line.length * RIGHT_LABEL_GLYPH_EM_WIDTH));
+  return Math.max(RIGHT_LABEL_MIN_FONT_SIZE, Math.min(RIGHT_LABEL_MAX_FONT_SIZE, fitted));
+};
+
+/** Whether ``line`` at ``fontSize`` fits within ``width`` by the em estimate. */
+const labelLineFits = (line: string, fontSize: number, width: number): boolean =>
+  line.length * fontSize * RIGHT_LABEL_GLYPH_EM_WIDTH <= width;
+
+/**
+ * Fits a right-column aspect label to its measured cell width, mirroring the
+ * ``fittedTitleFontSize`` idiom. The label is preferred on a single
+ * un-hyphenated line, shrinking from the ceiling toward the floor until it fits;
+ * only when even the floor size overflows does it fall back to the row's
+ * pre-hyphenated ``fallbackLines`` (each fitted to the same cell). An unmeasured
+ * width (<= 0) renders the full label at the ceiling until layout reports.
+ */
+export const fitRightLabel = (
+  label: string,
+  fallbackLines: readonly string[],
+  width: number,
+): { lines: string[]; fontSize: number } => {
+  if (width <= 0) return { lines: [label], fontSize: RIGHT_LABEL_MAX_FONT_SIZE };
+
+  const singleFontSize = fittedLabelLineFontSize(label, width);
+  if (labelLineFits(label, singleFontSize, width)) {
+    return { lines: [label], fontSize: singleFontSize };
+  }
+
+  // Even at the floor the single word overflows — use the pre-hyphenated lines,
+  // sized to the largest font at which the longest of them still fits.
+  const fallbackFontSize = Math.min(
+    ...fallbackLines.map((line) => fittedLabelLineFontSize(line, width)),
+  );
+  return { lines: [...fallbackLines], fontSize: fallbackFontSize };
+};
+
 /**
  * The title line each top stage carries in its own grid row (no absolute
  * overlay): stage 10 reads EMPTINESS, stage 9 reads UNITY. Stages 1–8 have none.
@@ -204,7 +259,7 @@ export const MAP_ROWS: readonly MapRow[] = [
   { rightLabel: 'Awareness', rightLabelLines: ['Awareness'], stageNumbers: [10] },
   { rightLabel: 'Being', rightLabelLines: ['Being'], stageNumbers: [9] },
   { rightLabel: 'Wisdom', rightLabelLines: ['Wisdom'], stageNumbers: [8, 7] },
-  { rightLabel: 'Understanding', rightLabelLines: ['Under-', 'standing'], stageNumbers: [6, 5] },
+  { rightLabel: 'Understanding', rightLabelLines: ['Understanding'], stageNumbers: [6, 5] },
   { rightLabel: 'Love', rightLabelLines: ['Love'], stageNumbers: [4, 3] },
   { rightLabel: 'Yes-And-Ness', rightLabelLines: ['Yes-And-', 'Ness'], stageNumbers: [2, 1] },
 ];

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -37,6 +37,7 @@ import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse } from '@/api';
 import { EmptyState } from '@/components/feedback/EmptyState';
+import { ContentContainer } from '@/components/layout/ContentContainer';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
 import { useAuth } from '@/context/AuthContext';
 import {
@@ -117,18 +118,20 @@ const PracticeScreen = (): React.JSX.Element => {
   }
   if (active.activeUserPractice && active.practice && active.effectiveConfig) {
     return (
-      <ActiveSessionView
-        userPractice={active.activeUserPractice}
-        practiceName={active.practice.name}
-        effectiveName={active.effectiveName}
-        effectiveConfig={active.effectiveConfig}
-        userTimezone={userTimezone}
-        weekly={weekly}
-        onUserPracticeUpdated={active.updateActivePractice}
-        onWriteReflection={handleWriteReflection}
-        banner={banner}
-        stageNumber={stageNumber}
-      />
+      <ContentContainer>
+        <ActiveSessionView
+          userPractice={active.activeUserPractice}
+          practiceName={active.practice.name}
+          effectiveName={active.effectiveName}
+          effectiveConfig={active.effectiveConfig}
+          userTimezone={userTimezone}
+          weekly={weekly}
+          onUserPracticeUpdated={active.updateActivePractice}
+          onWriteReflection={handleWriteReflection}
+          banner={banner}
+          stageNumber={stageNumber}
+        />
+      </ContentContainer>
     );
   }
 
@@ -215,8 +218,8 @@ const ActiveSessionView = ({
   const insets = useSafeAreaInsets();
   return (
     // paddingTop lives on the wrapper so the ScrollView's *viewport* starts
-    // below the notch (content can't scroll up behind it); paddingBottom rides
-    // contentContainerStyle so the scroll content clears the home indicator.
+    // below the notch (content can't scroll up behind it); paddingBottom
+    // rides contentContainerStyle so the scroll content clears the home indicator.
     <View style={[styles.screen, { paddingTop: insets.top }]} testID="practice-screen-safe-area">
       <ScrollView
         style={styles.fill}
@@ -260,20 +263,22 @@ interface EmptyStateViewProps {
 const EmptyStateView = ({ stageNumber }: EmptyStateViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
-    <EmptyState
-      glyph="🧘"
-      title="No practice yet"
-      body="No practice set for this stage yet."
-      cta={
-        <CatalogButton
-          stageNumber={stageNumber}
-          label="Browse practices"
-          testID="browse-catalog-button"
-        />
-      }
-      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
-      testID="practice-empty-state"
-    />
+    <ContentContainer>
+      <EmptyState
+        glyph="🧘"
+        title="No practice yet"
+        body="No practice set for this stage yet."
+        cta={
+          <CatalogButton
+            stageNumber={stageNumber}
+            label="Browse practices"
+            testID="browse-catalog-button"
+          />
+        }
+        style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+        testID="practice-empty-state"
+      />
+    </ContentContainer>
   );
 };
 

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -157,7 +157,7 @@ jest.mock('expo-haptics', () => ({
 }));
 
 // eslint-disable-next-line import/order
-const { render, waitFor, fireEvent, act } = require('@testing-library/react-native');
+const { render, waitFor, fireEvent, act, within } = require('@testing-library/react-native');
 const PracticeScreen = require('../PracticeScreen').default;
 
 interface ModeFixture {
@@ -752,5 +752,22 @@ describe('PracticeScreen', () => {
       expect(getByText(/9 of \d+/)).toBeTruthy();
     });
     expect(mockWeekCount).toHaveBeenCalled();
+  });
+
+  it('wraps the empty state in the shared content-capped container', async () => {
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    const container = getByTestId('content-container');
+    expect(within(container).getByTestId('practice-empty-state')).toBeTruthy();
+  });
+
+  it('wraps the active session view in the shared content-capped container', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+
+    const container = getByTestId('content-container');
+    expect(within(container).getByTestId('practice-screen')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Add a single shared `contentLayout.maxWidth` token (derived from the Journal sheet's `pageMaxWidth + marginColumnWidth`) and a reusable `ContentContainer`; adopt it on Today/Journal, Habits, Practice, Course, Map, and Settings so content is centered and capped on wide viewports while still filling phone-width screens. `useResponsive` gains `contentWidth` so `useTileLayout` sizes off the capped width.
- Map "Understanding" no longer forces a hardcoded hyphen: a new pure `fitRightLabel` measures the real column width and keeps the label on one line when it fits, mirroring the existing `fittedTitleFontSize` idiom; `MAP_ROWS` drops the pre-hyphenated `['Under-','standing']` literal.
- Map "Awareness" Android mid-word break fixed via a fitted single-line label plus unconditional `android_hyphenationFrequency="none"` + `textBreakStrategy="simple"` props (ignored on iOS/web); `Map.styles` drops the hardcoded label font size/line-height in favor of the fitted values.
- `ContentContainer` uses `flexGrow` (not `flex: 1`) so it fills definite-height parents but collapses to content height inside a ScrollView's content container (a plain `flex: 1` there resolves to zero height on native).

## Test plan
- `./scripts/frontend/check-all.sh` green (ESLint zero-warning, Prettier, `tsc --noEmit` strict, Jest 3583 tests, coverage thresholds unchanged).
- New/updated tests: `contentLayout` token invariant; `ContentContainer` style/merge/testID; `useResponsive.contentWidth` clamp; `ScreenScaffold` caps in both scroll and non-scroll modes; Habits/Practice/Course/Map content-container adoption; `HabitTile` sizing off `contentWidth`; `fitRightLabel` unit spec (width<=0, fits-at-max, shrink, fallback); Map label renders "Understanding" on one line with no hyphen and "Awareness" single fitted line with the hyphenation props.
- Journal's own writing-sheet width is untouched (reused only as the reference value).

Closes #1409
