### PR TITLE
refactor(practice): unify stage-selector renderers into one primitive

### DIFF
--- a/frontend/src/features/Practice/components/StageSelector.tsx
+++ b/frontend/src/features/Practice/components/StageSelector.tsx
@@ -1,0 +1,217 @@
+/**
+ * ``StageSelector`` — the one chip strip for choosing an APTITUDE stage.
+ *
+ * The catalog filter, the create-wizard assignment field, and the detail
+ * re-assign picker all render the same 1..10 stage chips with slightly
+ * different chrome. This component unifies them behind a ``variant`` so the
+ * chip set, the a11y labels, and the ``Skip`` affordance live in one place:
+ *
+ * - ``radio``  — wizard field; radio semantics with a leading ``Skip`` chip.
+ * - ``filter`` — catalog filter; button semantics, caller-formatted labels.
+ * - ``picker`` — detail re-assign; button boxes that grey out while assigning.
+ *
+ * Pure data → UI: ``onSelect`` (and optional ``onSkip``) are the only outputs;
+ * the caller owns the selection state.
+ */
+
+import React from 'react';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { stageRange } from '../constants';
+
+import { BORDER_RADIUS, SPACING, accent, editorialType, ink, surface } from '@/design/tokens';
+
+/** Minimum width of a ``picker`` stage box so single-digit numbers stay tappable. */
+const STAGE_BOX_MIN_WIDTH = 36;
+
+type StageVariant = 'radio' | 'filter' | 'picker';
+
+export interface StageSelectorProps {
+  variant: StageVariant;
+  onSelect: (stage: number) => void;
+  selectedStage?: number | null;
+  onSkip?: () => void;
+  disabled?: boolean;
+  formatLabel?: (stage: number) => string;
+  testIDPrefix: string;
+  rowTestID?: string;
+  rowStyle?: StyleProp<ViewStyle>;
+}
+
+/** A single resolved chip; all variant/branching decisions are made upstream. */
+interface StageChipProps {
+  role: 'radio' | 'button';
+  accessibilityLabel: string;
+  accessibilityState: { selected: boolean } | { disabled: boolean };
+  style: StyleProp<ViewStyle>;
+  textStyle: StyleProp<TextStyle>;
+  label: string;
+  onPress: (() => void) | undefined;
+  testID: string;
+}
+
+const StageChip = ({
+  role,
+  accessibilityLabel,
+  accessibilityState,
+  style,
+  textStyle,
+  label,
+  onPress,
+  testID,
+}: StageChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole={role}
+    accessibilityLabel={accessibilityLabel}
+    accessibilityState={accessibilityState}
+    onPress={onPress}
+    style={style}
+    testID={testID}
+  >
+    <Text style={textStyle}>{label}</Text>
+  </TouchableOpacity>
+);
+
+/** A logical stage chip before variant chrome (role/state/styles) is applied. */
+interface StageItem {
+  key: string;
+  testID: string;
+  visibleLabel: string;
+  accessibilityLabel: string;
+  selected: boolean;
+  onPress: (() => void) | undefined;
+}
+
+/** Flatten the selector props into the ordered chip list (Skip first, then 1..10). */
+const buildStageItems = ({
+  onSelect,
+  selectedStage,
+  onSkip,
+  disabled,
+  formatLabel,
+  testIDPrefix,
+}: {
+  onSelect: (stage: number) => void;
+  selectedStage: number | null | undefined;
+  onSkip: (() => void) | undefined;
+  disabled: boolean;
+  formatLabel: ((stage: number) => string) | undefined;
+  testIDPrefix: string;
+}): StageItem[] => {
+  const items: StageItem[] = [];
+  if (onSkip !== undefined) {
+    items.push({
+      key: 'skip',
+      testID: `${testIDPrefix}-skip`,
+      visibleLabel: 'Skip',
+      accessibilityLabel: 'Stage Skip',
+      selected: selectedStage === null,
+      onPress: onSkip,
+    });
+  }
+  for (const n of stageRange()) {
+    items.push({
+      key: String(n),
+      testID: `${testIDPrefix}-${n}`,
+      visibleLabel: formatLabel !== undefined ? formatLabel(n) : String(n),
+      accessibilityLabel: `Stage ${n}`,
+      selected: selectedStage === n,
+      onPress: disabled ? undefined : () => onSelect(n),
+    });
+  }
+  return items;
+};
+
+/** Apply the ``picker`` chrome: button box that greys out and drops onPress when disabled. */
+const renderPickerChip = (item: StageItem, disabled: boolean): React.JSX.Element => (
+  <StageChip
+    key={item.key}
+    role="button"
+    accessibilityLabel={item.accessibilityLabel}
+    accessibilityState={{ disabled }}
+    style={[styles.pickerBox, disabled && styles.pickerDisabled]}
+    textStyle={styles.pickerText}
+    label={item.visibleLabel}
+    onPress={item.onPress}
+    testID={item.testID}
+  />
+);
+
+/** Apply the ``radio``/``filter`` chrome: selectable pill with variant-specific text. */
+const renderSelectableChip = (item: StageItem, variant: StageVariant): React.JSX.Element => {
+  const isRadio = variant === 'radio';
+  const role = isRadio ? 'radio' : 'button';
+  const baseTextStyle = isRadio ? styles.radioText : styles.filterText;
+  return (
+    <StageChip
+      key={item.key}
+      role={role}
+      accessibilityLabel={item.accessibilityLabel}
+      accessibilityState={{ selected: item.selected }}
+      style={[styles.chip, item.selected && styles.chipSelected]}
+      textStyle={[baseTextStyle, item.selected && styles.selectedText]}
+      label={item.visibleLabel}
+      onPress={item.onPress}
+      testID={item.testID}
+    />
+  );
+};
+
+const StageSelector = ({
+  variant,
+  onSelect,
+  selectedStage = undefined,
+  onSkip,
+  disabled = false,
+  formatLabel,
+  testIDPrefix,
+  rowTestID,
+  rowStyle,
+}: StageSelectorProps): React.JSX.Element => {
+  const items = buildStageItems({
+    onSelect,
+    selectedStage,
+    onSkip,
+    disabled,
+    formatLabel,
+    testIDPrefix,
+  });
+  return (
+    <View style={[styles.row, rowStyle]} testID={rowTestID}>
+      {items.map((item) =>
+        variant === 'picker'
+          ? renderPickerChip(item, disabled)
+          : renderSelectableChip(item, variant),
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
+  chip: {
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
+  },
+  chipSelected: { backgroundColor: accent.primary, borderColor: accent.primary },
+  selectedText: { color: accent.onPrimary },
+  radioText: { ...editorialType.note, color: ink.primary },
+  filterText: { fontSize: 12, color: ink.primary, fontWeight: '600' },
+  pickerBox: {
+    minWidth: STAGE_BOX_MIN_WIDTH,
+    paddingVertical: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: surface.sunken,
+    alignItems: 'center',
+  },
+  pickerText: { color: ink.primary, fontWeight: '700' },
+  pickerDisabled: { opacity: 0.5 },
+});
+
+export default StageSelector;

--- a/frontend/src/features/Practice/components/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/StageSelector.test.tsx
@@ -1,0 +1,335 @@
+/* eslint-env jest */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import StageSelector from '../StageSelector';
+
+import { accent, BORDER_RADIUS, editorialType, ink, surface } from '@/design/tokens';
+
+const flatten = (style: unknown): Record<string, unknown> =>
+  StyleSheet.flatten(style as never) as Record<string, unknown>;
+
+describe('StageSelector — shared chip set', () => {
+  it('renders exactly 10 numbered stage chips for stages 1..10', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} testIDPrefix="stage" />,
+    );
+    for (let n = 1; n <= 10; n += 1) {
+      expect(getByTestId(`stage-${n}`)).toBeTruthy();
+    }
+  });
+
+  it('renders the visible chip label as String(n) by default', () => {
+    const { getByText } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} testIDPrefix="stage" />,
+    );
+    expect(getByText('7')).toBeTruthy();
+  });
+});
+
+describe('StageSelector — radio variant', () => {
+  it('exposes each numbered chip as a radio', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} testIDPrefix="stage" />,
+    );
+    expect(getByTestId('stage-3').props.accessibilityRole).toBe('radio');
+  });
+
+  it('labels each numbered chip Stage N for assistive tech, independent of formatLabel', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="radio"
+        onSelect={jest.fn()}
+        formatLabel={(n) => `S${n}`}
+        testIDPrefix="stage"
+      />,
+    );
+    expect(getByTestId('stage-3').props.accessibilityLabel).toBe('Stage 3');
+  });
+
+  it('does not render a skip chip when onSkip is not provided', () => {
+    const { queryByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} testIDPrefix="stage" />,
+    );
+    expect(queryByTestId('stage-skip')).toBeNull();
+  });
+
+  it('renders a skip chip labeled Stage Skip when onSkip is provided', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="radio"
+        onSelect={jest.fn()}
+        onSkip={jest.fn()}
+        testIDPrefix="stage"
+      />,
+    );
+    const skip = getByTestId('stage-skip');
+    expect(skip.props.accessibilityRole).toBe('radio');
+    expect(skip.props.accessibilityLabel).toBe('Stage Skip');
+  });
+
+  it('marks the skip chip selected when selectedStage is null', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="radio"
+        onSelect={jest.fn()}
+        onSkip={jest.fn()}
+        selectedStage={null}
+        testIDPrefix="stage"
+      />,
+    );
+    expect(getByTestId('stage-skip').props.accessibilityState).toEqual({ selected: true });
+  });
+
+  it('marks the skip chip unselected when a numbered stage is selected', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="radio"
+        onSelect={jest.fn()}
+        onSkip={jest.fn()}
+        selectedStage={3}
+        testIDPrefix="stage"
+      />,
+    );
+    expect(getByTestId('stage-skip').props.accessibilityState).toEqual({ selected: false });
+  });
+
+  it('marks the selected numbered chip with accessibilityState selected true', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} selectedStage={3} testIDPrefix="stage" />,
+    );
+    expect(getByTestId('stage-3').props.accessibilityState).toEqual({ selected: true });
+  });
+
+  it('applies the selected container and text token colors to the selected chip', () => {
+    const { getByTestId, getByText } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} selectedStage={3} testIDPrefix="stage" />,
+    );
+    const container = flatten(getByTestId('stage-3').props.style);
+    expect(container.backgroundColor).toBe(accent.primary);
+    expect(container.borderColor).toBe(accent.primary);
+    const text = flatten(getByText('3').props.style);
+    expect(text.color).toBe(accent.onPrimary);
+  });
+
+  it('applies the unselected container and text token colors to an unselected chip', () => {
+    const { getByTestId, getByText } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} selectedStage={3} testIDPrefix="stage" />,
+    );
+    const container = flatten(getByTestId('stage-5').props.style);
+    expect(container.backgroundColor).toBe(surface.raised);
+    expect(container.borderColor).toBe(surface.hairline);
+    const text = flatten(getByText('5').props.style);
+    expect(text.fontFamily).toBe(editorialType.note.fontFamily);
+    expect(text.fontSize).toBe(editorialType.note.fontSize);
+    expect(text.lineHeight).toBe(editorialType.note.lineHeight);
+    expect(text.fontWeight).toBe(editorialType.note.fontWeight);
+    expect(text.color).toBe(ink.primary);
+  });
+
+  it('calls onSelect with the tapped stage number', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <StageSelector variant="radio" onSelect={onSelect} testIDPrefix="stage" />,
+    );
+    fireEvent.press(getByTestId('stage-6'));
+    expect(onSelect).toHaveBeenCalledWith(6);
+  });
+
+  it('calls onSkip when the skip chip is pressed', () => {
+    const onSkip = jest.fn();
+    const { getByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} onSkip={onSkip} testIDPrefix="stage" />,
+    );
+    fireEvent.press(getByTestId('stage-skip'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set a row testID when rowTestID is omitted', () => {
+    const { queryByTestId } = render(
+      <StageSelector variant="radio" onSelect={jest.fn()} testIDPrefix="stage" />,
+    );
+    expect(queryByTestId('stage-row')).toBeNull();
+  });
+});
+
+describe('StageSelector — filter variant', () => {
+  it('exposes each numbered chip as a button', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="filter" onSelect={jest.fn()} testIDPrefix="filter" />,
+    );
+    expect(getByTestId('filter-3').props.accessibilityRole).toBe('button');
+  });
+
+  it('renders the visible label from formatLabel while the a11y label stays in the Stage N form', () => {
+    const { getByTestId, getByText } = render(
+      <StageSelector
+        variant="filter"
+        onSelect={jest.fn()}
+        formatLabel={(n) => `Stage ${n}`}
+        testIDPrefix="filter"
+      />,
+    );
+    expect(getByText('Stage 3')).toBeTruthy();
+    expect(getByTestId('filter-3').props.accessibilityLabel).toBe('Stage 3');
+  });
+
+  it('applies the fixed filter-chip text style', () => {
+    const { getByText } = render(
+      <StageSelector
+        variant="filter"
+        onSelect={jest.fn()}
+        formatLabel={(n) => `Stage ${n}`}
+        testIDPrefix="filter"
+      />,
+    );
+    const text = flatten(getByText('Stage 3').props.style);
+    expect(text).toEqual({ fontSize: 12, fontWeight: '600', color: ink.primary });
+  });
+
+  it('sets rowTestID on the wrapping row when provided', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="filter"
+        onSelect={jest.fn()}
+        testIDPrefix="filter"
+        rowTestID="filter-row"
+      />,
+    );
+    expect(getByTestId('filter-row')).toBeTruthy();
+  });
+
+  it('merges rowStyle into the flattened row style', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="filter"
+        onSelect={jest.fn()}
+        testIDPrefix="filter"
+        rowTestID="filter-row"
+        rowStyle={{ marginTop: 42 }}
+      />,
+    );
+    const row = flatten(getByTestId('filter-row').props.style);
+    expect(row.marginTop).toBe(42);
+  });
+
+  it('applies the selected background to the selected filter chip', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="filter"
+        onSelect={jest.fn()}
+        selectedStage={4}
+        testIDPrefix="filter"
+      />,
+    );
+    const container = flatten(getByTestId('filter-4').props.style);
+    expect(container.backgroundColor).toBe(accent.primary);
+  });
+
+  it('calls onSelect with the tapped stage number', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <StageSelector variant="filter" onSelect={onSelect} testIDPrefix="filter" />,
+    );
+    fireEvent.press(getByTestId('filter-8'));
+    expect(onSelect).toHaveBeenCalledWith(8);
+  });
+});
+
+describe('StageSelector — picker variant', () => {
+  it('exposes each numbered chip as a button', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} testIDPrefix="picker" />,
+    );
+    expect(getByTestId('picker-3').props.accessibilityRole).toBe('button');
+  });
+
+  it('defaults accessibilityState to disabled false and never carries a selected key', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} testIDPrefix="picker" />,
+    );
+    const state = getByTestId('picker-3').props.accessibilityState;
+    expect(state).toEqual({ disabled: false });
+    expect(state.selected).toBeUndefined();
+  });
+
+  it('sets accessibilityState disabled true when disabled', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} disabled testIDPrefix="picker" />,
+    );
+    const state = getByTestId('picker-3').props.accessibilityState;
+    expect(state).toEqual({ disabled: true });
+    expect(state.selected).toBeUndefined();
+  });
+
+  it('never carries a selected key even when selectedStage is passed', () => {
+    const { getByTestId } = render(
+      <StageSelector
+        variant="picker"
+        onSelect={jest.fn()}
+        selectedStage={3}
+        testIDPrefix="picker"
+      />,
+    );
+    const state = getByTestId('picker-3').props.accessibilityState as Record<string, unknown>;
+    expect(state.selected).toBeUndefined();
+  });
+
+  it('calls onSelect with the tapped stage number when enabled', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={onSelect} testIDPrefix="picker" />,
+    );
+    fireEvent.press(getByTestId('picker-2'));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('suppresses onPress entirely when disabled', () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={onSelect} disabled testIDPrefix="picker" />,
+    );
+    const chip = getByTestId('picker-2');
+    expect(chip.props.onPress).toBeUndefined();
+    fireEvent.press(chip);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('applies the fixed picker-box container style', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} testIDPrefix="picker" />,
+    );
+    const container = flatten(getByTestId('picker-3').props.style);
+    expect(container.minWidth).toBe(36);
+    expect(container.backgroundColor).toBe(surface.sunken);
+    expect(container.borderRadius).toBe(BORDER_RADIUS.sm);
+    expect(container.alignItems).toBe('center');
+  });
+
+  it('applies the fixed picker text style', () => {
+    const { getByText } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} testIDPrefix="picker" />,
+    );
+    const text = flatten(getByText('4').props.style);
+    expect(text.color).toBe(ink.primary);
+    expect(text.fontWeight).toBe('700');
+  });
+
+  it('adds opacity 0.5 to the container when disabled', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} disabled testIDPrefix="picker" />,
+    );
+    const container = flatten(getByTestId('picker-3').props.style);
+    expect(container.opacity).toBe(0.5);
+  });
+
+  it('does not dim the container when not disabled', () => {
+    const { getByTestId } = render(
+      <StageSelector variant="picker" onSelect={jest.fn()} testIDPrefix="picker" />,
+    );
+    const container = flatten(getByTestId('picker-3').props.style);
+    expect(container.opacity).not.toBe(0.5);
+  });
+});

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -53,7 +53,8 @@ import {
 } from '@/design/tokens';
 import ConfiguratorBody from '@/features/Practice/components/ConfiguratorBody';
 import ModePicker, { type PickableMode } from '@/features/Practice/components/ModePicker';
-import { FALLBACK_STAGE, stageRange } from '@/features/Practice/constants';
+import StageSelector from '@/features/Practice/components/StageSelector';
+import { FALLBACK_STAGE } from '@/features/Practice/constants';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import { parsePositiveInt } from '@/features/Practice/utils/parsePositiveInt';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -468,51 +469,18 @@ const DurationField = ({ state, setState }: MetadataFieldProps): React.JSX.Eleme
   );
 };
 
-const StageField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => {
-  const stages = stageRange();
-  return (
-    <View style={styles.field} testID="create-practice-stage-field">
-      <Text style={styles.fieldLabel}>Assign to a stage (optional)</Text>
-      <Text style={styles.fieldHelp}>Makes this your active practice for that stage.</Text>
-      <View style={styles.stageRow}>
-        <StageChip
-          label="Skip"
-          selected={state.stageNumber === null}
-          onPress={() => setState((prev) => ({ ...prev, stageNumber: null }))}
-          testID="create-practice-stage-skip"
-        />
-        {stages.map((n) => (
-          <StageChip
-            key={n}
-            label={String(n)}
-            selected={state.stageNumber === n}
-            onPress={() => setState((prev) => ({ ...prev, stageNumber: n }))}
-            testID={`create-practice-stage-${n}`}
-          />
-        ))}
-      </View>
-    </View>
-  );
-};
-
-interface StageChipProps {
-  label: string;
-  selected: boolean;
-  onPress: () => void;
-  testID: string;
-}
-
-const StageChip = ({ label, selected, onPress, testID }: StageChipProps): React.JSX.Element => (
-  <TouchableOpacity
-    accessibilityRole="radio"
-    accessibilityLabel={`Stage ${label}`}
-    accessibilityState={{ selected }}
-    onPress={onPress}
-    style={[styles.stageChip, selected && styles.stageChipSelected]}
-    testID={testID}
-  >
-    <Text style={[styles.stageChipText, selected && styles.stageChipTextSelected]}>{label}</Text>
-  </TouchableOpacity>
+const StageField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => (
+  <View style={styles.field} testID="create-practice-stage-field">
+    <Text style={styles.fieldLabel}>Assign to a stage (optional)</Text>
+    <Text style={styles.fieldHelp}>Makes this your active practice for that stage.</Text>
+    <StageSelector
+      variant="radio"
+      selectedStage={state.stageNumber}
+      onSelect={(n) => setState((prev) => ({ ...prev, stageNumber: n }))}
+      onSkip={() => setState((prev) => ({ ...prev, stageNumber: null }))}
+      testIDPrefix="create-practice-stage"
+    />
+  </View>
 );
 
 interface FieldLabelProps {
@@ -819,18 +787,6 @@ const styles = StyleSheet.create({
     backgroundColor: surface.raised,
   },
   inputMultiline: { minHeight: 64, textAlignVertical: 'top' },
-  stageRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
-  stageChip: {
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.xs,
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
-    borderColor: surface.hairline,
-    backgroundColor: surface.raised,
-  },
-  stageChipSelected: { backgroundColor: accent.primary, borderColor: accent.primary },
-  stageChipText: { ...editorialType.note, color: ink.primary },
-  stageChipTextSelected: { color: accent.onPrimary },
   notice: {
     backgroundColor: surface.sunken,
     padding: SPACING.md,

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -48,7 +48,8 @@ import {
 } from '@/design/tokens';
 import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import { MODE_CATEGORIES, type PickableMode } from '@/features/Practice/components/ModePicker';
-import { MIN_STAGE, stageRange } from '@/features/Practice/constants';
+import StageSelector from '@/features/Practice/components/StageSelector';
+import { MIN_STAGE } from '@/features/Practice/constants';
 import { useRecentPractices } from '@/features/Practice/hooks/useRecentPractices';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -499,22 +500,17 @@ interface StageChipsProps {
   onSelect: (stage: number) => void;
 }
 
-const StageChips = ({ selected, onSelect }: StageChipsProps): React.JSX.Element => {
-  const stages = stageRange();
-  return (
-    <View style={styles.chipRow} testID="practice-catalog-stage-chips">
-      {stages.map((n) => (
-        <FilterChip
-          key={n}
-          label={`Stage ${n}`}
-          selected={selected === n}
-          onPress={() => onSelect(n)}
-          testID={`practice-catalog-stage-${n}`}
-        />
-      ))}
-    </View>
-  );
-};
+const StageChips = ({ selected, onSelect }: StageChipsProps): React.JSX.Element => (
+  <StageSelector
+    variant="filter"
+    selectedStage={selected}
+    onSelect={onSelect}
+    formatLabel={(n) => `Stage ${n}`}
+    testIDPrefix="practice-catalog-stage"
+    rowTestID="practice-catalog-stage-chips"
+    rowStyle={styles.stageChipsRow}
+  />
+);
 
 interface ModeChipsProps {
   selected: string | null;
@@ -702,6 +698,7 @@ const styles = StyleSheet.create({
     gap: SPACING.xs,
     marginBottom: SPACING.sm,
   },
+  stageChipsRow: { marginBottom: SPACING.sm },
   chip: {
     paddingHorizontal: SPACING.sm,
     paddingVertical: SPACING.xs,

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/design/tokens';
 import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import ShareSheet from '@/features/Practice/components/ShareSheet';
-import { stageRange } from '@/features/Practice/constants';
+import StageSelector from '@/features/Practice/components/StageSelector';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
@@ -445,38 +445,26 @@ interface StagePickerProps {
   onClose: () => void;
 }
 
-const StagePicker = ({ assigning, onPick, onClose }: StagePickerProps): React.JSX.Element => {
-  const stages = stageRange();
-  return (
-    <View style={styles.pickerCard} testID="practice-detail-stage-picker">
-      <Text style={styles.pickerHeading}>Pick a stage</Text>
-      <View style={styles.pickerRow}>
-        {stages.map((n) => (
-          <TouchableOpacity
-            key={n}
-            accessibilityRole="button"
-            accessibilityLabel={`Stage ${n}`}
-            accessibilityState={{ disabled: assigning }}
-            onPress={assigning ? undefined : () => onPick(n)}
-            style={[styles.stageBox, assigning && styles.disabledButton]}
-            testID={`practice-detail-stage-pick-${n}`}
-          >
-            <Text style={styles.stageBoxText}>{n}</Text>
-          </TouchableOpacity>
-        ))}
-      </View>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Cancel"
-        onPress={onClose}
-        style={styles.pickerCancel}
-        testID="practice-detail-stage-pick-cancel"
-      >
-        <Text style={styles.pickerCancelText}>Cancel</Text>
-      </TouchableOpacity>
-    </View>
-  );
-};
+const StagePicker = ({ assigning, onPick, onClose }: StagePickerProps): React.JSX.Element => (
+  <View style={styles.pickerCard} testID="practice-detail-stage-picker">
+    <Text style={styles.pickerHeading}>Pick a stage</Text>
+    <StageSelector
+      variant="picker"
+      onSelect={onPick}
+      disabled={assigning}
+      testIDPrefix="practice-detail-stage-pick"
+    />
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel="Cancel"
+      onPress={onClose}
+      style={styles.pickerCancel}
+      testID="practice-detail-stage-pick-cancel"
+    >
+      <Text style={styles.pickerCancelText}>Cancel</Text>
+    </TouchableOpacity>
+  </View>
+);
 
 interface BadgeChipProps {
   label: string;
@@ -561,16 +549,6 @@ const styles = StyleSheet.create({
     color: ink.primary,
     marginBottom: SPACING.sm,
   },
-  pickerRow: { flexDirection: 'row', flexWrap: 'wrap', gap: SPACING.xs },
-  stageBox: {
-    minWidth: 36,
-    paddingVertical: SPACING.xs,
-    paddingHorizontal: SPACING.sm,
-    borderRadius: BORDER_RADIUS.sm,
-    backgroundColor: surface.sunken,
-    alignItems: 'center',
-  },
-  stageBoxText: { color: ink.primary, fontWeight: '700' },
   pickerCancel: { marginTop: SPACING.sm, alignSelf: 'flex-end' },
   pickerCancelText: { color: accent.primary, fontWeight: '600', fontSize: 13 },
   errorBlock: {


### PR DESCRIPTION
## Summary
- Collapse the three near-identical 1–10 stage-selector renderers — the wizard's `StageField`/`StageChip`, the catalog's `StageChips`/`FilterChip`, and the detail screen's `StagePicker`/`stageBox` — into one shared `StageSelector` primitive under `frontend/src/features/Practice/components/`, parameterized by a `variant` (`radio` | `filter` | `picker`) that bundles the a11y role, selected-vs-disabled state shape, and container/text styles.
- Pure refactor: each screen keeps its exact a11y role, accessibility labels, testIDs, selected/disabled semantics, `onPress` behavior (picker's `onPress` stays `undefined` while assigning), and flattened style/token values byte-for-byte. The out-of-scope mode-chip `FilterChip` and the detail `ActionButton`'s `disabledButton` style are intentionally left in place.
- The deliberate typography drift between the three variants (catalog raw `fontSize:12/'600'` vs wizard `editorialType.note` vs picker raw `'700'`) is preserved verbatim, not converged — converging it would also touch the out-of-scope mode chips and belongs to a separate follow-up.

## Test plan
- New unit suite `StageSelector.test.tsx` covers all three variants across selected/unselected/skip-present/disabled branches, `onSelect`/`onSkip` firing, disabled `onPress` suppression, row testID present/absent, and `rowStyle` merge.
- The four existing screen suites (`CreatePracticeWizard`, `CreatePracticeWizardTokens`, `PracticeCatalogScreen`, `PracticeDetailScreen`) pass unmodified, guarding the byte-for-byte contract.
- `./scripts/frontend/check-all.sh` green: 344 suites / 3659 tests, ESLint zero-warning, `tsc --noEmit`, and prettier all pass.

Closes #1433
