### PR TITLE
refactor(practice): remove dead SHOWCASE_SURFACE and its obsolete migration test

### DIFF
--- a/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
@@ -28,7 +28,7 @@ import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
 import { SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
 
 // ---------------------------------------------------------------------------
-// Helpers — verbatim from sessionSurfaceMigration.test.tsx
+// Local WCAG contrast + flattened-style helpers.
 // ---------------------------------------------------------------------------
 
 const AA_NORMAL = 4.5;
@@ -163,9 +163,8 @@ jest.mock('../../../../features/Map/services/stageService', () => ({
 
 // ---------------------------------------------------------------------------
 // Test A — mode view re-skins off umber (real wiring via PracticeScreen)
-// RED: ActiveRitualSession currently passes SHOWCASE_SURFACE to the provider,
-// so meditation-timer-view gets backgroundColor=showcase.canvas (#2a211a), not
-// surface.raised (#ffffff). Both assertions below fail today.
+// The live session used to render on an umber ground; it now re-skins onto
+// surface.raised / ink.primary, which these assertions pin.
 // ---------------------------------------------------------------------------
 
 describe('A: mode view re-skins off umber (real ActiveRitualSession wiring)', () => {

--- a/frontend/src/features/Practice/views/__tests__/sessionSurfaceMigration.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/sessionSurfaceMigration.test.tsx
@@ -1,17 +1,11 @@
 /**
- * Verifies the #859 showcase-ground migration of the in-session mode views.
+ * Verifies the default (no-provider) light-palette contract of the in-session
+ * mode views.
  *
- * Each mode view now reads its ground / cue / text colours from the
- * `SessionSurface` context (the seam #831 left). These tests pin the two
- * contracts that migration must honour:
- *
- *   1. WITH the showcase provider, a representative view renders on the umber
- *      ground with AA-clearing `onShowcase` cues (assert a showcase token, not
- *      the light ground).
- *   2. WITHOUT a provider the view renders its original light palette
- *      (backward-compatible — the default `LIGHT_SURFACE`).
- *
- * Plus an explicit AA contrast assertion on the cue colours used on the umber.
+ * Each mode view reads its ground / cue / text colours from the
+ * `SessionSurface` context. Without a provider, the views must fall back to
+ * their original light palette (backward-compatible — the default
+ * `LIGHT_SURFACE`), never a showcase token.
  */
 import { describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react-native';
@@ -20,28 +14,9 @@ import { StyleSheet } from 'react-native';
 
 import { fakeControls, fakeState } from './fixtures';
 
-import { colors, onShowcase, showcase } from '@/design/tokens';
+import { colors, onShowcase } from '@/design/tokens';
 import MeditationTimerView from '@/features/Practice/views/MeditationTimerView';
 import RepCounterView from '@/features/Practice/views/RepCounterView';
-import { SHOWCASE_SURFACE, SessionSurfaceProvider } from '@/features/Practice/views/sessionSurface';
-
-const AA_NORMAL = 4.5;
-
-/** WCAG relative luminance of a #rrggbb colour. */
-const luminance = (hex: string): number => {
-  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
-  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
-  const channels = [match[1], match[2], match[3]].map((pair) => {
-    const c = Number.parseInt(pair!, 16) / 255;
-    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-  });
-  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
-};
-
-const contrast = (a: string, b: string): number => {
-  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
-  return (hi! + 0.05) / (lo! + 0.05);
-};
 
 const flatColor = (style: unknown): string | undefined =>
   (StyleSheet.flatten(style as never) as { color?: string }).color;
@@ -49,36 +24,7 @@ const flatColor = (style: unknown): string | undefined =>
 const flatBackground = (style: unknown): string | undefined =>
   (StyleSheet.flatten(style as never) as { backgroundColor?: string }).backgroundColor;
 
-describe('mode-view showcase surface migration (#859)', () => {
-  describe('with the showcase SessionSurface provider', () => {
-    it('renders the meditation timer on the umber ground with onShowcase ink', () => {
-      const { getByTestId } = render(
-        <SessionSurfaceProvider value={SHOWCASE_SURFACE}>
-          <MeditationTimerView state={fakeState({ remainingMs: 0 })} controls={fakeControls()} />
-        </SessionSurfaceProvider>,
-      );
-      expect(flatBackground(getByTestId('meditation-timer-view').props.style)).toBe(
-        showcase.canvas,
-      );
-      expect(flatColor(getByTestId('meditation-time-remaining').props.style)).toBe(
-        onShowcase.primary,
-      );
-    });
-
-    it('renders the rep counter ground + cues from the showcase surface', () => {
-      const config = { mode: 'rep_counter', target_reps: 10, unit_label: 'reps' } as const;
-      const { getByTestId } = render(
-        <SessionSurfaceProvider value={SHOWCASE_SURFACE}>
-          <RepCounterView config={config} state={fakeState()} controls={fakeControls()} />
-        </SessionSurfaceProvider>,
-      );
-      expect(flatBackground(getByTestId('rep-counter-view').props.style)).toBe(showcase.canvas);
-      expect(flatBackground(getByTestId('rep-counter-tap-zone').props.style)).toBe(showcase.raised);
-      expect(flatColor(getByTestId('rep-counter-count').props.style)).toBe(onShowcase.primary);
-      expect(flatColor(getByTestId('rep-counter-unit').props.style)).toBe(onShowcase.soft);
-    });
-  });
-
+describe('mode-view default light-palette contract', () => {
   describe('without a provider (default light palette — backward compatible)', () => {
     it('keeps the meditation timer digits on the original light ink', () => {
       const { getByTestId } = render(
@@ -110,16 +56,5 @@ describe('mode-view showcase surface migration (#859)', () => {
         colors.background.card,
       );
     });
-  });
-
-  it('every showcase cue colour the views use clears WCAG AA on the umber', () => {
-    for (const cue of [
-      SHOWCASE_SURFACE.text,
-      SHOWCASE_SURFACE.textSoft,
-      SHOWCASE_SURFACE.textMuted,
-      SHOWCASE_SURFACE.accent,
-    ]) {
-      expect(contrast(cue, showcase.canvas)).toBeGreaterThanOrEqual(AA_NORMAL);
-    }
   });
 });

--- a/frontend/src/features/Practice/views/sessionSurface.ts
+++ b/frontend/src/features/Practice/views/sessionSurface.ts
@@ -1,23 +1,21 @@
 /**
- * Colour context for the in-session ritual views (#831).
+ * Colour context for the in-session ritual views.
  *
- * The mode views (`MeditationTimerView`, `RepCounterView`, …) historically
- * hard-coded the light `colors.*` palette in their static `StyleSheet`s, so a
- * meditation session read like a settings form. To put a *running* session on
- * the warm-dark `showcase` ground without rewriting every view's layout, each
- * view reads its text / cue / ring colours from this context and appends them as
- * inline overrides on top of its existing styles.
+ * The mode views (`MeditationTimerView`, `RepCounterView`, …) keep their static
+ * `StyleSheet`s and read their text / cue / ring colours from this context,
+ * appending them as inline overrides on top of those styles. This lets a
+ * running session take surface-colour overrides without rewriting each view's
+ * layout.
  *
- * The default value is the original light palette, so any view rendered WITHOUT
- * a provider (e.g. the idle selector, existing unit tests) is byte-for-byte
+ * The default value is {@link LIGHT_SURFACE}, so any view rendered WITHOUT a
+ * provider (e.g. the idle selector, existing unit tests) is byte-for-byte
  * unchanged. `ActiveRitualSession` wraps the live session in
  * {@link SessionSurfaceProvider} with {@link CALM_SURFACE} to skin the whole
- * mode view onto lifted white paper with AA-clearing `ink.*` cues, keeping the
- * deep umber `showcase` ground for the single Begin hero accent.
+ * mode view onto lifted white paper with AA-clearing `ink.*` cues.
  */
 import { createContext, useContext } from 'react';
 
-import { accent, colors, ink, onShowcase, showcase, surface } from '@/design/tokens';
+import { accent, colors, ink, surface } from '@/design/tokens';
 
 export interface SessionSurface {
   /** The ground the session renders on. */
@@ -35,13 +33,14 @@ export interface SessionSurface {
 }
 
 /**
- * The original light palette — the default so non-session views are unchanged.
+ * The default light palette — used so non-session (no-provider) views are
+ * unchanged.
  *
  * `textSoft` / `textMuted` map to the *Accessible* text tokens because that is
  * what the mode views' static `StyleSheet`s already used (the AA-tuned
  * `*Accessible` variants, not the legacy `secondary` / `tertiary`). Mapping them
- * here keeps the no-provider render byte-for-byte identical to the pre-migration
- * light palette.
+ * here keeps the no-provider render byte-for-byte identical to the static light
+ * styles.
  */
 export const LIGHT_SURFACE: SessionSurface = {
   ground: colors.background.primary,
@@ -50,16 +49,6 @@ export const LIGHT_SURFACE: SessionSurface = {
   textSoft: colors.text.secondaryAccessible,
   textMuted: colors.text.tertiaryAccessible,
   accent: colors.success,
-};
-
-/** The warm-dark showcase palette for a running session (AA on the umber). */
-export const SHOWCASE_SURFACE: SessionSurface = {
-  ground: showcase.canvas,
-  raised: showcase.raised,
-  text: onShowcase.primary,
-  textSoft: onShowcase.soft,
-  textMuted: onShowcase.muted,
-  accent: onShowcase.primary,
 };
 
 /**


### PR DESCRIPTION
## Summary
- Delete the dead `SHOWCASE_SURFACE` const from `sessionSurface.ts` (zero production consumers — the calm-surface migration reversed the "session on showcase ground" direction and live sessions use `CALM_SURFACE` exclusively), dropping its now-unused `onShowcase`/`showcase` token imports and the docstring narrative for the removed mechanism.
- Remove the obsolete showcase-provider render cases and the AA-on-umber contrast test (plus their now-orphaned `luminance`/`contrast`/`AA_NORMAL` helpers) from `sessionSurfaceMigration.test.tsx`, keeping the still-live `LIGHT_SURFACE` no-provider default-palette coverage.
- Rephrase the stale comments in `calmSurfaceMigration.test.tsx` that named the deleted symbol / referenced the removed helpers.

## Test plan
- `grep -rn SHOWCASE_SURFACE frontend/src` returns nothing.
- `./scripts/frontend/check-all.sh` exits 0 (ESLint zero-warning, `tsc --noEmit` strict, prettier, jest): 337 suites / 3591 tests pass. Frontend coverage thresholds still met (no live-behavior test removed; live surface remains covered by `calmSurfaceMigration.test.tsx`).
- code-review-orchestrator self-review returned CLEAN.

Closes #1393
