### PR TITLE
refactor(api): remove dead mapDetailToMessage helper

### DIFF
--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -4,7 +4,6 @@
 import {
   formatApiError,
   GENERIC_FALLBACK,
-  mapDetailToMessage,
   messageForCode,
   USER_FACING_ERROR_MESSAGES,
 } from '../errorMessages';
@@ -116,16 +115,6 @@ describe('messageForCode', () => {
     expect(messageForCode('')).toBeUndefined();
     expect(messageForCode(null)).toBeUndefined();
     expect(messageForCode(undefined)).toBeUndefined();
-  });
-});
-
-describe('mapDetailToMessage', () => {
-  it('maps known codes', () => {
-    expect(mapDetailToMessage('rate_limit_exceeded')).toMatch(/Slow down/);
-  });
-
-  it('falls back to the provider-trouble copy for unknown codes', () => {
-    expect(mapDetailToMessage('whatever_new_code')).toMatch(/having trouble/);
   });
 });
 

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -295,15 +295,6 @@ export function formatApiError(err: unknown, options: FormatErrorOptions = {}): 
   return resolved ?? GENERIC_FALLBACK;
 }
 
-/**
- * Narrower helper for BotMason chat where callers already have a raw
- * backend ``detail`` string (e.g. from an SSE ``error`` frame) and want
- * the mapped user copy. Preserves the old ``JournalScreen`` API.
- */
-export function mapDetailToMessage(detail: string): string {
-  return messageForCode(detail) ?? PROVIDER_TROUBLE;
-}
-
 // Re-export for use in contexts that can't import ``ApiError`` directly
 // without creating a circular import.
 export { ApiError };


### PR DESCRIPTION
## Summary
- Remove the dead `mapDetailToMessage()` helper and its misleading "JournalScreen API" docstring from `frontend/src/api/errorMessages.ts` — it had zero production callers and was kept alive only by its own unit test.
- The raw-`detail` → user-copy path is already served by `formatApiError` (via `messageForCode(extractDetail(...))`), so nothing needs to be wired in.
- Drop the dedicated `describe('mapDetailToMessage', …)` test block and its now-unused named import. `formatApiError`, `messageForCode`, `PROVIDER_TROUBLE`, and the `ApiError` re-export are untouched (all still have live consumers).

## Test plan
- `grep -rn mapDetailToMessage frontend/src` → zero hits (acceptance criterion).
- `./scripts/frontend/check-all.sh` → green: 349 suites / 3692 tests pass, ESLint zero-warning, `tsc --noEmit` clean, prettier clean. Coverage stays ≥ threshold (pure deletion of a dead function + its own test).

Closes #1444
