### PR TITLE
fix(backend): reconcile StageContent on stable content ref, not title

### DIFF
--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -22,6 +22,7 @@ Editing happens in the content repo; see ``docs/content.md``.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -51,18 +52,47 @@ async def _load_stage_map(session: AsyncSession) -> dict[int, int]:
     return {s.stage_number: s.id for s in result.scalars().all() if s.id is not None}
 
 
-async def _load_existing_keys(
-    session: AsyncSession,
-) -> dict[tuple[int, str], StageContent]:
-    """Index existing ``StageContent`` rows by ``(course_stage_id, title)``.
+@dataclass
+class _ExistingRows:
+    """Two-tier lookup over existing ``StageContent`` for reconciliation.
 
-    Title is the natural key today (no slug column).  Using a dict — not a
-    set — lets us update fields on a row whose reference has drifted from
-    the manifest (e.g. a chapter id renamed upstream) without
-    re-inserting.
+    A chapter's stable identity is its ``content://<id>`` reference (the
+    ``url`` column), so a manifest title edit must still land on the same
+    row.  ``by_url`` is therefore the primary index; ``by_title`` is a
+    fallback that heals legacy rows whose ``url`` drifted from the manifest
+    while their title held steady.  Rows are popped from both indexes when
+    claimed so one DB row can never satisfy two manifest records.
+    """
+
+    by_url: dict[tuple[int, str], StageContent]
+    by_title: dict[tuple[int, str], StageContent]
+
+    def claim(self, course_stage_id: int, record: ChapterRecord) -> StageContent | None:
+        """Find and remove the prior row for ``record``: url first, title fallback."""
+        prior = self.by_url.get((course_stage_id, record.url))
+        if prior is None:
+            prior = self.by_title.get((course_stage_id, record.title))
+        if prior is not None:
+            self.by_url.pop((course_stage_id, prior.url), None)
+            self.by_title.pop((course_stage_id, prior.title), None)
+        return prior
+
+
+async def _load_existing_keys(session: AsyncSession) -> _ExistingRows:
+    """Index existing ``StageContent`` rows for id-keyed reconciliation.
+
+    The ``content://<id>`` reference (``url``) is the stable identity, so
+    rows are indexed primarily by ``(course_stage_id, url)`` — a title edit
+    on that stable ref updates in place instead of duplicating.  A
+    secondary ``(course_stage_id, title)`` index is a fallback that keeps
+    healing legacy rows whose ``url`` drifted from the manifest.
     """
     result = await session.execute(select(StageContent))
-    return {(sc.course_stage_id, sc.title): sc for sc in result.scalars().all()}
+    rows = list(result.scalars().all())
+    return _ExistingRows(
+        by_url={(sc.course_stage_id, sc.url): sc for sc in rows},
+        by_title={(sc.course_stage_id, sc.title): sc for sc in rows},
+    )
 
 
 def _build_new_row(record: ChapterRecord, course_stage_id: int) -> StageContent:
@@ -79,7 +109,8 @@ def _build_new_row(record: ChapterRecord, course_stage_id: int) -> StageContent:
 def _row_is_in_sync(existing: StageContent, record: ChapterRecord) -> bool:
     """Whether the DB row already matches the config for this chapter."""
     return (
-        existing.content_type == record.content_type
+        existing.title == record.title
+        and existing.content_type == record.content_type
         and existing.release_day == record.release_day
         and existing.url == record.url
     )
@@ -87,6 +118,7 @@ def _row_is_in_sync(existing: StageContent, record: ChapterRecord) -> bool:
 
 def _update_row(existing: StageContent, record: ChapterRecord) -> None:
     """Mutate ``existing`` in place to match ``record``."""
+    existing.title = record.title
     existing.content_type = record.content_type
     existing.release_day = record.release_day
     existing.url = record.url
@@ -96,7 +128,7 @@ def _reconcile_one(
     session: AsyncSession,
     record: ChapterRecord,
     stage_map: dict[int, int],
-    existing: dict[tuple[int, str], StageContent],
+    existing: _ExistingRows,
 ) -> tuple[bool, bool]:
     """Insert or update a single record.
 
@@ -106,7 +138,7 @@ def _reconcile_one(
     course_stage_id = stage_map.get(record.stage_number)
     if course_stage_id is None:
         return False, False
-    prior = existing.get((course_stage_id, record.title))
+    prior = existing.claim(course_stage_id, record)
     if prior is None:
         session.add(_build_new_row(record, course_stage_id))
         return True, True
@@ -131,7 +163,7 @@ def _warn_unmapped_manifest_stages(stage_map: dict[int, int]) -> None:
 def _reconcile_all(
     session: AsyncSession,
     stage_map: dict[int, int],
-    existing: dict[tuple[int, str], StageContent],
+    existing: _ExistingRows,
 ) -> tuple[int, bool]:
     """Reconcile every desired record; return ``(inserted_count, dirty)``."""
     inserted = 0

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -393,6 +393,38 @@ async def test_seed_content_reconciles_ref_drift(
 
 
 @pytest.mark.asyncio
+async def test_seed_content_reconciles_title_drift(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A title edit on a stable content ref updates the row in place, not duplicated."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
+    await seed_content(db_session)
+
+    result = await db_session.execute(select(StageContent).where(StageContent.title == "Survival"))
+    row = result.scalars().one()
+    assert row.id is not None
+    assert row.url == content_ref("beige-1")
+    original_id = row.id
+
+    moved = json.loads(json.dumps(_MANIFEST))
+    moved["chapters"][0]["title"] = "Survival (revised)"
+    install_manifest(moved)
+
+    inserted = await seed_content(db_session)
+    assert inserted == 0
+
+    result = await db_session.execute(
+        select(StageContent).where(StageContent.url == content_ref("beige-1"))
+    )
+    survivors = result.scalars().all()
+    assert len(survivors) == 1
+    assert survivors[0].title == "Survival (revised)"
+    assert survivors[0].id == original_id
+
+
+@pytest.mark.asyncio
 async def test_read_completions_survive_content_resync(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],


### PR DESCRIPTION
## Summary
- `seed_content` reconciled existing `StageContent` rows on `(course_stage_id, title)`, but a chapter's stable identity is its `content://<id>` reference (the `url` column). A manifest **title** edit on a chapter with an unchanged id therefore missed the existing row and inserted a **duplicate**; the seeder is deliberately non-destructive, so the stale row lingered and `ContentCompletion` read-marks kept pointing at it.
- Reconciliation now keys on the stable `url` ref first, with a `(course_stage_id, title)` **fallback** that still heals legacy url/ref drift. Matched rows are popped from both indexes so no DB row can be claimed by two manifest records. `title` is now an updatable field (added to `_row_is_in_sync` and `_update_row`), and the stale docstrings were corrected.

## Root cause
The one field used as the reconcile key (`title`) was the one field whose change was never reconciled, while the stable id (`url`) was treated as mutable — inverting the module's non-destructive-update contract for title edits.

## Test plan
- Added `test_seed_content_reconciles_title_drift`: a title edit on a stable `content://beige-1` ref re-seeds to `inserted == 0`, leaves exactly one row for that ref with the revised title, and preserves the original row `id` (so read-marks never orphan). Confirmed RED on the old code (`assert 1 == 0`), GREEN after the fix.
- Existing `test_seed_content_reconciles_ref_drift` (url drift heals in place) and `test_read_completions_survive_content_resync` still pass.
- `./scripts/backend/check-all.sh` green: 2412 passed, 96.64% total coverage (`seed_content.py` 100%), ruff `select=ALL` clean, ruff-format clean, mypy strict clean. Also verified xenon A-grade, radon MI A, interrogate 100%.

Closes #1428
