### PR TITLE
refactor(store): extract shared normalized-by-id collection helper

### DIFF
--- a/frontend/src/store/__tests__/normalizedCollection.test.ts
+++ b/frontend/src/store/__tests__/normalizedCollection.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { createNormalizedById } from '../normalizedCollection';
+
+interface WithId {
+  id: number;
+  name: string;
+}
+
+interface WithCode {
+  code: number;
+  label: string;
+}
+
+const makeItem = (id: number, name: string): WithId => ({ id, name });
+const makeCoded = (code: number, label: string): WithCode => ({ code, label });
+
+describe('createNormalizedById', () => {
+  it('normalize on an empty array returns empty byId, order, and list', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+
+    const result = collection.normalize([]);
+
+    expect(result.byId).toEqual({});
+    expect(result.order).toEqual([]);
+    expect(result.list).toEqual([]);
+  });
+
+  it('normalize preserves input order in both order and list for ascending keys', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const first = makeItem(1, 'First');
+    const second = makeItem(2, 'Second');
+    const third = makeItem(3, 'Third');
+
+    const result = collection.normalize([first, second, third]);
+
+    expect(result.order).toEqual([1, 2, 3]);
+    expect(result.list).toEqual([first, second, third]);
+    expect(result.byId[1]).toEqual(first);
+    expect(result.byId[2]).toEqual(second);
+    expect(result.byId[3]).toEqual(third);
+  });
+
+  it('normalize preserves input order for descending keys, mirroring the stage store', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const tenth = makeItem(10, 'Tenth');
+    const fifth = makeItem(5, 'Fifth');
+    const first = makeItem(1, 'First');
+
+    const result = collection.normalize([tenth, fifth, first]);
+
+    expect(result.order).toEqual([10, 5, 1]);
+    expect(result.list).toEqual([tenth, fifth, first]);
+  });
+
+  it('normalize is generic over the key field via keyOf', () => {
+    const collection = createNormalizedById((item: WithCode) => item.code);
+    const alpha = makeCoded(100, 'Alpha');
+    const beta = makeCoded(200, 'Beta');
+
+    const result = collection.normalize([alpha, beta]);
+
+    expect(result.order).toEqual([100, 200]);
+    expect(result.byId[100]).toEqual(alpha);
+    expect(result.byId[200]).toEqual(beta);
+  });
+
+  it('normalize returns list as a shallow copy that preserves element references', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const input = [makeItem(1, 'First'), makeItem(2, 'Second')];
+
+    const result = collection.normalize(input);
+
+    expect(result.list).not.toBe(input);
+    expect(result.list[0]).toBe(input[0]);
+    expect(result.list[1]).toBe(input[1]);
+  });
+
+  it('normalize keeps the last item on duplicate keys and repeats the key in order', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const firstVersion = makeItem(1, 'Original');
+    const secondVersion = makeItem(1, 'Overwritten');
+
+    const result = collection.normalize([firstVersion, secondVersion]);
+
+    expect(result.order).toEqual([1, 1]);
+    expect(result.byId[1]).toEqual(secondVersion);
+    expect(result.byId[1]).not.toEqual(firstVersion);
+  });
+
+  it('rebuild maps order through byId preserving element references', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const first = makeItem(1, 'First');
+    const second = makeItem(2, 'Second');
+    const byId: Record<number, WithId> = { 1: first, 2: second };
+
+    const result = collection.rebuild(byId, [2, 1]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(second);
+    expect(result[1]).toBe(first);
+  });
+
+  it('rebuild silently drops keys absent from byId', () => {
+    const collection = createNormalizedById((item: WithId) => item.id);
+    const first = makeItem(1, 'First');
+    const byId: Record<number, WithId> = { 1: first };
+
+    const result = collection.rebuild(byId, [1, 99, 1]);
+
+    expect(result).toEqual([first, first]);
+  });
+});

--- a/frontend/src/store/normalizedCollection.ts
+++ b/frontend/src/store/normalizedCollection.ts
@@ -1,0 +1,55 @@
+/**
+ * Normalized-collection helper — the canonical `byId` + `order` + derived-list
+ * pattern shared by the habit and stage stores.
+ *
+ * Each store keeps an ID-keyed map (`byId`) as its source of truth for O(1)
+ * lookups, an `order` array of keys that preserves the caller-supplied array
+ * order, and a derived `list` cache so consumers can iterate without rebuilding
+ * on every render. This factory centralizes the two operations both stores
+ * hand-rolled: `normalize` turns a caller array into that triple, and `rebuild`
+ * projects `order` back through `byId` into a fresh list.
+ *
+ * Ordering always follows the caller-supplied array — ascending, descending, or
+ * arbitrary — because `order` is populated by iterating `items` as given. The
+ * callers adapt the generic field names (`byId`/`order`/`list`) onto their own
+ * domain field names.
+ */
+
+/** The normalized triple: ID-keyed map, key order, and derived list view. */
+export interface NormalizedById<T> {
+  /** ID-keyed map — the canonical source of truth for per-item lookups. */
+  byId: Record<number, T>;
+  /** Keys in caller-supplied order; duplicates are preserved. */
+  order: number[];
+  /** Derived array view of the items in `order`. */
+  list: T[];
+}
+
+/** Operations bound to a single `keyOf` extractor. */
+export interface NormalizedByIdFactory<T> {
+  normalize: (_items: T[]) => NormalizedById<T>;
+  rebuild: (_byId: Record<number, T>, _order: number[]) => T[];
+}
+
+/**
+ * Build normalize/rebuild bound to a key extractor. `normalize` iterates items
+ * in order (last-item-wins on duplicate keys, duplicate keys kept in `order`);
+ * `rebuild` projects `order` through `byId`, dropping keys absent from the map.
+ */
+export const createNormalizedById = <T>(keyOf: (_item: T) => number): NormalizedByIdFactory<T> => {
+  const normalize = (items: T[]): NormalizedById<T> => {
+    const byId: Record<number, T> = {};
+    const order: number[] = [];
+    for (const item of items) {
+      const key = keyOf(item);
+      byId[key] = item;
+      order.push(key);
+    }
+    return { byId, order, list: [...items] };
+  };
+
+  const rebuild = (byId: Record<number, T>, order: number[]): T[] =>
+    order.map((key) => byId[key]).filter((item): item is T => item !== undefined);
+
+  return { normalize, rebuild };
+};

--- a/frontend/src/store/useHabitStore.ts
+++ b/frontend/src/store/useHabitStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
+import { createNormalizedById } from './normalizedCollection';
 import { registerStoreReset } from './registry';
 
 /**
@@ -41,24 +42,14 @@ const INITIAL_STATE = {
   error: null as string | null,
 };
 
-interface NormalizedHabits {
-  habitsById: Record<number, Habit>;
-  habitOrder: number[];
-  habits: Habit[];
-}
+const habitCollection = createNormalizedById<Habit>((habit) => habit.id);
 
-const normalizeHabits = (habits: Habit[]): NormalizedHabits => {
-  const habitsById: Record<number, Habit> = {};
-  const habitOrder: number[] = [];
-  for (const habit of habits) {
-    habitsById[habit.id] = habit;
-    habitOrder.push(habit.id);
-  }
-  return { habitsById, habitOrder, habits: [...habits] };
+const normalizeHabits = (
+  habits: Habit[],
+): { habitsById: Record<number, Habit>; habitOrder: number[]; habits: Habit[] } => {
+  const { byId, order, list } = habitCollection.normalize(habits);
+  return { habitsById: byId, habitOrder: order, habits: list };
 };
-
-const rebuildHabitsList = (habitsById: Record<number, Habit>, habitOrder: number[]): Habit[] =>
-  habitOrder.map((id) => habitsById[id]!).filter((h): h is Habit => h !== undefined);
 
 export const useHabitStore = create<HabitStoreState>((set) => ({
   ...INITIAL_STATE,
@@ -70,7 +61,7 @@ export const useHabitStore = create<HabitStoreState>((set) => ({
     set((state) => {
       if (!(updatedHabit.id in state.habitsById)) return state;
       const habitsById = { ...state.habitsById, [updatedHabit.id]: updatedHabit };
-      return { habitsById, habits: rebuildHabitsList(habitsById, state.habitOrder) };
+      return { habitsById, habits: habitCollection.rebuild(habitsById, state.habitOrder) };
     }),
   removeHabit: (habitId) =>
     set((state) => {
@@ -78,7 +69,7 @@ export const useHabitStore = create<HabitStoreState>((set) => ({
       const habitsById = { ...state.habitsById };
       delete habitsById[habitId];
       const habitOrder = state.habitOrder.filter((id) => id !== habitId);
-      return { habitsById, habitOrder, habits: rebuildHabitsList(habitsById, habitOrder) };
+      return { habitsById, habitOrder, habits: habitCollection.rebuild(habitsById, habitOrder) };
     }),
   reset: () => set({ ...INITIAL_STATE }),
 }));

--- a/frontend/src/store/useStageStore.ts
+++ b/frontend/src/store/useStageStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import type { StageData } from '../features/Map/stageData';
 
+import { createNormalizedById } from './normalizedCollection';
 import { registerStoreReset } from './registry';
 
 /**
@@ -47,27 +48,14 @@ const INITIAL_STATE = {
   error: null as string | null,
 };
 
-interface NormalizedStages {
-  stagesByNumber: Record<number, StageData>;
-  stageOrder: number[];
-  stages: StageData[];
-}
+const stageCollection = createNormalizedById<StageData>((stage) => stage.stageNumber);
 
-const normalizeStages = (stages: StageData[]): NormalizedStages => {
-  const stagesByNumber: Record<number, StageData> = {};
-  const stageOrder: number[] = [];
-  for (const stage of stages) {
-    stagesByNumber[stage.stageNumber] = stage;
-    stageOrder.push(stage.stageNumber);
-  }
-  return { stagesByNumber, stageOrder, stages: [...stages] };
+const normalizeStages = (
+  stages: StageData[],
+): { stagesByNumber: Record<number, StageData>; stageOrder: number[]; stages: StageData[] } => {
+  const { byId, order, list } = stageCollection.normalize(stages);
+  return { stagesByNumber: byId, stageOrder: order, stages: list };
 };
-
-const rebuildStageList = (
-  stagesByNumber: Record<number, StageData>,
-  stageOrder: number[],
-): StageData[] =>
-  stageOrder.map((num) => stagesByNumber[num]!).filter((s): s is StageData => s !== undefined);
 
 export const useStageStore = create<StageStoreState>((set) => ({
   ...INITIAL_STATE,
@@ -97,7 +85,7 @@ export const useStageStore = create<StageStoreState>((set) => ({
         ...state.stagesByNumber,
         [stageNumber]: { ...existing, progress },
       };
-      return { stagesByNumber, stages: rebuildStageList(stagesByNumber, state.stageOrder) };
+      return { stagesByNumber, stages: stageCollection.rebuild(stagesByNumber, state.stageOrder) };
     }),
   reset: () => set({ ...INITIAL_STATE }),
 }));


### PR DESCRIPTION
## Summary
- Extract the duplicated "normalized-by-numeric-key collection with a derived list cache" machinery from `useHabitStore` and `useStageStore` into a single generic `createNormalizedById<T>(keyOf)` factory in `frontend/src/store/normalizedCollection.ts`.
- Rewire both stores onto the shared helper, deleting the parallel `interface Normalized*` + `normalize*` + `rebuild*List` copies while keeping each store's field-name adapter.
- Pure refactor: store behavior is byte-for-byte unchanged (shallow list copy in caller order, last-wins on duplicate keys, `rebuild` drops keys absent from the map). The `selectHabitById` selector cache, the `updateStageProgress` unknown-stage `console.warn` branch, and all `reset`/registry wiring are preserved verbatim.

## Test plan
- New `frontend/src/store/__tests__/normalizedCollection.test.ts` (8 cases) locks the helper's contract: empty input, ascending/descending order preservation, `keyOf` genericity over a non-`id` field, shallow-copy reference identity, duplicate-key last-wins, `rebuild` reference preservation, and `rebuild` silently dropping absent keys. Verified RED (module missing) before implementation.
- Existing `useHabitStore.test.ts`, `useStageStore.test.ts`, and `storeIntegration.test.ts` pass **unmodified** (they are the byte-for-byte regression check).
- `./scripts/frontend/check-all.sh` exits 0: ESLint (zero-warning), Prettier, `tsc --noEmit` strict, and Jest (3700 tests) all green.

Closes #1445
