### PR TITLE
refactor(backend): collapse duplicated idempotent-seed scaffold into shared helpers

### DIFF
--- a/backend/src/seed_helpers.py
+++ b/backend/src/seed_helpers.py
@@ -1,0 +1,76 @@
+"""Shared building blocks for the idempotent startup seeders.
+
+Two patterns recur across the ``seed_*`` modules that populate system
+(owner-less) rows on FastAPI startup:
+
+* a natural-key existence lookup, used to skip rows already present, and
+* a race-safe commit that treats a concurrent peer's winning insert as a
+  no-op.
+
+Collapsing both into one home keeps the individual seeders declarative
+and stops the two idioms from drifting apart as new seeders are added.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+#: Column count that selects a two-part composite natural key. One column
+#: yields a set of scalars; this many yields a set of ``(a, b)`` tuples.
+_COMPOSITE_KEY_WIDTH = 2
+
+
+async def existing_system_keys(
+    session: AsyncSession, *columns: object, owner_col: object | None = None
+) -> set[Any]:
+    """Return the natural keys of the system rows already in the table.
+
+    ``columns`` is the natural key to read back: pass one column for a
+    scalar key (returns a set of values) or two columns for a composite key
+    (returns a set of ``(a, b)`` tuples). When ``owner_col`` is supplied the
+    query is scoped to ``owner_col IS NULL`` so user-owned rows can't shadow
+    a system preset that collides on the same key; omit it to read every row
+    (for tables with no owner concept).
+
+    Seeders call this before staging inserts and skip any definition whose
+    key is already present, which is what makes re-running the seeder on a
+    populated database a no-op.
+    """
+    # The columns are opaque SQL expressions here, so widen before handing
+    # them to the arity-typed ``select`` rather than re-deriving a concrete
+    # select overload for every key shape.
+    key_columns: Any = columns
+    statement = select(*key_columns)
+    if owner_col is not None:
+        statement = statement.where(col(owner_col).is_(None))
+    rows = (await session.execute(statement)).all()
+    if len(columns) == _COMPOSITE_KEY_WIDTH:
+        return {(row[0], row[1]) for row in rows}
+    return {row[0] for row in rows}
+
+
+async def commit_or_yield_to_race_winner(session: AsyncSession, inserted: int) -> int:
+    """Commit ``inserted`` new rows, treating a unique-index collision as a no-op.
+
+    This is the one canonical race-safe commit for the idempotent seeders.
+    Race-loser path: a peer process committed the same row(s) between our
+    existence SELECT and our COMMIT. Roll back and return 0 — the work has
+    already been done by the peer — otherwise return ``inserted``.
+
+    It is only meaningful where a database unique index arbitrates
+    concurrent startup seeding; without such an index both peers would
+    commit and ship the duplicate the guard exists to prevent. The backing
+    indexes live in two migrations: ``d2e3f4a5b6c7`` for
+    ``Practice(stage_number, name)`` and ``07b8c9d0e1f2`` for the
+    ``PracticeTag.slug`` / ``PracticeRecipe.slug`` partial-unique indexes.
+    """
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return 0
+    return inserted

--- a/backend/src/seed_practice_recipes.py
+++ b/backend/src/seed_practice_recipes.py
@@ -29,9 +29,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
 
 from domain.practice_modes import PracticeMode
 from models.practice_recipe import PracticeRecipe, PracticeRecipeStep
@@ -42,6 +40,7 @@ from schemas.practice_recipe import (
     PracticeRecipeStepOut,
     materialise_mode_config,
 )
+from seed_helpers import commit_or_yield_to_race_winner, existing_system_keys
 
 # Default repeat counts for rounds-by-categories recipes.  Three is the
 # defacto "enough to settle, not so many you check out" round count the
@@ -323,25 +322,11 @@ if len(set(_tag_slugs)) != len(_tag_slugs):
     raise ValueError(msg)
 
 
-async def _existing_system_tag_slugs(session: AsyncSession) -> set[str]:
-    """Return slugs of system tags already in the DB."""
-    result = await session.execute(
-        select(PracticeTag.slug).where(col(PracticeTag.owner_user_id).is_(None))
-    )
-    return {row[0] for row in result.all()}
-
-
-async def _existing_system_recipe_slugs(session: AsyncSession) -> set[str]:
-    """Return slugs of system recipes already in the DB."""
-    result = await session.execute(
-        select(PracticeRecipe.slug).where(col(PracticeRecipe.owner_user_id).is_(None))
-    )
-    return {row[0] for row in result.all()}
-
-
 async def _seed_system_tags(session: AsyncSession) -> int:
     """Insert system tags not yet present.  Returns inserted row count."""
-    existing = await _existing_system_tag_slugs(session)
+    existing = await existing_system_keys(
+        session, PracticeTag.slug, owner_col=PracticeTag.owner_user_id
+    )
     inserted = 0
     for definition in SYSTEM_TAGS:
         if definition["slug"] in existing:
@@ -382,7 +367,9 @@ async def _insert_recipe_with_steps(session: AsyncSession, definition: dict[str,
 
 async def _seed_system_recipes(session: AsyncSession) -> int:
     """Insert system recipes not yet present.  Returns inserted row count."""
-    existing = await _existing_system_recipe_slugs(session)
+    existing = await existing_system_keys(
+        session, PracticeRecipe.slug, owner_col=PracticeRecipe.owner_user_id
+    )
     inserted = 0
     for definition in SYSTEM_RECIPES:
         if definition["slug"] in existing:
@@ -405,9 +392,4 @@ async def seed_practice_recipes(session: AsyncSession) -> int:
     total = tags_inserted + recipes_inserted
     if not total:
         return 0
-    try:
-        await session.commit()
-    except IntegrityError:
-        await session.rollback()
-        return 0
-    return total
+    return await commit_or_yield_to_race_winner(session, total)

--- a/backend/src/seed_practices.py
+++ b/backend/src/seed_practices.py
@@ -30,12 +30,11 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Any
 
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
 
 from models.practice import Practice
 from schemas.practice_mode_config import ModeConfigAdapter
+from seed_helpers import commit_or_yield_to_race_winner, existing_system_keys
 from seed_practice_copy import PRESET_COPY
 
 #: Nominal ``default_duration_minutes`` for the Dog Walkin' Shamanism
@@ -474,29 +473,12 @@ STAGE_TO_PRESET_NAME: MappingProxyType[int, str] = MappingProxyType(
 
 async def _existing_preset_keys(session: AsyncSession) -> set[tuple[int, str]]:
     """Return ``(stage_number, name)`` for every preset already in the DB."""
-    result = await session.execute(
-        select(Practice.stage_number, Practice.name).where(
-            col(Practice.submitted_by_user_id).is_(None)
-        )
+    return await existing_system_keys(
+        session,
+        Practice.stage_number,
+        Practice.name,
+        owner_col=Practice.submitted_by_user_id,
     )
-    return {(row[0], row[1]) for row in result.all()}
-
-
-async def _commit_or_yield_to_race_winner(session: AsyncSession, inserted: int) -> int:
-    """Commit ``inserted`` new rows, treating a unique-index collision as a no-op.
-
-    Race-loser path: a peer process committed the same preset(s) between
-    our SELECT and our COMMIT. Roll back and return 0 — the work has
-    already been done by the peer. Migration ``d2e3f4a5b6c7`` is what
-    makes the database arbitrate; without it both peers would commit and
-    we'd ship the duplicate the index was added to prevent.
-    """
-    try:
-        await session.commit()
-    except IntegrityError:
-        await session.rollback()
-        return 0
-    return inserted
 
 
 async def seed_practices(session: AsyncSession) -> int:
@@ -517,4 +499,4 @@ async def seed_practices(session: AsyncSession) -> int:
         inserted += 1
     if not inserted:
         return 0
-    return await _commit_or_yield_to_race_winner(session, inserted)
+    return await commit_or_yield_to_race_winner(session, inserted)

--- a/backend/src/seed_stages.py
+++ b/backend/src/seed_stages.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 from typing import Final
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
 import curriculum
 from models.course_stage import CourseStage
+from seed_helpers import existing_system_keys
 
 #: The curriculum dataset does not carry per-Stage overview URLs; they are a
 #: seeder concern and default to empty until populated elsewhere.
@@ -49,8 +49,7 @@ async def seed_stages(session: AsyncSession) -> int:
 
     Returns the number of stages inserted.
     """
-    result = await session.execute(select(CourseStage))
-    existing = {s.stage_number for s in result.scalars().all()}
+    existing = await existing_system_keys(session, CourseStage.stage_number)
 
     inserted = 0
     for definition in STAGE_DEFINITIONS:

--- a/backend/tests/test_seed_helpers.py
+++ b/backend/tests/test_seed_helpers.py
@@ -1,0 +1,168 @@
+"""Tests for the shared idempotent-seed helpers.
+
+Pins the contract two seeders (seed_practices, seed_practice_recipes) both
+need: a natural-key existence lookup and a commit-or-yield-to-race-winner
+guard, so future seeders can share one implementation instead of
+duplicating both patterns.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.course_stage import CourseStage
+from models.practice import Practice
+from models.practice_tag import PracticeTag
+from seed_helpers import commit_or_yield_to_race_winner, existing_system_keys
+
+#: Arbitrary owner id for a user-owned row planted to prove the owner filter
+#: excludes it from the "system" result set.
+_USER_OWNER_ID = 42
+
+_PRESET_PRACTICE: dict[str, object] = {
+    "stage_number": 1,
+    "name": "Preset Practice",
+    "description": "system preset",
+    "instructions": "do the thing",
+    "default_duration_minutes": 5,
+    "submitted_by_user_id": None,
+    "approved": True,
+    "mode": "count_up",
+    "mode_config": {"mode": "count_up", "soft_cap_minutes": None},
+}
+
+_USER_PRACTICE: dict[str, object] = {
+    "stage_number": 1,
+    "name": "User Practice",
+    "description": "user submission",
+    "instructions": "do the other thing",
+    "default_duration_minutes": 5,
+    "submitted_by_user_id": _USER_OWNER_ID,
+    "approved": False,
+    "mode": "count_up",
+    "mode_config": {"mode": "count_up", "soft_cap_minutes": None},
+}
+
+
+def _stage(stage_number: int) -> CourseStage:
+    """Build a fully-populated CourseStage (every column is NOT NULL)."""
+    return CourseStage(
+        stage_number=stage_number,
+        title=f"Stage {stage_number}",
+        subtitle="subtitle",
+        overview_url="",
+        category="category",
+        aspect="aspect",
+        spiral_dynamics_color="beige",
+        growing_up_stage="stage",
+        divine_gender_polarity="neutral",
+        relationship_to_free_will="none",
+        free_will_description="desc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_existing_system_keys_single_column_filters_by_owner(
+    db_session: AsyncSession,
+) -> None:
+    """Single-column lookup returns a ``set[str]`` of only the system rows."""
+    db_session.add(PracticeTag(slug="system-tag", label="System Tag"))
+    db_session.add(PracticeTag(slug="user-tag", label="User Tag", owner_user_id=_USER_OWNER_ID))
+    await db_session.commit()
+
+    result = await existing_system_keys(
+        db_session, PracticeTag.slug, owner_col=PracticeTag.owner_user_id
+    )
+
+    assert result == {"system-tag"}
+    assert isinstance(result, set)
+    assert all(isinstance(item, str) for item in result)
+
+
+@pytest.mark.asyncio
+async def test_existing_system_keys_two_columns_returns_tuple_set(
+    db_session: AsyncSession,
+) -> None:
+    """Two-column lookup returns a ``set`` of composite-key tuples."""
+    db_session.add(Practice(**_PRESET_PRACTICE))
+    db_session.add(Practice(**_USER_PRACTICE))
+    await db_session.commit()
+
+    result = await existing_system_keys(
+        db_session,
+        Practice.stage_number,
+        Practice.name,
+        owner_col=Practice.submitted_by_user_id,
+    )
+
+    assert result == {(1, "Preset Practice")}
+    key = next(iter(result))
+    assert isinstance(key, tuple)
+
+
+@pytest.mark.asyncio
+async def test_existing_system_keys_without_owner_col_returns_all_rows(
+    db_session: AsyncSession,
+) -> None:
+    """Omitting ``owner_col`` applies no ownership filter at all."""
+    db_session.add(_stage(1))
+    db_session.add(_stage(2))
+    db_session.add(_stage(3))
+    await db_session.commit()
+
+    result = await existing_system_keys(db_session, CourseStage.stage_number)
+
+    assert result == {1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_existing_system_keys_empty_table_returns_empty_set(
+    db_session: AsyncSession,
+) -> None:
+    """An empty table returns an empty set, not ``None`` or a KeyError."""
+    result = await existing_system_keys(
+        db_session, PracticeTag.slug, owner_col=PracticeTag.owner_user_id
+    )
+
+    assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_commit_or_yield_to_race_winner_happy_path_persists_row(
+    db_session: AsyncSession,
+) -> None:
+    """A clean commit returns ``inserted`` and the staged row is persisted."""
+    db_session.add(_stage(1))
+
+    result = await commit_or_yield_to_race_winner(db_session, 1)
+
+    assert result == 1
+    rows = (await db_session.execute(select(CourseStage))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].stage_number == 1
+
+
+@pytest.mark.asyncio
+async def test_commit_or_yield_to_race_winner_race_loser_returns_zero(
+    db_session: AsyncSession,
+) -> None:
+    """A duplicate-key commit rolls back, returns 0, and leaves the session usable."""
+    db_session.add(Practice(**_PRESET_PRACTICE))
+    await db_session.commit()
+
+    db_session.add(Practice(**_PRESET_PRACTICE))
+    result = await commit_or_yield_to_race_winner(db_session, 1)
+
+    assert result == 0
+    rows = (
+        (await db_session.execute(select(Practice).where(Practice.name == "Preset Practice")))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+    # The session must still be usable after the rollback.
+    stages = (await db_session.execute(select(CourseStage))).scalars().all()
+    assert stages == []

--- a/backend/tests/test_seed_practice_recipes.py
+++ b/backend/tests/test_seed_practice_recipes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -117,3 +119,42 @@ async def test_canonical_five_four_three_two_one_seeded(db_session: AsyncSession
     )
     assert [s.tag_slug for s in steps] == ["sight", "touch", "hearing", "smell", "taste"]
     assert [s.target_count for s in steps] == [5, 4, 3, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_seed_practice_recipes_race_loser_returns_zero(
+    db_session: AsyncSession,
+) -> None:
+    """The actual race-loser path: tag SELECT misses, COMMIT loses the race.
+
+    Patches ``existing_system_keys`` so the tag pass sees an empty set (every
+    system tag gets re-staged as a duplicate) while the recipe pass sees every
+    recipe slug as already present (no recipe insert, so no mid-seed flush
+    fires before the commit guard runs). The commit then hits the
+    ``PracticeTag.slug`` partial-unique index, and the shared helper rolls
+    back and returns 0.
+    """
+    first = await seed_practice_recipes(db_session)
+    assert first == len(SYSTEM_RECIPES) + len(SYSTEM_TAGS)
+
+    with patch(
+        "seed_practice_recipes.existing_system_keys",
+        new=AsyncMock(side_effect=[set(), {r["slug"] for r in SYSTEM_RECIPES}]),
+    ):
+        result = await seed_practice_recipes(db_session)
+
+    assert result == 0
+
+    tag_rows = (
+        await db_session.execute(
+            select(PracticeTag).where(col(PracticeTag.owner_user_id).is_(None))
+        )
+    ).all()
+    assert len(tag_rows) == len(SYSTEM_TAGS)
+
+    recipe_rows = (
+        await db_session.execute(
+            select(PracticeRecipe).where(col(PracticeRecipe.owner_user_id).is_(None))
+        )
+    ).all()
+    assert len(recipe_rows) == len(SYSTEM_RECIPES)


### PR DESCRIPTION
## Summary
- Collapse the copy-pasted idempotent-seed scaffold into one shared module `backend/src/seed_helpers.py`: `existing_system_keys(session, *columns, owner_col=None)` (natural-key existence lookup, scoped to `owner_col IS NULL` when given) and `commit_or_yield_to_race_winner(session, inserted)` (the one canonical race-safe commit).
- Rewire `seed_practices.py` (thin `_existing_preset_keys` wrapper + shared race commit), `seed_practice_recipes.py` (deletes the two byte-identical `_existing_system_*_slugs` helpers and the inlined `try/except IntegrityError` commit block), and `seed_stages.py` (shared existence lookup) onto the shared helpers.
- Add `test_seed_helpers.py` and a recipe commit-race regression test; `seed_content.py` is intentionally untouched.

## Chosen race-handling and why
The unified policy is **catch `IntegrityError` on commit → rollback → return 0** (the old `_commit_or_yield_to_race_winner` form), now the single `commit_or_yield_to_race_winner`. It is the correct handling because it is the only one that is race-safe for concurrent startup seeding: when a peer worker commits the same rows between our existence SELECT and our COMMIT, the DB unique index raises `IntegrityError`, which we convert to a no-op. This is meaningful **only where a DB unique index arbitrates** — `Practice(stage_number, name)` (migration `d2e3f4a5b6c7`) and `PracticeTag.slug` / `PracticeRecipe.slug` (migration `07b8c9d0e1f2`), so both practice/recipe seeders adopt it. The recipe seeder's previously-inlined copy and the practice seeder's already-extracted copy were logically identical; they now call one implementation.

### `seed_stages` / `seed_content` — no guard adopted (by design)
`CourseStage.stage_number` and `StageContent` have **no** backing unique constraint, so adding the race guard there would be dead code (there is no `IntegrityError` for the DB to raise — a concurrent boot would instead double-insert). `seed_stages` keeps its bare `commit()`. Whether these two should gain a unique-index-backed guard is a follow-up decision (would require a new migration), filed separately — see below. `seed_content` additionally does in-place reconciliation (url-primary/title-fallback, pop-on-claim) that needs full ORM rows, so its `_load_existing_keys` cannot be expressed as a flat key set and is left exactly as-is.

## Follow-ups (not built here)
- Add unique constraints + the race guard for `CourseStage.stage_number` and `StageContent` seeding — a concurrent boot can currently double-seed both.
- `seed_practice_recipes` flush window: an `IntegrityError` raised at the per-recipe `session.flush()` in `_insert_recipe_with_steps` escapes the commit guard, so a concurrent-boot race that attempts any recipe insert would crash startup rather than yield. Pre-existing; out of scope here.

## Test plan
- `./scripts/backend/check-all.sh` — green (2446 passed, 2 skipped; 96.69% line coverage).
- `ruff check` (select=ALL), `ruff format --check`, `mypy` (strict), `interrogate` (100% on the new module) — all clean.
- `xenon --max-absolute A --max-modules A --max-average A` and `radon mi` — A on all four changed source files.
- New: 6 `existing_system_keys`/`commit_or_yield_to_race_winner` behavior tests + a recipe commit-race regression test; existing seed-idempotency and race-loser tests pass unchanged.

Closes #1429
