### PR TITLE
refactor(frontend): extract shared useAuthSubmit hook across the five Auth screens

### DIFF
--- a/frontend/src/features/Auth/ForgotPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ForgotPasswordScreen.tsx
@@ -5,9 +5,9 @@ import { authStyles as styles } from './auth.styles';
 import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
 import { EmailField } from './components/EmailField';
+import { useAuthSubmit } from './useAuthSubmit';
 
 import { auth as authApi } from '@/api';
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 
 const FORGOT_FALLBACK =
@@ -96,22 +96,14 @@ function SuccessNotice({ onBackToLogin }: { onBackToLogin: () => void }): React.
 
 export default function ForgotPasswordScreen({ navigation }: Props) {
   const [email, setEmail] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-
-  const handleSubmit = async () => {
-    setError(null);
-    setSubmitting(true);
-    try {
+  const { submitting, error, run } = useAuthSubmit(
+    async () => {
       await authApi.requestPasswordReset({ email: canonicalizeEmail(email) });
       setSubmitted(true);
-    } catch (err: unknown) {
-      setError(formatApiError(err, { fallback: FORGOT_FALLBACK }));
-    } finally {
-      setSubmitting(false);
-    }
-  };
+    },
+    { fallback: FORGOT_FALLBACK },
+  );
 
   if (submitted) {
     return (
@@ -132,7 +124,7 @@ export default function ForgotPasswordScreen({ navigation }: Props) {
       {error && <Text style={styles.error}>{error}</Text>}
       <ForgotActions
         submitting={submitting}
-        onSubmit={handleSubmit}
+        onSubmit={run}
         onBackToLogin={() => navigation.navigate('Login')}
       />
     </AuthScreenContainer>

--- a/frontend/src/features/Auth/LoginScreen.tsx
+++ b/frontend/src/features/Auth/LoginScreen.tsx
@@ -7,8 +7,8 @@ import { AuthScreenContainer } from './AuthScreenContainer';
 import { canonicalizeEmail } from './canonicalizeEmail';
 import { EmailField } from './components/EmailField';
 import { PasswordField } from './components/PasswordField';
+import { useAuthSubmit } from './useAuthSubmit';
 
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 import { useAuth } from '@/context/AuthContext';
 
@@ -99,27 +99,15 @@ export default function LoginScreen({ navigation }: Props) {
   const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleLogin = async () => {
-    setError(null);
-    setSubmitting(true);
-    try {
-      // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
-      // produce a confusing 422 from the backend.
-      // BUG-FE-AUTH-015: lowercase the email client-side so the backend
-      // receives the canonical form and a "Foo@bar.com" / "foo@bar.com"
-      // login pair can't end up looking like two distinct accounts.
-      await login(canonicalizeEmail(email), password);
-    } catch (err: unknown) {
-      // BUG-FRONTEND-INFRA-016: ``formatApiError`` returns a dedicated
-      // timeout message when the new AbortController fires.
-      setError(formatApiError(err, { fallback: LOGIN_FALLBACK }));
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  const { submitting, error, run } = useAuthSubmit(
+    // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
+    // produce a confusing 422 from the backend.
+    // BUG-FE-AUTH-015: lowercase the email client-side so the backend
+    // receives the canonical form and a "Foo@bar.com" / "foo@bar.com"
+    // login pair can't end up looking like two distinct accounts.
+    () => login(canonicalizeEmail(email), password),
+    { fallback: LOGIN_FALLBACK },
+  );
 
   return (
     <AuthScreenContainer testID="login">
@@ -135,7 +123,7 @@ export default function LoginScreen({ navigation }: Props) {
       {error && <Text style={styles.error}>{error}</Text>}
       <LoginActions
         submitting={submitting}
-        onLogin={handleLogin}
+        onLogin={run}
         onNavigateSignup={() => navigation.navigate('Signup')}
         onNavigateForgot={() => navigation.navigate('ForgotPassword')}
       />

--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -13,8 +13,8 @@ import { authStyles } from './auth.styles';
 import { canonicalizeEmail } from './canonicalizeEmail';
 import { EmailField } from './components/EmailField';
 import { PasswordField } from './components/PasswordField';
+import { useAuthSubmit } from './useAuthSubmit';
 
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 import { useAuth } from '@/context/AuthContext';
 import {
@@ -116,20 +116,10 @@ export function ReauthSheet(): React.JSX.Element {
   const { login, dismissReauth } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleSubmit = useCallback(async () => {
-    setError(null);
-    setSubmitting(true);
-    try {
-      await login(canonicalizeEmail(email), password);
-    } catch (err: unknown) {
-      setError(formatApiError(err, { fallback: REAUTH_FALLBACK }));
-    } finally {
-      setSubmitting(false);
-    }
-  }, [login, email, password]);
+  const { submitting, error, run } = useAuthSubmit(
+    () => login(canonicalizeEmail(email), password),
+    { fallback: REAUTH_FALLBACK },
+  );
 
   const handleDismiss = useCallback(() => {
     void dismissReauth();
@@ -155,7 +145,7 @@ export function ReauthSheet(): React.JSX.Element {
           submitting={submitting}
           onEmailChange={setEmail}
           onPasswordChange={setPassword}
-          onSubmit={handleSubmit}
+          onSubmit={run}
           onDismiss={handleDismiss}
         />
       </KeyboardAvoidingView>

--- a/frontend/src/features/Auth/ResetPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ResetPasswordScreen.tsx
@@ -6,8 +6,8 @@ import { AuthScreenContainer } from './AuthScreenContainer';
 import { PasswordField } from './components/PasswordField';
 import { validatePasswordPair } from './passwordValidation';
 import { MIN_TOKEN_LENGTH } from './resetToken';
+import { useAuthSubmit } from './useAuthSubmit';
 
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 import { useAuth } from '@/context/AuthContext';
 
@@ -116,34 +116,30 @@ export default function ResetPasswordScreen({ navigation, route }: Props) {
   const { confirmPasswordReset } = useAuth();
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-
   const token = route?.params?.token ?? '';
 
-  if (!token || token.length < MIN_TOKEN_LENGTH) {
-    return <MissingTokenView onRequestNew={() => navigation.navigate('ForgotPassword')} />;
-  }
-
-  const handleSubmit = async () => {
-    setError(null);
-    const validationError = validatePasswordPair(password, confirmPassword);
-    if (validationError) {
-      setError(validationError);
-      return;
-    }
-    setSubmitting(true);
-    try {
+  const { submitting, error, setError, run } = useAuthSubmit(
+    async () => {
       await confirmPasswordReset(token, password);
       // applyAuthResponse inside the context flips authStatus to
       // ``authenticated``, which the App-level navigator picks up to
       // swap the AuthStack for RootStack.  No explicit navigation
       // call is needed here.
-    } catch (err: unknown) {
-      setError(formatApiError(err, { fallback: RESET_FALLBACK }));
-    } finally {
-      setSubmitting(false);
+    },
+    { fallback: RESET_FALLBACK },
+  );
+
+  if (!token || token.length < MIN_TOKEN_LENGTH) {
+    return <MissingTokenView onRequestNew={() => navigation.navigate('ForgotPassword')} />;
+  }
+
+  const handleSubmit = () => {
+    const validationError = validatePasswordPair(password, confirmPassword);
+    if (validationError) {
+      setError(validationError);
+      return;
     }
+    void run();
   };
 
   return (

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -8,8 +8,8 @@ import { canonicalizeEmail } from './canonicalizeEmail';
 import { EmailField } from './components/EmailField';
 import { PasswordField } from './components/PasswordField';
 import { validatePasswordPair } from './passwordValidation';
+import { useAuthSubmit } from './useAuthSubmit';
 
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 import { useAuth } from '@/context/AuthContext';
 
@@ -98,31 +98,20 @@ export default function SignupScreen({ navigation }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const { submitting, error, setError, run } = useAuthSubmit(
+    // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
+    // produce a confusing 422 from the backend.
+    () => signup(canonicalizeEmail(email), password),
+    { fallback: SIGNUP_FALLBACK },
+  );
 
-  const handleSignup = async () => {
-    setError(null);
-
+  const handleSignup = () => {
     const validationError = validatePasswordPair(password, confirmPassword);
     if (validationError) {
       setError(validationError);
       return;
     }
-
-    setSubmitting(true);
-    try {
-      // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
-      // produce a confusing 422 from the backend.
-      await signup(canonicalizeEmail(email), password);
-    } catch (err: unknown) {
-      // BUG-FRONTEND-INFRA-016 — timeout-specific message handled via
-      // formatApiError; backend detail codes mapped through the shared
-      // mapper instead of leaking snake_case to the user.
-      setError(formatApiError(err, { fallback: SIGNUP_FALLBACK }));
-    } finally {
-      setSubmitting(false);
-    }
+    void run();
   };
 
   return (

--- a/frontend/src/features/Auth/__tests__/useAuthSubmit.test.tsx
+++ b/frontend/src/features/Auth/__tests__/useAuthSubmit.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useAuthSubmit } from '../useAuthSubmit';
+
+const FALLBACK = 'We could not complete that. Try again in a moment.';
+
+function makeDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (_e: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (_e: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useAuthSubmit', () => {
+  it('starts with submitting false and error null', () => {
+    const fn = jest.fn(() => Promise.resolve());
+    const { result } = renderHook(() => useAuthSubmit(fn, { fallback: FALLBACK }));
+
+    expect(result.current.submitting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets submitting true mid-flight and clears it and any prior error on success', async () => {
+    const deferred = makeDeferred();
+    const fn = jest.fn(() => deferred.promise);
+    const { result } = renderHook(() => useAuthSubmit(fn, { fallback: FALLBACK }));
+
+    act(() => {
+      result.current.setError('boom');
+    });
+    expect(result.current.error).toBe('boom');
+
+    let runPromise!: Promise<void>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+    expect(result.current.submitting).toBe(true);
+
+    await act(async () => {
+      deferred.resolve();
+      await runPromise;
+    });
+
+    expect(result.current.submitting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error to the exact fallback string on rejection and resets submitting', async () => {
+    const deferred = makeDeferred();
+    const fn = jest.fn(() => deferred.promise);
+    const { result } = renderHook(() => useAuthSubmit(fn, { fallback: FALLBACK }));
+
+    let runPromise!: Promise<void>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    await act(async () => {
+      deferred.reject(new Error('network down'));
+      await runPromise;
+    });
+
+    expect(result.current.error).toBe(FALLBACK);
+    expect(result.current.submitting).toBe(false);
+  });
+
+  it('ignores a second run while one is already in flight', async () => {
+    const deferred = makeDeferred();
+    const fn = jest.fn(() => deferred.promise);
+    const { result } = renderHook(() => useAuthSubmit(fn, { fallback: FALLBACK }));
+
+    let firstRun!: Promise<void>;
+    let secondRun!: Promise<void>;
+    act(() => {
+      firstRun = result.current.run();
+      secondRun = result.current.run();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await firstRun;
+      await secondRun;
+    });
+
+    const secondDeferred = makeDeferred();
+    fn.mockReturnValueOnce(secondDeferred.promise);
+
+    let thirdRun!: Promise<void>;
+    act(() => {
+      thirdRun = result.current.run();
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      secondDeferred.resolve();
+      await thirdRun;
+    });
+  });
+
+  it('keeps a stable run identity and always invokes the latest fn passed in', async () => {
+    const firstFn = jest.fn(() => Promise.resolve());
+    const secondFn = jest.fn(() => Promise.resolve());
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: () => Promise<void> }) => useAuthSubmit(fn, { fallback: FALLBACK }),
+      { initialProps: { fn: firstFn } },
+    );
+
+    const firstRun = result.current.run;
+    rerender({ fn: secondFn });
+    expect(Object.is(firstRun, result.current.run)).toBe(true);
+
+    await act(async () => {
+      await result.current.run();
+    });
+
+    expect(secondFn).toHaveBeenCalledTimes(1);
+    expect(firstFn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Auth/useAuthSubmit.ts
+++ b/frontend/src/features/Auth/useAuthSubmit.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+import { formatApiError } from '@/api/errorMessages';
+
+/**
+ * Shared submit state-machine for the Auth screens.
+ *
+ * Every auth form is the same shape: an ``error``/``submitting`` pair wrapped
+ * around one async call whose failures map through ``formatApiError``. This hook
+ * owns that try/catch/finally so Login/Signup/Forgot/Reset/Reauth don't each
+ * re-derive it. ``run`` keeps a stable identity (config is stashed in a ref and
+ * re-read every call, mirroring ``useOptimisticMutation``) and an in-flight guard
+ * makes a synchronous second ``run()`` a no-op until the first settles.
+ */
+
+export interface AuthSubmit {
+  submitting: boolean;
+  error: string | null;
+  setError: Dispatch<SetStateAction<string | null>>;
+  run: () => Promise<void>;
+}
+
+interface AuthSubmitConfig {
+  fn: () => Promise<void>;
+  fallback: string;
+}
+
+export function useAuthSubmit(
+  fn: () => Promise<void>,
+  { fallback }: { fallback: string },
+): AuthSubmit {
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const cfgRef = useRef<AuthSubmitConfig>({ fn, fallback });
+  cfgRef.current = { fn, fallback };
+
+  const inFlightRef = useRef(false);
+
+  const run = useCallback(async (): Promise<void> => {
+    if (inFlightRef.current) {
+      return;
+    }
+    inFlightRef.current = true;
+    const cfg = cfgRef.current;
+    setError(null);
+    setSubmitting(true);
+    try {
+      await cfg.fn();
+    } catch (err: unknown) {
+      // BUG-FRONTEND-INFRA-016: formatApiError maps timeouts and backend codes to user copy.
+      setError(formatApiError(err, { fallback: cfg.fallback }));
+    } finally {
+      inFlightRef.current = false;
+      setSubmitting(false);
+    }
+  }, []);
+
+  return { submitting, error, setError, run };
+}


### PR DESCRIPTION
## Summary
- Extract a shared `useAuthSubmit(fn, { fallback })` hook (returns `{ submitting, error, setError, run }`) that owns the async submit state-machine — `setError(null)` → `setSubmitting(true)` → `try/await/catch(formatApiError)/finally(setSubmitting(false))` — and route all five Auth screens (Login, Signup, ForgotPassword, ResetPassword, ReauthSheet) through it, deleting the five hand-rolled `submitting`/`error` `useState` pairs and try/catch/finally wrappers.
- Each screen keeps its own validation gate and `*_FALLBACK` copy; Forgot's `setSubmitted(true)` success side-effect and ResetPassword's hook-before-early-return ordering are preserved. Screen markup, copy, validation rules, and navigation are unchanged.
- The hook adds a ref-based in-flight guard so a synchronous double-tap fires the wrapped auth call exactly once, closing the duplicate-account-POST window that `disabled={submitting}` (lagging React state) left open.

## Test plan
- New `frontend/src/features/Auth/__tests__/useAuthSubmit.test.tsx`: initial state, success (clears prior error, resets `submitting`), failure (exact `formatApiError` fallback), synchronous double-`run()` guard (fn fired once, re-arms after settle), and stable `run` identity always invoking the latest `fn`.
- `./scripts/frontend/check-all.sh` green: ESLint zero-warning, `tsc --noEmit` clean, all 3626 Jest tests pass. The five existing Auth screen test files are unmodified and still pass (behavior parity).
- Gate 2.5 code-review-orchestrator self-review returned CLEAN (no blocking findings).

Closes #1400
