### PR TITLE
skill(flare): add fast bug/feature report filing skill

### DIFF
--- a/.claude/skills/bug-squashing-methodology/SKILL.md
+++ b/.claude/skills/bug-squashing-methodology/SKILL.md
@@ -4,6 +4,9 @@ description: >-
   Structured 5-step bug fix process with root cause analysis and TDD.
   Use when fixing bugs, debugging failures, or investigating defects.
   Covers RCA documentation, reproduction, TDD fix cycle, and PR workflow.
+  Do NOT use for filing a new bug/feature report as a GitHub issue (use
+  flare) — this skill starts once an issue already exists and work is
+  underway.
 metadata:
   author: Geoff
   version: 1.0.0

--- a/.claude/skills/flare/SKILL.md
+++ b/.claude/skills/flare/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: flare
+description: >-
+  Fast, one-shot bug or feature reporting: research the repo, write a
+  world-class QA/PM ticket, and file it to GitHub Issues with Ralph-ready
+  labels in a single turn. Use when the user says "flare this", "file a bug",
+  "report this", "open an issue for X", "/flare", or hands you a short bug/idea
+  description and wants it turned into a ticket right now. Grounds the report
+  in real code (file:line, snippets, git history), applies the 6-component
+  prompt-engineering framework so the ticket is directly consumable by the
+  Ralph agent fleet, decomposes oversized asks into an epic + sub-issues, and
+  dedupes against existing issues before creating anything. Do NOT use for
+  automated tool-output-driven maintenance scans (use scan-issue-writer), for
+  triaging/closing/grooming the existing backlog (use backlog-grooming), for
+  the root-cause-analysis and TDD fix cycle once an issue already exists (use
+  bug-squashing-methodology), or for reviewing an open PR's diff (use
+  comprehensive-pr-review).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Flare
+
+Turn a quick verbal bug/feature report into a filed, agent-ready GitHub issue
+— fast. The whole point of `flare` is speed: the user says one sentence, you
+do the legwork, an issue lands with a URL. Don't make the user re-explain
+what a competent repo search would have told you.
+
+## Instructions
+
+### Step 1 — Capture the report, don't interrogate
+
+Take what the user gave you at face value. Only ask a clarifying question if
+something is genuinely blocking (e.g. "the toggle" could mean one of three
+different toggles and repo research doesn't disambiguate it). Otherwise:
+proceed on your best interpretation and record any assumption explicitly in
+the issue body's Context section — an assumption written down is fine; a
+silent guess is not, and a blocking question defeats the "fast" promise.
+
+### Step 2 — Repo research (this is what makes the ticket world-class)
+
+Before writing a word of the ticket, ground it in the actual codebase:
+
+- **Locate the code**: Grep/Glob for the feature or symptom (component name,
+  route, error string). Identify the exact file(s):line(s) involved.
+- **Read the current behavior**: Open the relevant handler/component/model
+  and understand what it actually does today, not what the user assumes it
+  does.
+- **Check history**: `git log -p --follow -- <file>` or `git blame` on the
+  suspect lines — was this recently changed? Is there a regression window?
+- **Check test coverage**: Does a test already cover this path? If yes and it
+  passes, that's evidence for the Context section (or a sign the bug is in
+  an untested branch). If no, note the gap — Ralph will need to write one.
+- **Dedupe**: Search before you draft, not after.
+  ```bash
+  gh issue list --search "<keywords>" --state all --limit 20
+  ```
+  If `gh` isn't available in this session, use `mcp__github__search_issues`
+  or `mcp__github__list_issues` instead. Exact or near-exact match → stop,
+  report the existing issue number to the user instead of filing a duplicate
+  (or add a comment with fresh evidence if the finding has new information).
+
+Spend real effort here — this step is what separates a `flare` ticket from a
+one-line vague complaint that sits in `needs-triage` forever.
+
+### Step 3 — Classify
+
+Decide, from the evidence gathered in Step 2:
+
+- **Type**: `bug` (behavior contradicts spec/expectation) or `feature`
+  (net-new capability, including enhancements to existing behavior).
+- **Severity / priority** (bugs — map to Ralph's priority tiers, see
+  `references/label-guide.md`):
+  - `P0` — crash, data loss, security hole, broken auth, prod-down.
+  - `P1` — a core user flow is broken with no workaround.
+  - `P2` — degraded behavior, workaround exists, or a well-scoped feature.
+  - `P3` — cosmetic, minor, or nice-to-have.
+- **Size**: Estimate rough LoC/complexity from what Step 2 found. If it looks
+  like it exceeds ~300 LoC or spans more than one clearly separable concern
+  (e.g. "backend model + API + two screens"), it needs decomposition — see
+  Step 4b and `references/decomposition.md`. A single well-scoped bug fix or
+  small feature stays one issue.
+
+### Step 4a — Draft a single issue
+
+Fill `references/report-template.md` completely — it follows the same
+6-component framework (Role / Goal / Context / Output Format / Examples /
+Constraints) the rest of this repo's agent-ready issues use, so Ralph can
+pick it straight off the backlog. No placeholders left unfilled. The
+Context section must cite real `file:line` and include an actual code
+snippet from Step 2 — not a paraphrase.
+
+For a **bug**, the Goal is the fix, and Context must include: exact
+reproduction steps, expected vs. actual behavior, and environment info (only
+if given or inferable — don't invent versions/platforms).
+
+For a **feature**, the Goal is the capability, and Context must include: the
+user story ("as a ..., I want ..., so that ..."), acceptance criteria as a
+checklist, and — if the request implies a design or UX choice — the smallest
+reasonable default so Ralph isn't blocked waiting on a decision.
+
+### Step 4b — Decompose oversized asks into an epic
+
+If Step 3 flagged this as too big for one issue, follow
+`references/decomposition.md`: create one epic issue (context + the overall
+goal, no `agent-ready` label — epics aren't directly pickable) and 2–5
+atomized sub-issues (~300 LoC each, each independently agent-ready), linked
+to the epic via `mcp__github__sub_issue_write` (or `gh issue edit --add-...`
+sub-issue linking where available) and a shared `epic:<slug>` label. Mark
+sub-issues `parallelizable` only if Step 2's research confirms they don't
+touch overlapping files/tables.
+
+### Step 5 — Label per Ralph's vocabulary
+
+See `references/label-guide.md` for the full set. At minimum apply:
+
+- Type: `bug` or `feature`
+- Priority: `P0`–`P3`
+- Readiness: `agent-ready` if every template section is filled with real
+  content, otherwise `needs-triage`
+- `epic:<slug>` on the epic issue and all its sub-issues, if decomposed
+- `solo` only if the change cannot safely run alongside parallel Ralph
+  workers (e.g. touches a migration or shared config every other issue also
+  touches)
+
+Check `gh label list` (or `mcp__github__list_issue_types`) first — reuse an
+existing label; only create a new one if nothing fits, per this repo's
+git-workflow skill.
+
+### Step 6 — File it
+
+```bash
+gh issue create --title "type(scope): specific, searchable title" \
+  --body-file /tmp/flare-issue.md \
+  --label "bug,P1,agent-ready"
+```
+
+If `gh` isn't available, use `mcp__github__issue_write` (action `create`)
+with the same title/body/labels. Title format: conventional-commit-style
+`type(scope): what's actually wrong or wanted` — specific enough that a
+title-only skim tells a maintainer what happened, not just "bug in habits".
+
+### Step 7 — Report back, fast
+
+Reply with the issue number, URL, and a one-line summary of what you filed
+(and, if decomposed, the epic URL plus each sub-issue URL). Nothing else —
+the user asked for speed, not a recap of your research process.
+
+## Examples
+
+### Example 1 — Quick bug report
+User: "flare — the habit streak resets to 0 even when I complete it same day"
+
+1. Grep for streak logic → `backend/src/domain/streaks.py:40-78`, find the
+   date-comparison bug (naive `date.today()` vs stored UTC timestamp).
+   Confirm no timezone test exists.
+2. Dedupe search: no match.
+3. Classify: `bug`, `P1` (core flow broken, no workaround), single issue.
+4. Draft with Context citing the exact comparison at `streaks.py:63`,
+   snippet included, repro steps, expected vs actual.
+5. Label `bug,P1,agent-ready`.
+6. File, reply with issue URL in one line.
+
+### Example 2 — Oversized feature ask
+User: "flare — add a leaderboard for weekly streaks across all users"
+
+Research shows this needs a new backend aggregation endpoint, a new DB
+query/index, a new frontend screen, and navigation wiring — four separable
+concerns, no existing scaffolding. Create epic `epic:weekly-leaderboard`
+("Weekly streak leaderboard") plus four sub-issues (backend aggregation
+endpoint, frontend leaderboard screen, navigation entry, opt-out privacy
+setting), each `agent-ready`, each labeled `epic:weekly-leaderboard`, backend
+and frontend sub-issues marked `parallelizable` since they don't share files.
+
+### Example 3 — Duplicate caught
+User: "flare — journal entries lose formatting on save"
+
+Dedupe search turns up open issue #212 with the identical repro. Reply with
+"Already tracked in #212 — added a comment with today's reproduction" instead
+of filing a new issue.
+
+## Troubleshooting
+
+### Can't tell if it's a bug or a feature
+If current behavior matches what the code was clearly designed to do, but
+the user wants it to do something else, it's a `feature` (or `enhancement`),
+not a `bug`. Say so in the ticket rather than mislabeling for urgency.
+
+### Repo research turns up nothing
+If Grep/Glob find no related code at all (genuinely new capability, not a
+missed regression), say so plainly in Context instead of forcing an
+in-code reference — don't fabricate a file:line.
+
+### User's report doesn't reproduce
+State that in Context: what you tried, what you expected, what actually
+happened when you checked. File it as `needs-triage` rather than guessing at
+a root cause you didn't verify.

--- a/.claude/skills/flare/SKILL.md
+++ b/.claude/skills/flare/SKILL.md
@@ -104,10 +104,13 @@ reasonable default so Ralph isn't blocked waiting on a decision.
 
 If Step 3 flagged this as too big for one issue, follow
 `references/decomposition.md`: create one epic issue (context + the overall
-goal, no `agent-ready` label — epics aren't directly pickable) and 2–5
-atomized sub-issues (~300 LoC each, each independently agent-ready), linked
-to the epic via `mcp__github__sub_issue_write` (or `gh issue edit --add-...`
-sub-issue linking where available) and a shared `epic:<slug>` label. Mark
+goal, labeled with both the bare `epic` label AND `epic:<slug>` — the bare
+`epic` token is what actually keeps it out of the picker; `epic:<slug>`
+alone does not, since `pick-next.sh` matches labels exactly, not by prefix)
+and 2–5 atomized sub-issues (~300 LoC each, each independently agent-ready,
+labeled `epic:<slug>` only — never the bare `epic` label, or they'd be
+excluded too), linked to the epic via `mcp__github__sub_issue_write` (or
+`gh issue edit --add-...` sub-issue linking where available). Mark
 sub-issues `parallelizable` only if Step 2's research confirms they don't
 touch overlapping files/tables.
 
@@ -123,7 +126,9 @@ See `references/label-guide.md` for the full set. At minimum apply:
   keeps an incomplete issue out of Ralph's auto-pick. `needs-triage` is not
   in that default exclude set and will NOT reliably stop the picker on its
   own — see `references/label-guide.md`.
-- `epic:<slug>` on the epic issue and all its sub-issues, if decomposed
+- `epic:<slug>` on the epic issue and all its sub-issues, if decomposed, PLUS
+  the bare `epic` label on the epic issue only (see Step 4b — `epic:<slug>`
+  alone does not exclude it from the picker; the bare `epic` token does)
 - `solo` only if the change cannot safely run alongside parallel Ralph
   workers (e.g. touches a migration or shared config every other issue also
   touches)

--- a/.claude/skills/flare/SKILL.md
+++ b/.claude/skills/flare/SKILL.md
@@ -62,7 +62,7 @@ Before writing a word of the ticket, ground it in the actual codebase:
   (or add a comment with fresh evidence if the finding has new information).
 
 Spend real effort here — this step is what separates a `flare` ticket from a
-one-line vague complaint that sits in `needs-triage` forever.
+one-line vague complaint that sits unpicked-but-unfinished forever.
 
 ### Step 3 — Classify
 
@@ -118,15 +118,22 @@ See `references/label-guide.md` for the full set. At minimum apply:
 - Type: `bug` or `feature`
 - Priority: `P0`–`P3`
 - Readiness: `agent-ready` if every template section is filled with real
-  content, otherwise `needs-triage`
+  content, otherwise `needs-spec` — this is the label `pick-next.sh`'s
+  default `RALPH_EXCLUDE_LABELS` actually excludes, so it's the one that
+  keeps an incomplete issue out of Ralph's auto-pick. `needs-triage` is not
+  in that default exclude set and will NOT reliably stop the picker on its
+  own — see `references/label-guide.md`.
 - `epic:<slug>` on the epic issue and all its sub-issues, if decomposed
 - `solo` only if the change cannot safely run alongside parallel Ralph
   workers (e.g. touches a migration or shared config every other issue also
   touches)
 
-Check `gh label list` (or `mcp__github__list_issue_types`) first — reuse an
-existing label; only create a new one if nothing fits, per this repo's
-git-workflow skill.
+Check `gh label list` first — reuse an existing label; only create a new one
+if nothing fits, per this repo's git-workflow skill. There's no bulk
+label-listing MCP tool; if `gh` isn't available, use
+`mcp__github__get_label` to check a specific candidate name, or infer the
+label set from labels already attached to issues returned by
+`mcp__github__list_issues`.
 
 ### Step 6 — File it
 
@@ -194,5 +201,6 @@ in-code reference — don't fabricate a file:line.
 
 ### User's report doesn't reproduce
 State that in Context: what you tried, what you expected, what actually
-happened when you checked. File it as `needs-triage` rather than guessing at
-a root cause you didn't verify.
+happened when you checked. File it as `needs-spec` (not `agent-ready`) rather
+than guessing at a root cause you didn't verify — `needs-spec` is what
+actually keeps the picker from auto-assigning it.

--- a/.claude/skills/flare/references/decomposition.md
+++ b/.claude/skills/flare/references/decomposition.md
@@ -16,7 +16,10 @@ two frontend screens). This mirrors the sizing convention already used across
    the overall Goal and Context (why this matters, what the finished feature
    looks like end-to-end), plus a checklist linking each sub-issue once
    created. No `agent-ready` label — an epic isn't a directly implementable
-   unit of work, it's a tracking/coordination issue.
+   unit of work, it's a tracking/coordination issue. It must also carry the
+   bare `epic` label (not just `epic:<slug>` — see step 5): that's the
+   literal token `pick-next.sh`'s default exclude list matches, and its
+   label filtering is exact-match, not prefix-match.
 
 3. **Write each sub-issue** using the full `report-template.md` (Role /
    Goal / Context / Output Format / Examples / Constraints), scoped to one
@@ -30,11 +33,13 @@ two frontend screens). This mirrors the sizing convention already used across
    picker's epic guard prevents same-epic issues running in parallel by
    default, but does not enforce ordering among them.
 
-5. **Label everything**: `epic:<slug>` on the epic and every sub-issue.
-   Backend/frontend split issues that verifiably don't touch the same files
-   may add `parallelizable` to let them run concurrently despite sharing the
-   epic label — only do this when Step 2's research confirmed no file/table
-   overlap.
+5. **Label everything**: `epic:<slug>` on the epic and every sub-issue, PLUS
+   the bare `epic` label on the epic issue only (never on sub-issues — a
+   sub-issue carrying the bare `epic` label would itself be excluded from
+   the picker). Backend/frontend split sub-issues that verifiably don't
+   touch the same files may add `parallelizable` to let them run
+   concurrently despite sharing the `epic:<slug>` label — only do this when
+   Step 2's research confirmed no file/table overlap.
 
 6. **Link sub-issues to the epic.** Prefer `mcp__github__sub_issue_write`
    (action `add_sub_issue`) so GitHub's native sub-issue relationship shows

--- a/.claude/skills/flare/references/decomposition.md
+++ b/.claude/skills/flare/references/decomposition.md
@@ -1,0 +1,53 @@
+# Decomposing an Oversized Ask into an Epic
+
+Trigger: Step 3 in SKILL.md estimates the request exceeds ~300 LoC, or spans
+more than one clearly separable concern (e.g. new DB model + API endpoint +
+two frontend screens). This mirrors the sizing convention already used across
+`prompts/github-issues/` (each phase issue is atomized to ~100–350 LoC).
+
+## Process
+
+1. **Identify the seams.** From Step 2's repo research, split along natural
+   architectural boundaries — backend model/migration, backend router,
+   frontend hook/state, frontend screen, navigation wiring. Each sub-issue
+   should be independently completable and independently testable.
+
+2. **Write the epic issue first.** Title: `epic: <capability name>`. Body:
+   the overall Goal and Context (why this matters, what the finished feature
+   looks like end-to-end), plus a checklist linking each sub-issue once
+   created. No `agent-ready` label — an epic isn't a directly implementable
+   unit of work, it's a tracking/coordination issue.
+
+3. **Write each sub-issue** using the full `report-template.md` (Role /
+   Goal / Context / Output Format / Examples / Constraints), scoped to one
+   seam. Each must be independently `agent-ready` — a Ralph worker picking
+   it up should never need to read the epic or a sibling sub-issue to
+   understand what to do.
+
+4. **Order dependencies explicitly.** If sub-issue B needs sub-issue A's
+   migration to exist first, say so in B's Context ("Depends on #<A>; do not
+   start until merged") rather than relying on label ordering alone — the
+   picker's epic guard prevents same-epic issues running in parallel by
+   default, but does not enforce ordering among them.
+
+5. **Label everything**: `epic:<slug>` on the epic and every sub-issue.
+   Backend/frontend split issues that verifiably don't touch the same files
+   may add `parallelizable` to let them run concurrently despite sharing the
+   epic label — only do this when Step 2's research confirmed no file/table
+   overlap.
+
+6. **Link sub-issues to the epic.** Prefer `mcp__github__sub_issue_write`
+   (action `add_sub_issue`) so GitHub's native sub-issue relationship shows
+   the hierarchy. If unavailable, reference the epic number in each
+   sub-issue's Context and list each sub-issue number in the epic's body.
+
+## Sizing rule of thumb
+
+| Scope | Action |
+|-------|--------|
+| Single file, single concern, < ~150 LoC | One issue |
+| One backend OR one frontend concern, < ~300 LoC | One issue |
+| Crosses backend + frontend, or > ~300 LoC, or > 1 independent concern | Epic + sub-issues |
+
+When in doubt, decompose — an oversized `agent-ready` issue that a Ralph
+worker can't finish in one PR is worse than a well-split epic.

--- a/.claude/skills/flare/references/label-guide.md
+++ b/.claude/skills/flare/references/label-guide.md
@@ -1,0 +1,58 @@
+# Ralph Label Quick Reference
+
+Source of truth for how the picker (`scripts/ralph/pick-next.sh`) interprets
+labels. Always run `gh label list` (or `mcp__github__list_issue_types`) first
+and reuse an existing label — only create a new one if nothing fits.
+
+## Type
+
+- `bug` — behavior contradicts spec/expectation
+- `feature` — net-new capability or enhancement to existing behavior
+
+## Priority (either vocabulary is honored — prefer the short form)
+
+| Short | Long form | Tier | Use for |
+|-------|-----------|------|---------|
+| `P0`  | `priority-critical` | 0 | Crash, data loss, security hole, broken auth, prod-down |
+| `P1`  | `priority-high`     | 1 | Core user flow broken, no workaround |
+| `P2`  | `priority-medium`   | 2 | Degraded behavior with a workaround; well-scoped feature |
+| `P3`  | `priority-low`      | 3 | Cosmetic, minor, nice-to-have |
+
+An issue with no priority label defaults to tier 1 (P1) in the picker — so
+always apply one explicitly rather than relying on the default.
+
+## Readiness
+
+- `agent-ready` — every template section (`references/report-template.md`)
+  is filled with real content; the picker can hand this straight to a Ralph
+  worker.
+- `needs-triage` — something is missing (reproduction failed, ambiguous
+  scope, unverifiable claim). A human or a grooming pass finishes it before
+  it's pickable.
+
+## Decomposition
+
+- `epic:<slug>` — applied to an epic issue and every one of its sub-issues.
+  The picker's same-epic guard prevents two sub-issues of the same epic from
+  running in parallel unless also labeled `parallelizable`. Epics themselves
+  should NOT carry `agent-ready` — they aren't directly implementable; the
+  picker isn't meant to pick them (exclude via not tagging `agent-ready`, or
+  add `epic` to `RALPH_EXCLUDE_LABELS` if the repo's picker config requires
+  it).
+- `parallelizable` — overrides the same-epic guard; only apply when repo
+  research (Step 2 in SKILL.md) confirms the sub-issues don't touch
+  overlapping files, tables, or migrations.
+
+## Coordination
+
+- `solo` — issue must run alone, never alongside any other active worker.
+  Use sparingly: migrations, shared-config changes, anything where parallel
+  writes would conflict.
+- `in-progress` — set by the fleet when work starts; `flare` should never
+  apply this manually.
+
+## Labels flare should never apply
+
+`wontfix`, `duplicate`, `invalid`, `question`, `blocked`, `future-work`,
+`do-not-auto-merge` — these are triage/lifecycle labels applied by humans or
+the backlog-grooming skill after the fact, not at filing time.

--- a/.claude/skills/flare/references/label-guide.md
+++ b/.claude/skills/flare/references/label-guide.md
@@ -1,8 +1,11 @@
 # Ralph Label Quick Reference
 
 Source of truth for how the picker (`scripts/ralph/pick-next.sh`) interprets
-labels. Always run `gh label list` (or `mcp__github__list_issue_types`) first
-and reuse an existing label — only create a new one if nothing fits.
+labels. Always run `gh label list` first and reuse an existing label — only
+create a new one if nothing fits. There's no bulk label-listing MCP tool; if
+`gh` isn't available, use `mcp__github__get_label` to check a specific
+candidate name (`mcp__github__list_issue_types` is GitHub's separate "Issue
+Types" feature, not labels — it won't help here).
 
 ## Type
 
@@ -26,9 +29,15 @@ always apply one explicitly rather than relying on the default.
 - `agent-ready` — every template section (`references/report-template.md`)
   is filled with real content; the picker can hand this straight to a Ralph
   worker.
-- `needs-triage` — something is missing (reproduction failed, ambiguous
-  scope, unverifiable claim). A human or a grooming pass finishes it before
-  it's pickable.
+- `needs-spec` — something is missing (reproduction failed, ambiguous scope,
+  unverifiable claim). Apply this, not `needs-triage`, when the issue must
+  not be auto-picked: `needs-spec` is the label `pick-next.sh`'s default
+  `RALPH_EXCLUDE_LABELS` actually excludes. A human or a grooming pass
+  finishes it, then relabels `agent-ready`.
+- `needs-triage` — informational only. It is NOT in the picker's default
+  exclude set, so an issue carrying `needs-triage` alone (without
+  `needs-spec`) remains pickable by default. Don't rely on it to keep an
+  incomplete issue out of the fleet.
 
 ## Decomposition
 

--- a/.claude/skills/flare/references/label-guide.md
+++ b/.claude/skills/flare/references/label-guide.md
@@ -43,11 +43,14 @@ always apply one explicitly rather than relying on the default.
 
 - `epic:<slug>` — applied to an epic issue and every one of its sub-issues.
   The picker's same-epic guard prevents two sub-issues of the same epic from
-  running in parallel unless also labeled `parallelizable`. Epics themselves
-  should NOT carry `agent-ready` — they aren't directly implementable; the
-  picker isn't meant to pick them (exclude via not tagging `agent-ready`, or
-  add `epic` to `RALPH_EXCLUDE_LABELS` if the repo's picker config requires
-  it).
+  running in parallel unless also labeled `parallelizable`.
+- `epic` (bare, on the epic issue ONLY, in addition to `epic:<slug>`) — this
+  is the literal token `pick-next.sh`'s default `RALPH_EXCLUDE_LABELS`
+  matches; the picker's label filtering is exact-match, not prefix-match, so
+  `epic:<slug>` alone does NOT trigger the exclusion. Without the bare
+  `epic` label, an epic issue is fully pickable despite not being directly
+  implementable. Sub-issues must NOT carry the bare `epic` label — only
+  `epic:<slug>` — or they'd be excluded too.
 - `parallelizable` — overrides the same-epic guard; only apply when repo
   research (Step 2 in SKILL.md) confirms the sub-issues don't touch
   overlapping files, tables, or migrations.

--- a/.claude/skills/flare/references/report-template.md
+++ b/.claude/skills/flare/references/report-template.md
@@ -5,7 +5,9 @@
   prompts/templates/scan-issue-body.md (Role / Goal / Context / Output Format
   / Examples / Constraints) because every agent-ready issue in this repo IS a
   prompt: it gets consumed directly by the Ralph agent. An issue missing any
-  component gets `needs-triage` instead of `agent-ready`.
+  component gets `needs-spec` instead of `agent-ready` — `needs-spec` is the
+  label the Ralph picker's default exclude list actually honors (see
+  `flare`'s `references/label-guide.md`).
 
   Replace every [bracketed] placeholder. Delete whichever of the Bug/Feature
   Context blocks doesn't apply. Leave no placeholder behind.

--- a/.claude/skills/flare/references/report-template.md
+++ b/.claude/skills/flare/references/report-template.md
@@ -1,0 +1,78 @@
+<!--
+  Canonical issue body template for `flare`-filed reports.
+
+  Follows the same 6-component prompt framework as
+  prompts/templates/scan-issue-body.md (Role / Goal / Context / Output Format
+  / Examples / Constraints) because every agent-ready issue in this repo IS a
+  prompt: it gets consumed directly by the Ralph agent. An issue missing any
+  component gets `needs-triage` instead of `agent-ready`.
+
+  Replace every [bracketed] placeholder. Delete whichever of the Bug/Feature
+  Context blocks doesn't apply. Leave no placeholder behind.
+-->
+
+## Role
+You are a [senior Python/FastAPI | senior React Native | full-stack] engineer
+working in the adepthood codebase, following its existing conventions (TDD via
+stay-green, check-all.sh gates, ≥90% line / ≥80% branch backend coverage,
+≥90% Jest frontend, zero lint/type suppressions).
+
+## Goal
+[One sentence. Specific, measurable, verifiable. e.g. "Fix streak calculation
+so a habit completed same-day (in the user's local timezone) does not reset
+the streak to 0, verified by a timezone-boundary test."]
+
+## Context
+
+<!-- BUG reports: fill this block -->
+- **Steps to reproduce**:
+  1. [Exact step]
+  2. [Exact step]
+  3. [Observed result]
+- **Expected behavior**: [What should happen]
+- **Actual behavior**: [What happens instead]
+- **Environment**: [Only what was given/inferable — platform, version, data
+  state. Do not invent details the report didn't provide.]
+- **Severity/impact**: [Who's affected, how badly, any workaround]
+
+<!-- FEATURE reports: fill this block instead -->
+- **User story**: As a [user type], I want [capability], so that [benefit].
+- **Acceptance criteria**:
+  - [ ] [Observable, testable criterion]
+  - [ ] [Observable, testable criterion]
+  - [ ] [Observable, testable criterion]
+- **Design defaults**: [Smallest reasonable default for any open UX/design
+  choice, so Ralph isn't blocked — note it's a default, not a mandate]
+
+<!-- Both: always fill this -->
+- **File(s)**: `path/to/file.py:120-164`
+- **Current behavior in code** (from repo research):
+  ```
+  [Actual snippet from the file, not a paraphrase]
+  ```
+- **Relevant history**: [Recent commit/PR that touched this code, if any —
+  `git log` or `git blame` findings]
+- **Test coverage**: [Existing test that covers/misses this path, file:line]
+- **Related**: [Links to related issues/PRs found during dedupe search]
+- **Assumptions made**: [Any interpretation you made because the original
+  report was ambiguous and asking would have slowed filing down]
+
+## Output Format
+A single PR that: (1) adds a failing test first, (2) makes it pass, (3)
+passes the relevant `./scripts/<side>/check-all.sh` —
+`scripts/backend/check-all.sh` for backend changes, `scripts/frontend/check-
+all.sh` for frontend changes, both if cross-cutting — and (4) references this
+issue with "Closes #N".
+
+## Examples
+[One concrete before/after sketch grounded in the Context snippet above — the
+current buggy/missing behavior vs. the fixed/added version. 5–15 lines.
+Enough to disambiguate, not a full spec.]
+
+## Constraints
+- Do not change public API signatures unless the Goal requires it
+- No lint/type suppressions (max-quality-no-shortcuts): fix root causes
+- Scope: this issue only — file follow-up issues for adjacent problems found
+  during research instead of scope-creeping this one
+- If the finding no longer reproduces at HEAD, close this issue with a
+  comment explaining what changed instead of forcing a PR

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   committing changes, or opening PRs. Covers the full issue-to-PR lifecycle
   using file-based templates instead of inline strings. Do NOT use for
   bug-specific debugging or RCA (use bug-squashing-methodology), PR code review
-  (use comprehensive-pr-review), or backlog cleanup and issue triage (use
-  backlog-grooming).
+  (use comprehensive-pr-review), backlog cleanup and issue triage (use
+  backlog-grooming), or fast research-backed bug/feature report filing with
+  Ralph labels (use flare).
 metadata:
   author: Geoff
   version: 1.0.0

--- a/.claude/skills/scan-issue-writer/SKILL.md
+++ b/.claude/skills/scan-issue-writer/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   prompts/scans/*.md file. Handles dedupe, priority labeling, and max-issue
   caps so the Ralph loop never starves and never bloats. Do NOT use for
   implementing fixes (use stay-green), reviewing PRs (use
-  comprehensive-pr-review), or closing/triaging existing issues (use
-  backlog-grooming).
+  comprehensive-pr-review), closing/triaging existing issues (use
+  backlog-grooming), or filing a one-off bug/feature report from a live user
+  description (use flare).
 metadata:
   author: Geoff
   version: 1.0.0


### PR DESCRIPTION
## Summary

Introduces the `flare` skill — a new Claude skill for fast, one-shot bug and feature report filing. Flare turns a brief user description into a filed, agent-ready GitHub issue in a single turn by grounding the report in real code research, applying the 6-component prompt-engineering framework, and applying Ralph-ready labels.

## Key Changes

- **New skill: `.claude/skills/flare/SKILL.md`**
  - 7-step process: capture report → repo research → classify → draft issue → decompose if needed → label → file
  - Emphasizes speed without sacrificing quality: user says one sentence, flare does the legwork
  - Includes deduplication before filing and explicit assumption documentation
  - Covers both single-issue and epic+sub-issue decomposition workflows
  - Provides troubleshooting guidance for edge cases (can't reproduce, ambiguous type, etc.)

- **New template: `.claude/skills/flare/references/report-template.md`**
  - Canonical issue body template following the 6-component framework (Role / Goal / Context / Output Format / Examples / Constraints)
  - Separate Context blocks for bug vs. feature reports
  - Requires real `file:line` citations and code snippets from repo research
  - Ensures every filed issue is directly consumable by Ralph agents

- **New reference: `.claude/skills/flare/references/label-guide.md`**
  - Quick reference for Ralph's label vocabulary (Type, Priority, Readiness, Decomposition, Coordination)
  - Maps priority tiers (P0–P3) to severity definitions
  - Clarifies which labels flare applies at filing time vs. which are applied later by humans/grooming

- **New reference: `.claude/skills/flare/references/decomposition.md`**
  - Process for splitting oversized asks (>~300 LoC or >1 separable concern) into epic + sub-issues
  - Sizing rule of thumb and seam-identification guidance
  - Dependency ordering and parallelization rules

- **Updated skill descriptions** in related skills to clarify scope boundaries:
  - `git-workflow/SKILL.md`: added note that flare handles fast research-backed report filing
  - `scan-issue-writer/SKILL.md`: added note that flare handles one-off user reports (vs. automated scans)
  - `bug-squashing-methodology/SKILL.md`: added note that flare handles report filing (vs. RCA/fix cycle)

## Notable Implementation Details

- **Deduplication is mandatory**: flare searches existing issues before drafting, using `gh issue list` or MCP GitHub tools
- **Repo research is the quality lever**: Step 2 requires actual code location, git history, test coverage analysis — this is what separates a flare ticket from a vague complaint
- **Assumptions are documented**: if the user's report is ambiguous and asking would slow filing, flare records the interpretation in Context rather than guessing silently
- **Decomposition is explicit**: oversized asks get an epic (non-agent-ready, coordination only) plus 2–5 atomized sub-issues (each independently agent-ready), linked via `epic:<slug>` labels and GitHub sub-issue relationships
- **Ralph-ready from filing**: every issue uses the same 6-component template, ensuring Ralph can pick it straight off the backlog without triage

## Scope Boundaries

Flare is **not** for:
- Automated tool-output-driven maintenance scans (use `scan-issue-writer`)
- Triaging, closing, or grooming the existing backlog (use `backlog-grooming`)
- Root-cause analysis and TDD fix cycle once an issue exists (use `bug-squashing-methodology`)
- Reviewing an open PR's diff (use `comprehensive-pr-review`)

Flare **is** for: user says "flare this", "file a bug", "report this", "/flare", or hands you a short description → you do the research and file an agent-ready issue in one turn.

https://claude.ai/code/session_01YGyJgMWCKtVSVztzkCbtmx