### PR TITLE
fix(journal): reset CareSupportNote collapse on a fresh care pass

### DIFF
--- a/frontend/src/features/Journal/CareSupportNote.tsx
+++ b/frontend/src/features/Journal/CareSupportNote.tsx
@@ -71,17 +71,19 @@ function ExpandedBody({
 }
 
 function CareSupportNote({ care }: CareSupportNoteProps): React.JSX.Element | null {
-  const [expanded, setExpanded] = useState(true);
+  // Reference-identity collapse: a fresh care object never matches the pinned one, so a new crisis signal always re-surfaces the resources.
+  const [collapsedFor, setCollapsedFor] = useState<CareResponse | null>(null);
   if (care == null) return null;
+  const expanded = collapsedFor !== care;
   return (
     <View style={reflectionCardStyles.root} testID="care-support">
       <Text style={reflectionCardStyles.header} accessibilityRole="header">
         {care.message}
       </Text>
       {expanded ? (
-        <ExpandedBody resources={care.resources} onDismiss={() => setExpanded(false)} />
+        <ExpandedBody resources={care.resources} onDismiss={() => setCollapsedFor(care)} />
       ) : (
-        <ReopenControl onPress={() => setExpanded(true)} />
+        <ReopenControl onPress={() => setCollapsedFor(null)} />
       )}
     </View>
   );

--- a/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
@@ -208,6 +208,19 @@ describe('CareSupportNote — dismiss and re-open', () => {
     fireEvent.press(getByTestId('care-dismiss'));
     expect(getByTestId('care-support')).toBeTruthy();
   });
+
+  it('re-shows the resources when a NEW care object arrives after a prior dismissal (fresh crisis signal)', () => {
+    const { getByTestId, queryByTestId, getByText, rerender } = render(
+      <CareSupportNote care={carePayload()} />,
+    );
+    fireEvent.press(getByTestId('care-dismiss'));
+    expect(queryByTestId('care-resource-hotline')).toBeNull();
+
+    rerender(<CareSupportNote care={carePayload({ message: 'second crisis pass' })} />);
+
+    expect(getByTestId('care-resource-hotline')).toBeTruthy();
+    expect(getByText('second crisis pass')).toBeTruthy();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `CareSupportNote` (the safety-critical crisis-care surface) reset its collapse state correctly only within a single render: expand/collapse lived in a component-local `useState(true)` that was never reset when the `care` prop changed.
- Root cause: the parent renders the note unconditionally and the component self-handles `null` via an early return, which does not unmount the fiber — so a dismissed resource list stayed collapsed across every subsequent resonance pass. A distressed user who dismissed the 988 / Crisis Text Line / clinician resources and triggered a fresh acute-distress `care` pass got them hidden behind a "Show support options" tap on the second signal, contradicting the component's "never lose their way back to help" contract.
- Fix: track collapse by reference identity (`collapsedFor: CareResponse | null`, `expanded = collapsedFor !== care`), mirroring the sibling `ContractionReflectionNote`. A fresh `care` object never matches the pinned one, so a new crisis signal always re-surfaces the resources (fail-open — never less visible than intended), while same-pass dismiss → reopen still works.

## Test plan
- Added a multi-pass regression test: dismiss the resources, `rerender` with a NEW `care` object, assert the resources re-appear and the new header message renders (analogous to `ContractionReflectionNote`'s "new object resurfaces" test).
- `npx jest src/features/Journal/__tests__/CareSupportNote.test.tsx` — 25/25 pass (was RED before the fix on the new test).
- `./scripts/frontend/check-all.sh` — green: 3603 tests pass, ESLint zero-warning, `tsc --noEmit` clean, coverage threshold met.

Closes #1438
