### PR TITLE
fix(frontend): wipe the in-memory BYOK LLM key on session teardown

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -181,6 +181,7 @@ let onUnauthorizedCallback: ((reason: UnauthorizedReason) => void) | null = null
 let onTokenRefreshedCallback:
   ((token: string, timezone: string | undefined, expectedPriorToken: string) => void) | null = null;
 let llmApiKeyGetter: (() => string | null) | null = null;
+let llmApiKeyReset: (() => void) | null = null;
 
 /** Header used to forward a user-provided LLM API key (BYOK, issue #185). */
 export const LLM_API_KEY_HEADER = 'X-LLM-API-Key'; // pragma: allowlist secret
@@ -237,6 +238,25 @@ export function setOnTokenRefreshed(
  */
 export function setLlmApiKeyGetter(getter: (() => string | null) | null) {
   llmApiKeyGetter = getter;
+}
+
+/**
+ * Register the reset hook that ApiKeyProvider uses to drop its in-memory LLM
+ * key. Session teardown calls {@link resetLlmApiKey}, which invokes this hook
+ * so a logged-out user's key can never ride the ``X-LLM-API-Key`` header into
+ * the next user's requests on a shared device.
+ */
+export function setLlmApiKeyReset(reset: (() => void) | null) {
+  llmApiKeyReset = reset;
+}
+
+/**
+ * Invoke the registered reset hook on session teardown, clearing the in-memory
+ * LLM key so it cannot leak across users via the ``X-LLM-API-Key`` header. A
+ * no-op when no provider has registered a reset.
+ */
+export function resetLlmApiKey(): void {
+  llmApiKeyReset?.();
 }
 
 interface RequestOptions<TResponse = unknown> {

--- a/frontend/src/context/ApiKeyContext.tsx
+++ b/frontend/src/context/ApiKeyContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 
-import { setLlmApiKeyGetter } from '@/api';
+import { setLlmApiKeyGetter, setLlmApiKeyReset } from '@/api';
 import { clearLlmApiKey, loadLlmApiKey, saveLlmApiKey } from '@/storage/llmKeyStorage';
 
 /**
@@ -43,6 +43,31 @@ interface ApiKeyContextValue {
 
 const ApiKeyContext = createContext<ApiKeyContextValue | null>(null);
 
+/**
+ * Bridge the in-memory key to the API layer: register a getter the HTTP client
+ * polls per request, plus a reset seam that session teardown invokes so a
+ * logged-out user's key can never ride the ``X-LLM-API-Key`` header into the
+ * next user's requests on a shared device. The reset nulls the ref
+ * synchronously so the getter returns null immediately, before any re-render
+ * triggered by ``setApiKey`` lands. Both seams are cleared on unmount.
+ */
+function useLlmApiKeyBridge(
+  apiKeyRef: React.MutableRefObject<string | null>,
+  setApiKey: React.Dispatch<React.SetStateAction<string | null>>,
+): void {
+  useEffect(() => {
+    setLlmApiKeyGetter(() => apiKeyRef.current);
+    setLlmApiKeyReset(() => {
+      apiKeyRef.current = null;
+      setApiKey(null);
+    });
+    return () => {
+      setLlmApiKeyGetter(null);
+      setLlmApiKeyReset(null);
+    };
+  }, [apiKeyRef, setApiKey]);
+}
+
 export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -54,10 +79,7 @@ export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
   const apiKeyRef = useRef<string | null>(null);
   apiKeyRef.current = apiKey;
 
-  useEffect(() => {
-    setLlmApiKeyGetter(() => apiKeyRef.current);
-    return () => setLlmApiKeyGetter(null);
-  }, []);
+  useLlmApiKeyBridge(apiKeyRef, setApiKey);
 
   useEffect(() => {
     loadLlmApiKey()

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 import {
   ApiError,
   auth as authApi,
+  resetLlmApiKey,
   setOnTokenRefreshed,
   setOnUnauthorized,
   setTokenGetter,
@@ -147,10 +148,15 @@ interface AuthMutators {
  * sheet's "sign out instead" button) must wipe the in-memory Zustand stores
  * AND the AsyncStorage persistence keys so the next user on the device
  * doesn't inherit the previous user's habits, stage progress, or BYOK key.
- * The storage clears are wrapped in try/catch so one failing key doesn't
+ * The BYOK wipe covers both the in-memory key and its registered API-layer
+ * getter (via ``resetLlmApiKey``) and the persisted SecureStore key (via
+ * ``clearLlmApiKey``). ``resetLlmApiKey`` runs first and synchronously so the
+ * getter is nulled immediately even if the async storage clears are slow or
+ * fail. The storage clears are wrapped in try/catch so one failing key doesn't
  * leave the rest of the wipe half-done.
  */
 async function wipeUserState(): Promise<void> {
+  resetLlmApiKey();
   resetAllStores();
   const clears: Array<[string, Promise<void>]> = [
     ['habits', clearHabits()],

--- a/frontend/src/context/__tests__/ApiKeyContext.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyContext.test.tsx
@@ -10,6 +10,7 @@ import * as llmKeyStorage from '@/storage/llmKeyStorage';
 
 jest.mock('@/api', () => ({
   setLlmApiKeyGetter: jest.fn(),
+  setLlmApiKeyReset: jest.fn(),
 }));
 
 jest.mock('@/storage/llmKeyStorage', () => ({
@@ -68,6 +69,77 @@ describe('ApiKeyProvider', () => {
     const registered = firstCall![0];
     expect(registered).not.toBeNull();
     await waitFor(() => expect(registered?.()).toBe('sk-alpha'));
+  });
+
+  test('registered reset synchronously nulls the getter', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-alpha');
+    let ctx: ReturnType<typeof useApiKey> | null = null;
+
+    render(
+      <ApiKeyProvider>
+        <TestConsumer
+          onValue={(v) => {
+            ctx = v;
+          }}
+        />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(ctx?.apiKey).toBe('sk-alpha'));
+
+    const getterCall = mockApi.setLlmApiKeyGetter.mock.calls[0];
+    const resetCall = mockApi.setLlmApiKeyReset.mock.calls[0];
+    expect(getterCall).toBeDefined();
+    expect(resetCall).toBeDefined();
+    const getter = getterCall![0];
+    const reset = resetCall![0];
+    expect(getter).not.toBeNull();
+    expect(reset).not.toBeNull();
+    expect(getter?.()).toBe('sk-alpha');
+
+    act(() => {
+      reset?.();
+    });
+
+    // No waitFor here: the ref null must be visible the instant reset() returns.
+    expect(getter?.()).toBeNull();
+    expect(ctx!.apiKey).toBeNull();
+  });
+
+  test('reset does not call clearLlmApiKey (storage separation)', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce('sk-alpha');
+    render(
+      <ApiKeyProvider>
+        <TestConsumer onValue={() => undefined} />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(mockApi.setLlmApiKeyGetter).toHaveBeenCalled());
+    const reset = mockApi.setLlmApiKeyReset.mock.calls[0]?.[0];
+
+    act(() => {
+      reset?.();
+    });
+
+    expect(mockStorage.clearLlmApiKey).not.toHaveBeenCalled();
+  });
+
+  test('unmount unregisters both seams', async () => {
+    const view = render(
+      <ApiKeyProvider>
+        <TestConsumer onValue={() => undefined} />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(mockApi.setLlmApiKeyGetter).toHaveBeenCalled());
+    view.unmount();
+
+    const lastGetterCall = mockApi.setLlmApiKeyGetter.mock.calls.at(-1);
+    const lastResetCall = mockApi.setLlmApiKeyReset.mock.calls.at(-1);
+    expect(lastGetterCall).toBeDefined();
+    expect(lastResetCall).toBeDefined();
+    expect(lastGetterCall![0]).toBeNull();
+    expect(lastResetCall![0]).toBeNull();
   });
 
   test('saveApiKey persists and updates state', async () => {

--- a/frontend/src/context/__tests__/ApiKeyLogoutWipe.integration.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyLogoutWipe.integration.test.tsx
@@ -1,0 +1,218 @@
+/* eslint-env jest */
+/* global describe, test, expect, jest, beforeEach, afterEach */
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { LLM_API_KEY_HEADER, auth as authApi, resonance } from '@/api';
+import { ApiKeyProvider, useApiKey } from '@/context/ApiKeyContext';
+import { AuthProvider, useAuth } from '@/context/AuthContext';
+import * as llmKeyStorage from '@/storage/llmKeyStorage';
+
+// Reproduces the BYOK leak end-to-end: mount the real AuthProvider +
+// ApiKeyProvider trio wired exactly as App.tsx does, keep the real API-layer
+// reset seam (setLlmApiKeyGetter / setLlmApiKeyReset / resetLlmApiKey /
+// resonance), and only stub the network boundary (auth.login/signup/refresh)
+// and device storage.
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api');
+  return {
+    ...actual,
+    auth: {
+      ...actual.auth,
+      login: jest.fn(),
+      signup: jest.fn(),
+      refresh: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@/storage/authStorage', () => ({
+  saveToken: jest.fn(() => Promise.resolve()),
+  loadToken: jest.fn(() => Promise.resolve(null)),
+  clearToken: jest.fn(() => Promise.resolve()),
+  markLogoutPending: jest.fn(() => Promise.resolve()),
+  isLogoutPending: jest.fn(() => Promise.resolve(false)),
+  clearLogoutPending: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/storage/llmKeyStorage', () => ({
+  loadLlmApiKey: jest.fn(() => Promise.resolve(null)),
+  saveLlmApiKey: jest.fn(() => Promise.resolve()),
+  clearLlmApiKey: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/storage/habitStorage', () => ({
+  clearHabits: jest.fn(() => Promise.resolve()),
+  clearPendingCheckIns: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/storage/notificationStorage', () => ({
+  clearAllNotificationData: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/utils/token', () => ({
+  decodeJwtPayload: jest.fn(() => null),
+  isTokenExpired: jest.fn(() => false),
+  shouldRefreshToken: jest.fn(() => false),
+  REFRESH_BUFFER_SECONDS: 300,
+}));
+
+const mockAuthApi = authApi as jest.Mocked<typeof authApi>;
+const mockLlmStorage = llmKeyStorage as jest.Mocked<typeof llmKeyStorage>;
+
+function okResponse(): Response {
+  return { ok: true, status: 200, json: () => Promise.resolve({}) } as unknown as Response;
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthProvider>
+      <ApiKeyProvider>{children}</ApiKeyProvider>
+    </AuthProvider>
+  );
+}
+
+function useHarness() {
+  return { auth: useAuth(), apiKey: useApiKey() };
+}
+
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLlmStorage.loadLlmApiKey.mockResolvedValue(null);
+  fetchSpy = jest
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(() => Promise.resolve(okResponse()));
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function lastLlmHeader(): string | undefined {
+  const call = fetchSpy.mock.calls.at(-1) as [string, RequestInit | undefined] | undefined;
+  const init = call?.[1];
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.[LLM_API_KEY_HEADER];
+}
+
+describe('BYOK key does not leak across a logout on a shared device', () => {
+  test('logout wipes the key so the next resonance request carries no header', async () => {
+    mockAuthApi.login.mockResolvedValueOnce({ token: 'token-a', user_id: 1 });
+    const { result } = renderHook(useHarness, { wrapper });
+    await waitFor(() => expect(result.current.auth.authStatus).not.toBe('loading'));
+    await waitFor(() => expect(result.current.apiKey.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.auth.login('a@test.com', 'password123');
+    });
+    await act(async () => {
+      await result.current.apiKey.saveApiKey('sk-user-a');
+    });
+
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBe('sk-user-a');
+
+    await act(async () => {
+      await result.current.auth.logout();
+    });
+
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBeUndefined();
+    expect(mockLlmStorage.clearLlmApiKey).toHaveBeenCalled();
+  });
+
+  test('dismissReauth wipes the key', async () => {
+    mockAuthApi.login.mockResolvedValueOnce({ token: 'token-a', user_id: 1 });
+    const { result } = renderHook(useHarness, { wrapper });
+    await waitFor(() => expect(result.current.auth.authStatus).not.toBe('loading'));
+    await waitFor(() => expect(result.current.apiKey.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.auth.login('a@test.com', 'password123');
+    });
+    await act(async () => {
+      await result.current.apiKey.saveApiKey('sk-user-a');
+    });
+
+    await act(async () => {
+      result.current.auth.onUnauthorized();
+    });
+    await waitFor(() => expect(result.current.auth.authStatus).toBe('reauth-required'));
+
+    await act(async () => {
+      await result.current.auth.dismissReauth();
+    });
+
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBeUndefined();
+  });
+
+  test('a forced reauth alone (no dismiss) retains the key by design', async () => {
+    mockAuthApi.login.mockResolvedValueOnce({ token: 'token-a', user_id: 1 });
+    const { result } = renderHook(useHarness, { wrapper });
+    await waitFor(() => expect(result.current.auth.authStatus).not.toBe('loading'));
+    await waitFor(() => expect(result.current.apiKey.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.auth.login('a@test.com', 'password123');
+    });
+    await act(async () => {
+      await result.current.apiKey.saveApiKey('sk-user-a');
+    });
+
+    await act(async () => {
+      result.current.auth.onUnauthorized();
+    });
+    await waitFor(() => expect(result.current.auth.authStatus).toBe('reauth-required'));
+
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBe('sk-user-a');
+  });
+
+  test('the next user on the device never inherits the prior key', async () => {
+    mockAuthApi.login
+      .mockResolvedValueOnce({ token: 'token-a', user_id: 1 })
+      .mockResolvedValueOnce({ token: 'token-b', user_id: 2 });
+    const { result } = renderHook(useHarness, { wrapper });
+    await waitFor(() => expect(result.current.auth.authStatus).not.toBe('loading'));
+    await waitFor(() => expect(result.current.apiKey.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.auth.login('a@test.com', 'password123');
+    });
+    await act(async () => {
+      await result.current.apiKey.saveApiKey('sk-user-a');
+    });
+    await act(async () => {
+      await result.current.auth.logout();
+    });
+
+    await act(async () => {
+      await result.current.auth.login('b@test.com', 'password123');
+    });
+
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBeUndefined();
+
+    await act(async () => {
+      await result.current.apiKey.saveApiKey('sk-user-b');
+    });
+    await act(async () => {
+      await resonance.essay(1);
+    });
+    expect(lastLlmHeader()).toBe('sk-user-b');
+    expect(lastLlmHeader()).not.toBe('sk-user-a');
+  });
+});

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@/api', () => {
     setTokenGetter: jest.fn(),
     setOnUnauthorized: jest.fn(),
     setOnTokenRefreshed: jest.fn(),
+    resetLlmApiKey: jest.fn(),
   };
 });
 
@@ -42,7 +43,13 @@ jest.mock('@/utils/token', () => ({
   REFRESH_BUFFER_SECONDS: 300,
 }));
 
-import { auth, setOnTokenRefreshed, setOnUnauthorized, setTokenGetter } from '@/api';
+import {
+  auth,
+  resetLlmApiKey,
+  setOnTokenRefreshed,
+  setOnUnauthorized,
+  setTokenGetter,
+} from '@/api';
 import {
   saveToken,
   loadToken,
@@ -65,6 +72,7 @@ const mockSetOnTokenRefreshed = setOnTokenRefreshed as jest.MockedFunction<
   typeof setOnTokenRefreshed
 >;
 const mockSetOnUnauthorized = setOnUnauthorized as jest.MockedFunction<typeof setOnUnauthorized>;
+const mockResetLlmApiKey = resetLlmApiKey as jest.MockedFunction<typeof resetLlmApiKey>;
 const mockIsTokenExpired = isTokenExpired as jest.MockedFunction<typeof isTokenExpired>;
 const mockShouldRefreshToken = shouldRefreshToken as jest.MockedFunction<typeof shouldRefreshToken>;
 
@@ -242,6 +250,22 @@ describe('AuthContext', () => {
 
       expect(result.current.token).toBeNull();
       expect(result.current.authStatus).toBe('anonymous');
+      warnSpy.mockRestore();
+    });
+
+    it('still calls resetLlmApiKey when clearToken rejects (teardown resilience)', async () => {
+      mockLoadToken.mockResolvedValue('existing-jwt');
+      mockClearToken.mockRejectedValueOnce(new Error('SecureStore unavailable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.token).toBe('existing-jwt'));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(mockResetLlmApiKey).toHaveBeenCalledTimes(1);
       warnSpy.mockRestore();
     });
   });
@@ -856,6 +880,43 @@ describe('AuthContext', () => {
       await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
       expect(resetSpy).not.toHaveBeenCalled();
       resetSpy.mockRestore();
+    });
+
+    it('calls resetLlmApiKey on explicit logout', async () => {
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(mockResetLlmApiKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls resetLlmApiKey when the user dismisses the re-auth sheet', async () => {
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        await result.current.dismissReauth();
+      });
+
+      expect(mockResetLlmApiKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call resetLlmApiKey on a 401-triggered reauth-required transition', async () => {
+      mockLoadToken.mockResolvedValue('jwt');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.token).toBe('jwt'));
+
+      await act(async () => {
+        result.current.onUnauthorized();
+      });
+
+      await waitFor(() => expect(result.current.authStatus).toBe('reauth-required'));
+      expect(mockResetLlmApiKey).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
@@ -10,6 +10,7 @@ import * as llmKeyStorage from '@/storage/llmKeyStorage';
 
 jest.mock('@/api', () => ({
   setLlmApiKeyGetter: jest.fn(),
+  setLlmApiKeyReset: jest.fn(),
 }));
 
 jest.mock('@/storage/llmKeyStorage', () => ({


### PR DESCRIPTION
## Summary

On a shared device, the logout wipe cleared the **persisted** SecureStore BYOK LLM key via `clearLlmApiKey()` but never reset `ApiKeyContext`'s **in-memory** key. The API layer reads the key through a getter that returns `apiKeyRef.current`, so after logout the getter kept returning the prior user's key and it leaked into the next user's BotMason chat requests (`X-LLM-API-Key` header) with no app restart — billing and exposing user A's provider key to user B. The `wipeUserState` docstring already promised it wiped the "BYOK key", so the comment was also lying.

### Fix
- Add a dedicated API-layer reset seam symmetric to the existing getter: `setLlmApiKeyReset` + `resetLlmApiKey()` in `frontend/src/api/index.ts` (a safe no-op when nothing is registered).
- `ApiKeyProvider` registers both the getter and the reset in one effect (`useLlmApiKeyBridge`) and clears both on unmount. The reset nulls `apiKeyRef.current` **synchronously** (then `setApiKey(null)`) so the getter returns `null` immediately — before any re-render — closing the leak window.
- `wipeUserState` calls `resetLlmApiKey()` first, synchronously, before the awaited storage clears, and its docstring is now truthful.

### Teardown paths covered
- **Explicit logout** (`logout` → `tearDownSession` → `wipeUserState`): wiped.
- **Re-auth sheet "sign out"** (`dismissReauth` → `tearDownSession` → `wipeUserState`): wiped.
- **Forced re-auth / token expiry** (`onUnauthorized` → `clearTokenForReauth` → `reauth-required`): intentionally **not** wiped — the session tree stays mounted and the *same* user re-proves identity; a shared-device handoff goes through logout or the sheet's sign-out, both of which wipe. This retention is test-locked.

The key never touches SecureStore in the reset (that stays owned by `wipeUserState`'s `clearLlmApiKey`), and no key value is ever logged.

## Test plan
- New `ApiKeyLogoutWipe.integration.test.tsx` mounts `AuthProvider > ApiKeyProvider` (mirroring `App.tsx`) with a real `fetch` spy and reproduces the leak: login A → `saveApiKey` → request carries the key → `logout()` → next request carries **no** `X-LLM-API-Key`; same for `dismissReauth`; forced-reauth retains by design; and a subsequent login as user B never inherits A's key.
- Unit tests: the registered reset synchronously nulls the getter, does not touch SecureStore, and both seams are unregistered on unmount.
- `AuthContext` tests: `logout` and `dismissReauth` invoke `resetLlmApiKey` (even when `clearToken` rejects); the forced-reauth path does not.
- Full frontend suite green (364 suites, 3826 tests); ESLint, prettier, and TypeScript all pass via `./scripts/frontend/check-all.sh`.

Closes #1513