### PR TITLE
fix(journal): persist weekly-prompt title with band-label default and override

### DIFF
--- a/backend/src/domain/weekly_prompts.py
+++ b/backend/src/domain/weekly_prompts.py
@@ -96,7 +96,48 @@ WEEKLY_PROMPTS: dict[int, str] = {
 
 TOTAL_WEEKS = 36
 
+# Archetypal Wavelength band labels in developmental order. Each band spans
+# ``WEEKS_PER_BAND`` consecutive weeks, so the 12 bands tile the 36-week
+# program exactly (12 * 3 == TOTAL_WEEKS).
+PROMPT_BANDS: tuple[str, ...] = (
+    "Beige",
+    "Purple",
+    "Red",
+    "Blue",
+    "Orange",
+    "Green",
+    "Yellow",
+    "Turquoise",
+    "Coral",
+    "Teal",
+    "Indigo",
+    "Ultraviolet",
+)
+
+# Weeks per Wavelength band; three weeks each tile the 36-week program.
+WEEKS_PER_BAND = 3
+
+# There is exactly one prompt per week, so the default title always reads
+# "... Prompt #1". Named so the ordinal in the title isn't a bare literal.
+PROMPTS_PER_WEEK = 1
+
 
 def get_prompt_for_week(week_number: int) -> str | None:
     """Return the prompt question for a given week, or None if out of range."""
     return WEEKLY_PROMPTS.get(week_number)
+
+
+def prompt_title_for_week(week_number: int) -> str | None:
+    """Return the default journal title for a week, or None if out of range.
+
+    Mirrors :func:`get_prompt_for_week`'s range contract: weeks outside
+    ``1..TOTAL_WEEKS`` yield ``None``. Otherwise the title is the week's
+    Wavelength band label plus its position within that band, e.g. week 8
+    (the second Red week) becomes ``"Red week 2 Prompt #1"``. This is the
+    default a user sees in the compose title; they may override it.
+    """
+    if week_number < 1 or week_number > TOTAL_WEEKS:
+        return None
+    band = PROMPT_BANDS[(week_number - 1) // WEEKS_PER_BAND]
+    week_in_band = ((week_number - 1) % WEEKS_PER_BAND) + 1
+    return f"{band} week {week_in_band} Prompt #{PROMPTS_PER_WEEK}"

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -14,6 +14,11 @@ from services.journal_encryption import EncryptedString
 # drifts from the curriculum length.
 ASPECT_MIN = 1
 
+# Maximum length of a journal entry title. Shared with the write-boundary
+# schemas (JournalEntryUpdate, PromptSubmit) so the DB column bound and the
+# request validation can't drift.
+JOURNAL_TITLE_MAX_LENGTH = 200
+
 # Bound at module scope so the partial unique index's ``*_where`` predicates can
 # resolve these columns by name at table-creation time (mirrors
 # :mod:`models.invitation_signal`). They are detached references used only by the
@@ -191,7 +196,7 @@ class JournalEntry(SQLModel, table=True):
     message: str = Field(sa_column=Column(EncryptedString(), nullable=False))
     # Long-form page metadata: an optional title and a draft/finished lifecycle.
     # ``message`` remains the body. ``updated_at`` tracks the last edit.
-    title: str | None = Field(default=None, max_length=200)
+    title: str | None = Field(default=None, max_length=JOURNAL_TITLE_MAX_LENGTH)
     status: str = Field(default=EntryStatus.DRAFT, max_length=20)
     # Privacy tier; defaults to ``personal``. The DB CHECK in ``__table_args__``
     # pins the persisted value to the JournalClassification set.

--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -15,9 +15,13 @@ from sqlmodel import col, select
 from database import get_session
 from domain.program_calendar import calendar_week, resolve_program_anchor
 from domain.stage_progress import get_user_progress
-from domain.weekly_prompts import TOTAL_WEEKS, get_prompt_for_week
+from domain.weekly_prompts import (
+    TOTAL_WEEKS,
+    get_prompt_for_week,
+    prompt_title_for_week,
+)
 from errors import conflict, forbidden, not_found, unprocessable
-from models.journal_entry import JournalEntry, JournalTag
+from models.journal_entry import JOURNAL_TITLE_MAX_LENGTH, JournalEntry, JournalTag
 from models.prompt_response import PromptResponse
 from routers.auth import get_current_user
 from schemas.pagination import page_has_more
@@ -209,6 +213,25 @@ async def get_prompt_by_week(
     )
 
 
+def _resolve_entry_title(payload_title: str | None, week_number: int) -> str | None:
+    """Resolve the journal title mirrored from a prompt submission.
+
+    A non-blank user override is sanitized and used verbatim; a blank,
+    whitespace-only, absent, or sanitized-to-empty override falls back to the
+    week's default band label (:func:`prompt_title_for_week`). ``week_number``
+    is already range-validated by the caller, so the fallback is non-``None``
+    for a real submission. An over-long title surfaces as a 422.
+    """
+    if payload_title and payload_title.strip():
+        try:
+            cleaned = sanitize_user_text(payload_title, max_len=JOURNAL_TITLE_MAX_LENGTH)
+        except TextTooLongError as exc:
+            raise unprocessable("title_too_long") from exc
+        if cleaned:
+            return cleaned
+    return prompt_title_for_week(week_number)
+
+
 @router.post(
     "/{week_number}/respond",
     response_model=PromptDetail,
@@ -255,6 +278,8 @@ async def submit_prompt_response(
     except TextTooLongError as exc:
         raise unprocessable("response_too_long") from exc
 
+    entry_title = _resolve_entry_title(payload.title, week_number)
+
     prompt_response = PromptResponse(
         week_number=week_number,
         question=question,
@@ -268,6 +293,7 @@ async def submit_prompt_response(
     # double-count it.
     journal_entry = JournalEntry(
         message=cleaned_response,
+        title=entry_title,
         sender="user",
         user_id=current_user,
         tag=JournalTag.WEEKLY_PROMPT,

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -9,7 +9,12 @@ from pydantic import BaseModel, Field, model_validator
 
 from domain.constants import TOTAL_STAGES
 from domain.reflection_hierarchy import ReflectionLevel, scope_weeks
-from models.journal_entry import EntryStatus, JournalClassification, JournalTag
+from models.journal_entry import (
+    JOURNAL_TITLE_MAX_LENGTH,
+    EntryStatus,
+    JournalClassification,
+    JournalTag,
+)
 
 JOURNAL_MESSAGE_MAX_LENGTH = 10_000
 
@@ -84,7 +89,7 @@ class JournalEntryUpdate(BaseModel):
     """
 
     message: str | None = Field(default=None, min_length=1, max_length=JOURNAL_MESSAGE_MAX_LENGTH)
-    title: str | None = Field(default=None, max_length=200)
+    title: str | None = Field(default=None, max_length=JOURNAL_TITLE_MAX_LENGTH)
     status: EntryStatus | None = None
     classification: JournalClassification | None = None
     primary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)

--- a/backend/src/schemas/prompt.py
+++ b/backend/src/schemas/prompt.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field, field_validator
 
+from models.journal_entry import JOURNAL_TITLE_MAX_LENGTH
+
 PROMPT_RESPONSE_MAX_LENGTH = 10_000
 
 # Threshold checked *after* ``str.strip()`` so a whitespace-padded
@@ -30,6 +32,9 @@ class PromptSubmit(BaseModel):
     """Payload for submitting a response to a weekly prompt."""
 
     response: str = Field(min_length=1, max_length=PROMPT_RESPONSE_MAX_LENGTH)
+    # Optional compose title. When omitted or blank the router falls back to
+    # the week's default band label; the length cap mirrors the DB column.
+    title: str | None = Field(default=None, max_length=JOURNAL_TITLE_MAX_LENGTH)
 
     @field_validator("response")
     @classmethod

--- a/backend/tests/domain/test_weekly_prompts.py
+++ b/backend/tests/domain/test_weekly_prompts.py
@@ -1,0 +1,53 @@
+"""Pure-domain tests for the per-week default prompt title (band label).
+
+Pins ``domain.weekly_prompts.prompt_title_for_week(week_number) -> str | None``:
+a 12-band table (Beige, Purple, Red, Blue, Orange, Green, Yellow, Turquoise,
+Coral, Teal, Indigo, Ultraviolet), three weeks each, format
+``"{band} week {week_in_band} Prompt #1"``. Out-of-range weeks return None.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.weekly_prompts import prompt_title_for_week
+
+
+@pytest.mark.parametrize(
+    ("week_number", "expected_title"),
+    [
+        (1, "Beige week 1 Prompt #1"),
+        (3, "Beige week 3 Prompt #1"),
+        (4, "Purple week 1 Prompt #1"),
+        (8, "Red week 2 Prompt #1"),
+        (36, "Ultraviolet week 3 Prompt #1"),
+    ],
+)
+def test_prompt_title_for_week_matches_band_label(week_number: int, expected_title: str) -> None:
+    assert prompt_title_for_week(week_number) == expected_title
+
+
+@pytest.mark.parametrize(
+    ("week_number", "expected_title"),
+    [
+        (1, "Beige week 1 Prompt #1"),
+        (4, "Purple week 1 Prompt #1"),
+        (7, "Red week 1 Prompt #1"),
+        (10, "Blue week 1 Prompt #1"),
+        (13, "Orange week 1 Prompt #1"),
+        (16, "Green week 1 Prompt #1"),
+        (19, "Yellow week 1 Prompt #1"),
+        (22, "Turquoise week 1 Prompt #1"),
+        (25, "Coral week 1 Prompt #1"),
+        (28, "Teal week 1 Prompt #1"),
+        (31, "Indigo week 1 Prompt #1"),
+        (34, "Ultraviolet week 1 Prompt #1"),
+    ],
+)
+def test_prompt_title_for_week_band_order_is_pinned(week_number: int, expected_title: str) -> None:
+    assert prompt_title_for_week(week_number) == expected_title
+
+
+@pytest.mark.parametrize("week_number", [0, 37])
+def test_prompt_title_for_week_out_of_range_is_none(week_number: int) -> None:
+    assert prompt_title_for_week(week_number) is None

--- a/backend/tests/test_prompts_api.py
+++ b/backend/tests/test_prompts_api.py
@@ -265,6 +265,95 @@ async def test_submit_response_creates_journal_entry(async_client: AsyncClient) 
     assert entry["sender"] == "user"
 
 
+# ── Prompt title (mirrored to the JournalEntry) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_submit_without_title_uses_band_default(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "title_default")
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Safety means having a stable home."},
+        headers=headers,
+    )
+    journal_resp = await async_client.get("/journal/", headers=headers)
+    entry = journal_resp.json()["items"][0]
+    assert entry["title"] == "Beige week 1 Prompt #1"
+
+
+@pytest.mark.asyncio
+async def test_submit_with_title_override_is_persisted(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "title_override")
+    await async_client.post(
+        "/prompts/1/respond",
+        json={
+            "response": "Safety means having a stable home.",
+            "title": "Reclaiming my anger",
+        },
+        headers=headers,
+    )
+    journal_resp = await async_client.get("/journal/", headers=headers)
+    entry = journal_resp.json()["items"][0]
+    assert entry["title"] == "Reclaiming my anger"
+
+
+@pytest.mark.asyncio
+async def test_submit_with_whitespace_only_title_falls_back_to_default(
+    async_client: AsyncClient,
+) -> None:
+    headers = await _signup(async_client, "title_whitespace")
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Safety means having a stable home.", "title": "   "},
+        headers=headers,
+    )
+    journal_resp = await async_client.get("/journal/", headers=headers)
+    entry = journal_resp.json()["items"][0]
+    assert entry["title"] == "Beige week 1 Prompt #1"
+
+
+@pytest.mark.asyncio
+async def test_submit_title_is_sanitized(async_client: AsyncClient) -> None:
+    """A zero-width space embedded in the title is stripped by ``sanitize_user_text``."""
+    headers = await _signup(async_client, "title_zerowidth")
+    dirty_title = "Anger" + chr(0x200B)
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Safety means having a stable home.", "title": dirty_title},
+        headers=headers,
+    )
+    journal_resp = await async_client.get("/journal/", headers=headers)
+    entry = journal_resp.json()["items"][0]
+    assert entry["title"] == "Anger"
+
+
+@pytest.mark.asyncio
+async def test_submit_zero_width_only_title_falls_back_to_default(
+    async_client: AsyncClient,
+) -> None:
+    """A title of only zero-width chars sanitizes to empty and must not persist blank."""
+    headers = await _signup(async_client, "title_all_zerowidth")
+    await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Safety means having a stable home.", "title": chr(0x200B) * 3},
+        headers=headers,
+    )
+    journal_resp = await async_client.get("/journal/", headers=headers)
+    entry = journal_resp.json()["items"][0]
+    assert entry["title"] == "Beige week 1 Prompt #1"
+
+
+@pytest.mark.asyncio
+async def test_submit_title_over_max_length_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "title_toolong")
+    resp = await async_client.post(
+        "/prompts/1/respond",
+        json={"response": "Safety means having a stable home.", "title": "x" * 201},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
 # ── GET /prompts/history ────────────────────────────────────────────────
 
 

--- a/frontend/src/api/__tests__/miscEndpoints-api.test.ts
+++ b/frontend/src/api/__tests__/miscEndpoints-api.test.ts
@@ -182,7 +182,7 @@ describe('prompts client', () => {
     };
     mockFetch.mockReturnValueOnce(jsonResponse(prompt));
 
-    const result = await prompts.respond(3, 'Everything.', 'tok');
+    const result = await prompts.respond(3, 'Everything.', null, 'tok');
 
     const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe('http://test/prompts/3/respond');

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1454,10 +1454,15 @@ export const prompts = {
   current(token?: string): Promise<PromptDetail> {
     return request<PromptDetail>('/prompts/current', { token });
   },
-  respond(weekNumber: number, response: string, token?: string): Promise<PromptDetail> {
+  respond(
+    weekNumber: number,
+    response: string,
+    title?: string | null,
+    token?: string,
+  ): Promise<PromptDetail> {
     return request<PromptDetail>(`/prompts/${weekNumber}/respond`, {
       method: 'POST',
-      body: { response },
+      body: { response, ...(title ? { title } : {}) },
       token,
     });
   },

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -30,6 +30,7 @@ import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
+import { promptTitleForWeek } from './promptTitle';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { useResonance } from './useResonance';
 
@@ -145,7 +146,7 @@ async function writeEntry(
   // submit exactly once and never pair it with journal.create (no double-create).
   if (ctx.weekNumber != null) {
     if (respondedRef.current) return;
-    await prompts.respond(ctx.weekNumber, body);
+    await prompts.respond(ctx.weekNumber, body, titleOrNull(title));
     respondedRef.current = true;
     return;
   }
@@ -921,12 +922,6 @@ interface WritingColumnProps {
    * (still in flight or failed), so they never write against an unseen entry.
    */
   controlsDisabled: boolean;
-  /**
-   * In weekly-prompt compose the title is fixed program context the respond
-   * endpoint cannot persist, so it is read-only rather than a lying editable
-   * affordance that silently discards a rename.
-   */
-  titleReadOnly: boolean;
 }
 
 /** Quiet control to mark a draft finished, with a warm retry notice on failure. */
@@ -989,11 +984,7 @@ function WritingFields({
   onChangeTitle,
   onChangeBody,
   bodyPlaceholder,
-  titleReadOnly,
-}: Pick<
-  WritingColumnProps,
-  'title' | 'body' | 'onChangeTitle' | 'onChangeBody' | 'titleReadOnly'
-> & {
+}: Pick<WritingColumnProps, 'title' | 'body' | 'onChangeTitle' | 'onChangeBody'> & {
   bodyPlaceholder: string;
 }) {
   return (
@@ -1005,8 +996,6 @@ function WritingFields({
         placeholder="Title"
         placeholderTextColor={colors.paper.inkSoft}
         accessibilityLabel="Entry title"
-        editable={!titleReadOnly}
-        accessibilityState={{ disabled: titleReadOnly }}
         testID="journal-title-input"
       />
       <View style={styles.hairline} />
@@ -1044,7 +1033,6 @@ function WritingColumn({
   finishError,
   bodyPlaceholder = 'Begin writing…',
   controlsDisabled,
-  titleReadOnly,
 }: WritingColumnProps) {
   return (
     <ScrollView
@@ -1065,7 +1053,6 @@ function WritingColumn({
         onChangeTitle={onChangeTitle}
         onChangeBody={onChangeBody}
         bodyPlaceholder={bodyPlaceholder}
-        titleReadOnly={titleReadOnly}
       />
       <Text style={styles.savedHint} testID="journal-save-hint">
         {savedHintLabel(saveState)}
@@ -1366,7 +1353,6 @@ function useJournalEntryController(
   });
 
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
-  // Weekly-prompt compose gates resonance and makes the title read-only.
   const gate = deriveResonanceGate({
     isIdle,
     isLoading: resonance.loading,
@@ -1387,7 +1373,8 @@ function useJournalEntryController(
     handleBody,
     modal,
     editGate,
-    titleReadOnly: ctx.weekNumber != null,
+    // Weekly-prompt compose withholds Finish (no local id); title stays editable.
+    isPromptCompose: ctx.weekNumber != null,
   };
 }
 
@@ -1402,8 +1389,8 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
   // controls are bound to an unseen entry, so disable them.
   const controlsDisabled = ctl.autosave.controlsLocked;
   // Withhold Finish in weekly-prompt compose: the respond endpoint has no local
-  // id to finish, so the affordance would be a dead end (see titleReadOnly).
-  const canOfferFinish = canFinish && !ctl.titleReadOnly;
+  // id to finish, so the affordance would be a dead end.
+  const canOfferFinish = canFinish && !ctl.isPromptCompose;
   return editMode ? (
     <WritingColumn
       title={title}
@@ -1420,7 +1407,6 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       finishError={finishError}
       bodyPlaceholder={bodyPlaceholder}
       controlsDisabled={controlsDisabled}
-      titleReadOnly={ctl.titleReadOnly}
     />
   ) : (
     <ReadColumn
@@ -1484,7 +1470,7 @@ interface EntryEntrypoint {
 function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntrypoint {
   const p = params ?? {};
   const initialTitle =
-    p.prefillTitle ?? (p.weekNumber != null ? `Week ${p.weekNumber} Reflection` : '');
+    p.prefillTitle ?? (p.weekNumber != null ? promptTitleForWeek(p.weekNumber) : '');
   return {
     ctx: {
       weekNumber: p.weekNumber,

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -15,6 +15,7 @@ import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
+import { promptTitleForWeek } from './promptTitle';
 import SearchBar from './SearchBar';
 import StatTileRow from './StatTileRow';
 
@@ -398,7 +399,7 @@ function useShelfNavigation(
     navigation.navigate('JournalEntry', {
       weekNumber: week,
       promptQuestion: prompt.question,
-      prefillTitle: `Week ${week} Reflection`,
+      prefillTitle: promptTitleForWeek(week),
     });
   }, [navigation, prompt, week]);
   return { openEntry, newEntry, openPrompt, openWithPrompt };

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -16,7 +16,9 @@ const mockUpdate = jest.fn() as jest.MockedFunction<
 >;
 
 const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
-const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+const mockRespond = jest.fn() as jest.MockedFunction<
+  (_w: number, _b: string, _t?: string) => Promise<unknown>
+>;
 
 jest.mock('@/api', () => ({
   journal: {
@@ -105,7 +107,7 @@ describe('JournalEntryScreen', () => {
       await act(async () => {
         await jest.advanceTimersByTimeAsync(100);
       });
-      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.');
+      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.', 'Week 3 Reflection');
       expect(mockCreate).not.toHaveBeenCalled(); // no double-create
       // Resonance can't run on a prompt-compose entry (no local id), so the
       // button must stay hidden even once idle with content.
@@ -126,12 +128,13 @@ describe('JournalEntryScreen', () => {
         },
         { autosaveDelayMs: 100 },
       );
-      expect(getByTestId('journal-title-input').props.editable).toBe(false);
+      expect(getByTestId('journal-title-input').props.editable).not.toBe(false);
+      fireEvent.changeText(getByTestId('journal-title-input'), 'Reclaiming my anger');
       fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
       await act(async () => {
         await jest.advanceTimersByTimeAsync(100);
       });
-      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.');
+      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.', 'Reclaiming my anger');
       expect(mockCreate).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -415,7 +415,7 @@ describe('JournalShelfScreen', () => {
       expect.objectContaining({
         weekNumber: 3,
         promptQuestion: 'What did you notice this week?',
-        prefillTitle: 'Week 3 Reflection',
+        prefillTitle: 'Beige week 3 Prompt #1',
       }),
     );
   });

--- a/frontend/src/features/Journal/__tests__/promptTitle.test.ts
+++ b/frontend/src/features/Journal/__tests__/promptTitle.test.ts
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { promptTitleForWeek } from '../promptTitle';
+
+describe('promptTitleForWeek', () => {
+  const cases: Array<[number, string]> = [
+    [1, 'Beige week 1 Prompt #1'],
+    [3, 'Beige week 3 Prompt #1'],
+    [4, 'Purple week 1 Prompt #1'],
+    [8, 'Red week 2 Prompt #1'],
+    [36, 'Ultraviolet week 3 Prompt #1'],
+  ];
+
+  it.each(cases)('week %i -> %s', (week, expected) => {
+    expect(promptTitleForWeek(week)).toBe(expected);
+  });
+});

--- a/frontend/src/features/Journal/promptTitle.ts
+++ b/frontend/src/features/Journal/promptTitle.ts
@@ -1,0 +1,40 @@
+// Mirrors backend/src/domain/weekly_prompts.py — keep the band table in sync.
+
+// Archetypal Wavelength band labels in developmental order; each band spans
+// WEEKS_PER_BAND consecutive weeks, tiling the 36-week program exactly.
+const PROMPT_BANDS: readonly string[] = [
+  'Beige',
+  'Purple',
+  'Red',
+  'Blue',
+  'Orange',
+  'Green',
+  'Yellow',
+  'Turquoise',
+  'Coral',
+  'Teal',
+  'Indigo',
+  'Ultraviolet',
+];
+
+// Weeks per Wavelength band; three weeks each tile the 36-week program.
+const WEEKS_PER_BAND = 3;
+
+// Exactly one prompt per week, so the default title always reads "... Prompt #1".
+const PROMPTS_PER_WEEK = 1;
+
+const FIRST_WEEK = 1;
+const TOTAL_WEEKS = PROMPT_BANDS.length * WEEKS_PER_BAND;
+
+/**
+ * The default journal title for a prompt week: the week's Wavelength band
+ * label plus its position within that band, e.g. week 8 -> "Red week 2
+ * Prompt #1". Callers pass valid route weeks; out-of-range input is clamped
+ * to [1, TOTAL_WEEKS] so this is total and never throws.
+ */
+export function promptTitleForWeek(week: number): string {
+  const clamped = Math.min(Math.max(Math.trunc(week), FIRST_WEEK), TOTAL_WEEKS);
+  const band = PROMPT_BANDS[Math.trunc((clamped - 1) / WEEKS_PER_BAND)];
+  const weekInBand = ((clamped - 1) % WEEKS_PER_BAND) + 1;
+  return `${band} week ${weekInBand} Prompt #${PROMPTS_PER_WEEK}`;
+}


### PR DESCRIPTION
## Summary
- Weekly-prompt journal entries now persist a title instead of saving `NULL`: the mirrored `JournalEntry` stores the user's override when present, otherwise the wavelength band label (e.g. `Red week 2 Prompt #1`) from the new `prompt_title_for_week` helper. The compose title field is editable again (replacing the #1391 read-only stopgap) and threads through `prompts.respond`; `readEntrypoint` and the shelf seed the same band label so what the user sees matches what persists.
- User-supplied titles pass the existing `sanitize_user_text` boundary (control/zero-width strip, NFC, 200-char cap via a new `JOURNAL_TITLE_MAX_LENGTH` constant); a zero-width-only or whitespace-only title falls back to the band default rather than persisting blank; over-length titles return 422.
- The #1454 atomic-Finish guarantee is preserved: Finish stays withheld in weekly-prompt compose (the respond endpoint has no local id to finish), decoupled from the removed `titleReadOnly` plumbing.

## Test plan
- Backend: `pytest tests/domain/test_weekly_prompts.py tests/test_prompts_api.py` — new domain fixtures for `prompt_title_for_week` (weeks 1/3/4/8/36 + band order + out-of-range `None`) and API tests for band default, override, whitespace/zero-width fallback, sanitize, and 422-over-200.
- Frontend: `jest promptTitle JournalShelfScreen JournalEntryScreen miscEndpoints` — band-label round-trip through `prompts.respond`, editable prompt-compose title, shelf/entrypoint band label, and the preserved Finish-withheld guard.
- Gate 2 green: `./scripts/backend/check-all.sh` (coverage 96.72%, xenon A, radon MI A, mypy/ruff clean) and `./scripts/frontend/check-all.sh` (351 suites / 3705 tests, ESLint zero-warning, tsc + prettier clean).

Closes #1462
