### PR TITLE
feat(backend): re-anchor or stale-mark promoted quotes on source-entry edit

### DIFF
--- a/backend/migrations/versions/a9b0c1d2e3f4_add_promoted_quote_stale.py
+++ b/backend/migrations/versions/a9b0c1d2e3f4_add_promoted_quote_stale.py
@@ -1,0 +1,56 @@
+"""Add promotedquote.stale re-anchor flag.
+
+Revision ID: a9b0c1d2e3f4
+Revises: c4f7a2b8d9e1
+Create Date: 2026-07-07 00:00:00.000000
+
+Adds ``stale`` to ``promotedquote``: set True when a source journal entry's body
+is edited such that a pending quote's anchored passage is deleted or mutated and
+can no longer be re-anchored. A stale quote is never revived or deleted — it
+stays for the user to resolve (mirrors ``Marginalia``). ``upgrade`` adds the
+column NOT NULL with a temporary ``server_default=false`` so it can be added to a
+table that already has rows, then drops the DB server default so the app owns the
+default via the model's ``Field`` default (keeping ``alembic check`` drift-free).
+``downgrade`` drops the column.
+
+The column is added and the default dropped inside ``batch_alter_table`` so the
+SQLite round-trip test stays compatible with the Postgres prod target.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a9b0c1d2e3f4"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c4f7a2b8d9e1"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``stale`` (NOT NULL, default False), then drop the DB server default."""
+    # Add with a server_default so the NOT NULL column can be added to a table
+    # that already has rows (each existing quote starts not-stale).
+    op.add_column(
+        "promotedquote",
+        sa.Column("stale", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    # Drop the DB-level server_default (the app owns the default via the model's
+    # Field default, keeping ``alembic check`` drift-free). Batch mode keeps the
+    # ALTER SQLite-compatible for the round-trip test.
+    with op.batch_alter_table("promotedquote") as batch_op:
+        batch_op.alter_column(
+            "stale",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    """Drop the stale column."""
+    # Batch mode keeps the downgrade SQLite-compatible.
+    with op.batch_alter_table("promotedquote") as batch_op:
+        batch_op.drop_column("stale")

--- a/backend/src/models/promoted_quote.py
+++ b/backend/src/models/promoted_quote.py
@@ -29,7 +29,9 @@ class PromotedQuote(SQLModel, table=True):
     ``anchor_start`` / ``anchor_end`` are character offsets into the source
     entry's text; ``anchor_text`` snapshots the spanned substring so the quote
     survives later edits. ``included_in_entry_id`` points at the entry the quote
-    was folded into, or NULL while it is still pending.
+    was folded into, or NULL while it is still pending. ``stale`` marks a pending
+    quote whose anchored passage a later source edit deleted or mutated, so it can
+    no longer be re-anchored (mirrors ``Marginalia``).
     """
 
     # The hot read is "all quotes for a source entry", so index that FK; a second
@@ -58,6 +60,11 @@ class PromotedQuote(SQLModel, table=True):
         foreign_key="journalentry.id",
         ondelete="SET NULL",
     )
+    # True once a source-body edit removed or mutated the anchored passage: the
+    # quote can no longer re-anchor, so it stays for the user to resolve and is
+    # never revived or deleted (mirrors ``Marginalia``). Only pending quotes go
+    # stale; a quote already folded into a reflection has a frozen span.
+    stale: bool = Field(default=False)
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -71,6 +71,7 @@ from services.llm_usage import record_llm_usage
 from services.marginalia import (
     BotmasonResonanceLLM,
     reanchor_entry_marginalia,
+    reanchor_entry_promoted_quotes,
     reanchor_entry_suggestions,
 )
 from services.practice_session_idempotency import record_session, recorded_session_id
@@ -292,7 +293,7 @@ async def get_journal_entry(
 async def _apply_message_edit(
     entry: JournalEntry, payload: JournalEntryUpdate, session: AsyncSession
 ) -> None:
-    """Re-sanitize the body on edit and re-anchor marginalia + suggestions."""
+    """Re-sanitize the body on edit and re-anchor marginalia, suggestions, and quotes."""
     if payload.message is None:
         return
     old_message = entry.message
@@ -301,6 +302,7 @@ async def _apply_message_edit(
         entry.message = new_message
         await reanchor_entry_marginalia(entry, new_message, session)
         await reanchor_entry_suggestions(entry, new_message, session)
+        await reanchor_entry_promoted_quotes(entry, new_message, session)
 
 
 def _apply_chord_update(entry: JournalEntry, payload: JournalEntryUpdate) -> None:

--- a/backend/src/routers/promotions.py
+++ b/backend/src/routers/promotions.py
@@ -38,6 +38,7 @@ def _quote_response(quote: PromotedQuote) -> PromotedQuoteResponse:
         anchor_end=quote.anchor_end,
         anchor_text=quote.anchor_text,
         pending=quote.included_in_entry_id is None,
+        stale=quote.stale,
     )
 
 

--- a/backend/src/schemas/promotion.py
+++ b/backend/src/schemas/promotion.py
@@ -56,3 +56,6 @@ class PromotedQuoteResponse(BaseModel):
     anchor_end: int
     anchor_text: str
     pending: bool
+    # True once a source-body edit deleted/mutated the anchored passage so the
+    # quote could no longer re-anchor; a stale quote stays for the user to resolve.
+    stale: bool

--- a/backend/src/services/marginalia.py
+++ b/backend/src/services/marginalia.py
@@ -1,11 +1,14 @@
 """Marginalia maintenance hooks.
 
-When a journal entry's body changes, the character spans that marginalia anchor
-to can shift or disappear. ``reanchor_entry_marginalia`` re-anchors each active
-note by re-finding its snapshot text in the new body (via ``reanchor_one``),
-updating the anchor span when it moves and marking the note stale when the text
-can no longer be found. Notes are never deleted — a stale note stays for the
-user to resolve. The PATCH endpoint calls this after persisting a body edit.
+When a journal entry's body changes, the character spans that marginalia,
+completion suggestions, and promoted quotes anchor to can shift or disappear.
+``reanchor_entry_marginalia`` re-anchors each active note by re-finding its
+snapshot text in the new body (via ``reanchor_one``), updating the anchor span
+when it moves and marking the note stale when the text can no longer be found.
+``reanchor_entry_suggestions`` and ``reanchor_entry_promoted_quotes`` apply the
+same rule to pending suggestions and pending promoted quotes. Nothing is ever
+deleted — a stale row stays for the user to resolve. The PATCH endpoint calls
+these after persisting a body edit.
 """
 
 from __future__ import annotations
@@ -14,12 +17,13 @@ from collections.abc import Iterable
 from typing import Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
 from domain.marginalia_anchoring import reanchor_one
 from models.completion_suggestion import CompletionSuggestion, SuggestionStatus
 from models.journal_entry import JournalEntry
 from models.marginalia import Marginalia, MarginaliaStatus
+from models.promoted_quote import PromotedQuote
 from services.botmason import LLMResponse, generate_response
 
 
@@ -109,3 +113,35 @@ async def reanchor_entry_suggestions(
         )
     )
     _reanchor(result.scalars().all(), new_message, SuggestionStatus.DISMISSED)
+
+
+async def reanchor_entry_promoted_quotes(
+    entry: JournalEntry,
+    new_message: str,
+    session: AsyncSession,
+) -> None:
+    """Re-anchor (or mark stale) the entry's pending promoted quotes after a body edit.
+
+    Mirrors :func:`reanchor_entry_marginalia` for promoted quotes: each pending
+    quote (not yet folded into a reflection, not already stale) re-anchors to its
+    span if its ``anchor_text`` still occurs in ``new_message``; otherwise the
+    ``stale`` flag flips True. Stale quotes stay stale and nothing is deleted. A
+    quote already included in a reflection has a frozen span and is left untouched.
+
+    A dedicated loop rather than ``_reanchor``: a promoted quote's terminal state
+    is a boolean flag, not the string ``status`` field that ``_AnchoredRow`` models.
+    """
+    result = await session.execute(
+        select(PromotedQuote).where(
+            PromotedQuote.source_entry_id == entry.id,
+            col(PromotedQuote.included_in_entry_id).is_(None),
+            col(PromotedQuote.stale).is_(False),
+        )
+    )
+    for quote in result.scalars().all():
+        outcome = reanchor_one(quote.anchor_text, quote.anchor_start, new_message)
+        if outcome.stale:
+            quote.stale = True
+        else:
+            quote.anchor_start = outcome.anchor_start
+            quote.anchor_end = outcome.anchor_end

--- a/backend/tests/test_promoted_quote_model.py
+++ b/backend/tests/test_promoted_quote_model.py
@@ -184,6 +184,22 @@ async def test_promoted_quote_persists_and_reads_back(db_session: AsyncSession) 
 
 
 @pytest.mark.asyncio
+async def test_promoted_quote_defaults_to_not_stale(db_session: AsyncSession) -> None:
+    """A freshly created PromotedQuote defaults stale to False."""
+    user_id = await _user(db_session)
+    entry = _reflection_entry(user_id)
+    db_session.add(entry)
+    await db_session.flush()
+    assert entry.id is not None
+
+    db_session.add(_quote(user_id, entry.id))
+    await db_session.commit()
+
+    row = (await db_session.execute(select(PromotedQuote))).scalar_one()
+    assert row.stale is False
+
+
+@pytest.mark.asyncio
 async def test_anchor_text_is_encrypted_at_rest(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_promoted_quote_reanchoring.py
+++ b/backend/tests/test_promoted_quote_reanchoring.py
@@ -1,0 +1,299 @@
+"""Tests for re-anchoring (or stale-marking) promoted quotes on entry edit."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import cast
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.journal_entry import JournalEntry, JournalTag
+from models.promoted_quote import PromotedQuote
+
+_BODY = "I walked by the river and the willow bent without breaking."
+_ANCHOR = "the willow"
+_ANCHOR_START = _BODY.index(_ANCHOR)
+_ANCHOR_END = _ANCHOR_START + len(_ANCHOR)
+
+
+async def _signup(client: AsyncClient, username: str = "quoter") -> tuple[dict[str, str], int]:
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    payload = resp.json()
+    return {"Authorization": f"Bearer {payload['token']}"}, int(payload["user_id"])
+
+
+async def _seed_entry(
+    session: AsyncSession, user_id: int, message: str = _BODY, **overrides: object
+) -> JournalEntry:
+    """Create and persist a user-authored JournalEntry."""
+    defaults: dict[str, object] = {"sender": "user"}
+    defaults.update(overrides)
+    entry = JournalEntry(user_id=user_id, message=message, **defaults)
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+    assert entry.id is not None
+    return entry
+
+
+async def _seed_quote(
+    session: AsyncSession,
+    user_id: int,
+    source_entry_id: int | None,
+    anchor_text: str = _ANCHOR,
+    anchor_start: int | None = None,
+    **overrides: object,
+) -> PromotedQuote:
+    """Create and persist a PromotedQuote anchored to ``anchor_text`` in ``_BODY``.
+
+    ``source_entry_id`` is accepted as ``int | None`` for the caller's convenience
+    (a freshly refreshed ``entry.id`` is typed nullable) and narrowed here.
+    """
+    start = _BODY.index(anchor_text) if anchor_start is None else anchor_start
+    defaults: dict[str, object] = {
+        "anchor_start": start,
+        "anchor_end": start + len(anchor_text),
+    }
+    defaults.update(overrides)
+    quote = PromotedQuote(
+        user_id=user_id,
+        source_entry_id=cast("int", source_entry_id),
+        anchor_text=anchor_text,
+        **defaults,
+    )
+    session.add(quote)
+    await session.commit()
+    await session.refresh(quote)
+    assert quote.id is not None
+    return quote
+
+
+@pytest.mark.asyncio
+async def test_edit_before_anchor_shifts_offsets_and_stays_active(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Prepending text before the anchor re-anchors it to the shifted offset."""
+    headers, user_id = await _signup(async_client, "before")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+    new_body = "Yesterday: " + _BODY
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == new_body.index(_ANCHOR)
+    assert reloaded.anchor_end == reloaded.anchor_start + len(_ANCHOR)
+    assert reloaded.anchor_text == _ANCHOR
+    assert reloaded.stale is False
+
+
+@pytest.mark.asyncio
+async def test_edit_after_anchor_keeps_offsets_via_fast_path(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Appending text after the anchor keeps the original offsets (fast path)."""
+    headers, user_id = await _signup(async_client, "after")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+    new_body = _BODY + " And then it was still."
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.stale is False
+
+
+@pytest.mark.asyncio
+async def test_edit_inside_anchor_marks_stale_with_offsets_unchanged(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Mutating the spanned characters goes stale, leaving the offsets untouched."""
+    headers, user_id = await _signup(async_client, "inside")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+    new_body = _BODY.replace("the willow", "the oak")
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.stale is True
+
+
+@pytest.mark.asyncio
+async def test_deleting_anchor_passage_marks_stale(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Removing the anchored passage entirely goes stale, offsets left unchanged."""
+    headers, user_id = await _signup(async_client, "deleted")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}",
+        json={"message": "An entirely different entry today."},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.stale is True
+
+
+@pytest.mark.asyncio
+async def test_included_quote_untouched_by_source_edit(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A quote already folded into a reflection is left alone by a source-body edit."""
+    headers, user_id = await _signup(async_client, "included")
+    entry = await _seed_entry(db_session, user_id)
+    target = await _seed_entry(
+        db_session,
+        user_id,
+        "Target reflection body",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+    )
+    quote = await _seed_quote(db_session, user_id, entry.id, included_in_entry_id=target.id)
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}",
+        json={"message": "An entirely different entry today."},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.anchor_text == _ANCHOR
+    assert reloaded.stale is False
+
+
+@pytest.mark.asyncio
+async def test_same_value_patch_leaves_quote_untouched(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """PATCHing the identical message leaves the quote's anchor and stale flag untouched."""
+    headers, user_id = await _signup(async_client, "samevalue")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": _BODY}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.stale is False
+
+
+@pytest.mark.asyncio
+async def test_single_edit_produces_mixed_outcomes_across_quotes(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """One edit can re-anchor one quote while marking a second one stale."""
+    headers, user_id = await _signup(async_client, "mixed")
+    entry = await _seed_entry(db_session, user_id)
+    quote_a = await _seed_quote(db_session, user_id, entry.id, anchor_text=_ANCHOR)
+    other_anchor = "without breaking"
+    quote_b = await _seed_quote(db_session, user_id, entry.id, anchor_text=other_anchor)
+    new_body = "Yesterday: I walked by the river and the willow bent."
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded_a = await db_session.get(PromotedQuote, quote_a.id)
+    reloaded_b = await db_session.get(PromotedQuote, quote_b.id)
+    assert reloaded_a is not None
+    assert reloaded_b is not None
+    assert reloaded_a.anchor_start == new_body.index(_ANCHOR)
+    assert reloaded_a.anchor_end == reloaded_a.anchor_start + len(_ANCHOR)
+    assert reloaded_b.anchor_start == _BODY.index(other_anchor)
+    assert reloaded_b.anchor_end == _BODY.index(other_anchor) + len(other_anchor)
+    assert reloaded_a.stale is False
+    assert reloaded_b.stale is True
+
+
+@pytest.mark.asyncio
+async def test_stale_quote_stays_stale_after_passage_returns(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Once a quote goes stale, restoring the original passage does not revive it."""
+    headers, user_id = await _signup(async_client, "stalestays")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+
+    removed = await async_client.patch(
+        f"/journal/{entry.id}",
+        json={"message": "An entirely different entry today."},
+        headers=headers,
+    )
+    assert removed.status_code == HTTPStatus.OK
+
+    restored = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": _BODY}, headers=headers
+    )
+    assert restored.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == _ANCHOR_START
+    assert reloaded.anchor_end == _ANCHOR_END
+    assert reloaded.stale is True
+
+
+@pytest.mark.asyncio
+async def test_duplicate_anchor_text_reanchors_to_first_occurrence(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A body containing the anchor text twice re-anchors to the first occurrence."""
+    headers, user_id = await _signup(async_client, "duplicate")
+    entry = await _seed_entry(db_session, user_id)
+    quote = await _seed_quote(db_session, user_id, entry.id)
+    new_body = f"{_ANCHOR} ... and again {_ANCHOR}."
+
+    resp = await async_client.patch(
+        f"/journal/{entry.id}", json={"message": new_body}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+
+    reloaded = await db_session.get(PromotedQuote, quote.id)
+    assert reloaded is not None
+    assert reloaded.anchor_start == 0
+    assert reloaded.anchor_end == len(_ANCHOR)
+    assert reloaded.stale is False

--- a/backend/tests/test_promotions_api.py
+++ b/backend/tests/test_promotions_api.py
@@ -109,6 +109,7 @@ async def test_promote_slices_body_server_side(
     assert data["anchor_start"] == 4
     assert data["anchor_end"] == 9
     assert data["pending"] is True
+    assert data["stale"] is False
     assert "user_id" not in data
 
 


### PR DESCRIPTION
## Summary

A `PromotedQuote` snapshots a span of a source journal entry by character offsets plus `anchor_text`. Because finished entries stay editable, a later edit of the source body could leave those offsets pointing at different text — the quote drifted silently (or was dropped by the frontend's `inRange` check), with no staleness signal. `Marginalia` and completion suggestions already re-anchor on body edit; `PromotedQuote` had neither a re-anchor call nor a stale concept.

**Decision: combination — exact-match re-anchor with a stale-mark fallback, applied to pending quotes only.** On a body edit, each pending quote is re-anchored via the existing pure `reanchor_one` (fast path keeps offsets if they still spell `anchor_text`; else first-occurrence `.find()`); if the passage was deleted or mutated it flips a new `stale` boolean instead. This mirrors the shipped `Marginalia`/`CompletionSuggestion` precedent for cross-artifact consistency, degrades gracefully (pure re-anchoring alone would silently lose deleted spans), and costs one boolean column rather than conflating anchor health with the existing `pending`/`included` lifecycle.

Per the epic's decomposing-reflections model, quotes already folded into a reflection carry their text independently, so they are excluded at the query level and left untouched — as are already-stale quotes (stale stays stale). `PromotedQuoteResponse` now exposes `stale` so the frontend can render a stale quote quietly (frontend rendering is out of scope here and left to the related open issues).

Changes:
- `PromotedQuote.stale` boolean column (default False) + Alembic revision `a9b0c1d2e3f4` (add NOT NULL via temporary `server_default`, then drop it; batch mode, SQLite-round-trip safe).
- `reanchor_entry_promoted_quotes` in `services/marginalia.py`, called from `_apply_message_edit` in `routers/journal.py` after the marginalia/suggestion re-anchors.
- `stale` mapped through `_quote_response` / `PromotedQuoteResponse`.

## Test plan

- New `backend/tests/test_promoted_quote_reanchoring.py` (9 tests via the real `PATCH /journal/{id}` seam): edit before / inside / after the anchor, delete the anchor passage, included-quote-untouched, same-value-PATCH no-op, multiple quotes with mixed outcomes, stale-stays-stale, duplicate first-occurrence.
- Response/model contract additions to `test_promoted_quote_model.py` (defaults `stale=False`) and `test_promotions_api.py`.
- `./scripts/backend/check-all.sh` green (2587 passed, 96.75% coverage, all 7 quality checks); xenon A-grade, radon MI ≥ B; migration round-trip tests pass.

Closes #1499
Refs #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)