### PR TITLE
feat(backend): add reflections API — due, sources feed, and quote promotion

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -46,7 +46,9 @@ from routers.practice_sessions import router as practice_sessions_router
 from routers.practice_share import router as practice_share_router
 from routers.practice_tags import router as practice_tags_router
 from routers.practices import router as practices_router
+from routers.promotions import router as promotions_router
 from routers.prompts import router as prompts_router
+from routers.reflections import router as reflections_router
 from routers.stages import router as stages_router
 from routers.user_practices import router as user_practices_router
 from routers.users import router as users_router
@@ -436,6 +438,8 @@ app.include_router(user_practices_router)
 app.include_router(practice_sessions_router)
 app.include_router(habits_router)
 app.include_router(journal_router)
+app.include_router(reflections_router)
+app.include_router(promotions_router)
 app.include_router(prompts_router)
 app.include_router(energy_router)
 app.include_router(goal_completion_router)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -9,6 +9,7 @@ from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from sqlalchemy import ColumnElement
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -19,6 +20,7 @@ from domain.care import CarePayload, build_care_payload
 from domain.contraction import build_contraction_invitation, detect_contraction
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
+from domain.reflection_hierarchy import ReflectionLevel
 from domain.resonance import MarginaliaAnchored, generate_essay, generate_marginalia
 from domain.safety import assess_distress
 from domain.stage_progress import get_user_progress
@@ -94,6 +96,18 @@ def _sanitize_message(message: str) -> str:
         raise unprocessable("message_too_long") from exc
 
 
+def _coerce_reflection_level(data: dict[str, object]) -> None:
+    """Flatten a ``ReflectionLevel`` enum in a dumped payload to its plain value.
+
+    ``model_dump`` yields the enum member; the ORM column is a plain string, so
+    persisting the bare value keeps the partial unique index and the reflection
+    grammar comparing ordinary strings rather than enum reprs.
+    """
+    level = data.get("reflection_level")
+    if isinstance(level, ReflectionLevel):
+        data["reflection_level"] = level.value
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/journal", tags=["journal"])
@@ -144,9 +158,18 @@ async def create_journal_entry(
     """
     data = payload.model_dump()
     data["message"] = _sanitize_message(data["message"])
+    _coerce_reflection_level(data)
     entry = JournalEntry(sender="user", user_id=current_user, **data)
     session.add(entry)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        # A partial unique index guards one live entry per (user, scope); only a
+        # scoped write can trip it, so a scopeless collision is a real bug to raise.
+        if data.get("reflection_scope_key") is not None:
+            raise conflict("reflection_scope_taken") from exc
+        raise
     await session.refresh(entry)
     logger.info("journal_entry_created", extra={"user_id": current_user, "entry_id": entry.id})
     return entry
@@ -293,6 +316,20 @@ def _apply_chord_update(entry: JournalEntry, payload: JournalEntryUpdate) -> Non
         entry.secondary_aspect = payload.secondary_aspect
 
 
+def _apply_scope_update(entry: JournalEntry, payload: JournalEntryUpdate) -> None:
+    """Apply the reflection-scope (level/key) as one atomic pair.
+
+    Touching either field writes both, mirroring the chord update: the schema
+    validator already guarantees both-or-neither plus a well-formed key, so the
+    persisted pair stays a valid, in-lock-step reflection scope.
+    """
+    scope_fields = {"reflection_level", "reflection_scope_key"}
+    if payload.model_fields_set & scope_fields:
+        level = payload.reflection_level
+        entry.reflection_level = level.value if level is not None else None
+        entry.reflection_scope_key = payload.reflection_scope_key
+
+
 async def _apply_entry_update(
     entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
 ) -> None:
@@ -305,6 +342,7 @@ async def _apply_entry_update(
     if payload.classification is not None:
         entry.classification = payload.classification
     _apply_chord_update(entry, payload)
+    _apply_scope_update(entry, payload)
     # ``updated_at`` is bumped by the column's ``onupdate`` only when a value
     # actually changes, so a same-value PATCH doesn't move it.
 
@@ -336,7 +374,15 @@ async def update_journal_entry(
         raise not_found("journal_entry")
     await _apply_entry_update(entry, payload, session)
     session.add(entry)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as exc:
+        await session.rollback()
+        # The partial unique index only fires on a scoped write; a scopeless
+        # PATCH tripping it would be a real bug, so re-raise those.
+        if payload.reflection_scope_key is not None:
+            raise conflict("reflection_scope_taken") from exc
+        raise
     await session.refresh(entry)
     logger.info("journal_entry_updated", extra={"user_id": current_user, "entry_id": entry_id})
     return entry

--- a/backend/src/routers/promotions.py
+++ b/backend/src/routers/promotions.py
@@ -1,0 +1,173 @@
+"""Quote-promotion API — lift a span from one entry, optionally fold it into another.
+
+Promoting a quote anchors a character span of a source journal entry; the server
+slices and snapshots the text (the client sends only offsets) so the quote
+survives later edits. A promotion can then be folded into a hierarchical
+reflection or returned to pending. ``user_id`` is never returned.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from database import get_session
+from dependencies.ownership import require_owned_journal_entry
+from errors import not_found, unprocessable
+from models.journal_entry import JournalEntry, JournalTag
+from models.promoted_quote import PROMOTED_QUOTE_TEXT_MAX, PromotedQuote
+from routers.auth import get_current_user
+from schemas.promotion import PromotedQuoteResponse, PromoteQuoteCreate, PromotionUpdate
+from security import TextTooLongError, sanitize_user_text
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["promotions"])
+
+
+def _quote_response(quote: PromotedQuote) -> PromotedQuoteResponse:
+    """Map a promoted-quote row to its user_id-free response DTO."""
+    return PromotedQuoteResponse(
+        id=cast("int", quote.id),
+        source_entry_id=quote.source_entry_id,
+        anchor_start=quote.anchor_start,
+        anchor_end=quote.anchor_end,
+        anchor_text=quote.anchor_text,
+        pending=quote.included_in_entry_id is None,
+    )
+
+
+def _slice_anchor_text(entry: JournalEntry, payload: PromoteQuoteCreate) -> str:
+    """Slice + sanitize the anchored span from the persisted body.
+
+    The span is validated against the *server-held* body (never client text): an
+    end past the body length is 422 ``anchor_out_of_range``, and a normalized
+    span longer than the plaintext cap is 422 ``quote_too_long``.
+    """
+    if payload.anchor_end > len(entry.message):
+        raise unprocessable("anchor_out_of_range")
+    span = entry.message[payload.anchor_start : payload.anchor_end]
+    try:
+        return sanitize_user_text(span, max_len=PROMOTED_QUOTE_TEXT_MAX)
+    except TextTooLongError as exc:
+        raise unprocessable("quote_too_long") from exc
+
+
+@router.post(
+    "/journal/{entry_id}/promote",
+    response_model=PromotedQuoteResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def promote_quote(
+    payload: PromoteQuoteCreate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    entry: Annotated[JournalEntry, Depends(require_owned_journal_entry)],
+) -> PromotedQuoteResponse:
+    """Promote a span of the caller's own entry into a pending quote.
+
+    Ownership is enforced by ``require_owned_journal_entry`` (a missing,
+    soft-deleted, or foreign entry all resolve to 404). The span is sliced and
+    snapshotted server-side, so the quote starts life pending (unfolded).
+    """
+    anchor_text = _slice_anchor_text(entry, payload)
+    quote = PromotedQuote(
+        user_id=current_user,
+        source_entry_id=cast("int", entry.id),
+        anchor_start=payload.anchor_start,
+        anchor_end=payload.anchor_end,
+        anchor_text=anchor_text,
+        included_in_entry_id=None,
+    )
+    session.add(quote)
+    await session.commit()
+    await session.refresh(quote)
+    logger.info("quote_promoted", extra={"user_id": current_user, "quote_id": quote.id})
+    return _quote_response(quote)
+
+
+async def _load_owned_quote(
+    session: AsyncSession, promotion_id: int, user_id: int
+) -> PromotedQuote | None:
+    """Load the caller's own promoted quote, or None (404-scoped, enumeration-safe)."""
+    result = await session.execute(
+        select(PromotedQuote).where(
+            PromotedQuote.id == promotion_id,
+            PromotedQuote.user_id == user_id,
+        )
+    )
+    return result.scalars().first()
+
+
+@router.delete("/promotions/{promotion_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_promotion(
+    promotion_id: int,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> Response:
+    """Hard-delete the caller's own promoted quote (the model has no soft-delete).
+
+    A missing or foreign quote resolves to 404, so a second delete of the same
+    id 404s (enumeration-safe).
+    """
+    quote = await _load_owned_quote(session, promotion_id, current_user)
+    if quote is None:
+        raise not_found("promotion")
+    await session.delete(quote)
+    await session.commit()
+    logger.info(
+        "quote_promotion_deleted", extra={"user_id": current_user, "quote_id": promotion_id}
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+async def _validate_inclusion_target(session: AsyncSession, target_id: int, user_id: int) -> None:
+    """Ensure ``target_id`` is the caller's own live hierarchical reflection.
+
+    A missing or foreign target is 404; a live but non-reflection target is 422
+    ``target_not_reflection`` so a quote can only fold into a reflection page.
+    """
+    result = await session.execute(
+        select(JournalEntry).where(
+            JournalEntry.id == target_id,
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+    )
+    target = result.scalars().first()
+    if target is None:
+        raise not_found("journal_entry")
+    if target.tag != JournalTag.HIERARCHICAL_REFLECTION:
+        raise unprocessable("target_not_reflection")
+
+
+@router.patch("/promotions/{promotion_id}", response_model=PromotedQuoteResponse)
+async def update_promotion(
+    promotion_id: int,
+    payload: PromotionUpdate,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PromotedQuoteResponse:
+    """Fold the caller's own quote into a reflection, or return it to pending.
+
+    A missing or foreign promotion is 404. Setting ``included_in_entry_id``
+    requires the target to be the caller's own live hierarchical reflection
+    (404 / 422 otherwise); ``null`` clears the inclusion back to pending.
+    """
+    quote = await _load_owned_quote(session, promotion_id, current_user)
+    if quote is None:
+        raise not_found("promotion")
+    if payload.included_in_entry_id is not None:
+        await _validate_inclusion_target(session, payload.included_in_entry_id, current_user)
+    quote.included_in_entry_id = payload.included_in_entry_id
+    session.add(quote)
+    await session.commit()
+    await session.refresh(quote)
+    logger.info(
+        "quote_promotion_updated", extra={"user_id": current_user, "quote_id": promotion_id}
+    )
+    return _quote_response(quote)

--- a/backend/src/routers/reflections.py
+++ b/backend/src/routers/reflections.py
@@ -1,0 +1,345 @@
+"""Hierarchical-reflection API — what is due, and the material that composes it.
+
+Two read surfaces over the nested APTITUDE reflection calendar:
+
+* ``GET /reflections/due`` peeks at the widest layer that has just closed for the
+  caller (if any) and hands back its calendar window plus any reflection already
+  claiming that scope.
+* ``GET /reflections/sources`` returns the ordered source material feeding a
+  reflection at a given ``(level, scope_key)`` — child reflections standing in for
+  their spans, and the raw daily entries of every gap.
+
+All schedule math lives in :mod:`domain.reflection_hierarchy`; this router only
+turns program weeks into datetime windows and shuttles rows to and from it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from database import get_session
+from domain.program_calendar import calendar_week, elapsed_days, resolve_program_anchor
+from domain.reflection_hierarchy import (
+    EntryRef,
+    ReflectionLevel,
+    ReflectionRef,
+    SourceItem,
+    SourceKind,
+    due_reflection,
+    resolve_sources,
+    scope_weeks,
+)
+from domain.stage_progress import get_user_progress
+from errors import forbidden, unprocessable
+from models.journal_entry import EntryStatus, JournalEntry
+from models.promoted_quote import PromotedQuote
+from models.stage_progress import StageProgress
+from routers.auth import get_current_user
+from schemas.reflection import (
+    PromotedQuoteSummary,
+    ReflectionDue,
+    ReflectionDueResponse,
+    ReflectionSourceItem,
+    ReflectionSourcesResponse,
+)
+
+# Seven days to a program week; the window math is a multiple of this.
+_DAYS_PER_WEEK = 7
+
+# A user with no StageProgress row has not started the program, so the calendar
+# unlock check treats them as sitting in week 1.
+_UNSTARTED_USER_WEEK = 1
+
+router = APIRouter(prefix="/reflections", tags=["reflections"])
+
+
+def _due_window(anchor: datetime, level: ReflectionLevel, key: str) -> tuple[datetime, datetime]:
+    """Turn a due reflection's week span into its (start, end) datetime window.
+
+    The span comes from :func:`scope_weeks`; the start is the first day of its
+    first week and the end is the last day of its final week, both offset off the
+    program anchor.
+    """
+    weeks = scope_weeks(level, key)
+    start_week = weeks.start
+    end_week = weeks.stop - 1
+    window_start = anchor + timedelta(days=(start_week - 1) * _DAYS_PER_WEEK)
+    window_end = anchor + timedelta(days=end_week * _DAYS_PER_WEEK)
+    return window_start, window_end
+
+
+async def _existing_scope_entry_id(
+    session: AsyncSession, user_id: int, scope_key: str
+) -> int | None:
+    """Return the caller's live reflection id claiming ``scope_key``, or None.
+
+    Soft-deleted rows are excluded, so deleting a reflection frees the scope and
+    this drops back to None.
+    """
+    result = await session.execute(
+        select(JournalEntry.id).where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.reflection_scope_key) == scope_key,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+    )
+    return result.scalars().first()
+
+
+@router.get("/due", response_model=ReflectionDueResponse)
+async def get_due_reflection(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ReflectionDueResponse:
+    """Return the reflection that has just come due for the caller, if any.
+
+    A user with no program progress, or whose current day is not a week-closing
+    day, has nothing due (``due`` is ``None``). Otherwise the widest layer that
+    closes today wins, carried with its calendar window and any reflection
+    already claiming its scope.
+    """
+    progress = await get_user_progress(session, current_user)
+    if progress is None:
+        return ReflectionDueResponse(due=None)
+    anchor = resolve_program_anchor(progress)
+    due = due_reflection(anchor, cycle=progress.cycle_number)
+    if due is None:
+        return ReflectionDueResponse(due=None)
+    window_start, window_end = _due_window(anchor, due.level, due.key)
+    existing_entry_id = await _existing_scope_entry_id(session, current_user, due.key)
+    return ReflectionDueResponse(
+        due=ReflectionDue(
+            level=due.level.value,
+            scope_key=due.key,
+            window_start=window_start,
+            window_end=window_end,
+            existing_entry_id=existing_entry_id,
+        )
+    )
+
+
+def _validated_scope_weeks(level: ReflectionLevel, scope_key: str) -> range:
+    """Return the scope's week span, mapping a bad key/level pairing to 422.
+
+    :func:`scope_weeks` rejects a malformed key, a level/token mismatch, and an
+    out-of-range index alike; all three surface here as ``invalid_scope``.
+    """
+    try:
+        return scope_weeks(level, scope_key)
+    except ValueError as exc:
+        raise unprocessable("invalid_scope") from exc
+
+
+def _guard_scope_unlocked(weeks: range, progress: StageProgress | None) -> None:
+    """Reject a scope whose first week the caller's calendar has not yet reached.
+
+    An unstarted user sits in week 1, so only scopes opening at week 1 are
+    readable for them; everyone else is gated by their date-derived week.
+    """
+    user_week = (
+        calendar_week(resolve_program_anchor(progress))
+        if progress is not None
+        else _UNSTARTED_USER_WEEK
+    )
+    if weeks.start > user_week:
+        raise forbidden("scope_locked")
+
+
+def _reflection_ref_from(row: JournalEntry) -> ReflectionRef:
+    """Build a domain :class:`ReflectionRef` from a scoped reflection row.
+
+    Callers pass rows whose ``reflection_level`` / ``reflection_scope_key`` are
+    non-null (the query filters on it), so the string casts are typing hints.
+    """
+    level = ReflectionLevel(cast("str", row.reflection_level))
+    key = cast("str", row.reflection_scope_key)
+    return ReflectionRef(
+        id=cast("int", row.id), level=level, key=key, week=scope_weeks(level, key).stop - 1
+    )
+
+
+async def _load_reflection_refs(
+    session: AsyncSession, user_id: int, scope_key: str
+) -> list[ReflectionRef]:
+    """Load the caller's finished, live, scoped reflections other than the composing one.
+
+    A reflection whose scope equals the requested one is excluded so it never
+    stands in for itself.
+    """
+    result = await session.execute(
+        select(JournalEntry).where(
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.status) == EntryStatus.FINISHED,
+            col(JournalEntry.deleted_at).is_(None),
+            col(JournalEntry.sender) == "user",
+            col(JournalEntry.reflection_scope_key).is_not(None),
+            col(JournalEntry.reflection_scope_key) != scope_key,
+        )
+    )
+    return [_reflection_ref_from(row) for row in result.scalars().all()]
+
+
+async def _inclusion_target_ids(session: AsyncSession, user_id: int) -> list[int]:
+    """Return the entry ids the caller has folded promoted quotes into.
+
+    Such an entry is a reflection under composition, not raw source material, so
+    the daily-entry query excludes it even when it carries no scope key yet.
+    """
+    result = await session.execute(
+        select(PromotedQuote.included_in_entry_id).where(
+            PromotedQuote.user_id == user_id,
+            col(PromotedQuote.included_in_entry_id).is_not(None),
+        )
+    )
+    return [cast("int", target_id) for target_id in result.scalars().all() if target_id is not None]
+
+
+def _entry_ref_from(anchor: datetime, row: JournalEntry) -> EntryRef:
+    """Build a domain :class:`EntryRef`, tagging the row with its program week."""
+    week = elapsed_days(anchor, row.timestamp) // _DAYS_PER_WEEK + 1
+    return EntryRef(id=cast("int", row.id), week=week, date=row.timestamp.date())
+
+
+async def _load_entry_refs(
+    session: AsyncSession, user_id: int, anchor: datetime, weeks: range
+) -> list[EntryRef]:
+    """Load the caller's finished, live, scopeless daily entries inside the scope's window.
+
+    The half-open window runs from the first day of the span's first week up to
+    (but not including) the day after its final week. Entries already being
+    composed into a reflection are excluded.
+    """
+    window_start = anchor + timedelta(days=(weeks.start - 1) * _DAYS_PER_WEEK)
+    window_end = anchor + timedelta(days=(weeks.stop - 1) * _DAYS_PER_WEEK)
+    excluded = await _inclusion_target_ids(session, user_id)
+    query = select(JournalEntry).where(
+        JournalEntry.user_id == user_id,
+        col(JournalEntry.status) == EntryStatus.FINISHED,
+        col(JournalEntry.deleted_at).is_(None),
+        col(JournalEntry.sender) == "user",
+        col(JournalEntry.reflection_scope_key).is_(None),
+        col(JournalEntry.timestamp) >= window_start,
+        col(JournalEntry.timestamp) < window_end,
+    )
+    if excluded:
+        query = query.where(col(JournalEntry.id).not_in(excluded))
+    result = await session.execute(query)
+    return [_entry_ref_from(anchor, row) for row in result.scalars().all()]
+
+
+async def _batch_entries(
+    session: AsyncSession, user_id: int, resolved: list[SourceItem]
+) -> dict[int, JournalEntry]:
+    """Load the caller's own rows behind the resolved source ids, keyed by id.
+
+    Re-scoping to ``user_id`` and live rows is defense-in-depth: the refs already
+    came from the caller's data, but this guards against a resolver returning an
+    id that has since been deleted or does not belong to them.
+    """
+    ids = [item.id for item in resolved]
+    if not ids:
+        return {}
+    result = await session.execute(
+        select(JournalEntry).where(
+            col(JournalEntry.id).in_(ids),
+            JournalEntry.user_id == user_id,
+            col(JournalEntry.deleted_at).is_(None),
+        )
+    )
+    return {cast("int", row.id): row for row in result.scalars().all()}
+
+
+async def _quotes_by_entry(
+    session: AsyncSession, user_id: int, resolved: list[SourceItem]
+) -> dict[int, list[PromotedQuote]]:
+    """Group the caller's promoted quotes for the resolved source entries by source id.
+
+    Ordered by ``anchor_start`` so each entry's quotes come back in reading
+    order; another user's quotes on the same source id are filtered out.
+    """
+    ids = [item.id for item in resolved]
+    if not ids:
+        return {}
+    result = await session.execute(
+        select(PromotedQuote)
+        .where(
+            col(PromotedQuote.source_entry_id).in_(ids),
+            PromotedQuote.user_id == user_id,
+        )
+        .order_by(col(PromotedQuote.anchor_start))
+    )
+    grouped: dict[int, list[PromotedQuote]] = {}
+    for quote in result.scalars().all():
+        grouped.setdefault(quote.source_entry_id, []).append(quote)
+    return grouped
+
+
+def _quote_summary(quote: PromotedQuote) -> PromotedQuoteSummary:
+    """Map a promoted-quote row to its summary DTO; pending == not yet folded in."""
+    return PromotedQuoteSummary(
+        id=cast("int", quote.id),
+        anchor_start=quote.anchor_start,
+        anchor_end=quote.anchor_end,
+        anchor_text=quote.anchor_text,
+        pending=quote.included_in_entry_id is None,
+    )
+
+
+def _to_source_item(
+    item: SourceItem, entry: JournalEntry, quotes: list[PromotedQuote]
+) -> ReflectionSourceItem:
+    """Map a resolved :class:`SourceItem` plus its row and quotes to the response DTO.
+
+    ``reflection_level`` is carried only for a REFLECTION item (naming the child
+    layer that stood in); a raw entry leaves it ``None``.
+    """
+    is_reflection = item.kind is SourceKind.REFLECTION and item.level is not None
+    return ReflectionSourceItem(
+        kind=item.kind.value,
+        id=item.id,
+        title=entry.title,
+        timestamp=entry.timestamp,
+        body=entry.message,
+        reflection_level=item.level.value if is_reflection and item.level is not None else None,
+        promoted_quotes=[_quote_summary(quote) for quote in quotes],
+    )
+
+
+@router.get("/sources", response_model=ReflectionSourcesResponse)
+async def get_reflection_sources(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    level: Annotated[ReflectionLevel, Query()],
+    scope_key: Annotated[str, Query()],
+) -> ReflectionSourcesResponse:
+    """Return the ordered source material feeding the reflection at ``(level, scope_key)``.
+
+    A malformed key, a level/token mismatch, or an out-of-range index is 422; a
+    scope whose first week the caller has not yet reached is 403 ``scope_locked``.
+    Otherwise the hierarchy is walked top-down: an existing child reflection
+    stands in for its whole span, and every gap decomposes to that week's raw
+    daily entries, yielding a chronological feed with each promoted quote flagged
+    pending or included.
+    """
+    weeks = _validated_scope_weeks(level, scope_key)
+    progress = await get_user_progress(session, current_user)
+    _guard_scope_unlocked(weeks, progress)
+    if progress is None:
+        return ReflectionSourcesResponse(items=[])
+    anchor = resolve_program_anchor(progress)
+    reflection_refs = await _load_reflection_refs(session, current_user, scope_key)
+    entry_refs = await _load_entry_refs(session, current_user, anchor, weeks)
+    resolved = resolve_sources(level, scope_key, existing=reflection_refs, entries=entry_refs)
+    entries_by_id = await _batch_entries(session, current_user, resolved)
+    quotes_by_entry = await _quotes_by_entry(session, current_user, resolved)
+    items = [
+        _to_source_item(item, entries_by_id[item.id], quotes_by_entry.get(item.id, []))
+        for item in resolved
+        if item.id in entries_by_id
+    ]
+    return ReflectionSourcesResponse(items=items)

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -8,6 +8,7 @@ from typing import Self
 from pydantic import BaseModel, Field, model_validator
 
 from domain.constants import TOTAL_STAGES
+from domain.reflection_hierarchy import ReflectionLevel, scope_weeks
 from models.journal_entry import EntryStatus, JournalClassification, JournalTag
 
 JOURNAL_MESSAGE_MAX_LENGTH = 10_000
@@ -35,6 +36,22 @@ def _validate_chord_shape(primary: int | None, secondary: int | None) -> None:
         raise ValueError(msg)
 
 
+def _validate_reflection_scope(level: ReflectionLevel | None, key: str | None) -> None:
+    """Enforce the both-or-neither reflection-scope pairing and its key grammar.
+
+    The layer and its ``c{cycle}:{token}`` key are an atomic pair: supplying
+    exactly one is rejected. When both are present the key is run through
+    :func:`scope_weeks`, whose ``ValueError`` for a malformed key, a
+    level/token mismatch, or an out-of-range index surfaces here as a 422.
+    """
+    if (level is None) != (key is None):
+        msg = "reflection_level and reflection_scope_key must be set together"
+        raise ValueError(msg)
+    if level is None or key is None:
+        return
+    scope_weeks(level, key)
+
+
 class JournalMessageCreate(BaseModel):
     """Payload for creating a user journal message.
 
@@ -49,10 +66,13 @@ class JournalMessageCreate(BaseModel):
     user_practice_id: int | None = None
     primary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
     secondary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
+    reflection_level: ReflectionLevel | None = None
+    reflection_scope_key: str | None = None
 
     @model_validator(mode="after")
     def _validate_chord(self) -> Self:
         _validate_chord_shape(self.primary_aspect, self.secondary_aspect)
+        _validate_reflection_scope(self.reflection_level, self.reflection_scope_key)
         return self
 
 
@@ -69,6 +89,8 @@ class JournalEntryUpdate(BaseModel):
     classification: JournalClassification | None = None
     primary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
     secondary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
+    reflection_level: ReflectionLevel | None = None
+    reflection_scope_key: str | None = None
 
     @model_validator(mode="after")
     def _require_at_least_one_field(self) -> Self:
@@ -79,6 +101,7 @@ class JournalEntryUpdate(BaseModel):
             msg = "at least one field must be provided"
             raise ValueError(msg)
         _validate_chord_shape(self.primary_aspect, self.secondary_aspect)
+        _validate_reflection_scope(self.reflection_level, self.reflection_scope_key)
         return self
 
 
@@ -102,6 +125,8 @@ class JournalMessageResponse(BaseModel):
     user_practice_id: int | None
     primary_aspect: int | None = None
     secondary_aspect: int | None = None
+    reflection_level: str | None = None
+    reflection_scope_key: str | None = None
 
 
 class JournalListResponse(BaseModel):

--- a/backend/src/schemas/promotion.py
+++ b/backend/src/schemas/promotion.py
@@ -1,0 +1,58 @@
+"""Request/response schemas for the quote-promotion API.
+
+A promotion anchors a character span of a source journal entry and, optionally,
+folds it into a later reflection. The client sends only anchor offsets — the
+server slices and snapshots the text — so no schema here carries entry body
+text. ``user_id`` never appears in a response.
+"""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PromoteQuoteCreate(BaseModel):
+    """Payload for promoting a span of a source entry into a pending quote.
+
+    Only offsets are accepted; the server slices ``anchor_text`` from the
+    persisted body. ``anchor_end`` must lie strictly past ``anchor_start`` so an
+    empty or inverted span is rejected before it reaches the database.
+    """
+
+    anchor_start: int = Field(ge=0)
+    anchor_end: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def _validate_span(self) -> Self:
+        """Reject a span whose end does not lie strictly past its start."""
+        if self.anchor_end <= self.anchor_start:
+            msg = "anchor_end must be greater than anchor_start"
+            raise ValueError(msg)
+        return self
+
+
+class PromotionUpdate(BaseModel):
+    """Payload for (un)folding a promoted quote into a reflection.
+
+    ``included_in_entry_id`` is required with no default, so an empty ``{}`` body
+    is a 422. A ``null`` value is valid and returns the quote to pending.
+    """
+
+    included_in_entry_id: int | None
+
+
+class PromotedQuoteResponse(BaseModel):
+    """A promoted quote as returned to its owner.
+
+    ``user_id`` is intentionally excluded — the caller already knows its own
+    identity and exposing surrogate keys aids enumeration.
+    """
+
+    id: int
+    source_entry_id: int
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+    pending: bool

--- a/backend/src/schemas/reflection.py
+++ b/backend/src/schemas/reflection.py
@@ -1,0 +1,74 @@
+"""Response schemas for the hierarchical-reflection API.
+
+These DTOs shape the two read surfaces of the nested reflection calendar: the
+``/reflections/due`` peek at what layer has just come due, and the
+``/reflections/sources`` feed of the raw material that composes a given
+reflection. ``user_id`` never appears in any of them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class PromotedQuoteSummary(BaseModel):
+    """A promoted quote as it rides along with its source entry in a tier feed.
+
+    ``pending`` is True while the quote has not yet been folded into any
+    reflection (its ``included_in_entry_id`` is NULL).
+    """
+
+    id: int
+    anchor_start: int
+    anchor_end: int
+    anchor_text: str
+    pending: bool
+
+
+class ReflectionSourceItem(BaseModel):
+    """One resolved source feeding a reflection: a child reflection or a raw entry.
+
+    ``reflection_level`` is populated only for a REFLECTION item (naming which
+    child layer stood in for its span) and is ``None`` for a raw daily entry.
+    """
+
+    kind: str
+    id: int
+    title: str | None
+    timestamp: datetime
+    body: str
+    reflection_level: str | None
+    promoted_quotes: list[PromotedQuoteSummary]
+
+
+class ReflectionSourcesResponse(BaseModel):
+    """The ordered source material feeding one reflection.
+
+    Deliberately unpaginated: a single tier's feed is at most a few dozen
+    items, so the whole set is returned in one call. Pagination can be layered
+    on later if a wider layer's feed ever grows past a comfortable page.
+    """
+
+    items: list[ReflectionSourceItem]
+
+
+class ReflectionDue(BaseModel):
+    """The reflection that has just come due, with its calendar window.
+
+    ``existing_entry_id`` names the caller's live reflection already claiming
+    this scope, or ``None`` when the layer is still open to compose.
+    """
+
+    level: str
+    scope_key: str
+    window_start: datetime
+    window_end: datetime
+    existing_entry_id: int | None
+
+
+class ReflectionDueResponse(BaseModel):
+    """Envelope for the due-reflection peek; ``due`` is ``None`` when nothing is due."""
+
+    due: ReflectionDue | None

--- a/backend/tests/test_journal_scope_api.py
+++ b/backend/tests/test_journal_scope_api.py
@@ -1,0 +1,198 @@
+"""Tests for the reflection_level / reflection_scope_key pair on the journal API.
+
+``JournalMessageCreate`` / ``JournalEntryUpdate`` do not carry these fields yet,
+so every payload below is silently accepted (extra keys ignored) instead of
+validated or persisted -- the assertions on the (currently absent) behavior
+fail, which is the correct RED state for Gate 1. The model layer and its
+partial-unique index already exist; only the schema + router wiring is new.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Create ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_with_scope_pair_persists_both_fields(async_client: AsyncClient) -> None:
+    """A valid (level, scope_key) pair is persisted and echoed back."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json={
+            "message": "Week one, closing thoughts.",
+            "reflection_level": "week",
+            "reflection_scope_key": "c1:w1",
+            "tag": "hierarchical_reflection",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    data = resp.json()
+    assert data.get("reflection_level") == "week"
+    assert data.get("reflection_scope_key") == "c1:w1"
+    assert data.get("tag") == "hierarchical_reflection"
+
+
+@pytest.mark.asyncio
+async def test_create_with_level_only_returns_422(async_client: AsyncClient) -> None:
+    """reflection_level with no reflection_scope_key is rejected (both-or-neither)."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Partial pair", "reflection_level": "week"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_with_scope_key_only_returns_422(async_client: AsyncClient) -> None:
+    """reflection_scope_key with no reflection_level is rejected (both-or-neither)."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Partial pair", "reflection_scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_with_mismatched_pair_returns_422(async_client: AsyncClient) -> None:
+    """A stage level with a week-token key is rejected."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json={
+            "message": "Mismatched pair",
+            "reflection_level": "stage",
+            "reflection_scope_key": "c1:w1",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_with_malformed_scope_key_returns_422(async_client: AsyncClient) -> None:
+    """A scope key that fails the c{cycle}:{token} grammar is rejected."""
+    headers = await _signup(async_client)
+    resp = await async_client.post(
+        "/journal/",
+        json={
+            "message": "Bad grammar",
+            "reflection_level": "week",
+            "reflection_scope_key": "nope",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_live_scope_returns_409(async_client: AsyncClient) -> None:
+    """A second live entry claiming the same scope key for the same user 409s."""
+    headers = await _signup(async_client)
+    payload = {
+        "message": "First take",
+        "reflection_level": "week",
+        "reflection_scope_key": "c1:w1",
+        "tag": "hierarchical_reflection",
+    }
+    first = await async_client.post("/journal/", json=payload, headers=headers)
+    assert first.status_code == HTTPStatus.CREATED
+
+    second = await async_client.post(
+        "/journal/",
+        json={**payload, "message": "Second take, same scope"},
+        headers=headers,
+    )
+    assert second.status_code == HTTPStatus.CONFLICT
+    assert second.json()["detail"] == "reflection_scope_taken"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_frees_scope_for_reuse(async_client: AsyncClient) -> None:
+    """Soft-deleting a scoped entry frees its scope key for a new one."""
+    headers = await _signup(async_client)
+    payload = {
+        "message": "First take",
+        "reflection_level": "week",
+        "reflection_scope_key": "c1:w1",
+        "tag": "hierarchical_reflection",
+    }
+    first = await async_client.post("/journal/", json=payload, headers=headers)
+    assert first.status_code == HTTPStatus.CREATED
+    entry_id = first.json()["id"]
+
+    delete_resp = await async_client.delete(f"/journal/{entry_id}", headers=headers)
+    assert delete_resp.status_code == HTTPStatus.NO_CONTENT
+
+    second = await async_client.post(
+        "/journal/",
+        json={**payload, "message": "Retaken after delete"},
+        headers=headers,
+    )
+    assert second.status_code == HTTPStatus.CREATED
+
+
+# ── Update ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_sets_scope_pair(async_client: AsyncClient) -> None:
+    """PATCHing a freeform entry with a valid pair persists both fields."""
+    headers = await _signup(async_client)
+    create_resp = await async_client.post(
+        "/journal/", json={"message": "Freeform thoughts"}, headers=headers
+    )
+    assert create_resp.status_code == HTTPStatus.CREATED
+    entry_id = create_resp.json()["id"]
+
+    patch_resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"reflection_level": "week", "reflection_scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert patch_resp.status_code == HTTPStatus.OK
+    data = patch_resp.json()
+    assert data.get("reflection_level") == "week"
+    assert data.get("reflection_scope_key") == "c1:w1"
+
+
+@pytest.mark.asyncio
+async def test_patch_single_scope_field_only_returns_422(async_client: AsyncClient) -> None:
+    """PATCHing only reflection_level (no scope_key) is rejected -- the pair is atomic."""
+    headers = await _signup(async_client)
+    create_resp = await async_client.post(
+        "/journal/", json={"message": "Freeform thoughts"}, headers=headers
+    )
+    assert create_resp.status_code == HTTPStatus.CREATED
+    entry_id = create_resp.json()["id"]
+
+    patch_resp = await async_client.patch(
+        f"/journal/{entry_id}",
+        json={"reflection_level": "week"},
+        headers=headers,
+    )
+    assert patch_resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_promotions_api.py
+++ b/backend/tests/test_promotions_api.py
@@ -1,0 +1,368 @@
+"""Tests for the quote-promotion API: POST /journal/{id}/promote, DELETE and PATCH /promotions/{id}.
+
+These pin the contract for a router that does not exist yet
+(``routers/promotions.py``) and a new sub-route on the journal router. Every
+request below either 404s (route missing) or the assertion on the (currently
+absent) response shape fails -- both are the correct RED state for Gate 1.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.journal_entry import EntryStatus, JournalEntry, JournalTag
+from models.promoted_quote import PROMOTED_QUOTE_TEXT_MAX, PromotedQuote
+from models.user import User
+
+_OVER_MAX_SPAN_LENGTH = PROMOTED_QUOTE_TEXT_MAX + 1
+_OVER_MAX_BODY_LENGTH = PROMOTED_QUOTE_TEXT_MAX + 500
+
+
+async def _signup(
+    client: AsyncClient, db_session: AsyncSession, username: str = "alice"
+) -> tuple[dict[str, str], int]:
+    """Create a user, return its auth headers and DB id."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    user = (
+        await db_session.execute(select(User).where(col(User.email) == f"{username}@example.com"))
+    ).scalar_one()
+    assert user.id is not None
+    return {"Authorization": f"Bearer {token}"}, user.id
+
+
+async def _seed_entry(
+    db_session: AsyncSession, user_id: int, message: str, **overrides: object
+) -> JournalEntry:
+    """Create and persist a JournalEntry, defaulting to a finished user entry."""
+    defaults: dict[str, object] = {"sender": "user", "status": EntryStatus.FINISHED}
+    defaults.update(overrides)
+    entry = JournalEntry(user_id=user_id, message=message, **defaults)
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+    return entry
+
+
+async def _seed_quote(
+    db_session: AsyncSession,
+    user_id: int,
+    source_entry_id: int | None,
+    anchor_text: str,
+    **overrides: object,
+) -> PromotedQuote:
+    """Create and persist a PromotedQuote spanning ``anchor_text``'s length from offset 0."""
+    defaults: dict[str, object] = {
+        "anchor_start": 0,
+        "anchor_end": len(anchor_text),
+    }
+    defaults.update(overrides)
+    quote = PromotedQuote(
+        user_id=user_id, source_entry_id=source_entry_id, anchor_text=anchor_text, **defaults
+    )
+    db_session.add(quote)
+    await db_session.commit()
+    await db_session.refresh(quote)
+    return quote
+
+
+# ── POST /journal/{entry_id}/promote ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_promote_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.post("/journal/1/promote", json={"anchor_start": 0, "anchor_end": 5})
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_promote_slices_body_server_side(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The server slices anchor_text from the persisted body -- the client sends no text."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "The quick brown fox jumps")
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 4, "anchor_end": 9},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    data = resp.json()
+    assert data["anchor_text"] == "quick"
+    assert data["source_entry_id"] == entry.id
+    assert data["anchor_start"] == 4
+    assert data["anchor_end"] == 9
+    assert data["pending"] is True
+    assert "user_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_other_users_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Promoting a span from an entry owned by another user 404s (enumeration-safe)."""
+    _owner_headers, owner_id = await _signup(async_client, db_session, username="alice")
+    other_headers, _other_id = await _signup(async_client, db_session, username="bob")
+    entry = await _seed_entry(db_session, owner_id, "Some private body text")
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 0, "anchor_end": 4},
+        headers=other_headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_soft_deleted_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A soft-deleted entry is treated as gone."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "Deleted body", deleted_at=datetime.now(UTC))
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 0, "anchor_end": 4},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_missing_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A nonexistent entry id 404s."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.post(
+        "/journal/999999/promote",
+        json={"anchor_start": 0, "anchor_end": 4},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_span_past_body_length_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An anchor_end past the body's length is unprocessable."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "short body")
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 0, "anchor_end": 10000},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_span_over_1000_chars_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A span longer than PROMOTED_QUOTE_TEXT_MAX chars is unprocessable."""
+    headers, user_id = await _signup(async_client, db_session)
+    body = "x" * _OVER_MAX_BODY_LENGTH
+    entry = await _seed_entry(db_session, user_id, body)
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 0, "anchor_end": _OVER_MAX_SPAN_LENGTH},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_inverted_span_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """anchor_end <= anchor_start is unprocessable (Pydantic-level)."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "abcdef")
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 5, "anchor_end": 2},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── DELETE /promotions/{id} ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_promotion_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.delete("/promotions/1")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_delete_promotion_removes_owned_quote(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The owner can delete their own quote; a second delete then 404s."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "Some body worth quoting")
+    quote = await _seed_quote(db_session, user_id, entry.id, "Some body")
+
+    resp = await async_client.delete(f"/promotions/{quote.id}", headers=headers)
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+
+    resp_again = await async_client.delete(f"/promotions/{quote.id}", headers=headers)
+    assert resp_again.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_delete_promotion_rejects_other_users_quote_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Deleting a quote owned by another user 404s."""
+    _owner_headers, owner_id = await _signup(async_client, db_session, username="alice")
+    other_headers, _other_id = await _signup(async_client, db_session, username="bob")
+    entry = await _seed_entry(db_session, owner_id, "Body text here")
+    quote = await _seed_quote(db_session, owner_id, entry.id, "Body text")
+
+    resp = await async_client.delete(f"/promotions/{quote.id}", headers=other_headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# ── PATCH /promotions/{id} ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.patch("/promotions/1", json={"included_in_entry_id": 1})
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_sets_and_clears_inclusion(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Setting included_in_entry_id flips pending False; clearing it flips pending True."""
+    headers, user_id = await _signup(async_client, db_session)
+    source_entry = await _seed_entry(db_session, user_id, "Source body text")
+    target_entry = await _seed_entry(
+        db_session,
+        user_id,
+        "Target reflection body",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+    )
+    quote = await _seed_quote(db_session, user_id, source_entry.id, "Source")
+
+    resp = await async_client.patch(
+        f"/promotions/{quote.id}",
+        json={"included_in_entry_id": target_entry.id},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["pending"] is False
+
+    resp_clear = await async_client.patch(
+        f"/promotions/{quote.id}",
+        json={"included_in_entry_id": None},
+        headers=headers,
+    )
+    assert resp_clear.status_code == HTTPStatus.OK
+    assert resp_clear.json()["pending"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_rejects_non_hierarchical_target_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A target entry that isn't tagged HIERARCHICAL_REFLECTION is unprocessable."""
+    headers, user_id = await _signup(async_client, db_session)
+    source_entry = await _seed_entry(db_session, user_id, "Source body text")
+    freeform_target = await _seed_entry(
+        db_session, user_id, "Freeform target", tag=JournalTag.FREEFORM
+    )
+    quote = await _seed_quote(db_session, user_id, source_entry.id, "Source")
+
+    resp = await async_client.patch(
+        f"/promotions/{quote.id}",
+        json={"included_in_entry_id": freeform_target.id},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_rejects_other_users_promotion_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Patching a quote owned by another user 404s."""
+    _owner_headers, owner_id = await _signup(async_client, db_session, username="alice")
+    other_headers, _other_id = await _signup(async_client, db_session, username="bob")
+    source_entry = await _seed_entry(db_session, owner_id, "Source body text")
+    target_entry = await _seed_entry(
+        db_session,
+        owner_id,
+        "Target reflection body",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+    )
+    quote = await _seed_quote(db_session, owner_id, source_entry.id, "Source")
+
+    resp = await async_client.patch(
+        f"/promotions/{quote.id}",
+        json={"included_in_entry_id": target_entry.id},
+        headers=other_headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_rejects_unowned_target_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A target entry that doesn't exist (or isn't the caller's) 404s."""
+    headers, user_id = await _signup(async_client, db_session)
+    source_entry = await _seed_entry(db_session, user_id, "Source body text")
+    quote = await _seed_quote(db_session, user_id, source_entry.id, "Source")
+
+    resp = await async_client.patch(
+        f"/promotions/{quote.id}",
+        json={"included_in_entry_id": 999999},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_promotion_rejects_empty_body_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An empty PATCH body is rejected -- included_in_entry_id is required."""
+    headers, user_id = await _signup(async_client, db_session)
+    source_entry = await _seed_entry(db_session, user_id, "Source body text")
+    quote = await _seed_quote(db_session, user_id, source_entry.id, "Source")
+
+    resp = await async_client.patch(f"/promotions/{quote.id}", json={}, headers=headers)
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/backend/tests/test_reflections_api.py
+++ b/backend/tests/test_reflections_api.py
@@ -1,0 +1,544 @@
+"""Tests for the hierarchical-reflection API: GET /reflections/due and /reflections/sources.
+
+These pin the contract for routers that do not exist yet
+(``routers/reflections.py``). Every request below either 404s (route missing)
+or the assertion on the (currently absent) response shape fails -- both are
+the correct RED state for Gate 1. Underlying domain math
+(``domain.reflection_hierarchy``) is already implemented and tested
+elsewhere; it is used here only as an oracle to compute expected values, not
+under test itself.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.reflection_hierarchy import ReflectionLevel, due_reflection, scope_weeks
+from models.journal_entry import EntryStatus, JournalEntry, JournalTag
+from models.promoted_quote import PromotedQuote
+from models.stage_progress import StageProgress
+from models.user import User
+
+_DAYS_PER_WEEK = 7
+_WINDOW_TOLERANCE = timedelta(seconds=5)
+
+
+async def _signup(
+    client: AsyncClient, db_session: AsyncSession, username: str = "alice"
+) -> tuple[dict[str, str], int]:
+    """Create a user, return its auth headers and DB id."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    user = (
+        await db_session.execute(select(User).where(col(User.email) == f"{username}@example.com"))
+    ).scalar_one()
+    assert user.id is not None
+    return {"Authorization": f"Bearer {token}"}, user.id
+
+
+async def _seed_progress(
+    db_session: AsyncSession,
+    user_id: int,
+    *,
+    anchor: datetime,
+    cycle_number: int = 1,
+    current_stage: int = 1,
+) -> StageProgress:
+    """Plant a StageProgress row anchored at ``anchor``."""
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=current_stage,
+        completed_stages=[],
+        stage_started_at=anchor,
+        program_started_at=anchor,
+        cycle_number=cycle_number,
+    )
+    db_session.add(progress)
+    await db_session.commit()
+    await db_session.refresh(progress)
+    return progress
+
+
+async def _seed_entry(
+    db_session: AsyncSession, user_id: int, message: str, **overrides: object
+) -> JournalEntry:
+    """Create and persist a JournalEntry, defaulting to a finished user entry."""
+    defaults: dict[str, object] = {"sender": "user", "status": EntryStatus.FINISHED}
+    defaults.update(overrides)
+    entry = JournalEntry(user_id=user_id, message=message, **defaults)
+    db_session.add(entry)
+    await db_session.commit()
+    await db_session.refresh(entry)
+    return entry
+
+
+def _window_bounds(anchor: datetime, level: ReflectionLevel, key: str) -> tuple[datetime, datetime]:
+    """Reconstruct the expected (window_start, window_end) from the same anchor arithmetic."""
+    weeks = scope_weeks(level, key)
+    start_week = weeks.start
+    end_week = weeks.stop - 1
+    window_start = anchor + timedelta(days=(start_week - 1) * _DAYS_PER_WEEK)
+    window_end = anchor + timedelta(days=end_week * _DAYS_PER_WEEK)
+    return window_start, window_end
+
+
+def _close(actual_iso: str, expected: datetime) -> bool:
+    """True if the ISO timestamp ``actual_iso`` is within tolerance of ``expected``."""
+    actual = datetime.fromisoformat(actual_iso)
+    if actual.tzinfo is None:
+        actual = actual.replace(tzinfo=UTC)
+    return abs(actual - expected) <= _WINDOW_TOLERANCE
+
+
+# ── GET /reflections/due ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_due_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.get("/reflections/due")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_due_with_no_stage_progress_returns_null(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user with no StageProgress row has nothing due."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["due"] is None
+
+
+@pytest.mark.asyncio
+async def test_due_not_on_due_day_returns_null(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Three days into week 1 (not day 7) has nothing due."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=3)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["due"] is None
+
+
+@pytest.mark.asyncio
+async def test_due_on_week_boundary_returns_week_scope(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Day 7 of week 1 is due at the WEEK layer, with the correct window."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=6)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    due = resp.json()["due"]
+    assert due is not None
+
+    expected = due_reflection(anchor, now=now)
+    assert expected is not None
+    assert due["level"] == expected.level.value
+    assert due["scope_key"] == expected.key
+    assert due["existing_entry_id"] is None
+
+    window_start, window_end = _window_bounds(anchor, expected.level, expected.key)
+    assert _close(due["window_start"], window_start)
+    assert _close(due["window_end"], window_end)
+
+
+@pytest.mark.asyncio
+async def test_due_on_stage_boundary_returns_stage_scope(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Week 3 closes stage 1, so the due layer widens to STAGE, not WEEK."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=20)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    due = resp.json()["due"]
+    assert due is not None
+    assert due["level"] == "stage"
+    assert due["scope_key"] == "c1:s1"
+
+
+@pytest.mark.asyncio
+async def test_due_existing_entry_id_toggles_with_soft_delete(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A live hierarchical reflection for the due scope surfaces as existing_entry_id.
+
+    Soft-deleting that entry clears ``existing_entry_id`` back to null.
+    """
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=6)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    entry = await _seed_entry(
+        db_session,
+        user_id,
+        "Week one, in review.",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+    )
+
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["due"]["existing_entry_id"] == entry.id
+
+    entry.deleted_at = datetime.now(UTC)
+    db_session.add(entry)
+    await db_session.commit()
+
+    resp_after_delete = await async_client.get("/reflections/due", headers=headers)
+    assert resp_after_delete.status_code == HTTPStatus.OK
+    assert resp_after_delete.json()["due"]["existing_entry_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_due_scope_key_carries_cycle_prefix(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A second-cycle user's due scope key is prefixed ``c2:``, not ``c1:``."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=6)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor, cycle_number=2)
+    resp = await async_client.get("/reflections/due", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    due = resp.json()["due"]
+    assert due is not None
+    assert due["scope_key"] == "c2:w1"
+
+
+# ── GET /reflections/sources ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sources_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.get(
+        "/reflections/sources", params={"level": "week", "scope_key": "c1:w1"}
+    )
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_sources_malformed_scope_key_returns_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A scope key that fails the ``c{cycle}:{token}`` grammar is 422."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "week", "scope_key": "garbage"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_sources_level_key_mismatch_returns_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A stage-level request against a week-token key is rejected."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "stage", "scope_key": "c1:w5"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_sources_out_of_range_index_returns_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Stage 11 doesn't exist (curriculum has 10 stages), so it's 422."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "stage", "scope_key": "c1:s11"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_sources_locked_future_scope_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Stage 2 (weeks 4-6) is locked for a user still in week 1."""
+    now = datetime.now(UTC)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=now)
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "stage", "scope_key": "c1:s2"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "scope_locked"
+
+
+@pytest.mark.asyncio
+async def test_sources_week_scope_returns_daily_entries_chronologically(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A week's sources are that week's finished daily entries, oldest first."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=8)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    await _seed_entry(
+        db_session, user_id, "Second day's thoughts", timestamp=anchor + timedelta(days=2)
+    )
+    await _seed_entry(
+        db_session, user_id, "First day's thoughts", timestamp=anchor + timedelta(days=1)
+    )
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "week", "scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert [item["body"] for item in items] == ["First day's thoughts", "Second day's thoughts"]
+    assert all(item["kind"] == "entry" for item in items)
+    assert all(item["reflection_level"] is None for item in items)
+
+
+@pytest.mark.asyncio
+async def test_sources_excludes_bot_deleted_foreign_and_out_of_window_entries(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Bot, soft-deleted, foreign, and out-of-window entries never appear."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=8)
+    headers, user_id = await _signup(async_client, db_session)
+    _other_headers, other_id = await _signup(async_client, db_session, username="bob")
+    await _seed_progress(db_session, user_id, anchor=anchor)
+
+    await _seed_entry(
+        db_session, user_id, "Bot reply", sender="bot", timestamp=anchor + timedelta(days=1)
+    )
+    deleted = await _seed_entry(
+        db_session, user_id, "Deleted body", timestamp=anchor + timedelta(days=1)
+    )
+    deleted.deleted_at = datetime.now(UTC)
+    db_session.add(deleted)
+    await db_session.commit()
+    await _seed_entry(
+        db_session, other_id, "Someone else's body", timestamp=anchor + timedelta(days=1)
+    )
+    await _seed_entry(
+        db_session, user_id, "Outside the window", timestamp=anchor + timedelta(days=30)
+    )
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "week", "scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_sources_excludes_draft_status_entries(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A draft (unfinished) entry inside the window is not yet a source."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=8)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    await _seed_entry(
+        db_session,
+        user_id,
+        "Still drafting",
+        status=EntryStatus.DRAFT,
+        timestamp=anchor + timedelta(days=1),
+    )
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "week", "scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_sources_stage_scope_decomposes_with_week_reflection_standing_in(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A completed week-1 reflection stands in for week 1 within a stage scope.
+
+    Weeks 2 and 3 (no reflection yet) decompose to their raw daily entries.
+    """
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=30)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    await _seed_entry(
+        db_session,
+        user_id,
+        "Week one summary",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+        timestamp=anchor + timedelta(days=6),
+    )
+    await _seed_entry(db_session, user_id, "Week two daily", timestamp=anchor + timedelta(days=8))
+    await _seed_entry(
+        db_session, user_id, "Week three daily", timestamp=anchor + timedelta(days=15)
+    )
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "stage", "scope_key": "c1:s1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert len(items) == 3
+    assert items[0]["kind"] == "reflection"
+    assert items[0]["reflection_level"] == "week"
+    assert items[0]["body"] == "Week one summary"
+    assert items[1]["kind"] == "entry"
+    assert items[1]["body"] == "Week two daily"
+    assert items[2]["kind"] == "entry"
+    assert items[2]["body"] == "Week three daily"
+
+
+@pytest.mark.asyncio
+async def test_sources_composing_reflection_excluded_from_its_own_sources(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A reflection whose scope equals the requested scope never stands in for itself."""
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=30)
+    headers, user_id = await _signup(async_client, db_session)
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    self_reflection = await _seed_entry(
+        db_session,
+        user_id,
+        "This is the stage-1 reflection itself",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="stage",
+        reflection_scope_key="c1:s1",
+        timestamp=anchor + timedelta(days=20),
+    )
+    await _seed_entry(db_session, user_id, "Week one daily", timestamp=anchor + timedelta(days=1))
+    await _seed_entry(db_session, user_id, "Week two daily", timestamp=anchor + timedelta(days=8))
+    await _seed_entry(
+        db_session, user_id, "Week three daily", timestamp=anchor + timedelta(days=15)
+    )
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "stage", "scope_key": "c1:s1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    ids = {item["id"] for item in items}
+    assert self_reflection.id not in ids
+    assert [item["body"] for item in items] == [
+        "Week one daily",
+        "Week two daily",
+        "Week three daily",
+    ]
+    assert all(item["kind"] == "entry" for item in items)
+
+
+@pytest.mark.asyncio
+async def test_sources_include_promoted_quotes_ordered_with_pending_flag(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A source entry's promoted_quotes are ordered by anchor_start with correct pending flags.
+
+    Another user's quote on the same source entry id must never leak in.
+    """
+    now = datetime.now(UTC)
+    anchor = now - timedelta(days=8)
+    headers, user_id = await _signup(async_client, db_session)
+    _other_headers, other_id = await _signup(async_client, db_session, username="bob")
+    await _seed_progress(db_session, user_id, anchor=anchor)
+    entry = await _seed_entry(
+        db_session,
+        user_id,
+        "Grateful for today and for tomorrow",
+        timestamp=anchor + timedelta(days=1),
+    )
+    target = await _seed_entry(
+        db_session, user_id, "Target entry for inclusion", timestamp=anchor + timedelta(days=1)
+    )
+
+    pending_quote = PromotedQuote(
+        user_id=user_id,
+        source_entry_id=entry.id,
+        anchor_start=10,
+        anchor_end=18,
+        anchor_text=entry.message[10:18],
+        included_in_entry_id=None,
+    )
+    included_quote = PromotedQuote(
+        user_id=user_id,
+        source_entry_id=entry.id,
+        anchor_start=0,
+        anchor_end=9,
+        anchor_text=entry.message[0:9],
+        included_in_entry_id=target.id,
+    )
+    foreign_quote = PromotedQuote(
+        user_id=other_id,
+        source_entry_id=entry.id,
+        anchor_start=20,
+        anchor_end=27,
+        anchor_text=entry.message[20:27],
+        included_in_entry_id=None,
+    )
+    db_session.add_all([pending_quote, included_quote, foreign_quote])
+    await db_session.commit()
+
+    resp = await async_client.get(
+        "/reflections/sources",
+        params={"level": "week", "scope_key": "c1:w1"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert len(items) == 1
+    quotes = items[0]["promoted_quotes"]
+    assert len(quotes) == 2
+    assert quotes[0]["anchor_start"] == 0
+    assert quotes[0]["anchor_text"] == entry.message[0:9]
+    assert quotes[0]["pending"] is False
+    assert quotes[1]["anchor_start"] == 10
+    assert quotes[1]["anchor_text"] == entry.message[10:18]
+    assert quotes[1]["pending"] is True
+    assert foreign_quote.id not in {q["id"] for q in quotes}


### PR DESCRIPTION
## Summary

Sub-issue 3 of the hierarchical-journaling epic (#1458). Exposes the reflection hierarchy over HTTP, joining the pure domain (#1459) and models (#1460):

- **`GET /reflections/due`** → `{due: {level, scope_key, window_start, window_end, existing_entry_id|null} | null}`. Derives the widest calendar layer that has just closed via `domain.reflection_hierarchy.due_reflection`, using `resolve_program_anchor(progress)` + `cycle_number`. Returns `{due: null}` (200) on non-closing days or when the user has no `StageProgress`. `existing_entry_id` reflects a live entry claiming that scope.
- **`GET /reflections/sources?level=&scope_key=`** → ordered `items` feed. Sources are computed by `resolve_sources`: child reflections stand in for their spans and skipped levels decompose to the raw daily entries beneath them, with each source's promoted quotes attached (flagged `pending`). 422 on a malformed/mismatched/out-of-range scope; 403 `scope_locked` when the scope window has not opened for the caller (mirrors the `_check_week_unlocked` pattern).
- **`POST /journal/{entry_id}/promote`** `{anchor_start, anchor_end}` → 201 `PromotedQuote`. `anchor_text` is sliced server-side from the decrypted body (client text is never trusted), bounds/1000-char cap validated, and sanitized through `sanitize_user_text`.
- **`DELETE /promotions/{id}`** → 204 (owner-only), **`PATCH /promotions/{id}`** `{included_in_entry_id}` → marks a quote included in an owned `hierarchical_reflection` entry (or `null` to return it to pending; 422 for a non-reflection target).
- **Journal create/update schemas** accept an optional `reflection_level` + `reflection_scope_key` pair (validated both-or-neither and grammar-matched via `scope_weeks`); the duplicate-scope partial unique index surfaces as 409 `reflection_scope_taken`.

All schedule/scope math delegates to `domain.reflection_hierarchy` (zero calendar arithmetic in the routers beyond week→datetime window conversion). Every read is owner-scoped and `deleted_at IS NULL`-filtered; `user_id` is never returned.

Per the issue AC, raw-entry sources are filtered to `status == "finished"` — draft daily entries are not yet sources (they become sources once finished, e.g. via the composer flow in 04/05). Reflections default to `draft` on create, so a hierarchical reflection must be marked finished to stand in for its span.

Known non-blocking follow-up (surfaced in self-review): the scoped `IntegrityError → 409` guard on journal create/update keys on `reflection_scope_key is not None`, matching the existing chord pattern; a scoped write that also carries an unrelated bad FK would surface as 409. Narrow edge, left as-is for scope discipline.

## Test plan

- New async-client suites: `test_reflections_api.py`, `test_promotions_api.py`, `test_journal_scope_api.py` (44 tests) covering due/not-due/no-progress + window + cycle prefix + existing-entry toggle; sources 422/403 gates, week + stage decomposition (skip-a-week), composing-reflection exclusion, bot/soft-delete/foreign/out-of-window/draft exclusions, promoted-quote ordering + pending + cross-user isolation; promote server-side slicing + span/cap validation + ownership 404s; promotion delete/patch ownership + pending toggle + non-reflection-target 422 + empty-body 422; journal scope-pair persistence, both-or-neither, mismatch/grammar 422, 409 duplicate scope, soft-delete frees scope, pair-atomic PATCH.
- `./scripts/backend/check-all.sh` green (7/7 checks, 2551 passed, 96.75% coverage); `xenon` A-grade and `radon mi` A on all new files.

Closes #1461
Refs #1458 (sub-issue 3 of 5; does not close the epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)