### PR TITLE
fix(journal): grow body input to fill the writing column

### DIFF
--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -105,7 +105,9 @@ const styles = StyleSheet.create({
     ...editorialType.body,
     color: colors.paper.ink,
     paddingTop: spacing(1.5),
-    // A growing multiline field; minHeight keeps the blank page inviting.
+    // A growing multiline field; flexGrow fills the writing column's
+    // available height while minHeight keeps the blank page inviting.
+    flexGrow: 1,
     minHeight: 240,
     textAlignVertical: 'top',
   },

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -225,6 +225,21 @@ describe('JournalEntryScreen', () => {
     expect(queryByText('Send')).toBeNull();
   });
 
+  it('grows the body input to fill available vertical space on a tall desktop viewport', () => {
+    const rn = require('react-native');
+    const spy = jest
+      .spyOn(rn, 'useWindowDimensions')
+      .mockReturnValue({ width: 1280, height: 900, scale: 1, fontScale: 1 });
+    try {
+      const { getByTestId } = renderScreen();
+      const body = StyleSheet.flatten(getByTestId('journal-body-input').props.style);
+      expect(body.flexGrow).toBeGreaterThan(0);
+      expect(body.minHeight).toBe(240);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('reserves a margin column for the inline marginalia UI', () => {
     const { getByTestId } = renderScreen();
     expect(getByTestId('journal-margin-column')).toBeTruthy();


### PR DESCRIPTION
## Summary

- The journal body `TextInput` carried a fixed `minHeight: 240` with no flex rule, so on tall/desktop viewports it rendered as a short box with a large dead zone below it — reading like a legacy `<textarea>` rather than a full-page writing surface.
- Added `flexGrow: 1` to the `bodyInput` style. The writing column's `ScrollView` content container already sets `flexGrow: 1`, so the body input (the sole flexible flat child) now absorbs the surplus vertical space and fills the column on load, while `minHeight: 240` stays the floor.
- Scroll ownership is unchanged: the outer `ScrollView` still owns scrolling (`scrollEnabled={false}`), and long entries still grow past the viewport and scroll. Narrow/mobile layout is unaffected.

## Test plan

- Added a Jest test that renders the entry screen on a mocked tall desktop viewport and asserts the flattened `journal-body-input` style has `flexGrow > 0` and preserves `minHeight === 240` (guards the floor against a future regression). Confirmed RED before the fix, GREEN after.
- `./scripts/frontend/check-all.sh` passes: ESLint (zero warnings), `tsc --noEmit` (strict), all 3594 Jest tests, prettier.

Closes #1449
