### PR TITLE
test(journal): assert real encryption-at-rest wiring in the ex-plaintext test

### DIFF
--- a/backend/tests/models/test_journal_entry_no_encryption_flag.py
+++ b/backend/tests/models/test_journal_entry_no_encryption_flag.py
@@ -1,26 +1,37 @@
-"""Regression: the hollow encryption flag must stay gone (audit-destub-05).
+"""Guards for JournalEntry's encryption-at-rest wiring (audit-destub-05b).
 
-``ENCRYPTION_AT_REST_ENABLED`` advertised Fernet column encryption that was
-never implemented — ``message`` was stored plaintext regardless. The flag was
-removed so the codebase stops promising a guarantee it does not keep; real
-encryption is tracked separately. This test fails if the flag is reintroduced
-without an actual encrypt/decrypt path.
+``message`` is wired for encryption at rest via ``EncryptedString`` rather than
+a hollow ``ENCRYPTION_AT_REST_ENABLED`` boolean (the ``EncryptedString`` type
+decorator encrypts on write / decrypts on read when a key is configured). This
+file pins two things: the flag must stay gone, and the mapped ``message`` column
+must keep its ``EncryptedString`` type. Behavioral round-trip and rotation
+coverage lives in ``tests/services/test_journal_encryption.py``.
 """
 
 from __future__ import annotations
 
-import inspect
+from typing import cast
+
+from sqlalchemy import Table
+from sqlalchemy import inspect as sa_inspect
 
 import models.journal_entry as journal_entry_module
+from models.journal_entry import JournalEntry
+from services.journal_encryption import EncryptedString
 
 
 def test_hollow_encryption_flag_is_removed() -> None:
+    """Encryption is a property of the column type, not a drift-prone flag."""
     assert not hasattr(journal_entry_module, "ENCRYPTION_AT_REST_ENABLED")
 
 
-def test_module_makes_no_false_encryption_claim() -> None:
-    """The module source (comments included) must not claim ``message`` is encrypted."""
-    # Inspect the actual file text, not ``__doc__`` — the original false claim
-    # lived in a ``#`` comment, so a docstring check would pass vacuously.
-    source = inspect.getsource(journal_entry_module).lower()
-    assert "encrypted before" not in source
+def test_message_column_is_encrypted_at_rest() -> None:
+    """The mapped ``message`` column must use ``EncryptedString`` and stay non-null.
+
+    This pins the encrypt-on-write / decrypt-on-read wiring declared on the
+    model; it fails if ``message`` reverts to a plain ``str``/``Text`` column.
+    """
+    table = cast("Table", sa_inspect(JournalEntry).local_table)
+    column = table.columns["message"]
+    assert isinstance(column.type, EncryptedString)
+    assert column.nullable is False


### PR DESCRIPTION
## Summary

`backend/tests/models/test_journal_entry_no_encryption_flag.py` was written when journal `message` was plaintext, to keep a hollow `ENCRYPTION_AT_REST_ENABLED` flag from lying. Fernet column encryption at rest has since shipped — `JournalEntry.message` is now `Column(EncryptedString())` — so the module docstring falsely claimed plaintext and `test_module_makes_no_false_encryption_claim` asserted `"encrypted before" not in source`, a brittle grep that actively resisted truthful documentation of the shipped feature.

This de-slop rewrite (single test file; no production changes):

- Rewrites the module docstring to describe the real `EncryptedString` encrypt-on-write / decrypt-on-read wiring (key-gated), and reframes the file as a guard against a hollow flag returning — not against documenting real encryption.
- Replaces the source-substring grep with `test_message_column_is_encrypted_at_rest`, which introspects the mapped `message` column via `sa_inspect(JournalEntry).local_table` and asserts its type `isinstance` `EncryptedString` and stays non-null. This is a mutation-grade, security-relevant regression guard: it fails if `message` silently reverts to a plain `str`/`Text` column.
- Keeps `test_hollow_encryption_flag_is_removed` with a corrected docstring.

Behavioral round-trip / rotation / ciphertext-at-rest coverage already lives in `backend/tests/services/test_journal_encryption.py` and is intentionally not duplicated. No net coverage loss.

## Test plan

- `pytest tests/models/test_journal_entry_no_encryption_flag.py` — 2 passed.
- `./scripts/backend/check-all.sh` — all 7 checks pass (ruff ALL, ruff-format, mypy strict, bandit, radon, 2432 tests / 2 skipped, coverage 96.66%).
- `xenon --max-absolute A --max-modules A --max-average A` on the file — exit 0; `radon mi` — grade A.

Closes #1425