### PR TITLE
fix(safety): clause-scope crisis-screen negation at coordinating conjunctions

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -39,7 +39,14 @@ when a negator (e.g. "never", "not", "no plans to", "don't") appears in the
 window of :data:`_NEGATION_WINDOW_WORDS` whitespace tokens strictly *before* the
 match, within the same clause (the window is clipped at the last ``.``, ``!``,
 ``?``, ``;``, or ``,``, so a negator in an earlier clause cannot suppress genuine
-intent in a later one). Logical negators ("never", "not", "don't", …) are counted
+intent in a later one). The same-clause window is also bounded by the
+coordinating conjunctions ``and``/``but``, so a negator governing a coordinated
+sibling clause ("I would not survive this AND I want to die") cannot suppress
+genuine intent in the following clause. ``or``/``nor`` are deliberately excluded:
+negative-polarity coordination shares one negator across "or"/"nor" conjuncts
+("I would never kill myself or hurt myself" is a single denial), so clipping
+there would un-suppress the second conjunct into a false positive. Logical
+negators ("never", "not", "don't", …) are counted
 by parity: an odd count negates, an even count (including zero) does not, so
 double negation ("I can't say I don't want to die") still flags. Temporal
 negators ("used to", "no longer") negate only when they directly abut the match,
@@ -182,17 +189,30 @@ _LOGICAL_NEGATORS = re.compile(
 # the very end of the window rather than counted anywhere in it.
 _TEMPORAL_NEGATOR = re.compile(r"\b(?:no longer|used to)\s*$", re.IGNORECASE)
 
+# Coordinating conjunctions that bound a clause the same way punctuation does.
+# Word-boundary anchored so "band"/"butter" never clip. Deliberately only "and"
+# and "but": English negative-polarity coordination shares one negator across
+# "or"/"nor" conjuncts ("I would never kill myself or hurt myself" is a single
+# denial), so clipping at "or"/"nor" would un-suppress the second conjunct and
+# manufacture a false positive on a genuine denial.
+_COORDINATING_CONJUNCTIONS = r"\b(?:and|but)\b"
+
 # Clause boundaries clip the preceding window. Commas count: a negator in an
 # earlier clause must not suppress genuine intent in a later one, so a mixed
 # statement ("I would never hurt myself, but I want to kill him") still flags.
-_CLAUSE_BOUNDARY = re.compile(r"[.!?;,]")
+# Coordinating conjunctions "and"/"but" also clip, so a negator governing a
+# coordinated sibling clause ("I would not survive this and I want to die")
+# cannot suppress genuine intent in the following clause. "or"/"nor" are
+# deliberately excluded (see _COORDINATING_CONJUNCTIONS).
+_CLAUSE_BOUNDARY = re.compile(rf"[.!?;,]|{_COORDINATING_CONJUNCTIONS}", re.IGNORECASE)
 
 
 def _tail_window(prefix: str) -> str:
     """Return the last :data:`_NEGATION_WINDOW_WORDS` tokens of ``prefix``.
 
     ``prefix`` is first clipped to the current clause — only the text after the
-    last clause-boundary character (``.``, ``!``, ``?``, ``;``, ``,``) is kept.
+    last clause-boundary character (``.``, ``!``, ``?``, ``;``, ``,``) or
+    coordinating conjunction (``and``/``but``) is kept.
     """
     boundaries = list(_CLAUSE_BOUNDARY.finditer(prefix))
     if boundaries:

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -111,6 +111,10 @@ _NEGATED_DENIALS = [
     f"I don{_CURLY}t want to die",
     "I would never say I no longer want to be alive",
     "I don't wish I wasn't here",
+    # per-clause negators: proves the fix scopes negation rather than disabling it
+    "I would never hurt myself and I would never kill him",
+    # or-exclusion pin: "or" must stay outside the clip list
+    "I would never kill myself or hurt myself",
 ]
 
 
@@ -138,6 +142,24 @@ def test_negated_denials_do_not_flag(text: str) -> None:
         (f"I wish I wasn{_CURLY}t here", DistressCategory.SUICIDAL_INTENT),
         ("Now more than I used to I want to die", DistressCategory.SUICIDAL_INTENT),
         ("I am not okay and lonely and I want to die", DistressCategory.SUICIDAL_INTENT),
+        # unrelated negator across "and" must not suppress the later clause
+        (
+            "I never thought I would not survive this and I want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        # unrelated negator across "but" must not suppress the later clause
+        ("I would not survive this but I want to die", DistressCategory.SUICIDAL_INTENT),
+        # and-control: same shape without a negator collision, must keep flagging
+        (
+            "I could not sleep last night and I want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        # comma-control: clause boundary already clips the window, must keep flagging
+        ("I could not sleep last night, I want to die", DistressCategory.SUICIDAL_INTENT),
+        # accepted tradeoff: a shared negator distributed across "and" (rare De Morgan
+        # phrasing) flags, the safe direction for a crisis screen (surface support over
+        # miss intent); pinned so the behavior is a deliberate decision, not a silent gap
+        ("I would never kill myself and hurt myself", DistressCategory.SELF_HARM),
     ],
 )
 def test_negation_does_not_suppress_genuine_signals(text: str, category: DistressCategory) -> None:


### PR DESCRIPTION
## Summary
- Fixes a crisis-screen **false negative**: `assess_distress()` silently downgraded an explicit suicidal-intent phrase to `level="none"` when an *unrelated* logical negator fell in the 5-token pre-match window across a coordinating conjunction (`"...I would not survive this and I want to die"` → the `not` governs `survive`, but flipped the parity count and suppressed the genuine `want to die`).
- **Root cause:** `_is_negated` counts logical negators by parity over the same-clause window, but the window was only bounded by punctuation — a negator governing a coordinated *sibling* clause reached across the conjunction and denied a phrase it does not govern.
- **Fix:** extend the negation-window clip in `_tail_window` to also break at the coordinating conjunctions `and`/`but` (`_COORDINATING_CONJUNCTIONS`), scoping negation per clause. `or`/`nor` are **deliberately excluded**: negative-polarity coordination shares one negator across those conjuncts (`"I would never kill myself or hurt myself"` is a single denial), so clipping there would un-suppress the second conjunct into a false positive on a genuine denial.
- Directionally safe: the clip only ever *shrinks* the negation window, so it strictly **tightens** suppression for explicit acute phrases (more sensitivity, fewer false negatives) and cannot regress ordinary-darkness handling, which never reaches the negation path.

### False negatives fixed (now `elevated` / `SUICIDAL_INTENT`)
- `"I never thought I would not survive this and I want to die"` (reproducing case)
- `"I would not survive this but I want to die"`

### No-regression guarantees (pinned by tests)
- `"I could not sleep last night and I want to die"` and the comma variant still flag.
- Double negation still flags: `"I can't say I don't want to die"`.
- Every existing denial still returns `none`, including the new per-clause pin `"I would never hurt myself and I would never kill him"` and the `or`-exclusion pin `"I would never kill myself or hurt myself"`.
- Accepted tradeoff pinned: the rare shared-negator De Morgan denial `"I would never kill myself and hurt myself"` now flags (safe direction for a crisis screen — surface support over miss intent).

No change to the phrase lists, the normalization pipeline, or the module's conservative false-negative-preferring posture toward genuinely ambiguous "ordinary darkness" text.

## Test plan
- `python -m pytest tests/domain/test_safety.py` — 96 passed (2 new RED cases confirmed failing before the fix, green after).
- `./scripts/backend/check-all.sh` — 7/7 quality checks pass; 2410 passed, 96.55% coverage (≥90 line / ≥80 branch).
- `xenon --max-absolute A --max-modules A --max-average A src/domain/safety.py` — exit 0 (A); `radon mi src/domain/safety.py` — A.
- Gate 2.5 self-review (incl. security dimension for the safety domain): `CLEAN`.

Closes #1424
