### PR TITLE
refactor(course): extract shared deriveCurrentStage into a feature-neutral domain module

### DIFF
--- a/frontend/src/domain/__tests__/stageProgression.test.ts
+++ b/frontend/src/domain/__tests__/stageProgression.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { Stage } from '../../api';
+import { deriveCurrentStage, STAGE_COUNT } from '../stageProgression';
+
+/** Build a minimal fake API Stage response; only progress varies per case. */
+function makeStage(stageNumber: number, progress: number): Stage {
+  return {
+    id: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    stage_number: stageNumber,
+    overview_url: '',
+    category: 'Test',
+    aspect: 'Aspect',
+    spiral_dynamics_color: 'Beige',
+    growing_up_stage: 'Growing',
+    divine_gender_polarity: 'Polarity',
+    relationship_to_free_will: 'Free Will',
+    free_will_description: 'Desc',
+    is_unlocked: true,
+    progress,
+  };
+}
+
+describe('deriveCurrentStage', () => {
+  it('returns 1 for an empty stage list', () => {
+    expect(deriveCurrentStage([])).toBe(1);
+  });
+
+  it('returns 1 when no stage is complete', () => {
+    const stages = [makeStage(1, 0.5), makeStage(2, 0.2)];
+    expect(deriveCurrentStage(stages)).toBe(1);
+  });
+
+  it('returns completed + 1 when some stages are complete', () => {
+    const stages = [
+      makeStage(1, 1),
+      makeStage(2, 1),
+      makeStage(3, 1),
+      makeStage(4, 0.4),
+      makeStage(5, 0),
+    ];
+    expect(deriveCurrentStage(stages)).toBe(4);
+  });
+
+  it('counts a stage with progress exactly 1 as complete', () => {
+    const stages = [makeStage(1, 1), makeStage(2, 0.9)];
+    expect(deriveCurrentStage(stages)).toBe(2);
+  });
+
+  it('counts a stage with progress above 1 as complete', () => {
+    const stages = [makeStage(1, 1.5), makeStage(2, 0)];
+    expect(deriveCurrentStage(stages)).toBe(2);
+  });
+
+  it('clamps to STAGE_COUNT when every stage is complete', () => {
+    const stages = Array.from({ length: 10 }, (_unused, index) => makeStage(index + 1, 1));
+    expect(deriveCurrentStage(stages)).toBe(STAGE_COUNT);
+  });
+
+  it('returns STAGE_COUNT when just one stage below the cap is complete', () => {
+    const stages = Array.from({ length: 10 }, (_unused, index) =>
+      makeStage(index + 1, index < 9 ? 1 : 0),
+    );
+    expect(deriveCurrentStage(stages)).toBe(STAGE_COUNT);
+  });
+});

--- a/frontend/src/domain/stageProgression.ts
+++ b/frontend/src/domain/stageProgression.ts
@@ -1,0 +1,23 @@
+import type { Stage } from '../api';
+
+/** Total number of APTITUDE stages. */
+export const STAGE_COUNT = 10;
+
+export const FULLY_COMPLETE = 1;
+
+/**
+ * Count-based current-stage derivation.
+ *
+ * Mirrors the backend's `next_stage_for(user)` under the chain-validation
+ * invariant: `current = completed + 1`.  A fresh user with nothing completed
+ * gets stage 1; each completed stage advances `current` by one, clamped to
+ * the catalog range.  This replaces the old "first unlocked, still-in-
+ * progress" heuristic which silently drifted to `max(stage_number)` over
+ * unlocked rows when the backend's `is_unlocked` flag was ahead of
+ * completion.
+ */
+export const deriveCurrentStage = (apiStages: Stage[]): number => {
+  if (apiStages.length === 0) return 1;
+  const completed = apiStages.filter((s) => s.progress >= FULLY_COMPLETE).length;
+  return Math.min(Math.max(1, completed + 1), STAGE_COUNT);
+};

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -19,10 +19,10 @@ import { EditorialSection } from '../../components/layout/EditorialSection';
 import { ScreenHeader } from '../../components/layout/ScreenHeader';
 import { ShowcaseCard } from '../../components/layout/ShowcaseCard';
 import { resolveStageColor } from '../../design/tokens';
+import { deriveCurrentStage } from '../../domain/stageProgression';
 import { useAppRoute } from '../../navigation/hooks';
 import type { RootStackParamList } from '../../navigation/RootStack';
 import { useProgramStore, programStage } from '../../store/useProgramStore';
-import { deriveCurrentStage } from '../Map/services/stageService';
 
 import ChapterReader from './ChapterReader';
 import ContentCard from './ContentCard';

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -10,6 +10,7 @@
 import { stages as stagesApi } from '../../../api';
 import type { Stage } from '../../../api';
 import { STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
+import { deriveCurrentStage, FULLY_COMPLETE } from '../../../domain/stageProgression';
 import { useStageStore } from '../../../store/useStageStore';
 import { STAGE_COUNT } from '../stageData';
 import type { StageData } from '../stageData';
@@ -49,25 +50,6 @@ export const toStageData = (apiStage: Stage): StageData => {
     freeWillDescription: apiStage.free_will_description,
     overviewUrl: apiStage.overview_url,
   };
-};
-
-const FULLY_COMPLETE = 1;
-
-/**
- * Count-based current-stage derivation.
- *
- * Mirrors the backend's `next_stage_for(user)` under the chain-validation
- * invariant: `current = completed + 1`.  A fresh user with nothing completed
- * gets stage 1; each completed stage advances `current` by one, clamped to
- * the catalog range.  This replaces the old "first unlocked, still-in-
- * progress" heuristic which silently drifted to `max(stage_number)` over
- * unlocked rows when the backend's `is_unlocked` flag was ahead of
- * completion.
- */
-export const deriveCurrentStage = (apiStages: Stage[]): number => {
-  if (apiStages.length === 0) return 1;
-  const completed = apiStages.filter((s) => s.progress >= FULLY_COMPLETE).length;
-  return Math.min(Math.max(1, completed + 1), STAGE_COUNT);
 };
 
 /** Unlocked on the map when the server `is_unlocked` flag is set OR the date-derived current stage has reached it, so the padlock matches the Practice/Course stage. */

--- a/frontend/src/features/Map/stageData.ts
+++ b/frontend/src/features/Map/stageData.ts
@@ -8,6 +8,8 @@
  * here. Stage *content* is fetched from the backend API.
  */
 
+export { STAGE_COUNT } from '../../domain/stageProgression';
+
 export interface StageData {
   id: number;
   title: string;
@@ -26,9 +28,6 @@ export interface StageData {
   freeWillDescription: string;
   overviewUrl: string;
 }
-
-/** Total number of APTITUDE stages. */
-export const STAGE_COUNT = 10;
 
 /**
  * Which way a stage's spiral arrow winds. Even (Divine-Feminine) stages return


### PR DESCRIPTION
## Summary
- Extract the pure, shared `deriveCurrentStage` derivation (plus `STAGE_COUNT`/`FULLY_COMPLETE`) out of Map's private `stageService` into a new feature-neutral `frontend/src/domain/stageProgression.ts`, mirroring the backend `domain/` layer.
- Removes the only cross-feature import in the entire `features/` tree: `CourseScreen` no longer reaches into `../Map/services/stageService`; both Map and Course now import from the shared domain module.
- `stageData.ts` re-exports `STAGE_COUNT` from the domain module, so every existing importer keeps working with zero changes and there is a single source of truth for the constant.

## Test plan
- Added `frontend/src/domain/__tests__/stageProgression.test.ts` with 7 cases covering `deriveCurrentStage` (empty list, none complete, completed+1, `>= 1` boundary, `> 1`, upper clamp to `STAGE_COUNT`, just-below-cap).
- `./scripts/frontend/check-all.sh` green: ESLint (0 warnings), Prettier, `tsc --noEmit`, and all 3591 Jest tests across 337 suites pass.
- Acceptance grep `grep -rnE "from '\.\./[A-Z][a-zA-Z]*/" frontend/src/features --include='*.tsx' --include='*.ts' | grep -v __tests__` returns zero hits.
- Behavior unchanged: `deriveCurrentStage` logic is byte-for-byte identical and the `dateDerived ?? deriveCurrentStage(stagesList)` precedence in `CourseScreen` is preserved.

Closes #1390
