### PR TITLE
refactor(practice): remove unreachable assign-success banner in PracticeDetailScreen

### DIFF
--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -44,7 +44,6 @@ interface ScreenState {
   assigning: boolean;
   loading: boolean;
   pickerOpen: boolean;
-  assignedStage: number | null;
 }
 
 function initialState(actionError: string | null): ScreenState {
@@ -55,7 +54,6 @@ function initialState(actionError: string | null): ScreenState {
     assigning: false,
     loading: true,
     pickerOpen: false,
-    assignedStage: null,
   };
 }
 
@@ -85,11 +83,6 @@ function LoadedDetail({
         <Text style={styles.errorText} testID="practice-detail-action-error">
           {state.actionError}
         </Text>
-      )}
-      {state.assignedStage !== null && (
-        <View style={styles.banner} testID="practice-detail-assigned-banner">
-          <Text style={styles.bannerText}>Set as your stage {state.assignedStage} practice.</Text>
-        </View>
       )}
       <ActionRow
         practice={practice}
@@ -152,19 +145,11 @@ interface PracticeDetailHook {
   assigning: boolean;
   loading: boolean;
   pickerOpen: boolean;
-  assignedStage: number | null;
   reload: () => void;
   openPicker: () => void;
   closePicker: () => void;
   assign: (stageNumber: number) => Promise<void>;
 }
-
-const withAssignSuccess = (prev: ScreenState, stageNumber: number): ScreenState => ({
-  ...prev,
-  assigning: false,
-  pickerOpen: false,
-  assignedStage: stageNumber,
-});
 
 const withAssignError = (prev: ScreenState, err: unknown): ScreenState => ({
   ...prev,
@@ -212,7 +197,7 @@ function usePracticeDetail(
       setState((prev) => ({ ...prev, assigning: true, actionError: null }));
       try {
         await userPractices.create({ practice_id: practiceId, stage_number: stageNumber });
-        setState((prev) => withAssignSuccess(prev, stageNumber));
+        setState((prev) => ({ ...prev, assigning: false, pickerOpen: false }));
         // The callback returns the user to the Practice screen after assigning.
         onAssigned?.();
       } catch (err) {
@@ -594,13 +579,6 @@ const styles = StyleSheet.create({
   stageBoxText: { color: ink.primary, fontWeight: '700' },
   pickerCancel: { marginTop: SPACING.sm, alignSelf: 'flex-end' },
   pickerCancelText: { color: accent.primary, fontWeight: '600', fontSize: 13 },
-  banner: {
-    backgroundColor: surface.sunken,
-    padding: SPACING.sm,
-    borderRadius: BORDER_RADIUS.sm,
-    marginBottom: SPACING.sm,
-  },
-  bannerText: { color: colors.successText, fontSize: 13, fontWeight: '600' },
   errorBlock: {
     flex: 1,
     padding: SPACING.lg,

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -179,6 +179,21 @@ describe('PracticeDetailScreen — Use for stage', () => {
     expect(nav.popToTop).toHaveBeenCalledTimes(1);
   });
 
+  it('does not render a write-only success banner on assign success', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+      await flushPromises();
+    });
+    expect(view.queryByTestId('practice-detail-assigned-banner')).toBeNull();
+    expect(nav.popToTop).toHaveBeenCalledTimes(1);
+    expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
+  });
+
   it('opens the share sheet from the Share action', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     const { view } = renderScreen();


### PR DESCRIPTION
## Summary

- Remove the unreachable "Set as your stage N practice." success banner from `PracticeDetailScreen`. It was gated on `assignedStage`, but a successful assign set that state and then synchronously called `navigation.popToTop()`, unmounting the screen before the banner could ever render — write-only dead code (`de-slop` / `dead-code`).
- Delete the `assignedStage` field, the `withAssignSuccess` helper, the banner JSX, and its orphaned styles. The success reset keeps its two live effects (`assigning: false`, `pickerOpen: false`) and the pop-to-top confirmation behavior is unchanged. The `actionError` / `assignError` failure banner is untouched.

Decision (the issue offered resolve-vs-remove): **remove**. Honoring the intent would require timer/toast machinery fighting the established one-tap "Use" UX (the catalog's one-tap "Use" also pops immediately, per the code's own comment), for a surface with no user-visible value.

## Test plan

- Added a regression test asserting `practice-detail-assigned-banner` never renders after a successful assign (the mocked `popToTop` no-ops, so the screen stays mounted — the banner would render on regression), plus `popToTop` called once and the stage picker closed.
- `./scripts/frontend/check-all.sh` exits 0: 337 suites / 3592 tests pass, ESLint zero-warning, `tsc --noEmit` strict clean, prettier clean.
- Existing assign-failure and `assignError`-route tests still pass (behavior unchanged).

Closes #1394
