### PR TITLE
feat(frontend): shared ScreenDrawer side-panel component + header hamburger trigger

### DIFF
--- a/frontend/src/components/drawer/DrawerItem.tsx
+++ b/frontend/src/components/drawer/DrawerItem.tsx
@@ -1,0 +1,58 @@
+/**
+ * A single tappable row inside a screen drawer: an optional leading icon slot
+ * followed by a label. The label doubles as the default accessibility label so
+ * screen-reader users hear the same text sighted users see.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, useWindowDimensions } from 'react-native';
+
+import { ink, SPACING, touchTarget, type } from '@/design/tokens';
+
+export interface DrawerItemProps {
+  /** Visible row label; also the default accessibility label. */
+  label: string;
+  /** Fired when the row is pressed. */
+  onPress: () => void;
+  /** Optional leading visual rendered before the label. */
+  icon?: React.ReactNode;
+  /** Overrides the announced label when it should differ from the text. */
+  accessibilityLabel?: string;
+  /** Test hook for the row. */
+  testID?: string;
+}
+
+/** A drawer row with an optional icon slot and an accessible label. */
+export default function DrawerItem({
+  label,
+  onPress,
+  icon,
+  accessibilityLabel,
+  testID,
+}: DrawerItemProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+
+  return (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      testID={testID}
+    >
+      {icon}
+      <Text style={[type(width).body, styles.label]}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.md,
+    minHeight: touchTarget.minimum,
+  },
+  label: {
+    color: ink.primary,
+  },
+});

--- a/frontend/src/components/drawer/DrawerToggle.tsx
+++ b/frontend/src/components/drawer/DrawerToggle.tsx
@@ -1,0 +1,55 @@
+/**
+ * Header-left toggle that opens a screen's contextual drawer. Mirrors the stable
+ * ``TabHeaderRight`` pattern in ``BottomTabs`` so it is defined once at module
+ * scope rather than being re-created on every render of its host screen.
+ */
+import { Menu } from 'lucide-react-native';
+import React from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+
+import { accent, SPACING, touchTarget } from '@/design/tokens';
+
+/** Lucide glyph size in dp for the toggle's menu icon. */
+const MENU_ICON_SIZE = 24;
+
+export interface DrawerToggleProps {
+  /** Human-readable screen name used to build the accessibility label. */
+  screenName: string;
+  /** Whether the drawer this toggle controls is currently open. */
+  expanded: boolean;
+  /** Fired when the toggle is pressed. */
+  onPress: () => void;
+  /** Test hook; defaults to ``drawer-toggle``. */
+  testID?: string;
+}
+
+/** A button that opens a screen's drawer, announced with its expanded state. */
+export default function DrawerToggle({
+  screenName,
+  expanded,
+  onPress,
+  testID,
+}: DrawerToggleProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      style={styles.toggle}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${screenName} menu`}
+      accessibilityState={{ expanded }}
+      testID={testID ?? 'drawer-toggle'}
+    >
+      <Menu color={accent.primary} size={MENU_ICON_SIZE} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  toggle: {
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginLeft: SPACING.sm,
+  },
+});

--- a/frontend/src/components/drawer/ScreenDrawer.tsx
+++ b/frontend/src/components/drawer/ScreenDrawer.tsx
@@ -1,0 +1,156 @@
+/**
+ * A left-anchored, slide-in drawer panel presented over the current screen. The
+ * panel width tracks the viewport (clamped for tablets), a labelled scrim closes
+ * it, and the slide honours the OS reduce-motion setting by snapping open with no
+ * transition. Because a ``Modal`` with ``visible={false}`` renders nothing, the
+ * component is fully unmounted when closed.
+ */
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+import { colors, ink, motion, SPACING, surface, surfaceShadow, type } from '@/design/tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+/** Fraction of the viewport width the drawer occupies before clamping. */
+const DRAWER_WIDTH_FRACTION = 0.8;
+/** Upper bound on drawer width in dp so it stays a drawer on wide screens. */
+const DRAWER_MAX_WIDTH = 320;
+/** Resting horizontal offset of the fully-open panel. */
+const OPEN_TRANSLATE_X = 0;
+
+export interface ScreenDrawerProps {
+  /** Whether the drawer is mounted and open. */
+  visible: boolean;
+  /** Fired when the scrim is pressed or the OS back gesture requests close. */
+  onClose: () => void;
+  /** Human-readable screen name used to build the scrim's accessibility label. */
+  screenName: string;
+  /** Optional heading rendered at the top of the panel. */
+  title?: string;
+  /** Panel contents. */
+  children: React.ReactNode;
+  /** Test hook for the underlying Modal; defaults to ``screen-drawer``. */
+  testID?: string;
+}
+
+/** Drive the panel's horizontal slide, snapping open under reduced motion. */
+function useDrawerSlide(panelWidth: number, visible: boolean): Animated.Value {
+  const reduced = useReducedMotion();
+  const translateX = useRef(new Animated.Value(-panelWidth)).current;
+
+  useEffect(() => {
+    const toValue = visible ? OPEN_TRANSLATE_X : -panelWidth;
+    if (reduced) {
+      translateX.setValue(toValue);
+      return;
+    }
+    const animation = Animated.timing(translateX, {
+      toValue,
+      duration: motion.base,
+      useNativeDriver: true,
+    });
+    animation.start();
+    return () => animation.stop();
+  }, [reduced, translateX, visible, panelWidth]);
+
+  return translateX;
+}
+
+interface DrawerPanelProps {
+  panelWidth: number;
+  translateX: Animated.Value;
+  title?: string;
+  children: React.ReactNode;
+}
+
+/** The sliding panel: an optional heading above a scrollable body. */
+function DrawerPanel({
+  panelWidth,
+  translateX,
+  title,
+  children,
+}: DrawerPanelProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  return (
+    <Animated.View
+      style={[styles.panel, { width: panelWidth, transform: [{ translateX }] }]}
+      testID="screen-drawer-panel"
+    >
+      {title === undefined ? null : (
+        <Text style={[type(width).heading, styles.title]}>{title}</Text>
+      )}
+      <ScrollView style={styles.scroll}>{children}</ScrollView>
+    </Animated.View>
+  );
+}
+
+/** A slide-in, scrim-dismissable drawer anchored to the left of the screen. */
+export default function ScreenDrawer({
+  visible,
+  onClose,
+  screenName,
+  title,
+  children,
+  testID,
+}: ScreenDrawerProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  const panelWidth = Math.min(width * DRAWER_WIDTH_FRACTION, DRAWER_MAX_WIDTH);
+  const translateX = useDrawerSlide(panelWidth, visible);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      testID={testID ?? 'screen-drawer'}
+    >
+      <View accessibilityViewIsModal style={styles.root}>
+        <DrawerPanel panelWidth={panelWidth} translateX={translateX} title={title}>
+          {children}
+        </DrawerPanel>
+        <TouchableOpacity
+          style={styles.scrim}
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel={`Close ${screenName} menu`}
+          testID="screen-drawer-scrim"
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  panel: {
+    backgroundColor: surface.raised,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: surface.hairline,
+    padding: SPACING.lg,
+    ...surfaceShadow.raised,
+  },
+  title: {
+    color: ink.primary,
+    marginBottom: SPACING.md,
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  scrim: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+  },
+});

--- a/frontend/src/components/drawer/__tests__/DrawerItem.test.tsx
+++ b/frontend/src/components/drawer/__tests__/DrawerItem.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import DrawerItem from '@/components/drawer/DrawerItem';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DrawerItem', () => {
+  it('renders the label text', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<DrawerItem label="Quick Log" onPress={onPress} />);
+
+    expect(getByText('Quick Log')).toBeTruthy();
+  });
+
+  it('renders the optional icon slot when given', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerItem label="Quick Log" onPress={onPress} icon={<View testID="probe-icon" />} />,
+    );
+
+    expect(getByTestId('probe-icon')).toBeTruthy();
+  });
+
+  it('exposes a button role labeled with the visible text by default', () => {
+    const onPress = jest.fn();
+    const { getByRole } = render(<DrawerItem label="Quick Log" onPress={onPress} />);
+
+    expect(getByRole('button', { name: 'Quick Log' })).toBeTruthy();
+  });
+
+  it('overrides the accessibility label when one is given', () => {
+    const onPress = jest.fn();
+    const { getByRole, getByText } = render(
+      <DrawerItem label="Quick Log" onPress={onPress} accessibilityLabel="Log a habit now" />,
+    );
+
+    expect(getByText('Quick Log')).toBeTruthy();
+    const button = getByRole('button', { name: 'Log a habit now' });
+    expect(button.props.accessibilityLabel).toBe('Log a habit now');
+  });
+
+  it('fires onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByRole } = render(<DrawerItem label="Quick Log" onPress={onPress} />);
+
+    fireEvent.press(getByRole('button', { name: 'Quick Log' }));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a custom testID', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerItem label="Quick Log" onPress={onPress} testID="quick-log-item" />,
+    );
+
+    expect(getByTestId('quick-log-item')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/drawer/__tests__/DrawerToggle.test.tsx
+++ b/frontend/src/components/drawer/__tests__/DrawerToggle.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import DrawerToggle from '@/components/drawer/DrawerToggle';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DrawerToggle', () => {
+  it('mounts the lucide Menu icon without throwing', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerToggle screenName="Habits" expanded={false} onPress={onPress} />,
+    );
+
+    expect(getByTestId('drawer-toggle')).toBeTruthy();
+  });
+
+  it('labels the toggle with the screen name', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerToggle screenName="Journal" expanded={false} onPress={onPress} />,
+    );
+
+    const toggle = getByTestId('drawer-toggle');
+    expect(toggle.props.accessibilityRole).toBe('button');
+    expect(toggle.props.accessibilityLabel).toBe('Open Journal menu');
+  });
+
+  it('reflects expanded=false in accessibilityState', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerToggle screenName="Journal" expanded={false} onPress={onPress} />,
+    );
+
+    expect(getByTestId('drawer-toggle').props.accessibilityState).toEqual({ expanded: false });
+  });
+
+  it('reflects expanded=true in accessibilityState after a rerender', () => {
+    const onPress = jest.fn();
+    const { getByTestId, rerender } = render(
+      <DrawerToggle screenName="Journal" expanded={false} onPress={onPress} />,
+    );
+
+    rerender(<DrawerToggle screenName="Journal" expanded onPress={onPress} />);
+
+    expect(getByTestId('drawer-toggle').props.accessibilityState).toEqual({ expanded: true });
+  });
+
+  it('fires onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerToggle screenName="Habits" expanded={false} onPress={onPress} />,
+    );
+
+    fireEvent.press(getByTestId('drawer-toggle'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a custom testID', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <DrawerToggle
+        screenName="Habits"
+        expanded={false}
+        onPress={onPress}
+        testID="habits-drawer-toggle"
+      />,
+    );
+
+    expect(getByTestId('habits-drawer-toggle')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/drawer/__tests__/ScreenDrawer.test.tsx
+++ b/frontend/src/components/drawer/__tests__/ScreenDrawer.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import type { ScaledSize } from 'react-native';
+
+const mockUseReducedMotion = jest.fn<() => boolean>();
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockUseReducedMotion(),
+}));
+
+import ScreenDrawer from '@/components/drawer/ScreenDrawer';
+
+const DEFAULT_DIMENSIONS: ScaledSize = { width: 390, height: 844, scale: 2, fontScale: 1 };
+
+type AnimatedNode = { __getValue: () => number };
+
+type WindowDimensionsSpy = ReturnType<typeof jest.spyOn>;
+let dimensionsSpy: WindowDimensionsSpy;
+
+const setDimensions = (dimensions: ScaledSize): void => {
+  dimensionsSpy.mockReturnValue(dimensions);
+};
+
+beforeEach(() => {
+  const rn = require('react-native') as { useWindowDimensions: () => ScaledSize };
+  dimensionsSpy = jest.spyOn(rn, 'useWindowDimensions').mockReturnValue(DEFAULT_DIMENSIONS);
+  mockUseReducedMotion.mockReturnValue(false);
+});
+
+afterEach(() => {
+  dimensionsSpy.mockRestore();
+  jest.clearAllMocks();
+});
+
+describe('ScreenDrawer', () => {
+  it('renders nothing when not visible', () => {
+    const onClose = jest.fn();
+    const { queryByText, queryByTestId } = render(
+      <ScreenDrawer visible={false} onClose={onClose} screenName="Habits">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    expect(queryByText('Drawer body')).toBeNull();
+    expect(queryByTestId('screen-drawer-scrim')).toBeNull();
+  });
+
+  it('renders the title and children when visible', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Habits" title="Menu">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    expect(getByText('Menu')).toBeTruthy();
+    expect(getByText('Drawer body')).toBeTruthy();
+  });
+
+  it('omits the title when none is given', () => {
+    const onClose = jest.fn();
+    const { getByText, queryByText } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Habits">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    expect(getByText('Drawer body')).toBeTruthy();
+    expect(queryByText('Menu')).toBeNull();
+  });
+
+  it('exposes the scrim as a labeled close control that fires onClose when pressed', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Journal">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    const scrim = getByTestId('screen-drawer-scrim');
+    expect(scrim.props.accessibilityRole).toBe('button');
+    expect(scrim.props.accessibilityLabel).toBe('Close Journal menu');
+
+    fireEvent.press(scrim);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onClose when the Modal reports an Android back request', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Journal">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    const modal = getByTestId('screen-drawer');
+    modal.props.onRequestClose();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults the Modal testID to screen-drawer and accepts an override', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Journal" testID="journal-drawer">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    expect(getByTestId('journal-drawer')).toBeTruthy();
+  });
+
+  describe('panel width clamping', () => {
+    it('sizes the panel to 80% of a narrow viewport', () => {
+      setDimensions({ width: 320, height: 640, scale: 2, fontScale: 1 });
+      const onClose = jest.fn();
+      const { getByTestId } = render(
+        <ScreenDrawer visible onClose={onClose} screenName="Habits">
+          <Text>Drawer body</Text>
+        </ScreenDrawer>,
+      );
+
+      const panel = getByTestId('screen-drawer-panel');
+      const flatStyle = StyleSheet.flatten(panel.props.style) as { width?: number };
+      expect(flatStyle.width).toBe(256);
+    });
+
+    it('clamps the panel width to 320 on a wide viewport', () => {
+      setDimensions({ width: 1200, height: 800, scale: 2, fontScale: 1 });
+      const onClose = jest.fn();
+      const { getByTestId } = render(
+        <ScreenDrawer visible onClose={onClose} screenName="Habits">
+          <Text>Drawer body</Text>
+        </ScreenDrawer>,
+      );
+
+      const panel = getByTestId('screen-drawer-panel');
+      const flatStyle = StyleSheet.flatten(panel.props.style) as { width?: number };
+      expect(flatStyle.width).toBe(320);
+    });
+  });
+
+  it('snaps the panel to the open position without animating under reduced motion', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <ScreenDrawer visible onClose={onClose} screenName="Habits">
+        <Text>Drawer body</Text>
+      </ScreenDrawer>,
+    );
+
+    const panel = getByTestId('screen-drawer-panel');
+    const flatStyle = StyleSheet.flatten(panel.props.style) as {
+      transform?: Array<{ translateX: number | AnimatedNode }>;
+    };
+    const transforms = flatStyle.transform;
+    if (transforms === undefined || transforms[0] === undefined) {
+      throw new Error('expected a translateX transform on the panel');
+    }
+    const translateX = transforms[0].translateX;
+    const value = typeof translateX === 'number' ? translateX : translateX.__getValue();
+    expect(value).toBe(0);
+  });
+});

--- a/frontend/src/components/drawer/__tests__/useScreenDrawer.test.tsx
+++ b/frontend/src/components/drawer/__tests__/useScreenDrawer.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { act, render, renderHook } from '@testing-library/react-native';
+import React from 'react';
+
+const mockUseNavigation = jest.fn();
+const mockUseRoute = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: (...args: unknown[]) => mockUseNavigation(...args),
+  useRoute: (...args: unknown[]) => mockUseRoute(...args),
+}));
+
+import { useScreenDrawer } from '@/components/drawer/useScreenDrawer';
+
+interface HeaderLeftOptions {
+  headerLeft: (() => React.ReactElement) | undefined;
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useScreenDrawer', () => {
+  it('installs a headerLeft render option on mount', () => {
+    const mockSetOptions = jest.fn();
+    mockUseNavigation.mockReturnValue({ setOptions: mockSetOptions });
+
+    renderHook(() => useScreenDrawer('Habits'));
+
+    expect(mockSetOptions).toHaveBeenCalled();
+    const firstCall = mockSetOptions.mock.calls[0];
+    if (firstCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const firstCallOptions = firstCall[0] as HeaderLeftOptions;
+    expect(typeof firstCallOptions.headerLeft).toBe('function');
+  });
+
+  it('renders a valid element from the headerLeft factory', () => {
+    const mockSetOptions = jest.fn();
+    mockUseNavigation.mockReturnValue({ setOptions: mockSetOptions });
+
+    renderHook(() => useScreenDrawer('Habits'));
+
+    const firstCall = mockSetOptions.mock.calls[0];
+    if (firstCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const firstCallOptions = firstCall[0] as HeaderLeftOptions;
+    const headerLeft = firstCallOptions.headerLeft;
+    if (headerLeft === undefined) {
+      throw new Error('headerLeft was not installed');
+    }
+    expect(React.isValidElement(headerLeft())).toBe(true);
+  });
+
+  it('starts closed and flips isOpen between open() and close()', () => {
+    const mockSetOptions = jest.fn();
+    mockUseNavigation.mockReturnValue({ setOptions: mockSetOptions });
+
+    const { result } = renderHook(() => useScreenDrawer('Habits'));
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('shows the toggle as expanded once the drawer is opened', () => {
+    const mockSetOptions = jest.fn();
+    mockUseNavigation.mockReturnValue({ setOptions: mockSetOptions });
+
+    const { result } = renderHook(() => useScreenDrawer('Journal'));
+
+    act(() => {
+      result.current.open();
+    });
+
+    const calls = mockSetOptions.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (lastCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const lastCallOptions = lastCall[0] as HeaderLeftOptions;
+    const headerLeft = lastCallOptions.headerLeft;
+    if (headerLeft === undefined) {
+      throw new Error('headerLeft was not installed');
+    }
+    const { getByTestId } = render(headerLeft());
+
+    expect(getByTestId('drawer-toggle').props.accessibilityState).toEqual({ expanded: true });
+  });
+
+  it('resets headerLeft to undefined on unmount', () => {
+    const mockSetOptions = jest.fn();
+    mockUseNavigation.mockReturnValue({ setOptions: mockSetOptions });
+
+    const { unmount } = renderHook(() => useScreenDrawer('Habits'));
+    const callsBeforeUnmount = mockSetOptions.mock.calls.length;
+
+    unmount();
+
+    const calls = mockSetOptions.mock.calls;
+    expect(calls.length).toBeGreaterThan(callsBeforeUnmount);
+    const lastCall = calls[calls.length - 1];
+    if (lastCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const lastCallOptions = lastCall[0] as HeaderLeftOptions;
+    expect(lastCallOptions.headerLeft).toBeUndefined();
+  });
+});

--- a/frontend/src/components/drawer/index.ts
+++ b/frontend/src/components/drawer/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Public surface of the shared screen-drawer module: the panel, its header-left
+ * toggle, a row primitive, and the state hook that ties a screen to its drawer.
+ */
+export { default as ScreenDrawer } from './ScreenDrawer';
+export type { ScreenDrawerProps } from './ScreenDrawer';
+export { default as DrawerToggle } from './DrawerToggle';
+export type { DrawerToggleProps } from './DrawerToggle';
+export { default as DrawerItem } from './DrawerItem';
+export type { DrawerItemProps } from './DrawerItem';
+export { useScreenDrawer } from './useScreenDrawer';
+export type { ScreenDrawerState } from './useScreenDrawer';

--- a/frontend/src/components/drawer/useScreenDrawer.ts
+++ b/frontend/src/components/drawer/useScreenDrawer.ts
@@ -1,0 +1,48 @@
+/**
+ * Wire a screen's header-left toggle to a local open/close drawer state. Installs
+ * a ``DrawerToggle`` as the navigator's ``headerLeft`` while the screen is mounted
+ * and clears it on unmount, so each screen owns its own drawer affordance. Uses
+ * ``createElement`` (not JSX) so this stays a plain ``.ts`` module.
+ */
+import React, { useCallback, useLayoutEffect, useState } from 'react';
+
+import DrawerToggle from './DrawerToggle';
+
+import { useAppNavigation } from '@/navigation/hooks';
+
+export interface ScreenDrawerState {
+  /** Whether the drawer is currently open. */
+  isOpen: boolean;
+  /** Open the drawer. */
+  open: () => void;
+  /** Close the drawer. */
+  close: () => void;
+}
+
+/** Manage a screen's drawer state and its header-left toggle affordance. */
+export function useScreenDrawer(screenName: string): ScreenDrawerState {
+  const navigation = useAppNavigation();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const renderHeaderLeft = useCallback(
+    () => React.createElement(DrawerToggle, { screenName, expanded: isOpen, onPress: open }),
+    [screenName, isOpen, open],
+  );
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerLeft: renderHeaderLeft });
+    return () => {
+      navigation.setOptions({ headerLeft: undefined });
+    };
+  }, [navigation, renderHeaderLeft]);
+
+  return { isOpen, open, close };
+}


### PR DESCRIPTION
## Summary

Foundation sub-issue (1 of 5) of epic #1465 (per-screen hamburger side panel). Adds a reusable, left-anchored slide-out drawer module under `frontend/src/components/drawer/` that any tab screen can adopt. No feature screen adopts the drawer in this PR — component + hook + tests only — so the four per-screen consumers (#1467–#1470) can land in parallel against a frozen API.

The public API (barrel `@/components/drawer`):

- **`ScreenDrawer`** — RN `Modal` + `Animated` translateX slide over a labeled scrim; scrim tap and Android back (`onRequestClose`) close it; the slide honors OS reduce-motion (snaps open, no transition); panel width is 80% of the viewport clamped to 320dp; `accessibilityViewIsModal` on the overlay traps assistive-tech focus to the drawer while keeping the scrim reachable. Panel `ScrollView` uses `flexGrow: 0` — no competing screen-level grow (respects the ContentContainer/ScreenScaffold contract from #1523).
- **`DrawerToggle`** — lucide `Menu` header button mirroring the existing settings gear, with `accessibilityRole="button"`, `accessibilityLabel="Open {screenName} menu"`, and `accessibilityState={{ expanded }}`.
- **`useScreenDrawer(screenName)`** — returns `{ isOpen, open, close }` and installs the toggle as `headerLeft` via `navigation.setOptions` (stable-component pattern), clearing it on unmount. No change to `BottomTabs`.
- **`DrawerItem`** — a11y-labeled icon + label row primitive for the common drawer row shape.

Candle & Ink design tokens throughout; no hard-coded colors/sizes.

## Test plan

- `./scripts/frontend/check-all.sh` green (ESLint zero-warning, Prettier, strict tsc, Jest 3871 tests).
- New suites under `frontend/src/components/drawer/__tests__/` cover: open/close via toggle, scrim close, Android-back close, visible/hidden render, title rendering, panel width clamp (256 at 320 vp, 320 at 1200 vp), reduced-motion snap-open, a11y roles/labels/expanded state, and the hook's `headerLeft` install + unmount cleanup.

Closes #1466
Refs #1465