### PR TITLE
fix(frontend): stop weekly-prompt title field from silently discarding edits

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -763,6 +763,12 @@ interface WritingColumnProps {
    * (still in flight or failed), so they never write against an unseen entry.
    */
   controlsDisabled: boolean;
+  /**
+   * In weekly-prompt compose the title is fixed program context the respond
+   * endpoint cannot persist, so it is read-only rather than a lying editable
+   * affordance that silently discards a rename.
+   */
+  titleReadOnly: boolean;
 }
 
 /** Quiet control to mark a draft finished. */
@@ -808,7 +814,11 @@ function WritingFields({
   onChangeTitle,
   onChangeBody,
   bodyPlaceholder,
-}: Pick<WritingColumnProps, 'title' | 'body' | 'onChangeTitle' | 'onChangeBody'> & {
+  titleReadOnly,
+}: Pick<
+  WritingColumnProps,
+  'title' | 'body' | 'onChangeTitle' | 'onChangeBody' | 'titleReadOnly'
+> & {
   bodyPlaceholder: string;
 }) {
   return (
@@ -820,6 +830,8 @@ function WritingFields({
         placeholder="Title"
         placeholderTextColor={colors.paper.inkSoft}
         accessibilityLabel="Entry title"
+        editable={!titleReadOnly}
+        accessibilityState={{ disabled: titleReadOnly }}
         testID="journal-title-input"
       />
       <View style={styles.hairline} />
@@ -855,6 +867,7 @@ function WritingColumn({
   onFinish,
   bodyPlaceholder = 'Begin writing…',
   controlsDisabled,
+  titleReadOnly,
 }: WritingColumnProps) {
   return (
     <ScrollView
@@ -875,6 +888,7 @@ function WritingColumn({
         onChangeTitle={onChangeTitle}
         onChangeBody={onChangeBody}
         bodyPlaceholder={bodyPlaceholder}
+        titleReadOnly={titleReadOnly}
       />
       <Text style={styles.savedHint} testID="journal-save-hint">
         {savedHintLabel(saveState)}
@@ -1161,6 +1175,7 @@ function useJournalEntryController(
   });
 
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
+  // Weekly-prompt compose gates resonance and makes the title read-only.
   const gate = deriveResonanceGate({
     isIdle,
     isLoading: resonance.loading,
@@ -1181,6 +1196,7 @@ function useJournalEntryController(
     handleBody,
     modal,
     editGate,
+    titleReadOnly: ctx.weekNumber != null,
   };
 }
 
@@ -1207,6 +1223,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       onFinish={canFinish ? markFinished : undefined}
       bodyPlaceholder={bodyPlaceholder}
       controlsDisabled={controlsDisabled}
+      titleReadOnly={ctl.titleReadOnly}
     />
   ) : (
     <ReadColumn

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -115,6 +115,42 @@ describe('JournalEntryScreen', () => {
     }
   });
 
+  it('does not silently discard a typed title in weekly-prompt compose mode', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        {
+          weekNumber: 3,
+          promptQuestion: 'What did you notice?',
+          prefillTitle: 'Week 3 Reflection',
+        },
+        { autosaveDelayMs: 100 },
+      );
+      expect(getByTestId('journal-title-input').props.editable).toBe(false);
+      fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.');
+      expect(mockCreate).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the title editable for a plain journal entry', () => {
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('journal-title-input').props.editable).not.toBe(false);
+  });
+
+  it('keeps the title editable for a practice-session entry', () => {
+    const { getByTestId } = renderScreen({
+      practiceSessionId: 55,
+      prefillTitle: 'After Forest grounding',
+    });
+    expect(getByTestId('journal-title-input').props.editable).not.toBe(false);
+  });
+
   it('pre-links a practice session on the created entry', async () => {
     jest.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary
- Fixes a silent-input-loss bug: in weekly-prompt compose mode the journal title field was pre-filled and fully editable, but any title the user typed was silently discarded while the save hint still reported "Saved".
- Makes the title field read-only in weekly-prompt mode (Option B — honest affordance), threading a `titleReadOnly` flag through the writing column so the pre-filled "Week N Reflection" reads as fixed context rather than a lying editable input. Plain-entry and practice-session paths are unchanged (they persist the title).

## Root cause
The weekly-prompt save path routes through `prompts.respond(weekNumber, body)`, which takes only `(weekNumber, response)` — it never sends a title and returns a `PromptDetail` with no journal id, so there is no entry id to PATCH a title onto afterward, and the backend mirror creates the `JournalEntry` with no title. Meanwhile the title `TextInput` was always rendered editable and pre-filled, so a rename went nowhere yet the save hint reported "Saved" (Taxonomy Family 0 — silent input loss on the write path; Family 6 — a "Saved" confirmation that lies about what was persisted).

The chosen fix removes the lying affordance rather than fabricating a persistence path the endpoint does not support (the issue is labeled frontend-only, and this is the smallest honest resolution). The title is fixed program context in this mode, so it is now presented read-only: `editable={false}` plus a matching `accessibilityState`. This makes the "Saved" hint truthful — everything still editable is in fact persisted.

## Test plan
- Added a RED regression test that, in weekly-prompt mode, asserts the title input is non-editable (`editable === false`) — fails against the pre-fix code (`editable` was `undefined`) — while confirming the save path is intact (`prompts.respond` called body-only, no `journal.create`).
- Added two non-regression tests asserting the title stays editable (`editable !== false`) for plain-entry and practice-session modes.
- `./scripts/frontend/check-all.sh` green: 3594 jest tests pass, `tsc --noEmit` clean, ESLint zero warnings, prettier clean.

Closes #1391
