### PR TITLE
refactor(domain): unify tz normalization on ensure_aware, drop duplicated _normalize

### DIFF
--- a/backend/src/domain/metta_return.py
+++ b/backend/src/domain/metta_return.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from domain.dates import ensure_aware
+
 if TYPE_CHECKING:
     from models.stage_progress import StageProgress
 
@@ -142,19 +144,9 @@ def current_offer_episode(progress: StageProgress | None) -> str | None:
     return f"{progress.cycle_number}:{progress.current_stage}"
 
 
-def _normalize(moment: datetime) -> datetime:
-    """Strip tzinfo so naive (SQLite) and aware (Postgres) values compare.
-
-    Both dialects store UTC; only the tzinfo flag differs. Subtracting a mixed
-    naive/aware pair raises, so every elapsed-time computation funnels through
-    this, mirroring the program-calendar normalization.
-    """
-    return moment.replace(tzinfo=None) if moment.tzinfo else moment
-
-
 def _elapsed_days(anchor: datetime, now: datetime) -> int:
     """Whole days since the anchor, floored at zero for clock skew."""
-    delta = _normalize(now) - _normalize(anchor)
+    delta = ensure_aware(now) - ensure_aware(anchor)
     return max(0, delta.days)
 
 
@@ -164,13 +156,13 @@ def resumed_start(started_at: datetime, paused_at: datetime, now: datetime) -> d
     Resuming a paused arc must not lose the frozen week: the time spent paused
     is pushed onto the start so elapsed-since-start once again matches the
     pre-pause elapsed. ``now`` and ``paused_at`` may carry different tzinfo
-    flags across SQLite (naive) and Postgres (aware), so both are normalized
-    before subtracting to form the pause duration, exactly as the elapsed-day
-    math does. The resulting timedelta is then added to the ORIGINAL
+    flags across SQLite (naive) and Postgres (aware), so both are coerced to
+    UTC-aware before subtracting to form the pause duration, exactly as the
+    elapsed-day math does. The resulting timedelta is then added to the ORIGINAL
     ``started_at`` — adding a timedelta preserves its tzinfo either way — so no
     mixed naive/aware subtraction is ever performed.
     """
-    paused_duration = _normalize(now) - _normalize(paused_at)
+    paused_duration = ensure_aware(now) - ensure_aware(paused_at)
     return started_at + paused_duration
 
 
@@ -181,7 +173,7 @@ def active_return_week(started_at: datetime, paused_at: datetime | None, now: da
     is paused, otherwise to ``now`` — so a paused arc reports a frozen week that
     ignores further elapsed time. The result is clamped to
     ``[1, RETURN_WEEK_COUNT]`` so it never climbs past the arc. Mixed
-    naive/aware datetimes are normalized rather than raising.
+    naive/aware datetimes are coerced to UTC-aware rather than raising.
     """
     reference = paused_at if paused_at is not None else now
     week = _elapsed_days(started_at, reference) // DAYS_PER_WEEK + 1
@@ -197,7 +189,8 @@ def is_return_complete(started_at: datetime, paused_at: datetime | None, now: da
     a pause before the boundary keeps completion frozen at False. The arc is
     complete once at least :data:`RETURN_TOTAL_DAYS` have elapsed — the fifth week
     has fully closed, a reflective close rather than a reward. Mixed naive/aware
-    datetimes are normalized by the shared elapsed-day helper rather than raising.
+    datetimes are coerced to UTC-aware by the shared elapsed-day helper rather
+    than raising.
     """
     reference = paused_at if paused_at is not None else now
     return _elapsed_days(started_at, reference) >= RETURN_TOTAL_DAYS

--- a/backend/src/domain/program_calendar.py
+++ b/backend/src/domain/program_calendar.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_STAGES
+from domain.dates import ensure_aware
 from domain.weekly_prompts import TOTAL_WEEKS
 
 if TYPE_CHECKING:
@@ -26,19 +27,9 @@ if TYPE_CHECKING:
 _DAYS_PER_WEEK = 7
 
 
-def _normalize(moment: datetime) -> datetime:
-    """Strip tzinfo so naive (SQLite) and aware (Postgres) values compare.
-
-    Both dialects store UTC; only the tzinfo flag differs (issue #412
-    class).  Subtracting mixed naive/aware datetimes raises, so every
-    calendar computation funnels through this.
-    """
-    return moment.replace(tzinfo=None) if moment.tzinfo else moment
-
-
 def _elapsed_days(anchor: datetime, now: datetime) -> int:
     """Whole days since the anchor, floored at zero for clock skew."""
-    delta = _normalize(now) - _normalize(anchor)
+    delta = ensure_aware(now) - ensure_aware(anchor)
     return max(0, delta.days)
 
 

--- a/backend/tests/domain/test_metta_return.py
+++ b/backend/tests/domain/test_metta_return.py
@@ -33,7 +33,7 @@ Pinned public surface:
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
@@ -321,6 +321,9 @@ def test_current_offer_episode_key_changes_when_cycle_bumps() -> None:
 # Week derivation from elapsed and paused time.
 # ---------------------------------------------------------------------------
 
+# Deterministic non-UTC offset (no ZoneInfo/tzdata/DST dependency).
+_NON_UTC = timezone(timedelta(hours=-8))
+
 
 def test_active_return_week_day_zero_is_week_one() -> None:
     """No elapsed time — the arc starts in week 1."""
@@ -370,6 +373,43 @@ def test_active_return_week_handles_naive_and_aware_datetime_mix() -> None:
     now_aware = datetime(2026, 1, 8, tzinfo=UTC)
     week = active_return_week(started_at_naive, None, now_aware)
     assert week == 2
+
+
+def test_active_return_week_uses_instant_not_wall_clock_for_non_utc_aware_now() -> None:
+    """A non-UTC aware ``now`` counts elapsed days by INSTANT, not wall clock.
+
+    2026-01-07T20:00-08:00 is the instant 2026-01-08T04:00Z: 7 elapsed days
+    from the start by instant (week 2), even though its naive wall-clock
+    reading (2026-01-07T20:00 minus 2026-01-01T00:00) is only 6 days (week 1).
+    """
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = datetime(2026, 1, 7, 20, 0, tzinfo=_NON_UTC)
+    assert active_return_week(started_at, None, now) == 2
+
+
+def test_active_return_week_and_is_return_complete_agree_across_naive_and_aware_utc() -> None:
+    """Naive, aware-UTC, and mixed inputs must agree for real UTC instants.
+
+    Pins that unifying the naive/aware normalization changes nothing
+    observable when every input already represents UTC.
+    """
+    naive_started = datetime(2026, 1, 1)  # noqa: DTZ001 - deliberately naive
+    naive_now = naive_started + timedelta(days=10)
+    aware_started = naive_started.replace(tzinfo=UTC)
+    aware_now = naive_now.replace(tzinfo=UTC)
+
+    assert active_return_week(naive_started, None, naive_now) == active_return_week(
+        aware_started, None, aware_now
+    )
+    assert active_return_week(naive_started, None, aware_now) == active_return_week(
+        aware_started, None, aware_now
+    )
+    assert is_return_complete(naive_started, None, naive_now) == is_return_complete(
+        aware_started, None, aware_now
+    )
+    assert is_return_complete(naive_started, None, aware_now) == is_return_complete(
+        aware_started, None, aware_now
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -435,6 +475,19 @@ def test_is_return_complete_handles_naive_and_aware_datetime_mix() -> None:
     assert is_return_complete(started_at_naive, None, now_aware) is True
 
 
+def test_is_return_complete_uses_instant_not_wall_clock_at_the_boundary() -> None:
+    """A non-UTC aware ``now`` that has crossed the boundary by INSTANT is complete.
+
+    2026-02-04T20:00-08:00 is the instant 2026-02-05T04:00Z: 35 elapsed days
+    from the start by instant (complete), even though its naive wall-clock
+    reading (2026-02-04T20:00 minus 2026-01-01T00:00) is only 34 days
+    (not yet complete).
+    """
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = datetime(2026, 2, 4, 20, 0, tzinfo=_NON_UTC)
+    assert is_return_complete(started_at, None, now) is True
+
+
 # ---------------------------------------------------------------------------
 # resumed_start
 # ---------------------------------------------------------------------------
@@ -482,6 +535,20 @@ def test_resumed_start_handles_naive_and_aware_datetime_mix() -> None:
     # Three paused days push the start to Jan 4; week stays frozen at week 1.
     assert resumed == started_at_naive + timedelta(days=3)
     assert active_return_week(resumed, None, now_aware) == 1
+
+
+def test_resumed_start_uses_instant_pause_duration_for_non_utc_aware_now() -> None:
+    """The pause duration is computed by INSTANT, not by stripped wall clock.
+
+    2026-01-07T20:00-08:00 is the instant 2026-01-08T04:00Z: a 7-day-4-hour
+    pause by instant, even though its naive wall-clock reading
+    (2026-01-07T20:00 minus 2026-01-01T00:00) is only 6 days 20 hours.
+    """
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    paused_at = datetime(2026, 1, 1, tzinfo=UTC)
+    now = datetime(2026, 1, 7, 20, 0, tzinfo=_NON_UTC)
+    resumed = resumed_start(started_at, paused_at, now)
+    assert resumed == started_at + timedelta(days=7, hours=4)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_program_calendar.py
+++ b/backend/tests/test_program_calendar.py
@@ -9,7 +9,7 @@ agree with what the user sees.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 
 from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_PROGRAM_DAYS, TOTAL_STAGES
 from domain.program_calendar import (
@@ -22,6 +22,8 @@ from domain.weekly_prompts import TOTAL_WEEKS
 from models.stage_progress import StageProgress
 
 _ANCHOR = datetime(2026, 1, 1, tzinfo=UTC)
+# Deterministic non-UTC offset (no ZoneInfo/tzdata/DST dependency).
+_NON_UTC = timezone(timedelta(hours=-8))
 
 
 def _at(days: int) -> datetime:
@@ -81,6 +83,17 @@ def test_calendar_week_accepts_naive_anchor() -> None:
     assert calendar_week(naive_anchor, _at(7)) == 2
 
 
+def test_calendar_week_uses_instant_not_wall_clock_for_non_utc_aware_now() -> None:
+    """A non-UTC aware ``now`` counts elapsed days by INSTANT, not wall clock.
+
+    2026-01-07T20:00-08:00 is the instant 2026-01-08T04:00Z: 7 elapsed days
+    from the anchor by instant (week 2), even though its naive wall-clock
+    reading (2026-01-07T20:00 minus 2026-01-01T00:00) is only 6 days (week 1).
+    """
+    now = datetime(2026, 1, 7, 20, 0, tzinfo=_NON_UTC)
+    assert calendar_week(_ANCHOR, now) == 2
+
+
 # ── calendar_stage ──────────────────────────────────────────────────────
 
 
@@ -131,6 +144,39 @@ def test_calendar_day_in_stage_accepts_naive_anchor() -> None:
     """SQLite returns naive datetimes; the math must not raise (issue #412 class)."""
     naive_anchor = _ANCHOR.replace(tzinfo=None)
     assert calendar_day_in_stage(naive_anchor, 2, _at(21)) == 1
+
+
+def test_calendar_day_in_stage_uses_instant_not_wall_clock_for_non_utc_aware_now() -> None:
+    """The same instant-crossing boundary carries through to the day-in-stage math.
+
+    See ``test_calendar_week_uses_instant_not_wall_clock_for_non_utc_aware_now``:
+    7 elapsed days by instant (day 8 of stage 1) versus 6 by stripped wall
+    clock (day 7).
+    """
+    now = datetime(2026, 1, 7, 20, 0, tzinfo=_NON_UTC)
+    assert calendar_day_in_stage(_ANCHOR, 1, now) == 8
+
+
+def test_calendar_math_agrees_across_naive_and_aware_utc_representations() -> None:
+    """Naive, aware-UTC, and mixed inputs must agree for real UTC instants.
+
+    Pins that unifying the naive/aware normalization changes nothing
+    observable when every input already represents UTC.
+    """
+    naive_anchor = _ANCHOR.replace(tzinfo=None)
+    naive_now = naive_anchor + timedelta(days=10)
+    aware_now = naive_now.replace(tzinfo=UTC)
+
+    assert calendar_week(naive_anchor, naive_now) == calendar_week(_ANCHOR, aware_now)
+    assert calendar_week(naive_anchor, aware_now) == calendar_week(_ANCHOR, aware_now)
+    assert calendar_stage(naive_anchor, naive_now) == calendar_stage(_ANCHOR, aware_now)
+    assert calendar_stage(naive_anchor, aware_now) == calendar_stage(_ANCHOR, aware_now)
+    assert calendar_day_in_stage(naive_anchor, 1, naive_now) == calendar_day_in_stage(
+        _ANCHOR, 1, aware_now
+    )
+    assert calendar_day_in_stage(naive_anchor, 1, aware_now) == calendar_day_in_stage(
+        _ANCHOR, 1, aware_now
+    )
 
 
 # ── resolve_program_anchor ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three sibling `domain/` modules solved the identical SQLite-naive vs.
Postgres-aware datetime-subtraction problem in two opposing ways:

- `program_calendar.py` and `metta_return.py` each carried a
  **byte-identical** private `_normalize` that **stripped** tzinfo to naive.
- `course.py` used `domain.dates.ensure_aware`, which **coerces** naive → UTC-aware.

The strip approach directly contradicted the `domain/dates.py` module contract,
which bills itself the "single source of truth for user-local day math" and
states it "never produce[s] a naive datetime."

**Contract decision:** standardize on **coerce-to-aware via the existing
`domain.dates.ensure_aware`** (the issue's default recommendation), honoring the
`dates.py` "never naive" invariant.

**Changes:**
- Route `program_calendar._elapsed_days`, `metta_return._elapsed_days`, and
  `metta_return.resumed_start`'s pause-duration math through `ensure_aware`.
- Delete both duplicated `_normalize` copies (this also removes an in-code issue
  reference from the old `program_calendar._normalize` docstring).
- `course.py` already used `ensure_aware` — left consistent, now all three call
  sites share one documented normalization path.
- Docstrings updated: "normalized" → "coerced to UTC-aware".

**Behavior:** For UTC inputs — every stored value in practice — the arithmetic
is byte-for-byte unchanged. For non-UTC aware inputs the math is now correctly
**instant-based** rather than stripped-wall-clock.

**Affected callers:** the gating call sites of `program_calendar.calendar_week /
calendar_stage / calendar_day_in_stage`, and `metta_return.active_return_week /
is_return_complete / resumed_start`. No stored column, migration, or arithmetic
result for UTC data changes.

## Test plan

- Added regression tests pinning naive / aware-UTC / mixed parity for both
  modules (unifying the normalization changes nothing observable for UTC data).
- Added tests asserting the new instant-based semantics for non-UTC aware `now`
  (week derivation, completion boundary, and pause duration), using a
  deterministic fixed offset (no ZoneInfo/tzdata/DST dependency).
- `./scripts/backend/check-all.sh` green (2439 passed, coverage 96.57% ≥ 90%).
- `xenon --max-absolute A --max-modules A --max-average A` exit 0; `radon mi` all A.
- Gate 2.5 code-review-orchestrator verdict: CLEAN.

Closes #1426