### PR TITLE
fix(safety): inherit shared negator across or/nor coordination for denied clauses

### DIFF
--- a/backend/src/domain/safety.py
+++ b/backend/src/domain/safety.py
@@ -55,6 +55,17 @@ to I want to die" still flags). Because the window is strictly before the match,
 negator that is itself part of a positive phrase (the "don't" in "don't want to
 be alive anymore") can never suppress that phrase.
 
+A further suppression realizes the negative-polarity coordination the module
+already relies on for keeping ``or``/``nor`` out of the clause boundaries: a match
+that is the bare right conjunct of an "X or Y" (or "X nor Y") coordination is
+suppressed when its left acute conjunct ``X`` is itself denied, so a shared
+negator is inherited rightward down the whole chain ("I have no plans to kill
+myself or hurt myself" is a single denial). The inheritance is resolved
+iteratively, not recursively, so an adversarially long or-chain terminates without
+RecursionError. Any intervening words or punctuation between the conjuncts break
+the coordination and restore normal per-match behavior ("I have no plans to kill
+myself or I will hurt myself" still flags the self-harm conjunct).
+
 Purity: no FastAPI, SQLModel, or network/LLM imports — only the standard library.
 """
 
@@ -206,6 +217,16 @@ _COORDINATING_CONJUNCTIONS = r"\b(?:and|but)\b"
 # deliberately excluded (see _COORDINATING_CONJUNCTIONS).
 _CLAUSE_BOUNDARY = re.compile(rf"[.!?;,]|{_COORDINATING_CONJUNCTIONS}", re.IGNORECASE)
 
+# A bare "or"/"nor" as the very last token of a prefix (only whitespace after it):
+# the coordinator joining a right conjunct to the acute clause immediately before
+# it. Intervening words fail the trailing anchor, breaking the coordination.
+_BARE_COORDINATOR = re.compile(r"\b(?:or|nor)\s*$", re.IGNORECASE)
+
+# Left-conjunct search is bounded to this many characters before the coordinator.
+# It comfortably exceeds the longest acute phrase, so a bare right conjunct always
+# finds its left conjunct while the search stays cheap on long or-chains.
+_CONJUNCT_LOOKBACK_CHARS = 80
+
 
 def _tail_window(prefix: str) -> str:
     """Return the last :data:`_NEGATION_WINDOW_WORDS` tokens of ``prefix``.
@@ -233,6 +254,75 @@ def _is_negated(normalized: str, match_start: int) -> bool:
     if _TEMPORAL_NEGATOR.search(window):
         return True
     return len(_LOGICAL_NEGATORS.findall(window)) % 2 == 1
+
+
+def _acute_phrase_start_ending_at(normalized: str, boundary: int) -> int | None:
+    """Return the earliest start of an acute phrase ending exactly at ``boundary``.
+
+    Each phrase is searched over the window ``[boundary - _CONJUNCT_LOOKBACK_CHARS,
+    boundary]`` of ``normalized`` (using ``pos``/``endpos`` on the full string so
+    word boundaries stay correct), and only a match ending precisely at
+    ``boundary`` qualifies. ``None`` when no acute phrase abuts that offset.
+    """
+    floor = max(0, boundary - _CONJUNCT_LOOKBACK_CHARS)
+    starts = [
+        match.start()
+        for _, pattern in _COMPILED
+        for match in pattern.finditer(normalized, floor, boundary)
+        if match.end() == boundary
+    ]
+    return min(starts) if starts else None
+
+
+def _coordinated_conjunct_start(normalized: str, match_start: int) -> int | None:
+    """Return the start of the acute left conjunct coordinated with this match.
+
+    When the match at ``match_start`` is the bare right conjunct of an "X or Y"
+    (or "X nor Y") coordination — the coordinator being the last token before the
+    match — the left conjunct ``X`` must be an acute phrase ending exactly where
+    the coordinator begins. The earliest such phrase's start offset is returned so
+    a shared negator can be inherited from it; ``None`` when there is no bare
+    coordinator or no acute left conjunct abutting it.
+    """
+    prefix = normalized[:match_start]
+    coordinator = _BARE_COORDINATOR.search(prefix)
+    if coordinator is None:
+        return None
+    boundary = len(prefix[: coordinator.start()].rstrip())
+    return _acute_phrase_start_ending_at(normalized, boundary)
+
+
+def _is_denied(normalized: str, match_start: int, cache: dict[int, bool]) -> bool:
+    """Return whether the match at ``match_start`` is denied by negation.
+
+    A match is denied when it is directly negated, or when it is the bare right
+    conjunct of an or/nor coordination whose left conjunct is itself denied. The
+    coordination is walked iteratively rather than recursively, so an adversarially
+    long or-chain terminates quickly and without ``RecursionError``; each step
+    moves strictly leftward, guaranteeing termination.
+
+    ``cache`` memoizes the denied-status of every offset visited within a single
+    :func:`assess_distress` call. Every offset on one walk shares the walk's
+    result (a not-yet-negated conjunct is denied exactly when the conjunct it
+    inherits from is), so caching them collapses the repeated left-walks of
+    overlapping or-chains from cubic to quadratic total work.
+    """
+    chain: list[int] = []
+    current = match_start
+    while current not in cache:
+        if _is_negated(normalized, current):
+            cache[current] = True
+            break
+        chain.append(current)
+        left = _coordinated_conjunct_start(normalized, current)
+        if left is None:
+            cache[current] = False
+            break
+        current = left
+    result = cache[current]
+    for offset in chain:
+        cache[offset] = result
+    return result
 
 
 def _normalize(text: str) -> str:
@@ -266,7 +356,8 @@ def assess_distress(text: str) -> DistressSignal:
     on explicit intent/action phrasing and lets ordinary sadness, grief,
     emptiness, and "dark night" reflection pass through unflagged, so the app does
     not pathologize ordinary darkness. Explicit denials ("I would never kill
-    myself") are suppressed by preceding-window negation handling. This is a
+    myself") are suppressed by preceding-window negation handling, which also
+    inherits a shared negator rightward across "or"/"nor" coordination. This is a
     screen, not a diagnosis, and introduces no medication, treatment, or medical
     advice.
 
@@ -276,8 +367,9 @@ def assess_distress(text: str) -> DistressSignal:
     normalized = _normalize(text)
     if not normalized:
         return _NONE
+    denied_cache: dict[int, bool] = {}
     for category, pattern in _COMPILED:
         for match in pattern.finditer(normalized):
-            if not _is_negated(normalized, match.start()):
+            if not _is_denied(normalized, match.start(), denied_cache):
                 return DistressSignal(level="elevated", category=category)
     return _NONE

--- a/backend/tests/domain/test_safety.py
+++ b/backend/tests/domain/test_safety.py
@@ -115,6 +115,18 @@ _NEGATED_DENIALS = [
     "I would never hurt myself and I would never kill him",
     # or-exclusion pin: "or" must stay outside the clip list
     "I would never kill myself or hurt myself",
+    # multi-word negator clipped by the 5-token window must still suppress the denied clause
+    "I have no plans to kill myself or hurt myself",
+    "I have no intention to kill myself or hurt myself",
+    "I have no desire to kill myself or hurt myself",
+    # chained shared-negator coordination: the denial inherits down the whole or-chain
+    "I have no plans to kill myself or hurt myself or cut myself",
+    # long left conjunct pushes "never" out of the base distance window; the shared-negator
+    # inheritance (not distance) is what suppresses the right conjunct here
+    "I would never take my own life or hurt myself",
+    # accepted tradeoff: a shared past-tense denial inherits across "or" the same way a
+    # logical negator does, the safe-for-a-denial direction; pinned as a deliberate decision
+    "I used to cut myself or hurt myself",
 ]
 
 
@@ -160,6 +172,47 @@ def test_negated_denials_do_not_flag(text: str) -> None:
         # phrasing) flags, the safe direction for a crisis screen (surface support over
         # miss intent); pinned so the behavior is a deliberate decision, not a silent gap
         ("I would never kill myself and hurt myself", DistressCategory.SELF_HARM),
+        # clause-boundary guards: clause clipping must still dominate a multi-word negator
+        (
+            "I have no plans to hurt myself, but I want to kill him",
+            DistressCategory.INTENT_TO_HARM,
+        ),
+        ("I have no desire to see him and I want to die", DistressCategory.SUICIDAL_INTENT),
+        # distant-negator guards: negator ends well outside the window; "because" isn't a clip word
+        (
+            "I have no intention of moving to the city because these days I want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        (
+            "I have no plans to travel over the holidays because honestly I want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        # sentence-boundary control: a period already clips the window, must keep flagging
+        ("I have no plans to travel. I want to die", DistressCategory.SUICIDAL_INTENT),
+        # window-widening tripwire: a single-word negator 7+ tokens back must still flag,
+        # killing the "just widen to 7 tokens" shortcut
+        (
+            "I will not let this heavy week convince me I want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        # parity-preservation pin: an in-window multi-word negator plus an in-window "not"
+        # is an even count, so it flags — the safe direction, pinned as deliberate
+        ("I have no plans to ever not kill myself", DistressCategory.SUICIDAL_INTENT),
+        # FN guards: a multi-word negator with no or/nor coordination must not suppress a
+        # later genuine signal
+        ("I have no desire to live so I want to die", DistressCategory.SUICIDAL_INTENT),
+        ("I have no plans to cope so I want to die", DistressCategory.SUICIDAL_INTENT),
+        (
+            "I have no desire to pretend anymore I just want to die",
+            DistressCategory.SUICIDAL_INTENT,
+        ),
+        # intended second conjunct: intervening words ("I will") break the bare adjacency
+        # a shared-negator inheritance requires, so the denial does not carry across "or"
+        ("I have no plans to kill myself or I will hurt myself", DistressCategory.SELF_HARM),
+        # non-acute left conjunct ("scream" isn't a denied phrase at all): no inheritance
+        ("I want to scream or hurt myself", DistressCategory.SELF_HARM),
+        # left conjunct "hurt myself" is not denied, so the right conjunct must still flag
+        ("I hurt myself or want to die", DistressCategory.SUICIDAL_INTENT),
     ],
 )
 def test_negation_does_not_suppress_genuine_signals(text: str, category: DistressCategory) -> None:
@@ -268,3 +321,11 @@ def test_zero_width_space_in_ordinary_darkness_does_not_flag() -> None:
     signal = assess_distress(text)
     assert signal.level == "none"
     assert signal.category is DistressCategory.NONE
+
+
+# Robustness: the shared-negator or-chain inheritance must stay iterative-safe, not
+# recurse per conjunct — an adversarially long chain must still resolve quickly and
+# without RecursionError.
+def test_long_or_chain_denial_does_not_recurse() -> None:
+    text = "I have no plans to kill myself" + " or hurt myself" * 300
+    assert assess_distress(text) == DistressSignal(level="none", category=DistressCategory.NONE)


### PR DESCRIPTION
## Summary
- Fixes a false positive in the acute-distress screen: a denied acute phrase was flagged `elevated` when the denial used a multi-word negator (`no plans to`, `no intention`, `no desire`) followed by an `or`/`nor`-coordinated acute phrase, e.g. `"I have no plans to kill myself or hurt myself"`. The second conjunct's 5-token negation window clipped the leading token of the multi-word negator, so it saw no negator and flagged a genuine denial.
- Realizes explicitly the negative-polarity coordination the module already relies on (it keeps `or`/`nor` out of its clause boundaries precisely because one negator is shared across such conjuncts). A match that is the **bare** right conjunct of an `X or/nor Y` coordination is now suppressed only when its left acute conjunct `X` is itself denied, walked iteratively down the chain.
- Also removes an unreported sibling of the same false-positive family (a long left conjunct, e.g. `"I would never take my own life or hurt myself"`, pushed even the single-word `never` out of the window).

## Root cause
The base distance-window negation only realized shared-negator coordination for **single-word** negators, which fit inside `_NEGATION_WINDOW_WORDS = 5`. A multi-word negator falls out of the window on the second conjunct, so `or`/`nor`-coordinated denials leaked through as false positives.

## No-regression / no-false-negative argument
This is the safety-critical crisis screen, where a **false negative** (missing genuine intent) is far worse than a false positive. The change is deliberately **strictly additive**:
- The base machinery (`_tail_window`, `_is_negated`) is restored **byte-for-byte from `main`** and remains the sole *flag-preventing* mechanism for non-coordinated text. Nothing that flagged on `main` can stop flagging unless it instantiates bare `or`/`nor` shared-negator coordination.
- Inheritance fires only when the coordinator is the immediately preceding token (whitespace-only gap), an acute phrase ends exactly at the coordinator, and that left conjunct is itself denied (clause-scoped). Any intervening subject/auxiliary/adverb or punctuation breaks the construction and restores normal per-match behavior.

A first attempt widened the window to count a straddling multi-word negator. It fixed the false positive but introduced a **false-negative regression on genuine suicidal intent** — `"I have no desire to live so I want to die"` was wrongly suppressed to `none` (verified against `main`, which flags it). The false positive and that false negative are distance-indistinguishable, so any window-widening approach silences genuine intent. That attempt was rejected. The coordination approach leaves the distance window untouched, so `"...so I want to die"` (an intervening `so`, not an `or`/`nor` conjunct) still flags — pinned by new true-positive guard tests.

## Performance / DoS
The coordination walk is **iterative** (no `RecursionError` on adversarial `or`-chains) and **memoizes denied-status per offset within a call**, keeping worst-case work quadratic. A denied 600-conjunct chain resolves in <0.1s (was ~seconds pre-memo), so the synchronous screen cannot stall the async event loop within the 10k-char journal-message bound.

## Test plan
- `./scripts/backend/check-all.sh` → 7/7 green, 2432 passed, coverage 96.6%.
- `xenon --max-absolute A --max-modules A --max-average A` and `radon mi` → A; `mypy` and `ruff` clean; `interrogate` 100% on the module.
- New tests in `backend/tests/domain/test_safety.py`:
  - The three reported false positives now return `none`, plus the chained (`... or hurt myself or cut myself`) and long-left-conjunct denials.
  - **True-positive guards** that must stay `elevated`: `"I have no desire to live so I want to die"`, `"I have no plans to cope so I want to die"`, and a non-`so` variant — these lock out the rejected first-attempt regression.
  - Intended-second-conjunct guards that must still flag: `"... or I will hurt myself"`, `"I want to scream or hurt myself"`, `"I hurt myself or want to die"`.
  - A pinned deliberate tradeoff for shared past-tense denials (`"I used to cut myself or hurt myself"` → `none`).
  - A robustness test asserting a 300x `or`-chain resolves to `none` without `RecursionError`.

Closes #1448
