### PR TITLE
test(backend): pin rate-limit boundaries at exactly N requests

### DIFF
--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -5,20 +5,38 @@ Verifies that:
 - Expensive endpoints have stricter per-endpoint limits
 - 429 responses include a Retry-After header
 - Existing auth rate limits remain unchanged
+
+Every limit is pinned at its exact value: each test proves the limit-th
+request is admitted *and* the (limit + 1)-th request is rejected, so a
+mutation that tightens a limit (e.g. 5/minute -> 2/minute) fails the test
+instead of slipping through unnoticed.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from models.user import User
-from rate_limit import DEFAULT_RATE_LIMIT
+
+_LIMIT_3 = 3
+_LIMIT_5 = 5
+_LIMIT_30 = 30
+_LIMIT_60 = 60
+
+_PRACTICE_PAYLOAD: dict[str, object] = {
+    "stage_number": 1,
+    "name": "Test Practice",
+    "description": "Test desc",
+    "instructions": "Test instructions",
+    "default_duration_minutes": 10,
+}
 
 
 async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
@@ -42,12 +60,52 @@ async def _promote_admin(db_session: AsyncSession, username: str = "alice") -> N
     await db_session.commit()
 
 
-# ── Configuration ────────────────────────────────────────────────────────
+async def _assert_limit_pinned(send: Callable[[], Awaitable[Response]], limit: int) -> None:
+    """Assert a rate limit is pinned at exactly ``limit`` requests per window.
+
+    Fires ``limit - 1`` warm-up requests, asserts the ``limit``-th request is
+    admitted (any non-429 status), then asserts request ``limit + 1`` is
+    rejected with the standard 429 payload and a Retry-After header.
+    """
+    for _ in range(limit - 1):
+        await send()
+
+    admitted = await send()
+    assert admitted.status_code != HTTPStatus.TOO_MANY_REQUESTS
+
+    throttled = await send()
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == "rate_limit_exceeded"
+    assert "retry-after" in throttled.headers
 
 
-def test_default_rate_limit_constant() -> None:
-    """The DEFAULT_RATE_LIMIT constant is set to 60 requests per minute."""
-    assert DEFAULT_RATE_LIMIT == "60/minute"
+def _post_practice(client: AsyncClient, headers: dict[str, str]) -> Awaitable[Response]:
+    return client.post("/practices/", json=_PRACTICE_PAYLOAD, headers=headers)
+
+
+def _get_journal_list(client: AsyncClient, headers: dict[str, str]) -> Awaitable[Response]:
+    return client.get("/journal/", headers=headers)
+
+
+def _get_content_body(client: AsyncClient, headers: dict[str, str]) -> Awaitable[Response]:
+    return client.get("/course/content/1/body", headers=headers)
+
+
+def _get_site_resource_body(client: AsyncClient, headers: dict[str, str]) -> Awaitable[Response]:
+    return client.get("/course/site-resources/about/body", headers=headers)
+
+
+# ── Default global limit ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_rate_limit_pinned_at_60_per_minute(async_client: AsyncClient) -> None:
+    """A route with no ``@limiter.limit()`` override inherits the 60/minute default."""
+
+    async def send() -> Response:
+        return await async_client.get("/health")
+
+    await _assert_limit_pinned(send, _LIMIT_60)
 
 
 # ── Retry-After header ──────────────────────────────────────────────────
@@ -55,147 +113,77 @@ def test_default_rate_limit_constant() -> None:
 
 @pytest.mark.asyncio
 async def test_rate_limit_response_includes_retry_after(async_client: AsyncClient) -> None:
-    """429 responses include a Retry-After header."""
-    # Use signup endpoint (3/minute) to trigger rate limit quickly
-    for i in range(3):
-        await async_client.post(
+    """429 responses include a Retry-After header, pinned at signup's 3/minute limit."""
+    emails = iter(range(_LIMIT_3 + 1))
+
+    async def send() -> Response:
+        return await async_client.post(
             "/auth/signup",
             json={
-                "email": f"ratelimit{i}@example.com",
+                "email": f"retryafter{next(emails)}@example.com",
                 "password": "secret12345",  # pragma: allowlist secret
             },
         )
 
-    # 4th request exceeds the limit
-    resp = await async_client.post(
-        "/auth/signup",
-        json={
-            "email": "ratelimit99@example.com",
-            "password": "secret12345",  # pragma: allowlist secret
-        },
-    )
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
+    await _assert_limit_pinned(send, _LIMIT_3)
 
 
 # ── Per-endpoint: POST /user/balance/add (5/minute) ─────────────────────
 
 
 @pytest.mark.asyncio
-async def test_add_balance_rate_limit_returns_429(
+async def test_add_balance_rate_limit_pinned_at_5_per_minute(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """POST /user/balance/add returns 429 after exceeding 5 requests/minute."""
+    """POST /user/balance/add is pinned at exactly 5 requests/minute.
+
+    The endpoint is admin-only, so promote before hammering to verify the
+    rate-limit gate fires *after* authz.
+    """
     headers = await _signup(async_client)
-    # Endpoint is admin-only, so promote before hammering to verify the
-    # rate-limit gate fires *after* authz.
     await _promote_admin(db_session)
 
-    # Make 5 requests (the limit)
-    for _ in range(5):
-        await async_client.post(
+    async def send() -> Response:
+        return await async_client.post(
             "/user/balance/add",
             json={"amount": 1},
             headers=headers,
         )
 
-    # 6th request should be rate-limited
-    resp = await async_client.post(
-        "/user/balance/add",
-        json={"amount": 1},
-        headers=headers,
-    )
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
+    await _assert_limit_pinned(send, _LIMIT_5)
 
 
-# ── Per-endpoint: POST /practices/ (5/minute) ───────────────────────────
+# ── Per-endpoint limits pinned exactly ───────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_submit_practice_rate_limit_returns_429(async_client: AsyncClient) -> None:
-    """POST /practices/ returns 429 after exceeding 5 requests/minute."""
+@pytest.mark.parametrize(
+    ("make_request", "limit"),
+    [
+        (_post_practice, _LIMIT_5),
+        (_get_journal_list, _LIMIT_30),
+        (_get_content_body, _LIMIT_30),
+        (_get_site_resource_body, _LIMIT_30),
+    ],
+    ids=[
+        "post-practices-pinned-at-5-per-minute",
+        "get-journal-list-pinned-at-30-per-minute",
+        "get-content-body-pinned-at-30-per-minute",
+        "get-site-resource-body-pinned-at-30-per-minute",
+    ],
+)
+async def test_per_endpoint_rate_limit_pinned(
+    async_client: AsyncClient,
+    make_request: Callable[[AsyncClient, dict[str, str]], Awaitable[Response]],
+    limit: int,
+) -> None:
+    """Each per-route limit is pinned at exactly its documented value."""
     headers = await _signup(async_client)
 
-    practice_payload = {
-        "stage_number": 1,
-        "name": "Test Practice",
-        "description": "Test desc",
-        "instructions": "Test instructions",
-        "default_duration_minutes": 10,
-    }
+    async def send() -> Response:
+        return await make_request(async_client, headers)
 
-    # Make 5 requests (the limit)
-    for _ in range(5):
-        await async_client.post("/practices/", json=practice_payload, headers=headers)
-
-    # 6th request should be rate-limited
-    resp = await async_client.post("/practices/", json=practice_payload, headers=headers)
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
-
-
-# ── Per-endpoint: GET /journal/ (30/minute) ──────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_journal_list_rate_limit_returns_429(async_client: AsyncClient) -> None:
-    """GET /journal/ returns 429 after exceeding 30 requests/minute."""
-    headers = await _signup(async_client)
-
-    # Make 30 requests (the limit)
-    for _ in range(30):
-        await async_client.get("/journal/", headers=headers)
-
-    # 31st request should be rate-limited
-    resp = await async_client.get("/journal/", headers=headers)
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
-
-
-# ── Per-endpoint: GET /course/content/{id}/body (30/minute) ─────────────
-
-
-@pytest.mark.asyncio
-async def test_content_body_rate_limit_returns_429(async_client: AsyncClient) -> None:
-    """GET /course/content/{id}/body returns 429 after 30 requests/minute.
-
-    The endpoint reads local content now, but the cap stays as
-    defense-in-depth.  The handler returns 404 here (no seeded content)
-    but the limit fires before the handler on request 31, regardless of
-    response code.
-    """
-    headers = await _signup(async_client)
-
-    for _ in range(30):
-        await async_client.get("/course/content/1/body", headers=headers)
-
-    resp = await async_client.get("/course/content/1/body", headers=headers)
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
-
-
-# ── Per-endpoint: GET /course/site-resources/{slug}/body (30/minute) ────
-
-
-@pytest.mark.asyncio
-async def test_site_resource_body_rate_limit_returns_429(async_client: AsyncClient) -> None:
-    """GET /course/site-resources/{slug}/body returns 429 after 30 requests/minute."""
-    headers = await _signup(async_client)
-    slug = "about"  # any slug works — the limiter fires before the handler
-
-    for _ in range(30):
-        await async_client.get(f"/course/site-resources/{slug}/body", headers=headers)
-
-    resp = await async_client.get(f"/course/site-resources/{slug}/body", headers=headers)
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
-    assert resp.json()["detail"] == "rate_limit_exceeded"
-    assert "retry-after" in resp.headers
+    await _assert_limit_pinned(send, limit)
 
 
 # ── Auth rate limits unchanged ───────────────────────────────────────────
@@ -204,7 +192,7 @@ async def test_site_resource_body_rate_limit_returns_429(async_client: AsyncClie
 @pytest.mark.asyncio
 async def test_auth_signup_limit_unchanged_at_3_per_minute(async_client: AsyncClient) -> None:
     """Auth signup rate limit remains at 3/minute (not overridden by default)."""
-    for i in range(3):
+    for i in range(_LIMIT_3 - 1):
         await async_client.post(
             "/auth/signup",
             json={
@@ -213,14 +201,23 @@ async def test_auth_signup_limit_unchanged_at_3_per_minute(async_client: AsyncCl
             },
         )
 
-    resp = await async_client.post(
+    third = await async_client.post(
         "/auth/signup",
         json={
-            "email": "auth99@example.com",
+            "email": "auth-third@example.com",
             "password": "secret12345",  # pragma: allowlist secret
         },
     )
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert third.status_code == HTTPStatus.OK
+
+    fourth = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "auth-fourth@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert fourth.status_code == HTTPStatus.TOO_MANY_REQUESTS
 
 
 @pytest.mark.asyncio
@@ -228,20 +225,16 @@ async def test_auth_login_limit_unchanged_at_5_per_minute(async_client: AsyncCli
     """Auth login rate limit remains at 5/minute (not overridden by default)."""
     await _signup(async_client)
 
-    for _ in range(5):
-        await async_client.post(
-            "/auth/login",
-            json={
-                "email": "alice@example.com",
-                "password": "secret12345",  # pragma: allowlist secret
-            },
-        )
+    login_payload = {
+        "email": "alice@example.com",
+        "password": "secret12345",  # pragma: allowlist secret
+    }
 
-    resp = await async_client.post(
-        "/auth/login",
-        json={
-            "email": "alice@example.com",
-            "password": "secret12345",  # pragma: allowlist secret
-        },
-    )
-    assert resp.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    for _ in range(_LIMIT_5 - 1):
+        await async_client.post("/auth/login", json=login_payload)
+
+    fifth = await async_client.post("/auth/login", json=login_payload)
+    assert fifth.status_code == HTTPStatus.OK
+
+    sixth = await async_client.post("/auth/login", json=login_payload)
+    assert sixth.status_code == HTTPStatus.TOO_MANY_REQUESTS


### PR DESCRIPTION
## Summary
- Harden every rate-limit test in `backend/tests/test_rate_limits.py` to pin each limit at **exactly N**: fire `N-1` warm-ups, assert the `N`th request is admitted (non-429), then assert the `N+1`th is 429 with `detail == "rate_limit_exceeded"` and a `Retry-After` header. Previously the tests only proved the limit was `<= N`, so a mutation *tightening* any limit slipped through green.
- Extract a shared `_assert_limit_pinned` helper, parametrize the four homogeneous per-endpoint tests, and harden the two auth `unchanged_at_*` tests to assert the `N`th request returns `HTTPStatus.OK` (so the "unchanged at N" contract the name promises is actually verified).
- Replace the string-equality `test_default_rate_limit_constant` (coverage theater) with a behavioral test that drives `GET /health` past the 60/minute default, exercising the real default-inheritance path.

This is a test-only de-slop change — no production code or rate limits are modified.

## Test plan
- `./scripts/backend/check-all.sh` green: ruff format + lint, mypy strict, bandit, pip-audit all pass.
- Full backend suite: **2405 passed, 2 skipped**, line coverage **96.67%** (>= 90%).
- Complexity: `xenon src/ --max-absolute A --max-modules A --max-average A` exit 0; `radon mi tests/test_rate_limits.py` grade A.
- Mutation check (per acceptance criteria): tightening `journal.py` `30/minute -> 5/minute` makes the parametrized journal test **fail**; reverting restores green — confirming the new assertions catch a tightened limit.
- Gate 2.5 code-review-orchestrator self-review: **CLEAN** (no blocking findings).

Closes #1382
