### PR TITLE
fix(course): guard useStageContent against a stale-response race

### DIFF
--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -89,8 +89,12 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
   const [progress, setProgress] = useState<CourseProgress | null>(null);
   const [loadingContent, setLoadingContent] = useState(false);
   const [error, setError] = useState(false);
+  const requestSeq = useRef(0);
 
   const refreshContent = useCallback(async () => {
+    // Only the newest in-flight request may settle; stale ones are dropped.
+    const requestId = (requestSeq.current += 1);
+    const isLatest = () => requestId === requestSeq.current;
     setLoadingContent(true);
     setError(false);
     try {
@@ -98,23 +102,30 @@ function useStageContent(selectedStage: number, stagesLoaded: boolean) {
         courseApi.stageContentAll(selectedStage),
         courseApi.stageProgress(selectedStage),
       ]);
+      if (!isLatest()) return;
       setContent(contentResult);
       setProgress(progressResult);
     } catch (err) {
       // A failed fetch is distinct from a genuinely empty stage: flag it so the
       // screen shows error+retry rather than "No Content Yet" (audit-ux-04).
       console.error('Failed to load stage content:', err);
-      setContent([]);
-      setProgress(null);
-      setError(true);
+      if (isLatest()) {
+        setContent([]);
+        setProgress(null);
+        setError(true);
+      }
     } finally {
-      setLoadingContent(false);
+      if (isLatest()) setLoadingContent(false);
     }
   }, [selectedStage]);
 
   useEffect(() => {
     if (!stagesLoaded) return;
     void refreshContent();
+    // On unmount, supersede any in-flight run so it cannot setState afterward.
+    return () => {
+      requestSeq.current += 1;
+    };
   }, [stagesLoaded, refreshContent]);
 
   const handleMarkRead = useCallback(() => {

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -282,6 +282,99 @@ describe('CourseScreen', () => {
     });
   });
 
+  it('keeps the current stage content when a stale fetch for a previously-selected stage resolves late', async () => {
+    // Stage 1 is incomplete so it stays the default selection, matching the repro scenario.
+    const incompleteStages: Stage[] = [
+      makeStage({ id: 1, stage_number: 1, is_unlocked: true, progress: 0 }),
+      makeStage({
+        id: 2,
+        stage_number: 2,
+        title: 'Stage 2',
+        subtitle: 'Second stage',
+        is_unlocked: true,
+        progress: 0,
+      }),
+    ];
+    mockStagesList.mockResolvedValue(incompleteStages);
+
+    const stageOneContent: ContentItem[] = [
+      {
+        id: 11,
+        title: 'Stage One Essay',
+        content_type: 'essay',
+        release_day: 0,
+        url: 'https://example.com/one',
+        is_locked: false,
+        is_read: false,
+      },
+    ];
+    const stageTwoContent: ContentItem[] = [
+      {
+        id: 21,
+        title: 'Stage Two Essay',
+        content_type: 'essay',
+        release_day: 0,
+        url: 'https://example.com/two',
+        is_locked: false,
+        is_read: false,
+      },
+    ];
+
+    const deferredCalls: Array<{ stage: number; resolve: (_value: ContentItem[]) => void }> = [];
+    mockStageContent.mockImplementation((stage: number) => {
+      let resolveCall: (_value: ContentItem[]) => void = () => undefined;
+      const promise = new Promise<ContentItem[]>((res) => {
+        resolveCall = res;
+      });
+      deferredCalls.push({ stage, resolve: resolveCall });
+      return promise;
+    });
+
+    // Narrow the indexed access so a missing deferred call fails loudly instead of silently.
+    const resolveDeferred = (index: number, content: ContentItem[]): void => {
+      const call = deferredCalls[index];
+      if (!call) throw new Error(`No deferred stageContentAll call at index ${index}`);
+      call.resolve(content);
+    };
+
+    // Several ticks so a resolved Promise.all fully propagates through state, regardless of chain depth.
+    const flushMicrotasks = async (): Promise<void> => {
+      for (let i = 0; i < 4; i += 1) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+    };
+
+    const { getByTestId, getByText, queryByText } = render(<CourseScreen />);
+
+    await waitFor(() => expect(deferredCalls.length).toBe(1));
+    resolveDeferred(0, stageOneContent);
+    await flushMicrotasks();
+    await waitFor(() => expect(getByText('Stage One Essay')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('stage-pill-2'));
+    });
+    await waitFor(() => expect(deferredCalls.length).toBe(2));
+
+    await act(async () => {
+      fireEvent.press(getByTestId('stage-pill-1'));
+    });
+    await waitFor(() => expect(deferredCalls.length).toBe(3));
+
+    // Resolve the current stage-1 fetch first.
+    resolveDeferred(2, stageOneContent);
+    await flushMicrotasks();
+
+    // Then resolve the stale stage-2 fetch that was left hanging from the earlier tap.
+    resolveDeferred(1, stageTwoContent);
+    await flushMicrotasks();
+
+    expect(within(getByTestId('content-list')).getByText('Stage One Essay')).toBeTruthy();
+    expect(queryByText('Stage Two Essay')).toBeNull();
+  });
+
   it('opens content viewer when tapping an unlocked item', async () => {
     const { getByText, getByTestId } = render(<CourseScreen />);
 


### PR DESCRIPTION
## Summary

`useStageContent` (in `frontend/src/features/Course/CourseScreen.tsx`) awaited `Promise.all([courseApi.stageContentAll(selectedStage), courseApi.stageProgress(selectedStage)])` and then called `setContent`/`setProgress` **unconditionally**, with no sequence token and no effect cleanup. Because `selectedStage` changes in place via the always-mounted `StageSelector`, a slower fetch for a previously-selected stage could resolve *after* a newer one and clobber the current stage's chapters — the pinned header/selector showed the selected stage while the chapter list showed a stale stage's chapters (Family 0: stale-response race).

### Root cause & fix

Last-write-wins on out-of-order responses. The fix adds a monotonic `requestSeq = useRef(0)` captured per call (`const requestId = (requestSeq.current += 1)`); only the latest in-flight request (`isLatest()`) may commit `content`/`progress`, set the error, or clear `loadingContent`. This mirrors the established in-repo idiom used by `useShelf` (#1370), `usePrompt`, and `useResonance`. An effect cleanup bumps the seq on unmount/re-run so a superseded run can never `setState` after unmount. `retry()` and `handleMarkRead()` stay correct because each call bumps the seq and becomes the latest.

## Test plan

- Added a regression test in `CourseScreen.test.tsx` that drives the real `CourseScreen` with per-stage deferred `stageContentAll` promises: load stage 1, tap stage-pill-2 (held), tap stage-pill-1 (held), resolve stage 1 first then the **stale** stage 2 late — asserts the selected stage's content wins (`Stage One Essay` visible, `Stage Two Essay` null). Confirmed RED before the fix, GREEN after.
- Full `./scripts/frontend/check-all.sh` green: ESLint (max-warnings 0), `tsc --noEmit`, prettier, 3698 tests pass.

Closes #1437