### PR TITLE
fix(frontend): restore native scroll by splitting ContentContainer's height contract

### DIFF
--- a/frontend/src/components/layout/ContentContainer.tsx
+++ b/frontend/src/components/layout/ContentContainer.tsx
@@ -6,6 +6,12 @@ import { contentLayout } from '@/design/tokens';
 
 interface ContentContainerProps {
   children: React.ReactNode;
+  /**
+   * Make the container a bounded ``flex: 1`` box for definite-height parents
+   * that host a nested scroller or a flex-sized body. Defaults to ``false``,
+   * leaving the container main-axis-inert (a pure width cap).
+   */
+  fill?: boolean;
   /** Extra style merged onto the shared content-capped container. */
   style?: StyleProp<ViewStyle>;
   testID?: string;
@@ -15,28 +21,42 @@ interface ContentContainerProps {
  * The shared content-width cap: a full-width box centered and capped at
  * ``contentLayout.maxWidth`` so screen bodies settle on the same comfortable
  * reading measure on tablets and wide web instead of stretching edge-to-edge.
- * It uses ``flexGrow`` (not ``flex``) so it fills its parent, which holds when
- * the parent is a definite-height box or a scroll content container that itself
- * sets ``flexGrow`` — a scroll content container without its own grow leaves
- * this child at ~0 height on RN web. Callers wrap their scroll/flow body in
- * this; a caller ``style`` is merged on top without dropping the cap.
+ *
+ * This container is used across two distinct surfaces, and the default is
+ * deliberately main-axis-inert to keep both native height chains intact:
+ *
+ * - **Default (no ``fill``): a pure width cap.** It sets no ``flex`` or
+ *   ``flexGrow`` of its own, so it stays content-sized on the main axis. This
+ *   is what makes it safe as a child of a ScrollView content container whose
+ *   own ``contentContainerStyle`` owns the single grow — the native
+ *   ``contentSize`` then tracks the real content height and scrolling works.
+ * - **``fill``: a bounded ``flex: 1`` box.** For definite-height parents (a
+ *   ``flex: 1`` ground) that host a nested scroller or a flex-sized body, this
+ *   gives the wrapper a bounded height so the nested scroller inherits real
+ *   bounds and can scroll natively.
+ *
+ * Callers wrap their scroll/flow body in this; a caller ``style`` is merged on
+ * top (last) without dropping the width cap.
  */
 export const ContentContainer = ({
   children,
+  fill = false,
   style,
   testID = 'content-container',
 }: ContentContainerProps): React.JSX.Element => (
-  <View style={[styles.container, style]} testID={testID}>
+  <View style={[styles.container, fill && styles.fill, style]} testID={testID}>
     {children}
   </View>
 );
 
 const styles = StyleSheet.create({
   container: {
-    flexGrow: 1,
     width: '100%',
     maxWidth: contentLayout.maxWidth,
     alignSelf: 'center',
+  },
+  fill: {
+    flex: 1,
   },
 });
 

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -30,8 +30,9 @@ export const ScreenScaffold = ({
     return (
       <ScrollView
         style={styles.ground}
-        // The content container must itself grow so its flex-grow child fills
-        // the viewport when short yet still scrolls when tall (journal idiom).
+        // Invariant: only the ScrollView content container grows. The inner
+        // wrapper stays content-sized so the native contentSize tracks the real
+        // content height (fills when short, scrolls when tall — journal idiom).
         contentContainerStyle={[styles.content, styles.scrollContent, style]}
         testID={testID}
       >
@@ -41,7 +42,7 @@ export const ScreenScaffold = ({
   }
   return (
     <View style={[styles.ground, styles.content, style]} testID={testID}>
-      <ContentContainer>{children}</ContentContainer>
+      <ContentContainer fill>{children}</ContentContainer>
     </View>
   );
 };

--- a/frontend/src/components/layout/__tests__/ContentContainer.test.tsx
+++ b/frontend/src/components/layout/__tests__/ContentContainer.test.tsx
@@ -36,15 +36,28 @@ describe('ContentContainer', () => {
     expect(getByTestId('custom-container')).toBeTruthy();
   });
 
-  it('fills a phone-width screen with a grow-flexed, full-width box centered and capped at the shared content max-width', () => {
+  it('defaults to a width-capped box with no grow of its own (content-sized, not flex-grown)', () => {
     const { getByTestId } = render(
       <ContentContainer>
         <Text>hello</Text>
       </ContentContainer>,
     );
     const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
-    expect(flat.flexGrow).toBe(1);
+    expect(flat.flexGrow).toBeUndefined();
     expect(flat.flex).toBeUndefined();
+    expect(flat.width).toBe('100%');
+    expect(flat.maxWidth).toBe(contentLayout.maxWidth);
+    expect(flat.alignSelf).toBe('center');
+  });
+
+  it('renders a bounded fill box (flex: 1) when the fill prop is set, keeping the width cap', () => {
+    const { getByTestId } = render(
+      <ContentContainer fill>
+        <Text>hello</Text>
+      </ContentContainer>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flex).toBe(1);
     expect(flat.width).toBe('100%');
     expect(flat.maxWidth).toBe(contentLayout.maxWidth);
     expect(flat.alignSelf).toBe('center');

--- a/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
@@ -60,6 +60,18 @@ describe('ScreenScaffold', () => {
     expect(flat.paddingTop).toBe(rhythm.screenPaddingTop);
   });
 
+  it('keeps the scroll contentContainerStyle as a single grow, not a bounded flex box', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll testID="scaffold">
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('scaffold').props.contentContainerStyle);
+    expect(flat.flexGrow).toBe(1);
+    expect(flat.flex).toBeUndefined();
+    expect(flat.flexShrink).toBeUndefined();
+  });
+
   it('lets a caller style win over the default scroll contentContainerStyle', () => {
     const { getByTestId } = render(
       <ScreenScaffold scroll testID="scaffold" style={{ paddingTop: 999 }}>
@@ -70,14 +82,25 @@ describe('ScreenScaffold', () => {
     expect(flat.paddingTop).toBe(999);
   });
 
-  it('keeps the content container grow-flexed inside the scroll variant', () => {
+  it('keeps the inner content container content-sized (non-growing) inside the scroll variant', () => {
     const { getByTestId } = render(
       <ScreenScaffold scroll>
         <Text>x</Text>
       </ScreenScaffold>,
     );
     const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
-    expect(flat.flexGrow).toBe(1);
+    expect(flat.flexGrow).toBeUndefined();
+    expect(flat.flex).toBeUndefined();
+  });
+
+  it('gives the inner content container a bounded fill in the non-scroll variant', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold>
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flex).toBe(1);
   });
 
   it('keeps the non-scroll root fill-flexed with screen padding', () => {

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -509,7 +509,7 @@ const CourseScreen = (): React.JSX.Element => {
 
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <ContentContainer>
+      <ContentContainer fill>
         <View style={styles.headerBand}>
           <ScreenHeader eyebrow={COURSE_EYEBROW} title={COURSE_TITLE} />
         </View>

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -199,6 +199,15 @@ describe('CourseScreen', () => {
     expect(within(container).getByTestId('content-list')).toBeTruthy();
   });
 
+  it('gives the shared content-capped container a bounded fill so native scroll/touch chains hold', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flex).toBe(1);
+  });
+
   it('selects completed_count + 1 as the default stage (backend-truth mirror)', async () => {
     // BUG-FE-COURSE-001: stage 1 is complete, stage 2 is in progress →
     // default selection is the first unfinished stage, not the highest

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -889,7 +889,7 @@ const HabitsScreen = () => {
   const paginationProps = buildPaginationProps(pagination, scale);
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(isLG || isXL ? 2 : 1, scale) }]}>
-      <ContentContainer>
+      <ContentContainer fill>
         <View style={styles.topBar}>
           <OverflowMenu
             scale={scale}

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -372,4 +372,20 @@ describe('HabitsScreen responsive layout', () => {
     const container = testRenderer.root.findByProps({ testID: 'content-container' });
     expect(container.findByProps({ testID: 'habits-list' })).toBeTruthy();
   });
+
+  it('gives the shared content-capped container a bounded fill so native scroll/touch chains hold', async () => {
+    jest
+      .spyOn(require('react-native'), 'useWindowDimensions')
+      .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
+
+    let testRenderer: any;
+    await renderer.act(async () => {
+      testRenderer = renderer.create(<HabitsScreen />);
+    });
+
+    const { StyleSheet } = require('react-native');
+    const container = testRenderer.root.findByProps({ testID: 'content-container' });
+    const flat = StyleSheet.flatten(container.props.style);
+    expect(flat.flex).toBe(1);
+  });
 });

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -1109,7 +1109,7 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
   <View style={styles.container}>
     {/* The parchment backdrop stays full-bleed; only the spiral content caps. */}
     <MapBackdrop />
-    <ContentContainer>
+    <ContentContainer fill>
       <JourneyHeader currentStage={props.currentStage} cycleNumber={props.cycleNumber} />
       <MapGrid
         lookup={props.lookup}

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -975,4 +975,11 @@ describe('MapScreen content-width cap', () => {
     const container = tree.root.findByProps({ testID: 'content-container' });
     expect(container.findByProps({ testID: 'map-grid' })).toBeTruthy();
   });
+
+  it('gives the shared content-capped container a bounded fill so native scroll/touch chains hold', () => {
+    const tree = create(<MapScreen />);
+    const container = tree.root.findByProps({ testID: 'content-container' });
+    const flat = StyleSheet.flatten(container.props.style) as { flex?: number };
+    expect(flat.flex).toBe(1);
+  });
 });

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -118,7 +118,7 @@ const PracticeScreen = (): React.JSX.Element => {
   }
   if (active.activeUserPractice && active.practice && active.effectiveConfig) {
     return (
-      <ContentContainer>
+      <ContentContainer fill>
         <ActiveSessionView
           userPractice={active.activeUserPractice}
           practiceName={active.practice.name}
@@ -263,7 +263,7 @@ interface EmptyStateViewProps {
 const EmptyStateView = ({ stageNumber }: EmptyStateViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
-    <ContentContainer>
+    <ContentContainer fill>
       <EmptyState
         glyph="🧘"
         title="No practice yet"

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -118,6 +118,8 @@ const PracticeScreen = (): React.JSX.Element => {
   }
   if (active.activeUserPractice && active.practice && active.effectiveConfig) {
     return (
+      // Screen root: `fill`'s bounded height comes from the navigator's screen
+      // container, which the nested session ScrollView needs to scroll natively.
       <ContentContainer fill>
         <ActiveSessionView
           userPractice={active.activeUserPractice}
@@ -263,6 +265,8 @@ interface EmptyStateViewProps {
 const EmptyStateView = ({ stageNumber }: EmptyStateViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
+    // Screen root: `fill`'s bounded height comes from the navigator's screen
+    // container (no wrapping flex:1 View is local to this file).
     <ContentContainer fill>
       <EmptyState
         glyph="🧘"

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -762,6 +762,15 @@ describe('PracticeScreen', () => {
     expect(within(container).getByTestId('practice-empty-state')).toBeTruthy();
   });
 
+  it('gives the shared content-capped container a bounded fill so native scroll/touch chains hold', async () => {
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    const { StyleSheet } = require('react-native');
+    const flat = StyleSheet.flatten(getByTestId('content-container').props.style);
+    expect(flat.flex).toBe(1);
+  });
+
   it('wraps the active session view in the shared content-capped container', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);


### PR DESCRIPTION
## Summary

Vertical touch scroll was dead on **every** screen on native iPhone — the third
report in this regression family. This fixes the actual native (Yoga) layout
cause that the two prior attempts missed.

### Root cause analysis

The shared `ContentContainer` wrapper (added by #1413 on every screen) carried
`flexGrow: 1`. On native iOS, `UIScrollView.contentSize` is exactly the
Yoga-computed frame of the content view, and a nested scroller only scrolls when
its ancestry gives it a **bounded** height. `flexGrow: 1` with React Native's
Yoga defaults (`flexShrink: 0`, `flexBasis: auto`) means "*at least my measured
content height, plus leftover space*" — it never bounds. That one style broke
two distinct surfaces:

1. **`ScreenScaffold scroll` consumers** (Settings, PracticeDetail):
   `ScrollView → contentContainer(flexGrow:1) → ContentContainer(flexGrow:1) →
   body`. Two competing grows over viewport-sized free space, with flex-collapsed
   bodies contributing ~0 intrinsic height, resolve `contentSize` to exactly the
   viewport → `UIScrollView` disables scrolling and the overflow is clipped.
2. **Main tab screens** (Habits, Course, Map, Practice — which never use
   `ScreenScaffold`): `definite-height root (flex:1) → ContentContainer(flexGrow:1)
   → nested FlatList/ScrollView`. The wrapper resolves to its content height and,
   because `flexShrink` is 0, can never be pulled back to the viewport, so the
   nested scroller's bounds equal its content height — it thinks everything is
   visible and disables scroll.

RN Web masked both because browser scrollability comes from `scrollHeight`, which
includes overflowing descendants — the browser scrolls the overflow regardless.

### Why #1495 was insufficient on native

- **Scope:** it only touched `ScreenScaffold`'s scroll branch. Habits, Course,
  Map, and Practice never render `ScreenScaffold scroll`, so 4 of the 6 dead
  screens were untouched by construction.
- **Direction:** it *added* a second `flexGrow:1` (on the contentContainer)
  rather than removing the competing grow, which on native made the
  viewport cap exact rather than lifting it.
- **Verification:** its tests asserted `StyleSheet.flatten`-ed style props and it
  was checked on web only; neither can observe Yoga's resolved `contentSize`, so
  native behavior was never exercised.

### The fix

Split `ContentContainer`'s contract so one wrapper can serve both surfaces:

- **Default = pure width cap** (`width:'100%'` + `maxWidth` + `alignSelf:'center'`,
  no `flex`/`flexGrow`): main-axis inert, safe as a child of a ScrollView content
  container whose `contentContainerStyle` owns the *single* grow.
- **New `fill` prop = bounded `flex:1` box**: for definite-height parents that host
  a nested scroller or flex body, giving the wrapper real bounds.
- `ScreenScaffold` keeps the single `flexGrow:1` on the scroll
  `contentContainerStyle` and renders a content-sized inner wrapper; the non-scroll
  branch passes `fill`.
- The five tab call sites (Habits, Course, Map, Practice ×2) pass `fill` — each
  parent is a confirmed `flex:1` box.

The max-width cap (#1409/#1413 feature) is preserved on both surfaces.

### Constraints pinned by tests

Jest/RNTL cannot execute Yoga, so the tests pin the **structural contract** the
native reasoning depends on (they are necessary but not sufficient — see the
manual script below):

- **(a) native scrolls when content exceeds the viewport** — `ContentContainer`
  default has no grow of its own; scroll-branch inner wrapper is content-sized
  (single grow on the contentContainer); each tab call site's wrapper carries
  `flex:1`.
- **(b) short content still fills the viewport (no zero-collapse)** — scroll
  `contentContainerStyle` keeps `flexGrow:1` with no `flex`/`flexShrink`;
  non-scroll wrapper is `flex:1`.
- **(c) journal body fill unregressed** — `JournalEntryScreen`'s own ScrollView
  idiom is untouched (`body.flexGrow > 0` stays green); JournalShelfScreen rides
  the non-scroll `fill` branch.
- **(d) max-width cap unregressed** — `width`/`maxWidth`/`alignSelf` remain on the
  base container style in every variant.

## Test plan

- `./scripts/frontend/check-all.sh` green (3833 tests, ESLint, prettier, tsc).
- Layout + screen tests fail RED against the old `flexGrow:1` default and pass
  GREEN after the split.

### Manual on-device verification (required — native behavior is reasoned, not machine-verified)

Native layout cannot be exercised in Jest, and this is the third attempt, so
please verify on a physical iPhone (Expo dev build) before trusting the fix:

1. Habits (10+ habits), Course chapter list, Practice active session, Journal
   shelf (many entries), Journal entry (long text), Settings hub, Practice detail
   — vertical touch scroll works and reaches the **last** element.
2. Short-content screens (empty journal, Settings) still paint the canvas
   edge-to-edge with no visual collapse.
3. iPad or wide web window — content capped at `contentLayout.maxWidth` and centered.
4. RN Web spot check — no zero-height collapse on any scaffold screen.
5. Map — grid lays out bounded; note whether the spiral grid needs its own
   scroller (file a follow-up if so — out of scope here).

Closes #1521
Refs #1491, #1495, #1413, #1409