### PR TITLE
fix(frontend): route TalliedGroundingForm limits through validation constants

### DIFF
--- a/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/__tests__/TalliedGroundingForm.test.tsx
@@ -4,7 +4,11 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
 import type { TalliedGroundingConfig } from '../../engine/types';
-import { TALLIED_KEY_PATTERN, validateModeConfig } from '../../engine/validation';
+import {
+  TALLIED_KEY_PATTERN,
+  TALLIED_LABEL_MAX,
+  validateModeConfig,
+} from '../../engine/validation';
 import TalliedGroundingForm from '../forms/TalliedGroundingForm';
 
 const base: TalliedGroundingConfig = {
@@ -85,6 +89,12 @@ describe('TalliedGroundingForm', () => {
     expect(getByTestId('tallied-grounding-form')).toBeTruthy();
     expect(getByTestId('tallied-add-category')).toBeTruthy();
     expect(queryByTestId('tallied-category-0')).toBeNull();
+  });
+
+  it('caps the category label at the validator limit, not a drifted local constant', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(<TalliedGroundingForm value={base} onChange={onChange} />);
+    expect(getByTestId('tallied-category-0-label').props.maxLength).toBe(TALLIED_LABEL_MAX);
   });
 
   it('keeps the surviving category after a non-tail delete (stable keys)', () => {

--- a/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { TalliedCategory, TalliedGroundingConfig } from '../../engine/types';
+import {
+  TALLIED_LABEL_MAX as LABEL_MAX,
+  TALLIED_ROUNDS_MAX as ROUNDS_MAX,
+  TALLIED_ROUNDS_MIN as ROUNDS_MIN,
+  TALLIED_TARGET_MAX as TARGET_MAX,
+  TALLIED_TARGET_MIN as TARGET_MIN,
+} from '../../engine/validation';
 
 import { LabeledRow, NumberStepper, TextField } from './shared';
 
@@ -11,12 +18,6 @@ interface Props {
   value: TalliedGroundingConfig;
   onChange: (next: TalliedGroundingConfig) => void;
 }
-
-const ROUNDS_MIN = 1;
-const ROUNDS_MAX = 10;
-const TARGET_MIN = 1;
-const TARGET_MAX = 20;
-const LABEL_MAX = 60;
 
 // Monotonic source of new category keys. The key is the machine id the engine
 // records in session metadata, so it is generated once and never derived from


### PR DESCRIPTION
## Summary

`TalliedGroundingForm` re-declared its five limit constants locally, and one had drifted: the category-label input capped at `maxLength={LABEL_MAX}` where `LABEL_MAX = 60`, while the validator (`checkTalliedCategory` / `TALLIED_LABEL_MAX = 255`) accepts up to 255. A label of 61-255 characters was validator-valid yet impossible to type. The other four locals (`ROUNDS_MIN/MAX`, `TARGET_MIN/MAX`) were exact duplicates of exported constants — silent drift risk.

**Root cause:** duplicated config that diverged from the single source of truth in `engine/validation.ts`.

**Fix:** delete the five local constants and import the exported validation constants (aliased), mirroring the sibling `MindfulAnchorForm` house style. The label input now clamps at `TALLIED_LABEL_MAX` (255) and all bounds share one source of truth with the validator. No validator or backend caps changed.

## Test plan

- Added a regression test asserting `getByTestId('tallied-category-0-label').props.maxLength === TALLIED_LABEL_MAX` (RED at 60, GREEN at 255) that pins the input cap to the validator constant so the drift cannot silently recur.
- `./scripts/frontend/check-all.sh` green: ESLint, prettier, tsc, and 3593 Jest tests pass.

Closes #1395