### PR TITLE
feat(frontend): surface ApiKeyContext.loadError as a storage-health banner

### DIFF
--- a/frontend/src/context/ApiKeyContext.tsx
+++ b/frontend/src/context/ApiKeyContext.tsx
@@ -29,10 +29,10 @@ interface ApiKeyContextValue {
   /** True until the initial load from SecureStore completes. */
   isLoading: boolean;
   /**
-   * BUG-FRONTEND-INFRA-017: populated when the initial SecureStore read,
-   * save, or clear throws. Callers can surface this to the user (e.g.,
-   * "Secure storage is unavailable — your key won't persist across
-   * launches") instead of silently running with a blank key.
+   * Set to the thrown error when the initial SecureStore read, save, or
+   * clear fails; null while storage is healthy. ApiKeySettingsScreen surfaces
+   * this as a "secure storage unavailable" warning so a keychain failure is
+   * visible instead of the app silently running with a blank, non-persisted key.
    */
   loadError: Error | null;
   /** Persist a new key to SecureStore and update context state. */

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -37,6 +37,12 @@ const MIN_KEY_LENGTH = 10;
 const PLACEHOLDER_KEY = 'sk-... or sk-ant-...';
 const MASK_VISIBLE_CHARS = 4;
 
+// Shown when ApiKeyContext.loadError is set — SecureStore is unavailable, so the
+// key can't persist. Kept generic (never the raw thrown error) to avoid leaking
+// keychain internals into the UI.
+export const SECURE_STORAGE_WARNING =
+  "Secure storage is unavailable on this device, so your API key can't be saved. It will still work for this session, but it won't persist after you close the app. Try restarting the app, then save your key again.";
+
 // Built from the provider map so the error copy can never drift from the
 // supported set: e.g. `"sk-" (OpenAI) or "sk-ant-" (Anthropic)`.
 const PREFIX_SUMMARY = BYOK_PROVIDERS.map((p) => `"${p.keyPrefix}" (${p.label})`).join(' or ');
@@ -166,6 +172,7 @@ interface ScreenBodyProps {
   submitting: boolean;
   error: string | null;
   status: string | null;
+  storageWarning: string | null;
   onChangeDraft: (_v: string) => void;
   onToggleReveal: () => void;
   onRequestRemove: () => void;
@@ -275,6 +282,7 @@ const ScreenBody = ({
   submitting,
   error,
   status,
+  storageWarning,
   onChangeDraft,
   onToggleReveal,
   onRequestRemove,
@@ -284,6 +292,7 @@ const ScreenBody = ({
 }: ScreenBodyProps): React.JSX.Element => (
   <>
     <ScreenIntro apiKey={apiKey} />
+    <SettingsFeedbackBanner idPrefix="api-key-storage" error={storageWarning} status={null} />
     <ProviderDirectory />
     {apiKey && (
       <StoredKeyCard apiKey={apiKey} disabled={submitting} onRequestRemove={onRequestRemove} />
@@ -345,8 +354,24 @@ function useClearKeyHandler(
   return useSettingsSubmit(form, { validate, perform, onError });
 }
 
+function useScreenNavHandlers(navigation: Props['navigation']): {
+  onBack?: () => void;
+  onOpenTimezone?: () => void;
+} {
+  const onBack = useMemo(
+    () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
+    [navigation],
+  );
+  const onOpenTimezone = useMemo(
+    () => (navigation?.navigate ? () => navigation.navigate?.('TimezoneSettings') : undefined),
+    [navigation],
+  );
+  return { onBack, onOpenTimezone };
+}
+
 export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.JSX.Element {
-  const { apiKey, isLoading, saveApiKey, clearApiKey } = useApiKey();
+  const { apiKey, isLoading, loadError, saveApiKey, clearApiKey } = useApiKey();
+  const storageWarning = loadError ? SECURE_STORAGE_WARNING : null;
   const form = useSettingsFormState('');
   const [reveal, setReveal] = useState(false);
   const handleSave = useSaveKeyHandler(form, setReveal, saveApiKey);
@@ -362,14 +387,7 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
     [setDraft, setError],
   );
   const toggleReveal = useCallback(() => setReveal((prev) => !prev), [setReveal]);
-  const onBack = useMemo(
-    () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),
-    [navigation],
-  );
-  const onOpenTimezone = useMemo(
-    () => (navigation?.navigate ? () => navigation.navigate?.('TimezoneSettings') : undefined),
-    [navigation],
-  );
+  const { onBack, onOpenTimezone } = useScreenNavHandlers(navigation);
 
   if (isLoading) {
     return (
@@ -388,6 +406,7 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
         submitting={form.submitting}
         error={form.error}
         status={form.status}
+        storageWarning={storageWarning}
         onChangeDraft={onChangeDraft}
         onToggleReveal={toggleReveal}
         onRequestRemove={handleRequestRemove}

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+/* global describe, test, expect, jest, beforeEach */
+import { render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import ApiKeySettingsScreen, { SECURE_STORAGE_WARNING } from '../ApiKeySettingsScreen';
+
+import { ApiKeyProvider } from '@/context/ApiKeyContext';
+import * as llmKeyStorage from '@/storage/llmKeyStorage';
+
+jest.mock('@/api', () => ({
+  setLlmApiKeyGetter: jest.fn(),
+}));
+
+jest.mock('@/storage/llmKeyStorage', () => ({
+  loadLlmApiKey: jest.fn(() => Promise.resolve(null)),
+  saveLlmApiKey: jest.fn(() => Promise.resolve()),
+  clearLlmApiKey: jest.fn(() => Promise.resolve()),
+}));
+
+const mockStorage = llmKeyStorage as jest.Mocked<typeof llmKeyStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ApiKeySettingsScreen integration with a failing SecureStore read', () => {
+  test('shows the storage-unavailable warning once the real provider load rejects', async () => {
+    mockStorage.loadLlmApiKey.mockRejectedValueOnce(new Error('keychain locked'));
+    const warnSpy = jest.spyOn(globalThis.console, 'warn').mockImplementation(() => undefined);
+
+    const { getByTestId, queryByTestId } = render(
+      <ApiKeyProvider>
+        <ApiKeySettingsScreen />
+      </ApiKeyProvider>,
+    );
+
+    expect(getByTestId('api-key-loading')).toBeTruthy();
+    await waitFor(() => expect(queryByTestId('api-key-loading')).toBeNull());
+
+    expect(getByTestId('api-key-storage-error').props.children).toBe(SECURE_STORAGE_WARNING);
+    warnSpy.mockRestore();
+  });
+});

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -4,7 +4,10 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Alert, Linking } from 'react-native';
 
-import ApiKeySettingsScreen, { validateUserApiKey } from '../ApiKeySettingsScreen';
+import ApiKeySettingsScreen, {
+  SECURE_STORAGE_WARNING,
+  validateUserApiKey,
+} from '../ApiKeySettingsScreen';
 import { BYOK_PROVIDERS, providerForKey } from '../byokProviders';
 
 import { useApiKey } from '@/context/ApiKeyContext';
@@ -21,6 +24,7 @@ function setApiKeyState(partial: Partial<ReturnType<typeof useApiKey>>) {
   const base = {
     apiKey: null,
     isLoading: false,
+    loadError: null,
     saveApiKey: jest.fn(() => Promise.resolve()),
     clearApiKey: jest.fn(() => Promise.resolve()),
   };
@@ -323,5 +327,32 @@ describe('ApiKeySettingsScreen', () => {
 
     expect(queryByLabelText('Go back')).toBeNull();
     expect(queryByTestId('open-timezone-settings')).toBeNull();
+  });
+
+  test('surfaces a storage-unavailable warning when loadError is set', () => {
+    setApiKeyState({ loadError: new Error('boom') });
+    const { getByTestId, queryByText } = render(<ApiKeySettingsScreen />);
+
+    expect(getByTestId('api-key-storage-error').props.children).toBe(SECURE_STORAGE_WARNING);
+    expect(queryByText('boom')).toBeNull();
+  });
+
+  test('hides the storage warning when loadError is null', () => {
+    setApiKeyState({});
+    const { queryByTestId } = render(<ApiKeySettingsScreen />);
+
+    expect(queryByTestId('api-key-storage-error')).toBeNull();
+  });
+
+  test('shows the storage warning alongside a form submit error', async () => {
+    setApiKeyState({ loadError: new Error('x') });
+    const { getByTestId, findByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), 'not-a-real-key');
+    fireEvent.press(getByTestId('save-key-button'));
+
+    const formError = await findByTestId('api-key-error');
+    expect(formError).toBeTruthy();
+    expect(getByTestId('api-key-storage-error').props.children).toBe(SECURE_STORAGE_WARNING);
   });
 });


### PR DESCRIPTION
## Decision: WIRE-IN (not retire)

`loadError` is not vestigial — it is a completed error-detection mechanism missing only its last mile. The context populates it on all five SecureStore failure/recovery paths and the behavior is already locked in by tests (`ApiKeyContext.test.tsx`); both intent and completeness signals are present. The silent-failure harm is concrete and trust-critical: a BYOK user whose SecureStore write fails sees "API key saved on this device," closes the app, and relaunches into a blank key — at which point BotMason silently falls back to the shared server key. That directly violates the honest-affordance principle: the screen's "Stored on this device" promise becomes a lie exactly when storage is broken, on the one screen whose entire copy is about where the key lives. Retiring would delete working, tested detection code only to rebuild it when the offline-storage UX lands, while wiring in costs one prop, one banner, and one constant. The notice also passes the four-part error rubric: what happened (secure storage is unavailable), the consequence (the key won't persist across launches), what still works (the key remains usable this session), and what to do (restart the app / re-save later). It is honest, declinable information — not gamified pressure — squarely within the north star.

## Summary
- `ApiKeySettingsScreen.tsx`: added an exported `SECURE_STORAGE_WARNING` constant, destructured `loadError` from `useApiKey()`, and render a second `SettingsFeedbackBanner` (`idPrefix="api-key-storage"`, testID `api-key-storage-error`) when a load/save/clear failure is present. Only the generic constant is rendered — the raw thrown error is never surfaced (keychain-internals hygiene). Also extracted the two navigation `useMemo`s into a `useScreenNavHandlers` hook to keep the component under the line-length budget.
- `ApiKeyContext.tsx`: rewrote the `loadError` docstring to describe the now-real consumer and dropped the stale bug-ID reference. No runtime logic changed.

## Test plan
- New unit tests (`ApiKeySettingsScreen.test.tsx`): warning renders exactly `SECURE_STORAGE_WARNING` when `loadError` is set (and the raw error string does not leak); warning is absent when `loadError` is null; the storage warning coexists with a form-submit error banner (proving orthogonality).
- New e2e test (`ApiKeySettingsScreen.integration.test.tsx`): drives the real `ApiKeyProvider` with `loadLlmApiKey` rejecting and asserts the surfaced warning after load resolves.
- `./scripts/frontend/check-all.sh` green locally (ESLint zero-warning, tsc strict, prettier, full jest suite 3621 passing).

## Known follow-up
Wiring in the load-failure banner surfaced a pre-existing inconsistency on the *save* path: `ApiKeyContext.saveApiKey` swallows a write failure (sets `loadError` but resolves), so a save while storage is broken shows both the green "API key saved" status and the storage warning. That is orthogonal to this field's wire-in and is tracked in #1474.

Closes #1399