### PR TITLE
feat(backend): reflection-hierarchy due-schedule and source resolution domain

### DIFF
--- a/backend/src/domain/program_calendar.py
+++ b/backend/src/domain/program_calendar.py
@@ -27,8 +27,14 @@ if TYPE_CHECKING:
 _DAYS_PER_WEEK = 7
 
 
-def _elapsed_days(anchor: datetime, now: datetime) -> int:
-    """Whole days since the anchor, floored at zero for clock skew."""
+def elapsed_days(anchor: datetime, now: datetime) -> int:
+    """Whole days since the anchor, floored at zero for clock skew.
+
+    Shared by every date-derived program helper (this module's calendar
+    math and :mod:`domain.reflection_hierarchy`'s due-date ladder) so the
+    naive/aware normalization and the clock-skew floor live in exactly one
+    place.
+    """
     delta = ensure_aware(now) - ensure_aware(anchor)
     return max(0, delta.days)
 
@@ -36,14 +42,14 @@ def _elapsed_days(anchor: datetime, now: datetime) -> int:
 def calendar_week(anchor: datetime, now: datetime | None = None) -> int:
     """The 1-based program week ``now`` falls in, clamped to the curriculum."""
     moment = now if now is not None else datetime.now(UTC)
-    week = _elapsed_days(anchor, moment) // _DAYS_PER_WEEK + 1
+    week = elapsed_days(anchor, moment) // _DAYS_PER_WEEK + 1
     return min(week, TOTAL_WEEKS)
 
 
 def calendar_stage(anchor: datetime, now: datetime | None = None) -> int:
     """The 1-based stage ``now`` falls in, walking the duration schedule."""
     moment = now if now is not None else datetime.now(UTC)
-    remaining = _elapsed_days(anchor, moment)
+    remaining = elapsed_days(anchor, moment)
     for stage_number, duration in enumerate(STAGE_DURATIONS_DAYS, start=1):
         if remaining < duration:
             return stage_number
@@ -67,7 +73,7 @@ def calendar_day_in_stage(anchor: datetime, stage_number: int, now: datetime | N
     stage = min(max(stage_number, 1), TOTAL_STAGES)
     window_start = sum(STAGE_DURATIONS_DAYS[: stage - 1])
     duration = STAGE_DURATIONS_DAYS[stage - 1]
-    day = _elapsed_days(anchor, moment) - window_start + 1
+    day = elapsed_days(anchor, moment) - window_start + 1
     return min(day, duration)
 
 

--- a/backend/src/domain/reflection_hierarchy.py
+++ b/backend/src/domain/reflection_hierarchy.py
@@ -1,0 +1,447 @@
+"""The multi-level reflection hierarchy — when a reflection falls due and what feeds it.
+
+The APTITUDE curriculum is a nested calendar. Ten stages
+(:data:`domain.constants.STAGE_DURATIONS_DAYS`) pair up into five *components*
+(stages ``2n-1`` and ``2n``), and those components split into two *tiers* — the
+first six stages, then the last four. Every layer closes with an invitation to
+reflect: at a plain week's end, at a stage's end, and — when several layers close
+on the very same day — at the most encompassing layer that closes there. The
+precedence is fixed: **program beats tier beats component beats stage beats a
+plain week.** A user who reaches day seven of week eighteen is not asked for four
+reflections; they are offered the single tier reflection that subsumes the rest.
+
+This module is pure. It reads an anchor datetime, a wall clock, and immutable
+value objects, and it never touches the database. Two ideas drive it:
+
+* **Everything derives from the duration schedule.** Week spans, component
+  membership, and the program length are all computed from
+  ``STAGE_DURATIONS_DAYS`` so a schedule change ripples through automatically —
+  there are no hand-written week numbers. The one thing the schedule *cannot*
+  tell us is where tier one ends: the six-then-four split is a curriculum design
+  choice, not a consequence of any duration, so it lives in the single named
+  constant :data:`_TIER_ONE_LAST_STAGE`.
+
+* **Uniform recursion, no special cases.** :func:`resolve_sources` answers "what
+  raw material feeds this reflection?" by walking the hierarchy top-down: if a
+  child layer already has its own completed reflection, that reflection stands in
+  for its whole span; otherwise we recurse into the child. The recursion bottoms
+  out at a week, which yields either its own weekly reflection or that week's raw
+  daily entries. Crucially, a stage's *final* week can never carry its own weekly
+  reflection — that day resolved to the STAGE (or higher) layer instead — so the
+  final week simply recurses to its dailies like any other gap. Because that is
+  true uniformly, the walk needs no boundary special-casing, and ascending child
+  order yields chronologically ordered output with reflections ahead of the raw
+  entries they summarize.
+
+Keys are strings of the form ``"c{cycle}:{token}"`` where ``token`` is ``prog``,
+``w<week>``, ``s<stage>``, ``p<component>``, or ``t<tier>``. The ``c{cycle}``
+prefix isolates repeat runs of the program: a reflection from cycle one never
+satisfies a cycle-two lookup.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import StrEnum
+
+from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_STAGES
+from domain.program_calendar import elapsed_days
+
+# Seven days to a program week; the whole calendar is a multiple of this.
+_DAYS_PER_WEEK = 7
+
+# Weeks each stage lasts, derived straight from the day schedule so a
+# curriculum edit never needs a matching edit here: (3,)*8 + (6, 6).
+_WEEKS_PER_STAGE: tuple[int, ...] = tuple(
+    duration // _DAYS_PER_WEEK for duration in STAGE_DURATIONS_DAYS
+)
+
+# The full curriculum length in weeks (36) — the sum of the per-stage spans.
+TOTAL_PROGRAM_WEEKS = sum(_WEEKS_PER_STAGE)
+
+# Two consecutive stages make one component; the second (even) stage of a
+# pair is the one whose end closes the component.
+_STAGES_PER_COMPONENT = 2
+
+# Five components across the ten stages.
+_COMPONENT_COUNT = TOTAL_STAGES // _STAGES_PER_COMPONENT
+
+# The components split into exactly two tiers (two halves of the journey).
+_TIER_COUNT = 2
+
+# Tier one is the first SIX stages; tier two is the remaining four. This
+# six-then-four split is a curriculum design decision — it is NOT derivable
+# from STAGE_DURATIONS_DAYS (the two long stages sit in tier two, but their
+# length is what makes them long, not what makes them tier two). Hence a
+# named constant rather than a computed value.
+_TIER_ONE_LAST_STAGE = 6
+
+# The token that names a whole-program reflection (it carries no index).
+_PROGRAM_TAG = "prog"
+
+# A key is "c<cycle>:<token>"; the token names one layer of the hierarchy.
+_KEY_PATTERN = re.compile(r"^c(\d+):(prog|w\d+|s\d+|p\d+|t\d+)$")
+
+
+class ReflectionLevel(StrEnum):
+    """One layer of the nested reflection calendar, widest last but for WEEK.
+
+    Ordered here from the narrowest span (a single WEEK) outward through STAGE,
+    COMPONENT, and TIER to the all-encompassing PROGRAM. When several layers
+    close on the same day the widest one wins.
+    """
+
+    WEEK = "week"
+    STAGE = "stage"
+    COMPONENT = "component"
+    TIER = "tier"
+    PROGRAM = "program"
+
+
+class SourceKind(StrEnum):
+    """What kind of source material a resolved item points at.
+
+    A REFLECTION already summarizes its span; an ENTRY is a single raw daily
+    journal entry that no reflection has yet gathered up.
+    """
+
+    REFLECTION = "reflection"
+    ENTRY = "entry"
+
+
+# The leading token letter that names each indexed layer (``prog`` is handled
+# separately as it carries no index).
+_LETTER_TO_LEVEL = {
+    "w": ReflectionLevel.WEEK,
+    "s": ReflectionLevel.STAGE,
+    "p": ReflectionLevel.COMPONENT,
+    "t": ReflectionLevel.TIER,
+}
+
+# The largest valid 1-based index for each indexed layer, so a stray ``s11`` or
+# ``t3`` is rejected rather than silently scoping an empty span.
+_LEVEL_MAX_INDEX = {
+    ReflectionLevel.WEEK: TOTAL_PROGRAM_WEEKS,
+    ReflectionLevel.STAGE: TOTAL_STAGES,
+    ReflectionLevel.COMPONENT: _COMPONENT_COUNT,
+    ReflectionLevel.TIER: _TIER_COUNT,
+}
+
+
+@dataclass(frozen=True)
+class DueReflection:
+    """A reflection that has just come due, at a given layer and program week."""
+
+    level: ReflectionLevel
+    key: str
+    week: int
+
+
+@dataclass(frozen=True)
+class ReflectionRef:
+    """A reference to a reflection that already exists, for source resolution."""
+
+    id: int
+    level: ReflectionLevel
+    key: str
+    week: int
+
+
+@dataclass(frozen=True)
+class EntryRef:
+    """A reference to one raw daily journal entry, tagged with its program week."""
+
+    id: int
+    week: int
+    date: date
+
+
+@dataclass(frozen=True)
+class SourceItem:
+    """One item feeding a reflection: either a child reflection or a raw entry.
+
+    ``level`` and ``key`` are populated only for REFLECTION items (identifying
+    which child reflection stood in for its span); ENTRY items leave them unset.
+    """
+
+    kind: SourceKind
+    id: int
+    week: int
+    level: ReflectionLevel | None = None
+    key: str | None = None
+
+
+def _stage_week_span(stage_number: int) -> tuple[int, int]:
+    """Return the inclusive (start, end) program-week span for a stage.
+
+    The start is one past the weeks of every earlier stage, mirroring the
+    cumulative-window idiom the calendar uses for day-in-stage math; callers pass
+    a validated stage number, so no out-of-range guard is needed.
+    """
+    start = sum(_WEEKS_PER_STAGE[: stage_number - 1]) + 1
+    end = start + _WEEKS_PER_STAGE[stage_number - 1] - 1
+    return (start, end)
+
+
+def _component_week_span(component_number: int) -> tuple[int, int]:
+    """Return the inclusive (start, end) program-week span for a component."""
+    first_stage = _STAGES_PER_COMPONENT * component_number - 1
+    second_stage = first_stage + 1
+    return (_stage_week_span(first_stage)[0], _stage_week_span(second_stage)[1])
+
+
+def _tier_week_span(tier_number: int) -> tuple[int, int]:
+    """Return the inclusive (start, end) program-week span for a tier."""
+    if tier_number == 1:
+        return (1, _stage_week_span(_TIER_ONE_LAST_STAGE)[1])
+    return (_stage_week_span(_TIER_ONE_LAST_STAGE + 1)[0], TOTAL_PROGRAM_WEEKS)
+
+
+def _stage_component(stage_number: int) -> int:
+    """Return the 1-based component number a stage belongs to (its pair index)."""
+    return (stage_number + _STAGES_PER_COMPONENT - 1) // _STAGES_PER_COMPONENT
+
+
+def _stage_ending_at_week(week: int) -> int | None:
+    """Return the stage that closes on ``week``, or None if none does."""
+    start = 1
+    for index, weeks in enumerate(_WEEKS_PER_STAGE, start=1):
+        end = start + weeks - 1
+        if end == week:
+            return index
+        start = end + 1
+    return None
+
+
+def _stage_boundary_level(stage_number: int) -> tuple[ReflectionLevel, str]:
+    """Return the widest layer (and its token) that a stage's end closes.
+
+    A stage that also caps a tier resolves to TIER; a stage that also caps a
+    component (the even stage of a pair) resolves to COMPONENT; otherwise the
+    stage stands on its own.
+    """
+    if stage_number in (_TIER_ONE_LAST_STAGE, TOTAL_STAGES):
+        return (ReflectionLevel.TIER, f"t{1 if stage_number == _TIER_ONE_LAST_STAGE else 2}")
+    if stage_number % _STAGES_PER_COMPONENT == 0:
+        return (ReflectionLevel.COMPONENT, f"p{_stage_component(stage_number)}")
+    return (ReflectionLevel.STAGE, f"s{stage_number}")
+
+
+def _closing_level(week: int) -> tuple[ReflectionLevel, str]:
+    """Return the widest layer (and its token) that program ``week`` closes.
+
+    The whole program wins at the final week; a mid-stage week is a plain WEEK;
+    otherwise the stage boundary decides the layer.
+    """
+    if week == TOTAL_PROGRAM_WEEKS:
+        return (ReflectionLevel.PROGRAM, _PROGRAM_TAG)
+    stage_number = _stage_ending_at_week(week)
+    if stage_number is None:
+        return (ReflectionLevel.WEEK, f"w{week}")
+    return _stage_boundary_level(stage_number)
+
+
+def due_reflection(
+    anchor: datetime,
+    now: datetime | None = None,
+    cycle: int = 1,
+) -> DueReflection | None:
+    """Return the reflection that comes due on the day ``now`` falls in, if any.
+
+    Reflections come due only on the seventh day of a program week; every other
+    day (and any clock skew that puts ``now`` before ``anchor``) yields None, as
+    does any day past the curriculum's final week. On a due day the widest layer
+    that closes that week wins. ``now`` defaults to the current UTC wall clock.
+    """
+    reference = now if now is not None else datetime.now(UTC)
+    elapsed = elapsed_days(anchor, reference)
+    if elapsed % _DAYS_PER_WEEK + 1 != _DAYS_PER_WEEK:
+        return None
+    week = elapsed // _DAYS_PER_WEEK + 1
+    if week > TOTAL_PROGRAM_WEEKS:
+        return None
+    level, token = _closing_level(week)
+    return DueReflection(level=level, key=f"c{cycle}:{token}", week=week)
+
+
+def _token_to_level_index(token: str) -> tuple[ReflectionLevel, int]:
+    """Map a validated token to its (level, numeric index); ``prog`` has index 0."""
+    if token == _PROGRAM_TAG:
+        return (ReflectionLevel.PROGRAM, 0)
+    return (_LETTER_TO_LEVEL[token[0]], int(token[1:]))
+
+
+def _validate_index(level: ReflectionLevel, index: int) -> None:
+    """Raise ValueError if ``index`` is out of range for its level."""
+    if level is ReflectionLevel.PROGRAM:
+        return
+    if not 1 <= index <= _LEVEL_MAX_INDEX[level]:
+        raise ValueError(f"index {index} out of range for {level}")
+
+
+def _parse_key(key: str) -> tuple[ReflectionLevel, int]:
+    """Parse a ``c<cycle>:<token>`` key into (level, index), validating the range.
+
+    Raises ValueError for a missing cycle prefix, an unknown token, or an index
+    past the curriculum's bounds. The cycle number itself is not returned — scope
+    and hierarchy are cycle-agnostic; callers that need the prefix read it back
+    off the raw key.
+    """
+    match = _KEY_PATTERN.match(key)
+    if match is None:
+        raise ValueError(f"malformed reflection key: {key!r}")
+    level, index = _token_to_level_index(match.group(2))
+    _validate_index(level, index)
+    return (level, index)
+
+
+def _span_for(level: ReflectionLevel, index: int) -> tuple[int, int]:
+    """Return the inclusive (start, end) week span for a (level, index) pair."""
+    if level is ReflectionLevel.WEEK:
+        return (index, index)
+    if level is ReflectionLevel.STAGE:
+        return _stage_week_span(index)
+    if level is ReflectionLevel.COMPONENT:
+        return _component_week_span(index)
+    if level is ReflectionLevel.TIER:
+        return _tier_week_span(index)
+    return (1, TOTAL_PROGRAM_WEEKS)
+
+
+def scope_weeks(level: ReflectionLevel, key: str) -> range:
+    """Return the program weeks a reflection covers, as ``range(start, end + 1)``.
+
+    The ``level`` argument must agree with the key's own token; a mismatch (say a
+    STAGE level with a ``w5`` key) is rejected so callers cannot silently scope
+    the wrong span. The result is cycle-agnostic.
+    """
+    parsed_level, index = _parse_key(key)
+    if parsed_level is not level:
+        raise ValueError(f"level {level} does not match key {key!r}")
+    start, end = _span_for(parsed_level, index)
+    return range(start, end + 1)
+
+
+def _tier_component_numbers(tier_number: int) -> range:
+    """Return the component numbers that make up a tier."""
+    if tier_number == 1:
+        return range(1, _stage_component(_TIER_ONE_LAST_STAGE) + 1)
+    return range(_stage_component(_TIER_ONE_LAST_STAGE + 1), _COMPONENT_COUNT + 1)
+
+
+def _component_stage_numbers(component_number: int) -> range:
+    """Return the stage numbers that make up a component (its consecutive pair)."""
+    first_stage = _STAGES_PER_COMPONENT * component_number - 1
+    return range(first_stage, first_stage + _STAGES_PER_COMPONENT)
+
+
+def _child_spec(level: ReflectionLevel, index: int) -> tuple[ReflectionLevel, str, range]:
+    """Return a node's child level, token letter, and ascending child numbers.
+
+    Program decomposes into tiers, a tier into its components, a component into
+    its stage pair, and a stage into every week it spans. The numbers come back
+    in ascending program order so the caller's walk stays chronological.
+    """
+    if level is ReflectionLevel.PROGRAM:
+        return (ReflectionLevel.TIER, "t", range(1, _TIER_COUNT + 1))
+    if level is ReflectionLevel.TIER:
+        return (ReflectionLevel.COMPONENT, "p", _tier_component_numbers(index))
+    if level is ReflectionLevel.COMPONENT:
+        return (ReflectionLevel.STAGE, "s", _component_stage_numbers(index))
+    start, end = _stage_week_span(index)
+    return (ReflectionLevel.WEEK, "w", range(start, end + 1))
+
+
+def _child_scopes(level: ReflectionLevel, key: str) -> list[tuple[ReflectionLevel, str]]:
+    """Return the (level, key) children of a node, carrying its cycle prefix."""
+    prefix = key.partition(":")[0]
+    _, index = _parse_key(key)
+    child_level, letter, numbers = _child_spec(level, index)
+    return [(child_level, f"{prefix}:{letter}{number}") for number in numbers]
+
+
+def _index_reflections(
+    existing: Sequence[ReflectionRef],
+) -> dict[tuple[ReflectionLevel, str], ReflectionRef]:
+    """Index existing reflections by (level, key); the first ref for a slot wins."""
+    lookup: dict[tuple[ReflectionLevel, str], ReflectionRef] = {}
+    for ref in existing:
+        lookup.setdefault((ref.level, ref.key), ref)
+    return lookup
+
+
+def _index_entries(entries: Sequence[EntryRef]) -> dict[int, list[EntryRef]]:
+    """Group entries by program week, each week's list sorted by (date, id)."""
+    by_week: dict[int, list[EntryRef]] = {}
+    for entry in entries:
+        by_week.setdefault(entry.week, []).append(entry)
+    for week_entries in by_week.values():
+        week_entries.sort(key=lambda entry: (entry.date, entry.id))
+    return by_week
+
+
+def _reflection_source(ref: ReflectionRef) -> SourceItem:
+    """Wrap an existing reflection as a REFLECTION source item."""
+    return SourceItem(
+        kind=SourceKind.REFLECTION, id=ref.id, week=ref.week, level=ref.level, key=ref.key
+    )
+
+
+def _entry_source(entry: EntryRef) -> SourceItem:
+    """Wrap a raw daily entry as an ENTRY source item."""
+    return SourceItem(kind=SourceKind.ENTRY, id=entry.id, week=entry.week)
+
+
+def _collect_sources(
+    level: ReflectionLevel,
+    key: str,
+    lookup: dict[tuple[ReflectionLevel, str], ReflectionRef],
+    by_week: dict[int, list[EntryRef]],
+) -> list[SourceItem]:
+    """Gather the sources for a node: its own reflection, else its children's.
+
+    An existing reflection for this exact (level, key) stands in for its whole
+    span. Otherwise a WEEK bottoms out in its raw dailies while any wider layer
+    recurses into each child in turn — uniformly, with no boundary special-case.
+    """
+    ref = lookup.get((level, key))
+    if ref is not None:
+        return [_reflection_source(ref)]
+    if level is ReflectionLevel.WEEK:
+        _, week = _parse_key(key)
+        return [_entry_source(entry) for entry in by_week.get(week, [])]
+    items: list[SourceItem] = []
+    for child_level, child_key in _child_scopes(level, key):
+        items.extend(_collect_sources(child_level, child_key, lookup, by_week))
+    return items
+
+
+def resolve_sources(
+    level: ReflectionLevel,
+    key: str,
+    existing: Sequence[ReflectionRef],
+    entries: Sequence[EntryRef],
+) -> list[SourceItem]:
+    """Return the ordered source material feeding the reflection at (level, key).
+
+    Walks the hierarchy top-down: wherever a child layer already has its own
+    reflection, that reflection represents its span; every gap recurses until it
+    reaches either a weekly reflection or the raw daily entries of a week. The
+    result is chronological, with each reflection appearing ahead of the entries
+    it summarizes.
+
+    ``level`` must agree with the key's own token, mirroring ``scope_weeks``, so a
+    caller cannot silently decompose the wrong span. Reflections are matched by
+    their full ``c{cycle}:`` key, so refs from another cycle never satisfy a
+    lookup; entries carry no cycle of their own, so the caller must pass only the
+    entries belonging to this reflection's cycle.
+    """
+    parsed_level, _ = _parse_key(key)
+    if parsed_level is not level:
+        raise ValueError(f"level {level} does not match key {key!r}")
+    lookup = _index_reflections(existing)
+    by_week = _index_entries(entries)
+    return _collect_sources(level, key, lookup, by_week)

--- a/backend/tests/domain/test_reflection_hierarchy.py
+++ b/backend/tests/domain/test_reflection_hierarchy.py
@@ -1,0 +1,516 @@
+"""Pure-domain tests for the multi-level reflection due-date and source hierarchy.
+
+The import of ``domain.reflection_hierarchy`` FAILs until the
+implementation-specialist creates that module. That is the correct RED state
+for Gate 1.
+
+Pinned public surface:
+  ReflectionLevel(StrEnum): week, stage, component, tier, program
+  SourceKind(StrEnum): reflection, entry
+  DueReflection(level, key, week) -- frozen dataclass
+  ReflectionRef(id, level, key, week) -- frozen dataclass
+  EntryRef(id, week, date) -- frozen dataclass
+  SourceItem(kind, id, week, level=None, key=None) -- frozen dataclass
+  due_reflection(anchor, now=None, cycle=1) -> DueReflection | None
+  scope_weeks(level, key) -> range
+  resolve_sources(level, key, existing, entries) -> list[SourceItem]
+
+Program shape: ten stages (``domain.constants.STAGE_DURATIONS_DAYS``) pair up
+into five components (stages 2n-1, 2n), which split into two tiers (stages
+1-6 and 7-10). A key is ``"c{cycle}:{token}"`` where token is ``w<week>``,
+``s<stage>``, ``p<component>``, ``t<tier>``, or ``prog``. When several levels
+become due on the same day, the most encompassing one wins: program beats
+tier beats component beats stage beats a plain week.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_STAGES
+from domain.reflection_hierarchy import (
+    DueReflection,
+    EntryRef,
+    ReflectionLevel,
+    ReflectionRef,
+    SourceItem,
+    SourceKind,
+    due_reflection,
+    resolve_sources,
+    scope_weeks,
+)
+from domain.weekly_prompts import TOTAL_WEEKS
+
+_DAYS_PER_WEEK = 7
+_ANCHOR = datetime(2026, 1, 5, tzinfo=UTC)
+
+# Components pair consecutive stages; tiers group the resulting five
+# components into two halves of the curriculum. This split (six stages then
+# four) is the shape under test here, not a value borrowed from elsewhere.
+_TIER_1_LAST_STAGE = 6
+
+
+def _stage_week_span(stage_number: int) -> tuple[int, int]:
+    """Derive the inclusive (start, end) program-week span for a stage."""
+    week = 1
+    for index, duration_days in enumerate(STAGE_DURATIONS_DAYS, start=1):
+        span_weeks = duration_days // _DAYS_PER_WEEK
+        end = week + span_weeks - 1
+        if index == stage_number:
+            return (week, end)
+        week = end + 1
+    raise ValueError(stage_number)
+
+
+def _component_week_span(component_number: int) -> tuple[int, int]:
+    """Derive the inclusive (start, end) program-week span for a component."""
+    first_stage = 2 * component_number - 1
+    second_stage = first_stage + 1
+    return (_stage_week_span(first_stage)[0], _stage_week_span(second_stage)[1])
+
+
+def _tier_week_span(tier_number: int) -> tuple[int, int]:
+    """Derive the inclusive (start, end) program-week span for a tier."""
+    if tier_number == 1:
+        return (1, _stage_week_span(_TIER_1_LAST_STAGE)[1])
+    return (_stage_week_span(_TIER_1_LAST_STAGE + 1)[0], TOTAL_WEEKS)
+
+
+def _end_of_week(week: int) -> datetime:
+    """The instant that is day 7 of program week ``week``, from the anchor."""
+    return _ANCHOR + timedelta(days=_DAYS_PER_WEEK * week - 1)
+
+
+def _week_entries(week: int) -> list[EntryRef]:
+    """Build the seven raw daily EntryRefs for one program week, date-ordered."""
+    base = date(2026, 1, 1) + timedelta(days=(week - 1) * _DAYS_PER_WEEK)
+    return [
+        EntryRef(id=week * 10 + day, week=week, date=base + timedelta(days=day))
+        for day in range(_DAYS_PER_WEEK)
+    ]
+
+
+def _reflection_ref(ref_id: int, level: ReflectionLevel, key: str, week: int) -> ReflectionRef:
+    """Build a completed ReflectionRef with the given identity fields."""
+    return ReflectionRef(id=ref_id, level=level, key=key, week=week)
+
+
+def _entry_items(entries: list[EntryRef]) -> list[SourceItem]:
+    """Wrap raw EntryRefs as the ENTRY SourceItems resolve_sources should emit."""
+    return [SourceItem(kind=SourceKind.ENTRY, id=entry.id, week=entry.week) for entry in entries]
+
+
+def _reflection_item(ref: ReflectionRef) -> SourceItem:
+    """Wrap a ReflectionRef as the REFLECTION SourceItem resolve_sources should emit."""
+    return SourceItem(
+        kind=SourceKind.REFLECTION, id=ref.id, week=ref.week, level=ref.level, key=ref.key
+    )
+
+
+# ---------------------------------------------------------------------------
+# Program shape sanity
+# ---------------------------------------------------------------------------
+
+
+def test_program_constants_pin_curriculum_shape() -> None:
+    """The reflection hierarchy is built on ten stages summing to 36 weeks."""
+    assert len(STAGE_DURATIONS_DAYS) == TOTAL_STAGES
+    assert TOTAL_WEEKS == 36
+    assert sum(duration // _DAYS_PER_WEEK for duration in STAGE_DURATIONS_DAYS) == TOTAL_WEEKS
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- mid-week and clock-skew short-circuits
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_mid_week_day_one_is_none() -> None:
+    """Day 1 of a program week (day_in_week=1) is never a due day."""
+    assert due_reflection(_ANCHOR, now=_ANCHOR) is None
+
+
+def test_due_reflection_mid_week_day_four_is_none() -> None:
+    """Day 4 of a program week (day_in_week=4) is never a due day."""
+    assert due_reflection(_ANCHOR, now=_ANCHOR + timedelta(days=3)) is None
+
+
+def test_due_reflection_now_before_anchor_is_none() -> None:
+    """Clock skew that puts ``now`` before the anchor never reports due."""
+    assert due_reflection(_ANCHOR, now=_ANCHOR - timedelta(days=1)) is None
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- plain week ends
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_end_of_week_one_is_plain_week() -> None:
+    """The end of week 1 is due at the plain WEEK level."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(1))
+    assert result == DueReflection(ReflectionLevel.WEEK, "c1:w1", 1)
+
+
+def test_due_reflection_end_of_week_twenty_seven_is_plain_week() -> None:
+    """Week 27 sits mid-stage-9, so it is due at the plain WEEK level."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(27))
+    assert result == DueReflection(ReflectionLevel.WEEK, "c1:w27", 27)
+
+
+def test_due_reflection_end_of_week_thirty_three_is_plain_week() -> None:
+    """Week 33 sits mid-stage-10, so it is due at the plain WEEK level."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(33))
+    assert result == DueReflection(ReflectionLevel.WEEK, "c1:w33", 33)
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- stage ends (odd-numbered stages, not absorbed upward)
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_end_of_week_three_is_stage_one() -> None:
+    """Week 3 closes stage 1 (odd), so STAGE outranks the plain week."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(3))
+    assert result == DueReflection(ReflectionLevel.STAGE, "c1:s1", 3)
+
+
+def test_due_reflection_end_of_week_nine_is_stage_three() -> None:
+    """Week 9 closes stage 3 (odd), so STAGE outranks the plain week."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(9))
+    assert result == DueReflection(ReflectionLevel.STAGE, "c1:s3", 9)
+
+
+def test_due_reflection_end_of_week_thirty_is_stage_nine() -> None:
+    """Week 30 closes the six-week stage 9 (odd), still STAGE not COMPONENT."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(30))
+    assert result == DueReflection(ReflectionLevel.STAGE, "c1:s9", 30)
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- component ends (even-numbered stages)
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_end_of_week_six_is_component_one() -> None:
+    """Week 6 closes stage 2, completing component 1 -- COMPONENT outranks STAGE."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(6))
+    assert result == DueReflection(ReflectionLevel.COMPONENT, "c1:p1", 6)
+    assert result is not None
+    assert result.level is not ReflectionLevel.STAGE
+
+
+def test_due_reflection_end_of_week_twenty_four_is_component_four() -> None:
+    """Week 24 closes stage 8, completing component 4."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(24))
+    assert result == DueReflection(ReflectionLevel.COMPONENT, "c1:p4", 24)
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- tier and program precedence
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_end_of_week_eighteen_is_tier_not_component() -> None:
+    """Week 18 closes tier 1; TIER outranks the component (p3) it also closes."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(18))
+    assert result == DueReflection(ReflectionLevel.TIER, "c1:t1", 18)
+    assert result is not None
+    assert result.key != "c1:p3"
+
+
+def test_due_reflection_end_of_week_thirty_six_is_program_not_tier_or_component() -> None:
+    """Week 36 closes the whole program; PROGRAM outranks tier 2 and component 5."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(36))
+    assert result == DueReflection(ReflectionLevel.PROGRAM, "c1:prog", 36)
+    assert result is not None
+    assert result.key not in {"c1:t2", "c1:p5"}
+
+
+def test_due_reflection_day_seven_past_week_thirty_six_is_none() -> None:
+    """There is no week 37 -- past the curriculum's end, nothing is due."""
+    assert due_reflection(_ANCHOR, now=_end_of_week(37)) is None
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- cycle prefixing
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_cycle_two_prefixes_the_key() -> None:
+    """A second cycle produces a ``c2:`` prefixed key at the same offset."""
+    result = due_reflection(_ANCHOR, now=_end_of_week(1), cycle=2)
+    assert result == DueReflection(ReflectionLevel.WEEK, "c2:w1", 1)
+
+
+# ---------------------------------------------------------------------------
+# due_reflection -- naive/aware normalization and default now
+# ---------------------------------------------------------------------------
+
+
+def test_due_reflection_naive_anchor_with_aware_now() -> None:
+    """A naive anchor combined with an aware ``now`` still resolves correctly."""
+    naive_anchor = datetime(2026, 1, 5)  # noqa: DTZ001 - deliberately naive
+    result = due_reflection(naive_anchor, now=_end_of_week(1))
+    assert result == DueReflection(ReflectionLevel.WEEK, "c1:w1", 1)
+
+
+def test_due_reflection_default_now_end_of_week_one_is_due() -> None:
+    """With ``now`` omitted, the wall clock stands in for ``now``."""
+    anchor = datetime.now(UTC) - timedelta(days=6)
+    result = due_reflection(anchor)
+    assert result == DueReflection(ReflectionLevel.WEEK, "c1:w1", 1)
+
+
+def test_due_reflection_default_now_mid_week_is_none() -> None:
+    """With ``now`` omitted and only three elapsed days, nothing is due."""
+    anchor = datetime.now(UTC) - timedelta(days=3)
+    assert due_reflection(anchor) is None
+
+
+# ---------------------------------------------------------------------------
+# scope_weeks -- one range per level
+# ---------------------------------------------------------------------------
+
+
+def test_scope_weeks_week_level_is_a_single_week() -> None:
+    """A WEEK-level key scopes to exactly that one week."""
+    assert scope_weeks(ReflectionLevel.WEEK, "c1:w5") == range(5, 6)
+
+
+def test_scope_weeks_stage_three_spans_its_derived_range() -> None:
+    """A STAGE-level key scopes to that stage's derived week span."""
+    start, end = _stage_week_span(3)
+    assert scope_weeks(ReflectionLevel.STAGE, "c1:s3") == range(start, end + 1)
+
+
+def test_scope_weeks_stage_nine_spans_its_derived_range() -> None:
+    """Stage 9's six-week span scopes correctly too."""
+    start, end = _stage_week_span(9)
+    assert scope_weeks(ReflectionLevel.STAGE, "c1:s9") == range(start, end + 1)
+
+
+def test_scope_weeks_stage_ten_spans_its_derived_range() -> None:
+    """Stage 10's six-week span scopes correctly too."""
+    start, end = _stage_week_span(10)
+    assert scope_weeks(ReflectionLevel.STAGE, "c1:s10") == range(start, end + 1)
+
+
+def test_scope_weeks_component_two_spans_its_derived_range() -> None:
+    """A COMPONENT-level key scopes to its two constituent stages."""
+    start, end = _component_week_span(2)
+    assert scope_weeks(ReflectionLevel.COMPONENT, "c1:p2") == range(start, end + 1)
+
+
+def test_scope_weeks_component_five_spans_its_derived_range() -> None:
+    """Component 5 (the final, six-week-stage pair) scopes correctly too."""
+    start, end = _component_week_span(5)
+    assert scope_weeks(ReflectionLevel.COMPONENT, "c1:p5") == range(start, end + 1)
+
+
+def test_scope_weeks_tier_one_spans_its_derived_range() -> None:
+    """A TIER-level key scopes to its half of the curriculum."""
+    start, end = _tier_week_span(1)
+    assert scope_weeks(ReflectionLevel.TIER, "c1:t1") == range(start, end + 1)
+
+
+def test_scope_weeks_tier_two_spans_its_derived_range() -> None:
+    """Tier 2 scopes correctly too."""
+    start, end = _tier_week_span(2)
+    assert scope_weeks(ReflectionLevel.TIER, "c1:t2") == range(start, end + 1)
+
+
+def test_scope_weeks_program_spans_the_whole_curriculum() -> None:
+    """A PROGRAM-level key scopes to every week."""
+    assert scope_weeks(ReflectionLevel.PROGRAM, "c1:prog") == range(1, TOTAL_WEEKS + 1)
+
+
+def test_scope_weeks_is_cycle_agnostic() -> None:
+    """The scope of a level/key pair does not depend on the cycle prefix."""
+    same_stage_other_cycle = scope_weeks(ReflectionLevel.STAGE, "c2:s3")
+    assert same_stage_other_cycle == scope_weeks(ReflectionLevel.STAGE, "c1:s3")
+
+
+# ---------------------------------------------------------------------------
+# scope_weeks -- rejected inputs
+# ---------------------------------------------------------------------------
+
+
+def test_scope_weeks_missing_cycle_prefix_raises() -> None:
+    """A key with no ``cN:`` prefix is rejected."""
+    with pytest.raises(ValueError, match="malformed"):
+        scope_weeks(ReflectionLevel.STAGE, "s3")
+
+
+def test_scope_weeks_unknown_token_raises() -> None:
+    """A key whose token does not match any known letter is rejected."""
+    with pytest.raises(ValueError, match="malformed"):
+        scope_weeks(ReflectionLevel.STAGE, "c1:x3")
+
+
+def test_scope_weeks_out_of_range_week_raises() -> None:
+    """A week number past the curriculum's end is rejected."""
+    with pytest.raises(ValueError, match="out of range"):
+        scope_weeks(ReflectionLevel.WEEK, "c1:w37")
+
+
+def test_scope_weeks_out_of_range_stage_raises() -> None:
+    """A stage number past the curriculum's end is rejected."""
+    with pytest.raises(ValueError, match="out of range"):
+        scope_weeks(ReflectionLevel.STAGE, "c1:s11")
+
+
+def test_scope_weeks_out_of_range_component_raises() -> None:
+    """A component number past the curriculum's end is rejected."""
+    with pytest.raises(ValueError, match="out of range"):
+        scope_weeks(ReflectionLevel.COMPONENT, "c1:p6")
+
+
+def test_scope_weeks_out_of_range_tier_raises() -> None:
+    """A tier number past the curriculum's end is rejected."""
+    with pytest.raises(ValueError, match="out of range"):
+        scope_weeks(ReflectionLevel.TIER, "c1:t3")
+
+
+def test_scope_weeks_level_key_mismatch_raises() -> None:
+    """A level argument that disagrees with the key's own token is rejected."""
+    with pytest.raises(ValueError, match="does not match"):
+        scope_weeks(ReflectionLevel.STAGE, "c1:w5")
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- week level, sorted and scope-filtered
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_week_level_sorts_dailies_and_filters_scope() -> None:
+    """WEEK-level resolution returns only that week's dailies, in date order."""
+    week_five = _week_entries(5)
+    order = [3, 0, 6, 1, 5, 2, 4]
+    scrambled = [week_five[i] for i in order]
+    entries = [*_week_entries(4), *scrambled, *_week_entries(6)]
+    result = resolve_sources(ReflectionLevel.WEEK, "c1:w5", existing=[], entries=entries)
+    assert result == _entry_items(week_five)
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- a skipped week inside a covered stage
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_stage_with_one_skipped_week_decomposes_only_that_week() -> None:
+    """Stage 1: week 1 has a reflection, week 2 is skipped, week 3 is stage-final raw."""
+    w1_ref = _reflection_ref(1, ReflectionLevel.WEEK, "c1:w1", 1)
+    entries = [*_week_entries(1), *_week_entries(2), *_week_entries(3)]
+    result = resolve_sources(ReflectionLevel.STAGE, "c1:s1", existing=[w1_ref], entries=entries)
+    expected = [
+        _reflection_item(w1_ref),
+        *_entry_items(_week_entries(2)),
+        *_entry_items(_week_entries(3)),
+    ]
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- a fully skipped stage inside a component
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_component_with_fully_skipped_stage_decomposes_deeply() -> None:
+    """Component 1: stage 1 has no reflection at all, so it decomposes to 21 dailies."""
+    w4_ref = _reflection_ref(1, ReflectionLevel.WEEK, "c1:w4", 4)
+    w5_ref = _reflection_ref(2, ReflectionLevel.WEEK, "c1:w5", 5)
+    entries = [week for n in range(1, 7) for week in _week_entries(n)]
+    result = resolve_sources(
+        ReflectionLevel.COMPONENT,
+        "c1:p1",
+        existing=[w4_ref, w5_ref],
+        entries=entries,
+    )
+    expected = [
+        *_entry_items(_week_entries(1)),
+        *_entry_items(_week_entries(2)),
+        *_entry_items(_week_entries(3)),
+        _reflection_item(w4_ref),
+        _reflection_item(w5_ref),
+        *_entry_items(_week_entries(6)),
+    ]
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- a deep program chain mixing every level
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_program_level_walks_the_full_chain() -> None:
+    """PROGRAM resolution stops early at each existing ref and recurses past each gap."""
+    t1_ref = _reflection_ref(1, ReflectionLevel.TIER, "c1:t1", 18)
+    p4_ref = _reflection_ref(2, ReflectionLevel.COMPONENT, "c1:p4", 24)
+    s9_ref = _reflection_ref(3, ReflectionLevel.STAGE, "c1:s9", 30)
+    w31_ref = _reflection_ref(4, ReflectionLevel.WEEK, "c1:w31", 31)
+    entries = [week for n in range(32, 37) for week in _week_entries(n)]
+    result = resolve_sources(
+        ReflectionLevel.PROGRAM,
+        "c1:prog",
+        existing=[t1_ref, p4_ref, s9_ref, w31_ref],
+        entries=entries,
+    )
+    expected = [
+        _reflection_item(t1_ref),
+        _reflection_item(p4_ref),
+        _reflection_item(s9_ref),
+        _reflection_item(w31_ref),
+        *(item for n in range(32, 37) for item in _entry_items(_week_entries(n))),
+    ]
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- a fully skipped first tier decomposes to every daily
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_tier_one_fully_skipped_decomposes_to_all_dailies() -> None:
+    """TIER 1 with no lower reflection walks p1-p3 down to weeks 1-18 dailies."""
+    entries = [week for n in range(1, 19) for week in _week_entries(n)]
+    result = resolve_sources(ReflectionLevel.TIER, "c1:t1", existing=[], entries=entries)
+    expected = [item for n in range(1, 19) for item in _entry_items(_week_entries(n))]
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources -- cycle isolation and duplicate refs
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sources_ignores_a_reflection_ref_from_another_cycle() -> None:
+    """A ``c1:`` ref never satisfies a ``c2:`` lookup -- it falls through to dailies."""
+    other_cycle_ref = _reflection_ref(1, ReflectionLevel.WEEK, "c1:w5", 5)
+    week_five = _week_entries(5)
+    result = resolve_sources(
+        ReflectionLevel.WEEK,
+        "c2:w5",
+        existing=[other_cycle_ref],
+        entries=week_five,
+    )
+    assert result == _entry_items(week_five)
+
+
+def test_resolve_sources_duplicate_ref_for_the_same_slot_keeps_the_first() -> None:
+    """Two ReflectionRefs claiming the same (level, key) resolve deterministically."""
+    first_ref = _reflection_ref(1, ReflectionLevel.WEEK, "c1:w5", 5)
+    second_ref = _reflection_ref(2, ReflectionLevel.WEEK, "c1:w5", 5)
+    result = resolve_sources(
+        ReflectionLevel.WEEK,
+        "c1:w5",
+        existing=[first_ref, second_ref],
+        entries=[],
+    )
+    assert result == [_reflection_item(first_ref)]
+
+
+def test_resolve_sources_level_key_mismatch_raises() -> None:
+    """A level that disagrees with the key's own token is rejected."""
+    with pytest.raises(ValueError, match="does not match"):
+        resolve_sources(ReflectionLevel.STAGE, "c1:w5", existing=[], entries=[])


### PR DESCRIPTION
## Summary

- Adds `backend/src/domain/reflection_hierarchy.py`, the pure, DB-free domain layer for hierarchical journaling: `ReflectionLevel`/`SourceKind` StrEnums and frozen `DueReflection`/`ReflectionRef`/`EntryRef`/`SourceItem` value objects that later sub-issues build on as a stable contract.
- `due_reflection` returns the seventh-day reflection due at the highest-precedence level a program week closes (`program > tier > component > stage > week`), keyed `c{cycle}:{token}`; `scope_weeks` maps any scope key to its inclusive program-week range; `resolve_sources` recursively decomposes skipped lower levels down to daily entries, chronologically ordered with reflections ahead of the entries they summarize. Every boundary derives from `STAGE_DURATIONS_DAYS` — no hardcoded week numbers.
- Promotes `program_calendar._elapsed_days` to a public `elapsed_days` (call sites updated, no behavior change) so timezone normalization stays single-sourced.

## Test plan

- New `backend/tests/domain/test_reflection_hierarchy.py` (44 pure sync tests): mid-week/clock-skew none, plain/odd/even stage ends, stage-6 tier-beats-component, week-36 program-beats-everything, 6-week stages, cycle-2 keys, `scope_weeks` ranges + all ValueError cases, and decomposition of a skipped week, a fully-skipped stage, a fully-skipped tier, and the deep program chain.
- `./scripts/backend/check-all.sh` green (2489 passed, 2 skipped; 96.8% total coverage). Module has 100% line + 100% branch coverage; ruff `select=ALL`, ruff-format, mypy strict, xenon A-grade, and interrogate (100%) all pass.

Pure domain only — models/migration land in hierarchical-journaling-02, the API in -03.

Closes #1459
Refs #1458
