### PR TITLE
refactor(practice): extract shared loading primitives (useMountedRef, toError, LoadErrorRetry)

### DIFF
--- a/frontend/src/features/Practice/components/LoadErrorRetry.tsx
+++ b/frontend/src/features/Practice/components/LoadErrorRetry.tsx
@@ -1,0 +1,79 @@
+/**
+ * Shared load/error presentational blocks for the Practice surfaces.
+ *
+ * `LoadingBlock` wraps an `ActivityIndicator` in a styled container; the caller
+ * chooses whether the container or the spinner carries the testID. `LoadErrorRetry`
+ * renders an error message with an optional Retry button — the button only appears
+ * when `onRetry` is supplied, matching the call sites that render a retry only on
+ * a retryable failure.
+ */
+import React from 'react';
+import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+const RETRY_LABEL = 'Retry';
+
+interface LoadingBlockProps {
+  style: StyleProp<ViewStyle>;
+  color: string;
+  size?: 'small' | 'large';
+  testID?: string;
+  spinnerTestID?: string;
+}
+
+/** A centered spinner in a styled container; testID may sit on either node. */
+export function LoadingBlock({
+  style,
+  color,
+  size,
+  testID,
+  spinnerTestID,
+}: LoadingBlockProps): React.JSX.Element {
+  return (
+    <View style={style} testID={testID}>
+      <ActivityIndicator color={color} size={size} testID={spinnerTestID} />
+    </View>
+  );
+}
+
+interface LoadErrorRetryProps {
+  message: string;
+  onRetry?: () => void;
+  containerStyle: StyleProp<ViewStyle>;
+  containerTestID?: string;
+  messageStyle: StyleProp<TextStyle>;
+  retryStyle: StyleProp<ViewStyle>;
+  retryTextStyle: StyleProp<TextStyle>;
+  retryTestID: string;
+  retryAccessibilityLabel?: string;
+}
+
+/** An error message with an optional Retry button (rendered only when `onRetry`). */
+export function LoadErrorRetry({
+  message,
+  onRetry,
+  containerStyle,
+  containerTestID,
+  messageStyle,
+  retryStyle,
+  retryTextStyle,
+  retryTestID,
+  retryAccessibilityLabel,
+}: LoadErrorRetryProps): React.JSX.Element {
+  return (
+    <View style={containerStyle} testID={containerTestID}>
+      <Text style={messageStyle}>{message}</Text>
+      {onRetry ? (
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={retryAccessibilityLabel}
+          onPress={onRetry}
+          style={retryStyle}
+          testID={retryTestID}
+        >
+          <Text style={retryTextStyle}>{RETRY_LABEL}</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+}

--- a/frontend/src/features/Practice/components/ShareSheet.tsx
+++ b/frontend/src/features/Practice/components/ShareSheet.tsx
@@ -15,7 +15,7 @@
  * the link in another app routes through `App.tsx`'s linking config to
  * the `SharePreviewScreen`.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -30,6 +30,8 @@ import {
 
 import { practiceShare, type ShareLinkResponse } from '@/api/practiceShare';
 import { BORDER_RADIUS, SPACING, colors, shadows } from '@/design/tokens';
+import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
+import { useMountedRef } from '@/features/Practice/hooks/useMountedRef';
 import { parsePositiveInt } from '@/features/Practice/utils/parsePositiveInt';
 
 const DEEP_LINK_PREFIX = 'adepthood://practices/share/';
@@ -72,17 +74,6 @@ export async function copyToClipboard(value: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-function useMountedRef() {
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-  return mountedRef;
 }
 
 interface MintFormState {
@@ -378,26 +369,26 @@ function LinkList({ state, onCopy }: LinkListProps) {
   const { links, isLoading, loadError, reload, revokingId, handleRevoke } = state;
   if (isLoading) {
     return (
-      <View style={styles.center}>
-        <ActivityIndicator color={colors.primary} testID="share-sheet-loading" />
-      </View>
+      <LoadingBlock
+        style={styles.center}
+        color={colors.primary}
+        spinnerTestID="share-sheet-loading"
+      />
     );
   }
   if (loadError) {
     return (
-      <View style={styles.center}>
-        <Text style={styles.loadErrorText}>{loadError}</Text>
-        <TouchableOpacity
-          accessibilityRole="button"
-          onPress={() => {
-            void reload();
-          }}
-          style={styles.retryButton}
-          testID="share-sheet-retry"
-        >
-          <Text style={styles.retryButtonText}>Retry</Text>
-        </TouchableOpacity>
-      </View>
+      <LoadErrorRetry
+        message={loadError}
+        onRetry={() => {
+          void reload();
+        }}
+        containerStyle={styles.center}
+        messageStyle={styles.loadErrorText}
+        retryStyle={styles.retryButton}
+        retryTextStyle={styles.retryButtonText}
+        retryTestID="share-sheet-retry"
+      />
     );
   }
   if (links.length === 0) {

--- a/frontend/src/features/Practice/components/__tests__/LoadErrorRetry.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/LoadErrorRetry.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { LoadErrorRetry, LoadingBlock } from '../LoadErrorRetry';
+
+describe('LoadingBlock', () => {
+  it('renders a container findable by testID', () => {
+    const { getByTestId } = render(
+      <LoadingBlock style={{}} color="#000" testID="loading-container" />,
+    );
+    expect(getByTestId('loading-container')).toBeTruthy();
+  });
+
+  it('renders a spinner findable by spinnerTestID without a container testID', () => {
+    const { getByTestId } = render(
+      <LoadingBlock style={{}} color="#000" spinnerTestID="loading-spinner" />,
+    );
+    expect(getByTestId('loading-spinner')).toBeTruthy();
+  });
+});
+
+describe('LoadErrorRetry', () => {
+  it('renders the message text', () => {
+    const { getByText } = render(
+      <LoadErrorRetry
+        message="Something went wrong."
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={{}}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+      />,
+    );
+    expect(getByText('Something went wrong.')).toBeTruthy();
+  });
+
+  it('renders the retry button and fires onRetry when pressed', () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(
+      <LoadErrorRetry
+        message="Failed"
+        onRetry={onRetry}
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={{}}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+      />,
+    );
+    fireEvent.press(getByTestId('retry-button'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the retry button when onRetry is not provided', () => {
+    const { queryByTestId } = render(
+      <LoadErrorRetry
+        message="Failed"
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={{}}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+      />,
+    );
+    expect(queryByTestId('retry-button')).toBeNull();
+  });
+
+  it('exposes the retry button via accessibility label when provided', () => {
+    const { getByLabelText, queryByLabelText, rerender } = render(
+      <LoadErrorRetry
+        message="Failed"
+        onRetry={jest.fn()}
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={{}}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+        retryAccessibilityLabel="Retry"
+      />,
+    );
+    expect(getByLabelText('Retry')).toBeTruthy();
+
+    rerender(
+      <LoadErrorRetry
+        message="Failed"
+        onRetry={jest.fn()}
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={{}}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+      />,
+    );
+    expect(queryByLabelText('Retry')).toBeNull();
+  });
+
+  it('accepts a style array for retryStyle without error', () => {
+    const { getByTestId } = render(
+      <LoadErrorRetry
+        message="Failed"
+        onRetry={jest.fn()}
+        containerStyle={{}}
+        messageStyle={{}}
+        retryStyle={[{}, {}]}
+        retryTextStyle={{}}
+        retryTestID="retry-button"
+      />,
+    );
+    expect(getByTestId('retry-button')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/hooks/__tests__/useMountedRef.test.tsx
+++ b/frontend/src/features/Practice/hooks/__tests__/useMountedRef.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+import { renderHook } from '@testing-library/react-native';
+
+import { useMountedRef } from '../useMountedRef';
+
+describe('useMountedRef', () => {
+  it('is true while mounted', () => {
+    const { result } = renderHook(() => useMountedRef());
+    expect(result.current.current).toBe(true);
+  });
+
+  it('returns the same ref object across a rerender', () => {
+    const { result, rerender } = renderHook(() => useMountedRef());
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+
+  it('flips to false after unmount', () => {
+    const { result, unmount } = renderHook(() => useMountedRef());
+    unmount();
+    expect(result.current.current).toBe(false);
+  });
+});

--- a/frontend/src/features/Practice/hooks/useActivePractice.ts
+++ b/frontend/src/features/Practice/hooks/useActivePractice.ts
@@ -20,13 +20,14 @@
  * `PracticeScreen` switches on this to render the selector instead of the
  * mode views.
  */
-import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from 'react';
+import type { Dispatch, RefObject, SetStateAction } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { practices, userPractices } from '@/api';
 import type { PracticeItem, UserPractice } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import type { ModeConfig } from '@/features/Practice/engine/types';
+import { useMountedRef } from '@/features/Practice/hooks/useMountedRef';
 
 const LOAD_FALLBACK =
   "We couldn't load your practices. Check your connection, then tap Retry to try again.";
@@ -77,17 +78,6 @@ function resolveEffective(
   const config =
     active.effective_config ?? active.mode_config_override ?? practice.mode_config ?? null;
   return { name, config };
-}
-
-function useMountedRef(): MutableRefObject<boolean> {
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-  return mountedRef;
 }
 
 function useRefreshAction(

--- a/frontend/src/features/Practice/hooks/useFrequency.ts
+++ b/frontend/src/features/Practice/hooks/useFrequency.ts
@@ -12,9 +12,11 @@
  * on refetch because retaining a stale failure would lie about the state of
  * the new request.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { frequency, type FrequencyResponse } from '@/api';
+import { useMountedRef } from '@/features/Practice/hooks/useMountedRef';
+import { toError } from '@/features/Practice/utils/toError';
 
 export interface UseFrequencyResult {
   data: FrequencyResponse | null;
@@ -24,25 +26,12 @@ export interface UseFrequencyResult {
   refetch: () => Promise<void>;
 }
 
-function toError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
-}
-
 export function useFrequency(stageNumber?: number | null): UseFrequencyResult {
   const [data, setData] = useState<FrequencyResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // Strict-mode + unmount safety: a slow fetch that resolves after the
-  // banner unmounts must NOT call setState. The same pattern is used by
-  // the existing PracticeScreen loaders.
-  const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const mountedRef = useMountedRef();
 
   const fetchOnce = useCallback(async () => {
     setIsLoading(true);
@@ -57,7 +46,7 @@ export function useFrequency(stageNumber?: number | null): UseFrequencyResult {
     } finally {
       if (mountedRef.current) setIsLoading(false);
     }
-  }, [stageNumber]);
+  }, [stageNumber, mountedRef]);
 
   useEffect(() => {
     void fetchOnce();

--- a/frontend/src/features/Practice/hooks/useMountedRef.ts
+++ b/frontend/src/features/Practice/hooks/useMountedRef.ts
@@ -1,0 +1,18 @@
+/**
+ * Strict-mode + unmount safety: a ref that reads `true` while mounted and flips
+ * to `false` on unmount, so async callbacks can guard `setState` after the
+ * component is gone. The ref identity is stable across re-renders.
+ */
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+
+export function useMountedRef(): MutableRefObject<boolean> {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  return mountedRef;
+}

--- a/frontend/src/features/Practice/hooks/useWeeklyProgress.ts
+++ b/frontend/src/features/Practice/hooks/useWeeklyProgress.ts
@@ -14,9 +14,11 @@
  * after a save (BUG-FE-PRACTICE-005). The `commit` callback inside
  * `useSaveSessionMutation` calls `refresh()` here on success.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { practiceSessions } from '@/api';
+import { useMountedRef } from '@/features/Practice/hooks/useMountedRef';
+import { toError } from '@/features/Practice/utils/toError';
 
 export interface UseWeeklyProgressResult {
   count: number;
@@ -29,10 +31,6 @@ export interface UseWeeklyProgressResult {
   decrement: () => void;
   /** Replace `count` with an authoritative value (e.g. from `commit`). */
   setCount: (_next: number) => void;
-}
-
-function toError(value: unknown): Error {
-  return value instanceof Error ? value : new Error(String(value));
 }
 
 async function fetchCurrentCount(): Promise<number> {
@@ -58,14 +56,7 @@ export function useWeeklyProgress(): UseWeeklyProgressResult {
   const [count, setCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
-  const mountedRef = useRef(true);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  const mountedRef = useMountedRef();
 
   const refresh = useCallback(async () => {
     setIsLoading(true);
@@ -80,7 +71,7 @@ export function useWeeklyProgress(): UseWeeklyProgressResult {
     } finally {
       if (mountedRef.current) setIsLoading(false);
     }
-  }, []);
+  }, [mountedRef]);
 
   useEffect(() => {
     void refresh();

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -21,7 +21,6 @@ import { useNavigation, useRoute, type RouteProp } from '@react-navigation/nativ
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
   Alert,
   SectionList,
   StyleSheet,
@@ -47,6 +46,7 @@ import {
   surfaceShadow,
   touchTarget,
 } from '@/design/tokens';
+import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
 import { MIN_STAGE, stageRange } from '@/features/Practice/constants';
 import { useRecentPractices } from '@/features/Practice/hooks/useRecentPractices';
@@ -395,25 +395,26 @@ interface CatalogStatusProps {
 const CatalogStatus = ({ state, onRetry }: CatalogStatusProps): React.JSX.Element | null => {
   if (state.loading) {
     return (
-      <View style={styles.loadingBlock} testID="practice-catalog-loading">
-        <ActivityIndicator color={accent.primary} />
-      </View>
+      <LoadingBlock
+        style={styles.loadingBlock}
+        color={accent.primary}
+        testID="practice-catalog-loading"
+      />
     );
   }
   if (state.error !== null) {
     return (
-      <View style={styles.errorBlock} testID="practice-catalog-error">
-        <Text style={styles.errorText}>{state.error}</Text>
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessibilityLabel="Retry"
-          onPress={onRetry}
-          style={styles.retryButton}
-          testID="practice-catalog-retry"
-        >
-          <Text style={styles.retryButtonText}>Retry</Text>
-        </TouchableOpacity>
-      </View>
+      <LoadErrorRetry
+        message={state.error}
+        onRetry={onRetry}
+        containerStyle={styles.errorBlock}
+        containerTestID="practice-catalog-error"
+        messageStyle={styles.errorText}
+        retryStyle={styles.retryButton}
+        retryTextStyle={styles.retryButtonText}
+        retryTestID="practice-catalog-retry"
+        retryAccessibilityLabel="Retry"
+      />
     );
   }
   return null;

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -10,7 +10,7 @@
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { ModeConfig } from '../engine/types';
 
@@ -27,6 +27,7 @@ import {
   surface,
   surfaceShadow,
 } from '@/design/tokens';
+import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import ShareSheet from '@/features/Practice/components/ShareSheet';
 import { stageRange } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
@@ -125,14 +126,27 @@ export function PracticeDetailScreen(props: PracticeDetailScreenProps): React.JS
   const state = usePracticeDetail(practiceId, onAssigned, assignError ?? null);
   if (state.loading) {
     return (
-      <View style={styles.loading} testID="practice-detail-loading">
-        <ActivityIndicator color={accent.primary} size="large" />
-      </View>
+      <LoadingBlock
+        style={styles.loading}
+        color={accent.primary}
+        size="large"
+        testID="practice-detail-loading"
+      />
     );
   }
   if (state.loadError !== null || state.practice === null) {
     return (
-      <ErrorView message={state.loadError ?? 'Could not load practice.'} onRetry={state.reload} />
+      <LoadErrorRetry
+        message={state.loadError ?? 'Could not load practice.'}
+        onRetry={state.reload}
+        containerStyle={styles.errorBlock}
+        containerTestID="practice-detail-error"
+        messageStyle={styles.errorText}
+        retryStyle={styles.actionButton}
+        retryTextStyle={styles.actionButtonText}
+        retryTestID="practice-detail-retry"
+        retryAccessibilityLabel="Retry"
+      />
     );
   }
   return <LoadedDetail props={props} state={state} practice={state.practice} />;
@@ -472,26 +486,6 @@ interface BadgeChipProps {
 const BadgeChip = ({ label, testID }: BadgeChipProps): React.JSX.Element => (
   <View style={styles.badge} testID={testID}>
     <Text style={styles.badgeText}>{label}</Text>
-  </View>
-);
-
-interface ErrorViewProps {
-  message: string;
-  onRetry: () => void;
-}
-
-const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
-  <View style={styles.errorBlock} testID="practice-detail-error">
-    <Text style={styles.errorText}>{message}</Text>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel="Retry"
-      onPress={onRetry}
-      style={styles.actionButton}
-      testID="practice-detail-retry"
-    >
-      <Text style={styles.actionButtonText}>Retry</Text>
-    </TouchableOpacity>
   </View>
 );
 

--- a/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
+++ b/frontend/src/features/Practice/screens/SharePreviewScreen.tsx
@@ -35,6 +35,7 @@ import {
   type ShareLinkPreviewResponse,
 } from '@/api/practiceShare';
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 export type SharePreviewScreenProps = NativeStackScreenProps<RootStackParamList, 'SharePreview'>;
@@ -209,19 +210,16 @@ function SuccessBanner({ imported, onDone }: SuccessProps) {
 
 function ErrorView({ banner, onRetry }: { banner: ErrorBanner; onRetry?: () => void }) {
   return (
-    <View style={styles.errorBlock} testID={`share-preview-error-${banner.kind}`}>
-      <Text style={styles.errorText}>{errorCopyFor(banner)}</Text>
-      {onRetry && (
-        <TouchableOpacity
-          accessibilityRole="button"
-          onPress={onRetry}
-          style={[styles.actionButton, styles.importButton]}
-          testID="share-preview-retry"
-        >
-          <Text style={styles.importButtonText}>Retry</Text>
-        </TouchableOpacity>
-      )}
-    </View>
+    <LoadErrorRetry
+      message={errorCopyFor(banner)}
+      onRetry={onRetry}
+      containerStyle={styles.errorBlock}
+      containerTestID={`share-preview-error-${banner.kind}`}
+      messageStyle={styles.errorText}
+      retryStyle={[styles.actionButton, styles.importButton]}
+      retryTextStyle={styles.importButtonText}
+      retryTestID="share-preview-retry"
+    />
   );
 }
 
@@ -280,9 +278,12 @@ export function SharePreviewScreen({
 
   if (state.isLoading) {
     return (
-      <View style={styles.loading} testID="share-preview-loading">
-        <ActivityIndicator color={colors.primary} size="large" />
-      </View>
+      <LoadingBlock
+        style={styles.loading}
+        color={colors.primary}
+        size="large"
+        testID="share-preview-loading"
+      />
     );
   }
   if (state.loadError || !state.preview) {

--- a/frontend/src/features/Practice/utils/__tests__/toError.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/toError.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { toError } from '../toError';
+
+describe('toError', () => {
+  it('passes an Error instance through by reference', () => {
+    const err = new Error('boom');
+    expect(toError(err)).toBe(err);
+  });
+
+  it('wraps a string into an Error carrying that message', () => {
+    const wrapped = toError('boom');
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped.message).toBe('boom');
+  });
+
+  it('wraps a plain object via String(value)', () => {
+    const wrapped = toError({});
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped.message).toBe('[object Object]');
+  });
+
+  it('wraps a number via String(value)', () => {
+    const wrapped = toError(42);
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped.message).toBe('42');
+  });
+});

--- a/frontend/src/features/Practice/utils/toError.ts
+++ b/frontend/src/features/Practice/utils/toError.ts
@@ -1,0 +1,7 @@
+/**
+ * Coerce an unknown thrown value into an `Error` — passes real errors through
+ * by reference and wraps everything else via `String(value)`.
+ */
+export function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}


### PR DESCRIPTION
## Summary
- Extract `hooks/useMountedRef.ts` and `utils/toError.ts` from the Practice feature, replacing 4 inlined mounted-ref guards and 2 byte-identical `toError` copies with imports.
- Add `components/LoadErrorRetry.tsx` (`LoadingBlock` + `LoadErrorRetry`) and route PracticeDetail, PracticeCatalog, SharePreview, and ShareSheet through it, removing both local `ErrorView` components.
- Pure refactor: rendered testIDs, accessibility labels, copy, spinner sizes/colors, and styles are unchanged. Each site keeps its exact output by passing its own styles/testIDs/labels as props (SharePreview keeps a thin one-expression adapter mapping its `ErrorBanner` to the shared component with its dynamic error testID and conditional retry).

## Test plan
- Added unit tests for the three new modules (`toError`, `useMountedRef`, `LoadErrorRetry`) — 14 tests, 100% coverage on the new files.
- `npx jest src/features/Practice` — 341 suites / 3617 tests pass (existing suites unchanged, confirming byte-for-byte behavior).
- `npx tsc --noEmit` clean; ESLint zero-warning on touched files.
- `./scripts/frontend/check-all.sh` exits 0 (eslint + prettier + typecheck + tests).

Scope note: the same mounted-ref/`toError` pattern exists in a few non-Practice features (Invitations, Course, Return); those are out of scope for this de-slop issue and left for a follow-up hoist.

Closes #1396
