### PR TITLE
ci(maintenance): gate producer scans on total open-backlog size

### DIFF
--- a/.github/workflows/_claude-scan.yml
+++ b/.github/workflows/_claude-scan.yml
@@ -48,8 +48,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Backlog drain gate: producer scans only ADD to the queue, so they must not
+  # keep filing while the backlog is already bloated with un-drained work —
+  # otherwise tech-debt/hygiene findings bury the user-facing bugs and features
+  # Ralph should be spending tokens on. Mirrors the threshold in hopper.yml's
+  # off-schedule refill gate; unlike the hopper (which only measures the
+  # agent-ready subset), this counts the WHOLE open backlog, since a bloated
+  # backlog starves grooming/triage capacity even before issues reach
+  # agent-ready.
+  gate:
+    name: Backlog drain gate
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      BACKLOG_MAX: "50"
+    steps:
+      - name: Check total open backlog size
+        id: check
+        run: |
+          set -euo pipefail
+          TOTAL=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+                    --limit 300 --json number --jq 'length')
+          echo "Total open backlog: $TOTAL (gate threshold: $BACKLOG_MAX)" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$TOTAL" -ge "$BACKLOG_MAX" ]; then
+            echo "::notice::Backlog has $TOTAL open issues (>= $BACKLOG_MAX) — standing down so it can drain instead of piling on more findings."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   scan:
     name: "Scan ${{ inputs.scan_name }}"
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/deslop.yml
+++ b/.github/workflows/deslop.yml
@@ -47,8 +47,37 @@ permissions:
   id-token: write
 
 jobs:
+  # Backlog drain gate — see _claude-scan.yml for the rationale. De-slop is a
+  # producer like the other maintenance scans: it only adds issues, so it must
+  # not keep filing while the backlog is already bloated with un-drained work.
+  gate:
+    name: Backlog drain gate
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      BACKLOG_MAX: "50"
+    steps:
+      - name: Check total open backlog size
+        id: check
+        run: |
+          set -euo pipefail
+          TOTAL=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+                    --limit 300 --json number --jq 'length')
+          echo "Total open backlog: $TOTAL (gate threshold: $BACKLOG_MAX)" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$TOTAL" -ge "$BACKLOG_MAX" ]; then
+            echo "::notice::Backlog has $TOTAL open issues (>= $BACKLOG_MAX) — standing down so it can drain instead of piling on more findings."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   plan:
     name: Resolve target areas
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.areas.outputs.matrix }}

--- a/.github/workflows/hopper.yml
+++ b/.github/workflows/hopper.yml
@@ -28,7 +28,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       MIN_QUEUE: "12"           # ~6 hrs of runway at ~2 issues/hr
-      MAX_QUEUE: "80"           # above this, let the backlog drain
+      MAX_QUEUE: "80"           # above this, let the agent-ready queue drain
+      BACKLOG_MAX: "50"         # total open issues; overrides MIN_QUEUE below
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -38,6 +39,22 @@ jobs:
       - name: Measure runway and refill if starving
         run: |
           set -euo pipefail
+          TOTAL=$(gh issue list --state open --limit 300 --json number --jq 'length')
+          echo "Total open backlog: $TOTAL (gate threshold: $BACKLOG_MAX)" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+          # The agent-ready subset can look "starving" (few triaged/labeled
+          # issues) even while the TOTAL backlog is bloated with un-triaged or
+          # tech-debt work — that's a grooming problem, not a supply problem.
+          # Refilling more scan output in that state buries user-facing bugs
+          # and features deeper. So the total-backlog gate wins outright,
+          # regardless of agent-ready runway.
+          if [ "$TOTAL" -ge "$BACKLOG_MAX" ]; then
+            echo "Backlog bloated (>= $BACKLOG_MAX total open issues) — standing down regardless of agent-ready runway; groom before refilling." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           COUNT=$(gh issue list --label agent-ready --state open \
                     --limit 300 --json number --jq 'length')
           echo "Agent-ready queue depth: $COUNT" | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Scheduled scans (de-slop + the 11 _claude-scan.yml-based producers) fired on
fixed crons regardless of backlog depth, while hopper.yml only stood down
based on the agent-ready subset. Add a shared BACKLOG_MAX=50 gate so scans
stand down once the total open backlog is bloated, and make hopper check
total backlog before its agent-ready refill logic — a thin agent-ready queue
with a bloated total backlog means grooming is needed, not more scan output.