### PR TITLE
feat(journal): in-panel re-promotion in the reflection sources feed

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -33,6 +33,7 @@ import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
+import QuoteSelectionSurface from './QuoteSelectionSurface';
 import ReflectionSourcesPanel from './ReflectionSourcesPanel';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { usePromotions } from './usePromotions';
@@ -1240,61 +1241,6 @@ function useQuotePromotion(routeEntryId: number | null): QuotePromotion {
   return { quotes, hint, ...interaction };
 }
 
-/**
- * The span-selection surface: a controlled, effectively read-only serif field
- * that mirrors the body so the reader can select a passage to promote without
- * editing it (soft keyboard suppressed, caret hidden; ``editable`` stays true so
- * Android text selection still works).
- */
-function QuoteSelectionSurface({
-  body,
-  onSelectionChange,
-  onConfirm,
-  onCancel,
-}: {
-  body: string;
-  onSelectionChange: (_e: SelectionChangeEvent) => void;
-  onConfirm: () => Promise<void>;
-  onCancel: () => void;
-}) {
-  return (
-    <View>
-      <TextInput
-        style={styles.bodyInput}
-        value={body}
-        multiline
-        editable
-        showSoftInputOnFocus={false}
-        caretHidden
-        scrollEnabled={false}
-        onSelectionChange={onSelectionChange}
-        accessibilityLabel="Select a passage to promote"
-        testID="quote-select-input"
-      />
-      <View style={styles.quoteSelectActions}>
-        <TouchableOpacity
-          onPress={() => void onConfirm()}
-          accessibilityRole="button"
-          accessibilityLabel="Promote the selected passage"
-          style={styles.quoteActionButton}
-          testID="quote-select-confirm"
-        >
-          <Text style={styles.controlLink}>Promote selection</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={onCancel}
-          accessibilityRole="button"
-          accessibilityLabel="Cancel promoting"
-          style={styles.quoteActionButton}
-          testID="quote-select-cancel"
-        >
-          <Text style={styles.controlLink}>Cancel</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-  );
-}
-
 /** Read-mode affordances: a remove offer (when a span is tapped), Promote, Edit. */
 function ReadModeControls({ quote, onEdit }: { quote: QuotePromotion; onEdit: () => void }) {
   return (
@@ -1874,6 +1820,7 @@ function ReflectionComposer({
         <ReflectionSourcesPanel
           items={reflection.sources}
           onInsertQuote={reflection.onInsertQuote}
+          onPromoteSpan={reflection.onPromoteSpan}
           onClose={closeSources}
         />
       ) : null}

--- a/frontend/src/features/Journal/QuoteSelectionSurface.tsx
+++ b/frontend/src/features/Journal/QuoteSelectionSurface.tsx
@@ -1,0 +1,80 @@
+/**
+ * ``QuoteSelectionSurface`` — a controlled, effectively read-only serif field
+ * that mirrors a body so the reader can select a passage to promote without
+ * editing it (soft keyboard suppressed, caret hidden; ``editable`` stays true so
+ * Android text selection still works). Shared by the read-mode promote flow on
+ * ``JournalEntryScreen`` and the in-panel re-promotion flow in
+ * ``ReflectionSourcesPanel``; ``testID`` prefixes every element so more than one
+ * surface can coexist on a page.
+ */
+import React from 'react';
+import {
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
+} from 'react-native';
+
+import styles from './JournalEntry.styles';
+
+type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+/** Prefix for the surface's testIDs; the read-mode flow relies on this default. */
+const DEFAULT_TEST_ID = 'quote-select';
+
+export interface QuoteSelectionSurfaceProps {
+  body: string;
+  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+  testID?: string;
+}
+
+function QuoteSelectionSurface({
+  body,
+  onSelectionChange,
+  onConfirm,
+  onCancel,
+  testID = DEFAULT_TEST_ID,
+}: QuoteSelectionSurfaceProps): React.JSX.Element {
+  return (
+    <View>
+      <TextInput
+        style={styles.bodyInput}
+        value={body}
+        multiline
+        editable
+        showSoftInputOnFocus={false}
+        caretHidden
+        scrollEnabled={false}
+        onSelectionChange={onSelectionChange}
+        accessibilityLabel="Select a passage to promote"
+        testID={`${testID}-input`}
+      />
+      <View style={styles.quoteSelectActions}>
+        <TouchableOpacity
+          onPress={() => void onConfirm()}
+          accessibilityRole="button"
+          accessibilityLabel="Promote the selected passage"
+          style={styles.quoteActionButton}
+          testID={`${testID}-confirm`}
+        >
+          <Text style={styles.controlLink}>Promote selection</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel promoting"
+          style={styles.quoteActionButton}
+          testID={`${testID}-cancel`}
+        >
+          <Text style={styles.controlLink}>Cancel</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+export default QuoteSelectionSurface;

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -13,7 +13,7 @@
  * Responsive per the margin-column precedent: a bottom-sheet ``Modal`` on a
  * narrow viewport, an inline side pane on a wide one. Reduced-motion safe.
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Modal,
   ScrollView,
@@ -22,11 +22,14 @@ import {
   TouchableOpacity,
   View,
   useWindowDimensions,
+  type NativeSyntheticEvent,
+  type TextInputSelectionChangeEventData,
 } from 'react-native';
 
+import QuoteSelectionSurface from './QuoteSelectionSurface';
 import { sourceAttribution } from './reflectionCopy';
 
-import type { PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
+import type { PromoteQuoteSpan, PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
 import {
   BORDER_RADIUS,
   SPACING,
@@ -53,9 +56,25 @@ const STRIPE_WIDTH = 3;
 /** Dim a pending quote once it has been folded into the reflection body. */
 const INCLUDED_ROW_OPACITY = 0.5;
 
+/** Warm, declinable copy when a re-promotion didn't take; invites a calm retry. */
+const PROMOTE_FAILURE_HINT =
+  'That selection didn’t quite take — you can try again whenever you like.';
+
+type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
 export interface ReflectionSourcesPanelProps {
   items: ReflectionSourceItem[];
-  onInsertQuote: (_quote: PromotedQuoteSummary, _sourceItem: ReflectionSourceItem) => void;
+  /**
+   * Fold a pending quote into the reflection body. Resolves ``true`` when it was
+   * marked included (keep the dim), ``false``/reject to revert the dim, or
+   * ``undefined`` on a legacy fire-and-forget caller (keep the dim).
+   */
+  onInsertQuote: (
+    _quote: PromotedQuoteSummary,
+    _sourceItem: ReflectionSourceItem,
+  ) => Promise<boolean> | undefined;
+  /** Re-promote a freshly selected span of a source; resolves ``true`` on success. */
+  onPromoteSpan?: (_sourceItem: ReflectionSourceItem, _span: PromoteQuoteSpan) => Promise<boolean>;
   onClose?: () => void;
 }
 
@@ -80,6 +99,26 @@ function levelLabel(level: string | null): string {
 /** Feed order: oldest → newest by timestamp. */
 function byTimestamp(a: ReflectionSourceItem, b: ReflectionSourceItem): number {
   return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+}
+
+/** A copy of ``ids`` with ``id`` added (the optimistic dim). */
+function withId(ids: ReadonlySet<number>, id: number): Set<number> {
+  return new Set(ids).add(id);
+}
+
+/** A copy of ``ids`` with ``id`` removed (reverting a failed fold-in's dim). */
+function withoutId(ids: ReadonlySet<number>, id: number): Set<number> {
+  const next = new Set(ids);
+  next.delete(id);
+  return next;
+}
+
+/** A copy of ``keys`` with ``key`` toggled (expand/collapse a row). */
+function toggleKey(keys: ReadonlySet<string>, key: string): Set<string> {
+  const next = new Set(keys);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  return next;
 }
 
 /** The pending quotes across every source (deduped by id), in source order. */
@@ -150,15 +189,70 @@ function PendingQuotesGroup({
   );
 }
 
+/** The gesture wiring an expanded row hands to its promote opener / selection. */
+interface RowPromoteControls {
+  /** True when this row currently owns the shared selection surface. */
+  selecting: boolean;
+  /** True when this row's last re-promotion could not be saved. */
+  promoteFailed: boolean;
+  /** True when re-promotion is available at all (the parent wired a handler). */
+  canPromote: boolean;
+  onStartSelecting: () => void;
+  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+/** An expanded row's body — either the read-only text or the selection surface. */
+function SourceExpansion({
+  item,
+  controls,
+}: {
+  item: ReflectionSourceItem;
+  controls: RowPromoteControls;
+}): React.JSX.Element {
+  if (controls.selecting) {
+    return (
+      <QuoteSelectionSurface
+        body={item.body}
+        onSelectionChange={controls.onSelectionChange}
+        onConfirm={controls.onConfirm}
+        onCancel={controls.onCancel}
+        testID={`source-select-${item.kind}-${item.id}`}
+      />
+    );
+  }
+  return (
+    <>
+      <Text style={styles.body} testID={`source-body-${item.id}`}>
+        {item.body}
+      </Text>
+      {controls.canPromote ? (
+        <TouchableOpacity
+          style={styles.promoteOpener}
+          onPress={controls.onStartSelecting}
+          accessibilityRole="button"
+          accessibilityLabel="Promote a passage from this source"
+          testID={`source-promote-${item.kind}-${item.id}`}
+        >
+          <Text style={styles.promoteOpenerLink}>Promote a quote</Text>
+        </TouchableOpacity>
+      ) : null}
+    </>
+  );
+}
+
 /** One source in the feed: a header + excerpt, expanding to the full body on tap. */
 function SourceRow({
   item,
   expanded,
   onToggle,
+  controls,
 }: {
   item: ReflectionSourceItem;
   expanded: boolean;
   onToggle: () => void;
+  controls: RowPromoteControls;
 }): React.JSX.Element {
   const isReflection = item.kind === 'reflection';
   return (
@@ -181,26 +275,111 @@ function SourceRow({
           </Text>
         )}
       </TouchableOpacity>
-      {expanded ? (
-        <Text style={styles.body} testID={`source-body-${item.id}`}>
-          {item.body}
+      {expanded ? <SourceExpansion item={item} controls={controls} /> : null}
+      {controls.promoteFailed ? (
+        <Text style={styles.promoteHint} testID="source-promote-hint">
+          {PROMOTE_FAILURE_HINT}
         </Text>
       ) : null}
     </View>
   );
 }
 
-/** The chronological feed; owns which rows are expanded. */
-function SourceFeed({ feed }: { feed: ReflectionSourceItem[] }): React.JSX.Element {
+/** A char-offset span (defaults to empty so a bare confirm promotes nothing). */
+type SelectionSpan = { start: number; end: number };
+
+/** A re-promotion span handler; absent when the parent doesn't offer it. */
+type PromoteSpanHandler = (
+  _item: ReflectionSourceItem,
+  _span: PromoteQuoteSpan,
+) => Promise<boolean>;
+
+/** The single-row selection state the feed threads down to its rows. */
+interface RowSelection {
+  selectingKey: string | null;
+  promoteFailedKey: string | null;
+  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  startSelecting: (_key: string) => void;
+  cancelSelecting: () => void;
+  confirmSelection: (_item: ReflectionSourceItem, _key: string) => Promise<void>;
+}
+
+/**
+ * Own the one row that currently holds the shared selection surface and the one
+ * whose last re-promotion failed. Only one row selects at a time, so a single
+ * key + a single captured span suffice.
+ */
+function useRowSelection(onPromoteSpan?: PromoteSpanHandler): RowSelection {
+  const [selectingKey, setSelectingKey] = useState<string | null>(null);
+  const [promoteFailedKey, setPromoteFailedKey] = useState<string | null>(null);
+  const selectionRef = useRef<SelectionSpan>({ start: 0, end: 0 });
+
+  const startSelecting = useCallback((key: string) => {
+    selectionRef.current = { start: 0, end: 0 };
+    setPromoteFailedKey(null);
+    setSelectingKey(key);
+  }, []);
+
+  const cancelSelecting = useCallback(() => setSelectingKey(null), []);
+
+  const onSelectionChange = useCallback((event: SelectionChangeEvent) => {
+    selectionRef.current = event.nativeEvent.selection;
+  }, []);
+
+  const confirmSelection = useCallback(
+    async (item: ReflectionSourceItem, key: string): Promise<void> => {
+      const { start, end } = selectionRef.current;
+      if (end <= start) return; // An empty selection promotes nothing; stay put.
+      setSelectingKey(null);
+      if (onPromoteSpan == null) return;
+      const ok = await onPromoteSpan(item, { anchor_start: start, anchor_end: end });
+      if (!ok) setPromoteFailedKey(key);
+    },
+    [onPromoteSpan],
+  );
+
+  return {
+    selectingKey,
+    promoteFailedKey,
+    onSelectionChange,
+    startSelecting,
+    cancelSelecting,
+    confirmSelection,
+  };
+}
+
+/** Bind the shared selection state to one row's promote controls. */
+function buildControls(
+  item: ReflectionSourceItem,
+  key: string,
+  canPromote: boolean,
+  selection: RowSelection,
+): RowPromoteControls {
+  return {
+    selecting: selection.selectingKey === key,
+    promoteFailed: selection.promoteFailedKey === key,
+    canPromote,
+    onStartSelecting: () => selection.startSelecting(key),
+    onSelectionChange: selection.onSelectionChange,
+    onConfirm: () => selection.confirmSelection(item, key),
+    onCancel: selection.cancelSelecting,
+  };
+}
+
+/** The chronological feed; owns which rows are expanded + the selection surface. */
+function SourceFeed({
+  feed,
+  onPromoteSpan,
+}: {
+  feed: ReflectionSourceItem[];
+  onPromoteSpan?: PromoteSpanHandler;
+}): React.JSX.Element {
   const [expandedKeys, setExpandedKeys] = useState<ReadonlySet<string>>(() => new Set<string>());
   const toggle = useCallback((key: string) => {
-    setExpandedKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
+    setExpandedKeys((prev) => toggleKey(prev, key));
   }, []);
+  const selection = useRowSelection(onPromoteSpan);
+  const canPromote = onPromoteSpan != null;
   return (
     <View>
       {feed.map((item) => {
@@ -211,6 +390,7 @@ function SourceFeed({ feed }: { feed: ReflectionSourceItem[] }): React.JSX.Eleme
             item={item}
             expanded={expandedKeys.has(key)}
             onToggle={() => toggle(key)}
+            controls={buildControls(item, key, canPromote, selection)}
           />
         );
       })}
@@ -218,23 +398,54 @@ function SourceFeed({ feed }: { feed: ReflectionSourceItem[] }): React.JSX.Eleme
   );
 }
 
+/**
+ * Own the "which pending quotes are folded in" dim and reconcile it with the
+ * fold-in outcome: dim on tap, revert on a ``false``/rejected result, keep the
+ * dim on ``true`` or a legacy fire-and-forget (``undefined``) caller.
+ */
+function useDimReconciler(onInsertQuote: ReflectionSourcesPanelProps['onInsertQuote']): {
+  includedIds: ReadonlySet<number>;
+  onInsert: (_entry: PendingEntry) => void;
+} {
+  const [includedIds, setIncludedIds] = useState<ReadonlySet<number>>(() => new Set<number>());
+
+  const reconcileInsert = useCallback(
+    async (entry: PendingEntry): Promise<void> => {
+      const { id } = entry.quote;
+      setIncludedIds((prev) => withId(prev, id)); // Dim optimistically.
+      const outcome = onInsertQuote(entry.quote, entry.item);
+      if (outcome == null) return; // Legacy fire-and-forget caller: keep the dim.
+      let foldedIn = false;
+      try {
+        foldedIn = await outcome;
+      } catch {
+        foldedIn = false; // A rejected fold-in reverts the dim, like a false.
+      }
+      if (!foldedIn) setIncludedIds((prev) => withoutId(prev, id));
+    },
+    [onInsertQuote],
+  );
+
+  const onInsert = useCallback(
+    (entry: PendingEntry): void => {
+      void reconcileInsert(entry);
+    },
+    [reconcileInsert],
+  );
+
+  return { includedIds, onInsert };
+}
+
 /** The panel's inner content, shared by the sheet and pane containers. */
 function SourcesContent({
   items,
   onInsertQuote,
+  onPromoteSpan,
   onClose,
 }: ReflectionSourcesPanelProps): React.JSX.Element {
-  const [includedIds, setIncludedIds] = useState<ReadonlySet<number>>(() => new Set<number>());
   const pending = useMemo(() => collectPending(items), [items]);
   const feed = useMemo(() => [...items].sort(byTimestamp), [items]);
-
-  const onInsert = useCallback(
-    (entry: PendingEntry) => {
-      setIncludedIds((prev) => new Set(prev).add(entry.quote.id));
-      onInsertQuote(entry.quote, entry.item);
-    },
-    [onInsertQuote],
-  );
+  const { includedIds, onInsert } = useDimReconciler(onInsertQuote);
 
   return (
     <ScrollView
@@ -254,7 +465,7 @@ function SourcesContent({
         </TouchableOpacity>
       )}
       <PendingQuotesGroup pending={pending} includedIds={includedIds} onInsert={onInsert} />
-      <SourceFeed feed={feed} />
+      <SourceFeed feed={feed} onPromoteSpan={onPromoteSpan} />
     </ScrollView>
   );
 }
@@ -381,6 +592,21 @@ const styles = StyleSheet.create({
     ...editorialType.caption,
     color: accent.primary,
     fontWeight: '600',
+  },
+  promoteOpener: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingTop: spacing(1),
+  },
+  promoteOpenerLink: {
+    ...editorialType.caption,
+    color: accent.primary,
+    fontWeight: '600',
+  },
+  promoteHint: {
+    ...editorialType.caption,
+    color: ink.soft,
+    paddingTop: spacing(0.5),
   },
 });
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 
 import type {
   JournalMessage,
+  PromotedQuote,
   PromotedQuoteSummary,
   ReflectionDue,
   ReflectionSourceItem,
@@ -39,6 +40,9 @@ const mockReflectionsDue = jest.fn() as jest.MockedFunction<
 const mockReflectionsSources = jest.fn() as jest.MockedFunction<
   (_level: string, _scopeKey: string) => Promise<{ items: ReflectionSourceItem[] }>
 >;
+const mockPromotionsCreate = jest.fn() as jest.MockedFunction<
+  (_entryId: number, _span: { anchor_start: number; anchor_end: number }) => Promise<PromotedQuote>
+>;
 
 jest.mock('@/api', () => ({
   journal: {
@@ -60,7 +64,8 @@ jest.mock('@/api', () => ({
     dismiss: jest.fn(),
   },
   promotions: {
-    create: jest.fn(),
+    create: (...a: unknown[]) =>
+      (mockPromotionsCreate as unknown as (...x: unknown[]) => unknown)(...a),
     remove: jest.fn(),
     setIncluded: (...a: unknown[]) =>
       (mockSetIncluded as unknown as (...x: unknown[]) => unknown)(...a),
@@ -92,20 +97,52 @@ const mockStubSourceItem: ReflectionSourceItem = {
   promoted_quotes: [mockStubQuote],
 };
 
+// Fixed span the stub asks to promote from `mockStubSourceItem`.
+const mockStubPromoteSpan = { anchor_start: 2, anchor_end: 19 };
+
 jest.mock('../ReflectionSourcesPanel', () => {
   const { Text, TouchableOpacity } = require('react-native');
   const Stub = ({
+    items,
     onInsertQuote,
+    onPromoteSpan,
   }: {
-    onInsertQuote: (_q: PromotedQuoteSummary, _item: ReflectionSourceItem) => void;
-  }) => (
-    <TouchableOpacity
-      testID="stub-insert-quote"
-      onPress={() => onInsertQuote(mockStubQuote, mockStubSourceItem)}
-    >
-      <Text>Insert stub quote</Text>
-    </TouchableOpacity>
-  );
+    items: ReflectionSourceItem[];
+    onInsertQuote: (
+      _q: PromotedQuoteSummary,
+      _item: ReflectionSourceItem,
+    ) => Promise<boolean> | undefined;
+    onPromoteSpan?: (
+      _item: ReflectionSourceItem,
+      _span: { anchor_start: number; anchor_end: number },
+    ) => Promise<boolean>;
+  }) => {
+    const pendingIds = items
+      .flatMap((source) => source.promoted_quotes)
+      .filter((quote) => quote.pending)
+      .map((quote) => quote.id);
+    return (
+      <>
+        <TouchableOpacity
+          testID="stub-insert-quote"
+          onPress={() => onInsertQuote(mockStubQuote, mockStubSourceItem)}
+        >
+          <Text>Insert stub quote</Text>
+        </TouchableOpacity>
+        {onPromoteSpan == null ? null : (
+          <TouchableOpacity
+            testID="stub-promote-span"
+            onPress={() => {
+              void onPromoteSpan(mockStubSourceItem, mockStubPromoteSpan);
+            }}
+          >
+            <Text>Promote stub span</Text>
+          </TouchableOpacity>
+        )}
+        <Text testID="stub-pending-ids">{pendingIds.join(',')}</Text>
+      </>
+    );
+  };
   return { __esModule: true, default: Stub };
 });
 
@@ -160,6 +197,7 @@ beforeEach(() => {
   mockReflectionsDue.mockResolvedValue({ due: null });
   mockReflectionsSources.mockReset();
   mockReflectionsSources.mockResolvedValue({ items: [] });
+  mockPromotionsCreate.mockReset();
 });
 
 const REFLECTION_PARAMS = {
@@ -288,6 +326,109 @@ describe('JournalEntryScreen -- reflection mode', () => {
           (replaceCall[1] as Record<string, unknown> | undefined)?.entryId === 77) ||
         navigateCall != null;
       expect(routedToExisting).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// RED: the screen does not yet pass `onPromoteSpan` to the sources panel.
+describe('JournalEntryScreen -- in-panel re-promotion (reflection mode)', () => {
+  it('promotes a selected span from a source and folds the created quote into the pending set', async () => {
+    mockReflectionsSources.mockResolvedValue({ items: [mockStubSourceItem] });
+    mockPromotionsCreate.mockResolvedValue({
+      id: 501,
+      source_entry_id: mockStubSourceItem.id,
+      anchor_start: mockStubPromoteSpan.anchor_start,
+      anchor_end: mockStubPromoteSpan.anchor_end,
+      anchor_text: 'went for a daily walk',
+      pending: true,
+    });
+    const { findByTestId } = renderScreen(REFLECTION_PARAMS);
+    await act(async () => {
+      fireEvent.press(await findByTestId('reflection-sources-toggle'));
+    });
+    await act(async () => {
+      fireEvent.press(await findByTestId('stub-promote-span'));
+    });
+
+    expect(mockPromotionsCreate).toHaveBeenCalledWith(mockStubSourceItem.id, mockStubPromoteSpan);
+    expect((await findByTestId('stub-pending-ids')).props.children).toContain('501');
+  });
+
+  it('leaves the pending set unchanged when promotions.create rejects, without crashing', async () => {
+    mockReflectionsSources.mockResolvedValue({ items: [mockStubSourceItem] });
+    mockPromotionsCreate.mockRejectedValue({ status: 500, detail: 'boom' });
+    const { findByTestId } = renderScreen(REFLECTION_PARAMS);
+    await act(async () => {
+      fireEvent.press(await findByTestId('reflection-sources-toggle'));
+    });
+    await act(async () => {
+      fireEvent.press(await findByTestId('stub-promote-span'));
+    });
+
+    expect((await findByTestId('stub-pending-ids')).props.children).not.toContain('501');
+  });
+
+  it('single-flights a hanging promote so a double press calls create once', async () => {
+    mockReflectionsSources.mockResolvedValue({ items: [mockStubSourceItem] });
+    let resolveCreate: (_value: PromotedQuote) => void = () => undefined;
+    mockPromotionsCreate.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+    const { findByTestId } = renderScreen(REFLECTION_PARAMS);
+    await act(async () => {
+      fireEvent.press(await findByTestId('reflection-sources-toggle'));
+    });
+    const button = await findByTestId('stub-promote-span');
+    await act(async () => {
+      fireEvent.press(button);
+      fireEvent.press(button);
+    });
+    resolveCreate({
+      id: 501,
+      source_entry_id: mockStubSourceItem.id,
+      anchor_start: mockStubPromoteSpan.anchor_start,
+      anchor_end: mockStubPromoteSpan.anchor_end,
+      anchor_text: 'went for a daily walk',
+      pending: true,
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockPromotionsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the fold-in hint on a failed setIncluded, then clears it on the next successful one', async () => {
+    mockSetIncluded.mockRejectedValueOnce({ status: 500, detail: 'boom' });
+    mockSetIncluded.mockResolvedValueOnce(mockStubQuote);
+    jest.useFakeTimers();
+    try {
+      const { findByTestId, queryByTestId } = renderScreen(REFLECTION_PARAMS, {
+        autosaveDelayMs: 100,
+      });
+      await act(async () => {
+        fireEvent.press(await findByTestId('reflection-sources-toggle'));
+      });
+      const insertButton = await findByTestId('stub-insert-quote');
+
+      await act(async () => {
+        fireEvent.press(insertButton);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(await findByTestId('quote-inclusion-hint')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.press(insertButton);
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+      expect(queryByTestId('quote-inclusion-hint')).toBeNull();
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
@@ -20,7 +20,7 @@
 // panel in a bottom-sheet `Modal` (testID `reflection-sources-sheet`); >= 600
 // renders an inline side pane (testID `reflection-sources-pane`).
 import { jest, describe, it, expect } from '@jest/globals';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 import type { PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
@@ -169,5 +169,147 @@ describe('ReflectionSourcesPanel -- responsive layout', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// RED: `onPromoteSpan` prop and `source-promote-<kind>-<id>` don't exist yet.
+describe('ReflectionSourcesPanel -- in-panel re-promotion opener', () => {
+  it('shows the promote opener only on an expanded row when onPromoteSpan is provided', () => {
+    const items = [item({ id: 1 })];
+    const withPromote = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} onPromoteSpan={jest.fn()} />,
+    );
+    fireEvent.press(withPromote.getByTestId('entry-source-1'));
+    expect(withPromote.getByTestId('source-promote-entry-1')).toBeTruthy();
+
+    const withoutPromote = render(
+      <ReflectionSourcesPanel items={items} onInsertQuote={jest.fn()} />,
+    );
+    fireEvent.press(withoutPromote.getByTestId('entry-source-1'));
+    expect(withoutPromote.queryByTestId('source-promote-entry-1')).toBeNull();
+  });
+});
+
+describe('ReflectionSourcesPanel -- in-panel re-promotion selection surface', () => {
+  it('confirming a selected span calls onPromoteSpan with the source item and offsets', async () => {
+    const onPromoteSpan = jest.fn(() => Promise.resolve(true));
+    const sourceItem = item({ id: 1 });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel
+        items={[sourceItem]}
+        onInsertQuote={jest.fn()}
+        onPromoteSpan={onPromoteSpan}
+      />,
+    );
+    fireEvent.press(getByTestId('entry-source-1'));
+    fireEvent.press(getByTestId('source-promote-entry-1'));
+    const input = getByTestId('source-select-entry-1-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 9 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('source-select-entry-1-confirm'));
+    });
+    expect(onPromoteSpan).toHaveBeenCalledWith(sourceItem, { anchor_start: 2, anchor_end: 9 });
+  });
+
+  it('does not fire onPromoteSpan on a collapsed selection and stays on the selection surface', async () => {
+    const onPromoteSpan = jest.fn(() => Promise.resolve(true));
+    const items = [item({ id: 1 })];
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel
+        items={items}
+        onInsertQuote={jest.fn()}
+        onPromoteSpan={onPromoteSpan}
+      />,
+    );
+    fireEvent.press(getByTestId('entry-source-1'));
+    fireEvent.press(getByTestId('source-promote-entry-1'));
+    const input = getByTestId('source-select-entry-1-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 5, end: 5 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('source-select-entry-1-confirm'));
+    });
+    expect(onPromoteSpan).not.toHaveBeenCalled();
+    expect(getByTestId('source-select-entry-1-input')).toBeTruthy();
+  });
+
+  it('cancel restores the plain body without firing onPromoteSpan', () => {
+    const onPromoteSpan = jest.fn();
+    const items = [item({ id: 1, body: 'A river-bank sentence to reread.' })];
+    const { getByTestId, queryByTestId } = render(
+      <ReflectionSourcesPanel
+        items={items}
+        onInsertQuote={jest.fn()}
+        onPromoteSpan={onPromoteSpan}
+      />,
+    );
+    fireEvent.press(getByTestId('entry-source-1'));
+    fireEvent.press(getByTestId('source-promote-entry-1'));
+    fireEvent.press(getByTestId('source-select-entry-1-cancel'));
+    expect(queryByTestId('source-select-entry-1-input')).toBeNull();
+    expect(getByTestId('source-body-1').props.children).toContain(
+      'A river-bank sentence to reread.',
+    );
+    expect(onPromoteSpan).not.toHaveBeenCalled();
+  });
+
+  it('shows a declinable hint when onPromoteSpan resolves false, and the opener stays usable', async () => {
+    const onPromoteSpan = jest.fn(() => Promise.resolve(false));
+    const items = [item({ id: 1 })];
+    const { getByTestId, findByTestId } = render(
+      <ReflectionSourcesPanel
+        items={items}
+        onInsertQuote={jest.fn()}
+        onPromoteSpan={onPromoteSpan}
+      />,
+    );
+    fireEvent.press(getByTestId('entry-source-1'));
+    fireEvent.press(getByTestId('source-promote-entry-1'));
+    const input = getByTestId('source-select-entry-1-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 9 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('source-select-entry-1-confirm'));
+    });
+    expect(await findByTestId('source-promote-hint')).toBeTruthy();
+    expect(getByTestId('source-promote-entry-1')).toBeTruthy();
+  });
+});
+
+// RED: `onInsertQuote`'s Promise<boolean> result is not yet reconciled with the dim.
+describe('ReflectionSourcesPanel -- dim reconciles with a failed fold-in', () => {
+  it('reverts the dim when onInsertQuote resolves false, and a second press re-fires it', async () => {
+    const onInsertQuote = jest.fn(() => Promise.resolve(false));
+    const sourceItem = item({ id: 1, promoted_quotes: [quote({ id: 90, pending: true })] });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={[sourceItem]} onInsertQuote={onInsertQuote} />,
+    );
+    fireEvent.press(getByTestId('pending-quote-90'));
+    await waitFor(() => {
+      expect(getByTestId('pending-quote-90').props.accessibilityState?.disabled).toBeFalsy();
+    });
+    fireEvent.press(getByTestId('pending-quote-90'));
+    expect(onInsertQuote).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the dim when onInsertQuote resolves true', async () => {
+    const onInsertQuote = jest.fn(() => Promise.resolve(true));
+    const sourceItem = item({ id: 1, promoted_quotes: [quote({ id: 90, pending: true })] });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={[sourceItem]} onInsertQuote={onInsertQuote} />,
+    );
+    fireEvent.press(getByTestId('pending-quote-90'));
+    await waitFor(() => expect(onInsertQuote).toHaveBeenCalledTimes(1));
+    expect(getByTestId('pending-quote-90').props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('reverts the dim when onInsertQuote rejects', async () => {
+    const onInsertQuote = jest.fn(() => Promise.reject(new Error('fold-in failed')));
+    const sourceItem = item({ id: 1, promoted_quotes: [quote({ id: 90, pending: true })] });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel items={[sourceItem]} onInsertQuote={onInsertQuote} />,
+    );
+    fireEvent.press(getByTestId('pending-quote-90'));
+    await waitFor(() => {
+      expect(getByTestId('pending-quote-90').props.accessibilityState?.disabled).toBeFalsy();
+    });
   });
 });

--- a/frontend/src/features/Journal/useReflectionMode.ts
+++ b/frontend/src/features/Journal/useReflectionMode.ts
@@ -7,15 +7,30 @@
  * a Markdown blockquote at the caret, let the normal draft path create/save the
  * entry, then mark the quote included on that entry. A failed inclusion leaves
  * the quote pending and raises a warm, declinable hint — never a crash, never a
- * nag.
+ * nag. It also re-promotes a freshly selected span from a source and folds the
+ * created quote into the feed's pending set.
  */
-import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from 'react';
 import type { NativeSyntheticEvent, TextInputSelectionChangeEventData } from 'react-native';
 
 import { formatBlockquote, sourceAttribution } from './reflectionCopy';
 
 import { promotions, reflections } from '@/api';
-import type { PromotedQuoteSummary, ReflectionLevel, ReflectionSourceItem } from '@/api';
+import type {
+  PromoteQuoteSpan,
+  PromotedQuote,
+  PromotedQuoteSummary,
+  ReflectionLevel,
+  ReflectionSourceItem,
+} from '@/api';
 
 type SelectionEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
 
@@ -39,8 +54,13 @@ export interface UseReflectionModeResult {
   inclusionHint: boolean;
   /** Track the body caret so an inserted quote lands where the writer is. */
   onBodySelectionChange: (_e: SelectionEvent) => void;
-  /** Fold a chosen pending quote into the reflection body. */
-  onInsertQuote: (_quote: PromotedQuoteSummary, _sourceItem: ReflectionSourceItem) => void;
+  /** Fold a chosen pending quote in; resolves true when it was marked included. */
+  onInsertQuote: (
+    _quote: PromotedQuoteSummary,
+    _sourceItem: ReflectionSourceItem,
+  ) => Promise<boolean>;
+  /** Promote a freshly selected span of a source; resolves true on success. */
+  onPromoteSpan: (_sourceItem: ReflectionSourceItem, _span: PromoteQuoteSpan) => Promise<boolean>;
 }
 
 /**
@@ -57,11 +77,39 @@ function spliceAtCaret(
   return { text: body.slice(0, at) + block + body.slice(at), nextCaret: at + block.length };
 }
 
+/** True when ``item`` is the source a created quote belongs to (kind + id). */
+function isSameSource(item: ReflectionSourceItem, sourceItem: ReflectionSourceItem): boolean {
+  return item.kind === sourceItem.kind && item.id === sourceItem.id;
+}
+
+/**
+ * Append the created quote (as a feed summary, minus ``source_entry_id``) onto
+ * its source item's pending set, leaving every other item untouched.
+ */
+function mergeCreatedQuote(
+  items: ReflectionSourceItem[],
+  sourceItem: ReflectionSourceItem,
+  created: PromotedQuote,
+): ReflectionSourceItem[] {
+  const summary: PromotedQuoteSummary = {
+    id: created.id,
+    anchor_start: created.anchor_start,
+    anchor_end: created.anchor_end,
+    anchor_text: created.anchor_text,
+    pending: created.pending,
+  };
+  return items.map((item) =>
+    isSameSource(item, sourceItem)
+      ? { ...item, promoted_quotes: [...item.promoted_quotes, summary] }
+      : item,
+  );
+}
+
 /** Fetch the rereadable sources feed for a reflection scope (hidden on any error). */
 function useSourcesFeed(
   reflectionLevel: ReflectionLevel | undefined,
   reflectionScopeKey: string | undefined,
-): ReflectionSourceItem[] {
+): [ReflectionSourceItem[], Dispatch<SetStateAction<ReflectionSourceItem[]>>] {
   const [sources, setSources] = useState<ReflectionSourceItem[]>([]);
   useEffect(() => {
     if (reflectionLevel == null || reflectionScopeKey == null) return undefined;
@@ -78,7 +126,77 @@ function useSourcesFeed(
       alive = false;
     };
   }, [reflectionLevel, reflectionScopeKey]);
-  return sources;
+  return [sources, setSources];
+}
+
+/** The caret tracker plus the fold-a-pending-quote-into-the-body flow. */
+function useFoldIn(
+  bodyRef: MutableRefObject<string>,
+  onChangeBody: (_next: string) => void,
+  flush: () => Promise<number | null>,
+): {
+  inclusionHint: boolean;
+  onBodySelectionChange: (_e: SelectionEvent) => void;
+  onInsertQuote: (
+    _quote: PromotedQuoteSummary,
+    _sourceItem: ReflectionSourceItem,
+  ) => Promise<boolean>;
+} {
+  const [inclusionHint, setInclusionHint] = useState(false);
+  const caretRef = useRef<number | null>(null);
+
+  const onBodySelectionChange = useCallback((event: SelectionEvent) => {
+    caretRef.current = event.nativeEvent.selection.start;
+  }, []);
+
+  const onInsertQuote = useCallback(
+    async (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem): Promise<boolean> => {
+      const block = formatBlockquote(quote.anchor_text, sourceAttribution(sourceItem));
+      const { text, nextCaret } = spliceAtCaret(bodyRef.current, block, caretRef.current);
+      onChangeBody(text);
+      caretRef.current = nextCaret;
+      const entryId = await flush();
+      if (entryId == null) return false;
+      try {
+        await promotions.setIncluded(quote.id, entryId);
+        // A retried fold-in should not leave a stale warning from an earlier try.
+        setInclusionHint(false);
+        return true;
+      } catch {
+        // Leave the quote pending and invite a calm retry — no crash, no nag.
+        setInclusionHint(true);
+        return false;
+      }
+    },
+    [bodyRef, onChangeBody, flush],
+  );
+
+  return { inclusionHint, onBodySelectionChange, onInsertQuote };
+}
+
+/** The in-panel re-promote flow: lift a fresh span into its source's pending set. */
+function usePromoteSpan(
+  setSources: Dispatch<SetStateAction<ReflectionSourceItem[]>>,
+): (_sourceItem: ReflectionSourceItem, _span: PromoteQuoteSpan) => Promise<boolean> {
+  // One re-promote at a time so a double press can't double-post the same span.
+  const promotingRef = useRef(false);
+  return useCallback(
+    async (sourceItem: ReflectionSourceItem, span: PromoteQuoteSpan): Promise<boolean> => {
+      if (promotingRef.current) return false;
+      promotingRef.current = true;
+      try {
+        const created = await promotions.create(sourceItem.id, span);
+        setSources((prev) => mergeCreatedQuote(prev, sourceItem, created));
+        return true;
+      } catch {
+        // The source is unchanged and the writer can try again — no crash, no nag.
+        return false;
+      } finally {
+        promotingRef.current = false;
+      }
+    },
+    [setSources],
+  );
 }
 
 export function useReflectionMode({
@@ -89,38 +207,13 @@ export function useReflectionMode({
   flush,
 }: UseReflectionModeArgs): UseReflectionModeResult {
   const active = reflectionLevel != null && reflectionScopeKey != null;
-  const sources = useSourcesFeed(reflectionLevel, reflectionScopeKey);
-  const [inclusionHint, setInclusionHint] = useState(false);
-  const caretRef = useRef<number | null>(null);
-
-  const onBodySelectionChange = useCallback((event: SelectionEvent) => {
-    caretRef.current = event.nativeEvent.selection.start;
-  }, []);
-
-  const foldIn = useCallback(
-    async (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem): Promise<void> => {
-      const block = formatBlockquote(quote.anchor_text, sourceAttribution(sourceItem));
-      const { text, nextCaret } = spliceAtCaret(bodyRef.current, block, caretRef.current);
-      onChangeBody(text);
-      caretRef.current = nextCaret;
-      const entryId = await flush();
-      if (entryId == null) return;
-      try {
-        await promotions.setIncluded(quote.id, entryId);
-      } catch {
-        // Leave the quote pending and invite a calm retry — no crash, no nag.
-        setInclusionHint(true);
-      }
-    },
-    [bodyRef, onChangeBody, flush],
+  const [sources, setSources] = useSourcesFeed(reflectionLevel, reflectionScopeKey);
+  const { inclusionHint, onBodySelectionChange, onInsertQuote } = useFoldIn(
+    bodyRef,
+    onChangeBody,
+    flush,
   );
+  const onPromoteSpan = usePromoteSpan(setSources);
 
-  const onInsertQuote = useCallback(
-    (quote: PromotedQuoteSummary, sourceItem: ReflectionSourceItem): void => {
-      void foldIn(quote, sourceItem);
-    },
-    [foldIn],
-  );
-
-  return { active, sources, inclusionHint, onBodySelectionChange, onInsertQuote };
+  return { active, sources, inclusionHint, onBodySelectionChange, onInsertQuote, onPromoteSpan };
 }


### PR DESCRIPTION
## Summary

- Embed the promote-selection surface inside an expanded source row in the reflection composer's sources feed, so a reader can lift a *fresh* span from a reread source into the pending group (`promotions.create`) and then fold it in like any other pending quote. Extracts the shared `QuoteSelectionSurface` from the read view so both flows use one implementation.
- Reconcile the optimistic "included" dim with a failed fold-in: the fold-in handler now reports success, and the pending-quote dim reverts on a failed/rejected `setIncluded` so the row stays tappable and the retry hint stays truthful (a legacy fire-and-forget caller keeps the dim).

## Test plan

- Added RED-first tests, then implemented to green:
  - `ReflectionSourcesPanel.test.tsx` — opener shown only on expanded rows when `onPromoteSpan` is wired; select-span → confirm calls `onPromoteSpan` with the source item and offsets; empty selection is a no-op; cancel restores the plain body; a `false` result surfaces the declinable hint; dim reverts on `false`/reject and persists on `true`/`undefined`.
  - `JournalEntryScreenReflection.test.tsx` — promoting a span calls `promotions.create(sourceEntryId, span)` and merges the created quote into the pending set; a rejected create leaves the set unchanged without crashing; single-flight (double-press → one create); the fold-in hint appears on a failed `setIncluded` and clears on the next successful one.
- `./scripts/frontend/check-all.sh` exits 0: 3838 Jest tests pass, ESLint zero-warning, `tsc --noEmit` clean, prettier clean.

Closes #1516
Refs #1458
