### PR TITLE
test(practice): pin exact behavior in coverage-theater tests

### DIFF
--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
@@ -103,9 +103,7 @@ describe('ActiveRitualSession harvesters — interval_bell', () => {
     const state = fakeState({ elapsedMs: 5 * 60_000 });
     const wire = harvestMetadata(intervalBellConfig, state, null);
     const summary = harvestSummaryMetadata(intervalBellConfig, state, 0, null);
-    expect(wire).toEqual(
-      expect.objectContaining({ mode: 'interval_bell', total_intervals: expect.any(Number) }),
-    );
+    expect(wire).toEqual({ mode: 'interval_bell', intervals_struck: 2, total_intervals: 5 });
     expect(summary).toEqual(wire);
   });
 });

--- a/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
@@ -175,10 +175,22 @@ describe('ShareSheet', () => {
   });
 
   it('copyToClipboard returns false when navigator.clipboard is missing', async () => {
-    const result = await copyToClipboard('hello');
-    // Jest's jsdom may or may not provide navigator.clipboard; just assert
-    // the helper does not throw and returns a boolean.
-    expect(typeof result).toBe('boolean');
+    const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const result = await copyToClipboard('hello');
+      expect(result).toBe(false);
+    } finally {
+      if (original) {
+        Object.defineProperty(navigator, 'clipboard', original);
+      } else {
+        delete (navigator as { clipboard?: unknown }).clipboard;
+      }
+    }
   });
 
   it('does not load links while the sheet is not visible', () => {

--- a/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ShareSheet.test.tsx
@@ -175,20 +175,24 @@ describe('ShareSheet', () => {
   });
 
   it('copyToClipboard returns false when navigator.clipboard is missing', async () => {
-    const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
-    Object.defineProperty(navigator, 'clipboard', {
+    const nav = (globalThis as { navigator?: { clipboard?: unknown } }).navigator;
+    if (nav === undefined) {
+      expect(await copyToClipboard('hello')).toBe(false);
+      return;
+    }
+    const original = Object.getOwnPropertyDescriptor(nav, 'clipboard');
+    Object.defineProperty(nav, 'clipboard', {
       value: undefined,
       configurable: true,
       writable: true,
     });
     try {
-      const result = await copyToClipboard('hello');
-      expect(result).toBe(false);
+      expect(await copyToClipboard('hello')).toBe(false);
     } finally {
       if (original) {
-        Object.defineProperty(navigator, 'clipboard', original);
+        Object.defineProperty(nav, 'clipboard', original);
       } else {
-        delete (navigator as { clipboard?: unknown }).clipboard;
+        delete nav.clipboard;
       }
     }
   });

--- a/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipeEditorModal.test.tsx
@@ -224,5 +224,10 @@ describe('RecipeEditorModal', () => {
     const utils = mountEditor({ listTags: listTags as never });
     await waitFor(() => expect(listTags).toHaveBeenCalled());
     expect(utils.getByTestId('recipe-editor-step-0')).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('tag-picker-0-trigger'));
+    });
+    await waitFor(() => expect(utils.getByTestId('tag-picker-0-empty')).toBeTruthy());
+    expect(utils.queryByTestId('tag-picker-0-option-red')).toBeNull();
   });
 });

--- a/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
+++ b/frontend/src/features/Practice/recipes/__tests__/RecipePickerModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
 import React from 'react';
 
 import RecipePickerModal from '../RecipePickerModal';
@@ -105,7 +105,8 @@ describe('RecipePickerModal', () => {
   it('shows a System badge on read-only recipes', async () => {
     const utils = mountPicker();
     await waitFor(() => expect(utils.getByTestId('recipe-row-1')).toBeTruthy());
-    expect(utils.queryByText('System')).toBeTruthy();
+    expect(within(utils.getByTestId('recipe-row-1')).getByText('System')).toBeTruthy();
+    expect(within(utils.getByTestId('recipe-row-2')).queryByText('System')).toBeNull();
   });
 
   it('renders "Edit a copy" on system rows and "Edit" on user rows', async () => {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
 import type { PracticeItem, UserPractice } from '@/api';
@@ -303,15 +303,16 @@ describe('PracticeDetailScreen — assignError route param', () => {
 
 describe('PracticeDetailScreen — config summary variants', () => {
   it.each([
-    [{ mode: 'meditation_timer', duration_minutes: 10 } as const],
-    [{ mode: 'count_up' } as const],
-    [{ mode: 'count_up', soft_cap_minutes: 20 } as const],
+    [{ mode: 'meditation_timer', duration_minutes: 10 } as const, ['Duration: 10 min']],
+    [{ mode: 'count_up' } as const, ['Open-ended']],
+    [{ mode: 'count_up', soft_cap_minutes: 20 } as const, ['Soft cap: 20 min']],
     [
       {
         mode: 'metronome',
         bpm: 60,
         timer: { mode: 'meditation_timer', duration_minutes: 10 },
       } as const,
+      ['BPM: 60', 'Duration: 10 min'],
     ],
     [
       {
@@ -320,6 +321,7 @@ describe('PracticeDetailScreen — config summary variants', () => {
         interval_minutes: 5,
         bell_tone: 'bowl',
       } as const,
+      ['Duration: 20 min', 'Spacing: every 5 min', 'Tone: bowl'],
     ],
     [
       {
@@ -328,13 +330,15 @@ describe('PracticeDetailScreen — config summary variants', () => {
         cue_offsets_minutes: [2, 7, 15],
         bell_tone: 'bowl',
       } as const,
+      ['Duration: 20 min', 'Spacing: 3 custom cues', 'Tone: bowl'],
     ],
-    [{ mode: 'rep_counter', target_reps: 12, unit_label: 'reps' } as const],
+    [{ mode: 'rep_counter', target_reps: 12, unit_label: 'reps' } as const, ['Target: 12 reps']],
     [
       {
         mode: 'sense_grounding',
         prompts: [{ sense: 'sight', label: 'blue' }],
       } as const,
+      ['1 prompts across the senses'],
     ],
     [
       {
@@ -342,9 +346,10 @@ describe('PracticeDetailScreen — config summary variants', () => {
         rounds: 2,
         categories: [{ key: 'c', label: 'a circle', target_count: 3 }],
       } as const,
+      ['2 rounds', '1 categories'],
     ],
-    [{ mode: 'tarot', deck: 'major_arcana' } as const],
-    [{ mode: 'card_meditation', deck_id: 'rws' } as const],
+    [{ mode: 'tarot', deck: 'major_arcana' } as const, ['Major arcana — one card per sit']],
+    [{ mode: 'card_meditation', deck_id: 'rws' } as const, ['Deck: rws']],
     [
       {
         mode: 'mindful_anchor',
@@ -353,6 +358,7 @@ describe('PracticeDetailScreen — config summary variants', () => {
         options: [],
         require_option_choice: false,
       } as const,
+      ['Soft minimum: 60s', 'no chooser'],
     ],
     [
       {
@@ -362,12 +368,17 @@ describe('PracticeDetailScreen — config summary variants', () => {
         options: [{ key: 'touch_grass', label: 'Touch grass' }],
         require_option_choice: false,
       } as const,
+      ['Soft minimum: 60s', '1 options'],
     ],
-  ])('summarises %p', async (config) => {
+  ])('summarises %p as %p', async (config, lines) => {
     mockPracticesGet.mockResolvedValueOnce({ ...samplePractice, mode_config: config });
     const { view } = renderScreen();
     await waitForLoad();
-    expect(view.getByTestId('practice-detail-config-summary')).toBeTruthy();
+    const summary = view.getByTestId('practice-detail-config-summary');
+    expect(within(summary).getAllByText(/^• /)).toHaveLength(lines.length);
+    for (const line of lines) {
+      expect(within(summary).getByText(`• ${line}`)).toBeTruthy();
+    }
   });
 });
 

--- a/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/RitualControlsBar.test.tsx
@@ -2,9 +2,37 @@ import { describe, expect, it } from '@jest/globals';
 import { fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
+import type { EngineStatus } from '../../engine/types';
 import RitualControlsBar from '../RitualControlsBar';
 
-import { allStatuses, fakeControls } from './fixtures';
+import { fakeControls } from './fixtures';
+
+const STATUS_CONTROL_MATRIX: readonly {
+  status: EngineStatus;
+  present: readonly string[];
+  absent: readonly string[];
+}[] = [
+  {
+    status: 'idle',
+    present: ['ritual-start'],
+    absent: ['ritual-pause', 'ritual-resume', 'ritual-cancel', 'ritual-complete-label'],
+  },
+  {
+    status: 'running',
+    present: ['ritual-pause', 'ritual-cancel'],
+    absent: ['ritual-start', 'ritual-resume', 'ritual-complete-label'],
+  },
+  {
+    status: 'paused',
+    present: ['ritual-resume', 'ritual-cancel'],
+    absent: ['ritual-start', 'ritual-pause', 'ritual-complete-label'],
+  },
+  {
+    status: 'complete',
+    present: ['ritual-complete-label'],
+    absent: ['ritual-start', 'ritual-pause', 'ritual-resume', 'ritual-cancel'],
+  },
+];
 
 describe('RitualControlsBar', () => {
   it('renders Start only when idle and calls controls.start on press', () => {
@@ -64,8 +92,15 @@ describe('RitualControlsBar', () => {
     expect(getByText('Begin')).toBeTruthy();
   });
 
-  it.each(allStatuses)('renders without crashing for every status (%s)', (status) => {
-    const controls = fakeControls();
-    expect(() => render(<RitualControlsBar status={status} controls={controls} />)).not.toThrow();
-  });
+  it.each(STATUS_CONTROL_MATRIX)(
+    'renders exactly the right controls for status $status',
+    ({ status, present, absent }) => {
+      const controls = fakeControls();
+      const { getByTestId, queryByTestId } = render(
+        <RitualControlsBar status={status} controls={controls} />,
+      );
+      for (const id of present) expect(getByTestId(id)).toBeTruthy();
+      for (const id of absent) expect(queryByTestId(id)).toBeNull();
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- Strengthens six coverage-theater tests in the frontend Practice suite, replacing presence/`typeof`/`expect.any(Number)`/`.not.toThrow()`/unscoped `queryByText` assertions with exact-value behavioral assertions so plausible mutants die (mutation-testing philosophy). No production code changes.
- Re-verified each flagged weak assertion still exists in current code (the suite changed heavily since the issue was filed) — all six were still present and all were tightened; none were already fixed or obsolete.

## What changed
- `PracticeDetailScreen.test.tsx` — the 13-case config-summary `it.each` now pins the exact summarized bullet lines (and exact bullet count) per mode instead of asserting only block presence.
- `ActiveRitualSession.harvesters.test.ts` — the `interval_bell` harvester test pins the exact crafted counts (`intervals_struck: 2`, `total_intervals: 5`) via `toEqual`, matching its sibling harvesters, instead of `total_intervals: expect.any(Number)`.
- `RitualControlsBar.test.tsx` — the `.not.toThrow()` smoke `it.each` becomes an exhaustive per-status control matrix asserting exactly which control testIDs are present/absent for each status (kills a Resume/Pause swap and stray-control mutants).
- `RecipeEditorModal.test.tsx` — "leaves the tag library empty when listTags rejects" now opens the step's TagPicker and asserts the empty state with zero tag options.
- `RecipePickerModal.test.tsx` — the System-badge assertion is scoped to the system row (`within(recipe-row-1)`) with a negative assertion on the user row.
- `ShareSheet.test.tsx` — `copyToClipboard` "returns false when clipboard is missing" now deterministically removes `navigator.clipboard` (descriptor save/restore) and asserts `result === false` instead of `typeof result === 'boolean'`.

## Test plan
- `npx jest` on all six targeted suites: 94 passed.
- `./scripts/frontend/check-all.sh`: ESLint (zero-warning), Prettier, `tsc --noEmit` (strict), and full Jest (3617 tests) all green.
- code-review-orchestrator self-review over the diff: `CLEAN` (no production files touched, no coverage regression, no slop).

Round 2 of coverage-theater cases is owned by #1435 and intentionally out of scope here.

Closes #1397
