### PR TITLE
fix(habits): sync backfillMissedDays/setNewStartDate to the server

### DIFF
--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -77,6 +77,7 @@ import {
 import { saveHabits, savePendingCheckIn } from '../../../../storage/habitStorage';
 import { useHabitStore } from '../../../../store/useHabitStore';
 import type { Habit } from '../../Habits.types';
+import { habitManager } from '../../services/habitManager';
 import { useHabitActions } from '../useHabitActions';
 import { useHabitUI } from '../useHabitUI';
 
@@ -370,6 +371,23 @@ describe('useHabitActions.addHabit', () => {
     expect(habitsApi.create).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Brand New', icon: '🆕' }),
     );
+  });
+});
+
+describe('useHabitActions tz binding for date-shifted mutations', () => {
+  it('forwards the hook tz prop as the third argument to backfillMissedDays', () => {
+    // Spy before render: useMemo captures whatever habitManager.backfillMissedDays
+    // currently is, so the spy must already be in place at capture time.
+    const backfillSpy = jest.spyOn(habitManager, 'backfillMissedDays').mockImplementation(() => {});
+    const { result } = renderActions();
+    const days = [new Date('2025-01-02')];
+
+    act(() => {
+      result.current.actions.backfillMissedDays(1, days);
+    });
+
+    expect(backfillSpy).toHaveBeenCalledWith(1, days, 'UTC');
+    backfillSpy.mockRestore();
   });
 });
 

--- a/frontend/src/features/Habits/hooks/useHabitActions.ts
+++ b/frontend/src/features/Habits/hooks/useHabitActions.ts
@@ -171,7 +171,10 @@ export const useHabitActions = (
       deleteHabit: habitManager.deleteHabit,
       addHabit: habitManager.addHabit,
       saveHabitOrder: habitManager.saveHabitOrder,
-      backfillMissedDays: habitManager.backfillMissedDays,
+      // Bind the hook tz so a backfill buckets its completed_on days into the
+      // user's stored zone, matching the online log path.
+      backfillMissedDays: (habitId: number, days: Date[]) =>
+        habitManager.backfillMissedDays(habitId, days, tz),
       setNewStartDate: habitManager.setNewStartDate,
       onboardingSave,
       iconPress,

--- a/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
+++ b/frontend/src/features/Habits/services/__tests__/habitManager.test.ts
@@ -1551,10 +1551,138 @@ describe('habitManager', () => {
       // #783: must persist or the backfill is lost on the next cold rehydrate.
       expect(saveHabits).toHaveBeenLastCalledWith([expect.objectContaining({ streak: 4 })]);
     });
+
+    // The bug this whole suite pins: a backfill that only ever touches the
+    // Zustand store is silently erased the moment loadHabits() re-fetches,
+    // because handleApiSuccess trusts the server as the source of truth.
+    it('survives the next loadHabits reload once the completions are posted', async () => {
+      const habit = makeHabit({ id: 1, streak: 0 });
+      useHabitStore.setState({ habits: [habit] });
+      // Fixed, unambiguously-past calendar days — no system-time anchor needed.
+      const dayOne = new Date('2020-06-10T00:00:00.000Z');
+      const dayTwo = new Date('2020-06-11T00:00:00.000Z');
+
+      // Stand in for the server: what it returns is only what actually got
+      // posted, so a fix that forgets the POST reloads back to nothing.
+      (habitsApi.listAll as jest.Mock).mockImplementationOnce(() => {
+        const posted = (goalCompletionsApi.create as jest.Mock).mock.calls.map(
+          (call) => call[0] as { completed_on?: string },
+        );
+        return Promise.resolve([
+          {
+            id: 1,
+            name: habit.name,
+            icon: habit.icon,
+            start_date: '2020-01-01',
+            energy_cost: 1,
+            energy_return: 2,
+            stage: 'Beige',
+            streak: posted.length,
+            milestone_notifications: false,
+            revealed: true,
+            goals: [
+              {
+                ...freshServerGoal(1, 'Low', 'low', 1),
+                completions: posted.map((p, i) => ({
+                  id: i + 1,
+                  timestamp: `${p.completed_on ?? '2020-06-12'}T00:00:00.000Z`,
+                  completed_units: 1,
+                })),
+              },
+              freshServerGoal(2, 'Clear', 'clear', 2),
+              freshServerGoal(3, 'Stretch', 'stretch', 3),
+            ],
+          },
+        ] as never);
+      });
+
+      habitManager.backfillMissedDays(1, [dayOne, dayTwo], 'UTC');
+      // Flush the fire-and-forget POST fan-out before reloading.
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      await habitManager.loadHabits('UTC');
+
+      const reloaded = useHabitStore.getState().habits.find((h) => h.id === 1)!;
+      const dayKeys = (reloaded.completions ?? []).map((c) => dayKeyInTZ(c.timestamp, 'UTC'));
+      expect(dayKeys).toEqual(expect.arrayContaining(['2020-06-10', '2020-06-11']));
+    });
+
+    it('POSTs one completion per missed day against the low-tier goal', async () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, streak: 0 })] });
+      const dayOne = new Date('2020-06-10T00:00:00.000Z');
+      const dayTwo = new Date('2020-06-11T00:00:00.000Z');
+
+      habitManager.backfillMissedDays(1, [dayOne, dayTwo], 'UTC');
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      expect(goalCompletionsApi.create).toHaveBeenCalledTimes(2);
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: '2020-06-10',
+      });
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: '2020-06-11',
+      });
+    });
+
+    it('buckets completed_on using the supplied IANA zone, not UTC', async () => {
+      useHabitStore.setState({ habits: [makeHabit({ id: 1, streak: 0 })] });
+      const day = new Date('2020-06-10T03:00:00.000Z');
+      const expectedAnchorageKey = dayKeyInTZ(day, 'America/Anchorage');
+      // Sanity check the fixture actually straddles the UTC/Anchorage
+      // boundary — otherwise the assertion below would pass by accident.
+      expect(expectedAnchorageKey).not.toBe(dayKeyInTZ(day, 'UTC'));
+
+      habitManager.backfillMissedDays(1, [day], 'America/Anchorage');
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      expect(goalCompletionsApi.create).toHaveBeenCalledWith({
+        goal_id: 1,
+        did_complete: true,
+        completed_on: expectedAnchorageKey,
+      });
+    });
+
+    it('rolls back the store and disk, and alerts the user, when a completion POST rejects', async () => {
+      const habit = makeHabit({ id: 1, streak: 2, completions: [] });
+      const prev = [habit];
+      useHabitStore.setState({ habits: prev });
+      (goalCompletionsApi.create as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
+
+      habitManager.backfillMissedDays(1, [new Date('2025-01-02'), new Date('2025-01-03')], 'UTC');
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      const rolledBack = useHabitStore.getState().habits[0]!;
+      expect(rolledBack.streak).toBe(2);
+      expect(rolledBack.completions).toHaveLength(0);
+      expect(saveHabits).toHaveBeenLastCalledWith(prev);
+      const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
+      expect(Alert.alert).toHaveBeenCalled();
+    });
+
+    it('skips the network call but still applies the optimistic update when the low goal has no id', async () => {
+      const habit = makeHabit({ streak: 1 });
+      habit.goals = habit.goals.map((g) => (g.tier === 'low' ? { ...g, id: undefined } : g));
+      useHabitStore.setState({ habits: [habit] });
+
+      habitManager.backfillMissedDays(1, [new Date('2025-01-02')], 'UTC');
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      const updated = useHabitStore.getState().habits[0]!;
+      expect(updated.streak).toBe(2);
+      expect(updated.completions).toHaveLength(1);
+      expect(saveHabits).toHaveBeenLastCalledWith([expect.objectContaining({ streak: 2 })]);
+      expect(goalCompletionsApi.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('setNewStartDate', () => {
-    it('resets streak and completions when the start date changes', () => {
+    it('resets streak and completions when the start date changes, and PUTs it', async () => {
       const habit = makeHabit({
         streak: 10,
         completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 1 }],
@@ -1563,6 +1691,7 @@ describe('habitManager', () => {
 
       const newDate = new Date('2025-06-01');
       habitManager.setNewStartDate(1, newDate);
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
 
       const updated = useHabitStore.getState().habits[0]!;
       expect(updated.streak).toBe(0);
@@ -1572,6 +1701,33 @@ describe('habitManager', () => {
       expect(saveHabits).toHaveBeenLastCalledWith([
         expect.objectContaining({ start_date: newDate }),
       ]);
+      // Must reach the server too — otherwise the next loadHabits() GET
+      // returns the stale start_date and silently reverts the reset.
+      expect(habitsApi.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ start_date: '2025-06-01' }),
+      );
+    });
+
+    it('rolls back the store and disk, and alerts the user, when the start-date PUT rejects', async () => {
+      const habit = makeHabit({
+        streak: 10,
+        completions: [{ id: 'c-1', timestamp: new Date(), completed_units: 1 }],
+      });
+      const prev = [habit];
+      useHabitStore.setState({ habits: prev });
+      (habitsApi.update as jest.Mock).mockRejectedValueOnce(new Error('boom') as never);
+
+      habitManager.setNewStartDate(1, new Date('2025-06-01'));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+      const rolledBack = useHabitStore.getState().habits[0]!;
+      expect(rolledBack.streak).toBe(10);
+      expect(rolledBack.completions).toHaveLength(1);
+      expect(saveHabits).toHaveBeenLastCalledWith(prev);
+      const { Alert } = jest.requireMock('react-native') as { Alert: { alert: jest.Mock } };
+      expect(Alert.alert).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -710,6 +710,32 @@ const replayPendingCheckIns = async (tz?: string): Promise<void> => {
   await clearPendingCheckIns();
 };
 
+/**
+ * Build one goal-completion POST per backfilled day, bucketing each day into
+ * the user's IANA zone. A day that resolves to "today" omits ``completed_on``
+ * so the server stamps real wall-clock time — the same genuine-backfill rule
+ * the online log path uses; any earlier day sends its ``YYYY-MM-DD`` key so
+ * the completion lands on the calendar day the user actually missed, not on
+ * the wall-clock day the request happened to fire. Extracted so the caller
+ * stays a flat, low-complexity sequence of guarded steps.
+ */
+const postBackfillCompletions = (
+  lowGoalId: number,
+  days: Date[],
+  zone: string,
+): Array<Promise<unknown>> => {
+  const today = todayInUserTZ(zone);
+  return days.map((day) => {
+    const dayKey = dayKeyInTZ(day, zone);
+    const completedOn = dayKey !== today ? dayKey : undefined;
+    return goalCompletionsApi.create({
+      goal_id: lowGoalId,
+      did_complete: true,
+      completed_on: completedOn,
+    });
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Public service: a plain object with async methods. Composable from hooks
 // but not itself a hook. Every method is independently unit-testable.
@@ -1032,19 +1058,63 @@ export const habitManager = {
     return milestone ?? buildLogConfirmationToast(ctx.habitName, ctx.amount);
   },
 
-  backfillMissedDays: (habitId: number, days: Date[]): void => {
-    // Persist like every sibling mutation — without this the backfill lives only
-    // in the Zustand store and is silently lost on the next cold rehydrate (#783).
-    const next = getHabits().map((h) => (h.id === habitId ? backfillHabit(h, days) : h));
+  /**
+   * Backfill missed days: bump the local streak + completions, persist the
+   * optimistic state, then POST one goal completion per day against the
+   * habit's LOW-tier goal so the backfill survives the next ``loadHabits``
+   * reload (which trusts the server as the source of truth). A single
+   * ``Promise.all`` rejection rolls the store AND the on-disk snapshot back
+   * to ``prev`` and alerts the user — the same deterministic single-rollback
+   * pattern as ``saveHabitOrder``. When the habit or its low goal has no
+   * server id we keep the optimistic update but skip the network call, so a
+   * pre-sync onboarding habit still shows the backfill locally.
+   *
+   * ``tz`` is the user's stored IANA zone forwarded by the hook; it falls
+   * back to the last zone a ``loadHabits`` observed, then to the device zone.
+   */
+  backfillMissedDays: (habitId: number, days: Date[], tz?: string): void => {
+    const prev = getHabits();
+    const next = prev.map((h) => (h.id === habitId ? backfillHabit(h, days) : h));
     setHabits(next);
     void persistHabits(next);
+    const lowGoal = prev.find((h) => h.id === habitId)?.goals.find((g) => g.tier === 'low');
+    if (!lowGoal?.id) return;
+    const zone = tz ?? lastKnownTz ?? detectDeviceTimezone();
+    const updates = postBackfillCompletions(lowGoal.id, days, zone);
+    Promise.all(updates).catch(
+      revertOnFailure(
+        prev,
+        "We couldn't save those backfilled days. Your previous state was restored — check your connection and try again.",
+      ),
+    );
   },
 
+  /**
+   * Reset a habit's start date: clear the streak + completions locally,
+   * persist, then PUT the new start date so that half of the reset reaches
+   * the server. Only ``start_date`` is durable — the PUT carries no streak
+   * and does not delete the habit's goal-completion rows, so the local
+   * streak/completions clear is optimistic and is rebuilt from the surviving
+   * server rows on the next ``loadHabits``. Without the PUT even the new
+   * start date would revert to the stale server value. On failure the
+   * rollback restores both the store and the on-disk snapshot and alerts the
+   * user.
+   */
   setNewStartDate: (habitId: number, newDate: Date): void => {
-    // Persist so the reset start date survives a rehydrate (#783).
-    const next = getHabits().map((h) => (h.id === habitId ? resetHabitStart(h, newDate) : h));
+    const prev = getHabits();
+    const next = prev.map((h) => (h.id === habitId ? resetHabitStart(h, newDate) : h));
     setHabits(next);
     void persistHabits(next);
+    const updated = next.find((h) => h.id === habitId);
+    if (!updated?.id) return;
+    habitsApi
+      .update(updated.id, toApiPayload(updated))
+      .catch(
+        revertOnFailure(
+          prev,
+          "We couldn't save the new start date. Your previous state was restored — check your connection and try again.",
+        ),
+      );
   },
 
   onboardingSave: async (newHabits: OnboardingHabit[], showToast?: ShowToast): Promise<void> => {


### PR DESCRIPTION
## Summary
- `backfillMissedDays` and `setNewStartDate` mutated the Zustand store and disk but never called the API, so the next `loadHabits()` refetch overwrote the store with the server's un-backfilled data and silently erased the user's deliberate "backfill missed days" action.
- `backfillMissedDays(habitId, days, tz?)` now POSTs one `goalCompletions.create({ goal_id, did_complete: true, completed_on })` per missed day against the habit's **low-tier** goal — `completed_on` bucketed into the user's IANA zone with the today-omission rule matching the online log path — and rolls back the optimistic store+disk update with a single `Promise.all` rollback on failure (the `saveHabitOrder` pattern). `useHabitActions` binds the hook `tz` into the call.
- `setNewStartDate` decision: **persist via the existing `start_date` field** on `PUT /habits/{id}` (with rollback parity). There is no bulk completion-delete endpoint, so only `start_date` is durable server-side; the streak/completions clear stays optimistic and is rebuilt from the surviving server rows on the next reload. This is harmless (streak/progress anchor on `start_date` + today's buckets) and the docstring states it explicitly.

## Known limitation / follow-up
A start-date reset does not delete the habit's server-side goal-completion rows (no endpoint exists), so after a reload the habit shows the new `start_date` alongside its old completions. A follow-up should either add a server-side clear-on-reset affordance or formally document the mixed state as intended. (Issue-creation was outside this task's write scope, so it is recorded here.)

## Test plan
- Extended `habitManager.test.ts`:
  - **reload-survival (headline e2e)**: backfill → `loadHabits()` whose fake server echoes back only what was POSTed → backfilled days survive.
  - POSTs one completion per missed day against the low-tier goal; `completed_on` bucketed via a non-UTC zone (`America/Anchorage`).
  - rollback parity on POST failure (store + disk restored, alert fired).
  - `setNewStartDate` PUTs `start_date`; rollback on PUT failure.
- `useHabitActions.test.tsx`: proves the hook forwards its `tz` as the third arg to `backfillMissedDays`.
- Full `./scripts/frontend/check-all.sh` green: eslint, prettier, tsc, jest (3815 tests) + coverage all pass.

Closes #1508
