### PR TITLE
feat(frontend): promote a selected passage as a quote in journal read mode

### DIFF
--- a/frontend/src/api/__tests__/promotionSchemas.test.ts
+++ b/frontend/src/api/__tests__/promotionSchemas.test.ts
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * RED tests for ``promotedQuoteSchema`` / ``promotedQuoteSummarySchema``
+ * (select-a-span -> promote-quote).
+ *
+ * These import symbols that do not exist yet on ``@/api/schemas`` -- this file
+ * fails with ``SyntaxError`` / ``Cannot find module`` / ``is not a function``
+ * until the implementation-specialist adds the schemas.
+ */
+import { promotedQuoteSchema, promotedQuoteSummarySchema } from '../schemas';
+
+/** Return a shallow copy of ``obj`` without ``key`` (avoids unused rest-sibling bindings). */
+function omitKey<T extends Record<string, unknown>>(obj: T, key: string): Record<string, unknown> {
+  const copy: Record<string, unknown> = { ...obj };
+  delete copy[key];
+  return copy;
+}
+
+const FULL_QUOTE = {
+  id: 55,
+  source_entry_id: 7,
+  anchor_start: 2,
+  anchor_end: 19,
+  anchor_text: 'went for a run to',
+  pending: true,
+};
+
+const SUMMARY_QUOTE = {
+  id: 55,
+  anchor_start: 2,
+  anchor_end: 19,
+  anchor_text: 'went for a run to',
+  pending: true,
+};
+
+describe('promotedQuoteSchema', () => {
+  it('accepts a full PromotedQuote payload (mirrors PromotedQuoteResponse)', () => {
+    expect(() => promotedQuoteSchema.parse(FULL_QUOTE)).not.toThrow();
+  });
+
+  it('round-trips every field exactly', () => {
+    const parsed = promotedQuoteSchema.parse(FULL_QUOTE);
+    expect(parsed.id).toBe(55);
+    expect(parsed.source_entry_id).toBe(7);
+    expect(parsed.anchor_start).toBe(2);
+    expect(parsed.anchor_end).toBe(19);
+    expect(parsed.anchor_text).toBe('went for a run to');
+    expect(parsed.pending).toBe(true);
+  });
+
+  it('rejects a missing source_entry_id', () => {
+    expect(() => promotedQuoteSchema.parse(omitKey(FULL_QUOTE, 'source_entry_id'))).toThrow();
+  });
+
+  it('rejects a missing pending flag', () => {
+    expect(() => promotedQuoteSchema.parse(omitKey(FULL_QUOTE, 'pending'))).toThrow();
+  });
+
+  it('rejects a non-boolean pending flag (type drift)', () => {
+    expect(() => promotedQuoteSchema.parse({ ...FULL_QUOTE, pending: 'true' })).toThrow();
+  });
+
+  it('rejects a non-integer anchor_start (type drift)', () => {
+    expect(() => promotedQuoteSchema.parse({ ...FULL_QUOTE, anchor_start: 'two' })).toThrow();
+  });
+});
+
+describe('promotedQuoteSummarySchema', () => {
+  it('accepts a payload with no source_entry_id (the sources-feed shape)', () => {
+    expect(() => promotedQuoteSummarySchema.parse(SUMMARY_QUOTE)).not.toThrow();
+  });
+
+  it('round-trips every field exactly', () => {
+    const parsed = promotedQuoteSummarySchema.parse(SUMMARY_QUOTE);
+    expect(parsed.id).toBe(55);
+    expect(parsed.anchor_start).toBe(2);
+    expect(parsed.anchor_end).toBe(19);
+    expect(parsed.anchor_text).toBe('went for a run to');
+    expect(parsed.pending).toBe(true);
+  });
+
+  it('rejects a missing anchor_text', () => {
+    expect(() => promotedQuoteSummarySchema.parse(omitKey(SUMMARY_QUOTE, 'anchor_text'))).toThrow();
+  });
+
+  it('rejects a missing pending flag', () => {
+    expect(() => promotedQuoteSummarySchema.parse(omitKey(SUMMARY_QUOTE, 'pending'))).toThrow();
+  });
+});

--- a/frontend/src/api/__tests__/promotions.test.ts
+++ b/frontend/src/api/__tests__/promotions.test.ts
@@ -1,0 +1,112 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+
+/**
+ * RED tests for the ``promotions`` API client (select-a-span -> promote-quote).
+ *
+ * ``promotions`` does not exist on ``@/api`` yet -- this file fails with
+ * ``TypeError: promotions is undefined`` / ``is not a function`` until the
+ * implementation-specialist adds the client to ``@/api/index``.
+ */
+import { ApiError, promotions } from '../index';
+import type { PromotedQuote } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function quote(overrides: Partial<PromotedQuote> = {}): PromotedQuote {
+  return {
+    id: 1,
+    source_entry_id: 7,
+    anchor_start: 2,
+    anchor_end: 19,
+    anchor_text: 'went for a run to',
+    pending: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('promotions.create', () => {
+  test('POSTs the anchor offsets to /journal/{id}/promote and parses the 201 quote', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(quote(), 201));
+    const result = await promotions.create(7, { anchor_start: 2, anchor_end: 19 }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7/promote');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ anchor_start: 2, anchor_end: 19 });
+    expect(result.id).toBe(1);
+    expect(result.pending).toBe(true);
+    expect(result.anchor_text).toBe('went for a run to');
+  });
+
+  test('surfaces a 422 anchor_out_of_range as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'anchor_out_of_range' }, 422));
+    const err = await promotions
+      .create(7, { anchor_start: 0, anchor_end: 9999 }, 'tok')
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(422);
+    expect((err as ApiError).detail).toBe('anchor_out_of_range');
+  });
+
+  test('surfaces a 422 quote_too_long as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'quote_too_long' }, 422));
+    await expect(
+      promotions.create(7, { anchor_start: 0, anchor_end: 5000 }, 'tok'),
+    ).rejects.toMatchObject({ status: 422, detail: 'quote_too_long' });
+  });
+});
+
+describe('promotions.remove', () => {
+  test('DELETEs /promotions/{id} and resolves to void on 204', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(undefined, 204));
+    const result = await promotions.remove(55, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/promotions/55');
+    expect(init.method).toBe('DELETE');
+    expect(result).toBeUndefined();
+  });
+
+  test('surfaces a 404 (missing or foreign quote) as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'promotion_not_found' }, 404));
+    await expect(promotions.remove(55, 'tok')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('promotions.setIncluded', () => {
+  test('PATCHes /promotions/{id} with the target entry id, folding the quote in', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(quote({ id: 55, pending: false }), 200));
+    const result = await promotions.setIncluded(55, 12, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/promotions/55');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({ included_in_entry_id: 12 });
+    expect(result.pending).toBe(false);
+  });
+
+  test('PATCHes null to return a folded quote to pending', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(quote({ id: 55, pending: true }), 200));
+    const result = await promotions.setIncluded(55, null, 'tok');
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ included_in_entry_id: null });
+    expect(result.pending).toBe(true);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -24,6 +24,7 @@ import {
   practiceSessionResponseSchema,
   practiceTagSchema,
   programCalendarSchema,
+  promotedQuoteSchema,
   promptListResponseSchema,
   resonanceResponseSchema,
   stageIntroSchema,
@@ -49,6 +50,8 @@ import {
   type ReturnWeekT,
   type PasswordResetAcceptedT,
   type ProgramCalendarT,
+  type PromotedQuoteT,
+  type PromotedQuoteSummaryT,
   type StageProgressRecordT,
   type SuggestionStatusT,
   type Tier,
@@ -1163,6 +1166,15 @@ export interface Marginalia {
   updated_at: string;
 }
 
+/**
+ * A promoted quote — a reader-chosen span of an entry raised into the corpus
+ * (mirrors the backend ``PromotedQuoteResponse``). ``pending`` is true until the
+ * quote is folded into another entry.
+ */
+export type PromotedQuote = PromotedQuoteT;
+/** A promoted quote in the cross-entry sources feed (no ``source_entry_id``). */
+export type PromotedQuoteSummary = PromotedQuoteSummaryT;
+
 /** One of the four non-clinical care routings (mirrors ``domain.care.CareKind``). */
 export type CareKind = CareKindT;
 /** One support pointer (mirrors the backend ``CareResourceResponse``). */
@@ -1262,6 +1274,44 @@ export const journal = {
   },
   delete(entryId: number, token?: string): Promise<void> {
     return request<void>(`/journal/${entryId}`, { method: 'DELETE', token });
+  },
+};
+
+/** The char-offset span a reader selected to promote (end-exclusive). */
+export interface PromoteQuoteSpan {
+  anchor_start: number;
+  anchor_end: number;
+}
+
+/**
+ * Promoted-quotes client (select-a-span -> promote-quote). ``create`` raises the
+ * selected span into the corpus (may surface ``422 anchor_out_of_range`` /
+ * ``422 quote_too_long`` as an ``ApiError``); ``remove`` un-promotes it; and
+ * ``setIncluded`` folds a quote into another entry (or returns it to pending
+ * with ``null``).
+ */
+export const promotions = {
+  /** Promote a reader-selected span of an entry into the corpus. */
+  create(entryId: number, span: PromoteQuoteSpan, token?: string): Promise<PromotedQuote> {
+    return request<PromotedQuote>(`/journal/${entryId}/promote`, {
+      method: 'POST',
+      body: span,
+      token,
+      schema: promotedQuoteSchema as unknown as z.ZodType<PromotedQuote>,
+    });
+  },
+  /** Un-promote a quote by id. */
+  remove(id: number, token?: string): Promise<void> {
+    return request<void>(`/promotions/${id}`, { method: 'DELETE', token });
+  },
+  /** Fold a quote into ``entryId`` (or pass ``null`` to return it to pending). */
+  setIncluded(id: number, entryId: number | null, token?: string): Promise<PromotedQuote> {
+    return request<PromotedQuote>(`/promotions/${id}`, {
+      method: 'PATCH',
+      body: { included_in_entry_id: entryId },
+      token,
+      schema: promotedQuoteSchema as unknown as z.ZodType<PromotedQuote>,
+    });
   },
 };
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -615,6 +615,30 @@ export const marginaliaSchema = z.object({
  * ``professional`` support. Anything else is a contract drift and is rejected
  * at the boundary so an unknown routing can never render an unlabelled card.
  */
+// ---------------------------------------------------------------------------
+// Promoted quotes (select-a-span -> promote-quote)
+// ---------------------------------------------------------------------------
+
+/** A promoted quote (mirrors the backend ``PromotedQuoteResponse``). */
+export const promotedQuoteSchema = z.object({
+  id: z.number().int(),
+  source_entry_id: z.number().int(),
+  anchor_start: z.number().int(),
+  anchor_end: z.number().int(),
+  anchor_text: z.string(),
+  pending: z.boolean(),
+});
+
+/**
+ * A promoted quote as it appears in the cross-entry sources feed (mirrors the
+ * backend ``PromotedQuoteSummary``): the same shape minus ``source_entry_id``,
+ * which the feed groups by rather than repeating on every row.
+ */
+export const promotedQuoteSummarySchema = promotedQuoteSchema.omit({ source_entry_id: true });
+
+export type PromotedQuoteT = z.infer<typeof promotedQuoteSchema>;
+export type PromotedQuoteSummaryT = z.infer<typeof promotedQuoteSummarySchema>;
+
 export const careKindSchema = z.enum(['hotline', 'text_line', 'human', 'professional']);
 
 /** One support pointer (mirrors the backend ``CareResourceResponse``). */

--- a/frontend/src/design/__tests__/editorialTokens.test.ts
+++ b/frontend/src/design/__tests__/editorialTokens.test.ts
@@ -51,6 +51,17 @@ describe('editorial tokens', () => {
       expect(colors.paper.sheetEdge).toMatch(/^#[\da-f]{6}$/i);
       expect(luminance(colors.paper.desk)).toBeLessThan(luminance(colors.paper.background));
     });
+
+    // RED (promote-a-quote): `quoteHighlight` does not exist on `colors.paper`
+    // yet -- this fails with a TypeError reading `.quoteHighlight` of
+    // undefined until the implementation-specialist adds the token.
+    it('exports a quoteHighlight wash distinct from the note anchorHighlight, meeting AA ink contrast', () => {
+      expect(colors.paper.quoteHighlight).toMatch(/^#[\da-f]{6}$/i);
+      expect(colors.paper.quoteHighlight).not.toBe(colors.paper.anchorHighlight);
+      expect(contrast(colors.paper.ink, colors.paper.quoteHighlight)).toBeGreaterThanOrEqual(
+        AA_NORMAL,
+      );
+    });
   });
 
   describe('paperShadow', () => {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -142,6 +142,10 @@ export const colors = {
     inkSoft: '#5a5046',
     hairline: '#e3dccd',
     anchorHighlight: '#f0e3c2',
+    // Promoted-quote wash — a warm apricot/blush, deliberately rosier than the
+    // golden ``anchorHighlight`` so a promoted span reads as a distinct gesture
+    // from a margin-note anchor. Ink (#2b2620) on it clears WCAG AA (~11.5:1).
+    quoteHighlight: '#f7ddcb',
   },
 
   /**

--- a/frontend/src/features/Journal/HighlightedBody.tsx
+++ b/frontend/src/features/Journal/HighlightedBody.tsx
@@ -1,41 +1,82 @@
 /**
  * Read-mode rendering of an entry body with each anchored span softly
- * highlighted and tappable. The offset math lives in {@link buildHighlightSegments};
- * this only maps segments to a composed ``<Text>`` tree.
+ * highlighted and tappable. The offset math lives in {@link buildAnchoredSegments};
+ * this only maps segments to a composed ``<Text>`` tree. Margin-note anchors and
+ * reader-promoted quote spans share the same body, resolved to one anchor stream.
  */
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
 
-import { buildHighlightSegments } from './highlightSegments';
+import { buildAnchoredSegments, type AnchoredSegment } from './highlightSegments';
 
-import type { Marginalia } from '@/api';
+import type { Marginalia, PromotedQuote } from '@/api';
 import { colors, editorialType } from '@/design/tokens';
 
 export interface HighlightedBodyProps {
   body: string;
   notes: Marginalia[];
   onOpen: (_note: Marginalia) => void;
+  /** Reader-promoted quote spans; defaults to none. */
+  quotes?: PromotedQuote[];
+  /** Tapping a promoted-quote span hands back its quote. */
+  onQuotePress?: (_quote: PromotedQuote) => void;
 }
 
-function HighlightedBody({ body, notes, onOpen }: HighlightedBodyProps): React.JSX.Element {
-  const segments = buildHighlightSegments(body, notes);
+/** A promoted-quote span: washed while pending, quietly dimmed once folded in. */
+function QuoteSpan({
+  segment,
+  quote,
+  onPress,
+}: {
+  segment: AnchoredSegment;
+  quote: PromotedQuote;
+  onPress?: (_quote: PromotedQuote) => void;
+}): React.JSX.Element {
+  return (
+    <Text
+      style={quote.pending ? styles.quotePending : styles.quoteIncluded}
+      onPress={onPress ? () => onPress(quote) : undefined}
+      accessibilityRole="link"
+      accessibilityLabel={quote.pending ? 'Promoted passage' : 'Included passage'}
+      testID={`quote-highlight-${quote.id}`}
+    >
+      {segment.text}
+    </Text>
+  );
+}
+
+function HighlightedBody({
+  body,
+  notes,
+  onOpen,
+  quotes = [],
+  onQuotePress,
+}: HighlightedBodyProps): React.JSX.Element {
+  const segments = buildAnchoredSegments(body, notes, quotes);
   return (
     <Text style={styles.body} testID="journal-body-read">
       {segments.map((segment) => {
-        const { note } = segment;
-        if (note == null) return segment.text;
-        return (
-          <Text
-            key={segment.start}
-            style={[styles.highlight, { color: colors.marginalia[note.kind] }]}
-            onPress={() => onOpen(note)}
-            accessibilityRole="link"
-            accessibilityLabel={`Highlighted ${note.kind} passage`}
-            testID={`highlight-${note.id}`}
-          >
-            {segment.text}
-          </Text>
-        );
+        const { note, quote } = segment;
+        if (note != null) {
+          return (
+            <Text
+              key={segment.start}
+              style={[styles.highlight, { color: colors.marginalia[note.kind] }]}
+              onPress={() => onOpen(note)}
+              accessibilityRole="link"
+              accessibilityLabel={`Highlighted ${note.kind} passage`}
+              testID={`highlight-${note.id}`}
+            >
+              {segment.text}
+            </Text>
+          );
+        }
+        if (quote != null) {
+          return (
+            <QuoteSpan key={segment.start} segment={segment} quote={quote} onPress={onQuotePress} />
+          );
+        }
+        return segment.text;
       })}
     </Text>
   );
@@ -51,6 +92,17 @@ const styles = StyleSheet.create({
     // there are no colour literals here.
     backgroundColor: colors.paper.anchorHighlight,
     fontWeight: '600',
+  },
+  quotePending: {
+    // A warm apricot wash marks a live promoted span, distinct from the golden
+    // note anchor; the ink keeps full contrast (AA) over the wash.
+    backgroundColor: colors.paper.quoteHighlight,
+    color: colors.paper.ink,
+    fontWeight: '600',
+  },
+  quoteIncluded: {
+    // Once folded into another entry the span reads quietly — dimmed ink, no wash.
+    color: colors.paper.inkSoft,
   },
 });
 

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -149,6 +149,17 @@ const styles = StyleSheet.create({
     color: colors.paper.inkSoft,
     paddingTop: spacing(2),
   },
+  /** Read-mode quote affordances (Promote / Remove promotion): 44dp touch floor. */
+  quoteActionButton: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+  },
+  /** Row holding the Promote / Cancel actions under the span-selection field. */
+  quoteSelectActions: {
+    flexDirection: 'row',
+    gap: SPACING.md,
+    paddingTop: spacing(1),
+  },
   /** Privacy tier chooser block above the growing body. */
   privacyTierControl: {
     paddingBottom: spacing(1),

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -16,6 +16,8 @@ import {
   TouchableOpacity,
   View,
   useWindowDimensions,
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -32,6 +34,7 @@ import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
 import ResonanceEssayModal from './ResonanceEssayModal';
+import { usePromotions } from './usePromotions';
 import { useResonance } from './useResonance';
 
 import { journal, prompts } from '@/api';
@@ -42,6 +45,7 @@ import type {
   JournalClassification,
   JournalMessage,
   Marginalia,
+  PromotedQuote,
 } from '@/api';
 import { Button } from '@/components/Button';
 import { colors } from '@/design/tokens';
@@ -1073,17 +1077,186 @@ function ResonanceMargin({ error }: { error: string | null }) {
   ) : null;
 }
 
+type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+/** The read-mode quote surface: the promoted-quote list plus its UI gestures. */
+interface QuotePromotion {
+  quotes: PromotedQuote[];
+  /** Warm, declinable copy for the latest failed promote/remove; null otherwise. */
+  hint: string | null;
+  /** True while the reader is choosing a span in the selection TextInput. */
+  selecting: boolean;
+  /** The quote whose "Remove promotion" affordance is currently revealed, if any. */
+  removeTargetId: number | null;
+  startSelecting: () => void;
+  cancelSelecting: () => void;
+  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  confirmSelection: () => Promise<void>;
+  onQuotePress: (_quote: PromotedQuote) => void;
+  confirmRemove: () => void;
+}
+
+/** The read-mode selection/removal gestures over the {@link usePromotions} state. */
+function useQuoteInteraction(
+  promote: (_start: number, _end: number) => Promise<void>,
+  removePromotion: (_id: number) => Promise<void>,
+): Omit<QuotePromotion, 'quotes' | 'hint'> {
+  const [selecting, setSelecting] = useState(false);
+  const [removeTargetId, setRemoveTargetId] = useState<number | null>(null);
+  // The latest selection, held in a ref so a keystroke-free selection change
+  // doesn't re-render the read-only surface until the reader confirms.
+  const selectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+
+  const startSelecting = useCallback(() => {
+    setRemoveTargetId(null);
+    selectionRef.current = { start: 0, end: 0 };
+    setSelecting(true);
+  }, []);
+  const cancelSelecting = useCallback(() => setSelecting(false), []);
+  const onSelectionChange = useCallback((e: SelectionChangeEvent) => {
+    selectionRef.current = e.nativeEvent.selection;
+  }, []);
+  // A collapsed/empty selection (a caret tap, no highlighted span) can't be
+  // promoted — stay in selection mode rather than post a span the server would
+  // only reject. Otherwise leave selection mode first so a 422 returns the
+  // reader to their place in the read view; ``promote`` never throws (it maps
+  // failures to a hint).
+  const confirmSelection = useCallback(async () => {
+    const { start, end } = selectionRef.current;
+    if (end <= start) return;
+    setSelecting(false);
+    await promote(start, end);
+  }, [promote]);
+  const onQuotePress = useCallback((quote: PromotedQuote) => setRemoveTargetId(quote.id), []);
+  const confirmRemove = useCallback(() => {
+    const id = removeTargetId;
+    setRemoveTargetId(null);
+    if (id != null) void removePromotion(id);
+  }, [removeTargetId, removePromotion]);
+
+  return {
+    selecting,
+    removeTargetId,
+    startSelecting,
+    cancelSelecting,
+    onSelectionChange,
+    confirmSelection,
+    onQuotePress,
+    confirmRemove,
+  };
+}
+
+/** Compose the promoted-quote state with its read-mode selection gestures. */
+function useQuotePromotion(routeEntryId: number | null): QuotePromotion {
+  const { quotes, hint, promote, removePromotion } = usePromotions({ entryId: routeEntryId ?? 0 });
+  const interaction = useQuoteInteraction(promote, removePromotion);
+  return { quotes, hint, ...interaction };
+}
+
+/**
+ * The span-selection surface: a controlled, effectively read-only serif field
+ * that mirrors the body so the reader can select a passage to promote without
+ * editing it (soft keyboard suppressed, caret hidden; ``editable`` stays true so
+ * Android text selection still works).
+ */
+function QuoteSelectionSurface({
+  body,
+  onSelectionChange,
+  onConfirm,
+  onCancel,
+}: {
+  body: string;
+  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}) {
+  return (
+    <View>
+      <TextInput
+        style={styles.bodyInput}
+        value={body}
+        multiline
+        editable
+        showSoftInputOnFocus={false}
+        caretHidden
+        scrollEnabled={false}
+        onSelectionChange={onSelectionChange}
+        accessibilityLabel="Select a passage to promote"
+        testID="quote-select-input"
+      />
+      <View style={styles.quoteSelectActions}>
+        <TouchableOpacity
+          onPress={() => void onConfirm()}
+          accessibilityRole="button"
+          accessibilityLabel="Promote the selected passage"
+          style={styles.quoteActionButton}
+          testID="quote-select-confirm"
+        >
+          <Text style={styles.controlLink}>Promote selection</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel promoting"
+          style={styles.quoteActionButton}
+          testID="quote-select-cancel"
+        >
+          <Text style={styles.controlLink}>Cancel</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+/** Read-mode affordances: a remove offer (when a span is tapped), Promote, Edit. */
+function ReadModeControls({ quote, onEdit }: { quote: QuotePromotion; onEdit: () => void }) {
+  return (
+    <>
+      {quote.removeTargetId != null ? (
+        <TouchableOpacity
+          onPress={quote.confirmRemove}
+          accessibilityRole="button"
+          accessibilityLabel="Remove promotion"
+          style={styles.quoteActionButton}
+          testID={`promotion-remove-${quote.removeTargetId}`}
+        >
+          <Text style={styles.controlLink}>Remove promotion</Text>
+        </TouchableOpacity>
+      ) : null}
+      <TouchableOpacity
+        onPress={quote.startSelecting}
+        accessibilityRole="button"
+        accessibilityLabel="Promote a quote"
+        style={styles.quoteActionButton}
+        testID="promote-quote-button"
+      >
+        <Text style={styles.controlLink}>Promote a quote</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={onEdit}
+        accessibilityRole="button"
+        accessibilityLabel="Edit this entry"
+        testID="journal-edit-button"
+      >
+        <Text style={styles.controlLink}>Edit</Text>
+      </TouchableOpacity>
+    </>
+  );
+}
+
 /** Read-mode body: the title + the highlighted passage tree + an Edit affordance. */
 function ReadColumn({
   title,
   body,
   notes,
+  quote,
   onOpen,
   onEdit,
 }: {
   title: string;
   body: string;
   notes: Marginalia[];
+  quote: QuotePromotion;
   onOpen: (_note: Marginalia) => void;
   onEdit: () => void;
 }) {
@@ -1095,15 +1268,28 @@ function ReadColumn({
     >
       {title ? <Text style={styles.titleInput}>{title}</Text> : null}
       <View style={styles.hairline} />
-      <HighlightedBody body={body} notes={notes} onOpen={onOpen} />
-      <TouchableOpacity
-        onPress={onEdit}
-        accessibilityRole="button"
-        accessibilityLabel="Edit this entry"
-        testID="journal-edit-button"
-      >
-        <Text style={styles.controlLink}>Edit</Text>
-      </TouchableOpacity>
+      {quote.selecting ? (
+        <QuoteSelectionSurface
+          body={body}
+          onSelectionChange={quote.onSelectionChange}
+          onConfirm={quote.confirmSelection}
+          onCancel={quote.cancelSelecting}
+        />
+      ) : (
+        <HighlightedBody
+          body={body}
+          notes={notes}
+          onOpen={onOpen}
+          quotes={quote.quotes}
+          onQuotePress={quote.onQuotePress}
+        />
+      )}
+      {quote.hint != null ? (
+        <Text style={styles.savedHint} testID="quote-promotion-error">
+          {quote.hint}
+        </Text>
+      ) : null}
+      {quote.selecting ? null : <ReadModeControls quote={quote} onEdit={onEdit} />}
     </ScrollView>
   );
 }
@@ -1340,8 +1526,8 @@ function useJournalEntryController(
   );
   const { isIdle, bump } = useIdle();
   const resonance = useResonance({ routeEntryId, flush: autosave.flush });
+  const quote = useQuotePromotion(routeEntryId);
   refreshRef.current = resonance.refresh;
-
   const modal = useEssayModal(resonance.updateNote);
   const editGate = useEditGate({
     status: autosave.status,
@@ -1351,7 +1537,6 @@ function useJournalEntryController(
     navigation,
     onConfirmEdit,
   });
-
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
   const gate = deriveResonanceGate({
     isIdle,
@@ -1365,10 +1550,9 @@ function useJournalEntryController(
   return {
     autosave,
     resonance,
+    quote,
     isIdle,
-    visible: gate.visible,
-    resonanceDisabled: gate.resonanceDisabled,
-    resonanceReason: gate.resonanceReason,
+    ...gate,
     handleTitle,
     handleBody,
     modal,
@@ -1413,6 +1597,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       title={title}
       body={body}
       notes={ctl.resonance.marginalia}
+      quote={ctl.quote}
       onOpen={ctl.modal.onOpenNote}
       onEdit={requestEdit}
     />

--- a/frontend/src/features/Journal/__tests__/HighlightedBody.test.tsx
+++ b/frontend/src/features/Journal/__tests__/HighlightedBody.test.tsx
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import HighlightedBody from '../HighlightedBody';
+
+import type { Marginalia, PromotedQuote } from '@/api';
+import { colors } from '@/design/tokens';
+
+const BODY = 'I walked by the river and the willow bent.';
+
+function note(overrides: Partial<Marginalia> = {}): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 1,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 1,
+    anchor_text: 'x',
+    note: 'n',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+function quote(overrides: Partial<PromotedQuote> = {}): PromotedQuote {
+  const start = BODY.indexOf('the willow');
+  return {
+    id: 90,
+    source_entry_id: 1,
+    anchor_start: start,
+    anchor_end: start + 'the willow'.length,
+    anchor_text: 'the willow',
+    pending: true,
+    ...overrides,
+  };
+}
+
+describe('HighlightedBody -- render parity with no quotes (existing behavior)', () => {
+  it('renders identical testIDs to the pre-existing (notes-only) tree when quotes is []', () => {
+    const n = note({ id: 7 });
+    const { getByTestId, queryAllByTestId } = render(
+      <HighlightedBody body={BODY} notes={[n]} onOpen={jest.fn()} quotes={[]} />,
+    );
+    expect(getByTestId('journal-body-read')).toBeTruthy();
+    expect(getByTestId('highlight-7')).toBeTruthy();
+    expect(queryAllByTestId(/^quote-highlight-/)).toHaveLength(0);
+  });
+
+  it('renders the same tree when quotes is omitted entirely (default [])', () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <HighlightedBody body={BODY} notes={[]} onOpen={jest.fn()} />,
+    );
+    expect(getByTestId('journal-body-read')).toBeTruthy();
+    expect(queryAllByTestId(/^quote-highlight-/)).toHaveLength(0);
+  });
+});
+
+describe('HighlightedBody -- quote spans', () => {
+  it('renders a pending quote span with a testID, link role, and the quote wash', () => {
+    const q = quote({ id: 90, pending: true });
+    const { getByTestId } = render(
+      <HighlightedBody
+        body={BODY}
+        notes={[]}
+        onOpen={jest.fn()}
+        quotes={[q]}
+        onQuotePress={jest.fn()}
+      />,
+    );
+    const span = getByTestId('quote-highlight-90');
+    expect(span.props.accessibilityRole).toBe('link');
+    const style = StyleSheet.flatten(span.props.style);
+    expect(style.backgroundColor).toBe(colors.paper.quoteHighlight);
+    expect(style.color).toBe(colors.paper.ink);
+  });
+
+  it('renders an included (non-pending) quote span dimmed, with no wash', () => {
+    const q = quote({ id: 91, pending: false });
+    const { getByTestId } = render(
+      <HighlightedBody
+        body={BODY}
+        notes={[]}
+        onOpen={jest.fn()}
+        quotes={[q]}
+        onQuotePress={jest.fn()}
+      />,
+    );
+    const span = getByTestId('quote-highlight-91');
+    const style = StyleSheet.flatten(span.props.style);
+    expect(style.color).toBe(colors.paper.inkSoft);
+    expect(style.backgroundColor).not.toBe(colors.paper.quoteHighlight);
+  });
+
+  it('fires onQuotePress with the quote when its span is pressed', () => {
+    const onQuotePress = jest.fn();
+    const q = quote({ id: 92 });
+    const { getByTestId } = render(
+      <HighlightedBody
+        body={BODY}
+        notes={[]}
+        onOpen={jest.fn()}
+        quotes={[q]}
+        onQuotePress={onQuotePress}
+      />,
+    );
+    fireEvent.press(getByTestId('quote-highlight-92'));
+    expect(onQuotePress).toHaveBeenCalledWith(q);
+  });
+
+  it('splits the body correctly when a note and a quote both anchor into it', () => {
+    const n = note({ id: 7, anchor_start: 0, anchor_end: 8 }); // "I walked"
+    const q = quote({ id: 90 });
+    const { getByTestId } = render(
+      <HighlightedBody
+        body={BODY}
+        notes={[n]}
+        onOpen={jest.fn()}
+        quotes={[q]}
+        onQuotePress={jest.fn()}
+      />,
+    );
+    expect(getByTestId('highlight-7')).toBeTruthy();
+    expect(getByTestId('quote-highlight-90')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -129,6 +129,16 @@ describe('JournalEntryScreen -- promote-a-quote affordance', () => {
     expect(input.props.value).toBe(BODY);
   });
 
+  it('cancelling selection leaves selection mode without promoting', async () => {
+    const { findByTestId, getByTestId, queryByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    expect(getByTestId('quote-select-input')).toBeTruthy();
+    fireEvent.press(getByTestId('quote-select-cancel'));
+    expect(queryByTestId('quote-select-input')).toBeNull();
+    expect(getByTestId('promote-quote-button')).toBeTruthy(); // back in read mode
+    expect(mockPromote).not.toHaveBeenCalled();
+  });
+
   it('confirming a collapsed selection promotes nothing and stays in selection mode', async () => {
     const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
     fireEvent.press(await findByTestId('promote-quote-button'));

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -1,0 +1,226 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+// RED (select-a-span -> promote-quote, journal entry read mode): the screen
+// does not yet render a "Promote a quote" affordance, a selection-mode
+// TextInput, or promoted-quote spans -- every testID below is missing until
+// the implementation-specialist wires `usePromotions` + the new affordance
+// into `JournalEntryScreen`/`ReadColumn`.
+import type { JournalMessage, PromotedQuote } from '@/api';
+import { touchTarget } from '@/design/tokens';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockCompletionList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: unknown[] }>
+>;
+const mockPromote = jest.fn() as jest.MockedFunction<
+  (_entryId: number, _span: { anchor_start: number; anchor_end: number }) => Promise<PromotedQuote>
+>;
+const mockRemovePromotion = jest.fn() as jest.MockedFunction<(_id: number) => Promise<void>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: { respond: jest.fn() },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: (...a: unknown[]) =>
+      (mockCompletionList as unknown as (...x: unknown[]) => unknown)(...a),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+  promotions: {
+    create: (...a: unknown[]) => (mockPromote as unknown as (...x: unknown[]) => unknown)(...a),
+    remove: (...a: unknown[]) =>
+      (mockRemovePromotion as unknown as (...x: unknown[]) => unknown)(...a),
+    setIncluded: jest.fn(),
+  },
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+const BODY = 'A page about a daily run to the river and back.';
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: BODY,
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Runs',
+    status: 'finished', // read mode -- the surface this issue lives in
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function promotedQuote(overrides: Partial<PromotedQuote> = {}): PromotedQuote {
+  return {
+    id: 55,
+    source_entry_id: 7,
+    anchor_start: 2,
+    anchor_end: 19,
+    anchor_text: 'went for a daily',
+    pending: true,
+    ...overrides,
+  };
+}
+
+function renderScreen(params?: { entryId?: number }) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return { ...render(<Screen navigation={navigation} route={route} />), navigation };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockCompletionList.mockReset();
+  mockCompletionList.mockResolvedValue({ items: [] });
+  mockPromote.mockReset();
+  mockRemovePromotion.mockReset();
+  mockGet.mockResolvedValue(entry());
+});
+
+describe('JournalEntryScreen -- promote-a-quote render parity', () => {
+  it('with zero promotions, the existing read-mode tree is unchanged', async () => {
+    const { findByTestId, queryAllByTestId } = renderScreen({ entryId: 7 });
+    expect(await findByTestId('journal-body-read')).toBeTruthy();
+    expect(queryAllByTestId(/^quote-highlight-/)).toHaveLength(0);
+  });
+});
+
+describe('JournalEntryScreen -- promote-a-quote affordance', () => {
+  it('shows a touch-target-sized "Promote a quote" affordance in read mode', async () => {
+    const { findByTestId } = renderScreen({ entryId: 7 });
+    const button = await findByTestId('promote-quote-button');
+    expect(button.props.accessibilityLabel).toBe('Promote a quote');
+    const style = StyleSheet.flatten(button.props.style);
+    expect(style.minHeight).toBeGreaterThanOrEqual(touchTarget.minimum);
+  });
+
+  it('entering selection mode renders a controlled TextInput seeded with the body', async () => {
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    expect(input.props.value).toBe(BODY);
+  });
+
+  it('confirming a collapsed selection promotes nothing and stays in selection mode', async () => {
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    // A caret tap with no highlighted span reports start === end.
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 5, end: 5 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+    expect(mockPromote).not.toHaveBeenCalled();
+    expect(getByTestId('quote-select-input')).toBeTruthy(); // still selecting
+  });
+
+  it('confirming a selection calls promotions.create with the exact offsets', async () => {
+    mockPromote.mockResolvedValue(promotedQuote());
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 19 } } });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+    expect(mockPromote).toHaveBeenCalledWith(7, { anchor_start: 2, anchor_end: 19 });
+  });
+
+  it('on a 201 the promoted span appears back in the read-mode body', async () => {
+    mockPromote.mockResolvedValue(promotedQuote({ id: 90 }));
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 19 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+    expect(await findByTestId('quote-highlight-90')).toBeTruthy();
+  });
+
+  it('a 422 error surfaces a hint, keeps the body rendered, and never navigates away', async () => {
+    mockPromote.mockRejectedValue({ status: 422, detail: 'anchor_out_of_range' });
+    const { findByTestId, getByTestId, navigation } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 0, end: 9999 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+
+    expect(await findByTestId('quote-promotion-error')).toBeTruthy();
+    expect(getByTestId('journal-body-read')).toBeTruthy();
+    expect(navigation.navigate).not.toHaveBeenCalled();
+    expect(mockGet).toHaveBeenCalledTimes(1); // reading position wasn't lost to a reload
+  });
+});
+
+describe('JournalEntryScreen -- removing a promoted quote', () => {
+  async function promoteOne(screen: ReturnType<typeof renderScreen>): Promise<void> {
+    mockPromote.mockResolvedValue(promotedQuote({ id: 90 }));
+    fireEvent.press(await screen.findByTestId('promote-quote-button'));
+    const input = screen.getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 19 } } });
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('quote-select-confirm'));
+    });
+    await screen.findByTestId('quote-highlight-90');
+  }
+
+  it('tapping a quote span offers "Remove promotion", which calls promotions.remove', async () => {
+    const screen = renderScreen({ entryId: 7 });
+    await promoteOne(screen);
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    const removeButton = await screen.findByTestId('promotion-remove-90');
+    expect(removeButton.props.accessibilityLabel).toBe('Remove promotion');
+
+    await act(async () => {
+      fireEvent.press(removeButton);
+    });
+    expect(mockRemovePromotion).toHaveBeenCalledWith(90);
+    await waitFor(() => expect(screen.queryByTestId('quote-highlight-90')).toBeNull());
+  });
+
+  it('a failed removal reverts the span back into view', async () => {
+    mockRemovePromotion.mockRejectedValue({ status: 500, detail: 'boom' });
+    const screen = renderScreen({ entryId: 7 });
+    await promoteOne(screen);
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    const removeButton = await screen.findByTestId('promotion-remove-90');
+    await act(async () => {
+      fireEvent.press(removeButton);
+    });
+    expect(await screen.findByTestId('quote-highlight-90')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
@@ -1,0 +1,147 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+// RED: `buildAnchoredSegments` does not exist on `../highlightSegments` yet --
+// this file fails with "Cannot find module" / "is not a function" until the
+// implementation-specialist adds it (highlightSegments.ts becomes a thin
+// wrapper around it; `buildHighlightSegments` stays byte-identical -- see
+// highlightSegments.test.ts, which is untouched).
+import { buildAnchoredSegments, buildHighlightSegments } from '../highlightSegments';
+
+import type { Marginalia, PromotedQuote } from '@/api';
+
+const BODY = 'I walked by the river and the willow bent.';
+
+function note(overrides: Partial<Marginalia>): Marginalia {
+  return {
+    id: 1,
+    journal_entry_id: 1,
+    kind: 'theme',
+    anchor_start: 0,
+    anchor_end: 1,
+    anchor_text: 'x',
+    note: 'n',
+    essay: null,
+    essay_generated_at: null,
+    status: 'active',
+    created_at: '',
+    updated_at: '',
+    ...overrides,
+  };
+}
+
+function quote(overrides: Partial<PromotedQuote>): PromotedQuote {
+  return {
+    id: 100,
+    source_entry_id: 1,
+    anchor_start: 0,
+    anchor_end: 1,
+    anchor_text: 'x',
+    pending: true,
+    ...overrides,
+  };
+}
+
+describe('buildAnchoredSegments', () => {
+  it('returns the whole body as one plain segment when there are no notes or quotes', () => {
+    const segments = buildAnchoredSegments(BODY, [], []);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null, quote: null }]);
+  });
+
+  it('splits the body at a quote anchor boundary, tagging the segment with the quote', () => {
+    const start = BODY.indexOf('the willow');
+    const q = quote({ id: 55, anchor_start: start, anchor_end: start + 'the willow'.length });
+    const segments = buildAnchoredSegments(BODY, [], [q]);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toEqual({ start: 0, text: BODY.slice(0, start), note: null, quote: null });
+    expect(segments[1]).toMatchObject({ start, text: 'the willow', note: null });
+    expect(segments[1]!.quote?.id).toBe(55);
+    expect(segments[2]!.quote).toBeNull();
+    expect(segments[2]!.note).toBeNull();
+    expect(segments.map((s) => s.text).join('')).toBe(BODY);
+  });
+
+  it('merges a note and a quote at different anchors, sorted by anchor_start', () => {
+    const noteStart = BODY.indexOf('river');
+    const quoteStart = BODY.indexOf('willow');
+    const n = note({ id: 1, anchor_start: noteStart, anchor_end: noteStart + 'river'.length });
+    const q = quote({ id: 55, anchor_start: quoteStart, anchor_end: quoteStart + 'willow'.length });
+    // Unsorted input (quote first) -- the builder must sort by anchor itself.
+    const segments = buildAnchoredSegments(BODY, [n], [q]);
+
+    const anchored = segments.filter((s) => s.note != null || s.quote != null);
+    expect(anchored).toHaveLength(2);
+    expect(anchored[0]!.note?.id).toBe(1);
+    expect(anchored[1]!.quote?.id).toBe(55);
+  });
+
+  it('draws the note first when a note and a quote share the same anchor_start', () => {
+    const start = BODY.indexOf('willow');
+    const n = note({ id: 1, anchor_start: start, anchor_end: start + 3 }); // "wil"
+    const q = quote({ id: 55, anchor_start: start, anchor_end: start + 6 }); // "willow"
+    const segments = buildAnchoredSegments(BODY, [n], [q]);
+
+    const anchored = segments.filter((s) => s.note != null || s.quote != null);
+    // The note wins the tie; the overlapping quote is skipped by the same
+    // first-wins cursor-skip rule `buildHighlightSegments` already uses.
+    expect(anchored).toHaveLength(1);
+    expect(anchored[0]!.note?.id).toBe(1);
+  });
+
+  it('keeps the earliest-starting anchor regardless of note vs quote', () => {
+    const quoteStart = BODY.indexOf('the river');
+    const noteStart = BODY.indexOf('river'); // overlaps and starts later
+    const q = quote({ id: 55, anchor_start: quoteStart, anchor_end: quoteStart + 9 });
+    const n = note({ id: 1, anchor_start: noteStart, anchor_end: noteStart + 20 });
+    const segments = buildAnchoredSegments(BODY, [n], [q]);
+
+    const anchored = segments.filter((s) => s.note != null || s.quote != null);
+    expect(anchored).toHaveLength(1);
+    expect(anchored[0]!.quote?.id).toBe(55);
+    expect(anchored[0]!.note).toBeNull();
+  });
+
+  it('drops a quote that falls outside the body', () => {
+    const q = quote({ id: 55, anchor_start: 100, anchor_end: 120 });
+    const segments = buildAnchoredSegments(BODY, [], [q]);
+    expect(segments.every((s) => s.quote == null)).toBe(true);
+  });
+
+  it('drops an empty quote anchor whose start equals its end', () => {
+    const at = BODY.indexOf('willow');
+    const q = quote({ id: 55, anchor_start: at, anchor_end: at });
+    const segments = buildAnchoredSegments(BODY, [], [q]);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null, quote: null }]);
+  });
+
+  it('includes a quote anchor that ends exactly at the end of the body', () => {
+    const end = BODY.length;
+    const tail = 'bent.';
+    const q = quote({ id: 55, anchor_start: end - tail.length, anchor_end: end });
+    const segments = buildAnchoredSegments(BODY, [], [q]);
+    const last = segments[segments.length - 1]!;
+    expect(last.quote?.id).toBe(55);
+    expect(last.text).toBe(tail);
+  });
+
+  it('still filters a stale note out of the merged anchored stream', () => {
+    const start = BODY.indexOf('the willow');
+    const stale = note({
+      id: 8,
+      anchor_start: start,
+      anchor_end: start + 'the willow'.length,
+      status: 'stale',
+    });
+    const segments = buildAnchoredSegments(BODY, [stale], []);
+    expect(segments.every((s) => s.note == null)).toBe(true);
+  });
+
+  it('is a strict superset of buildHighlightSegments when there are no quotes', () => {
+    const start = BODY.indexOf('the willow');
+    const n = note({ id: 7, anchor_start: start, anchor_end: start + 'the willow'.length });
+    const legacy = buildHighlightSegments(BODY, [n]);
+    const anchored = buildAnchoredSegments(BODY, [n], []);
+    expect(anchored).toEqual(legacy.map((s) => ({ ...s, quote: null })));
+  });
+});

--- a/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { PromotedQuote } from '@/api';
+import { ApiError } from '@/api';
+
+/** A pending promoted quote anchored near the head of a body. */
+function quote(overrides: Partial<PromotedQuote> = {}): PromotedQuote {
+  return {
+    id: 1,
+    source_entry_id: 7,
+    anchor_start: 2,
+    anchor_end: 19,
+    anchor_text: 'went for a run to',
+    pending: true,
+    ...overrides,
+  };
+}
+
+const mockCreate = jest.fn() as jest.MockedFunction<
+  (_entryId: number, _span: { anchor_start: number; anchor_end: number }) => Promise<PromotedQuote>
+>;
+const mockRemove = jest.fn() as jest.MockedFunction<(_id: number) => Promise<void>>;
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    promotions: {
+      create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+      remove: (...a: unknown[]) => (mockRemove as unknown as (...x: unknown[]) => unknown)(...a),
+      setIncluded: jest.fn(),
+    },
+  };
+});
+
+// RED: `usePromotions` does not exist yet -- this `require` fails with
+// "Cannot find module" until the implementation-specialist adds the hook.
+const { usePromotions } = require('../usePromotions');
+
+beforeEach(() => {
+  mockCreate.mockReset();
+  mockRemove.mockReset();
+});
+
+describe('usePromotions', () => {
+  it('seeds its quote list from initialQuotes', () => {
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+    expect(result.current.quotes).toEqual([seeded]);
+  });
+
+  it('defaults to an empty quote list with no initialQuotes', () => {
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+    expect(result.current.quotes).toEqual([]);
+  });
+
+  it('promote calls promotions.create with the entry id and the exact span', async () => {
+    mockCreate.mockResolvedValue(quote({ id: 9 }));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await act(async () => {
+      await result.current.promote(2, 19);
+    });
+    expect(mockCreate).toHaveBeenCalledWith(7, { anchor_start: 2, anchor_end: 19 });
+  });
+
+  it('promote appends the returned quote on 201', async () => {
+    mockCreate.mockResolvedValue(quote({ id: 9 }));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await act(async () => {
+      await result.current.promote(2, 19);
+    });
+    expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([9]);
+  });
+
+  it('promote maps an error to a non-blocking hint and does not append a quote', async () => {
+    mockCreate.mockRejectedValue(new ApiError(422, 'anchor_out_of_range'));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await act(async () => {
+      await result.current.promote(0, 9999);
+    });
+    expect(result.current.quotes).toEqual([]);
+    expect(result.current.hint).toBeTruthy();
+  });
+
+  it('removePromotion optimistically removes the quote', async () => {
+    mockRemove.mockResolvedValue(undefined);
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+
+    await act(async () => {
+      await result.current.removePromotion(5);
+    });
+    expect(result.current.quotes).toEqual([]);
+    expect(mockRemove).toHaveBeenCalledWith(5);
+  });
+
+  it('removePromotion reverts the optimistic removal on error and sets a hint', async () => {
+    mockRemove.mockRejectedValue(new ApiError(500, 'boom'));
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+
+    await act(async () => {
+      await result.current.removePromotion(5);
+    });
+    expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([5]); // reverted
+    expect(result.current.hint).toBeTruthy();
+  });
+
+  it('removePromotion guards a double-tap on the same id (no second network call)', async () => {
+    let resolveRemove: () => void = () => {};
+    mockRemove.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRemove = resolve;
+      }),
+    );
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+
+    await act(async () => {
+      void result.current.removePromotion(5);
+      void result.current.removePromotion(5); // second tap while the first is in flight
+      resolveRemove();
+    });
+    await waitFor(() => expect(result.current.quotes).toEqual([]));
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -1,9 +1,9 @@
 /**
  * Split an entry body into render segments, tagging each anchored range with its
- * note. Pure offset math — no React — so the highlight logic is unit-testable
- * apart from the ``<Text>`` tree that consumes it.
+ * note and/or promoted quote. Pure offset math — no React — so the highlight
+ * logic is unit-testable apart from the ``<Text>`` tree that consumes it.
  */
-import type { Marginalia } from '@/api';
+import type { Marginalia, PromotedQuote } from '@/api';
 
 export interface HighlightSegment {
   /** Character offset of this segment in the body (stable, unique → React key). */
@@ -13,41 +13,113 @@ export interface HighlightSegment {
   note: Marginalia | null;
 }
 
-/** Anchors that fall inside the body and are non-empty, earliest first. */
-function usableNotes(body: string, notes: Marginalia[]): Marginalia[] {
-  return notes
-    .filter(
-      (n) =>
-        // Stale anchors no longer point at a trustworthy span, so they are not
-        // drawn inline (the note itself stays openable in the margin).
-        n.status !== 'stale' &&
-        n.anchor_start >= 0 &&
-        n.anchor_end <= body.length &&
-        n.anchor_start < n.anchor_end,
-    )
-    .sort((a, b) => a.anchor_start - b.anchor_start);
+/** A segment that may carry a margin note, a promoted quote, or neither. */
+export interface AnchoredSegment extends HighlightSegment {
+  /** The promoted quote whose anchor this segment is, or null. */
+  quote: PromotedQuote | null;
 }
 
-export function buildHighlightSegments(body: string, notes: Marginalia[]): HighlightSegment[] {
-  const segments: HighlightSegment[] = [];
+/** ``order`` keeps a note ahead of a quote when the two share an anchor_start. */
+const NOTE_ORDER = 0;
+const QUOTE_ORDER = 1;
+
+/** A margin note or a promoted quote reduced to a comparable anchored range. */
+interface Anchor {
+  start: number;
+  end: number;
+  order: number;
+  id: number;
+  note: Marginalia | null;
+  quote: PromotedQuote | null;
+}
+
+/** An anchor is drawn only if it falls inside the body and is non-empty. */
+function inRange(body: string, start: number, end: number): boolean {
+  return start >= 0 && end <= body.length && start < end;
+}
+
+/** Live (non-stale), in-range note anchors — stale notes are not drawn inline. */
+function noteAnchors(body: string, notes: Marginalia[]): Anchor[] {
+  return notes
+    .filter((n) => n.status !== 'stale' && inRange(body, n.anchor_start, n.anchor_end))
+    .map((n) => ({
+      start: n.anchor_start,
+      end: n.anchor_end,
+      order: NOTE_ORDER,
+      id: n.id,
+      note: n,
+      quote: null,
+    }));
+}
+
+/** In-range quote anchors (quotes have no stale status to filter on). */
+function quoteAnchors(body: string, quotes: PromotedQuote[]): Anchor[] {
+  return quotes
+    .filter((q) => inRange(body, q.anchor_start, q.anchor_end))
+    .map((q) => ({
+      start: q.anchor_start,
+      end: q.anchor_end,
+      order: QUOTE_ORDER,
+      id: q.id,
+      note: null,
+      quote: q,
+    }));
+}
+
+/** Merge + sort by (anchor_start, note-before-quote at equal start, then id). */
+function usableAnchors(body: string, notes: Marginalia[], quotes: PromotedQuote[]): Anchor[] {
+  return [...noteAnchors(body, notes), ...quoteAnchors(body, quotes)].sort(
+    (a, b) => a.start - b.start || a.order - b.order || a.id - b.id,
+  );
+}
+
+/**
+ * Segment the body against the merged note + quote anchor stream. The same
+ * first-wins cursor-skip rule as the notes-only path resolves overlaps: the
+ * earliest-starting anchor wins and any anchor overlapping a committed range is
+ * skipped.
+ */
+export function buildAnchoredSegments(
+  body: string,
+  notes: Marginalia[],
+  quotes: PromotedQuote[],
+): AnchoredSegment[] {
+  const segments: AnchoredSegment[] = [];
   let cursor = 0;
-  for (const note of usableNotes(body, notes)) {
-    // Skip any anchor that overlaps a range we've already committed to — first
-    // (earliest-start) wins, deterministically.
-    if (note.anchor_start < cursor) continue;
-    if (note.anchor_start > cursor) {
-      segments.push({ start: cursor, text: body.slice(cursor, note.anchor_start), note: null });
+  for (const anchor of usableAnchors(body, notes, quotes)) {
+    if (anchor.start < cursor) continue; // overlaps a committed range — skip it
+    if (anchor.start > cursor) {
+      segments.push({
+        start: cursor,
+        text: body.slice(cursor, anchor.start),
+        note: null,
+        quote: null,
+      });
     }
     segments.push({
-      start: note.anchor_start,
-      text: body.slice(note.anchor_start, note.anchor_end),
-      note,
+      start: anchor.start,
+      text: body.slice(anchor.start, anchor.end),
+      note: anchor.note,
+      quote: anchor.quote,
     });
-    cursor = note.anchor_end;
+    cursor = anchor.end;
   }
   if (cursor < body.length) {
-    segments.push({ start: cursor, text: body.slice(cursor), note: null });
+    segments.push({ start: cursor, text: body.slice(cursor), note: null, quote: null });
   }
-  if (segments.length === 0) segments.push({ start: 0, text: body, note: null });
+  if (segments.length === 0) segments.push({ start: 0, text: body, note: null, quote: null });
   return segments;
+}
+
+/**
+ * The notes-only segmentation the read-mode highlight tree consumes. A thin
+ * wrapper over {@link buildAnchoredSegments} (no quotes) that drops the quote
+ * key, so its shape and behaviour stay exactly as before.
+ */
+export function buildHighlightSegments(body: string, notes: Marginalia[]): HighlightSegment[] {
+  return buildAnchoredSegments(body, notes, []).map(({ start, text, note }) => ({
+    start,
+    text,
+    note,
+  }));
 }

--- a/frontend/src/features/Journal/usePromotions.ts
+++ b/frontend/src/features/Journal/usePromotions.ts
@@ -50,6 +50,11 @@ export function usePromotions({
   // One promote at a time; per-id guard for removals — no double-post/-delete.
   const promotingRef = useRef(false);
   const removingIdsRef = useRef<Set<number>>(new Set());
+  // Mirror the latest quotes so ``removePromotion`` can look up the row it drops
+  // (for revert-on-error) without depending on ``quotes`` — that keeps its
+  // identity stable across every add/remove.
+  const quotesRef = useRef(quotes);
+  quotesRef.current = quotes;
 
   const promote = useCallback(
     async (start: number, end: number): Promise<void> => {
@@ -68,24 +73,21 @@ export function usePromotions({
     [entryId],
   );
 
-  const removePromotion = useCallback(
-    async (id: number): Promise<void> => {
-      if (removingIdsRef.current.has(id)) return;
-      removingIdsRef.current.add(id);
-      setHint(null);
-      const removed = quotes.find((q) => q.id === id);
-      setQuotes((prev) => dropById(prev, id)); // optimistic
-      try {
-        await promotions.remove(id);
-      } catch (err) {
-        if (removed) setQuotes((prev) => insertSorted(prev, removed)); // revert
-        setHint(formatApiError(err));
-      } finally {
-        removingIdsRef.current.delete(id);
-      }
-    },
-    [quotes],
-  );
+  const removePromotion = useCallback(async (id: number): Promise<void> => {
+    if (removingIdsRef.current.has(id)) return;
+    removingIdsRef.current.add(id);
+    setHint(null);
+    const removed = quotesRef.current.find((q) => q.id === id);
+    setQuotes((prev) => dropById(prev, id)); // optimistic
+    try {
+      await promotions.remove(id);
+    } catch (err) {
+      if (removed) setQuotes((prev) => insertSorted(prev, removed)); // revert
+      setHint(formatApiError(err));
+    } finally {
+      removingIdsRef.current.delete(id);
+    }
+  }, []);
 
   return { quotes, hint, promote, removePromotion };
 }

--- a/frontend/src/features/Journal/usePromotions.ts
+++ b/frontend/src/features/Journal/usePromotions.ts
@@ -1,0 +1,91 @@
+/**
+ * ``usePromotions`` — owns the promoted-quote list for one journal entry
+ * (select-a-span -> promote-quote).
+ *
+ * ``promote`` raises a reader-selected span into the corpus and appends the
+ * returned quote on success; a failure maps to a warm, non-blocking hint and
+ * appends nothing. ``removePromotion`` optimistically drops a quote and reverts
+ * it on error, guarding a double-tap per id (mirrors ``useResonance``'s
+ * ``runDismiss``). One promote runs at a time so a double-tap can't double-post.
+ */
+import { useCallback, useRef, useState } from 'react';
+
+import { promotions } from '@/api';
+import type { PromotedQuote } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+
+export interface UsePromotionsArgs {
+  /** The entry whose spans are being promoted. */
+  entryId: number;
+  /** Quotes already promoted for this entry (seeds the list). */
+  initialQuotes?: PromotedQuote[];
+}
+
+export interface UsePromotionsResult {
+  quotes: PromotedQuote[];
+  /** Warm, declinable copy for the latest failed action; null when all is well. */
+  hint: string | null;
+  /** Promote the ``[start, end)`` span; appends the new quote on success. */
+  promote: (_start: number, _end: number) => Promise<void>;
+  /** Un-promote a quote by id; optimistic, reverting on error. */
+  removePromotion: (_id: number) => Promise<void>;
+}
+
+/** Re-insert a reverted quote, keeping the list ordered by anchor then id. */
+function insertSorted(quotes: PromotedQuote[], quote: PromotedQuote): PromotedQuote[] {
+  return [...quotes, quote].sort((a, b) => a.anchor_start - b.anchor_start || a.id - b.id);
+}
+
+/** Drop the quote with ``id`` (a named helper so it isn't a nested callback). */
+function dropById(quotes: PromotedQuote[], id: number): PromotedQuote[] {
+  return quotes.filter((q) => q.id !== id);
+}
+
+export function usePromotions({
+  entryId,
+  initialQuotes = [],
+}: UsePromotionsArgs): UsePromotionsResult {
+  const [quotes, setQuotes] = useState<PromotedQuote[]>(initialQuotes);
+  const [hint, setHint] = useState<string | null>(null);
+  // One promote at a time; per-id guard for removals — no double-post/-delete.
+  const promotingRef = useRef(false);
+  const removingIdsRef = useRef<Set<number>>(new Set());
+
+  const promote = useCallback(
+    async (start: number, end: number): Promise<void> => {
+      if (promotingRef.current) return;
+      promotingRef.current = true;
+      setHint(null);
+      try {
+        const created = await promotions.create(entryId, { anchor_start: start, anchor_end: end });
+        setQuotes((prev) => insertSorted(prev, created));
+      } catch (err) {
+        setHint(formatApiError(err));
+      } finally {
+        promotingRef.current = false;
+      }
+    },
+    [entryId],
+  );
+
+  const removePromotion = useCallback(
+    async (id: number): Promise<void> => {
+      if (removingIdsRef.current.has(id)) return;
+      removingIdsRef.current.add(id);
+      setHint(null);
+      const removed = quotes.find((q) => q.id === id);
+      setQuotes((prev) => dropById(prev, id)); // optimistic
+      try {
+        await promotions.remove(id);
+      } catch (err) {
+        if (removed) setQuotes((prev) => insertSorted(prev, removed)); // revert
+        setHint(formatApiError(err));
+      } finally {
+        removingIdsRef.current.delete(id);
+      }
+    },
+    [quotes],
+  );
+
+  return { quotes, hint, promote, removePromotion };
+}


### PR DESCRIPTION
## Summary

Lets a journaler rereading a finished entry select a span of the body and
**promote it as a quote** — persisted via `POST /journal/{id}/promote` — so a
line that surprises them is waiting when the next reflection opens.

- **API client** (`api/index.ts`): a `promotions` client with `create(entryId, {anchor_start, anchor_end})`, `remove(id)`, and `setIncluded(id, entryId | null)`, plus `PromotedQuote`/`PromotedQuoteSummary` types. Zod schemas (`api/schemas.ts`) mirror the backend `PromotedQuoteResponse`/summary field-for-field, kept in sync with the TS types.
- **Read-mode selection surface**: in `JournalEntryScreen` read mode a token-styled, 44dp "Promote a quote" affordance opens a controlled, effectively read-only serif `TextInput` that mirrors the body. Its `onSelectionChange` captures the offsets; confirming a non-empty selection calls `promotions.create` and optimistically adds the span. A collapsed/empty selection is guarded (no doomed round-trip).
- **Second highlight kind**: a new pure helper `buildAnchoredSegments` composes marginalia anchors and promoted-quote anchors deterministically (first-wins overlap, note-before-quote at equal start). `buildHighlightSegments` stays a thin wrapper so notes-only rendering is byte-identical. Promoted spans render in a new `colors.paper.quoteHighlight` apricot wash (AA over ink); included (folded-in) quotes read quietly dimmed.
- **Removal**: tapping a promoted span offers a declinable "Remove promotion" → `promotions.remove`, optimistic with revert-on-error.
- **Non-blocking errors**: promote/remove failures surface a warm hint consistent with the save-hint copy; a failed promote never reloads or loses the reading position.

**Design choice** (per the issue's fallback note): read-mode selection uses a read-only controlled `TextInput`'s `onSelectionChange` (soft keyboard suppressed, caret hidden, `editable` left true so Android selection still works) rather than `Text` selection callbacks, which are unreliable for long spans.

The promotion affordance stays a resonant, declinable invitation — no gamified pressure (NORTH-STAR).

Scope: this is the *create/remove* gesture only. Loading previously-promoted spans on reopen and folding a quote into a reflection (`setIncluded`, sources feed) belong to hierarchical-journaling-05.

## Test plan

- `promotions.test.ts` — client posts offsets to `/journal/{id}/promote`, parses the 201; `remove` DELETEs; `setIncluded` PATCHes `included_in_entry_id` (incl. `null`); 422/404 surface as `ApiError`.
- `promotionSchemas.test.ts` — Zod schemas accept the full/summary payloads and reject missing/type-drifted fields.
- `buildAnchoredSegments.test.ts` — marginalia+quote overlap composition, first-wins, and byte-identical parity with the legacy notes-only builder when there are zero quotes.
- `HighlightedBody.test.tsx` — pending vs included span styling and testIDs.
- `usePromotions.test.tsx` — single-flight promote, optimistic-revert removal, warm hint on failure.
- `JournalEntryScreenPromotions.test.tsx` — zero-promotion render parity, affordance touch target, selection → create with exact offsets, collapsed-selection guard, 201 optimistic add, 422 non-blocking hint (no navigation/reload), remove flow, failed-removal revert.
- Full `./scripts/frontend/check-all.sh` green (jest 3760 passed, tsc, eslint, prettier).

Closes #1463 · epic #1458 (sub-4)