### PR TITLE
fix(journal): persist full body atomically on Finish and surface failures

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -65,6 +65,15 @@ const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonan
 const LOAD_ERROR_MESSAGE =
   "We couldn't open this entry. Check your connection and try again — your existing writing is safe.";
 
+/**
+ * Shown when the atomic Finish write fails. The Finish write is the only path
+ * that flips status, so on failure the entry stays a draft: this reassures the
+ * writing is untouched (still in local state, autosave keeps retrying) and asks
+ * for a simple retry.
+ */
+const FINISH_ERROR_MESSAGE =
+  "We couldn't finish this entry. Check your connection and tap Finish again — your writing is safe here and still saving.";
+
 type SaveState = 'idle' | 'typing' | 'saving' | 'saved' | 'error';
 
 export type JournalEntryScreenProps = NativeStackScreenProps<RootStackParamList, 'JournalEntry'> & {
@@ -100,6 +109,30 @@ interface WriteEntryRefs {
   chordRef: React.MutableRefObject<AspectChordValue>;
 }
 
+/**
+ * Create the entry with its full body + tags in one call, returning the new
+ * server id. Only attaches context keys when present, so a plain entry's payload
+ * stays lean rather than carrying explicit nulls. ``classification`` always rides
+ * along so the entry's privacy tier is set at birth (defaults to personal).
+ */
+async function createEntry(refs: WriteEntryRefs, body: string, ctx: SaveContext): Promise<number> {
+  const { classificationRef, chordRef } = refs;
+  const created = await journal.create({
+    message: body,
+    classification: classificationRef.current,
+    primary_aspect: chordRef.current.primary,
+    secondary_aspect: chordRef.current.secondary,
+    ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
+    ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
+  });
+  return created.id;
+}
+
+/** A blank title collapses to null so an empty title is stored as absent. */
+function titleOrNull(title: string): string | null {
+  return title.trim() ? title : null;
+}
+
 /** Create on first save, then update; title is optional and saved separately. */
 async function writeEntry(
   refs: WriteEntryRefs,
@@ -107,7 +140,7 @@ async function writeEntry(
   body: string,
   ctx: SaveContext,
 ): Promise<void> {
-  const { entryIdRef, respondedRef, classificationRef, chordRef } = refs;
+  const { entryIdRef, respondedRef } = refs;
   // Weekly-prompt mode: the respond endpoint persists the entry itself, so we
   // submit exactly once and never pair it with journal.create (no double-create).
   if (ctx.weekNumber != null) {
@@ -116,26 +149,42 @@ async function writeEntry(
     respondedRef.current = true;
     return;
   }
-  const trimmedTitle = title.trim() ? title : null;
+  const trimmedTitle = titleOrNull(title);
   if (entryIdRef.current == null) {
-    // Only attach context keys when present, so a plain entry's payload stays
-    // lean rather than carrying explicit nulls. ``classification`` always rides
-    // along so the entry's privacy tier is set at birth (defaults to personal).
-    const created = await journal.create({
-      message: body,
-      classification: classificationRef.current,
-      primary_aspect: chordRef.current.primary,
-      secondary_aspect: chordRef.current.secondary,
-      ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
-      ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
-    });
-    entryIdRef.current = created.id;
+    entryIdRef.current = await createEntry(refs, body, ctx);
     if (trimmedTitle != null) {
-      await journal.update(created.id, { title: trimmedTitle, status: 'draft' });
+      await journal.update(entryIdRef.current, { title: trimmedTitle, status: 'draft' });
     }
   } else {
     await journal.update(entryIdRef.current, { message: body, title: trimmedTitle });
   }
+}
+
+/**
+ * The single authoritative Finish write: one atomic update that carries the FULL
+ * body + title alongside the ``finished`` status flip, so an earlier, shorter
+ * autosave can never win. Rejects on failure (never swallows) so the caller keeps
+ * the entry a draft and surfaces a retry. Resolves to the finished entry's id.
+ *
+ * Weekly-prompt compose has no local id to finish, so the Finish affordance is
+ * withheld there and this path handles only plain/practice entries.
+ */
+async function finishWrite(
+  refs: WriteEntryRefs,
+  title: string,
+  body: string,
+  ctx: SaveContext,
+): Promise<number> {
+  const finishTitle = titleOrNull(title);
+  const id = refs.entryIdRef.current;
+  if (id == null) {
+    const created = await createEntry(refs, body, ctx);
+    refs.entryIdRef.current = created;
+    await journal.update(created, { title: finishTitle, status: 'finished' });
+    return created;
+  }
+  await journal.update(id, { message: body, title: finishTitle, status: 'finished' });
+  return id;
 }
 
 interface AutosaveApi {
@@ -156,6 +205,12 @@ interface AutosaveApi {
   onChangeChord: (_next: AspectChordValue) => void;
   /** Persist the latest text immediately and resolve to the entry id (or null). */
   flush: () => Promise<number | null>;
+  /**
+   * Perform the single atomic Finish write (full body + title + ``finished``
+   * status) after draining any in-flight autosave, resolving to the entry id.
+   * Rejects on failure so the caller keeps the entry a draft and offers a retry.
+   */
+  finish: () => Promise<number>;
   /** Set when loading an existing entry failed; drives the banner. */
   loadError: string | null;
   /**
@@ -448,6 +503,73 @@ function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) =
   );
 }
 
+/** The refs the Finish writer reads: the write payload plus its timers + gates. */
+type FinishRunnerRefs = WriteEntryRefs & {
+  entryUnsettledRef: React.MutableRefObject<boolean>;
+  ctxRef: React.MutableRefObject<SaveContext>;
+  inFlightRef: React.MutableRefObject<Promise<void> | null>;
+  timerRef: TimerRef;
+};
+
+/** Raised when Finish is pressed before an existing entry's load has settled. */
+const UNSETTLED_FINISH_ERROR = 'Cannot finish an entry that has not finished loading.';
+
+type RunFinish = (_title: string, _body: string) => Promise<number>;
+
+/**
+ * The Finish action: cancel any pending debounce, drain in-flight autosaves so a
+ * shorter one can't land after us, then issue the single atomic Finish write.
+ * Tracks the save state and rethrows on failure so the caller keeps the draft.
+ */
+function useFinishWriter(
+  refs: FinishRunnerRefs,
+  setSaveState: (_state: SaveState) => void,
+): RunFinish {
+  const { entryIdRef, respondedRef, classificationRef, chordRef } = refs;
+  const { entryUnsettledRef, ctxRef, inFlightRef, timerRef } = refs;
+  return useCallback<RunFinish>(
+    async (title, body) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      // The tracked autosave never rejects, so draining it is safe; this ensures a
+      // slower, shorter autosave can't overwrite the body after the Finish write.
+      while (inFlightRef.current) await inFlightRef.current;
+      if (entryUnsettledRef.current) throw new Error(UNSETTLED_FINISH_ERROR);
+      setSaveState('saving');
+      const writeRefs = { entryIdRef, respondedRef, classificationRef, chordRef };
+      const task = finishWrite(writeRefs, title, body, ctxRef.current);
+      // Register a never-rejecting shadow in the single-flight slot so a keystroke
+      // that schedules an autosave mid-finish drains onto us (and sees the id our
+      // create set) rather than firing a second journal.create.
+      const shadow = task.then(
+        () => undefined,
+        () => undefined,
+      );
+      inFlightRef.current = shadow;
+      try {
+        const id = await task;
+        setSaveState('saved');
+        return id;
+      } catch (error) {
+        setSaveState('error');
+        throw error;
+      } finally {
+        if (inFlightRef.current === shadow) inFlightRef.current = null;
+      }
+    },
+    [
+      entryIdRef,
+      respondedRef,
+      classificationRef,
+      chordRef,
+      entryUnsettledRef,
+      ctxRef,
+      inFlightRef,
+      timerRef,
+      setSaveState,
+    ],
+  );
+}
+
 /**
  * Compose the tier + chord persisters: their refs (read by the writer), their
  * seeders (for load), and error-surfacing change wrappers sharing the save hint.
@@ -476,6 +598,22 @@ function usePersistControls(
     persistClassification: useErrorSurfacingPersist(changeClassification, setSaveState),
     persistChord: useErrorSurfacingPersist(changeChord, setSaveState),
   };
+}
+
+/** The debounced save + immediate flush + atomic finish, over one shared ref bundle. */
+type DraftWriters = SaveTimer & { finish: (_title: string, _body: string) => Promise<number> };
+
+/** Wire the three writers (debounced save, flush, atomic finish) over shared refs. */
+function useDraftWriters(
+  refs: SaveRunnerRefs & FinishRunnerRefs,
+  delayMs: number,
+  setSaveState: (_state: SaveState) => void,
+): DraftWriters {
+  const setTyping = useCallback(() => setSaveState('typing'), [setSaveState]);
+  const run = useSaveRunner(refs, setSaveState);
+  const { save, flush } = useSaveTimer(run, refs.timerRef, refs.entryIdRef, delayMs, setTyping);
+  const finish = useFinishWriter(refs, setSaveState);
+  return { save, flush, finish };
 }
 
 /** Debounced create-then-update draft saver; tracks the save state. */
@@ -511,7 +649,7 @@ function useDebouncedSave(
   });
   useTimerCleanup(timerRef);
 
-  const run = useSaveRunner(
+  const { save, flush, finish } = useDraftWriters(
     {
       entryIdRef,
       respondedRef,
@@ -521,17 +659,17 @@ function useDebouncedSave(
       ctxRef,
       onSavedRef,
       inFlightRef,
+      timerRef,
     },
+    delayMs,
     setSaveState,
   );
-
-  const setTyping = useCallback(() => setSaveState('typing'), []);
-  const { save, flush } = useSaveTimer(run, timerRef, entryIdRef, delayMs, setTyping);
 
   return {
     saveState,
     save,
     flush,
+    finish,
     changeClassification: persist.persistClassification,
     changeChord: persist.persistChord,
     seedPersist: persist.seedPersist,
@@ -539,6 +677,24 @@ function useDebouncedSave(
 }
 
 type StrRef = React.MutableRefObject<string>;
+
+/** Bind flush + finish to the latest title/body refs so callers pass no args. */
+function useBoundWriters(
+  flush: (_title: string, _body: string) => Promise<number | null>,
+  finish: (_title: string, _body: string) => Promise<number>,
+  titleRef: StrRef,
+  bodyRef: StrRef,
+): { flushNow: () => Promise<number | null>; finishNow: () => Promise<number> } {
+  const flushNow = useCallback(
+    () => flush(titleRef.current, bodyRef.current),
+    [flush, titleRef, bodyRef],
+  );
+  const finishNow = useCallback(
+    () => finish(titleRef.current, bodyRef.current),
+    [finish, titleRef, bodyRef],
+  );
+  return { flushNow, finishNow };
+}
 
 /** Referentially-stable change handlers; each save reads the other field's ref. */
 function useFieldHandlers(
@@ -707,7 +863,7 @@ function useJournalAutosave(
   // and failed-load windows (and is irrelevant for a new entry — routeEntryId is
   // null). Gate the writer + controls on this so neither touches an unseen entry.
   const entryUnsettled = routeEntryId != null && !entry.loaded;
-  const { saveState, save, flush, changeClassification, changeChord, seedPersist } =
+  const { saveState, save, flush, finish, changeClassification, changeChord, seedPersist } =
     useDebouncedSave(routeEntryId, delayMs, ctx, entryUnsettled, onSaved);
   useSeedPersistOnLoad(entry, seedPersist);
 
@@ -718,10 +874,7 @@ function useJournalAutosave(
     entry.setTitle,
     entry.setBody,
   );
-  const flushNow = useCallback(
-    () => flush(titleRef.current, bodyRef.current),
-    [flush, titleRef, bodyRef],
-  );
+  const { flushNow, finishNow } = useBoundWriters(flush, finish, titleRef, bodyRef);
   const { onChangeClassification, onChangeChord } = useChoiceHandlers(
     entry,
     changeClassification,
@@ -741,6 +894,7 @@ function useJournalAutosave(
     onChangeClassification,
     onChangeChord,
     flush: flushNow,
+    finish: finishNow,
     loadError: entry.loadError,
     controlsLocked: entryUnsettled,
   };
@@ -757,6 +911,10 @@ interface WritingColumnProps {
   onChangeClassification: (_tier: JournalClassification) => void;
   onChangeChord: (_next: AspectChordValue) => void;
   onFinish?: () => void;
+  /** True while the Finish write is in flight; drives the busy/disabled control. */
+  finishing: boolean;
+  /** Set (to {@link FINISH_ERROR_MESSAGE}) when the Finish write failed. */
+  finishError: string | null;
   bodyPlaceholder?: string;
   /**
    * Disables the tier + chord controls until an existing entry's load settles
@@ -771,16 +929,33 @@ interface WritingColumnProps {
   titleReadOnly: boolean;
 }
 
-/** Quiet control to mark a draft finished. */
-function FinishControl({ onFinish }: { onFinish: () => void }) {
+/** Quiet control to mark a draft finished, with a warm retry notice on failure. */
+function FinishControl({
+  onFinish,
+  finishing,
+  finishError,
+}: {
+  onFinish: () => void;
+  finishing: boolean;
+  finishError: string | null;
+}) {
   return (
-    <Button
-      variant="tertiary"
-      onPress={onFinish}
-      accessibilityLabel="Mark this entry finished"
-      testID="journal-finish-button"
-      label="Finish"
-    />
+    <>
+      <Button
+        variant="tertiary"
+        onPress={onFinish}
+        accessibilityLabel="Mark this entry finished"
+        testID="journal-finish-button"
+        label="Finish"
+        busy={finishing}
+        disabled={finishing}
+      />
+      {finishError == null ? null : (
+        <Text style={styles.marginError} testID="journal-finish-error">
+          {finishError}
+        </Text>
+      )}
+    </>
   );
 }
 
@@ -865,6 +1040,8 @@ function WritingColumn({
   onChangeClassification,
   onChangeChord,
   onFinish,
+  finishing,
+  finishError,
   bodyPlaceholder = 'Begin writing…',
   controlsDisabled,
   titleReadOnly,
@@ -893,7 +1070,9 @@ function WritingColumn({
       <Text style={styles.savedHint} testID="journal-save-hint">
         {savedHintLabel(saveState)}
       </Text>
-      {onFinish ? <FinishControl onFinish={onFinish} /> : null}
+      {onFinish ? (
+        <FinishControl onFinish={onFinish} finishing={finishing} finishError={finishError} />
+      ) : null}
     </ScrollView>
   );
 }
@@ -1015,16 +1194,18 @@ function useEssayModal(updateNote: (_note: Marginalia) => void) {
 interface EditGateArgs {
   status: EntryStatus;
   setStatus: (_status: EntryStatus) => void;
-  flush: () => Promise<number | null>;
+  finish: () => Promise<number>;
   body: string;
   navigation: ScreenNavigation;
   onConfirmEdit: () => void;
 }
 
 /** The deliberate edit gate for finished entries + the draft "Finish" action. */
-function useEditGate({ status, setStatus, flush, body, navigation, onConfirmEdit }: EditGateArgs) {
+function useEditGate({ status, setStatus, finish, body, navigation, onConfirmEdit }: EditGateArgs) {
   const [editing, setEditing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
   // A finished entry is read-only until the user deliberately chooses to edit.
   const editMode = editing || status !== 'finished';
 
@@ -1039,13 +1220,21 @@ function useEditGate({ status, setStatus, flush, body, navigation, onConfirmEdit
     setConfirmOpen(false);
     navigation.push('JournalEntry');
   }, [navigation]);
+  // Only flip to finished once the single atomic write resolves; on failure the
+  // entry stays a draft (editable) and the error invites a retry.
   const markFinished = useCallback(async () => {
-    const id = await flush();
-    if (id == null) return;
-    await journal.update(id, { status: 'finished' });
-    setStatus('finished');
-    setEditing(false);
-  }, [flush, setStatus]);
+    setFinishError(null);
+    setFinishing(true);
+    try {
+      await finish();
+      setStatus('finished');
+      setEditing(false);
+    } catch {
+      setFinishError(FINISH_ERROR_MESSAGE);
+    } finally {
+      setFinishing(false);
+    }
+  }, [finish, setStatus]);
 
   const canFinish = status === 'draft' && body.trim().length > 0;
   return {
@@ -1057,6 +1246,8 @@ function useEditGate({ status, setStatus, flush, body, navigation, onConfirmEdit
     startNew,
     markFinished,
     canFinish,
+    finishing,
+    finishError,
   };
 }
 
@@ -1168,7 +1359,7 @@ function useJournalEntryController(
   const editGate = useEditGate({
     status: autosave.status,
     setStatus: autosave.setStatus,
-    flush: autosave.flush,
+    finish: autosave.finish,
     body: autosave.body,
     navigation,
     onConfirmEdit,
@@ -1206,9 +1397,13 @@ type Controller = ReturnType<typeof useJournalEntryController>;
 function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
   const { title, body, saveState, classification, chord } = ctl.autosave;
   const { editMode, canFinish, markFinished, requestEdit } = ctl.editGate;
+  const { finishing, finishError } = ctl.editGate;
   // Until an existing entry's load settles (still in flight or failed) the
   // controls are bound to an unseen entry, so disable them.
   const controlsDisabled = ctl.autosave.controlsLocked;
+  // Withhold Finish in weekly-prompt compose: the respond endpoint has no local
+  // id to finish, so the affordance would be a dead end (see titleReadOnly).
+  const canOfferFinish = canFinish && !ctl.titleReadOnly;
   return editMode ? (
     <WritingColumn
       title={title}
@@ -1220,7 +1415,9 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       onChangeBody={ctl.handleBody}
       onChangeClassification={ctl.autosave.onChangeClassification}
       onChangeChord={ctl.autosave.onChangeChord}
-      onFinish={canFinish ? markFinished : undefined}
+      onFinish={canOfferFinish ? markFinished : undefined}
+      finishing={finishing}
+      finishError={finishError}
       bodyPlaceholder={bodyPlaceholder}
       controlsDisabled={controlsDisabled}
       titleReadOnly={ctl.titleReadOnly}

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -585,7 +585,12 @@ describe('JournalEntryScreen', () => {
       await act(async () => {
         await Promise.resolve();
       });
-      expect(mockUpdate).toHaveBeenCalledWith(42, { status: 'finished' });
+      // Spec change: Finish now writes the full body + title atomically with the status flip, not a status-only PATCH.
+      expect(mockUpdate).toHaveBeenCalledWith(42, {
+        message: 'A finished thought.',
+        title: null,
+        status: 'finished',
+      });
       // Returns to read mode.
       expect(await findByTestId('journal-edit-button')).toBeTruthy();
     } finally {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenFinish.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenFinish.test.tsx
@@ -1,0 +1,307 @@
+/* eslint-env jest */
+// Pins the Journal "Finish" data-loss bug: a failed final write can silently flip status to 'finished' on top of a stale/shorter autosaved body.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { JournalMessage } from '@/api';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+// Comfortably longer than the shelf's EXCERPT_MAX (140 chars) and multi-paragraph,
+// so a truncation regression on the Finish write path is meaningful, not incidental.
+const LONG_BODY = `The morning light moved slowly across the kitchen table, and something about it made me want to keep writing well past the point where I would usually stop for the day.
+
+By the time the kettle finally whistled the thought had unspooled into something far longer than I expected, so I kept going anyway, filling the page with more than I meant to say.`;
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'An existing page about rivers.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderScreen(
+  params?: { entryId?: number; weekNumber?: number; promptQuestion?: string },
+  extraProps: Record<string, unknown> = {},
+) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+});
+
+describe('JournalEntryScreen Finish — atomic write', () => {
+  it('persists the full body atomically with the status flip, not a status-only PATCH', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      // Isolate exactly what Finish itself writes.
+      mockCreate.mockClear();
+      mockUpdate.mockClear();
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      // Exactly one write carrying the full body, not a body PATCH plus a separate status-only PATCH.
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith(42, {
+        message: LONG_BODY,
+        title: null,
+        status: 'finished',
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('creates with the full (untruncated) body when Finish is pressed before the autosave debounce fires', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 1500 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      // Press Finish immediately, well inside the 1500ms debounce window, so the entry has no id yet.
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ message: LONG_BODY }));
+      expect(mockUpdate).toHaveBeenCalledWith(42, expect.objectContaining({ status: 'finished' }));
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('JournalEntryScreen Finish — failure is visible and safe', () => {
+  it('does not flip status to finished when the write fails partway (the data-loss case)', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId, queryByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      mockUpdate.mockReset();
+      // First write (the one Finish issues) fails; any later write would succeed.
+      mockUpdate.mockResolvedValue(entry({ id: 42, status: 'finished' }));
+      mockUpdate.mockRejectedValueOnce(new Error('network down'));
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Still in edit mode: body input present, read-mode Edit affordance absent.
+      expect(getByTestId('journal-body-input')).toBeTruthy();
+      expect(queryByTestId('journal-edit-button')).toBeNull();
+      expect(queryByTestId('journal-finish-error')).not.toBeNull();
+      // The control is re-enabled so a retry is possible.
+      const btn = getByTestId('journal-finish-button');
+      expect(btn.props.accessibilityState.disabled).toBeFalsy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('lets a retry succeed after a failed Finish attempt', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId, findByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      mockUpdate.mockReset();
+      mockUpdate.mockResolvedValue(entry({ id: 42, status: 'finished' }));
+      mockUpdate.mockRejectedValueOnce(new Error('network down'));
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // First attempt failed — still editable.
+      expect(getByTestId('journal-body-input')).toBeTruthy();
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      expect(await findByTestId('journal-edit-button')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps a retryable draft when Finish creates the entry but the status write fails', async () => {
+    jest.useFakeTimers();
+    try {
+      // Long debounce so the entry has no id yet: Finish must create it, then flip status.
+      const { getByTestId, queryByTestId, findByTestId } = renderScreen(undefined, {
+        autosaveDelayMs: 1500,
+      });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      mockUpdate.mockReset();
+      mockUpdate.mockResolvedValue(entry({ id: 42, status: 'finished' }));
+      mockUpdate.mockRejectedValueOnce(new Error('network down'));
+
+      // First Finish: the create lands (full body saved as a draft), the status write fails.
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(queryByTestId('journal-finish-error')).not.toBeNull();
+      expect(getByTestId('journal-body-input')).toBeTruthy();
+
+      // Retry takes the update branch (the id now exists) and succeeds — no second create.
+      fireEvent.press(getByTestId('journal-finish-button'));
+      expect(await findByTestId('journal-edit-button')).toBeTruthy();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('never leaves an unhandled promise rejection when the finish write fails outright', async () => {
+    // Cast through `unknown`: process is a real EventEmitter at runtime, but this project's tsconfig omits ambient Node types.
+    const emitter = process as unknown as {
+      on: (_event: 'unhandledRejection', _listener: (_reason: unknown) => void) => void;
+      off: (_event: 'unhandledRejection', _listener: (_reason: unknown) => void) => void;
+    };
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      rejections.push(reason);
+    };
+    emitter.on('unhandledRejection', onUnhandled);
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 0 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+
+      mockUpdate.mockReset();
+      mockUpdate.mockRejectedValue(new Error('network down'));
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      // Give the real event loop a couple of full turns so a rejection would surface.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(rejections).toEqual([]);
+    } finally {
+      emitter.off('unhandledRejection', onUnhandled);
+    }
+  });
+});
+
+describe('JournalEntryScreen Finish — busy state', () => {
+  it('marks the Finish control busy/disabled while the write is in flight and ignores a second press', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), LONG_BODY);
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      mockUpdate.mockReset();
+      mockUpdate.mockReturnValue(new Promise<JournalMessage>(() => {})); // never resolves
+
+      fireEvent.press(getByTestId('journal-finish-button'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const btn = getByTestId('journal-finish-button');
+      expect(btn.props.accessibilityState.busy).toBe(true);
+      expect(btn.props.accessibilityState.disabled).toBe(true);
+
+      fireEvent.press(getByTestId('journal-finish-button')); // second press while busy
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockUpdate).toHaveBeenCalledTimes(1); // no double-fire
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('JournalEntryScreen Finish — prompt-compose has no Finish affordance', () => {
+  it('does not render the Finish control when weekNumber is set (respond has no local id to finish)', () => {
+    const { getByTestId, queryByTestId } = renderScreen({
+      weekNumber: 3,
+      promptQuestion: 'What did you notice?',
+    });
+    fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
+    expect(queryByTestId('journal-finish-button')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -12,10 +12,14 @@ const mockList = jest.fn() as jest.MockedFunction<
 >;
 const mockPromptCurrent = jest.fn() as jest.MockedFunction<() => Promise<PromptDetail>>;
 const mockNavigate = jest.fn();
+// Present so a display-only excerpt() regression that starts writing back to the
+// server (instead of only truncating the rendered preview) has something to trip.
+const mockUpdate = jest.fn();
 
 jest.mock('@/api', () => ({
   journal: {
     list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
   },
   prompts: {
     current: (...a: unknown[]) =>
@@ -131,6 +135,7 @@ beforeEach(() => {
   mockList.mockReset();
   mockNavigate.mockReset();
   mockPromptCurrent.mockReset();
+  mockUpdate.mockReset();
   mockList.mockResolvedValue(page([]));
   // Default: the weekly prompt is already answered, so no card surfaces.
   mockPromptCurrent.mockResolvedValue(prompt({ has_responded: true }));
@@ -236,13 +241,15 @@ describe('JournalShelfScreen', () => {
     expect(within(card).queryByText(/saved today/)).toBeNull();
   });
 
-  it('truncates a long entry body to an ellipsis excerpt', async () => {
+  it('truncates a long entry body to an ellipsis excerpt, display-only (no journal.update)', async () => {
     const longBody = 'word '.repeat(60).trim();
     mockList.mockResolvedValue(page([entry(4, { message: longBody })]));
     const { findByTestId } = render(<JournalShelfScreen />);
     const card = await findByTestId('journal-shelf-card-4');
     expect(within(card).getByText(new RegExp(`${String.fromCharCode(0x2026)}$`))).toBeTruthy();
     expect(within(card).queryByText(longBody)).toBeNull();
+    // Rendering the excerpt must never write anything back to the server.
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it('starts a blank page from the empty-state call to action', async () => {


### PR DESCRIPTION
## Summary

The Journal **Finish** button silently failed and could persist a body truncated to the shelf preview length — a data-loss bug (#1450). Root cause was entirely in `JournalEntryScreen`; two distinct failures:

1. **Silent failure.** `markFinished` awaited `flush()` then a status-only PATCH with no try/catch, loading state, or error surface. Any rejection was an unhandled promise: the button showed nothing, status never flipped, and the user got no signal the save failed.
2. **Truncation / data loss.** Finish issued a *status-only* PATCH that did **not** carry the body. Racing the debounced autosave, only an earlier, shorter autosaved body could survive server-side — the "cut off at preview length" symptom. (The preview-length match was coincidental: `excerpt()` is render-only. The backend does **not** truncate — it caps at the message max length and raises 422; there is no silent 140-char cut. Confirmed, so no backend change was needed.)

### The fix
- A single **atomic `finishWrite`** carries the full body + title + the `status:'finished'` flip in **one** update (creating the entry first when it has no id yet), so an earlier/shorter autosave can never win.
- `useFinishWriter` cancels the pending debounce, **drains any in-flight autosave** before writing, and registers a never-rejecting shadow in the single-flight slot so a keystroke mid-finish can't spawn a duplicate `journal.create`.
- `useEditGate` now tracks `finishing`/`finishError`: it flips status **only on success**, keeps the entry a **retryable draft** on failure, and surfaces an actionable error notice.
- `FinishControl` is busy/disabled while the write is in flight (no double-fire) and is withheld in weekly-prompt compose (which has no local id to finish).
- Extracted `useDraftWriters` / `useBoundWriters` to keep the touched hooks within complexity limits.

## Test plan
- New `JournalEntryScreenFinish.test.tsx` (8 cases): atomic full-body write on the update and create branches; status does **not** flip on partial write failure; retry succeeds after a failed attempt (update branch, no second create); no unhandled rejection on outright failure; busy/disabled with no double-fire; no Finish affordance in prompt-compose.
- Updated `JournalEntryScreen.test.tsx` (Finish now writes body+title+status atomically) and `JournalShelfScreen.test.tsx` (preview `excerpt()` is display-only — never writes back).
- `./scripts/frontend/check-all.sh` green (lint, prettier, typecheck, 3601 tests); Gate 2.5 self-review verdict CLEAN.

Closes #1450