### PR TITLE
refactor(practice): share list-editor chrome and unify configurator row keys

### DIFF
--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { resolveCardImage } from '../../data/assetResolver';
@@ -14,7 +14,17 @@ import {
 } from '../../engine/types';
 import { pickCardPhoto } from '../../utils/pickCardPhoto';
 
-import { Chip, CollapsibleSection, LabeledRow, NumericField, TextField, ToggleRow } from './shared';
+import { useStableRowKeys } from './rowKeys';
+import {
+  AddRowButton,
+  Chip,
+  CollapsibleSection,
+  HideTimerToggle,
+  LabeledRow,
+  NumericField,
+  TextField,
+  ToggleRow,
+} from './shared';
 
 import { BORDER_RADIUS, SPACING, colors, editorialType, ink, surface } from '@/design/tokens';
 
@@ -118,28 +128,20 @@ const KnownDeckSummary = ({ deck }: { deck: DeckMeta }): React.JSX.Element => {
   );
 };
 
-// Monotonic source of per-row keys. Cards have no persistable id (the
-// backend config schema is `extra="forbid"`), so row identity is tracked
-// transiently here instead of on the card object.
-let nextCardKey = 0;
-
 const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
   const cards = value.cards ?? [];
-  // One stable key per row, kept in lockstep with add/remove so a non-tail
-  // removal cannot shift a surviving row onto a different key (which would
-  // let React reuse the wrong row instance).
-  const keysRef = useRef<string[] | null>(null);
-  keysRef.current ??= cards.map(() => `card-${(nextCardKey += 1)}`);
-  const keys = keysRef.current;
+  // Cards have no persistable id (the backend config schema is `extra="forbid"`),
+  // so row identity is tracked transiently and kept in lockstep with add/remove.
+  const rows = useStableRowKeys('card', cards.length);
   const setCards = (next: readonly CardMeditationCard[]) => onChange({ ...value, cards: next });
   const updateCard = (index: number, patch: Partial<CardMeditationCard>) =>
     setCards(cards.map((card, i) => (i === index ? { ...card, ...patch } : card)));
   const removeCard = (index: number) => {
-    keysRef.current = keys.filter((_, i) => i !== index);
+    rows.remove(index);
     setCards(cards.filter((_, i) => i !== index));
   };
   const addCard = () => {
-    keysRef.current = [...keys, `card-${(nextCardKey += 1)}`];
+    rows.append();
     setCards([...cards, EMPTY_CARD]);
   };
   return (
@@ -155,7 +157,7 @@ const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
       )}
       {cards.map((card, index) => (
         <CardRow
-          key={keys[index] ?? `card-fallback-${index}`}
+          key={rows.keyAt(index)}
           index={index}
           card={card}
           onUpdate={updateCard}
@@ -163,15 +165,12 @@ const CustomCardEditor = ({ value, onChange }: Props): React.JSX.Element => {
         />
       ))}
       {cards.length < CARD_MEDITATION_CARDS_MAX && (
-        <TouchableOpacity
-          accessibilityRole="button"
-          accessibilityLabel="Add card"
+        <AddRowButton
+          noun="card"
           onPress={addCard}
-          style={styles.addButton}
+          variant="filled"
           testID="card-meditation-add-card"
-        >
-          <Text style={styles.addButtonText}>+ Add card</Text>
-        </TouchableOpacity>
+        />
       )}
     </View>
   );
@@ -286,14 +285,7 @@ const AdvancedFields = ({ value, onChange }: Props): React.JSX.Element => (
       onChange={(reveal_after_meditation) => onChange({ ...value, reveal_after_meditation })}
       testID="card-meditation-reveal"
     />
-    <ToggleRow
-      label="Hide timer during sit"
-      value={value.hide_timer_during_meditation ?? true}
-      onChange={(hide_timer_during_meditation) =>
-        onChange({ ...value, hide_timer_during_meditation })
-      }
-      testID="card-meditation-hide-timer"
-    />
+    <HideTimerToggle value={value} onChange={onChange} testID="card-meditation-hide-timer" />
   </View>
 );
 
@@ -369,13 +361,6 @@ const styles = StyleSheet.create({
   },
   photoButtonText: { ...editorialType.caption, fontWeight: '500', color: ink.primary },
   photoThumb: { width: THUMB_SIZE, height: THUMB_SIZE, borderRadius: BORDER_RADIUS.sm },
-  addButton: {
-    paddingVertical: SPACING.sm,
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: surface.sunken,
-  },
-  addButtonText: { ...editorialType.note, color: ink.primary },
 });
 
 export default CardMeditationForm;

--- a/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/MindfulAnchorForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { MindfulAnchorConfig, MindfulAnchorOption } from '../../engine/types';
 import {
@@ -8,19 +8,26 @@ import {
   OPTION_LABEL_MAX as LABEL_MAX,
 } from '../../engine/validation';
 
-import { LabeledRow, NumericField, TextField, ToggleRow } from './shared';
-
-import { BORDER_RADIUS, SPACING, accent, colors, surface } from '@/design/tokens';
+import { makeRowKeyFactory } from './rowKeys';
+import {
+  AddRowButton,
+  LabeledRow,
+  NumericField,
+  RemoveButton,
+  RowCard,
+  TextField,
+  ToggleRow,
+} from './shared';
 
 interface Props {
   value: MindfulAnchorConfig;
   onChange: (next: MindfulAnchorConfig) => void;
 }
 
-// Monotonic source of new option keys — the machine id recorded in session
-// metadata, generated once and never derived from the array index (audit
-// section 5.2 stable-key guidance).
-let nextOptionKey = 0;
+// New option keys are the machine id recorded in session metadata, minted once
+// and never derived from the array index. Underscore, not hyphen: the key must
+// match OPTION_KEY_PATTERN (^[a-z][a-z0-9_]*$) or validateModeConfig rejects it.
+const nextOptionKey = makeRowKeyFactory('option');
 
 interface OptionRowProps {
   option: MindfulAnchorOption;
@@ -30,7 +37,7 @@ interface OptionRowProps {
 }
 
 const OptionRow = ({ option, index, onChange, onRemove }: OptionRowProps) => (
-  <View style={localStyles.card} testID={`anchor-option-${index}`}>
+  <RowCard testID={`anchor-option-${index}`}>
     <TextField
       value={option.label}
       onChange={(label) => onChange({ label })}
@@ -45,16 +52,13 @@ const OptionRow = ({ option, index, onChange, onRemove }: OptionRowProps) => (
       maxLength={DESCRIPTION_MAX}
       testID={`anchor-option-${index}-description`}
     />
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel={`Remove option ${index + 1}`}
+    <RemoveButton
+      noun="option"
+      index={index}
       onPress={onRemove}
-      style={localStyles.removeButton}
       testID={`anchor-option-${index}-remove`}
-    >
-      <Text style={localStyles.removeButtonText}>Remove</Text>
-    </TouchableOpacity>
-  </View>
+    />
+  </RowCard>
 );
 
 /** The scalar settings (instruction, minimum duration, require-choice toggle). */
@@ -93,10 +97,7 @@ const MindfulAnchorForm = ({ value, onChange }: Props): React.JSX.Element => {
   const removeOption = (index: number) =>
     onChange({ ...value, options: value.options.filter((_, i) => i !== index) });
   const addOption = () => {
-    // Underscore, not hyphen: the key must match OPTION_KEY_PATTERN
-    // (^[a-z][a-z0-9_]*$) or validateModeConfig rejects the new row.
-    const key = `option_${(nextOptionKey += 1)}`;
-    const next: MindfulAnchorOption = { key, label: '' };
+    const next: MindfulAnchorOption = { key: nextOptionKey(), label: '' };
     onChange({ ...value, options: [...value.options, next] });
   };
   return (
@@ -111,31 +112,9 @@ const MindfulAnchorForm = ({ value, onChange }: Props): React.JSX.Element => {
           onRemove={() => removeOption(index)}
         />
       ))}
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Add option"
-        onPress={addOption}
-        style={localStyles.addButton}
-        testID="anchor-add-option"
-      >
-        <Text style={localStyles.addButtonText}>+ Add option</Text>
-      </TouchableOpacity>
+      <AddRowButton noun="option" onPress={addOption} testID="anchor-add-option" />
     </View>
   );
 };
-
-const localStyles = StyleSheet.create({
-  card: {
-    borderWidth: 1,
-    borderColor: surface.hairline,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.sm,
-    marginBottom: SPACING.sm,
-  },
-  addButton: { paddingVertical: SPACING.sm },
-  addButtonText: { color: accent.primary, fontWeight: '600' },
-  removeButton: { paddingVertical: SPACING.xs },
-  removeButtonText: { color: colors.danger },
-});
 
 export default MindfulAnchorForm;

--- a/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
@@ -1,11 +1,12 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { SenseGroundingConfig, SensePrompt } from '../../engine/types';
 import { PROMPT_LABEL_MAX } from '../../engine/validation';
 
 import GroundingDropdown from './GroundingDropdown';
-import { TextField } from './shared';
+import { useStableRowKeys } from './rowKeys';
+import { AddRowButton, TextField } from './shared';
 
 import { BORDER_RADIUS, SPACING, editorialType, ink, surface } from '@/design/tokens';
 
@@ -14,29 +15,20 @@ interface Props {
   onChange: (next: SenseGroundingConfig) => void;
 }
 
-// Monotonic source of per-row keys. Prompts have no persistable id (the backend
-// config schema is `extra="forbid"`), so row identity is tracked transiently
-// here and kept in lockstep with add/remove/move — keying by array index would
-// remap a row's instance state (open dropdown, focus) onto the wrong row on a
-// reorder or non-tail delete.
-let nextPromptKey = 0;
-
 interface PromptRowsApi {
-  keys: string[];
+  keyAt: (_index: number) => string;
   setPrompt: (_index: number, _patch: Partial<SensePrompt>) => void;
   move: (_index: number, _direction: -1 | 1) => void;
   remove: (_index: number) => void;
   append: () => void;
 }
 
-/** Owns the prompt list + its transient stable row keys (kept in lockstep). */
+/** Owns the prompt list, delegating transient stable row keys to the shared hook. */
 function usePromptRows(
   value: SenseGroundingConfig,
   onChange: (next: SenseGroundingConfig) => void,
 ): PromptRowsApi {
-  const keysRef = useRef<string[] | null>(null);
-  keysRef.current ??= value.prompts.map(() => `prompt-${(nextPromptKey += 1)}`);
-  const keys = keysRef.current;
+  const rows = useStableRowKeys('prompt', value.prompts.length);
 
   const setPrompt = (index: number, patch: Partial<SensePrompt>) => {
     const next = value.prompts.map((prompt, i) => (i === index ? { ...prompt, ...patch } : prompt));
@@ -50,30 +42,27 @@ function usePromptRows(
     const next = value.prompts.slice();
     next[index] = swapWith;
     next[target] = current;
-    // Swap the keys alongside the rows so each stable id follows its prompt.
-    const nextKeys = keys.slice();
-    [nextKeys[index], nextKeys[target]] = [keys[target]!, keys[index]!];
-    keysRef.current = nextKeys;
+    rows.swap(index, target);
     onChange({ ...value, prompts: next });
   };
   const remove = (index: number) => {
-    keysRef.current = keys.filter((_, i) => i !== index);
+    rows.remove(index);
     onChange({ ...value, prompts: value.prompts.filter((_, i) => i !== index) });
   };
   const append = () => {
-    keysRef.current = [...keys, `prompt-${(nextPromptKey += 1)}`];
+    rows.append();
     onChange({ ...value, prompts: [...value.prompts, { sense: 'sight', label: '' }] });
   };
-  return { keys, setPrompt, move, remove, append };
+  return { keyAt: rows.keyAt, setPrompt, move, remove, append };
 }
 
 const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
-  const { keys, setPrompt, move, remove, append } = usePromptRows(value, onChange);
+  const { keyAt, setPrompt, move, remove, append } = usePromptRows(value, onChange);
   return (
     <View testID="sense-grounding-form">
       {value.prompts.map((prompt, index) => (
         <PromptRow
-          key={keys[index] ?? `prompt-fallback-${index}`}
+          key={keyAt(index)}
           prompt={prompt}
           index={index}
           last={index === value.prompts.length - 1}
@@ -82,15 +71,13 @@ const SenseGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
           onRemove={() => remove(index)}
         />
       ))}
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Add prompt"
+      <AddRowButton
+        noun="prompt"
         onPress={append}
+        variant="filled"
         style={localStyles.addButton}
         testID="sense-grounding-add"
-      >
-        <Text style={localStyles.addButtonText}>+ Add prompt</Text>
-      </TouchableOpacity>
+      />
     </View>
   );
 };
@@ -182,14 +169,7 @@ const localStyles = StyleSheet.create({
   },
   smallButtonText: { ...editorialType.caption, color: ink.primary },
   disabled: { opacity: 0.4 },
-  addButton: {
-    paddingVertical: SPACING.sm,
-    borderRadius: BORDER_RADIUS.md,
-    backgroundColor: surface.sunken,
-    alignItems: 'center',
-    marginTop: SPACING.sm,
-  },
-  addButtonText: { ...editorialType.note, color: ink.primary },
+  addButton: { marginTop: SPACING.sm },
 });
 
 export default SenseGroundingForm;

--- a/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TalliedGroundingForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 import type { TalliedCategory, TalliedGroundingConfig } from '../../engine/types';
 import {
@@ -10,19 +10,26 @@ import {
   TALLIED_TARGET_MIN as TARGET_MIN,
 } from '../../engine/validation';
 
-import { LabeledRow, NumberStepper, TextField } from './shared';
-
-import { BORDER_RADIUS, SPACING, accent, colors, surface } from '@/design/tokens';
+import { makeRowKeyFactory } from './rowKeys';
+import {
+  AddRowButton,
+  LabeledRow,
+  NumberStepper,
+  RemoveButton,
+  RowCard,
+  TextField,
+} from './shared';
 
 interface Props {
   value: TalliedGroundingConfig;
   onChange: (next: TalliedGroundingConfig) => void;
 }
 
-// Monotonic source of new category keys. The key is the machine id the engine
-// records in session metadata, so it is generated once and never derived from
-// the array position (stable-key guidance, audit section 5.2).
-let nextCategoryKey = 0;
+// New category keys are the machine id the engine records in session metadata,
+// minted once and never derived from the array position. Underscore, not
+// hyphen: the key must match TALLIED_KEY_PATTERN (^[a-z][a-z0-9_]*$) or
+// validateModeConfig rejects it.
+const nextCategoryKey = makeRowKeyFactory('category');
 
 interface CategoryRowProps {
   category: TalliedCategory;
@@ -32,7 +39,7 @@ interface CategoryRowProps {
 }
 
 const CategoryRow = ({ category, index, onChange, onRemove }: CategoryRowProps) => (
-  <View style={localStyles.card} testID={`tallied-category-${index}`}>
+  <RowCard testID={`tallied-category-${index}`}>
     <TextField
       value={category.label}
       onChange={(label) => onChange({ label })}
@@ -50,16 +57,13 @@ const CategoryRow = ({ category, index, onChange, onRemove }: CategoryRowProps) 
         testID={`tallied-category-${index}-count`}
       />
     </LabeledRow>
-    <TouchableOpacity
-      accessibilityRole="button"
-      accessibilityLabel={`Remove category ${index + 1}`}
+    <RemoveButton
+      noun="category"
+      index={index}
       onPress={onRemove}
-      style={localStyles.removeButton}
       testID={`tallied-category-${index}-remove`}
-    >
-      <Text style={localStyles.removeButtonText}>Remove</Text>
-    </TouchableOpacity>
-  </View>
+    />
+  </RowCard>
 );
 
 const TalliedGroundingForm = ({ value, onChange }: Props): React.JSX.Element => {
@@ -70,10 +74,7 @@ const TalliedGroundingForm = ({ value, onChange }: Props): React.JSX.Element => 
   const removeCategory = (index: number) =>
     onChange({ ...value, categories: value.categories.filter((_, i) => i !== index) });
   const addCategory = () => {
-    // Underscore, not hyphen: the key must match TALLIED_KEY_PATTERN
-    // (^[a-z][a-z0-9_]*$) or validateModeConfig rejects the new row.
-    const key = `category_${(nextCategoryKey += 1)}`;
-    const next: TalliedCategory = { key, label: '', target_count: 1 };
+    const next: TalliedCategory = { key: nextCategoryKey(), label: '', target_count: 1 };
     onChange({ ...value, categories: [...value.categories, next] });
   };
   return (
@@ -97,31 +98,9 @@ const TalliedGroundingForm = ({ value, onChange }: Props): React.JSX.Element => 
           onRemove={() => removeCategory(index)}
         />
       ))}
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessibilityLabel="Add category"
-        onPress={addCategory}
-        style={localStyles.addButton}
-        testID="tallied-add-category"
-      >
-        <Text style={localStyles.addButtonText}>+ Add category</Text>
-      </TouchableOpacity>
+      <AddRowButton noun="category" onPress={addCategory} testID="tallied-add-category" />
     </View>
   );
 };
-
-const localStyles = StyleSheet.create({
-  card: {
-    borderWidth: 1,
-    borderColor: surface.hairline,
-    borderRadius: BORDER_RADIUS.md,
-    padding: SPACING.sm,
-    marginBottom: SPACING.sm,
-  },
-  addButton: { paddingVertical: SPACING.sm },
-  addButtonText: { color: accent.primary, fontWeight: '600' },
-  removeButton: { paddingVertical: SPACING.xs },
-  removeButtonText: { color: colors.danger },
-});
 
 export default TalliedGroundingForm;

--- a/frontend/src/features/Practice/configurator/forms/TarotForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/TarotForm.tsx
@@ -4,7 +4,7 @@ import { View } from 'react-native';
 import type { TarotConfig } from '../../engine/types';
 import { DEFAULT_TAROT_MINUTES } from '../../engine/types';
 
-import { LabeledRow, NumericField, ToggleRow } from './shared';
+import { HideTimerToggle, LabeledRow, NumericField } from './shared';
 
 interface Props {
   value: TarotConfig;
@@ -24,14 +24,7 @@ const TarotForm = ({ value, onChange }: Props): React.JSX.Element => {
           testID="tarot-per-card"
         />
       </LabeledRow>
-      <ToggleRow
-        label="Hide timer during sit"
-        value={value.hide_timer_during_meditation ?? true}
-        onChange={(hide_timer_during_meditation) =>
-          onChange({ ...value, hide_timer_during_meditation })
-        }
-        testID="tarot-hide-timer"
-      />
+      <HideTimerToggle value={value} onChange={onChange} testID="tarot-hide-timer" />
     </View>
   );
 };

--- a/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 import type { CardMeditationCard, CardMeditationConfig } from '../../../engine/types';
+import { CARD_MEDITATION_CARDS_MAX } from '../../../engine/types';
 import { pickCardPhoto } from '../../../utils/pickCardPhoto';
 import CardMeditationForm from '../CardMeditationForm';
 
@@ -226,5 +227,23 @@ describe('CardMeditationForm — advanced section', () => {
     fireEvent.press(getByTestId('card-meditation-advanced-toggle'));
     fireEvent.changeText(getByTestId('card-meditation-per-card'), '');
     expect(onChange).toHaveBeenCalledWith({ ...bundled(), per_card_minutes: 5 });
+  });
+});
+
+describe('CardMeditationForm — card cap', () => {
+  it('hides the add-card button once the deck reaches CARD_MEDITATION_CARDS_MAX', () => {
+    const atMax = Array.from({ length: CARD_MEDITATION_CARDS_MAX }, () => EMPTY_CARD);
+    const { queryByTestId } = render(
+      <CardMeditationForm value={custom(atMax)} onChange={jest.fn()} />,
+    );
+    expect(queryByTestId('card-meditation-add-card')).toBeNull();
+  });
+
+  it('still offers the add-card button one below the cap', () => {
+    const belowMax = Array.from({ length: CARD_MEDITATION_CARDS_MAX - 1 }, () => EMPTY_CARD);
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom(belowMax)} onChange={jest.fn()} />,
+    );
+    expect(getByTestId('card-meditation-add-card')).toBeTruthy();
   });
 });

--- a/frontend/src/features/Practice/configurator/forms/__tests__/MindfulAnchorForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/MindfulAnchorForm.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+
+import type { MindfulAnchorConfig } from '../../../engine/types';
+import MindfulAnchorForm from '../MindfulAnchorForm';
+
+function anchorConfig(): MindfulAnchorConfig {
+  return {
+    mode: 'mindful_anchor',
+    instruction: 'Stand on grass',
+    min_duration_seconds: 60,
+    options: [
+      { key: 'o1', label: 'Bare feet' },
+      { key: 'o2', label: 'Socks' },
+    ],
+    require_option_choice: false,
+  };
+}
+
+function Harness({ initial }: { initial: MindfulAnchorConfig }): React.JSX.Element {
+  const [value, setValue] = useState(initial);
+  return <MindfulAnchorForm value={value} onChange={setValue} />;
+}
+
+describe('MindfulAnchorForm add', () => {
+  it('appends a new row with a generated option_N key and a blank label', () => {
+    const onChange = jest.fn();
+    const config = anchorConfig();
+    const { getByTestId } = render(<MindfulAnchorForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('anchor-add-option'));
+
+    const next = onChange.mock.calls[0]![0] as MindfulAnchorConfig;
+    expect(next.options).toHaveLength(3);
+    expect(next.options[2]!.key).toMatch(/^option_\d+$/);
+    expect(next.options[2]!.label).toBe('');
+  });
+
+  it('gives two successive additions distinct keys', () => {
+    const onChange = jest.fn();
+    const { getByTestId, rerender } = render(
+      <MindfulAnchorForm value={anchorConfig()} onChange={onChange} />,
+    );
+
+    fireEvent.press(getByTestId('anchor-add-option'));
+    const first = onChange.mock.calls[0]![0] as MindfulAnchorConfig;
+    rerender(<MindfulAnchorForm value={first} onChange={onChange} />);
+    fireEvent.press(getByTestId('anchor-add-option'));
+    const second = onChange.mock.calls[1]![0] as MindfulAnchorConfig;
+
+    expect(second.options[3]!.key).not.toBe(first.options[2]!.key);
+  });
+});
+
+describe('MindfulAnchorForm edit-then-delete', () => {
+  it('preserves the surviving row value and its original persisted key', () => {
+    const { getByTestId } = render(<Harness initial={anchorConfig()} />);
+
+    fireEvent.changeText(getByTestId('anchor-option-1-label'), 'Typed');
+    fireEvent.press(getByTestId('anchor-option-0-remove'));
+
+    expect(getByTestId('anchor-option-0-label').props.value).toBe('Typed');
+  });
+
+  it('keeps the surviving option key unchanged in the onChange payload', () => {
+    const onChange = jest.fn();
+    const config = anchorConfig();
+    const { getByTestId, rerender } = render(
+      <MindfulAnchorForm value={config} onChange={onChange} />,
+    );
+
+    fireEvent.changeText(getByTestId('anchor-option-1-label'), 'Typed');
+    const edited = onChange.mock.calls[0]![0] as MindfulAnchorConfig;
+    rerender(<MindfulAnchorForm value={edited} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('anchor-option-0-remove'));
+    const afterRemove = onChange.mock.calls[1]![0] as MindfulAnchorConfig;
+
+    expect(afterRemove.options).toEqual([{ key: 'o2', label: 'Typed' }]);
+  });
+});
+
+describe('MindfulAnchorForm payloads', () => {
+  it('patches the label and description at the right index', () => {
+    const onChange = jest.fn();
+    const config = anchorConfig();
+    const { getByTestId } = render(<MindfulAnchorForm value={config} onChange={onChange} />);
+
+    fireEvent.changeText(getByTestId('anchor-option-1-label'), 'New socks');
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      options: [config.options[0], { ...config.options[1]!, label: 'New socks' }],
+    });
+
+    fireEvent.changeText(getByTestId('anchor-option-1-description'), 'Thick wool');
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      options: [config.options[0], { ...config.options[1]!, description: 'Thick wool' }],
+    });
+  });
+
+  it('leaves the scalar fields addressable by their unchanged testIDs', () => {
+    const onChange = jest.fn();
+    const config = anchorConfig();
+    const { getByTestId } = render(<MindfulAnchorForm value={config} onChange={onChange} />);
+
+    fireEvent.changeText(getByTestId('anchor-instruction'), 'Stand on grass and breathe');
+    expect(onChange).toHaveBeenCalledWith({ ...config, instruction: 'Stand on grass and breathe' });
+
+    fireEvent.changeText(getByTestId('anchor-min-duration'), '90');
+    expect(onChange).toHaveBeenCalledWith({ ...config, min_duration_seconds: 90 });
+
+    fireEvent(getByTestId('anchor-require-choice'), 'valueChange', true);
+    expect(onChange).toHaveBeenCalledWith({ ...config, require_option_choice: true });
+  });
+});
+
+describe('MindfulAnchorForm testIDs and labels', () => {
+  it('exposes the row, add, and remove testIDs and their accessibility labels', () => {
+    const { getByTestId } = render(
+      <MindfulAnchorForm value={anchorConfig()} onChange={jest.fn()} />,
+    );
+
+    expect(getByTestId('anchor-option-0')).toBeTruthy();
+    expect(getByTestId('anchor-option-0-label')).toBeTruthy();
+    expect(getByTestId('anchor-option-0-description')).toBeTruthy();
+    expect(getByTestId('anchor-add-option').props.accessibilityLabel).toBe('Add option');
+    expect(getByTestId('anchor-option-0-remove').props.accessibilityLabel).toBe('Remove option 1');
+    expect(getByTestId('anchor-option-1-remove').props.accessibilityLabel).toBe('Remove option 2');
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/__tests__/SenseGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/SenseGroundingForm.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+
+import type { SenseGroundingConfig } from '../../../engine/types';
+import SenseGroundingForm from '../SenseGroundingForm';
+
+function senseConfig(): SenseGroundingConfig {
+  return {
+    mode: 'sense_grounding',
+    prompts: [
+      { sense: 'sight', label: 'A' },
+      { sense: 'hearing', label: 'B' },
+      { sense: 'touch', label: 'C' },
+    ],
+  };
+}
+
+function Harness({ initial }: { initial: SenseGroundingConfig }): React.JSX.Element {
+  const [value, setValue] = useState(initial);
+  return <SenseGroundingForm value={value} onChange={setValue} />;
+}
+
+describe('SenseGroundingForm row identity', () => {
+  it('keeps an open dropdown attached to its row when the row moves up', () => {
+    const { getByTestId, queryByTestId } = render(<Harness initial={senseConfig()} />);
+    fireEvent.press(getByTestId('sense-prompt-1-thing-trigger'));
+    expect(queryByTestId('sense-prompt-1-panel')).toBeTruthy();
+
+    fireEvent.press(getByTestId('sense-prompt-1-up'));
+
+    expect(queryByTestId('sense-prompt-0-panel')).toBeTruthy();
+    expect(queryByTestId('sense-prompt-1-panel')).toBeNull();
+  });
+
+  it('keeps an open dropdown on the surviving row after a non-tail delete', () => {
+    const { getByTestId, queryByTestId } = render(<Harness initial={senseConfig()} />);
+    fireEvent.press(getByTestId('sense-prompt-1-thing-trigger'));
+
+    fireEvent.press(getByTestId('sense-prompt-0-remove'));
+
+    expect(queryByTestId('sense-prompt-0-panel')).toBeTruthy();
+  });
+});
+
+describe('SenseGroundingForm payloads', () => {
+  it('appends a blank sight prompt', () => {
+    const onChange = jest.fn();
+    const config = senseConfig();
+    const { getByTestId } = render(<SenseGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('sense-grounding-add'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      prompts: [...config.prompts, { sense: 'sight', label: '' }],
+    });
+  });
+
+  it('patches the label at the edited index', () => {
+    const onChange = jest.fn();
+    const config = senseConfig();
+    const { getByTestId } = render(<SenseGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.changeText(getByTestId('sense-prompt-1-label'), 'Edited');
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      prompts: [config.prompts[0], { ...config.prompts[1]!, label: 'Edited' }, config.prompts[2]],
+    });
+  });
+
+  it('swaps the two prompts in the onChange payload on a move', () => {
+    const onChange = jest.fn();
+    const config = senseConfig();
+    const { getByTestId } = render(<SenseGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('sense-prompt-1-down'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      prompts: [config.prompts[0], config.prompts[2], config.prompts[1]],
+    });
+  });
+
+  it('filters the removed prompt out of the payload', () => {
+    const onChange = jest.fn();
+    const config = senseConfig();
+    const { getByTestId } = render(<SenseGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('sense-prompt-1-remove'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      prompts: [config.prompts[0], config.prompts[2]],
+    });
+  });
+
+  it('treats first-row up and last-row down as disabled no-ops', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <SenseGroundingForm value={senseConfig()} onChange={onChange} />,
+    );
+
+    fireEvent.press(getByTestId('sense-prompt-0-up'));
+    fireEvent.press(getByTestId('sense-prompt-2-down'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('SenseGroundingForm testIDs', () => {
+  it('exposes the add button and per-row action testIDs', () => {
+    const { getByTestId } = render(
+      <SenseGroundingForm value={senseConfig()} onChange={jest.fn()} />,
+    );
+
+    expect(getByTestId('sense-grounding-add')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-label')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-up')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-down')).toBeTruthy();
+    expect(getByTestId('sense-prompt-0-remove')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/__tests__/TalliedGroundingForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/TalliedGroundingForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+
+import type { TalliedGroundingConfig } from '../../../engine/types';
+import TalliedGroundingForm from '../TalliedGroundingForm';
+
+function talliedConfig(): TalliedGroundingConfig {
+  return {
+    mode: 'tallied_grounding',
+    rounds: 2,
+    categories: [
+      { key: 'c1', label: 'Red things', target_count: 3 },
+      { key: 'c2', label: 'Round things', target_count: 5 },
+    ],
+  };
+}
+
+function Harness({ initial }: { initial: TalliedGroundingConfig }): React.JSX.Element {
+  const [value, setValue] = useState(initial);
+  return <TalliedGroundingForm value={value} onChange={setValue} />;
+}
+
+describe('TalliedGroundingForm add', () => {
+  it('appends a new row with a generated category_N key, blank label and target_count 1', () => {
+    const onChange = jest.fn();
+    const config = talliedConfig();
+    const { getByTestId } = render(<TalliedGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('tallied-add-category'));
+
+    const next = onChange.mock.calls[0]![0] as TalliedGroundingConfig;
+    expect(next.categories).toHaveLength(3);
+    expect(next.categories[2]!.key).toMatch(/^category_\d+$/);
+    expect(next.categories[2]!.label).toBe('');
+    expect(next.categories[2]!.target_count).toBe(1);
+  });
+
+  it('gives two successive additions distinct keys', () => {
+    const onChange = jest.fn();
+    const { getByTestId, rerender } = render(
+      <TalliedGroundingForm value={talliedConfig()} onChange={onChange} />,
+    );
+
+    fireEvent.press(getByTestId('tallied-add-category'));
+    const first = onChange.mock.calls[0]![0] as TalliedGroundingConfig;
+    rerender(<TalliedGroundingForm value={first} onChange={onChange} />);
+    fireEvent.press(getByTestId('tallied-add-category'));
+    const second = onChange.mock.calls[1]![0] as TalliedGroundingConfig;
+
+    expect(second.categories[3]!.key).not.toBe(first.categories[2]!.key);
+  });
+});
+
+describe('TalliedGroundingForm edit-then-delete', () => {
+  it('preserves the surviving row value after a non-tail delete', () => {
+    const { getByTestId } = render(<Harness initial={talliedConfig()} />);
+
+    fireEvent.changeText(getByTestId('tallied-category-1-label'), 'Typed');
+    fireEvent.press(getByTestId('tallied-category-0-remove'));
+
+    expect(getByTestId('tallied-category-0-label').props.value).toBe('Typed');
+  });
+
+  it('keeps the surviving category key unchanged in the onChange payload', () => {
+    const onChange = jest.fn();
+    const config = talliedConfig();
+    const { getByTestId, rerender } = render(
+      <TalliedGroundingForm value={config} onChange={onChange} />,
+    );
+
+    fireEvent.changeText(getByTestId('tallied-category-1-label'), 'Typed');
+    const edited = onChange.mock.calls[0]![0] as TalliedGroundingConfig;
+    rerender(<TalliedGroundingForm value={edited} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('tallied-category-0-remove'));
+    const afterRemove = onChange.mock.calls[1]![0] as TalliedGroundingConfig;
+
+    expect(afterRemove.categories).toEqual([{ key: 'c2', label: 'Typed', target_count: 5 }]);
+  });
+});
+
+describe('TalliedGroundingForm steppers and remove', () => {
+  it('patches target_count at the right index via the stepper', () => {
+    const onChange = jest.fn();
+    const config = talliedConfig();
+    const { getByTestId } = render(<TalliedGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('tallied-category-1-count-plus'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      categories: [config.categories[0], { ...config.categories[1]!, target_count: 6 }],
+    });
+  });
+
+  it('patches rounds via its stepper', () => {
+    const onChange = jest.fn();
+    const config = talliedConfig();
+    const { getByTestId } = render(<TalliedGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('tallied-rounds-plus'));
+
+    expect(onChange).toHaveBeenCalledWith({ ...config, rounds: 3 });
+  });
+
+  it('filters the removed category out of the payload', () => {
+    const onChange = jest.fn();
+    const config = talliedConfig();
+    const { getByTestId } = render(<TalliedGroundingForm value={config} onChange={onChange} />);
+
+    fireEvent.press(getByTestId('tallied-category-1-remove'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...config,
+      categories: [config.categories[0]],
+    });
+  });
+});
+
+describe('TalliedGroundingForm testIDs', () => {
+  it('exposes the row, label, count, remove, and add testIDs', () => {
+    const { getByTestId } = render(
+      <TalliedGroundingForm value={talliedConfig()} onChange={jest.fn()} />,
+    );
+
+    expect(getByTestId('tallied-category-0')).toBeTruthy();
+    expect(getByTestId('tallied-category-0-label')).toBeTruthy();
+    expect(getByTestId('tallied-category-0-count')).toBeTruthy();
+    expect(getByTestId('tallied-category-0-remove')).toBeTruthy();
+    expect(getByTestId('tallied-add-category')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/__tests__/TarotForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/TarotForm.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { TarotConfig } from '../../../engine/types';
+import TarotForm from '../TarotForm';
+
+function tarotConfig(): TarotConfig {
+  return {
+    mode: 'tarot',
+    deck: 'major_arcana',
+    per_card_minutes: 5,
+    hide_timer_during_meditation: true,
+  };
+}
+
+describe('TarotForm hide-timer toggle', () => {
+  it('emits hide_timer_during_meditation: false on toggle-off', () => {
+    const onChange = jest.fn();
+    const config = tarotConfig();
+    const { getByTestId } = render(<TarotForm value={config} onChange={onChange} />);
+
+    fireEvent(getByTestId('tarot-hide-timer'), 'valueChange', false);
+
+    expect(onChange).toHaveBeenCalledWith({ ...config, hide_timer_during_meditation: false });
+  });
+
+  it('renders the toggle as true when hide_timer_during_meditation is undefined', () => {
+    const { getByTestId } = render(
+      <TarotForm
+        value={{ mode: 'tarot', deck: 'major_arcana', per_card_minutes: 5 }}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(getByTestId('tarot-hide-timer').props.value).toBe(true);
+  });
+});
+
+describe('TarotForm per-card minutes', () => {
+  it('updates per-card minutes from typed text', () => {
+    const onChange = jest.fn();
+    const config = tarotConfig();
+    const { getByTestId } = render(<TarotForm value={config} onChange={onChange} />);
+
+    fireEvent.changeText(getByTestId('tarot-per-card'), '7');
+
+    expect(onChange).toHaveBeenCalledWith({ ...config, per_card_minutes: 7 });
+  });
+
+  it('falls back to the default minutes when the field is cleared', () => {
+    const onChange = jest.fn();
+    const config = tarotConfig();
+    const { getByTestId } = render(<TarotForm value={config} onChange={onChange} />);
+
+    fireEvent.changeText(getByTestId('tarot-per-card'), '');
+
+    expect(onChange).toHaveBeenCalledWith({ ...config, per_card_minutes: 5 });
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/__tests__/rowKeys.test.ts
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/rowKeys.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { makeRowKeyFactory, useStableRowKeys } from '../rowKeys';
+
+describe('useStableRowKeys', () => {
+  it('seeds one key per initial row, stable across a re-render', () => {
+    const { result, rerender } = renderHook(
+      ({ count }: { count: number }) => useStableRowKeys('prompt', count),
+      { initialProps: { count: 3 } },
+    );
+    const before = [0, 1, 2].map((i) => result.current.keyAt(i));
+
+    rerender({ count: 3 });
+
+    const after = [0, 1, 2].map((i) => result.current.keyAt(i));
+    expect(after).toEqual(before);
+  });
+
+  it('append yields a fresh key distinct from every existing key', () => {
+    const { result } = renderHook(() => useStableRowKeys('prompt', 2));
+    const existing = [result.current.keyAt(0), result.current.keyAt(1)];
+
+    act(() => {
+      result.current.append();
+    });
+
+    expect(existing).not.toContain(result.current.keyAt(2));
+  });
+
+  it('remove(0) shifts the surviving keys down without renaming them', () => {
+    const { result } = renderHook(() => useStableRowKeys('prompt', 3));
+    const survivorOne = result.current.keyAt(1);
+    const survivorTwo = result.current.keyAt(2);
+
+    act(() => {
+      result.current.remove(0);
+    });
+
+    expect(result.current.keyAt(0)).toBe(survivorOne);
+    expect(result.current.keyAt(1)).toBe(survivorTwo);
+  });
+
+  it('swap(0, 1) exchanges the keys at those two indices', () => {
+    const { result } = renderHook(() => useStableRowKeys('prompt', 3));
+    const keyZero = result.current.keyAt(0);
+    const keyOne = result.current.keyAt(1);
+
+    act(() => {
+      result.current.swap(0, 1);
+    });
+
+    expect(result.current.keyAt(0)).toBe(keyOne);
+    expect(result.current.keyAt(1)).toBe(keyZero);
+  });
+
+  it('swap with an out-of-range index is a no-op', () => {
+    const { result } = renderHook(() => useStableRowKeys('prompt', 2));
+    const keyZero = result.current.keyAt(0);
+    const keyOne = result.current.keyAt(1);
+
+    act(() => {
+      result.current.swap(0, 5);
+    });
+
+    expect(result.current.keyAt(0)).toBe(keyZero);
+    expect(result.current.keyAt(1)).toBe(keyOne);
+  });
+
+  it('keyAt beyond range returns a deterministic fallback', () => {
+    const { result } = renderHook(() => useStableRowKeys('prompt', 2));
+    expect(result.current.keyAt(5)).toBe('prompt-fallback-5');
+  });
+});
+
+describe('makeRowKeyFactory', () => {
+  it('emits sequential, underscore-separated keys', () => {
+    const factory = makeRowKeyFactory('option');
+    expect(factory()).toBe('option_1');
+    expect(factory()).toBe('option_2');
+  });
+
+  it('keeps two independently-created factories on separate counters', () => {
+    const options = makeRowKeyFactory('option');
+    const categories = makeRowKeyFactory('category');
+
+    expect(options()).toBe('option_1');
+    expect(categories()).toBe('category_1');
+    expect(options()).toBe('option_2');
+  });
+
+  it('emits values that match the backend key pattern', () => {
+    const factory = makeRowKeyFactory('category');
+    const keyPattern = /^[a-z][a-z0-9_]*$/;
+
+    expect(keyPattern.test(factory())).toBe(true);
+    expect(keyPattern.test(factory())).toBe(true);
+    expect(keyPattern.test(factory())).toBe(true);
+  });
+});

--- a/frontend/src/features/Practice/configurator/forms/rowKeys.ts
+++ b/frontend/src/features/Practice/configurator/forms/rowKeys.ts
@@ -1,0 +1,67 @@
+import { useRef } from 'react';
+
+/**
+ * Two row-key strategies for the configurator's dynamic lists.
+ *
+ * `useStableRowKeys` hands out *transient* keys for rows whose backend config
+ * schema is `extra="forbid"` (SensePrompt, CardMeditationCard): no key can be
+ * persisted onto the row itself, so React needs a stable identity tracked
+ * outside the payload. The keys live in a ref and move in lockstep with the
+ * rows on add/remove/swap, keeping per-row instance state (an open dropdown,
+ * focus) attached to the right row across a reorder or non-tail delete. They
+ * never enter the onChange payload, so the module-level numbering is
+ * unobservable.
+ *
+ * `makeRowKeyFactory` mints *persisted* keys for rows that carry a
+ * backend-validated `key` field (TalliedCategory, MindfulAnchorOption). Those
+ * keys must match `^[a-z][a-z0-9_]*$`, so they are underscore-separated; each
+ * is generated once, stored on the row, and round-tripped through the config.
+ */
+
+// One monotonic source for every transient key: the shared counter guarantees
+// uniqueness across forms, and the per-form prefix just makes a key legible.
+// Since transient keys never reach a payload, the numbering itself is
+// unobservable.
+let nextTransientKey = 0;
+
+interface StableRowKeys {
+  keyAt: (index: number) => string;
+  append: () => void;
+  remove: (index: number) => void;
+  swap: (a: number, b: number) => void;
+}
+
+/** Transient stable row keys kept in lockstep with the row list (no re-render). */
+export function useStableRowKeys(prefix: string, rowCount: number): StableRowKeys {
+  const keysRef = useRef<string[] | null>(null);
+  keysRef.current ??= Array.from(
+    { length: rowCount },
+    () => `${prefix}-${(nextTransientKey += 1)}`,
+  );
+
+  const current = (): string[] => keysRef.current ?? [];
+  const keyAt = (index: number): string => current()[index] ?? `${prefix}-fallback-${index}`;
+  const append = (): void => {
+    keysRef.current = [...current(), `${prefix}-${(nextTransientKey += 1)}`];
+  };
+  const remove = (index: number): void => {
+    keysRef.current = current().filter((_, i) => i !== index);
+  };
+  const swap = (a: number, b: number): void => {
+    const keys = current();
+    const keyA = keys[a];
+    const keyB = keys[b];
+    if (keyA === undefined || keyB === undefined) return;
+    const next = keys.slice();
+    next[a] = keyB;
+    next[b] = keyA;
+    keysRef.current = next;
+  };
+  return { keyAt, append, remove, swap };
+}
+
+/** Closure counter emitting persisted keys `${prefix}_1`, `${prefix}_2`, and so on. */
+export function makeRowKeyFactory(prefix: string): () => string {
+  let counter = 0;
+  return () => `${prefix}_${(counter += 1)}`;
+}

--- a/frontend/src/features/Practice/configurator/forms/shared.tsx
+++ b/frontend/src/features/Practice/configurator/forms/shared.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
 import { StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import type { IntervalBellTone } from '../../engine/types';
@@ -262,8 +263,119 @@ export const CollapsibleSection = ({
   );
 };
 
+interface RowCardProps {
+  testID: string;
+  children: React.ReactNode;
+}
+
+/** Bordered container for one editable row (mindful-anchor / tallied lists). */
+export const RowCard = ({ testID, children }: RowCardProps): React.JSX.Element => (
+  <View style={formStyles.rowCard} testID={testID}>
+    {children}
+  </View>
+);
+
+interface AddRowButtonProps {
+  noun: string;
+  onPress: () => void;
+  testID: string;
+  /** ``link`` = inline accent text (default); ``filled`` = a sunken block button. */
+  variant?: 'link' | 'filled';
+  style?: StyleProp<ViewStyle>;
+}
+
+/** "+ Add <noun>" affordance shared by the list forms, in two visual variants. */
+export const AddRowButton = ({
+  noun,
+  onPress,
+  testID,
+  variant = 'link',
+  style,
+}: AddRowButtonProps): React.JSX.Element => {
+  const filled = variant === 'filled';
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`Add ${noun}`}
+      onPress={onPress}
+      style={[filled ? formStyles.addButtonFilled : formStyles.addButtonLink, style]}
+      testID={testID}
+    >
+      <Text style={filled ? formStyles.addButtonFilledText : formStyles.addButtonLinkText}>
+        {`+ Add ${noun}`}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+interface RemoveButtonProps {
+  noun: string;
+  index: number;
+  onPress: () => void;
+  testID: string;
+}
+
+/** "Remove" affordance for a row, labelled with its 1-based position. */
+export const RemoveButton = ({
+  noun,
+  index,
+  onPress,
+  testID,
+}: RemoveButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={`Remove ${noun} ${index + 1}`}
+    onPress={onPress}
+    style={formStyles.removeButton}
+    testID={testID}
+  >
+    <Text style={formStyles.removeButtonText}>Remove</Text>
+  </TouchableOpacity>
+);
+
+interface HideTimerToggleProps<T extends { hide_timer_during_meditation?: boolean }> {
+  value: T;
+  onChange: (_next: T) => void;
+  /** testID stays per-caller, e.g. ``card-meditation-hide-timer`` / ``tarot-hide-timer``. */
+  testID: string;
+}
+
+/** "Hide timer during sit" toggle shared by the card-meditation and tarot forms. */
+export const HideTimerToggle = <T extends { hide_timer_during_meditation?: boolean }>({
+  value,
+  onChange,
+  testID,
+}: HideTimerToggleProps<T>): React.JSX.Element => (
+  <ToggleRow
+    label="Hide timer during sit"
+    value={value.hide_timer_during_meditation ?? true}
+    onChange={(hide_timer_during_meditation) =>
+      onChange({ ...value, hide_timer_during_meditation })
+    }
+    testID={testID}
+  />
+);
+
 const formStyles = StyleSheet.create({
   toneRow: { flexDirection: 'row', gap: SPACING.xs, flexWrap: 'wrap' },
+  rowCard: {
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.sm,
+    marginBottom: SPACING.sm,
+  },
+  addButtonLink: { paddingVertical: SPACING.sm },
+  addButtonLinkText: { color: accent.primary, fontWeight: '600' },
+  addButtonFilled: {
+    paddingVertical: SPACING.sm,
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: surface.sunken,
+  },
+  addButtonFilledText: { ...editorialType.note, color: ink.primary },
+  removeButton: { paddingVertical: SPACING.xs },
+  removeButtonText: { color: colors.danger },
   advancedToggle: { paddingVertical: SPACING.md, marginTop: SPACING.sm },
   advancedToggleText: { ...editorialType.note, color: ink.primary },
   row: {


### PR DESCRIPTION
## Summary
- Extract the duplicated list-editor chrome from the four "editable list of named rows" practice configurator forms into `configurator/forms/shared.tsx`: `RowCard`, `AddRowButton` (link/filled variants), `RemoveButton`, and a generic `HideTimerToggle`. Deletes the byte-identical `localStyles` card/add/remove blocks and the re-authored add/remove scaffolds.
- Consolidate the two divergent row-key mechanisms into one `configurator/forms/rowKeys.ts` module and adopt it across `MindfulAnchorForm`, `TalliedGroundingForm`, `CardMeditationForm`, `SenseGroundingForm`, and `TarotForm`. Behavior, onChange payloads, testIDs, and accessibility labels are unchanged.

## Row-key decision
Keep **two documented strategies in one module** rather than collapsing to a single mechanism — a single storage strategy is impossible without changing payloads:
- `SensePrompt` and `CardMeditationCard` are `extra="forbid"` on the backend, so no `key` can be persisted onto the row. `useStableRowKeys(prefix, rowCount)` hands out transient, `useRef`-tracked keys kept in lockstep with add/remove/swap (no re-render of its own). This preserves per-row instance state — an open dropdown, focus/typing — attached to the right row across a **non-tail delete or reorder**; index keys would remap that state onto the wrong row.
- `TalliedCategory` and `MindfulAnchorOption` carry a backend-validated `key` field (`^[a-z][a-z0-9_]*$`, uniqueness-enforced) that is semantic payload. `makeRowKeyFactory(prefix)` mints those persisted underscore keys once per new row; the forms use `row.key` as the React key.

The transient-key logic is now defined once, and the two near-identical stable-key comments are collapsed into the module doc.

## Test plan
- New `rowKeys.test.ts` pins the hook/factory contract: stable keys across re-render, `append` freshness, `remove`/`swap` survivor semantics, out-of-range no-op, `${prefix}-fallback-${i}`, and the `${prefix}_N` underscore pattern.
- New per-form characterization tests pin the reconciliation-sensitive behavior: `SenseGroundingForm` — open dropdown follows its row on move and survives a non-tail delete on the correct surviving row; `MindfulAnchorForm`/`TalliedGroundingForm` — edit row 2 then delete row 1 keeps values and the persisted `key` attached to the right surviving rows, plus distinct keys on repeat adds; `TarotForm` — hide-timer/per-card behavior; `CardMeditationForm` — add-button hidden at the card cap.
- `./scripts/frontend/check-all.sh` green: jest 3697 tests / 349 suites pass, `tsc --noEmit` clean, ESLint zero-warning, prettier clean.

## Not in scope
The `DurationRow` extraction and the hand-rolled `NumberStepper` in `RecipeEditorModal` (tracked in #1398).

Closes #1434
