### PR TITLE
fix(frontend): grow ScreenScaffold's scroll content container to restore scrolling

### DIFF
--- a/frontend/src/components/layout/ContentContainer.tsx
+++ b/frontend/src/components/layout/ContentContainer.tsx
@@ -15,11 +15,11 @@ interface ContentContainerProps {
  * The shared content-width cap: a full-width box centered and capped at
  * ``contentLayout.maxWidth`` so screen bodies settle on the same comfortable
  * reading measure on tablets and wide web instead of stretching edge-to-edge.
- * It uses ``flexGrow`` (not ``flex``) so it fills a definite-height parent while
- * still collapsing to its content height inside a ScrollView's content
- * container — a plain ``flex: 1`` there would resolve to zero height on native.
- * Callers wrap their scroll/flow body in this; a caller ``style`` is merged on
- * top without dropping the cap.
+ * It uses ``flexGrow`` (not ``flex``) so it fills its parent, which holds when
+ * the parent is a definite-height box or a scroll content container that itself
+ * sets ``flexGrow`` — a scroll content container without its own grow leaves
+ * this child at ~0 height on RN web. Callers wrap their scroll/flow body in
+ * this; a caller ``style`` is merged on top without dropping the cap.
  */
 export const ContentContainer = ({
   children,

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -30,7 +30,9 @@ export const ScreenScaffold = ({
     return (
       <ScrollView
         style={styles.ground}
-        contentContainerStyle={[styles.content, style]}
+        // The content container must itself grow so its flex-grow child fills
+        // the viewport when short yet still scrolls when tall (journal idiom).
+        contentContainerStyle={[styles.content, styles.scrollContent, style]}
         testID={testID}
       >
         <ContentContainer>{children}</ContentContainer>
@@ -52,6 +54,9 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: rhythm.screenPaddingH,
     paddingTop: rhythm.screenPaddingTop,
+  },
+  scrollContent: {
+    flexGrow: 1,
   },
 });
 

--- a/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, Text } from 'react-native';
 
 import { ScreenScaffold } from '../ScreenScaffold';
 
-import { surface } from '@/design/tokens';
+import { rhythm, surface } from '@/design/tokens';
 
 describe('ScreenScaffold', () => {
   it('renders children on the warm canvas ground', () => {
@@ -46,5 +46,49 @@ describe('ScreenScaffold', () => {
     );
     const container = getByTestId('content-container');
     expect(within(container).getByTestId('scaffold-scroll-child')).toBeTruthy();
+  });
+
+  it('grows the scroll contentContainerStyle to fill the viewport while keeping screen padding', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll testID="scaffold">
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('scaffold').props.contentContainerStyle);
+    expect(flat.flexGrow).toBe(1);
+    expect(flat.paddingHorizontal).toBe(rhythm.screenPaddingH);
+    expect(flat.paddingTop).toBe(rhythm.screenPaddingTop);
+  });
+
+  it('lets a caller style win over the default scroll contentContainerStyle', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll testID="scaffold" style={{ paddingTop: 999 }}>
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('scaffold').props.contentContainerStyle);
+    expect(flat.paddingTop).toBe(999);
+  });
+
+  it('keeps the content container grow-flexed inside the scroll variant', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll>
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flexGrow).toBe(1);
+  });
+
+  it('keeps the non-scroll root fill-flexed with screen padding', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold testID="scaffold-plain">
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('scaffold-plain').props.style);
+    expect(flat.flex).toBe(1);
+    expect(flat.paddingHorizontal).toBe(rhythm.screenPaddingH);
+    expect(flat.paddingTop).toBe(rhythm.screenPaddingTop);
   });
 });


### PR DESCRIPTION
## Summary

Scrolling was inert app-wide on scrollable screens (Journal shelf, Settings, Practice detail — every screen using `ScreenScaffold scroll`) on both native and Expo web, a regression from PR #1413.

**Root cause (why `flexGrow` starved the ScrollView):** PR #1413 gave the shared `ContentContainer` `flexGrow: 1` so it fills a definite-height parent, then wired it as the sole child of `ScreenScaffold`'s scroll-branch `ScrollView`. But that `ScrollView`'s `contentContainerStyle` (`styles.content`) only carried padding — it never got a matching `flexGrow`. A ScrollView's content container is auto-sized (content determines its height). A `flexGrow: 1` child inside an auto-sized flex parent that has no grow of its own has no defined free space to grow into; on React Native Web this resolves the child to ~0 height. The ScrollView then computes `contentSize <= viewport` and treats the view as non-scrollable — exactly "nothing happens" on touch drag and mouse wheel simultaneously.

**Why the new approach satisfies BOTH constraints:** This is the same two-part fill+scroll idiom the journal writing column already uses successfully (`writingColumnContent` `contentContainerStyle` has `flexGrow: 1` paired with the body input's `flexGrow: 1`, PR #1453). We add a dedicated `scrollContent: { flexGrow: 1 }` and compose the scroll branch as `contentContainerStyle={[styles.content, styles.scrollContent, style]}` (caller `style` stays last so overrides still win):

- **Short content → fills the viewport (no zero-height collapse):** the content container now grows to a viewport-height minimum, giving `ContentContainer`'s `flexGrow: 1` a real box to fill. Column default `justify-content: flex-start` keeps children top-aligned, so short screens don't shift.
- **Tall content → scrolls:** when content exceeds the viewport, the content container grows past it, `contentSize > viewport`, and touch/wheel scroll works again.

`ContentContainer`'s `flexGrow: 1` is intentionally **kept** — it is required by its non-scroll usages that fill a definite-height parent (Practice screen root, Map, Habits, and `ScreenScaffold`'s non-scroll branch); removing it would introduce a second regression. Its docstring is corrected to state the real two-part contract (the old comment wrongly claimed the child collapses to its content height inside a ScrollView — it collapses to ~0 on RN web). The shared `content` style, the non-scroll branch, and all journal code are untouched.

## Test plan

RNTL cannot measure real layout, so the contract is pinned **structurally** (flattened style props) in `ScreenScaffold.test.tsx`:

- **Regression pin (RED before, GREEN after):** the scroll branch's `ScrollView` `contentContainerStyle` flattens to `flexGrow === 1` while preserving `paddingHorizontal`/`paddingTop`. Confirmed failing (`flexGrow: undefined`) against the pre-fix code.
- **Caller override wins:** a caller `style` prop's `paddingTop` beats the default (pins merge order `[content, scrollContent, style]`).
- **Two-part chain:** in scroll mode the `ContentContainer` child still has `flexGrow === 1` (fixing the parent doesn't license dropping the child's grow).
- **Non-scroll branch unchanged:** root `View` keeps `flex: 1` + padding.
- Existing guards stay green: `ContentContainer` child-`flexGrow` pin and the journal body `flexGrow` guard (PR #1453) are in untouched files.
- `./scripts/frontend/check-all.sh` green: ESLint (zero warnings), Prettier, `tsc --noEmit` strict, all 3709 Jest tests.

Closes #1491