### PR TITLE
fix(practice): stop metronome truncating valid long/fast sessions at 10k ticks

### DIFF
--- a/frontend/src/features/Practice/engine/__tests__/cues.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/cues.test.ts
@@ -9,6 +9,8 @@ import type {
   ModeConfig,
   TarotConfig,
 } from '../types';
+import { MS_PER_MINUTE } from '../types';
+import { BPM_MAX, DURATION_MAX_MINUTES } from '../validation';
 
 const MIN = 60_000;
 
@@ -70,19 +72,52 @@ describe('scheduledCues — metronome', () => {
     expect(cues.filter((c) => c.kind === 'halfway_bell')).toHaveLength(1);
   });
 
-  it('respects the 10k tick safety cap', () => {
+  it('emits every tick for the worst-case valid session (max bpm, max duration)', () => {
     const config: MetronomeConfig = {
       mode: 'metronome',
-      bpm: 240,
+      bpm: BPM_MAX,
       timer: {
         mode: 'meditation_timer',
-        duration_minutes: 1440,
+        duration_minutes: DURATION_MAX_MINUTES,
         start_bell: false,
         end_bell: false,
       },
     };
     const ticks = scheduledCues(config).filter((c) => c.kind === 'metronome_tick');
-    expect(ticks.length).toBeLessThanOrEqual(10_000);
+    expect(ticks.length).toBe(BPM_MAX * DURATION_MAX_MINUTES);
+    expect(ticks.at(-1)?.atMs).toBe(DURATION_MAX_MINUTES * MS_PER_MINUTE);
+  });
+
+  it('emits all ticks for a mid-range session that exceeds the old 10k cap', () => {
+    const config: MetronomeConfig = {
+      mode: 'metronome',
+      bpm: 240,
+      timer: {
+        mode: 'meditation_timer',
+        duration_minutes: 60,
+        start_bell: false,
+        halfway_bell: false,
+        end_bell: false,
+      },
+    };
+    const ticks = scheduledCues(config).filter((c) => c.kind === 'metronome_tick');
+    expect(ticks.length).toBe(240 * 60);
+    expect(ticks.at(-1)?.atMs).toBe(60 * MS_PER_MINUTE);
+  });
+
+  it('caps ticks at the worst-case ceiling for out-of-range input that bypasses validation', () => {
+    const config: MetronomeConfig = {
+      mode: 'metronome',
+      bpm: BPM_MAX,
+      timer: {
+        mode: 'meditation_timer',
+        duration_minutes: 2 * DURATION_MAX_MINUTES,
+        start_bell: false,
+        end_bell: false,
+      },
+    };
+    const ticks = scheduledCues(config).filter((c) => c.kind === 'metronome_tick');
+    expect(ticks.length).toBe(BPM_MAX * DURATION_MAX_MINUTES);
   });
 });
 

--- a/frontend/src/features/Practice/engine/cues.ts
+++ b/frontend/src/features/Practice/engine/cues.ts
@@ -8,9 +8,12 @@ import type {
   TarotConfig,
 } from './types';
 import { DEFAULT_CARD_MEDITATION_MINUTES, DEFAULT_TAROT_MINUTES, MS_PER_MINUTE } from './types';
+import { BPM_MAX, DURATION_MAX_MINUTES } from './validation';
 
-// Defensive: at bpm=240 over the max session this would otherwise blow up.
-const MAX_METRONOME_TICKS = 10_000;
+// The validated worst case (max duration x max bpm): no in-range session ever
+// hits it, so nothing valid is truncated. It only bounds memory for configs
+// that reach here without passing validateMetronome.
+const MAX_METRONOME_TICKS = DURATION_MAX_MINUTES * BPM_MAX;
 
 /** Cue builder for modes whose pacing the engine does not drive (open-ended or view-owned). */
 const noCues = (): readonly Cue[] => [];
@@ -50,7 +53,8 @@ function cuesForMetronome(config: MetronomeConfig): readonly Cue[] {
   const totalMs = config.timer.duration_minutes * MS_PER_MINUTE;
   const intervalMs = MS_PER_MINUTE / config.bpm;
   const ticks: Cue[] = [];
-  for (let i = 1; i <= MAX_METRONOME_TICKS; i++) {
+  const tickCount = Math.min(Math.floor(totalMs / intervalMs), MAX_METRONOME_TICKS);
+  for (let i = 1; i <= tickCount; i++) {
     const atMs = i * intervalMs;
     if (atMs > totalMs) break;
     ticks.push({ atMs, kind: 'metronome_tick' });


### PR DESCRIPTION
## Summary

The metronome tick loop in `cuesForMetronome` was bounded by a hardcoded `MAX_METRONOME_TICKS = 10_000`, whose comment framed it as an unreachable safety ceiling. **It was reachable inside the validated config envelope.** `validateMetronome` accepts `bpm` up to `BPM_MAX = 240` and `duration_minutes` up to `DURATION_MAX_MINUTES = 1440`, so a valid session silently went quiet once its required tick count crossed 10,000 (e.g. `240 bpm / 60 min` needs 14,400 ticks but stopped at tick 10,000 ≈ 41.7 min, leaving ~18 min silent).

### Root cause
`for (i = 1; i <= MAX_METRONOME_TICKS; i++)` capped the loop before `if (atMs > totalMs) break;` could fire, truncating any session where `duration_minutes * bpm / 60 > 10_000`.

### Fix
- Derive the loop bound from the session itself: `Math.min(Math.floor(totalMs / intervalMs), MAX_METRONOME_TICKS)`, so exactly the ticks the session needs are produced and nothing in-range is truncated.
- Raise the real ceiling to the validated worst case: `MAX_METRONOME_TICKS = DURATION_MAX_MINUTES * BPM_MAX` (= 345,600), imported from `./validation` so it stays in lockstep with the validator (no free-standing magic number). Memory stays bounded; the ceiling now only guards input that bypasses validation.
- Keep the in-loop `break` guard to absorb floating-point rounding on fractional intervals.
- Rewrite the misleading comment to state the true invariant.

A full lazy-generator refactor of the reducer/engine is intentionally out of scope; worst-case materialization of ~345k bounded cue objects at session start is accepted.

## Test plan
- Added/updated engine tests in `cues.test.ts`:
  - Worst-case valid session (`240 bpm / 1440 min`) emits exactly `BPM_MAX * DURATION_MAX_MINUTES` ticks, last at `totalMs`.
  - Mid-range repro (`240 bpm / 60 min`) emits 14,400 ticks (was truncated to 10,000 before the fix).
  - Out-of-range input bypassing validation is capped at the ceiling.
  - All three fail against the old cap and pass after the fix; regression anchors untouched.
- `./scripts/frontend/check-all.sh` green locally (ESLint, tsc, prettier, 3628 Jest tests).

Closes #1431