### PR TITLE
refactor(map): remove test-only geometry outputs pole and contentOffset

### DIFF
--- a/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
@@ -3,7 +3,6 @@
 
 import {
   clampLensCenter,
-  contentOffset,
   DRAG_TAP_SLOP,
   glideDurationMs,
   inertialStageTarget,
@@ -141,7 +140,7 @@ describe('inertialStageTarget', () => {
   });
 });
 
-describe('magnifierTransform + contentOffset', () => {
+describe('magnifierTransform', () => {
   it('maps the lens-center grid point onto the pill center for any center', () => {
     const frame = lensFrame(GRID_WIDTH, GRID_HEIGHT);
     const transform = magnifierTransform(frame, GRID_WIDTH, GRID_HEIGHT);
@@ -151,7 +150,8 @@ describe('magnifierTransform + contentOffset', () => {
       { x: 240, y: 300 },
     ];
     for (const center of centers) {
-      const { tx, ty } = contentOffset(center, transform);
+      const tx = transform.kx - MAGNIFICATION * center.x;
+      const ty = transform.ky - MAGNIFICATION * center.y;
       // RN scales about the content's own midpoint, then translates.
       const contentMidX = GRID_WIDTH / 2;
       const contentMidY = GRID_HEIGHT / 2;

--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -183,17 +183,6 @@ describe('stageWavePoint', () => {
       expect(y).toBeLessThanOrEqual(UNIT_MAX);
     }
   });
-
-  it('reports pole -1 for even stages and +1 for odd stages, 1-8', () => {
-    for (let stage = 1; stage <= 8; stage += 1) {
-      const expected = isLeftReturning(stage) ? -1 : 1;
-      expect(stageWavePoint(stage).pole).toBe(expected);
-    }
-  });
-
-  it('reports pole 0 at the converged top, stage 10', () => {
-    expect(stageWavePoint(10).pole).toBe(0);
-  });
 });
 
 describe('waveSegments', () => {

--- a/frontend/src/features/Map/magnifierGeometry.ts
+++ b/frontend/src/features/Map/magnifierGeometry.ts
@@ -172,15 +172,6 @@ export const magnifierTransform = (
   magnification: MAGNIFICATION,
 });
 
-/** The magnified content's translation for a given lens center. */
-export const contentOffset = (
-  center: LensCenter,
-  transform: MagnifierTransform,
-): { tx: number; ty: number } => ({
-  tx: transform.kx - transform.magnification * center.x,
-  ty: transform.ky - transform.magnification * center.y,
-});
-
 /**
  * Glide duration scaled to travel distance, clamped so short hops still read
  * as motion and long journeys still settle promptly. Pairs with an

--- a/frontend/src/features/Map/waveGeometry.ts
+++ b/frontend/src/features/Map/waveGeometry.ts
@@ -58,10 +58,9 @@ const WAVE_AMPLITUDE = 0.32;
  */
 const APEX_AMPLITUDE = 0.02;
 
-/** Pole encoding: even stages return left, odd stages point right, apex neutral. */
+/** Horizontal direction multipliers: even stages return left, odd stages point right. */
 const POLE_LEFT = -1;
 const POLE_RIGHT = 1;
-const POLE_NEUTRAL = 0;
 
 /** Half-width of the arrowhead triangle base, in pixels. */
 const ARROWHEAD_HALF_WIDTH = 6;
@@ -95,14 +94,12 @@ const STAGE_COLORS: readonly StageColor[] = Object.entries(STAGE_DISPLAY)
   }))
   .sort((a, b) => a.stageNumber - b.stageNumber);
 
-/** A single stage's anchor point on the wave, plus which pole it swings to. */
+/** A single stage's anchor point on the wave. */
 export interface WavePoint {
   /** Horizontal position in unit space [0,1]. */
   x: number;
   /** Vertical position in unit space [0,1]; smaller means higher up. */
   y: number;
-  /** -1 left pole (even), +1 right pole (odd), 0 at the converged apex. */
-  pole: -1 | 0 | 1;
 }
 
 /**
@@ -113,12 +110,6 @@ export interface WavePoint {
 const amplitudeFor = (stageNumber: number): number =>
   APEX_AMPLITUDE +
   ((WAVE_AMPLITUDE - APEX_AMPLITUDE) * (STAGE_COUNT - stageNumber)) / (STAGE_COUNT - 1);
-
-/** The pole a stage swings toward: left for even, right for odd, neutral at apex. */
-const poleFor = (stageNumber: number): -1 | 0 | 1 => {
-  if (stageNumber === STAGE_COUNT) return POLE_NEUTRAL;
-  return isLeftReturning(stageNumber) ? POLE_LEFT : POLE_RIGHT;
-};
 
 /**
  * Measured vertical centers keyed by stage number, in unit space [0,1]. May be
@@ -161,15 +152,15 @@ const resolveAnchorY = (stageNumber: number, anchors: StageAnchors): number =>
  * the stage's amplitude toward its pole, tapering smoothly toward center at the
  * top.
  *
- * The apex (stage 10) reports a neutral pole but its x still uses the left/right
- * rule, so it lands a hair off dead-center (by APEX_AMPLITUDE) rather than
- * degenerating into a vertical stub. This apparent mismatch is deliberate.
+ * The apex (stage 10) still uses the left/right rule, so it lands a hair
+ * off dead-center (by APEX_AMPLITUDE) rather than degenerating into a vertical
+ * stub. This is deliberate.
  */
 export const stageWavePoint = (stageNumber: number, anchors: StageAnchors = {}): WavePoint => {
   const y = resolveAnchorY(stageNumber, anchors);
   const direction = isLeftReturning(stageNumber) ? POLE_LEFT : POLE_RIGHT;
   const x = CENTER_X + amplitudeFor(stageNumber) * direction;
-  return { x, y, pole: poleFor(stageNumber) };
+  return { x, y };
 };
 
 /** Which centerline-split piece of a stage pair's cubic a segment carries. */


### PR DESCRIPTION
## Summary

De-slop cleanup (Family 3 Dispensables + Family 9 testing slop): removes two
Map geometry outputs that no production path consumed — only their unit tests
read them, making those assertions coverage theater.

- `WavePoint.pole` field, the `poleFor` helper, and `POLE_NEUTRAL`
  (`waveGeometry.ts`). The left/right polarity the app actually draws comes
  from the `x` position (the `POLE_LEFT`/`POLE_RIGHT` direction term, which
  stay). `pole` was a vestigial second encoding of a decision `x` already made.
- `contentOffset` (`magnifierGeometry.ts`). The shipping magnifier already
  recomputes the identical `tx`/`ty` formula inline in `MagnifierLens`, so the
  pure export was a spec-mirror the app never called.

No rendered output changes. `POLE_LEFT`/`POLE_RIGHT` and the `magnification`
field are intentionally kept (both are live).

## Test plan

- Dropped the two `.pole` assertions in `waveGeometry.test.ts`.
- Rewrote the `magnifierTransform` test (renamed from `magnifierTransform +
  contentOffset`) to inline the production translation formula, so it still
  covers the live `kx`/`ky` derivation without asserting a deleted symbol.
- `./scripts/frontend/check-all.sh` green: 336 suites / 3581 tests pass, ESLint
  / prettier / tsc clean. Coverage flat (every deleted test line covered a
  now-deleted symbol).
- Verified `grep -rn "\.pole\b|poleFor|POLE_NEUTRAL" src` and
  `grep -rn "contentOffset" src/features/Map` return no hits.

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)