### PR TITLE
fix(journal): merge load-on-open snapshot and clear stale privateMessage

### DIFF
--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -120,6 +120,61 @@ describe('useResonance', () => {
     expect(mockGenerate).not.toHaveBeenCalled();
     expect(result.current.error).toBeTruthy();
   });
+
+  it('a slow initial load resolving after a generate pass keeps the generated notes and suggestions', async () => {
+    let resolveLoad: (_v: { items: Marginalia[] }) => void = () => {};
+    let resolveSugLoad: (_v: { items: CompletionSuggestion[] }) => void = () => {};
+    mockList.mockReturnValue(
+      new Promise<{ items: Marginalia[] }>((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+    mockSugList.mockReturnValue(
+      new Promise<{ items: CompletionSuggestion[] }>((resolve) => {
+        resolveSugLoad = resolve;
+      }),
+    );
+    mockGenerate.mockResolvedValue(
+      resonancePayload({
+        marginalia: [note({ id: 9, anchor_start: 10 })],
+        suggestions: [suggestion({ id: 9, anchor_start: 10 })],
+      }),
+    );
+    const flush = jest.fn(async () => 7);
+    const { result } = renderHook(() => useResonance({ routeEntryId: 7, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+
+    await act(async () => {
+      resolveLoad({ items: [note({ id: 1 })] });
+      resolveSugLoad({ items: [suggestion({ id: 1 })] });
+    });
+
+    expect(result.current.marginalia.map((m: Marginalia) => m.id)).toEqual([1, 9]);
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 9]);
+  });
+
+  it('a stale privateMessage from a withheld pass is cleared when a later pass errors', async () => {
+    const flush = jest.fn(async () => 42);
+    mockGenerate.mockResolvedValueOnce(
+      resonancePayload({ private_message: 'Intimate entry - resonance paused.' }),
+    );
+    const { result } = renderHook(() => useResonance({ routeEntryId: null, flush }));
+
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.privateMessage).toBe('Intimate entry - resonance paused.');
+
+    mockGenerate.mockRejectedValueOnce(new ApiError(500, 'boom'));
+    await act(async () => {
+      await result.current.requestResonance();
+    });
+    expect(result.current.privateMessage).toBeNull();
+    expect(result.current.error).toBeTruthy();
+  });
 });
 
 describe('useResonance — suggestions', () => {

--- a/frontend/src/features/Journal/__tests__/useResonance.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useResonance.test.tsx
@@ -156,6 +156,32 @@ describe('useResonance', () => {
     expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([1, 9]);
   });
 
+  it('replaces the prior entry notes and suggestions when routeEntryId changes to a different entry', async () => {
+    mockList.mockResolvedValueOnce({ items: [note({ id: 1 })] });
+    mockSugList.mockResolvedValueOnce({ items: [suggestion({ id: 1 })] });
+    const flush = jest.fn(async () => 7);
+    const { result, rerender } = renderHook(
+      ({ id }: { id: number }) => useResonance({ routeEntryId: id, flush }),
+      { initialProps: { id: 7 } },
+    );
+    await waitFor(() =>
+      expect(result.current.marginalia.map((m: Marginalia) => m.id)).toEqual([1]),
+    );
+
+    mockList.mockResolvedValueOnce({
+      items: [note({ id: 2, journal_entry_id: 8, anchor_start: 10 })],
+    });
+    mockSugList.mockResolvedValueOnce({
+      items: [suggestion({ id: 2, journal_entry_id: 8, anchor_start: 10 })],
+    });
+    rerender({ id: 8 });
+
+    await waitFor(() =>
+      expect(result.current.marginalia.map((m: Marginalia) => m.id)).toEqual([2]),
+    );
+    expect(result.current.suggestions.map((s: CompletionSuggestion) => s.id)).toEqual([2]);
+  });
+
   it('a stale privateMessage from a withheld pass is cleared when a later pass errors', async () => {
     const flush = jest.fn(async () => 42);
     mockGenerate.mockResolvedValueOnce(

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -92,7 +92,6 @@ function mergeByIdSorted<T extends { id: number; anchor_start: number }>(
 function mergeSnapshotUnder<T extends { id: number; anchor_start: number }>(
   snapshot: T[],
 ): (_prev: T[]) => T[] {
-  // Server rows as existing, in-memory as incoming: in-memory wins id collisions.
   return (prev) => mergeByIdSorted(snapshot, prev);
 }
 
@@ -100,7 +99,9 @@ function mergeSnapshotUnder<T extends { id: number; anchor_start: number }>(
  * Load a list-shaped resource once on open; silent on failure (id only).
  * Merges the loaded snapshot into current state by id (server rows as existing,
  * in-memory as incoming) so a slow load can't clobber state that advanced past
- * its snapshot (generate deltas, accepted flips, essay-bearing notes).
+ * its snapshot (generate deltas, accepted flips, essay-bearing notes). Resets to
+ * an empty list on each entry change (deps are stable), so a prior entry's rows
+ * can't union into a new one while same-entry late loads still merge under state.
  */
 function useLoadOnOpen<T extends { id: number; anchor_start: number }>(
   routeEntryId: number | null,
@@ -109,6 +110,8 @@ function useLoadOnOpen<T extends { id: number; anchor_start: number }>(
 ): void {
   useEffect(() => {
     if (routeEntryId == null) return undefined;
+    // Start each entry from empty so a prior entry's rows can't union into it.
+    apply([]);
     let active = true;
     void load(routeEntryId)
       .then((res) => {

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -59,8 +59,9 @@ export interface UseResonanceResult {
   contraction: ContractionReflection | null;
   /**
    * Reason copy from a pass that was withheld for an intimate entry.
-   * ``null`` until a generate pass returns a ``private_message``; the privacy
-   * gate falls back to its own default copy when this is null.
+   * ``null`` until a generate pass returns a ``private_message``; a new pass
+   * clears any stale copy, and the privacy gate falls back to its own default
+   * copy when this is null.
    */
   privateMessage: string | null;
   loading: boolean;
@@ -87,18 +88,31 @@ function mergeByIdSorted<T extends { id: number; anchor_start: number }>(
   return [...byId.values()].sort((a, b) => a.anchor_start - b.anchor_start);
 }
 
-/** Load a list-shaped resource once on open; silent on failure (id only). */
-function useLoadOnOpen<T>(
+/** State updater that folds a loaded snapshot under any state that outran it. */
+function mergeSnapshotUnder<T extends { id: number; anchor_start: number }>(
+  snapshot: T[],
+): (_prev: T[]) => T[] {
+  // Server rows as existing, in-memory as incoming: in-memory wins id collisions.
+  return (prev) => mergeByIdSorted(snapshot, prev);
+}
+
+/**
+ * Load a list-shaped resource once on open; silent on failure (id only).
+ * Merges the loaded snapshot into current state by id (server rows as existing,
+ * in-memory as incoming) so a slow load can't clobber state that advanced past
+ * its snapshot (generate deltas, accepted flips, essay-bearing notes).
+ */
+function useLoadOnOpen<T extends { id: number; anchor_start: number }>(
   routeEntryId: number | null,
   load: (_id: number) => Promise<{ items: T[] }>,
-  apply: (_items: T[]) => void,
+  apply: Dispatch<SetStateAction<T[]>>,
 ): void {
   useEffect(() => {
     if (routeEntryId == null) return undefined;
     let active = true;
     void load(routeEntryId)
       .then((res) => {
-        if (active) apply(res.items);
+        if (active) apply(mergeSnapshotUnder(res.items));
       })
       .catch(() => {
         // A failed initial load shouldn't block writing; stay silent here.
@@ -240,6 +254,9 @@ function useGeneratePass(deps: GeneratePassDeps): GeneratePass {
     // Likewise clear any prior contraction so an eased-then-healthy sequence
     // never leaves a stale "tend your foundation" reflection on the page.
     setContraction(null);
+    // Likewise clear any withheld-privacy copy up front so an errored or
+    // non-withheld pass never leaves a stale privacy surface on the page.
+    setPrivateMessage(null);
     try {
       const entryId = await flush();
       if (entryId == null) {


### PR DESCRIPTION
## Summary
Fixes two independent async-writer defects in `useResonance` (journal resonance pass) that left its state stale or wrong.

- **Defect 1 (High) — load-on-open clobbered freshly generated notes.** The generic `useLoadOnOpen` helper *replaced* state on resolve, wired for both marginalia and completion suggestions. On a slow connection, opening an existing entry while its initial `resonance.list` / `completionSuggestions.list` was still in flight, then tapping Get Resonance, let the generate pass merge new notes first — then the stale initial load resolved and overwrote state with the pre-generate snapshot, silently dropping the just-generated marginalia and suggestions until a refresh. Root cause: the load path *replaced* while the generate path *merged*, with no coordination. Since the backend generate response is a **delta** (only newly-persisted rows) and load-on-open is the sole source of prior persisted rows, a drop-guard would be lossy — so the helper now **merges the loaded snapshot by id** (server rows as `existing`, in-memory as `incoming`), letting in-memory state that outran the snapshot win id collisions. Lossless and idempotent when no generate has run (empty `prev` → snapshot unchanged).
- **Defect 2 (Medium) — stale withheld-privacy copy survived an errored pass.** `requestResonance` cleared `care` and `contraction` up front but set `privateMessage` only inside the `try`. A withheld pass then a pass that threw left the pass-1 privacy copy on screen next to the new error. Fixed by clearing `privateMessage` up front alongside the existing `care`/`contraction` resets (also covers the empty-body early return).

## Test plan
- Added two regression tests to `useResonance.test.tsx`, confirmed **RED** against the old code then **GREEN** after the fix:
  - a slow initial load resolving *after* a generate pass keeps the generated notes and suggestions (asserts the union `[1, 9]` for both marginalia and suggestions);
  - a withheld-then-errored pass clears `privateMessage` to `null` while surfacing the error.
- `./scripts/frontend/check-all.sh` exits 0: ESLint zero-warning, `tsc --noEmit` strict, prettier, and the full Jest suite (**3807 tests, 363 suites**) all pass. Coverage unchanged.
- Gate 2.5 self-review returned CLEAN.

Closes #1503
