### PR TITLE
feat(backend): add reflection scope to journal entries and the promoted-quote table

### DIFF
--- a/backend/migrations/versions/c4f7a2b8d9e1_hierarchical_reflection_scope_and_promoted_quote.py
+++ b/backend/migrations/versions/c4f7a2b8d9e1_hierarchical_reflection_scope_and_promoted_quote.py
@@ -1,0 +1,123 @@
+"""Add hierarchical reflection scope to journalentry and the promotedquote table.
+
+Revision ID: c4f7a2b8d9e1
+Revises: f7a8b9c0d1e3
+Create Date: 2026-07-08 00:00:00.000000
+
+Backs the hierarchical-journaling data layer (issue #1460):
+
+* Two nullable columns on ``journalentry`` -- ``reflection_level`` and
+  ``reflection_scope_key`` -- plus a CHECK pinning the level to the
+  ReflectionLevel set, a paired CHECK keeping the two columns in lock-step, and
+  a partial unique index enforcing at most one *live* entry per
+  ``(user_id, reflection_scope_key)`` coordinate (NULL scopes excluded, soft-
+  deleted rows excluded).
+* A new ``promotedquote`` table holding one row per quote a user lifted from a
+  source entry, with anchor-bound CHECKs and two FKs back to ``journalentry``
+  (its source, CASCADE, and the entry it was folded into, SET NULL).
+
+A migration is a frozen historical snapshot and must be self-contained: it
+cannot import live application code (``domain.reflection_hierarchy``,
+``services.journal_encryption``), so the level list is inlined and the encrypted
+text column is declared as a plain ``sa.Text``. The CHECK/index names and SQL
+below are IDENTICAL to the model's ``__table_args__`` so ``alembic check`` sees
+no drift. Both dialects get ``postgresql_where`` and ``sqlite_where`` on the
+partial index for the same reason. ``upgrade`` adds the columns, CHECKs, index,
+and table; ``downgrade`` reverses them in order.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4f7a2b8d9e1"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "f7a8b9c0d1e3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_JOURNAL_TABLE = "journalentry"
+_QUOTE_TABLE = "promotedquote"
+
+_LEVEL_CHECK = "ck_journalentry_reflection_level_valid"
+_SCOPE_PAIRED_CHECK = "ck_journalentry_reflection_scope_paired"
+_SCOPE_INDEX = "ix_journalentry_user_reflection_scope"
+
+# Inlined literals mirroring the model. ``_LEVEL_CONDITION`` lists the
+# ReflectionLevel values as of this revision; ``_SCOPE_PREDICATE`` is the partial
+# index's WHERE clause, identical for both dialects.
+_LEVEL_CONDITION = (
+    "reflection_level IS NULL "
+    "OR reflection_level IN ('week', 'stage', 'component', 'tier', 'program')"
+)
+_SCOPE_PAIRED_CONDITION = "(reflection_level IS NULL) = (reflection_scope_key IS NULL)"
+_SCOPE_PREDICATE = "reflection_scope_key IS NOT NULL AND deleted_at IS NULL"
+
+_QUOTE_SOURCE_INDEX = "ix_promotedquote_source_entry_id"
+_QUOTE_USER_INCLUDED_INDEX = "ix_promotedquote_user_included"
+_QUOTE_START_CHECK = "ck_promotedquote_anchor_start_nonneg"
+_QUOTE_SPAN_CHECK = "ck_promotedquote_anchor_span_positive"
+
+
+def upgrade() -> None:
+    """Add the reflection-scope columns, CHECKs, and index, then create promotedquote."""
+    op.add_column(
+        _JOURNAL_TABLE,
+        sa.Column("reflection_level", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        _JOURNAL_TABLE,
+        sa.Column("reflection_scope_key", sa.String(length=30), nullable=True),
+    )
+    # Install the CHECKs in a single batch rebuild so SQLite (round-trip test)
+    # stays compatible.
+    with op.batch_alter_table(_JOURNAL_TABLE) as batch_op:
+        batch_op.create_check_constraint(_LEVEL_CHECK, _LEVEL_CONDITION)
+        batch_op.create_check_constraint(_SCOPE_PAIRED_CHECK, _SCOPE_PAIRED_CONDITION)
+    op.create_index(
+        _SCOPE_INDEX,
+        _JOURNAL_TABLE,
+        ["user_id", "reflection_scope_key"],
+        unique=True,
+        postgresql_where=sa.text(_SCOPE_PREDICATE),
+        sqlite_where=sa.text(_SCOPE_PREDICATE),
+    )
+
+    op.create_table(
+        _QUOTE_TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("source_entry_id", sa.Integer(), nullable=False),
+        sa.Column("anchor_start", sa.Integer(), nullable=False),
+        sa.Column("anchor_end", sa.Integer(), nullable=False),
+        sa.Column("anchor_text", sa.Text(), nullable=False),
+        sa.Column("included_in_entry_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["source_entry_id"], ["journalentry.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["included_in_entry_id"],
+            ["journalentry.id"],
+            ondelete="SET NULL",
+        ),
+        sa.CheckConstraint("anchor_start >= 0", name=_QUOTE_START_CHECK),
+        sa.CheckConstraint("anchor_end > anchor_start", name=_QUOTE_SPAN_CHECK),
+    )
+    op.create_index(_QUOTE_SOURCE_INDEX, _QUOTE_TABLE, ["source_entry_id"])
+    op.create_index(_QUOTE_USER_INCLUDED_INDEX, _QUOTE_TABLE, ["user_id", "included_in_entry_id"])
+
+
+def downgrade() -> None:
+    """Drop promotedquote, the partial index, the CHECKs, and the reflection columns."""
+    op.drop_index(_QUOTE_USER_INCLUDED_INDEX, table_name=_QUOTE_TABLE)
+    op.drop_index(_QUOTE_SOURCE_INDEX, table_name=_QUOTE_TABLE)
+    op.drop_table(_QUOTE_TABLE)
+
+    op.drop_index(_SCOPE_INDEX, table_name=_JOURNAL_TABLE)
+    with op.batch_alter_table(_JOURNAL_TABLE) as batch_op:
+        batch_op.drop_constraint(_SCOPE_PAIRED_CHECK, type_="check")
+        batch_op.drop_constraint(_LEVEL_CHECK, type_="check")
+        batch_op.drop_column("reflection_scope_key")
+        batch_op.drop_column("reflection_level")

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -22,6 +22,7 @@ from .practice_session import PracticeSession
 from .practice_session_idempotency import PracticeSessionSpend
 from .practice_share_link import PracticeShareLink
 from .practice_tag import PracticeTag
+from .promoted_quote import PromotedQuote
 from .prompt_response import PromptResponse
 from .revoked_token import RevokedToken
 from .stage_content import StageContent
@@ -55,6 +56,7 @@ __all__ = [
     "PracticeSessionSpend",
     "PracticeShareLink",
     "PracticeTag",
+    "PromotedQuote",
     "PromptResponse",
     "RevokedToken",
     "StageContent",

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -2,10 +2,11 @@ import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Index
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, String, and_
 from sqlmodel import Field, Relationship, SQLModel
 
 from domain.constants import TOTAL_STAGES
+from domain.reflection_hierarchy import ReflectionLevel
 from services.journal_encryption import EncryptedString
 
 # The inclusive lower bound of a valid Aspect tag. The upper bound is
@@ -13,9 +14,19 @@ from services.journal_encryption import EncryptedString
 # drifts from the curriculum length.
 ASPECT_MIN = 1
 
+# Bound at module scope so the partial unique index's ``*_where`` predicates can
+# resolve these columns by name at table-creation time (mirrors
+# :mod:`models.invitation_signal`). They are detached references used only by the
+# predicate — the real columns are declared as ``Field``s on the model — so both
+# Postgres and SQLite render the same ``IS NULL`` / ``IS NOT NULL`` form and the
+# partial index stays drift-free against the migration.
+_REFLECTION_SCOPE_COLUMN = Column("reflection_scope_key", String, nullable=True)
+_DELETED_AT_COLUMN = Column("deleted_at", DateTime(timezone=True), nullable=True)
+
 if TYPE_CHECKING:
     from .completion_suggestion import CompletionSuggestion
     from .marginalia import Marginalia
+    from .promoted_quote import PromotedQuote
     from .user import User
 
 
@@ -34,6 +45,10 @@ class JournalTag(enum.StrEnum):
     # distinct tag so stage-scoped aggregates (filtered by
     # ``STAGE_REFLECTION``) do not double-count them.
     WEEKLY_PROMPT = "weekly_prompt"
+    # A reflection that closes a layer of the nested APTITUDE calendar (week,
+    # stage, component, tier, or program). Carries a ``reflection_level`` /
+    # ``reflection_scope_key`` pair pinning which layer it summarizes.
+    HIERARCHICAL_REFLECTION = "hierarchical_reflection"
 
 
 class EntryStatus(enum.StrEnum):
@@ -66,6 +81,23 @@ def _classification_check() -> CheckConstraint:
     return CheckConstraint(
         f"classification IN ({quoted})",
         name="ck_journalentry_classification_valid",
+    )
+
+
+def _reflection_level_check() -> CheckConstraint:
+    """CHECK derived from ``ReflectionLevel`` so the DB set can't drift from the enum."""
+    quoted = ", ".join(f"'{level.value}'" for level in ReflectionLevel)
+    return CheckConstraint(
+        f"reflection_level IS NULL OR reflection_level IN ({quoted})",
+        name="ck_journalentry_reflection_level_valid",
+    )
+
+
+def _reflection_scope_paired_check() -> CheckConstraint:
+    """CHECK that ``reflection_level`` and ``reflection_scope_key`` are set (or unset) together."""
+    return CheckConstraint(
+        "(reflection_level IS NULL) = (reflection_scope_key IS NULL)",
+        name="ck_journalentry_reflection_scope_paired",
     )
 
 
@@ -123,6 +155,27 @@ class JournalEntry(SQLModel, table=True):
         _aspect_range_check("primary_aspect", "ck_journalentry_primary_aspect_range"),
         _aspect_range_check("secondary_aspect", "ck_journalentry_secondary_aspect_range"),
         _chord_shape_check(),
+        _reflection_level_check(),
+        _reflection_scope_paired_check(),
+        # At most one *live* entry may hold a given (user, scope) coordinate: a
+        # partial unique index over live rows (``deleted_at IS NULL``) that
+        # excludes NULL scopes, so soft-deleting an entry frees its scope for
+        # reuse and freeform (scopeless) entries never collide. Both dialects
+        # render the same predicate; the migration installs the identical index.
+        Index(
+            "ix_journalentry_user_reflection_scope",
+            "user_id",
+            "reflection_scope_key",
+            unique=True,
+            postgresql_where=and_(
+                _REFLECTION_SCOPE_COLUMN.is_not(None),
+                _DELETED_AT_COLUMN.is_(None),
+            ),
+            sqlite_where=and_(
+                _REFLECTION_SCOPE_COLUMN.is_not(None),
+                _DELETED_AT_COLUMN.is_(None),
+            ),
+        ),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -151,6 +204,10 @@ class JournalEntry(SQLModel, table=True):
     sender: str = Field(max_length=10)  # 'user' or 'bot'
     user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
     tag: str = Field(default=JournalTag.FREEFORM, max_length=50)
+    # Hierarchical-reflection scope: which calendar layer this entry closes and
+    # its ``c{cycle}:{token}`` key. The paired CHECK keeps the two in lock-step.
+    reflection_level: str | None = Field(default=None, max_length=20)
+    reflection_scope_key: str | None = Field(default=None, max_length=30)
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")
     # BUG-JOURNAL-007: soft-delete column.  ``None`` = live row; non-None = deleted.
@@ -174,4 +231,14 @@ class JournalEntry(SQLModel, table=True):
     suggestions: list["CompletionSuggestion"] = Relationship(
         back_populates="entry",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+    # ``PromotedQuote`` carries two FKs back to ``journalentry`` (its source and,
+    # optionally, the entry it was later folded into); this relationship binds
+    # only the source side, so ``foreign_keys`` is required to disambiguate.
+    promoted_quotes: list["PromotedQuote"] = Relationship(
+        back_populates="source_entry",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "foreign_keys": "PromotedQuote.source_entry_id",
+        },
     )

--- a/backend/src/models/promoted_quote.py
+++ b/backend/src/models/promoted_quote.py
@@ -1,0 +1,80 @@
+"""A quote a user promoted from one journal entry to carry into another.
+
+A ``PromotedQuote`` row anchors a span of a source journal entry (by character
+offsets, with the spanned text snapshotted so it survives later edits) that the
+user chose to lift out and, optionally, weave into a subsequent reflection. Data-
+layer only — endpoints and the promotion flow live in later issues.
+"""
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Index
+from sqlmodel import Field, Relationship, SQLModel
+
+from services.journal_encryption import EncryptedString
+
+if TYPE_CHECKING:
+    from .journal_entry import JournalEntry
+
+# The plaintext cap on a promoted quote's snapshotted text. Enforced at the write
+# boundary by the schema layer (a later issue), not on the encrypted DB column —
+# the constant lives here so that layer imports a single source of truth.
+PROMOTED_QUOTE_TEXT_MAX = 1000
+
+
+class PromotedQuote(SQLModel, table=True):
+    """A single anchored quote lifted from a source journal entry.
+
+    ``anchor_start`` / ``anchor_end`` are character offsets into the source
+    entry's text; ``anchor_text`` snapshots the spanned substring so the quote
+    survives later edits. ``included_in_entry_id`` points at the entry the quote
+    was folded into, or NULL while it is still pending.
+    """
+
+    # The hot read is "all quotes for a source entry", so index that FK; a second
+    # composite index covers "a user's quotes by the entry they were folded into".
+    # The CHECKs keep anchor bounds honest at the DB level so a non-ORM writer
+    # can't persist a negative start or an inverted span (mirrors ``Marginalia``).
+    __table_args__ = (
+        Index("ix_promotedquote_source_entry_id", "source_entry_id"),
+        Index("ix_promotedquote_user_included", "user_id", "included_in_entry_id"),
+        CheckConstraint("anchor_start >= 0", name="ck_promotedquote_anchor_start_nonneg"),
+        CheckConstraint("anchor_end > anchor_start", name="ck_promotedquote_anchor_span_positive"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE")
+    source_entry_id: int = Field(foreign_key="journalentry.id", ondelete="CASCADE")
+    anchor_start: int = Field(ge=0)
+    anchor_end: int = Field(ge=1)  # DB CHECK also enforces anchor_end > anchor_start
+    # Encrypted at rest via EncryptedString. No Field max_length here (it can't
+    # coexist with sa_column, and ciphertext exceeds the plaintext so the column
+    # is Text): the PROMOTED_QUOTE_TEXT_MAX plaintext cap is enforced at the write
+    # boundary by the schema layer (a later issue), mirroring JournalEntry.message.
+    anchor_text: str = Field(sa_column=Column(EncryptedString(), nullable=False))
+    included_in_entry_id: int | None = Field(
+        default=None,
+        foreign_key="journalentry.id",
+        ondelete="SET NULL",
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            nullable=False,
+            onupdate=lambda: datetime.now(UTC),
+        ),
+    )
+    # Two FKs point back to ``journalentry`` (source + optional inclusion target),
+    # so this relationship MUST name ``foreign_keys`` or SQLAlchemy raises
+    # AmbiguousForeignKeysError at import. ``included_in_entry_id`` is a bare FK
+    # column with no relationship of its own.
+    source_entry: "JournalEntry" = Relationship(
+        back_populates="promoted_quotes",
+        sa_relationship_kwargs={"foreign_keys": "PromotedQuote.source_entry_id"},
+    )

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2184,3 +2184,135 @@ def test_local_day_migration_archives_same_day_duplicate_on_sqlite(
     assert _ids_from_query(db_url, "SELECT id FROM goalcompletion ORDER BY id") == [1]
     assert _table_exists(db_url, "_duplicates_goalcompletion")
     assert _ids_from_query(db_url, "SELECT id FROM _duplicates_goalcompletion ORDER BY id") == [2]
+
+
+# -- hierarchical reflection scope + promotedquote migration round-trip ------
+
+# down_revision is f7a8b9c0d1e3 (the goalcompletion local_day migration, current head).
+_HIER_REFLECTION_BASE_REVISION = "f7a8b9c0d1e3"  # pragma: allowlist secret
+_HIER_REFLECTION_REVISION = "c4f7a2b8d9e1"  # pragma: allowlist secret
+
+
+def _index_names(db_url: str, table: str) -> set[str]:
+    """Return the set of index names installed on ``table``."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        return {ix["name"] for ix in inspect(engine).get_indexes(table) if ix["name"] is not None}
+    finally:
+        engine.dispose()
+
+
+def _bootstrap_hier_reflection_baseline(sync_url: str) -> None:
+    """Bootstrap minimal ``user`` and ``journalentry`` tables for the round-trip fixture.
+
+    Mirrors the shape just before the hierarchical-reflection migration,
+    without pulling in every preceding migration.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'hier@example.com')"))
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " tag VARCHAR(50) NOT NULL DEFAULT 'freeform',"
+                " status VARCHAR(20) NOT NULL DEFAULT 'draft',"
+                " title VARCHAR(200),"
+                " deleted_at DATETIME,"
+                " updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                " timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry (id, user_id, sender, message)"
+                " VALUES (1, 1, 'user', 'Pre-hierarchical-reflection entry.')"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_hier_reflection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the hierarchical-reflection migration.
+
+    Bootstraps minimal ``user`` and ``journalentry`` tables and stamps the DB
+    at ``f7a8b9c0d1e3`` (the chain head before this migration) so the
+    round-trip exercises only the new migration.
+    """
+    db_path = tmp_path / "hier_reflection_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_hier_reflection_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _HIER_REFLECTION_BASE_REVISION)
+    return cfg
+
+
+def test_hier_reflection_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_hier_reflection: Config,
+) -> None:
+    """Round-trip the hierarchical-reflection migration.
+
+    Phase 1: upgrade adds journalentry.reflection_level / reflection_scope_key,
+    creates the promotedquote table with the expected columns, and installs
+    the partial unique index on (user_id, reflection_scope_key).
+    Phase 2: downgrade removes the columns, the index, and the table.
+    Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_hier_reflection
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds the journalentry columns and the promotedquote table.
+    command.upgrade(cfg, _HIER_REFLECTION_REVISION)
+    journal_cols = _columns_of(db_url, "journalentry")
+    assert "reflection_level" in journal_cols
+    assert "reflection_scope_key" in journal_cols
+
+    assert _table_exists(db_url, "promotedquote")
+    quote_cols = _columns_of(db_url, "promotedquote")
+    expected_quote_cols = {
+        "id",
+        "user_id",
+        "source_entry_id",
+        "anchor_start",
+        "anchor_end",
+        "anchor_text",
+        "included_in_entry_id",
+        "created_at",
+        "updated_at",
+    }
+    assert expected_quote_cols.issubset(quote_cols)
+
+    assert "ix_journalentry_user_reflection_scope" in _index_names(db_url, "journalentry")
+
+    # Phase 2: downgrade removes the columns, index, and table.
+    command.downgrade(cfg, _HIER_REFLECTION_BASE_REVISION)
+    journal_cols_after = _columns_of(db_url, "journalentry")
+    assert "reflection_level" not in journal_cols_after
+    assert "reflection_scope_key" not in journal_cols_after
+    assert not _table_exists(db_url, "promotedquote")
+
+    # Phase 3: re-upgrade is idempotent.
+    command.upgrade(cfg, _HIER_REFLECTION_REVISION)
+    journal_cols_final = _columns_of(db_url, "journalentry")
+    assert "reflection_level" in journal_cols_final
+    assert "reflection_scope_key" in journal_cols_final
+    assert _table_exists(db_url, "promotedquote")

--- a/backend/tests/test_promoted_quote_model.py
+++ b/backend/tests/test_promoted_quote_model.py
@@ -1,0 +1,310 @@
+"""Data-layer tests for hierarchical reflection scope and PromotedQuote."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel, col
+
+from models.journal_entry import JournalEntry, JournalTag
+from models.promoted_quote import PromotedQuote
+from models.user import User
+from services import journal_encryption as je
+
+
+async def _user(session: AsyncSession, email: str = "reflect@example.com") -> int:
+    """Insert a user row and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.flush()
+    assert user.id is not None
+    return user.id
+
+
+def _reflection_entry(user_id: int, **over: object) -> JournalEntry:
+    """Build a hierarchical-reflection JournalEntry with sane defaults."""
+    base: dict[str, object] = {
+        "sender": "user",
+        "user_id": user_id,
+        "message": "A stage of grief and grace.",
+        "tag": JournalTag.HIERARCHICAL_REFLECTION,
+        "reflection_level": "stage",
+        "reflection_scope_key": "c1:s3",
+    }
+    base.update(over)
+    return JournalEntry(**base)
+
+
+def _quote(user_id: int, source_entry_id: int, **over: object) -> PromotedQuote:
+    """Build a PromotedQuote with sane defaults."""
+    base: dict[str, object] = {
+        "user_id": user_id,
+        "source_entry_id": source_entry_id,
+        "anchor_start": 120,
+        "anchor_end": 214,
+        "anchor_text": "I noticed the anger was really grief",
+    }
+    base.update(over)
+    return PromotedQuote(**base)
+
+
+def test_hierarchical_reflection_tag_value() -> None:
+    """The new tag enum member exists with the expected string value."""
+    assert JournalTag.HIERARCHICAL_REFLECTION.value == "hierarchical_reflection"
+
+
+@pytest.mark.asyncio
+async def test_reflection_entry_persists_level_and_scope(db_session: AsyncSession) -> None:
+    """A hierarchical-reflection entry round-trips reflection_level and reflection_scope_key."""
+    user_id = await _user(db_session)
+    db_session.add(_reflection_entry(user_id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(JournalEntry))).scalar_one()
+    assert row.reflection_level == "stage"
+    assert row.reflection_scope_key == "c1:s3"
+    assert row.tag == JournalTag.HIERARCHICAL_REFLECTION
+
+
+@pytest.mark.asyncio
+async def test_invalid_reflection_level_is_rejected(db_session: AsyncSession) -> None:
+    """A reflection_level outside the ReflectionLevel set violates the CHECK constraint."""
+    user_id = await _user(db_session)
+    db_session.add(_reflection_entry(user_id, reflection_level="galaxy"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_level_without_scope_key_is_rejected(db_session: AsyncSession) -> None:
+    """reflection_level set with reflection_scope_key NULL violates the pairing CHECK."""
+    user_id = await _user(db_session)
+    db_session.add(_reflection_entry(user_id, reflection_scope_key=None))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_scope_key_without_level_is_rejected(db_session: AsyncSession) -> None:
+    """reflection_scope_key set with reflection_level NULL violates the pairing CHECK."""
+    user_id = await _user(db_session)
+    db_session.add(_reflection_entry(user_id, reflection_level=None))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_live_scope_key_is_rejected(db_session: AsyncSession) -> None:
+    """Two live entries sharing (user_id, reflection_scope_key) violate the partial unique index."""
+    user_id = await _user(db_session)
+    db_session.add(_reflection_entry(user_id))
+    await db_session.commit()
+
+    db_session.add(_reflection_entry(user_id))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_same_scope_key_allowed_across_users(db_session: AsyncSession) -> None:
+    """The partial unique index is per-user: two users may share one scope key."""
+    first_user = await _user(db_session, email="one@example.com")
+    second_user = await _user(db_session, email="two@example.com")
+    db_session.add_all([_reflection_entry(first_user), _reflection_entry(second_user)])
+    await db_session.commit()
+
+    count = (await db_session.execute(select(func.count()).select_from(JournalEntry))).scalar_one()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_scope_key_frees_it_for_reuse(db_session: AsyncSession) -> None:
+    """A soft-deleted entry does not count toward the live partial unique index."""
+    user_id = await _user(db_session)
+    first = _reflection_entry(user_id)
+    db_session.add(first)
+    await db_session.commit()
+
+    first.deleted_at = datetime.now(UTC)
+    await db_session.commit()
+
+    db_session.add(_reflection_entry(user_id))
+    await db_session.commit()
+
+    live_count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(JournalEntry)
+            .where(col(JournalEntry.deleted_at).is_(None)),
+        )
+    ).scalar_one()
+    assert live_count == 1
+
+
+@pytest.mark.asyncio
+async def test_null_scope_key_entries_never_collide(db_session: AsyncSession) -> None:
+    """Two entries with reflection_scope_key NULL never collide (partial index excludes NULLs)."""
+    user_id = await _user(db_session)
+    db_session.add_all(
+        [
+            JournalEntry(sender="user", user_id=user_id, message="freeform one"),
+            JournalEntry(sender="user", user_id=user_id, message="freeform two"),
+        ],
+    )
+    await db_session.commit()
+
+    count = (await db_session.execute(select(func.count()).select_from(JournalEntry))).scalar_one()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_promoted_quote_persists_and_reads_back(db_session: AsyncSession) -> None:
+    """A PromotedQuote row persists and its anchor fields round-trip."""
+    user_id = await _user(db_session)
+    entry = _reflection_entry(user_id)
+    db_session.add(entry)
+    await db_session.flush()
+    assert entry.id is not None
+
+    db_session.add(_quote(user_id, entry.id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(PromotedQuote))).scalar_one()
+    assert row.anchor_start == 120
+    assert row.anchor_end == 214
+    assert row.anchor_text == "I noticed the anger was really grief"
+    assert row.included_in_entry_id is None
+    assert row.created_at is not None
+    assert row.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_anchor_text_is_encrypted_at_rest(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With encryption configured, the raw column holds ciphertext, not the plaintext quote."""
+    monkeypatch.setenv("JOURNAL_ENCRYPTION_KEYS", Fernet.generate_key().decode())
+    je.reset_cache()
+    try:
+        user_id = await _user(db_session)
+        entry = _reflection_entry(user_id)
+        db_session.add(entry)
+        await db_session.flush()
+        assert entry.id is not None
+
+        db_session.add(_quote(user_id, entry.id))
+        await db_session.commit()
+
+        raw = (await db_session.execute(text("SELECT anchor_text FROM promotedquote"))).scalar_one()
+        assert raw != "I noticed the anger was really grief"
+        assert "grief" not in raw
+        assert je.decrypt(raw) == "I noticed the anger was really grief"
+    finally:
+        je.reset_cache()
+
+
+@pytest.mark.asyncio
+async def test_negative_anchor_start_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_start must be non-negative (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry = _reflection_entry(user_id)
+    db_session.add(entry)
+    await db_session.flush()
+    assert entry.id is not None
+
+    db_session.add(_quote(user_id, entry.id, anchor_start=-1))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_inverted_anchor_span_is_rejected(db_session: AsyncSession) -> None:
+    """anchor_end must be greater than anchor_start (CHECK constraint)."""
+    user_id = await _user(db_session)
+    entry = _reflection_entry(user_id)
+    db_session.add(entry)
+    await db_session.flush()
+    assert entry.id is not None
+
+    db_session.add(_quote(user_id, entry.id, anchor_start=100, anchor_end=100))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_source_entry_delete_cascades_to_quotes(db_session: AsyncSession) -> None:
+    """Deleting the source journal entry removes its promoted quotes (delete-orphan)."""
+    user_id = await _user(db_session)
+    entry = _reflection_entry(user_id)
+    db_session.add(entry)
+    await db_session.flush()
+    assert entry.id is not None
+    entry_id = entry.id
+
+    db_session.add(_quote(user_id, entry_id))
+    await db_session.commit()
+
+    loaded = await db_session.get(JournalEntry, entry_id)
+    assert loaded is not None
+    await db_session.delete(loaded)
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(select(func.count()).select_from(PromotedQuote))
+    ).scalar_one()
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_deleting_included_entry_sets_quote_back_to_pending() -> None:
+    """Deleting the reflection entry a quote was included in nulls out included_in_entry_id.
+
+    Uses a dedicated in-memory engine so PRAGMA foreign_keys = ON is scoped
+    entirely to this test and never leaks to the shared test_engine.
+    """
+    isolated_engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    factory = async_sessionmaker(isolated_engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with isolated_engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+            await conn.execute(text("PRAGMA foreign_keys = ON"))
+
+        async with factory() as session:
+            user_id = await _user(session)
+            source = _reflection_entry(user_id, reflection_scope_key="c1:s3")
+            session.add(source)
+            await session.flush()
+            assert source.id is not None
+            source_id = source.id
+
+            included = _reflection_entry(user_id, reflection_scope_key="c1:s4")
+            session.add(included)
+            await session.flush()
+            assert included.id is not None
+            included_id = included.id
+
+            quote = _quote(user_id, source_id, included_in_entry_id=included_id)
+            session.add(quote)
+            await session.commit()
+
+            await session.execute(text("PRAGMA foreign_keys = ON"))
+            loaded = await session.get(JournalEntry, included_id)
+            assert loaded is not None
+            await session.delete(loaded)
+            await session.commit()
+
+            await session.refresh(quote)
+            assert quote.included_in_entry_id is None
+
+            remaining = (
+                await session.execute(select(func.count()).select_from(PromotedQuote))
+            ).scalar_one()
+            assert remaining == 1
+    finally:
+        await isolated_engine.dispose()


### PR DESCRIPTION
## Summary

Sub-issue 2 of the hierarchical-journaling epic (#1458). Persists the reflection vocabulary defined by the sub-1 domain layer (`backend/src/domain/reflection_hierarchy.py`) so a 7th-day reflection is a real journal entry that knows its zoom level and scope, and promoted quotes are stored durably against their source entries. Data layer only — routers/schemas land in sub-3 (#1461).

- `JournalTag` gains `HIERARCHICAL_REFLECTION` (string column — no migration needed for the tag itself).
- `JournalEntry` gains nullable `reflection_level` (max 20) and `reflection_scope_key` (max 30) with (a) an enum-derived CHECK pinning `reflection_level` to the `ReflectionLevel` set, (b) a paired CHECK `(reflection_level IS NULL) = (reflection_scope_key IS NULL)`, and (c) a partial unique index on `(user_id, reflection_scope_key)` WHERE the key is non-NULL and the row is live — one live reflection per scope per user.
- New `PromotedQuote` table (`backend/src/models/promoted_quote.py`): marginalia-style span anchor (`anchor_start >= 0`, `anchor_end > anchor_start` CHECKs), `anchor_text` encrypted at rest via `EncryptedString`, `source_entry_id` FK CASCADE, `included_in_entry_id` FK SET NULL (deleting a reflection returns its quotes to pending), indexes on `source_entry_id` and `(user_id, included_in_entry_id)`. Registered `JournalEntry.promoted_quotes` (cascade delete-orphan; explicit `foreign_keys` disambiguates the two FKs to `journalentry`).
- One reversible Alembic migration (`c4f7a2b8d9e1`, chained to the single head `f7a8b9c0d1e3`) installing identical CHECK/index SQL for both dialects.

## Test plan

- New `backend/tests/test_promoted_quote_model.py`: tag value; reflection field round-trip; level CHECK rejects an off-enum value; pairing CHECK both directions; partial unique index rejects a second live row, allows reuse after soft-delete, allows the same key across users, and never collides on NULL scopes; PromotedQuote persistence + anchor CHECKs; `anchor_text` ciphertext-at-rest + decrypt round-trip; source-entry delete cascades to quotes; deleting an inclusion target resets the quote to pending (SET NULL).
- New SQLite round-trip test in `backend/tests/test_migrations.py`: upgrade adds both columns, the CHECKs, the partial unique index, and the `promotedquote` table; downgrade removes them; re-upgrade is idempotent.
- `./scripts/backend/check-all.sh` green (tests 96.67% coverage, ruff lint/format, mypy, bandit, pip-audit, detect-secrets); xenon A-grade + radon MI ≥ B; interrogate 95.6%. Single alembic head confirmed; the model's Postgres-compiled partial-index predicate matches the migration's WHERE text byte-for-byte (drift-free).

Closes #1460
Refs #1458