### PR TITLE
feat(journal): 7th-day reflection invitation + composer with rereadable sources

### DIFF
--- a/frontend/src/api/__tests__/reflections-api.test.ts
+++ b/frontend/src/api/__tests__/reflections-api.test.ts
@@ -1,0 +1,125 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// RED: the `reflections` client does not exist on `@/api` yet -- every case
+// below fails with "reflections is not defined" / "is not a function" until
+// the implementation-specialist adds `reflections.due` and
+// `reflections.sources` to `@/api/index`.
+// Harness note: this file uses the ambient jest globals (matching the sibling
+// `promotions.test.ts`) rather than the `@jest/globals` import so that
+// `global.fetch = mockFetch` and the `mock.calls[0]` tuple destructure below
+// type-check cleanly. No assertion, URL, or payload expectation is changed.
+import { reflections } from '../index';
+import type { ReflectionDue, ReflectionSourceItem } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('reflections.due', () => {
+  it('GETs /reflections/due and parses a non-null due window', async () => {
+    const due: ReflectionDue = {
+      level: 'week',
+      scope_key: 'c1:w14',
+      window_start: '2026-07-01T00:00:00Z',
+      window_end: '2026-07-08T00:00:00Z',
+      existing_entry_id: null,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse({ due }, 200));
+
+    const result = await reflections.due('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/reflections/due');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result.due).toEqual(due);
+  });
+
+  it('parses a null due window when nothing is currently due', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ due: null }, 200));
+
+    const result = await reflections.due('tok');
+
+    expect(result.due).toBeNull();
+  });
+
+  it('carries a set existing_entry_id through for a resumable in-progress reflection', async () => {
+    const due: ReflectionDue = {
+      level: 'stage',
+      scope_key: 'c1:s1',
+      window_start: '2026-06-01T00:00:00Z',
+      window_end: '2026-07-01T00:00:00Z',
+      existing_entry_id: 42,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse({ due }, 200));
+
+    const result = await reflections.due('tok');
+
+    expect(result.due?.existing_entry_id).toBe(42);
+  });
+});
+
+describe('reflections.sources', () => {
+  it('URL-encodes a colon-bearing scope_key onto the query string', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ items: [] }, 200));
+
+    await reflections.sources('stage', 'c1:s3', 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/reflections/sources?level=stage&scope_key=c1%3As3');
+    expect(init.method ?? 'GET').toBe('GET');
+  });
+
+  it('parses entry and reflection source items with nested promoted quotes', async () => {
+    const items: ReflectionSourceItem[] = [
+      {
+        kind: 'entry',
+        id: 1,
+        title: 'A quiet morning',
+        timestamp: '2026-06-02T08:00:00Z',
+        body: 'I noticed the willow again.',
+        reflection_level: null,
+        promoted_quotes: [
+          {
+            id: 90,
+            anchor_start: 2,
+            anchor_end: 19,
+            anchor_text: 'noticed the willow',
+            pending: true,
+          },
+        ],
+      },
+      {
+        kind: 'reflection',
+        id: 2,
+        title: null,
+        timestamp: '2026-06-15T08:00:00Z',
+        body: 'A week of steady walking.',
+        reflection_level: 'week',
+        promoted_quotes: [],
+      },
+    ];
+    mockFetch.mockReturnValueOnce(jsonResponse({ items }, 200));
+
+    const result = await reflections.sources('stage', 'c1:s3', 'tok');
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      kind: 'entry',
+      promoted_quotes: [{ anchor_text: 'noticed the willow' }],
+    });
+    expect(result.items[1]).toMatchObject({ kind: 'reflection', reflection_level: 'week' });
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -26,6 +26,8 @@ import {
   programCalendarSchema,
   promotedQuoteSchema,
   promptListResponseSchema,
+  reflectionDueResponseSchema,
+  reflectionSourcesResponseSchema,
   resonanceResponseSchema,
   stageIntroSchema,
   userPracticeSchema,
@@ -52,6 +54,9 @@ import {
   type ProgramCalendarT,
   type PromotedQuoteT,
   type PromotedQuoteSummaryT,
+  type ReflectionDueT,
+  type ReflectionLevelT,
+  type ReflectionSourceItemT,
   type StageProgressRecordT,
   type SuggestionStatusT,
   type Tier,
@@ -1107,6 +1112,10 @@ export interface JournalMessageCreate {
   primary_aspect?: number | null;
   /** Secondary chord Aspect (a stage 1..10); only meaningful with a primary. */
   secondary_aspect?: number | null;
+  /** Reflection scope this entry closes (a 7th-day reflection); omitted otherwise. */
+  reflection_level?: ReflectionLevel;
+  /** The scope key the reflection covers (e.g. ``c1:w14``); pairs with ``reflection_level``. */
+  reflection_scope_key?: string;
 }
 
 export type EntryStatus = 'draft' | 'finished';
@@ -1146,6 +1155,10 @@ export interface JournalEntryUpdate {
   primary_aspect?: number | null;
   /** Update the secondary chord Aspect (a stage 1..10); null clears it. */
   secondary_aspect?: number | null;
+  /** Reflection scope this entry closes (a 7th-day reflection); omitted otherwise. */
+  reflection_level?: ReflectionLevel;
+  /** The scope key the reflection covers (e.g. ``c1:w14``); pairs with ``reflection_level``. */
+  reflection_scope_key?: string;
 }
 
 export type MarginaliaKind = 'theme' | 'connection' | 'symbol';
@@ -1312,6 +1325,50 @@ export const promotions = {
       token,
       schema: promotedQuoteSchema as unknown as z.ZodType<PromotedQuote>,
     });
+  },
+};
+
+// Hierarchical reflections client (the 7th-day reflection invitation + sources)
+export type ReflectionLevel = ReflectionLevelT;
+export type ReflectionDue = ReflectionDueT;
+export type ReflectionSourceItem = ReflectionSourceItemT;
+
+/** ``GET /reflections/due`` result: the due window, or ``null`` when nothing is due. */
+export interface ReflectionDueResponse {
+  due: ReflectionDue | null;
+}
+
+/** ``GET /reflections/sources`` result: the chronological rereadable-source feed. */
+export interface ReflectionSourcesResponse {
+  items: ReflectionSourceItem[];
+}
+
+/**
+ * The declinable reflection surface. ``due`` reports the currently-open
+ * reflection window (safe to poll on focus); ``sources`` returns the entries and
+ * earlier reflections that fall inside a given scope so the reader can reread and
+ * fold quotes into the new reflection. The colon-bearing ``scopeKey`` is
+ * URL-encoded onto the query string (``c1:s3`` → ``c1%3As3``).
+ */
+export const reflections = {
+  due(token?: string): Promise<ReflectionDueResponse> {
+    return request<ReflectionDueResponse>('/reflections/due', {
+      token,
+      schema: reflectionDueResponseSchema as unknown as z.ZodType<ReflectionDueResponse>,
+    });
+  },
+  sources(
+    level: ReflectionLevel,
+    scopeKey: string,
+    token?: string,
+  ): Promise<ReflectionSourcesResponse> {
+    return request<ReflectionSourcesResponse>(
+      `/reflections/sources?level=${level}&scope_key=${encodeURIComponent(scopeKey)}`,
+      {
+        token,
+        schema: reflectionSourcesResponseSchema as unknown as z.ZodType<ReflectionSourcesResponse>,
+      },
+    );
   },
 };
 

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -755,3 +755,60 @@ export const wheelBalanceSchema = z.object({
 
 export type WheelAspectT = z.infer<typeof wheelAspectSchema>;
 export type WheelBalanceT = z.infer<typeof wheelBalanceSchema>;
+
+// ---------------------------------------------------------------------------
+// Hierarchical reflections (the 7th-day reflection invitation + sources feed)
+// ---------------------------------------------------------------------------
+
+/**
+ * The reflection scope a due window covers, in ascending breadth: a single
+ * ``week``, a Wavelength ``stage``, a curriculum ``component``, a ``tier`` of
+ * stages, or the whole ``program``. Mirrors the backend ``ReflectionLevel``;
+ * an unknown value is rejected at the boundary so it can never key untitled copy.
+ */
+export const reflectionLevelSchema = z.enum(['week', 'stage', 'component', 'tier', 'program']);
+
+/** Whether a source row is a plain journal entry or an earlier reflection. */
+export const reflectionSourceKindSchema = z.enum(['entry', 'reflection']);
+
+/**
+ * A currently-due reflection window (mirrors the backend ``ReflectionDue``).
+ * ``existing_entry_id`` is set when an in-progress reflection already exists for
+ * this scope, so the invitation can resume it rather than open a fresh page.
+ */
+export const reflectionDueSchema = z.object({
+  level: reflectionLevelSchema,
+  scope_key: z.string(),
+  window_start: isoDateTime,
+  window_end: isoDateTime,
+  existing_entry_id: z.number().int().nullable(),
+});
+
+/**
+ * One rereadable source in the reflection's sources feed (mirrors the backend
+ * ``ReflectionSourceItem``): an entry or an earlier reflection, with any promoted
+ * quotes the reader can fold into the new reflection. ``reflection_level`` is a
+ * free string label (present only on ``reflection`` rows) so a future backend
+ * level cannot fail the whole feed at the client edge.
+ */
+export const reflectionSourceItemSchema = z.object({
+  kind: reflectionSourceKindSchema,
+  id: z.number().int(),
+  title: z.string().nullable(),
+  timestamp: isoDateTime,
+  body: z.string(),
+  reflection_level: z.string().nullable(),
+  promoted_quotes: z.array(promotedQuoteSummarySchema),
+});
+
+/** ``GET /reflections/due`` envelope: the due window, or ``null`` when nothing is due. */
+export const reflectionDueResponseSchema = z.object({ due: reflectionDueSchema.nullable() });
+
+/** ``GET /reflections/sources`` envelope: the chronological source feed. */
+export const reflectionSourcesResponseSchema = z.object({
+  items: z.array(reflectionSourceItemSchema),
+});
+
+export type ReflectionLevelT = z.infer<typeof reflectionLevelSchema>;
+export type ReflectionDueT = z.infer<typeof reflectionDueSchema>;
+export type ReflectionSourceItemT = z.infer<typeof reflectionSourceItemSchema>;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -33,11 +33,13 @@ import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
+import ReflectionSourcesPanel from './ReflectionSourcesPanel';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { usePromotions } from './usePromotions';
+import { useReflectionMode } from './useReflectionMode';
 import { useResonance } from './useResonance';
 
-import { journal, prompts } from '@/api';
+import { journal, prompts, reflections } from '@/api';
 import type {
   CheckInResult,
   CompletionSuggestion,
@@ -46,6 +48,7 @@ import type {
   JournalMessage,
   Marginalia,
   PromotedQuote,
+  ReflectionLevel,
 } from '@/api';
 import { Button } from '@/components/Button';
 import { colors } from '@/design/tokens';
@@ -103,6 +106,30 @@ export interface SaveContext {
   weekNumber?: number;
   practiceSessionId?: number;
   userPracticeId?: number;
+  /** Reflection scope this page closes (7th-day reflection compose mode). */
+  reflectionLevel?: ReflectionLevel;
+  /** The scope key the reflection covers (e.g. ``c1:w14``); pairs with ``reflectionLevel``. */
+  reflectionScopeKey?: string;
+}
+
+/** HTTP status the backend returns when a reflection already exists for the scope. */
+const REFLECTION_CONFLICT_STATUS = 409;
+
+/**
+ * Warm, declinable hint shown when a folded quote could not be marked included.
+ * The quote stays pending and the entry is safe — the writer can simply try
+ * again later; there is deliberately no urgency or blame here.
+ */
+const QUOTE_INCLUSION_HINT =
+  "That quote is saved but didn't fold in just yet — no rush, you can add it again anytime.";
+
+/** True for a create rejection that means "this reflection already exists". */
+function isCreateConflict(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === REFLECTION_CONFLICT_STATUS
+  );
 }
 
 interface WriteEntryRefs {
@@ -129,6 +156,8 @@ async function createEntry(refs: WriteEntryRefs, body: string, ctx: SaveContext)
     secondary_aspect: chordRef.current.secondary,
     ...(ctx.practiceSessionId != null && { practice_session_id: ctx.practiceSessionId }),
     ...(ctx.userPracticeId != null && { user_practice_id: ctx.userPracticeId }),
+    ...(ctx.reflectionLevel != null && { reflection_level: ctx.reflectionLevel }),
+    ...(ctx.reflectionScopeKey != null && { reflection_scope_key: ctx.reflectionScopeKey }),
   });
   return created.id;
 }
@@ -437,15 +466,21 @@ function trackedWrite(
   ctx: SaveContext,
   setSaveState: (_state: SaveState) => void,
   onSaved: (() => void) | undefined,
+  onConflict: (() => void) | undefined,
 ): Promise<void> {
   return (async () => {
     try {
       await writeEntry(refs, title, body, ctx);
       setSaveState('saved');
       onSaved?.();
-    } catch {
+    } catch (error) {
       // Surface a distinct error state so the hint isn't mistaken for "untouched".
       setSaveState('error');
+      // Additive: a reflection-scope create can 409 because the reflection
+      // already exists. Hand that case to the caller (which routes to the
+      // existing entry); every other failure keeps the plain save-error hint.
+      // This never rejects, so the single-flight drain loops stay safe.
+      if (isCreateConflict(error)) onConflict?.();
     }
   })();
 }
@@ -455,6 +490,8 @@ type SaveRunnerRefs = WriteEntryRefs & {
   entryUnsettledRef: React.MutableRefObject<boolean>;
   ctxRef: React.MutableRefObject<SaveContext>;
   onSavedRef: React.MutableRefObject<(() => void) | undefined>;
+  /** Additively invoked on a reflection-scope create 409 (routes to the existing entry). */
+  onConflictRef: React.MutableRefObject<(() => void) | undefined>;
   inFlightRef: React.MutableRefObject<Promise<void> | null>;
 };
 
@@ -465,7 +502,7 @@ type SaveRunnerRefs = WriteEntryRefs & {
  */
 function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) => void): RunSave {
   const { entryIdRef, respondedRef, classificationRef, chordRef } = refs;
-  const { entryUnsettledRef, ctxRef, onSavedRef, inFlightRef } = refs;
+  const { entryUnsettledRef, ctxRef, onSavedRef, onConflictRef, inFlightRef } = refs;
   return useCallback<RunSave>(
     async (title, body) => {
       // Never overwrite an entry until its load settles (still in flight or failed).
@@ -486,6 +523,7 @@ function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) =
         ctxRef.current,
         setSaveState,
         onSavedRef.current,
+        onConflictRef.current,
       );
       inFlightRef.current = task;
       try {
@@ -502,6 +540,7 @@ function useSaveRunner(refs: SaveRunnerRefs, setSaveState: (_state: SaveState) =
       entryUnsettledRef,
       ctxRef,
       onSavedRef,
+      onConflictRef,
       inFlightRef,
       setSaveState,
     ],
@@ -621,6 +660,73 @@ function useDraftWriters(
   return { save, flush, finish };
 }
 
+/** The non-memoised inputs the writer reads through refs (kept fresh each render). */
+interface MirroredInputs {
+  onSaved?: () => void;
+  onConflict?: () => void;
+  ctx: SaveContext;
+  entryUnsettled: boolean;
+}
+
+/** Mirror the latest non-memoised writer inputs onto their refs (no callback churn). */
+function useMirroredInputs(
+  onSavedRef: React.MutableRefObject<(() => void) | undefined>,
+  onConflictRef: React.MutableRefObject<(() => void) | undefined>,
+  ctxRef: React.MutableRefObject<SaveContext>,
+  entryUnsettledRef: React.MutableRefObject<boolean>,
+  values: MirroredInputs,
+): void {
+  useEffect(() => {
+    onSavedRef.current = values.onSaved;
+    onConflictRef.current = values.onConflict;
+    ctxRef.current = values.ctx;
+    entryUnsettledRef.current = values.entryUnsettled;
+  });
+}
+
+/** The stable refs the draft writer reads (created once, mirrored each render). */
+interface DraftRefs {
+  entryIdRef: React.MutableRefObject<number | null>;
+  timerRef: TimerRef;
+  inFlightRef: React.MutableRefObject<Promise<void> | null>;
+  respondedRef: React.MutableRefObject<boolean>;
+  onSavedRef: React.MutableRefObject<(() => void) | undefined>;
+  onConflictRef: React.MutableRefObject<(() => void) | undefined>;
+  ctxRef: React.MutableRefObject<SaveContext>;
+  entryUnsettledRef: React.MutableRefObject<boolean>;
+}
+
+/**
+ * Create the draft writer's refs and keep the non-memoised ones mirrored.
+ *
+ * ``entryUnsettledRef`` gates every write: until an existing entry's load
+ * settles, ``entryIdRef`` points at the real, unloaded entry with a blank body,
+ * so a save (or tier/chord PATCH) would overwrite it. ``respondedRef`` makes a
+ * weekly-prompt response write-once, and ``inFlightRef`` single-flights saves so
+ * two id-less saves can't each fire ``journal.create``.
+ */
+function useDraftRefs(routeEntryId: number | null, values: MirroredInputs): DraftRefs {
+  const entryIdRef = useRef<number | null>(routeEntryId);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const respondedRef = useRef(false);
+  const onSavedRef = useRef(values.onSaved);
+  const onConflictRef = useRef(values.onConflict);
+  const ctxRef = useRef(values.ctx);
+  const entryUnsettledRef = useRef(values.entryUnsettled);
+  useMirroredInputs(onSavedRef, onConflictRef, ctxRef, entryUnsettledRef, values);
+  return {
+    entryIdRef,
+    timerRef,
+    inFlightRef,
+    respondedRef,
+    onSavedRef,
+    onConflictRef,
+    ctxRef,
+    entryUnsettledRef,
+  };
+}
+
 /** Debounced create-then-update draft saver; tracks the save state. */
 function useDebouncedSave(
   routeEntryId: number | null,
@@ -628,44 +734,15 @@ function useDebouncedSave(
   ctx: SaveContext,
   entryUnsettled: boolean,
   onSaved?: () => void,
+  onConflict?: () => void,
 ) {
   const [saveState, setSaveState] = useState<SaveState>('idle');
-  const entryIdRef = useRef<number | null>(routeEntryId);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Single-flight guard: the in-flight save, so overlapping saves of an id-less
-  // entry can't each fire journal.create (a duplicate-entry TOCTOU otherwise).
-  const inFlightRef = useRef<Promise<void> | null>(null);
-  // A weekly-prompt response is write-once; this guards against the debounce or
-  // flush submitting it twice (the backend 409s on a duplicate week).
-  const respondedRef = useRef(false);
-  // Refs so non-memoised inputs don't churn the save callbacks below.
-  const onSavedRef = useRef(onSaved);
-  const ctxRef = useRef(ctx);
-  // Until an existing entry's load settles (still in flight or failed), entryIdRef
-  // points at the real, unloaded entry with a blank body — so any save (or
-  // tier/chord PATCH) here would overwrite it. Gate on the latest flag; declared
-  // before the persisters so they can read it too.
-  const entryUnsettledRef = useRef(entryUnsettled);
-  const persist = usePersistControls(entryIdRef, setSaveState, entryUnsettledRef);
-  useEffect(() => {
-    onSavedRef.current = onSaved;
-    ctxRef.current = ctx;
-    entryUnsettledRef.current = entryUnsettled;
-  });
-  useTimerCleanup(timerRef);
+  const refs = useDraftRefs(routeEntryId, { onSaved, onConflict, ctx, entryUnsettled });
+  const persist = usePersistControls(refs.entryIdRef, setSaveState, refs.entryUnsettledRef);
+  useTimerCleanup(refs.timerRef);
 
   const { save, flush, finish } = useDraftWriters(
-    {
-      entryIdRef,
-      respondedRef,
-      classificationRef: persist.classificationRef,
-      chordRef: persist.chordRef,
-      entryUnsettledRef,
-      ctxRef,
-      onSavedRef,
-      inFlightRef,
-      timerRef,
-    },
+    { ...refs, classificationRef: persist.classificationRef, chordRef: persist.chordRef },
     delayMs,
     setSaveState,
   );
@@ -860,6 +937,7 @@ function useJournalAutosave(
   ctx: SaveContext,
   initialTitle: string,
   onSaved?: () => void,
+  onConflict?: () => void,
 ): AutosaveApi {
   const entry = useEntryState(routeEntryId, initialTitle);
   const { titleRef, bodyRef } = entry;
@@ -869,7 +947,7 @@ function useJournalAutosave(
   // null). Gate the writer + controls on this so neither touches an unseen entry.
   const entryUnsettled = routeEntryId != null && !entry.loaded;
   const { saveState, save, flush, finish, changeClassification, changeChord, seedPersist } =
-    useDebouncedSave(routeEntryId, delayMs, ctx, entryUnsettled, onSaved);
+    useDebouncedSave(routeEntryId, delayMs, ctx, entryUnsettled, onSaved, onConflict);
   useSeedPersistOnLoad(entry, seedPersist);
 
   const { onChangeTitle, onChangeBody } = useFieldHandlers(
@@ -926,6 +1004,8 @@ interface WritingColumnProps {
    * (still in flight or failed), so they never write against an unseen entry.
    */
   controlsDisabled: boolean;
+  /** Reflection mode: track the body caret so a folded quote lands at the cursor. */
+  onBodySelectionChange?: (_e: SelectionChangeEvent) => void;
 }
 
 /** Quiet control to mark a draft finished, with a warm retry notice on failure. */
@@ -987,8 +1067,12 @@ function WritingFields({
   body,
   onChangeTitle,
   onChangeBody,
+  onBodySelectionChange,
   bodyPlaceholder,
-}: Pick<WritingColumnProps, 'title' | 'body' | 'onChangeTitle' | 'onChangeBody'> & {
+}: Pick<
+  WritingColumnProps,
+  'title' | 'body' | 'onChangeTitle' | 'onChangeBody' | 'onBodySelectionChange'
+> & {
   bodyPlaceholder: string;
 }) {
   return (
@@ -1007,6 +1091,7 @@ function WritingFields({
         style={styles.bodyInput}
         value={body}
         onChangeText={onChangeBody}
+        onSelectionChange={onBodySelectionChange}
         placeholder={bodyPlaceholder}
         placeholderTextColor={colors.paper.inkSoft}
         multiline
@@ -1037,6 +1122,7 @@ function WritingColumn({
   finishError,
   bodyPlaceholder = 'Begin writing…',
   controlsDisabled,
+  onBodySelectionChange,
 }: WritingColumnProps) {
   return (
     <ScrollView
@@ -1056,6 +1142,7 @@ function WritingColumn({
         body={body}
         onChangeTitle={onChangeTitle}
         onChangeBody={onChangeBody}
+        onBodySelectionChange={onBodySelectionChange}
         bodyPlaceholder={bodyPlaceholder}
       />
       <Text style={styles.savedHint} testID="journal-save-hint">
@@ -1508,6 +1595,61 @@ function useRefreshAfterEdit(): RefreshAfterEdit {
 }
 
 /** Compose the autosave + idle + resonance hooks into the screen's view-model. */
+/**
+ * A reflection-scope create can 409 because the reflection already exists.
+ * Consult the due window and, when it points at an existing reflection for the
+ * same scope, route there instead of leaving a dead-ended save error.
+ */
+function useCreateConflictHandler(ctx: SaveContext, navigation: ScreenNavigation): () => void {
+  return useCallback(() => {
+    const scopeKey = ctx.reflectionScopeKey;
+    if (scopeKey == null) return;
+    void reflections
+      .due()
+      .then(({ due }) => {
+        if (due != null && due.scope_key === scopeKey && due.existing_entry_id != null) {
+          navigation.replace('JournalEntry', { entryId: due.existing_entry_id });
+        }
+      })
+      .catch(() => {
+        // Fall back to the plain save-error hint; the draft is safe and retryable.
+      });
+  }, [ctx.reflectionScopeKey, navigation]);
+}
+
+/**
+ * Wire the reflection composer: mirror the latest body onto a ref so a folded
+ * quote can be spliced at the caret without threading the autosave's draft ref
+ * out, and hand the sources/insert flow the body writer + flush.
+ */
+function useReflectionComposer(ctx: SaveContext, autosave: AutosaveApi) {
+  const reflectionBodyRef = useRef(autosave.body);
+  reflectionBodyRef.current = autosave.body;
+  return useReflectionMode({
+    reflectionLevel: ctx.reflectionLevel,
+    reflectionScopeKey: ctx.reflectionScopeKey,
+    bodyRef: reflectionBodyRef,
+    onChangeBody: autosave.onChangeBody,
+    flush: autosave.flush,
+  });
+}
+
+/** The finished-entry edit gate wired from the autosave's status + finish write. */
+function useEntryEditGate(
+  autosave: AutosaveApi,
+  navigation: ScreenNavigation,
+  onConfirmEdit: () => void,
+) {
+  return useEditGate({
+    status: autosave.status,
+    setStatus: autosave.setStatus,
+    finish: autosave.finish,
+    body: autosave.body,
+    navigation,
+    onConfirmEdit,
+  });
+}
+
 function useJournalEntryController(
   routeEntryId: number | null,
   autosaveDelayMs: number,
@@ -1516,27 +1658,22 @@ function useJournalEntryController(
   initialTitle: string,
 ) {
   const { refreshRef, handleSaved, onConfirmEdit } = useRefreshAfterEdit();
-
+  const onCreateConflict = useCreateConflictHandler(ctx, navigation);
   const autosave = useJournalAutosave(
     routeEntryId,
     autosaveDelayMs,
     ctx,
     initialTitle,
     handleSaved,
+    onCreateConflict,
   );
   const { isIdle, bump } = useIdle();
   const resonance = useResonance({ routeEntryId, flush: autosave.flush });
   const quote = useQuotePromotion(routeEntryId);
   refreshRef.current = resonance.refresh;
+  const reflection = useReflectionComposer(ctx, autosave);
   const modal = useEssayModal(resonance.updateNote);
-  const editGate = useEditGate({
-    status: autosave.status,
-    setStatus: autosave.setStatus,
-    finish: autosave.finish,
-    body: autosave.body,
-    navigation,
-    onConfirmEdit,
-  });
+  const editGate = useEntryEditGate(autosave, navigation, onConfirmEdit);
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
   const gate = deriveResonanceGate({
     isIdle,
@@ -1551,6 +1688,7 @@ function useJournalEntryController(
     autosave,
     resonance,
     quote,
+    reflection,
     isIdle,
     ...gate,
     handleTitle,
@@ -1591,6 +1729,9 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       finishError={finishError}
       bodyPlaceholder={bodyPlaceholder}
       controlsDisabled={controlsDisabled}
+      onBodySelectionChange={
+        ctl.reflection.active ? ctl.reflection.onBodySelectionChange : undefined
+      }
     />
   ) : (
     <ReadColumn
@@ -1661,6 +1802,8 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
       weekNumber: p.weekNumber,
       practiceSessionId: p.practiceSessionId,
       userPracticeId: p.userPracticeId,
+      reflectionLevel: p.reflectionLevel,
+      reflectionScopeKey: p.reflectionScopeKey,
     },
     initialTitle,
     bodyPlaceholder: p.promptQuestion ?? 'Begin writing…',
@@ -1702,6 +1845,47 @@ function LoadErrorBanner({ message }: { message: string | null }): React.JSX.Ele
   );
 }
 
+/**
+ * Reflection compose surface: the rereadable sources panel plus a warm hint when
+ * a folded quote could not be marked included. Renders nothing outside reflection
+ * mode so the plain and weekly-prompt paths are untouched.
+ */
+function ReflectionComposer({
+  reflection,
+}: {
+  reflection: Controller['reflection'];
+}): React.JSX.Element | null {
+  const [open, setOpen] = useState(false);
+  const openSources = useCallback(() => setOpen(true), []);
+  const closeSources = useCallback(() => setOpen(false), []);
+  if (!reflection.active) return null;
+  return (
+    <>
+      <TouchableOpacity
+        style={styles.quoteActionButton}
+        onPress={openSources}
+        accessibilityRole="button"
+        accessibilityLabel="Open the sources to reread earlier writing and gather quotes"
+        testID="reflection-sources-toggle"
+      >
+        <Text style={styles.controlLink}>Sources</Text>
+      </TouchableOpacity>
+      {open ? (
+        <ReflectionSourcesPanel
+          items={reflection.sources}
+          onInsertQuote={reflection.onInsertQuote}
+          onClose={closeSources}
+        />
+      ) : null}
+      {reflection.inclusionHint ? (
+        <Text style={styles.savedHint} testID="quote-inclusion-hint">
+          {QUOTE_INCLUSION_HINT}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
 function JournalEntryScreen({
   route,
   navigation,
@@ -1728,6 +1912,7 @@ function JournalEntryScreen({
       <ContractionReflectionNote contraction={ctl.resonance.contraction} />
       <LoadErrorBanner message={ctl.autosave.loadError} />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
+      <ReflectionComposer reflection={ctl.reflection} />
       <PrivacyResonanceReason
         visible={ctl.visible && ctl.resonanceDisabled}
         reason={ctl.resonanceReason}

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -16,6 +16,7 @@ import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
 import { promptTitleForWeek } from './promptTitle';
+import ReflectionInvitationBand from './ReflectionInvitationBand';
 import SearchBar from './SearchBar';
 import StatTileRow from './StatTileRow';
 
@@ -365,6 +366,7 @@ function ShelfTopMatter({
         action={<Button label="New entry" onPress={onNew} testID="journal-new-entry" />}
       />
       {prompt ? <PromptCard week={week} question={prompt.question} onOpen={onPrompt} /> : null}
+      <ReflectionInvitationBand />
       <View style={styles.searchRow}>
         <SearchBar onSearch={onSearch} searchQuery={query || undefined} resultCount={resultCount} />
       </View>

--- a/frontend/src/features/Journal/ReflectionInvitationBand.tsx
+++ b/frontend/src/features/Journal/ReflectionInvitationBand.tsx
@@ -1,0 +1,195 @@
+/**
+ * ``ReflectionInvitationBand`` — the 7th-day reflection invitation on the
+ * Journal shelf. Self-contained like ``ReturnStack`` / ``InvitationStack``: it
+ * takes no props, fetches its own "is a reflection due?" state, and quietly
+ * renders nothing when nothing is due, when the scope was set aside, or on any
+ * fetch error.
+ *
+ * "You choose your depth": this is a warm, one-tap-declinable invitation — never
+ * a gate and never gamified. There is deliberately no streak, no count, and no
+ * guilt copy. Declining persists per scope key, so the same window stays quiet
+ * while a genuinely new scope still surfaces its own invitation.
+ */
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { reflectionTitle } from './reflectionCopy';
+import ReflectionDismiss from './ReflectionDismiss';
+
+import { reflections, stages } from '@/api';
+import type { ReflectionDue } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  spacing,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+import {
+  loadReflectionDismissed,
+  saveReflectionDismissed,
+} from '@/storage/reflectionDismissalStorage';
+
+/** Extracts the stage ordinal from a stage scope key (``c1:s1`` → ``1``). */
+const STAGE_SCOPE_KEY = /^c\d+:s(\d+)$/;
+
+/** The band's identifying warm left rule (matches the weekly-prompt band), in dp. */
+const ACCENT_BAR_WIDTH = 3;
+
+/** Warm, declinable copy — no streaks, no counts, no guilt. */
+const BAND_LABEL = 'A reflection has come round';
+const INVITE_SUBLINE = 'A quiet space to look back — only if you like.';
+const DISMISS_LABEL = 'Not now';
+const DISMISS_A11Y = 'Set this reflection invitation aside';
+
+type BandNavigation = NativeStackNavigationProp<RootStackParamList>;
+
+/** A due reflection plus the stage title resolved for stage-level copy. */
+interface DueBand {
+  due: ReflectionDue;
+  stageTitle: string | null;
+}
+
+/** Resolve the stage title for a stage scope key, or null when unavailable. */
+async function resolveStageTitle(scopeKey: string): Promise<string | null> {
+  const captured = STAGE_SCOPE_KEY.exec(scopeKey)?.[1];
+  const stageNumber = captured == null ? Number.NaN : Number.parseInt(captured, 10);
+  if (Number.isNaN(stageNumber)) return null;
+  const all = await stages.listAll();
+  const found = all.find((stage) => stage.stage_number === stageNumber);
+  return found?.title ?? null;
+}
+
+/**
+ * Fetch the due window and derive the band, or null when there is nothing to
+ * show. Any failure resolves null so the shelf never sees an error from a
+ * background poll — the invitation simply stays quiet.
+ */
+async function resolveDueBand(): Promise<DueBand | null> {
+  try {
+    const { due } = await reflections.due();
+    if (due == null) return null;
+    if (await loadReflectionDismissed(due.scope_key)) return null;
+    const stageTitle = due.level === 'stage' ? await resolveStageTitle(due.scope_key) : null;
+    return { due, stageTitle };
+  } catch {
+    return null;
+  }
+}
+
+/** Owns the due-band state, the fetch-on-mount, and the open/dismiss actions. */
+function useReflectionInvitation(navigation: BandNavigation) {
+  const [band, setBand] = useState<DueBand | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void resolveDueBand().then((resolved) => {
+      if (active && resolved != null) setBand(resolved);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const onOpen = useCallback(() => {
+    if (band == null) return;
+    const { due, stageTitle } = band;
+    if (due.existing_entry_id != null) {
+      navigation.navigate('JournalEntry', { entryId: due.existing_entry_id });
+      return;
+    }
+    navigation.navigate('JournalEntry', {
+      reflectionLevel: due.level,
+      reflectionScopeKey: due.scope_key,
+      prefillTitle: reflectionTitle(due.level, due.scope_key, stageTitle ?? undefined),
+    });
+  }, [band, navigation]);
+
+  const onDismiss = useCallback(() => {
+    if (band == null) return;
+    void saveReflectionDismissed(band.due.scope_key, true);
+    setBand(null);
+  }, [band]);
+
+  return { band, onOpen, onDismiss };
+}
+
+function ReflectionInvitationBand(): React.JSX.Element | null {
+  const navigation = useNavigation<BandNavigation>();
+  const { band, onOpen, onDismiss } = useReflectionInvitation(navigation);
+  if (band == null) return null;
+
+  const { due, stageTitle } = band;
+  const title = reflectionTitle(due.level, due.scope_key, stageTitle ?? undefined);
+  const resuming = due.existing_entry_id != null;
+  const accessibilityLabel = resuming ? `Continue your ${title}` : `Begin your ${title}`;
+
+  // A plain container, not a pressable, so the inner "open" and "decline"
+  // buttons stay independently reachable by assistive tech (a pressable wrapper
+  // would collapse the subtree and hide the one-tap decline). Mirrors the
+  // ``InvitationNote`` card shape.
+  return (
+    <View style={styles.band}>
+      <TouchableOpacity
+        style={styles.openArea}
+        onPress={onOpen}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        testID="journal-reflection-band"
+      >
+        <Text style={styles.label}>{BAND_LABEL}</Text>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.subline}>
+          {resuming ? 'Pick up where you left off.' : INVITE_SUBLINE}
+        </Text>
+      </TouchableOpacity>
+      <ReflectionDismiss
+        label={DISMISS_LABEL}
+        accessibilityLabel={DISMISS_A11Y}
+        testID="journal-reflection-dismiss"
+        onPress={onDismiss}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  band: {
+    marginTop: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    // A raised sheet with the same warm accent rule as the weekly-prompt band,
+    // so the two invitations read as a matched pair on the shelf.
+    backgroundColor: surface.raised,
+    borderLeftWidth: ACCENT_BAR_WIDTH,
+    borderLeftColor: accent.primary,
+    ...surfaceShadow.card,
+  },
+  openArea: {
+    minHeight: touchTarget.minimum,
+  },
+  label: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+  },
+  title: {
+    ...editorialType.title,
+    color: ink.primary,
+    paddingTop: spacing(0.5),
+  },
+  subline: {
+    ...editorialType.note,
+    color: ink.soft,
+    paddingTop: spacing(0.5),
+  },
+});
+
+export default ReflectionInvitationBand;

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -1,0 +1,387 @@
+/**
+ * ``ReflectionSourcesPanel`` — the rereadable sources feed beside a reflection.
+ *
+ * Two stacked regions:
+ *   1. Pending promoted quotes (across every source) rise to the top so the
+ *      reader can fold a remembered passage into the reflection with one tap.
+ *      A folded quote dims and stays (a gentle "already used" trace), never
+ *      vanishing under the reader's finger.
+ *   2. The chronological feed (oldest → newest) of the entries and earlier
+ *      reflections in scope. Each row collapses to an excerpt and expands to its
+ *      full body on tap.
+ *
+ * Responsive per the margin-column precedent: a bottom-sheet ``Modal`` on a
+ * narrow viewport, an inline side pane on a wide one. Reduced-motion safe.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+import { sourceAttribution } from './reflectionCopy';
+
+import type { PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  editorialType,
+  ink,
+  spacing,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/** Below this viewport width the panel is a bottom sheet; at/above it, a side pane. */
+const NARROW_BREAKPOINT = 600;
+
+/** Collapsed-row excerpt length before an ellipsis. */
+const EXCERPT_MAX = 120;
+
+/** Warm left rule marking a pending quote / a reflection row, in dp. */
+const STRIPE_WIDTH = 3;
+
+/** Dim a pending quote once it has been folded into the reflection body. */
+const INCLUDED_ROW_OPACITY = 0.5;
+
+export interface ReflectionSourcesPanelProps {
+  items: ReflectionSourceItem[];
+  onInsertQuote: (_quote: PromotedQuoteSummary, _sourceItem: ReflectionSourceItem) => void;
+  onClose?: () => void;
+}
+
+/** One pending quote paired with the source it came from. */
+interface PendingEntry {
+  quote: PromotedQuoteSummary;
+  item: ReflectionSourceItem;
+}
+
+/** A single-line excerpt of a body for a collapsed row. */
+function excerpt(body: string): string {
+  const flat = body.replace(/\s+/g, ' ').trim();
+  return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
+}
+
+/** Warm, sentence-case label for a reflection row's level (e.g. "Week reflection"). */
+function levelLabel(level: string | null): string {
+  if (!level) return 'Reflection';
+  return `${level.charAt(0).toUpperCase()}${level.slice(1)} reflection`;
+}
+
+/** Feed order: oldest → newest by timestamp. */
+function byTimestamp(a: ReflectionSourceItem, b: ReflectionSourceItem): number {
+  return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+}
+
+/** The pending quotes across every source (deduped by id), in source order. */
+function collectPending(items: ReflectionSourceItem[]): PendingEntry[] {
+  const pending: PendingEntry[] = [];
+  const seen = new Set<number>();
+  for (const item of items) {
+    for (const quote of item.promoted_quotes) {
+      if (!quote.pending || seen.has(quote.id)) continue;
+      seen.add(quote.id);
+      pending.push({ quote, item });
+    }
+  }
+  return pending;
+}
+
+/** One tappable pending quote; dims to an "already folded in" trace once inserted. */
+function PendingQuoteRow({
+  entry,
+  included,
+  onInsert,
+}: {
+  entry: PendingEntry;
+  included: boolean;
+  onInsert: (_e: PendingEntry) => void;
+}): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={[styles.pendingRow, included && styles.pendingRowIncluded]}
+      onPress={() => {
+        if (!included) onInsert(entry);
+      }}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: included }}
+      accessibilityLabel={`Fold the quote "${entry.quote.anchor_text}" into your reflection`}
+      testID={`pending-quote-${entry.quote.id}`}
+    >
+      <Text style={styles.pendingText} numberOfLines={2}>
+        {entry.quote.anchor_text}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+/** The pending-quotes group above the feed; renders nothing when empty. */
+function PendingQuotesGroup({
+  pending,
+  includedIds,
+  onInsert,
+}: {
+  pending: PendingEntry[];
+  includedIds: ReadonlySet<number>;
+  onInsert: (_e: PendingEntry) => void;
+}): React.JSX.Element | null {
+  if (pending.length === 0) return null;
+  return (
+    <View style={styles.group}>
+      <Text style={styles.groupHeading}>Quotes to fold in</Text>
+      {pending.map((entry) => (
+        <PendingQuoteRow
+          key={entry.quote.id}
+          entry={entry}
+          included={includedIds.has(entry.quote.id)}
+          onInsert={onInsert}
+        />
+      ))}
+    </View>
+  );
+}
+
+/** One source in the feed: a header + excerpt, expanding to the full body on tap. */
+function SourceRow({
+  item,
+  expanded,
+  onToggle,
+}: {
+  item: ReflectionSourceItem;
+  expanded: boolean;
+  onToggle: () => void;
+}): React.JSX.Element {
+  const isReflection = item.kind === 'reflection';
+  return (
+    <View style={styles.row}>
+      <TouchableOpacity
+        style={[styles.rowHeader, isReflection && styles.rowHeaderReflection]}
+        onPress={onToggle}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${sourceAttribution(item)}`}
+        testID={`${item.kind}-source-${item.id}`}
+      >
+        {isReflection ? (
+          <Text style={styles.levelLabel}>{levelLabel(item.reflection_level)}</Text>
+        ) : null}
+        <Text style={styles.rowTitle}>{sourceAttribution(item)}</Text>
+        {expanded ? null : (
+          <Text style={styles.rowExcerpt} numberOfLines={2}>
+            {excerpt(item.body)}
+          </Text>
+        )}
+      </TouchableOpacity>
+      {expanded ? (
+        <Text style={styles.body} testID={`source-body-${item.id}`}>
+          {item.body}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+/** The chronological feed; owns which rows are expanded. */
+function SourceFeed({ feed }: { feed: ReflectionSourceItem[] }): React.JSX.Element {
+  const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set<string>());
+  const toggle = useCallback((key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+  return (
+    <View>
+      {feed.map((item) => {
+        const key = `${item.kind}-${item.id}`;
+        return (
+          <SourceRow
+            key={key}
+            item={item}
+            expanded={expandedKeys.has(key)}
+            onToggle={() => toggle(key)}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+/** The panel's inner content, shared by the sheet and pane containers. */
+function SourcesContent({
+  items,
+  onInsertQuote,
+  onClose,
+}: ReflectionSourcesPanelProps): React.JSX.Element {
+  const [includedIds, setIncludedIds] = useState<ReadonlySet<number>>(() => new Set<number>());
+  const pending = useMemo(() => collectPending(items), [items]);
+  const feed = useMemo(() => [...items].sort(byTimestamp), [items]);
+
+  const onInsert = useCallback(
+    (entry: PendingEntry) => {
+      setIncludedIds((prev) => new Set(prev).add(entry.quote.id));
+      onInsertQuote(entry.quote, entry.item);
+    },
+    [onInsertQuote],
+  );
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.scrollContent}
+      keyboardShouldPersistTaps="handled"
+    >
+      {onClose == null ? null : (
+        <TouchableOpacity
+          style={styles.action}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close the sources"
+          testID="reflection-sources-close"
+        >
+          <Text style={styles.actionLink}>Done</Text>
+        </TouchableOpacity>
+      )}
+      <PendingQuotesGroup pending={pending} includedIds={includedIds} onInsert={onInsert} />
+      <SourceFeed feed={feed} />
+    </ScrollView>
+  );
+}
+
+function ReflectionSourcesPanel(props: ReflectionSourcesPanelProps): React.JSX.Element {
+  const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
+  const reducedMotion = useReducedMotion();
+
+  if (narrow) {
+    return (
+      <Modal
+        visible
+        transparent
+        animationType={reducedMotion ? 'none' : 'slide'}
+        onRequestClose={props.onClose}
+        testID="reflection-sources-sheet"
+      >
+        <View style={styles.sheetBackdrop}>
+          <View style={styles.sheet}>
+            <SourcesContent {...props} />
+          </View>
+        </View>
+      </Modal>
+    );
+  }
+  return (
+    <View style={styles.pane} testID="reflection-sources-pane">
+      <SourcesContent {...props} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pane: {
+    width: '100%',
+    maxHeight: '100%',
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.lg,
+    ...surfaceShadow.card,
+  },
+  sheetBackdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: colors.mystical.overlay,
+  },
+  sheet: {
+    maxHeight: '80%',
+    backgroundColor: surface.raised,
+    borderTopLeftRadius: BORDER_RADIUS.lg,
+    borderTopRightRadius: BORDER_RADIUS.lg,
+    ...surfaceShadow.raised,
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  scrollContent: {
+    padding: SPACING.lg,
+  },
+  group: {
+    marginBottom: SPACING.lg,
+  },
+  groupHeading: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+    marginBottom: SPACING.sm,
+  },
+  pendingRow: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    marginBottom: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    backgroundColor: colors.paper.quoteHighlight,
+    borderLeftWidth: STRIPE_WIDTH,
+    borderLeftColor: accent.primary,
+  },
+  pendingRowIncluded: {
+    opacity: INCLUDED_ROW_OPACITY,
+  },
+  pendingText: {
+    ...editorialType.note,
+    color: ink.primary,
+  },
+  row: {
+    marginBottom: SPACING.md,
+  },
+  rowHeader: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingVertical: SPACING.sm,
+  },
+  rowHeaderReflection: {
+    borderLeftWidth: STRIPE_WIDTH,
+    borderLeftColor: accent.strong,
+    paddingLeft: SPACING.md,
+  },
+  levelLabel: {
+    ...editorialType.caption,
+    color: accent.strong,
+    textTransform: 'uppercase',
+  },
+  rowTitle: {
+    ...editorialType.note,
+    color: ink.primary,
+    fontWeight: '600',
+  },
+  rowExcerpt: {
+    ...editorialType.caption,
+    color: ink.soft,
+    paddingTop: spacing(0.5),
+  },
+  body: {
+    ...editorialType.body,
+    color: ink.primary,
+    paddingTop: spacing(1),
+  },
+  action: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+  },
+  actionLink: {
+    ...editorialType.caption,
+    color: accent.primary,
+    fontWeight: '600',
+  },
+});
+
+export default ReflectionSourcesPanel;

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
@@ -1,0 +1,321 @@
+/* eslint-env jest */
+// RED: `JournalEntryScreen` does not yet recognize the `reflectionLevel` /
+// `reflectionScopeKey` route params, does not call `reflections.sources`, and
+// never sends `reflection_level`/`reflection_scope_key` on `journal.create` --
+// every case below fails until the implementation-specialist wires reflection
+// mode through the screen.
+//
+// `../ReflectionSourcesPanel` is stubbed to a button that fires
+// `onInsertQuote(quote, sourceItem)` -- this file pins the create/setIncluded/
+// 409 wiring, not the panel's own rendering (covered by
+// `ReflectionSourcesPanel.test.tsx`).
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type {
+  JournalMessage,
+  PromotedQuoteSummary,
+  ReflectionDue,
+  ReflectionSourceItem,
+} from '@/api';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+const mockCompletionList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: unknown[] }>
+>;
+const mockRespond = jest.fn() as jest.MockedFunction<(_w: number, _b: string) => Promise<unknown>>;
+const mockSetIncluded = jest.fn() as jest.MockedFunction<
+  (_id: number, _entryId: number | null) => Promise<unknown>
+>;
+const mockReflectionsDue = jest.fn() as jest.MockedFunction<
+  () => Promise<{ due: ReflectionDue | null }>
+>;
+const mockReflectionsSources = jest.fn() as jest.MockedFunction<
+  (_level: string, _scopeKey: string) => Promise<{ items: ReflectionSourceItem[] }>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: {
+    respond: (...a: unknown[]) => (mockRespond as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: (...a: unknown[]) =>
+      (mockCompletionList as unknown as (...x: unknown[]) => unknown)(...a),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: (...a: unknown[]) =>
+      (mockSetIncluded as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  reflections: {
+    due: (...a: unknown[]) => (mockReflectionsDue as unknown as (...x: unknown[]) => unknown)(...a),
+    sources: (...a: unknown[]) =>
+      (mockReflectionsSources as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+// Names are `mock`-prefixed so babel-plugin-jest-hoist allows referencing
+// them from inside the `jest.mock(...)` factory below.
+const mockStubQuote: PromotedQuoteSummary = {
+  id: 90,
+  anchor_start: 2,
+  anchor_end: 19,
+  anchor_text: 'went for a daily walk',
+  pending: true,
+};
+
+const mockStubSourceItem: ReflectionSourceItem = {
+  kind: 'entry',
+  id: 1,
+  title: 'Runs',
+  timestamp: '2026-06-01T00:00:00Z',
+  body: 'I went for a daily walk to the river.',
+  reflection_level: null,
+  promoted_quotes: [mockStubQuote],
+};
+
+jest.mock('../ReflectionSourcesPanel', () => {
+  const { Text, TouchableOpacity } = require('react-native');
+  const Stub = ({
+    onInsertQuote,
+  }: {
+    onInsertQuote: (_q: PromotedQuoteSummary, _item: ReflectionSourceItem) => void;
+  }) => (
+    <TouchableOpacity
+      testID="stub-insert-quote"
+      onPress={() => onInsertQuote(mockStubQuote, mockStubSourceItem)}
+    >
+      <Text>Insert stub quote</Text>
+    </TouchableOpacity>
+  );
+  return { __esModule: true, default: Stub };
+});
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 42,
+    message: 'A reflection on the week.',
+    sender: 'user',
+    timestamp: '2026-07-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Stage Reflection — Survival',
+    status: 'draft',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderScreen(params?: Record<string, unknown>, extraProps: Record<string, unknown> = {}) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = {
+    navigate: jest.fn(),
+    replace: jest.fn(),
+    goBack: jest.fn(),
+    push: jest.fn(),
+  };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return {
+    ...render(<Screen navigation={navigation} route={route} {...extraProps} />),
+    navigation,
+  };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+  mockCompletionList.mockReset();
+  mockCompletionList.mockResolvedValue({ items: [] });
+  mockRespond.mockReset();
+  mockRespond.mockResolvedValue({});
+  mockSetIncluded.mockReset();
+  mockSetIncluded.mockResolvedValue(mockStubQuote);
+  mockReflectionsDue.mockReset();
+  mockReflectionsDue.mockResolvedValue({ due: null });
+  mockReflectionsSources.mockReset();
+  mockReflectionsSources.mockResolvedValue({ items: [] });
+});
+
+const REFLECTION_PARAMS = {
+  reflectionLevel: 'stage',
+  reflectionScopeKey: 'c1:s1',
+  prefillTitle: 'Stage Reflection — Survival',
+};
+
+describe('JournalEntryScreen -- reflection mode', () => {
+  it('pre-fills the title, sends reflection fields on create, offers Finish, and never calls prompts.respond', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(REFLECTION_PARAMS, { autosaveDelayMs: 100 });
+      expect(getByTestId('journal-title-input').props.value).toBe('Stage Reflection — Survival');
+
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A reflection on the week.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'A reflection on the week.',
+          reflection_level: 'stage',
+          reflection_scope_key: 'c1:s1',
+        }),
+      );
+      expect(mockRespond).not.toHaveBeenCalled();
+      expect(getByTestId('journal-finish-button')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fetches the sources feed for the reflection level/scope on mount', async () => {
+    renderScreen(REFLECTION_PARAMS);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockReflectionsSources.mock.calls[0]?.slice(0, 2)).toEqual(['stage', 'c1:s1']);
+  });
+
+  it('inserts a blockquote on a tapped pending quote and folds it in via setIncluded once the entry saves', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId, findByTestId } = renderScreen(REFLECTION_PARAMS, {
+        autosaveDelayMs: 100,
+      });
+      await act(async () => {
+        fireEvent.press(await findByTestId('reflection-sources-toggle'));
+      });
+      const insertButton = await findByTestId('stub-insert-quote');
+
+      await act(async () => {
+        fireEvent.press(insertButton);
+      });
+
+      const body = getByTestId('journal-body-input').props.value as string;
+      expect(body).toContain('went for a daily walk');
+      expect(body).toContain('>');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockSetIncluded).toHaveBeenCalledWith(90, 42);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('leaves the quote pending and surfaces a warm hint when setIncluded rejects, without crashing', async () => {
+    mockSetIncluded.mockRejectedValue({ status: 500, detail: 'boom' });
+    jest.useFakeTimers();
+    try {
+      const { findByTestId } = renderScreen(REFLECTION_PARAMS, { autosaveDelayMs: 100 });
+      await act(async () => {
+        fireEvent.press(await findByTestId('reflection-sources-toggle'));
+      });
+      const insertButton = await findByTestId('stub-insert-quote');
+
+      await act(async () => {
+        fireEvent.press(insertButton);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(await findByTestId('quote-inclusion-hint')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('on a 409 create conflict, consults reflections.due and routes to the existing entry', async () => {
+    mockCreate.mockRejectedValue({ status: 409, detail: 'reflection_already_exists' });
+    mockReflectionsDue.mockResolvedValue({
+      due: {
+        level: 'stage',
+        scope_key: 'c1:s1',
+        window_start: '2026-06-01T00:00:00Z',
+        window_end: '2026-07-01T00:00:00Z',
+        existing_entry_id: 77,
+      },
+    });
+    jest.useFakeTimers();
+    try {
+      const { getByTestId, navigation } = renderScreen(REFLECTION_PARAMS, {
+        autosaveDelayMs: 100,
+      });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A reflection on the week.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockReflectionsDue).toHaveBeenCalled();
+      const replaceCall = navigation.replace.mock.calls[0];
+      const navigateCall = navigation.navigate.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === 'JournalEntry' &&
+          (call[1] as Record<string, unknown> | undefined)?.entryId === 77,
+      );
+      const routedToExisting =
+        (replaceCall != null &&
+          replaceCall[0] === 'JournalEntry' &&
+          (replaceCall[1] as Record<string, unknown> | undefined)?.entryId === 77) ||
+        navigateCall != null;
+      expect(routedToExisting).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('JournalEntryScreen -- weekly-prompt mode regression', () => {
+  it('still calls prompts.respond and carries no reflection scope fields', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        {
+          weekNumber: 3,
+          promptQuestion: 'What did you notice?',
+          prefillTitle: 'Week 3 Reflection',
+        },
+        { autosaveDelayMs: 100 },
+      );
+      fireEvent.changeText(getByTestId('journal-body-input'), 'I noticed the willow.');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(mockRespond).toHaveBeenCalledWith(3, 'I noticed the willow.', 'Week 3 Reflection');
+      expect(mockCreate).not.toHaveBeenCalled();
+      const respondArgs = mockRespond.mock.calls[0];
+      expect(respondArgs).toHaveLength(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/ReflectionInvitationBand.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionInvitationBand.test.tsx
@@ -1,0 +1,178 @@
+/* eslint-env jest */
+// RED: `ReflectionInvitationBand` does not exist yet -- `require('../ReflectionInvitationBand')`
+// throws until the implementation-specialist adds it (self-contained, like
+// `ReturnStack`/`InvitationStack`: no props, fetches its own due-reflection state).
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { ReflectionDue, Stage } from '@/api';
+
+const mockDue = jest.fn() as jest.MockedFunction<() => Promise<{ due: ReflectionDue | null }>>;
+const mockStagesListAll = jest.fn() as jest.MockedFunction<() => Promise<Stage[]>>;
+const mockLoadDismissed = jest.fn() as jest.MockedFunction<(_k: string) => Promise<boolean>>;
+const mockSaveDismissed = jest.fn() as jest.MockedFunction<
+  (_k: string, _v: boolean) => Promise<void>
+>;
+const mockNavigate = jest.fn();
+
+jest.mock('@/api', () => ({
+  reflections: {
+    due: (...a: unknown[]) => (mockDue as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  stages: {
+    listAll: (...a: unknown[]) =>
+      (mockStagesListAll as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+jest.mock('@/storage/reflectionDismissalStorage', () => ({
+  loadReflectionDismissed: (...a: unknown[]) =>
+    (mockLoadDismissed as unknown as (...x: unknown[]) => unknown)(...a),
+  saveReflectionDismissed: (...a: unknown[]) =>
+    (mockSaveDismissed as unknown as (...x: unknown[]) => unknown)(...a),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const ReflectionInvitationBand = require('../ReflectionInvitationBand').default;
+
+function due(overrides: Partial<ReflectionDue> = {}): ReflectionDue {
+  return {
+    level: 'week',
+    scope_key: 'c1:w14',
+    window_start: '2026-07-01T00:00:00Z',
+    window_end: '2026-07-08T00:00:00Z',
+    existing_entry_id: null,
+    ...overrides,
+  };
+}
+
+function stage(overrides: Partial<Stage> = {}): Stage {
+  return {
+    id: 1,
+    title: 'Survival',
+    subtitle: 'Beige',
+    stage_number: 1,
+    overview_url: 'https://example.com',
+    category: 'foundation',
+    aspect: 'body',
+    spiral_dynamics_color: 'Beige',
+    growing_up_stage: 'Archaic',
+    divine_gender_polarity: 'neutral',
+    relationship_to_free_will: 'reactive',
+    free_will_description: 'Instinctual survival',
+    is_unlocked: true,
+    progress: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockDue.mockReset();
+  mockStagesListAll.mockReset();
+  mockLoadDismissed.mockReset();
+  mockSaveDismissed.mockReset();
+  mockNavigate.mockReset();
+  mockDue.mockResolvedValue({ due: due() });
+  mockStagesListAll.mockResolvedValue([stage()]);
+  mockLoadDismissed.mockResolvedValue(false);
+  mockSaveDismissed.mockResolvedValue(undefined);
+});
+
+describe('ReflectionInvitationBand', () => {
+  it('renders the band with level-appropriate copy when a reflection is due', async () => {
+    const { findByTestId, getByTestId } = render(<ReflectionInvitationBand />);
+    const band = await findByTestId('journal-reflection-band');
+    expect(band).toBeTruthy();
+    expect(getByTestId('journal-reflection-band')).toBeTruthy();
+  });
+
+  it('shows the stage title alongside stage-level copy', async () => {
+    mockDue.mockResolvedValue({ due: due({ level: 'stage', scope_key: 'c1:s1' }) });
+    const { findByText } = render(<ReflectionInvitationBand />);
+    expect(await findByText(/Stage Reflection/)).toBeTruthy();
+    expect(await findByText(/Survival/)).toBeTruthy();
+  });
+
+  it('renders nothing when nothing is due', async () => {
+    mockDue.mockResolvedValue({ due: null });
+    const { queryByTestId } = render(<ReflectionInvitationBand />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-reflection-band')).toBeNull();
+  });
+
+  it('renders nothing when a dismissal is already stored for this scope key', async () => {
+    mockLoadDismissed.mockResolvedValue(true);
+    const { queryByTestId } = render(<ReflectionInvitationBand />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-reflection-band')).toBeNull();
+  });
+
+  it('renders quietly hidden when the due lookup rejects, without crashing', async () => {
+    mockDue.mockRejectedValue(new Error('network down'));
+    const { queryByTestId } = render(<ReflectionInvitationBand />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-reflection-band')).toBeNull();
+  });
+
+  it('dismissing persists the scope key and hides the band, with no nag/streak copy', async () => {
+    const { findByTestId, getByTestId, queryByTestId, queryByText } = render(
+      <ReflectionInvitationBand />,
+    );
+    await findByTestId('journal-reflection-band');
+    expect(queryByText(/streak/i)).toBeNull();
+    expect(queryByText(/don't break/i)).toBeNull();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-reflection-dismiss'));
+    });
+
+    expect(mockSaveDismissed).toHaveBeenCalledWith('c1:w14', true);
+    await waitFor(() => expect(queryByTestId('journal-reflection-band')).toBeNull());
+  });
+
+  it('resurfaces for a new scope key even after a prior scope key was dismissed', async () => {
+    mockLoadDismissed.mockImplementation((key: string) => Promise.resolve(key === 'c1:w14'));
+    mockDue.mockResolvedValue({ due: due({ scope_key: 'c1:w15' }) });
+
+    const { findByTestId } = render(<ReflectionInvitationBand />);
+    expect(await findByTestId('journal-reflection-band')).toBeTruthy();
+  });
+
+  it('shows a Continue affordance and navigates with the existing entryId when one is in progress', async () => {
+    mockDue.mockResolvedValue({ due: due({ existing_entry_id: 99 }) });
+    const { findByTestId, getByTestId } = render(<ReflectionInvitationBand />);
+    await findByTestId('journal-reflection-band');
+    expect(getByTestId('journal-reflection-band').props.accessibilityLabel).toMatch(/continue/i);
+
+    fireEvent.press(getByTestId('journal-reflection-band'));
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry', { entryId: 99 });
+  });
+
+  it('navigates a fresh reflection with the level/scope/prefillTitle params, not weekNumber', async () => {
+    const { findByTestId, getByTestId } = render(<ReflectionInvitationBand />);
+    await findByTestId('journal-reflection-band');
+
+    fireEvent.press(getByTestId('journal-reflection-band'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'JournalEntry',
+      expect.objectContaining({
+        reflectionLevel: 'week',
+        reflectionScopeKey: 'c1:w14',
+        prefillTitle: 'Week 14 Reflection',
+      }),
+    );
+    const [, params] = mockNavigate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(params).not.toHaveProperty('weekNumber');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
@@ -1,0 +1,173 @@
+/* eslint-env jest */
+// RED: `ReflectionSourcesPanel` does not exist yet -- `require(...)` throws
+// until the implementation-specialist adds it.
+//
+// Assumed prop/callback contract (implementer: match this exactly):
+//   interface ReflectionSourcesPanelProps {
+//     items: ReflectionSourceItem[];
+//     onInsertQuote: (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem) => void;
+//     onClose?: () => void;
+//   }
+// Rendering rules pinned below: pending promoted quotes render as a distinct
+// group above the chronological (oldest -> newest) entry/reflection list;
+// `kind: 'reflection'` rows get testID `reflection-source-<id>` and show their
+// `reflection_level`; `kind: 'entry'` rows get testID `entry-source-<id>`.
+// Each row is collapsed to an excerpt until tapped, which reveals
+// testID `source-body-<id>` with the full body. A pending quote is testID
+// `pending-quote-<id>`; tapping it fires `onInsertQuote` and marks the quote
+// included (dimmed / `accessibilityState.disabled`) without removing it.
+// Layout is responsive on `useWindowDimensions().width`: < 600 wraps the
+// panel in a bottom-sheet `Modal` (testID `reflection-sources-sheet`); >= 600
+// renders an inline side pane (testID `reflection-sources-pane`).
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
+
+const ReflectionSourcesPanel = require('../ReflectionSourcesPanel').default;
+
+function quote(overrides: Partial<PromotedQuoteSummary> = {}): PromotedQuoteSummary {
+  return {
+    id: 1,
+    anchor_start: 0,
+    anchor_end: 10,
+    anchor_text: 'a steady walk',
+    pending: true,
+    ...overrides,
+  };
+}
+
+function item(overrides: Partial<ReflectionSourceItem> = {}): ReflectionSourceItem {
+  return {
+    kind: 'entry',
+    id: 1,
+    title: 'Entry title',
+    timestamp: '2026-06-01T00:00:00Z',
+    body: 'The full body of the entry, longer than any excerpt.',
+    reflection_level: null,
+    promoted_quotes: [],
+    ...overrides,
+  };
+}
+
+describe('ReflectionSourcesPanel -- pending quotes', () => {
+  it('renders pending promoted quotes at the top, ahead of the chronological feed', () => {
+    const items = [
+      item({
+        id: 1,
+        timestamp: '2026-06-05T00:00:00Z',
+        promoted_quotes: [quote({ id: 90, pending: true })],
+      }),
+    ];
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} />,
+    );
+    expect(getByTestId('pending-quote-90')).toBeTruthy();
+  });
+
+  it('fires onInsertQuote with the quote and its source item when tapped', () => {
+    const onInsertQuote = jest.fn();
+    const sourceItem = item({
+      id: 1,
+      timestamp: '2026-06-05T00:00:00Z',
+      promoted_quotes: [quote({ id: 90, pending: true })],
+    });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={[sourceItem]} onInsertQuote={onInsertQuote} />,
+    );
+    fireEvent.press(getByTestId('pending-quote-90'));
+    expect(onInsertQuote).toHaveBeenCalledWith(sourceItem.promoted_quotes[0], sourceItem);
+  });
+
+  it('marks a tapped quote included (dimmed) without removing it from view', () => {
+    const sourceItem = item({
+      id: 1,
+      promoted_quotes: [quote({ id: 90, pending: true })],
+    });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={[sourceItem]} onInsertQuote={jest.fn()} />,
+    );
+    fireEvent.press(getByTestId('pending-quote-90'));
+    const quoteNode = getByTestId('pending-quote-90');
+    expect(quoteNode).toBeTruthy();
+    expect(quoteNode.props.accessibilityState?.disabled).toBe(true);
+  });
+});
+
+describe('ReflectionSourcesPanel -- chronological feed', () => {
+  it('renders entry and reflection rows oldest to newest', () => {
+    const items = [
+      item({ kind: 'entry', id: 3, timestamp: '2026-06-15T00:00:00Z' }),
+      item({ kind: 'entry', id: 1, timestamp: '2026-06-01T00:00:00Z' }),
+      item({
+        kind: 'reflection',
+        id: 2,
+        reflection_level: 'week',
+        timestamp: '2026-06-08T00:00:00Z',
+      }),
+    ];
+    const { getAllByTestId } = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} />,
+    );
+    const rowIds = getAllByTestId(/^(entry|reflection)-source-\d+$/).map(
+      (node) => node.props.testID as string,
+    );
+    expect(rowIds).toEqual(['entry-source-1', 'reflection-source-2', 'entry-source-3']);
+  });
+
+  it('visually distinguishes a reflection row and shows its level label', () => {
+    const items = [item({ kind: 'reflection', id: 2, reflection_level: 'week' })];
+    const { getByTestId, getByText } = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} />,
+    );
+    expect(getByTestId('reflection-source-2')).toBeTruthy();
+    expect(getByText(/week/i)).toBeTruthy();
+  });
+
+  it('expands a row to reveal its full body on tap', () => {
+    const items = [item({ id: 5, body: 'A very particular sentence about the river.' })];
+    const { getByTestId, queryByTestId } = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} />,
+    );
+    expect(queryByTestId('source-body-5')).toBeNull();
+    fireEvent.press(getByTestId('entry-source-5'));
+    expect(getByTestId('source-body-5').props.children).toContain(
+      'A very particular sentence about the river.',
+    );
+  });
+});
+
+describe('ReflectionSourcesPanel -- responsive layout', () => {
+  it('renders as a bottom-sheet Modal on a narrow viewport', () => {
+    const rn = require('react-native');
+    const spy = jest
+      .spyOn(rn, 'useWindowDimensions')
+      .mockReturnValue({ width: 400, height: 800, scale: 2, fontScale: 1 });
+    try {
+      const { getByTestId, queryByTestId } = render(
+        <ReflectionSourcesPanel items={[item()]} onInsertQuote={jest.fn()} />,
+      );
+      expect(getByTestId('reflection-sources-sheet')).toBeTruthy();
+      expect(queryByTestId('reflection-sources-pane')).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('renders as an inline side pane on a wide viewport', () => {
+    const rn = require('react-native');
+    const spy = jest
+      .spyOn(rn, 'useWindowDimensions')
+      .mockReturnValue({ width: 1280, height: 900, scale: 1, fontScale: 1 });
+    try {
+      const { getByTestId, queryByTestId } = render(
+        <ReflectionSourcesPanel items={[item()]} onInsertQuote={jest.fn()} />,
+      );
+      expect(getByTestId('reflection-sources-pane')).toBeTruthy();
+      expect(queryByTestId('reflection-sources-sheet')).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
+++ b/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
@@ -1,0 +1,57 @@
+// RED: `reflectionCopy` does not exist yet -- these imports fail until the
+// implementation-specialist adds `reflectionTitle` and `formatBlockquote`.
+import { describe, it, expect } from '@jest/globals';
+
+import { reflectionTitle, formatBlockquote } from '../reflectionCopy';
+
+describe('reflectionTitle', () => {
+  it('titles a week reflection from its week-number scope key', () => {
+    expect(reflectionTitle('week', 'c1:w14')).toBe('Week 14 Reflection');
+  });
+
+  it('titles a stage reflection with the stage title appended', () => {
+    const title = reflectionTitle('stage', 'c1:s1', 'Survival');
+    expect(title).toContain('Stage Reflection');
+    expect(title).toContain('Survival');
+  });
+
+  it('still returns a usable stage title with no stageTitle supplied', () => {
+    const title = reflectionTitle('stage', 'c1:s1');
+    expect(title).toContain('Stage Reflection');
+  });
+
+  it('titles a component reflection', () => {
+    expect(reflectionTitle('component', 'c1:p2')).toBe('Component Reflection');
+  });
+
+  it('titles a tier reflection', () => {
+    expect(reflectionTitle('tier', 'c1:t1')).toBe('Tier Reflection');
+  });
+
+  it('titles a program reflection', () => {
+    expect(reflectionTitle('program', 'c1:prog')).toBe('Program Reflection');
+  });
+});
+
+describe('formatBlockquote', () => {
+  it('opens on a fresh line with a blockquote marker before the anchor text', () => {
+    const block = formatBlockquote('went for a daily walk', 'Runs');
+    expect(block.startsWith('\n>')).toBe(true);
+    expect(block).toContain('> went for a daily walk');
+  });
+
+  it('includes the attribution on its own quoted line', () => {
+    const block = formatBlockquote('went for a daily walk', 'Runs');
+    expect(block).toContain('Runs');
+  });
+
+  it('closes with a blank line so the inserted quote never runs into surrounding prose', () => {
+    const block = formatBlockquote('went for a daily walk', 'Runs');
+    expect(block.endsWith('\n\n')).toBe(true);
+  });
+
+  it('falls back to a formatted date attribution when no title is given', () => {
+    const block = formatBlockquote('went for a daily walk', 'Jun 1, 2026');
+    expect(block).toContain('Jun 1, 2026');
+  });
+});

--- a/frontend/src/features/Journal/reflectionCopy.ts
+++ b/frontend/src/features/Journal/reflectionCopy.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure copy helpers for the hierarchical-reflection surface: the invitation
+ * title per scope, a Markdown blockquote for a folded-in quote, and the
+ * attribution line beneath it. No React, no I/O — trivially unit-testable.
+ *
+ * Scope-key grammar (mirrors the backend): ``c{cycle}:{token}`` where the token
+ * is one of ``prog`` | ``w<n>`` | ``s<n>`` | ``p<n>`` | ``t<n>`` (week / stage /
+ * component / tier / program).
+ */
+import type { ReflectionLevel, ReflectionSourceItem } from '@/api';
+
+/** Extracts the week ordinal from a week scope key (``c1:w14`` → ``14``). */
+const WEEK_SCOPE_KEY = /^c\d+:w(\d+)$/;
+
+/** The fixed titles for the breadth levels that carry no per-scope number. */
+const FIXED_LEVEL_TITLES: Record<Exclude<ReflectionLevel, 'week' | 'stage'>, string> = {
+  component: 'Component Reflection',
+  tier: 'Tier Reflection',
+  program: 'Program Reflection',
+};
+
+/** A week title, degrading gracefully when the scope key is not the ``w<n>`` shape. */
+function weekTitle(scopeKey: string): string {
+  const week = WEEK_SCOPE_KEY.exec(scopeKey)?.[1];
+  return week == null ? 'Week Reflection' : `Week ${week} Reflection`;
+}
+
+/**
+ * The pre-filled title for a reflection invitation. A ``week`` reads
+ * "Week 14 Reflection"; a ``stage`` appends its title when known
+ * ("Stage Reflection — Survival"); the broader levels use their fixed label.
+ */
+export function reflectionTitle(
+  level: ReflectionLevel,
+  scopeKey: string,
+  stageTitle?: string,
+): string {
+  if (level === 'week') return weekTitle(scopeKey);
+  if (level === 'stage') {
+    return stageTitle ? `Stage Reflection — ${stageTitle}` : 'Stage Reflection';
+  }
+  return FIXED_LEVEL_TITLES[level];
+}
+
+/**
+ * A Markdown blockquote for a quote folded into the reflection body. Opens on a
+ * fresh line, attributes the source on its own quoted line, and closes with a
+ * blank line so it never runs into surrounding prose.
+ */
+export function formatBlockquote(anchorText: string, attribution: string): string {
+  return `\n> ${anchorText}\n> — ${attribution}\n\n`;
+}
+
+/** ``short`` month/day/year attribution date (e.g. "Jun 1, 2026"); '' if unparseable. */
+function formatSourceDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** The attribution shown beneath a folded quote: the source's title, else its date. */
+export function sourceAttribution(item: ReflectionSourceItem): string {
+  const title = item.title?.trim();
+  return title ? title : formatSourceDate(item.timestamp);
+}

--- a/frontend/src/features/Journal/useReflectionMode.ts
+++ b/frontend/src/features/Journal/useReflectionMode.ts
@@ -1,0 +1,126 @@
+/**
+ * ``useReflectionMode`` — the reflection-composer glue for ``JournalEntryScreen``.
+ *
+ * Active only when the screen was opened with a reflection scope. It fetches the
+ * rereadable sources feed on mount, tracks the body caret so a folded-in quote
+ * lands where the writer left off, and folds a chosen quote into the body: splice
+ * a Markdown blockquote at the caret, let the normal draft path create/save the
+ * entry, then mark the quote included on that entry. A failed inclusion leaves
+ * the quote pending and raises a warm, declinable hint — never a crash, never a
+ * nag.
+ */
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import type { NativeSyntheticEvent, TextInputSelectionChangeEventData } from 'react-native';
+
+import { formatBlockquote, sourceAttribution } from './reflectionCopy';
+
+import { promotions, reflections } from '@/api';
+import type { PromotedQuoteSummary, ReflectionLevel, ReflectionSourceItem } from '@/api';
+
+type SelectionEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+export interface UseReflectionModeArgs {
+  reflectionLevel?: ReflectionLevel;
+  reflectionScopeKey?: string;
+  /** The latest body text (read to splice a quote at the caret). */
+  bodyRef: MutableRefObject<string>;
+  /** The screen's body change handler (updates state + schedules the draft save). */
+  onChangeBody: (_next: string) => void;
+  /** Persist the draft now and resolve to the entry id (single-flight writer). */
+  flush: () => Promise<number | null>;
+}
+
+export interface UseReflectionModeResult {
+  /** True when the screen is composing a reflection (both scope fields present). */
+  active: boolean;
+  /** The rereadable entries + earlier reflections in scope. */
+  sources: ReflectionSourceItem[];
+  /** Set when a folded quote could not be marked included; drives a warm hint. */
+  inclusionHint: boolean;
+  /** Track the body caret so an inserted quote lands where the writer is. */
+  onBodySelectionChange: (_e: SelectionEvent) => void;
+  /** Fold a chosen pending quote into the reflection body. */
+  onInsertQuote: (_quote: PromotedQuoteSummary, _sourceItem: ReflectionSourceItem) => void;
+}
+
+/**
+ * Splice ``block`` into ``body`` at ``caret`` (or the end when untracked),
+ * returning the new text and the caret position just past the inserted block so
+ * a second fold-in lands after the first rather than re-splitting it.
+ */
+function spliceAtCaret(
+  body: string,
+  block: string,
+  caret: number | null,
+): { text: string; nextCaret: number } {
+  const at = caret == null ? body.length : Math.min(caret, body.length);
+  return { text: body.slice(0, at) + block + body.slice(at), nextCaret: at + block.length };
+}
+
+/** Fetch the rereadable sources feed for a reflection scope (hidden on any error). */
+function useSourcesFeed(
+  reflectionLevel: ReflectionLevel | undefined,
+  reflectionScopeKey: string | undefined,
+): ReflectionSourceItem[] {
+  const [sources, setSources] = useState<ReflectionSourceItem[]>([]);
+  useEffect(() => {
+    if (reflectionLevel == null || reflectionScopeKey == null) return undefined;
+    let alive = true;
+    void reflections
+      .sources(reflectionLevel, reflectionScopeKey)
+      .then((result) => {
+        if (alive) setSources(result.items);
+      })
+      .catch(() => {
+        // The composer works without the feed; a fetch failure just hides it.
+      });
+    return () => {
+      alive = false;
+    };
+  }, [reflectionLevel, reflectionScopeKey]);
+  return sources;
+}
+
+export function useReflectionMode({
+  reflectionLevel,
+  reflectionScopeKey,
+  bodyRef,
+  onChangeBody,
+  flush,
+}: UseReflectionModeArgs): UseReflectionModeResult {
+  const active = reflectionLevel != null && reflectionScopeKey != null;
+  const sources = useSourcesFeed(reflectionLevel, reflectionScopeKey);
+  const [inclusionHint, setInclusionHint] = useState(false);
+  const caretRef = useRef<number | null>(null);
+
+  const onBodySelectionChange = useCallback((event: SelectionEvent) => {
+    caretRef.current = event.nativeEvent.selection.start;
+  }, []);
+
+  const foldIn = useCallback(
+    async (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem): Promise<void> => {
+      const block = formatBlockquote(quote.anchor_text, sourceAttribution(sourceItem));
+      const { text, nextCaret } = spliceAtCaret(bodyRef.current, block, caretRef.current);
+      onChangeBody(text);
+      caretRef.current = nextCaret;
+      const entryId = await flush();
+      if (entryId == null) return;
+      try {
+        await promotions.setIncluded(quote.id, entryId);
+      } catch {
+        // Leave the quote pending and invite a calm retry — no crash, no nag.
+        setInclusionHint(true);
+      }
+    },
+    [bodyRef, onChangeBody, flush],
+  );
+
+  const onInsertQuote = useCallback(
+    (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem): void => {
+      void foldIn(quote, sourceItem);
+    },
+    [foldIn],
+  );
+
+  return { active, sources, inclusionHint, onBodySelectionChange, onInsertQuote };
+}

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -15,6 +15,7 @@ import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen'
 import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
 
+import type { ReflectionLevel } from '@/api';
 import { accent, fonts, ink } from '@/design/tokens';
 import type { ModeConfig } from '@/features/Practice/engine/types';
 
@@ -57,6 +58,10 @@ export type RootStackParamList = {
         practiceSessionId?: number;
         userPracticeId?: number;
         prefillTitle?: string;
+        /** Reflection scope this page closes (7th-day reflection compose mode). */
+        reflectionLevel?: ReflectionLevel;
+        /** The scope key the reflection covers (e.g. ``c1:w14``); pairs with ``reflectionLevel``. */
+        reflectionScopeKey?: string;
       }
     | undefined;
 };

--- a/frontend/src/storage/__tests__/reflectionDismissalStorage.test.ts
+++ b/frontend/src/storage/__tests__/reflectionDismissalStorage.test.ts
@@ -1,0 +1,69 @@
+// RED: `reflectionDismissalStorage` does not exist yet -- this import fails
+// until the implementation-specialist adds the module (mirrors
+// `returnOfferStorage.ts`, keyed per reflection scope instead of globally).
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { saveReflectionDismissed, loadReflectionDismissed } from '../reflectionDismissalStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('reflectionDismissalStorage', () => {
+  describe('saveReflectionDismissed', () => {
+    test('stores true under a scope-key-specific storage key', async () => {
+      await saveReflectionDismissed('c1:w14', true);
+
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/reflection_dismissed:c1:w14',
+        'true',
+      );
+    });
+
+    test('stores false when a dismissal is reset', async () => {
+      await saveReflectionDismissed('c1:w14', false);
+
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/reflection_dismissed:c1:w14',
+        'false',
+      );
+    });
+  });
+
+  describe('loadReflectionDismissed', () => {
+    test('returns false for an unknown scope key', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+      const result = await loadReflectionDismissed('c1:s1');
+      expect(result).toBe(false);
+    });
+
+    test('returns true when the stored flag is true', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+      const result = await loadReflectionDismissed('c1:w14');
+      expect(result).toBe(true);
+    });
+
+    test('keeps distinct scope keys independent -- dismissing one leaves another false', async () => {
+      mockAsyncStorage.getItem.mockImplementation((key: string) =>
+        Promise.resolve(key === '@adepthood/reflection_dismissed:c1:w14' ? 'true' : null),
+      );
+
+      expect(await loadReflectionDismissed('c1:w14')).toBe(true);
+      expect(await loadReflectionDismissed('c1:s1')).toBe(false);
+    });
+
+    test('returns false on a storage error rather than throwing', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('storage error'));
+      const result = await loadReflectionDismissed('c1:w14');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/frontend/src/storage/reflectionDismissalStorage.ts
+++ b/frontend/src/storage/reflectionDismissalStorage.ts
@@ -1,0 +1,33 @@
+// Persists a "this reflection invitation was set aside" flag, keyed per
+// reflection scope so a decline is honoured across launches for that scope only
+// — a later scope (a new week/stage) still surfaces its own fresh invitation.
+// Mirrors ``returnOfferStorage.ts``, but scoped rather than global.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY_PREFIX = '@adepthood/reflection_dismissed:';
+const FLAG_TRUE = 'true';
+
+/** The AsyncStorage key that isolates one reflection scope's dismissal flag. */
+function storageKey(scopeKey: string): string {
+  return `${KEY_PREFIX}${scopeKey}`;
+}
+
+/** Record (or clear) the dismissal for a single reflection scope. */
+export async function saveReflectionDismissed(scopeKey: string, value: boolean): Promise<void> {
+  await AsyncStorage.setItem(storageKey(scopeKey), String(value));
+}
+
+/**
+ * Whether the invitation for ``scopeKey`` was previously set aside. A storage
+ * read failure resolves ``false`` (surface the invitation rather than crash) so
+ * a flaky disk never suppresses a genuinely-due reflection.
+ */
+export async function loadReflectionDismissed(scopeKey: string): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(storageKey(scopeKey));
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[reflectionDismissalStorage] failed to load dismissal flag', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the frontend for 7th-day hierarchical reflections (epic #1458):

- **Reflection invitation band** on the Journal shelf (`ReflectionInvitationBand`) — self-contained like the return/invitation stacks: fetches its own "is a reflection due?" state, renders nothing when nothing is due / the scope was set aside / the lookup fails. Warm and one-tap-declinable; a dismissal persists per scope key (`reflectionDismissalStorage`) while a genuinely new scope still surfaces its own invitation. No streak, count, or guilt copy.
- **Reflection-mode composer** — `JournalEntryScreen` opened with a reflection scope reuses the *plain* journal create/update path (never `prompts.respond`). A "Sources" affordance opens a rereadable feed (`ReflectionSourcesPanel`: bottom sheet on narrow, side pane on wide) of in-scope entries + earlier reflections. Tapping a pending quote folds it in as a Markdown blockquote at the caret and marks it included via `promotions.setIncluded` once the draft saves; a failed inclusion leaves the quote pending behind a calm, declinable hint.
- **409 handling** — a reflection-scope create that conflicts (the reflection already exists) consults the due window and routes to the existing entry instead of dead-ending, additively, without rejecting the single-flight writer.
- **API client + schemas** — `reflections.due` / `reflections.sources` with URL-encoded scope keys, Zod response schemas, and additive `reflection_level` / `reflection_scope_key` fields on the journal create/update payloads; `RootStack` reflection route params.

Product principle honored throughout — "you choose your depth": every affordance is a resonant, declinable invitation.

## Test plan

- `./scripts/frontend/check-all.sh` green: ESLint (zero warnings), Prettier, `tsc --noEmit` (strict), 3805 Jest tests across 363 suites.
- New suites: `reflectionCopy`, `reflectionDismissalStorage`, `reflections-api`, `ReflectionInvitationBand`, `ReflectionSourcesPanel`, `JournalEntryScreenReflection` — cover due-state gating, per-scope dismissal + resurface, URL-encoding, sheet/pane responsiveness, blockquote fold-in + `setIncluded`, the inclusion-failure hint, and the 409 route-to-existing path.

## Reviewer notes

- Gate 2.5 self-review fixes applied: made the band a plain container with independently-focusable open + decline buttons (was a nested pressable that hid the decline from assistive tech); gated the sources panel behind the Sources toggle with a wired `onClose` (was an undismissable full-screen modal on phones); advanced the fold-in caret so sequential quotes land in order.
- **Deferred (tracked in #1516):** in-panel re-promotion of a *fresh* span inside the sources feed (the #1463 promote surface embedded in an expanded source body), and reconciling the optimistic "included" dim with `setIncluded` failure. The core reread-and-fold loop ships here.
- The band fetches due-state via `useEffect` on mount rather than `useFocusEffect`; it self-hides on dismiss via local state, so re-poll-on-refocus is a nice-to-have, not correctness.

Closes #1464
Refs #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)