### PR TITLE
feat(habits): move overflow menu and pagination controls into the Habits screen drawer

### DIFF
--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -948,31 +948,6 @@ export const styles = StyleSheet.create({
     color: COLORS.text.primary,
     fontWeight: '600',
   },
-
-  // ===== Overflow Menu =====
-  topBar: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    marginBottom: SPACING.sm,
-    zIndex: 1000,
-  },
-  overflowMenuContainer: {
-    zIndex: 1001,
-  },
-  mobileMenu: {
-    position: 'absolute',
-    top: 36,
-    right: 8,
-    backgroundColor: surface.raised,
-    borderRadius: 8,
-    padding: 8,
-    zIndex: 1002,
-    shadowColor: COLORS.paper.ink,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 10,
-  },
 });
 
 export default styles;

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -1,15 +1,5 @@
 // HabitsScreen.tsx
 
-import {
-  BarChart2,
-  Check,
-  Lock,
-  MoreHorizontal,
-  Pencil,
-  Plus,
-  Unlock,
-  Zap,
-} from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -20,9 +10,9 @@ import { STAGE_COLORS, spacing } from '../../design/tokens';
 import useResponsive from '../../design/useResponsive';
 
 import AddHabitModal from './components/AddHabitModal';
-import ConfirmDialog from './components/ConfirmDialog';
 import GoalModal from './components/GoalModal';
 import HabitEmojiPicker from './components/HabitEmojiPicker';
+import HabitsDrawer from './components/HabitsDrawer';
 import { HabitsEmptyState } from './components/HabitsEmptyState';
 import HabitSettingsModal from './components/HabitSettingsModal';
 import MissedDaysModal from './components/MissedDaysModal';
@@ -44,32 +34,13 @@ import {
 import { useHabits } from './hooks/useHabits';
 import { useModalCoordinator } from './hooks/useModalCoordinator';
 import { usePagination } from './hooks/usePagination';
+import { usePaginationBarVisibility } from './hooks/usePaginationBarVisibility';
 
+import { ScreenDrawer, useScreenDrawer } from '@/components/drawer';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 
 /** Habits per page — the ceiling that fills the screen 1-up on mobile and 2x5 on landscape/desktop. */
 const HABITS_PER_PAGE = MAX_HABITS;
-
-interface MenuItemProps {
-  icon: React.ReactNode;
-  label: string;
-  onPress: () => void;
-  scale: number;
-}
-
-const MenuItem = ({ icon, label, onPress, scale }: MenuItemProps) => (
-  <TouchableOpacity
-    onPress={onPress}
-    accessibilityRole="button"
-    accessibilityLabel={label}
-    style={{ paddingVertical: spacing(0.5, scale) }}
-  >
-    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-      {icon}
-      <Text>{label}</Text>
-    </View>
-  </TouchableOpacity>
-);
 
 const MODE_LABELS: Record<string, string> = {
   stats: 'Stats Mode',
@@ -104,133 +75,6 @@ const openModalForMode = (
   else if (mode === 'edit') open('settings');
   else if (mode === 'quickLog') logUnit(itemId, 1);
   else open('goal');
-};
-
-interface OverflowMenuProps {
-  scale: number;
-  menuVisible: boolean;
-  onToggle: () => void;
-  onSelectMode: (_mode: 'quickLog' | 'stats' | 'edit') => void;
-  onOpenOnboarding: () => void;
-  onOpenAddHabit: () => void;
-  allRevealed: boolean;
-  onToggleReveal: () => void;
-}
-
-type MenuAction = 'quickLog' | 'stats' | 'edit' | 'addHabit' | 'onboarding';
-
-const MENU_ITEMS: Array<{
-  Icon: typeof Check;
-  label: string;
-  action: MenuAction;
-}> = [
-  { Icon: Check, label: 'Quick Log', action: 'quickLog' },
-  { Icon: BarChart2, label: 'Stats', action: 'stats' },
-  { Icon: Pencil, label: 'Edit', action: 'edit' },
-  { Icon: Plus, label: 'Add Habit', action: 'addHabit' },
-  { Icon: Zap, label: 'Energy Scaffolding', action: 'onboarding' },
-];
-
-interface OverflowMenuListProps {
-  scale: number;
-  iconMargin: { marginRight: number };
-  handleMenuPress: (_action: MenuAction) => void;
-  allRevealed: boolean;
-  onToggleReveal: () => void;
-}
-
-const OverflowMenuList = ({
-  scale,
-  iconMargin,
-  handleMenuPress,
-  allRevealed,
-  onToggleReveal,
-}: OverflowMenuListProps) => {
-  const RevealIcon = allRevealed ? Lock : Unlock;
-  // Locking re-locks only untouched habits; the toggle label reflects that
-  // it acts on unstarted habits. Unlocking-all is destructive enough (it
-  // bypasses every per-tile confirm) to warrant its own confirmation.
-  const revealLabel = allRevealed ? 'Lock Unstarted Habits' : 'Unlock All Habits';
-  const [showUnlockAllConfirm, setShowUnlockAllConfirm] = useState(false);
-  const handleRevealPress = () => {
-    if (allRevealed) onToggleReveal();
-    else setShowUnlockAllConfirm(true);
-  };
-  return (
-    <View testID="overflow-menu" style={[styles.mobileMenu, { top: spacing(4, scale), right: 0 }]}>
-      {MENU_ITEMS.map((item) => (
-        <MenuItem
-          key={item.label}
-          icon={<item.Icon size={spacing(2, scale)} style={iconMargin} />}
-          label={item.label}
-          onPress={() => handleMenuPress(item.action)}
-          scale={scale}
-        />
-      ))}
-      <MenuItem
-        key="reveal-toggle"
-        icon={<RevealIcon size={spacing(2, scale)} style={iconMargin} />}
-        label={revealLabel}
-        onPress={handleRevealPress}
-        scale={scale}
-      />
-      <ConfirmDialog
-        visible={showUnlockAllConfirm}
-        title="Unlock all habits?"
-        message="This opens every locked habit at once. You can always re-lock the ones you haven't started."
-        testID="unlock-all-confirm"
-        cancelTestID="unlock-all-cancel"
-        confirmTestID="unlock-all-confirm-button"
-        confirmLabel="Unlock All"
-        onCancel={() => setShowUnlockAllConfirm(false)}
-        onConfirm={() => {
-          setShowUnlockAllConfirm(false);
-          onToggleReveal();
-        }}
-      />
-    </View>
-  );
-};
-
-export const OverflowMenu = ({
-  scale,
-  menuVisible,
-  onToggle,
-  onSelectMode,
-  onOpenOnboarding,
-  onOpenAddHabit,
-  allRevealed,
-  onToggleReveal,
-}: OverflowMenuProps) => {
-  const iconMargin = { marginRight: spacing(1, scale) };
-  const handleMenuPress = (action: MenuAction) => {
-    if (action === 'onboarding') onOpenOnboarding();
-    else if (action === 'addHabit') onOpenAddHabit();
-    else onSelectMode(action);
-  };
-  return (
-    <View style={styles.overflowMenuContainer} testID="overflow-menu-wrapper">
-      <TouchableOpacity
-        testID="overflow-menu-toggle"
-        onPress={onToggle}
-        accessibilityRole="button"
-        accessibilityLabel="Habit options menu"
-        accessibilityState={{ expanded: menuVisible }}
-        style={{ padding: spacing(1, scale) }}
-      >
-        <MoreHorizontal size={spacing(3, scale)} />
-      </TouchableOpacity>
-      {menuVisible && (
-        <OverflowMenuList
-          scale={scale}
-          iconMargin={iconMargin}
-          handleMenuPress={handleMenuPress}
-          allRevealed={allRevealed}
-          onToggleReveal={onToggleReveal}
-        />
-      )}
-    </View>
-  );
 };
 
 interface HabitModalsProps {
@@ -882,26 +726,58 @@ const HabitsContentSection = ({
   />
 );
 
+interface HabitsScreenDrawerProps {
+  state: ReturnType<typeof useHabitsScreenState>;
+  drawer: ReturnType<typeof useScreenDrawer>;
+  barVisible: boolean;
+  toggleBarVisible: () => void;
+}
+
+// The header drawer: every moved overflow-menu action plus the stage pager and
+// the in-body-bar show/hide toggle. Kept as its own component so the screen's
+// render stays small and the drawer wiring lives in one place.
+const HabitsScreenDrawer = ({
+  state,
+  drawer,
+  barVisible,
+  toggleBarVisible,
+}: HabitsScreenDrawerProps) => {
+  const { modals, pagination } = state;
+  const drawerRange = stageRangeForPage(pagination.page, HABITS_PER_PAGE);
+  return (
+    <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Habits" title="Habits">
+      <HabitsDrawer
+        onSelectMode={state.handleSelectMode}
+        onOpenOnboarding={() => modals.open('onboarding')}
+        onOpenAddHabit={() => modals.open('addHabit')}
+        allRevealed={state.allRevealed}
+        onToggleReveal={state.handleToggleReveal}
+        page={pagination.page}
+        pageCount={pagination.pageCount}
+        onPrev={pagination.goPrev}
+        onNext={pagination.goNext}
+        stageStart={drawerRange.start}
+        stageEnd={drawerRange.end}
+        barVisible={barVisible}
+        onToggleBarVisible={toggleBarVisible}
+        onClose={drawer.close}
+      />
+    </ScreenDrawer>
+  );
+};
+
 const HabitsScreen = () => {
   const state = useHabitsScreenState();
   const { habits, modals, actions, ui, responsive, pagination } = state;
   const { columns, gridGutter, scale, isLG, isXL } = responsive;
-  const paginationProps = buildPaginationProps(pagination, scale);
+  const drawer = useScreenDrawer('Habits');
+  const { barVisible, toggleBarVisible } = usePaginationBarVisibility();
+  // The in-body bar is suppressed while hidden; the drawer's pager stays wired
+  // regardless so the user can always page or re-show the bar.
+  const paginationProps = barVisible ? buildPaginationProps(pagination, scale) : null;
   return (
     <SafeAreaView style={[styles.container, { padding: spacing(isLG || isXL ? 2 : 1, scale) }]}>
       <ContentContainer fill>
-        <View style={styles.topBar}>
-          <OverflowMenu
-            scale={scale}
-            menuVisible={modals.menu}
-            onToggle={modals.toggleMenu}
-            onSelectMode={state.handleSelectMode}
-            onOpenOnboarding={() => modals.open('onboarding')}
-            onOpenAddHabit={() => modals.open('addHabit')}
-            allRevealed={state.allRevealed}
-            onToggleReveal={state.handleToggleReveal}
-          />
-        </View>
         <HabitsContentSection
           state={state}
           columns={columns}
@@ -925,6 +801,12 @@ const HabitsScreen = () => {
           onAddHabit={state.handleAddHabit}
         />
       </ContentContainer>
+      <HabitsScreenDrawer
+        state={state}
+        drawer={drawer}
+        barVisible={barVisible}
+        toggleBarVisible={toggleBarVisible}
+      />
     </SafeAreaView>
   );
 };

--- a/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
@@ -1,17 +1,50 @@
 /* eslint-env jest */
 // Pins the Edit-mode branch of ``openModalForMode``: tapping a tile while
 // Edit mode is active opens the habit-settings modal, not the goal modal.
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 
 import HabitsScreen from '../HabitsScreen';
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so the
+// drawer opens in-tree and its rows are pressable.
+const HabitsScreenWithHeader = (): React.JSX.Element => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <HabitsScreen />
+    </>
+  );
+};
 
 interface SettingsModalProps {
   visible: boolean;
 }
 
 const mockHabitSettingsModal = jest.fn((_props: SettingsModalProps) => null);
+
+// HabitsScreen installs its drawer toggle as the navigator's headerLeft via
+// useAppNavigation. Rendering the screen bare would strand that toggle in a
+// detached tree whose presses never reach the screen's Modal-based drawer, so a
+// small external store relays the headerLeft into the same tree (see harness).
+const headerLeftStore: {
+  current: (() => React.ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: mockSetOptions }),
+}));
 
 jest.mock('../../../api', () => ({
   habits: {
@@ -92,13 +125,18 @@ jest.mock('../components/ReorderHabitsModal', () => () => null);
 jest.mock('../components/AddHabitModal', () => () => null);
 jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
 
+beforeEach(() => {
+  headerLeftStore.current = undefined;
+  headerLeftStore.listeners.clear();
+});
+
 describe('Habits Edit-mode tile tap', () => {
   it('opens the habit settings modal when a tile is tapped in Edit mode', async () => {
-    const { getByTestId, getByText, getAllByTestId } = render(<HabitsScreen />);
+    const { getByText, getByLabelText, getAllByTestId } = render(<HabitsScreenWithHeader />);
 
     await waitFor(() => expect(getAllByTestId('habit-tile').length).toBeGreaterThan(0));
 
-    fireEvent.press(getByTestId('overflow-menu-toggle'));
+    fireEvent.press(getByLabelText('Open Habits menu'));
     fireEvent.press(getByText('Edit'));
     fireEvent.press(getAllByTestId('habit-tile')[0]!);
 

--- a/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
@@ -8,6 +8,12 @@ import HabitsScreen from '../HabitsScreen';
 
 const mockUpdateHabit = jest.fn((..._args: unknown[]) => Promise.resolve());
 
+// HabitsScreen installs its header-left toggle via useAppNavigation; mock the
+// navigation hooks so the screen renders outside a real NavigationContainer.
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: jest.fn() }),
+}));
+
 jest.mock('../../../api', () => ({
   habits: {
     list: () =>

--- a/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
@@ -2,11 +2,44 @@
 // Pins the overflow menu's reveal toggle in its other direction: pressing
 // "Lock Unstarted Habits" flips an early-unlocked (revealed, future
 // start_date) habit back to locked.
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 
 import HabitsScreen from '../HabitsScreen';
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so the
+// drawer opens in-tree and its rows are pressable.
+const HabitsScreenWithHeader = (): React.JSX.Element => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <HabitsScreen />
+    </>
+  );
+};
+
+// HabitsScreen installs its drawer toggle as the navigator's headerLeft via
+// useAppNavigation. Rendering the screen bare would strand that toggle in a
+// detached tree whose presses never reach the screen's Modal-based drawer, so a
+// small external store relays the headerLeft into the same tree (see harness).
+const headerLeftStore: {
+  current: (() => React.ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: mockSetOptions }),
+}));
 
 jest.mock('../../../api', () => ({
   habits: {
@@ -84,17 +117,24 @@ jest.mock('../components/ReorderHabitsModal', () => () => null);
 jest.mock('../components/AddHabitModal', () => () => null);
 jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
 
-describe('Habits overflow menu lock-unstarted toggle', () => {
+beforeEach(() => {
+  headerLeftStore.current = undefined;
+  headerLeftStore.listeners.clear();
+});
+
+describe('Habits drawer lock-unstarted toggle', () => {
   it('locks an early-unlocked habit via Lock Unstarted Habits', async () => {
-    const { getAllByTestId, getByTestId, getByText, queryByText } = render(<HabitsScreen />);
+    const { getAllByTestId, getByText, getByLabelText, queryByText } = render(
+      <HabitsScreenWithHeader />,
+    );
 
     await waitFor(() => expect(getAllByTestId('habit-icon').length).toBeGreaterThan(0));
 
     // All seeded habits are revealed, so the toggle offers the lock action.
-    fireEvent.press(getByTestId('overflow-menu-toggle'));
+    fireEvent.press(getByLabelText('Open Habits menu'));
     fireEvent.press(getByText('Lock Unstarted Habits'));
 
-    // Acting on a menu item closes the overflow menu.
+    // Acting on a drawer row closes the drawer.
     await waitFor(() => expect(queryByText('Lock Unstarted Habits')).toBeNull());
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsPaginationVisibility.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsPaginationVisibility.test.tsx
@@ -1,11 +1,10 @@
 /* eslint-env jest */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// Second habit set (stages 11-20): once a lap fills every slot, the screen
-// offers a trailing invite page into the next lap instead of stranding the
-// user on a full first page with no way forward.
+// The in-body pagination bar is now optional: a persisted "hidden" flag
+// (toggled from the header drawer) must suppress it even on a full lap
+// that would otherwise show it.
 import { jest, describe, afterEach, it, expect } from '@jest/globals';
 import React from 'react';
-import { Text } from 'react-native';
 import renderer from 'react-test-renderer';
 
 import type * as ApiModule from '../../../api';
@@ -38,16 +37,19 @@ const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
 const buildApiHabits = (count: number) =>
   Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
 
-// HabitsScreen now installs its header-left toggle through useAppNavigation
-// (useScreenDrawer); mock the navigation hooks module so the screen renders
-// outside a real NavigationContainer.
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: jest.fn() }),
 }));
 
+// This test targets HabitsScreen's pagination-gating behavior, not the storage
+// module itself (covered separately in paginationVisibilityStorage.test.ts), so
+// the module is mocked to report the bar as persisted-hidden.
+jest.mock('../../../storage/paginationVisibilityStorage', () => ({
+  loadPaginationBarHidden: jest.fn(() => Promise.resolve(true)),
+  savePaginationBarHidden: jest.fn(() => Promise.resolve(undefined)),
+}));
+
 jest.mock('../../../api', () => {
-  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
-  // the network namespaces this screen exercises.
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
@@ -106,62 +108,37 @@ jest.mock('../components/StatsModal', () => ({
 const { habits: habitsApi } = require('../../../api');
 const HabitsScreen = require('../HabitsScreen').default;
 
-const renderScreen = async (apiHabits: ReturnType<typeof buildApiHabits>) => {
-  habitsApi.listAll.mockResolvedValue(apiHabits);
-  jest
-    .spyOn(require('react-native'), 'useWindowDimensions')
-    .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });
-  let testRenderer: any;
-  await renderer.act(async () => {
-    testRenderer = renderer.create(React.createElement(HabitsScreen));
-  });
-  await renderer.act(async () => {
-    await Promise.resolve();
-  });
-  return testRenderer;
-};
-
 const hasTestId = (tree: any, testID: string): boolean =>
   tree.findAllByProps({ testID }).length > 0;
 
-const visibleTextMatches = (tree: any, pattern: RegExp): boolean =>
-  tree.findAllByType(Text).some((node: any) => {
-    const children = node.props.children;
-    const text = Array.isArray(children) ? children.join('') : String(children ?? '');
-    return pattern.test(text);
-  });
-
-describe('Habits screen second-lap pagination flow', () => {
+describe('Habits screen pagination-bar visibility', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('shows the stage-range pagination bar for a full first lap, invites into the second lap, and returns on Prev', async () => {
-    const testRenderer = await renderScreen(buildApiHabits(10));
-    const tree = testRenderer.root;
+  it('hides the in-body pagination bar when the hidden flag was persisted, even on a full lap', async () => {
+    habitsApi.listAll.mockResolvedValue(buildApiHabits(10));
+    jest
+      .spyOn(require('react-native'), 'useWindowDimensions')
+      .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });
 
-    // A full first lap (10 habits) must show pagination, not just a bare list.
-    expect(hasTestId(tree, 'habits-pagination')).toBe(true);
-    expect(visibleTextMatches(tree, /Stages\s*1[\s\S]*10/)).toBe(true);
-
-    const nextButton = tree.findByProps({ testID: 'pagination-next' });
+    let testRenderer: any;
     await renderer.act(async () => {
-      nextButton.props.onPress();
+      testRenderer = renderer.create(React.createElement(HabitsScreen));
     });
+    // Both the habit load and the persisted-hidden flag resolve asynchronously;
+    // flush pending microtasks until the bar is gone (bounded so a genuine
+    // regression that never hides it still fails rather than hangs).
+    for (
+      let attempt = 0;
+      attempt < 10 && hasTestId(testRenderer.root, 'habits-pagination');
+      attempt += 1
+    ) {
+      await renderer.act(async () => {
+        await Promise.resolve();
+      });
+    }
 
-    // The invite page: no second-lap habits yet, so the range-aware empty
-    // state renders, and the pagination bar stays visible (not stranded).
-    expect(hasTestId(tree, 'habits-empty-state')).toBe(true);
-    expect(hasTestId(tree, 'habits-pagination')).toBe(true);
-    expect(visibleTextMatches(tree, /Stages\s*11[\s\S]*20/)).toBe(true);
-
-    const prevButton = tree.findByProps({ testID: 'pagination-prev' });
-    await renderer.act(async () => {
-      prevButton.props.onPress();
-    });
-
-    // Back on the first lap: the list is showing again, not the empty state.
-    expect(hasTestId(tree, 'habits-list')).toBe(true);
-    expect(hasTestId(tree, 'habits-empty-state')).toBe(false);
+    expect(hasTestId(testRenderer.root, 'habits-pagination')).toBe(false);
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -5,7 +5,23 @@ import { brightenColor, STAGE_COLORS, SPACING } from '../../../design/tokens';
 
 const renderer = require('react-test-renderer');
 
+// HabitsScreen installs its header-left drawer toggle via useAppNavigation;
+// capture setOptions so the tests can open the drawer that now hosts the menu.
+const mockSetOptions = jest.fn();
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: mockSetOptions }),
+}));
+
 const HabitsScreen = require('../HabitsScreen').default;
+
+// Open the header drawer by invoking the installed header-left toggle's press.
+const openHabitsDrawer = (): void => {
+  const calls = mockSetOptions.mock.calls;
+  const last = calls[calls.length - 1] as any;
+  renderer.act(() => {
+    last[0].headerLeft().props.onPress();
+  });
+};
 
 // Mock the API so HabitsScreen loads instantly with an empty list (triggers fallback defaults)
 jest.mock('../../../api', () => ({
@@ -152,62 +168,21 @@ describe('HabitsScreen responsive layout', () => {
     expect(secondList.props.numColumns).toBe(1);
   });
 
-  it('renders overflow menu in top bar', async () => {
+  it('exposes the drawer menu rows once the drawer is open', async () => {
     jest
       .spyOn(require('react-native'), 'useWindowDimensions')
       .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
 
-    let testRenderer: any;
-    await renderer.act(async () => {
-      testRenderer = renderer.create(<HabitsScreen />);
-    });
-    const { StyleSheet } = require('react-native');
-    const wrapper = testRenderer.root.findByProps({ testID: 'overflow-menu-wrapper' });
-    const wrapperStyle = StyleSheet.flatten(wrapper.props.style);
-    expect(wrapperStyle.position).toBeUndefined();
-    expect(wrapperStyle.zIndex).toBeGreaterThan(0);
-
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
-
-    const menu = testRenderer.root.findByProps({ testID: 'overflow-menu' });
-    const style = Array.isArray(menu.props.style)
-      ? menu.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
-      : menu.props.style;
-
-    expect(style.zIndex).toBeGreaterThan(0);
-  });
-
-  it('places overflow menu above habit tiles', async () => {
-    jest
-      .spyOn(require('react-native'), 'useWindowDimensions')
-      .mockReturnValue({ width: 900, height: 600, scale: 1, fontScale: 1 });
-
-    const { StyleSheet, TouchableOpacity, Text } = require('react-native');
+    const { TouchableOpacity, Text } = require('react-native');
     let testRenderer: any;
     await renderer.act(async () => {
       testRenderer = renderer.create(<HabitsScreen />);
     });
 
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
+    openHabitsDrawer();
 
-    const menu = testRenderer.root.findByProps({ testID: 'overflow-menu' });
-    const menuStyle = StyleSheet.flatten(menu.props.style);
-
-    const firstTile = testRenderer.root.findAllByProps({ testID: 'habit-tile' })[0];
-    const tileStyle = StyleSheet.flatten(firstTile.props.style);
-
-    const tileZ = typeof tileStyle.zIndex === 'number' ? tileStyle.zIndex : 0;
-    expect(menuStyle.zIndex).toBeGreaterThan(tileZ);
-
-    // ensure menu options are tappable
-    const options = menu.findAllByType(TouchableOpacity);
+    // The Quick Log row lives in the header drawer, not an in-body overflow menu.
+    const options = testRenderer.root.findAllByType(TouchableOpacity);
     const quickLog = options.find((o: any) =>
       o.findAllByType(Text).some((t: any) => t.props.children === 'Quick Log'),
     );
@@ -225,11 +200,7 @@ describe('HabitsScreen responsive layout', () => {
     await renderer.act(async () => {
       testRenderer = renderer.create(<HabitsScreen />);
     });
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
+    openHabitsDrawer();
 
     const { TouchableOpacity, Text } = require('react-native');
     const options = testRenderer.root.findAll(
@@ -260,11 +231,7 @@ describe('HabitsScreen responsive layout', () => {
     await renderer.act(async () => {
       testRenderer = renderer.create(<HabitsScreen />);
     });
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
+    openHabitsDrawer();
 
     const { TouchableOpacity, Text } = require('react-native');
     const statsOption = testRenderer.root.findAll(
@@ -298,11 +265,7 @@ describe('HabitsScreen responsive layout', () => {
     await renderer.act(async () => {
       testRenderer = renderer.create(<HabitsScreen />);
     });
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
+    openHabitsDrawer();
 
     const { TouchableOpacity, Text } = require('react-native');
     const quickOption = testRenderer.root.findAll(
@@ -347,10 +310,7 @@ describe('HabitsScreen responsive layout', () => {
     const postTimerTexts = testRenderer.root.findAllByType(Text).map((t: any) => t.props.children);
     expect(postTimerTexts).not.toContain('Energy Scaffolding button moved to menu.');
 
-    const toggle = testRenderer.root.findByProps({ testID: 'overflow-menu-toggle' });
-    renderer.act(() => {
-      toggle.props.onPress();
-    });
+    openHabitsDrawer();
 
     const hasMenuItem = testRenderer.root
       .findAllByType(Text)

--- a/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenA11y.test.tsx
@@ -1,4 +1,4 @@
-// audit-ux-01: the Habits screen chrome (overflow menu, mode bar, pagination,
+// audit-ux-01: the Habits screen chrome (header drawer, mode bar, pagination,
 // energy CTA) must expose accessibilityRole/Label/State so screen-reader users
 // can identify and operate the controls.
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
@@ -24,7 +24,8 @@ jest.mock('../components/OnboardingModal', () => ({ __esModule: true, default: (
 jest.mock('../components/ReorderHabitsModal', () => ({ __esModule: true, default: () => null }));
 jest.mock('../components/StatsModal', () => ({ __esModule: true, default: () => null }));
 
-import { EnergyCTA, ModeBar, OverflowMenu, PaginationBar } from '../HabitsScreen';
+import HabitsDrawer from '../components/HabitsDrawer';
+import { EnergyCTA, ModeBar, PaginationBar } from '../HabitsScreen';
 
 const noop = (..._args: unknown[]): void => {};
 
@@ -33,32 +34,27 @@ afterEach(() => {
 });
 
 describe('HabitsScreen chrome accessibility', () => {
-  describe('OverflowMenu', () => {
+  describe('HabitsDrawer', () => {
     const baseProps = {
       scale: 1,
-      onToggle: noop,
       onSelectMode: noop,
       onOpenOnboarding: noop,
       onOpenAddHabit: noop,
       allRevealed: false,
       onToggleReveal: noop,
+      page: 0,
+      pageCount: 1,
+      onPrev: noop,
+      onNext: noop,
+      stageStart: 1,
+      stageEnd: 10,
+      barVisible: true,
+      onToggleBarVisible: noop,
+      onClose: noop,
     };
 
-    it('labels the toggle and reflects its expanded state', () => {
-      const { getByLabelText, rerender } = render(
-        <OverflowMenu {...baseProps} menuVisible={false} />,
-      );
-      const toggle = getByLabelText('Habit options menu');
-      expect(toggle.props.accessibilityState).toEqual({ expanded: false });
-
-      rerender(<OverflowMenu {...baseProps} menuVisible />);
-      expect(getByLabelText('Habit options menu').props.accessibilityState).toEqual({
-        expanded: true,
-      });
-    });
-
-    it('exposes each open menu item as a named button', () => {
-      const { getByRole } = render(<OverflowMenu {...baseProps} menuVisible />);
+    it('exposes each action row as a named button', () => {
+      const { getByRole } = render(<HabitsDrawer {...baseProps} />);
       for (const name of ['Quick Log', 'Stats', 'Edit', 'Add Habit', 'Energy Scaffolding']) {
         expect(getByRole('button', { name })).toBeTruthy();
       }
@@ -68,8 +64,18 @@ describe('HabitsScreen chrome accessibility', () => {
     });
 
     it('switches the reveal-toggle label when all habits are revealed', () => {
-      const { getByRole } = render(<OverflowMenu {...baseProps} menuVisible allRevealed />);
+      const { getByRole } = render(<HabitsDrawer {...baseProps} allRevealed />);
       expect(getByRole('button', { name: 'Lock Unstarted Habits' })).toBeTruthy();
+    });
+
+    it('labels the pagination Prev/Next controls and disables Prev on the first page', () => {
+      const { getByLabelText } = render(
+        <HabitsDrawer {...baseProps} page={0} pageCount={3} stageStart={1} stageEnd={10} />,
+      );
+      expect(getByLabelText('Previous page').props.accessibilityState).toEqual({
+        disabled: true,
+      });
+      expect(getByLabelText('Next page').props.accessibilityState).toEqual({ disabled: false });
     });
   });
 

--- a/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
@@ -2,7 +2,14 @@ import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
-import HabitsScreen from '../HabitsScreen';
+// HabitsScreen now installs its header-left toggle through useAppNavigation
+// (useScreenDrawer); mock the navigation hooks module so the screen renders
+// outside a real NavigationContainer. mockSetOptions is prefixed "mock" so
+// jest's hoist plugin allows the jest.mock factory to reference it.
+const mockSetOptions = jest.fn();
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: mockSetOptions }),
+}));
 
 // Mock the API so HabitsScreen loads instantly with an empty list. Plain
 // promise-returning functions avoid the typed-mock `never` inference of
@@ -58,28 +65,54 @@ jest.mock('../components/ReorderHabitsModal', () => () => null);
 jest.mock('../components/AddHabitModal', () => () => null);
 jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
 
-describe('HabitsScreen icon chrome (lucide-react-native)', () => {
+import HabitsScreen from '../HabitsScreen';
+
+interface HeaderLeftOptions {
+  headerLeft: (() => React.ReactElement) | undefined;
+}
+
+describe('HabitsScreen top-bar chrome', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('mounts the top-bar overflow toggle without throwing', async () => {
-    const { getByTestId } = render(<HabitsScreen />);
-
-    // The top-bar MoreHorizontal icon lives inside this toggle; mounting it
-    // proves the native lucide icon renders under @testing-library/react-native.
-    await waitFor(() => expect(getByTestId('overflow-menu-toggle')).toBeTruthy());
+  it('does not render the removed in-body overflow menu toggle', () => {
+    const { queryByTestId } = render(<HabitsScreen />);
+    expect(queryByTestId('overflow-menu-toggle')).toBeNull();
+    expect(queryByTestId('overflow-menu')).toBeNull();
   });
 
-  it('renders the overflow menu icons when the toggle is pressed', async () => {
-    const { getByTestId, getByText } = render(<HabitsScreen />);
+  it('installs a header-left drawer toggle via useAppNavigation', async () => {
+    render(<HabitsScreen />);
+    await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
 
-    const toggle = await waitFor(() => getByTestId('overflow-menu-toggle'));
-    fireEvent.press(toggle);
+    const lastCall = mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1];
+    if (lastCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const options = lastCall[0] as HeaderLeftOptions;
+    expect(typeof options.headerLeft).toBe('function');
+  });
+
+  it('opens the header drawer and renders the menu rows when the toggle is pressed', async () => {
+    const { getByTestId, getByText } = render(<HabitsScreen />);
+    await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+
+    const lastCall = mockSetOptions.mock.calls[mockSetOptions.mock.calls.length - 1];
+    if (lastCall === undefined) {
+      throw new Error('expected a setOptions call');
+    }
+    const headerLeft = (lastCall[0] as HeaderLeftOptions).headerLeft;
+    if (headerLeft === undefined) {
+      throw new Error('headerLeft was not installed');
+    }
+
+    const { getByTestId: getByTestIdInToggle } = render(headerLeft());
+    fireEvent.press(getByTestIdInToggle('drawer-toggle'));
 
     // The menu rows each render a lucide-react-native icon next to a label;
     // their presence proves the icon chrome mounts without throwing on native.
-    expect(getByTestId('overflow-menu')).toBeTruthy();
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
     expect(getByText('Quick Log')).toBeTruthy();
     expect(getByText('Stats')).toBeTruthy();
     expect(getByText('Add Habit')).toBeTruthy();

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -38,6 +38,12 @@ const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
 const buildApiHabits = (count: number) =>
   Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
 
+// HabitsScreen installs its header-left toggle via useAppNavigation; mock the
+// navigation hooks so the screen renders outside a real NavigationContainer.
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: jest.fn() }),
+}));
+
 jest.mock('../../../api', () => {
   // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
   // the network namespaces this screen exercises.

--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -6,6 +6,12 @@ import { ToastProvider } from '../../../components/ToastProvider';
 
 const HabitsScreen = require('../HabitsScreen').default;
 
+// HabitsScreen installs its header-left toggle via useAppNavigation; mock the
+// navigation hooks so the screen renders outside a real NavigationContainer.
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: jest.fn() }),
+}));
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 jest.mock('../../../api', () => ({
   habits: {

--- a/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
+++ b/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
@@ -3,13 +3,46 @@
 // fetched, doubling the call. This drives the real open flow through
 // HabitsScreen with the real StatsModal, so a re-introduced second fetch would
 // make the count 2.
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 
 import HabitsScreen from '../HabitsScreen';
 
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen so the
+// drawer opens in-tree and its rows are pressable.
+const HabitsScreenWithHeader = (): React.JSX.Element => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <HabitsScreen />
+    </>
+  );
+};
+
 const mockGetStats = jest.fn();
+
+// HabitsScreen installs its drawer toggle as the navigator's headerLeft via
+// useAppNavigation. Rendering the screen outside a navigator would strand that
+// toggle in a detached tree whose presses never reach the screen's Modal-based
+// drawer, so a small external store relays the headerLeft into the same tree.
+const headerLeftStore: {
+  current: (() => React.ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: mockSetOptions }),
+}));
 
 jest.mock('../../../api', () => ({
   habits: {
@@ -92,14 +125,19 @@ jest.mock('../components/OnboardingModal', () => () => null);
 jest.mock('../components/ReorderHabitsModal', () => () => null);
 jest.mock('../components/AddHabitModal', () => () => null);
 
+beforeEach(() => {
+  headerLeftStore.current = undefined;
+  headerLeftStore.listeners.clear();
+});
+
 describe('Habits stats modal fetch dedup', () => {
   it('fires getStats exactly once when the stats modal opens', async () => {
-    const { getByTestId, getAllByTestId, getByText } = render(<HabitsScreen />);
+    const { getAllByTestId, getByText, getByLabelText } = render(<HabitsScreenWithHeader />);
 
-    // Wait for the habit list to load, then drive: overflow menu → Stats mode →
+    // Wait for the habit list to load, then drive: header drawer -> Stats mode ->
     // tap the tile (which opens the stats modal in stats mode).
-    const toggle = await waitFor(() => getByTestId('overflow-menu-toggle'));
-    fireEvent.press(toggle);
+    await waitFor(() => expect(getAllByTestId('habit-tile').length).toBeGreaterThan(0));
+    fireEvent.press(getByLabelText('Open Habits menu'));
     fireEvent.press(getByText('Stats'));
     fireEvent.press(getAllByTestId('habit-tile')[0]!);
 

--- a/frontend/src/features/Habits/__tests__/UnlockAll.test.tsx
+++ b/frontend/src/features/Habits/__tests__/UnlockAll.test.tsx
@@ -4,7 +4,7 @@
 // confirm on a locked tile.
 //
 // Mirrors the isolated-component convention in HabitsScreenA11y.test.tsx:
-// render OverflowMenu directly with explicit props rather than mounting the
+// render HabitsDrawer directly with explicit props rather than mounting the
 // whole screen + API layer.
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
@@ -25,26 +25,34 @@ jest.mock('../components/OnboardingModal', () => ({ __esModule: true, default: (
 jest.mock('../components/ReorderHabitsModal', () => ({ __esModule: true, default: () => null }));
 jest.mock('../components/StatsModal', () => ({ __esModule: true, default: () => null }));
 
-import { OverflowMenu } from '../HabitsScreen';
+import HabitsDrawer from '../components/HabitsDrawer';
 
 const noop = (..._args: unknown[]): void => {};
 
 const baseProps = {
   scale: 1,
-  onToggle: noop,
   onSelectMode: noop,
   onOpenOnboarding: noop,
   onOpenAddHabit: noop,
+  page: 0,
+  pageCount: 1,
+  onPrev: noop,
+  onNext: noop,
+  stageStart: 1,
+  stageEnd: 10,
+  barVisible: true,
+  onToggleBarVisible: noop,
+  onClose: noop,
 };
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('OverflowMenu unlock-all confirm flow', () => {
+describe('HabitsDrawer unlock-all confirm flow', () => {
   it('labels the toggle "Unlock All Habits" (not "Reveal All Habits") when nothing is unlocked', () => {
     const { getByRole } = render(
-      <OverflowMenu {...baseProps} menuVisible allRevealed={false} onToggleReveal={jest.fn()} />,
+      <HabitsDrawer {...baseProps} allRevealed={false} onToggleReveal={jest.fn()} />,
     );
     expect(getByRole('button', { name: 'Unlock All Habits' })).toBeTruthy();
   });
@@ -52,12 +60,7 @@ describe('OverflowMenu unlock-all confirm flow', () => {
   it('pressing "Unlock All Habits" opens a confirm dialog instead of firing the toggle immediately', () => {
     const onToggleReveal = jest.fn();
     const { getByRole, getByTestId } = render(
-      <OverflowMenu
-        {...baseProps}
-        menuVisible
-        allRevealed={false}
-        onToggleReveal={onToggleReveal}
-      />,
+      <HabitsDrawer {...baseProps} allRevealed={false} onToggleReveal={onToggleReveal} />,
     );
 
     fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
@@ -70,12 +73,7 @@ describe('OverflowMenu unlock-all confirm flow', () => {
   it('confirming the dialog invokes the unlock-all action exactly once', () => {
     const onToggleReveal = jest.fn();
     const { getByRole, getByTestId } = render(
-      <OverflowMenu
-        {...baseProps}
-        menuVisible
-        allRevealed={false}
-        onToggleReveal={onToggleReveal}
-      />,
+      <HabitsDrawer {...baseProps} allRevealed={false} onToggleReveal={onToggleReveal} />,
     );
 
     fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
@@ -87,12 +85,7 @@ describe('OverflowMenu unlock-all confirm flow', () => {
   it('cancelling does NOT invoke the unlock-all action', () => {
     const onToggleReveal = jest.fn();
     const { getByRole, getByTestId, queryByTestId } = render(
-      <OverflowMenu
-        {...baseProps}
-        menuVisible
-        allRevealed={false}
-        onToggleReveal={onToggleReveal}
-      />,
+      <HabitsDrawer {...baseProps} allRevealed={false} onToggleReveal={onToggleReveal} />,
     );
 
     fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));

--- a/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
+++ b/frontend/src/features/Habits/__tests__/useModalCoordinator.test.ts
@@ -15,7 +15,6 @@ describe('useModalCoordinator', () => {
     expect(result.current.onboarding).toBe(false);
     expect(result.current.addHabit).toBe(false);
     expect(result.current.emojiPicker).toBe(false);
-    expect(result.current.menu).toBe(false);
   });
 
   it('BUG-FE-HABIT-008: open() preserves prior modal flags', () => {
@@ -49,18 +48,13 @@ describe('useModalCoordinator', () => {
     expect(result.current.onboarding).toBe(false);
     expect(result.current.addHabit).toBe(false);
     expect(result.current.emojiPicker).toBe(false);
-    expect(result.current.menu).toBe(false);
   });
 
-  it('open("addHabit") opens the AddHabit modal and collapses the menu', () => {
+  it('open("addHabit") opens the AddHabit modal', () => {
     const { result } = renderHook(() => useModalCoordinator());
-
-    act(() => result.current.toggleMenu());
-    expect(result.current.menu).toBe(true);
 
     act(() => result.current.open('addHabit'));
     expect(result.current.addHabit).toBe(true);
-    expect(result.current.menu).toBe(false);
   });
 
   it('close(name) closes only that modal', () => {
@@ -69,26 +63,5 @@ describe('useModalCoordinator', () => {
     act(() => result.current.open('goal'));
     act(() => result.current.close('goal'));
     expect(result.current.goal).toBe(false);
-  });
-
-  it('toggleMenu toggles the menu state', () => {
-    const { result } = renderHook(() => useModalCoordinator());
-
-    act(() => result.current.toggleMenu());
-    expect(result.current.menu).toBe(true);
-
-    act(() => result.current.toggleMenu());
-    expect(result.current.menu).toBe(false);
-  });
-
-  it('opening a modal closes the menu', () => {
-    const { result } = renderHook(() => useModalCoordinator());
-
-    act(() => result.current.toggleMenu());
-    expect(result.current.menu).toBe(true);
-
-    act(() => result.current.open('goal'));
-    expect(result.current.menu).toBe(false);
-    expect(result.current.goal).toBe(true);
   });
 });

--- a/frontend/src/features/Habits/components/HabitsDrawer.tsx
+++ b/frontend/src/features/Habits/components/HabitsDrawer.tsx
@@ -1,0 +1,246 @@
+// The Habits header-drawer body. Replaces the removed in-body overflow menu and
+// hosts the pagination controls: action rows, the unlock-all confirm gate, the
+// Prev/Next pager with its stage-range label, and the pagination-visibility
+// toggle. Rendered as ScreenDrawer children by HabitsScreen.
+import {
+  BarChart2,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Lock,
+  Pencil,
+  Plus,
+  Unlock,
+  Zap,
+} from 'lucide-react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+
+import ConfirmDialog from './ConfirmDialog';
+
+import { DrawerItem } from '@/components/drawer';
+import { accent, ink, SPACING, touchTarget, type } from '@/design/tokens';
+
+/** Lucide glyph size in dp for the drawer's row and pager icons. */
+const ICON_SIZE = 20;
+
+type SelectableMode = 'quickLog' | 'stats' | 'edit';
+
+export interface HabitsDrawerProps {
+  onSelectMode: (_mode: SelectableMode) => void;
+  onOpenOnboarding: () => void;
+  onOpenAddHabit: () => void;
+  allRevealed: boolean;
+  onToggleReveal: () => void;
+  page: number;
+  pageCount: number;
+  onPrev: () => void;
+  onNext: () => void;
+  stageStart: number;
+  stageEnd: number;
+  barVisible: boolean;
+  onToggleBarVisible: () => void;
+  onClose: () => void;
+}
+
+interface ActionRowsProps {
+  onSelectMode: (_mode: SelectableMode) => void;
+  onOpenOnboarding: () => void;
+  onOpenAddHabit: () => void;
+  onClose: () => void;
+}
+
+/** The five mode/action rows; each fires its action then dismisses the drawer. */
+function ActionRows({
+  onSelectMode,
+  onOpenOnboarding,
+  onOpenAddHabit,
+  onClose,
+}: ActionRowsProps): React.JSX.Element {
+  const rows: Array<{ Icon: typeof Check; label: string; run: () => void }> = [
+    { Icon: Check, label: 'Quick Log', run: () => onSelectMode('quickLog') },
+    { Icon: BarChart2, label: 'Stats', run: () => onSelectMode('stats') },
+    { Icon: Pencil, label: 'Edit', run: () => onSelectMode('edit') },
+    { Icon: Plus, label: 'Add Habit', run: onOpenAddHabit },
+    { Icon: Zap, label: 'Energy Scaffolding', run: onOpenOnboarding },
+  ];
+  return (
+    <>
+      {rows.map((row) => (
+        <DrawerItem
+          key={row.label}
+          label={row.label}
+          icon={<row.Icon size={ICON_SIZE} color={accent.primary} />}
+          onPress={() => {
+            row.run();
+            onClose();
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+interface RevealRowProps {
+  allRevealed: boolean;
+  onToggleReveal: () => void;
+  onClose: () => void;
+}
+
+/**
+ * The unlock/lock-all row. Unlocking every habit at once bypasses each per-tile
+ * confirm, so it is gated behind its own dialog; re-locking untouched habits is
+ * reversible and fires directly.
+ */
+function RevealRow({ allRevealed, onToggleReveal, onClose }: RevealRowProps): React.JSX.Element {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const label = allRevealed ? 'Lock Unstarted Habits' : 'Unlock All Habits';
+  const RevealIcon = allRevealed ? Lock : Unlock;
+  const confirmReveal = (): void => {
+    setShowConfirm(false);
+    onToggleReveal();
+    onClose();
+  };
+  const handlePress = (): void => {
+    if (allRevealed) {
+      onToggleReveal();
+      onClose();
+    } else {
+      setShowConfirm(true);
+    }
+  };
+  return (
+    <>
+      <DrawerItem
+        label={label}
+        icon={<RevealIcon size={ICON_SIZE} color={accent.primary} />}
+        onPress={handlePress}
+      />
+      <ConfirmDialog
+        visible={showConfirm}
+        title="Unlock all habits?"
+        message="This opens every locked habit at once. You can always re-lock the ones you haven't started."
+        testID="unlock-all-confirm"
+        cancelTestID="unlock-all-cancel"
+        confirmTestID="unlock-all-confirm-button"
+        confirmLabel="Unlock All"
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={confirmReveal}
+      />
+    </>
+  );
+}
+
+interface PaginationSectionProps {
+  page: number;
+  pageCount: number;
+  onPrev: () => void;
+  onNext: () => void;
+  stageStart: number;
+  stageEnd: number;
+}
+
+/** Prev/Next pager around a stage-range label that also announces the position. */
+function PaginationSection({
+  page,
+  pageCount,
+  onPrev,
+  onNext,
+  stageStart,
+  stageEnd,
+}: PaginationSectionProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  const canPrev = page > 0;
+  const canNext = page < pageCount - 1;
+  const positionLabel = `Stages ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
+  return (
+    <View style={styles.paginationRow} testID="drawer-pagination">
+      <TouchableOpacity
+        onPress={onPrev}
+        disabled={!canPrev}
+        accessibilityRole="button"
+        accessibilityLabel="Previous page"
+        accessibilityState={{ disabled: !canPrev }}
+        style={styles.pagerButton}
+        testID="drawer-pagination-prev"
+      >
+        <ChevronLeft size={ICON_SIZE} color={canPrev ? accent.primary : ink.muted} />
+      </TouchableOpacity>
+      <Text
+        style={[type(width).body, styles.rangeLabel]}
+        accessibilityLabel={positionLabel}
+        testID="drawer-pagination-label"
+      >
+        Stages {stageStart}–{stageEnd}
+      </Text>
+      <TouchableOpacity
+        onPress={onNext}
+        disabled={!canNext}
+        accessibilityRole="button"
+        accessibilityLabel="Next page"
+        accessibilityState={{ disabled: !canNext }}
+        style={styles.pagerButton}
+        testID="drawer-pagination-next"
+      >
+        <ChevronRight size={ICON_SIZE} color={canNext ? accent.primary : ink.muted} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/** The Habits header-drawer body composed from its action, reveal, and pager sections. */
+export default function HabitsDrawer(props: HabitsDrawerProps): React.JSX.Element {
+  const visibilityLabel = props.barVisible ? 'Hide page controls' : 'Show page controls';
+  const VisibilityIcon = props.barVisible ? EyeOff : Eye;
+  return (
+    <View>
+      <ActionRows
+        onSelectMode={props.onSelectMode}
+        onOpenOnboarding={props.onOpenOnboarding}
+        onOpenAddHabit={props.onOpenAddHabit}
+        onClose={props.onClose}
+      />
+      <RevealRow
+        allRevealed={props.allRevealed}
+        onToggleReveal={props.onToggleReveal}
+        onClose={props.onClose}
+      />
+      <PaginationSection
+        page={props.page}
+        pageCount={props.pageCount}
+        onPrev={props.onPrev}
+        onNext={props.onNext}
+        stageStart={props.stageStart}
+        stageEnd={props.stageEnd}
+      />
+      <DrawerItem
+        label={visibilityLabel}
+        icon={<VisibilityIcon size={ICON_SIZE} color={accent.primary} />}
+        onPress={props.onToggleBarVisible}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  paginationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: touchTarget.minimum,
+    gap: SPACING.md,
+  },
+  pagerButton: {
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rangeLabel: {
+    flex: 1,
+    textAlign: 'center',
+    color: ink.primary,
+  },
+});

--- a/frontend/src/features/Habits/components/__tests__/HabitsDrawer.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitsDrawer.test.tsx
@@ -1,0 +1,247 @@
+// RED: HabitsDrawer does not exist yet -- this import fails until the
+// implementation-specialist adds the component. Specifies the header-drawer
+// replacement for the removed in-body overflow menu and pagination bar:
+// action rows, unlock-all confirm gating, pagination controls, and the
+// pagination-visibility toggle.
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import HabitsDrawer from '../HabitsDrawer';
+
+const noop = (..._args: unknown[]): void => {};
+
+const baseProps = {
+  onSelectMode: noop,
+  onOpenOnboarding: noop,
+  onOpenAddHabit: noop,
+  allRevealed: false,
+  onToggleReveal: noop,
+  page: 0,
+  pageCount: 3,
+  onPrev: noop,
+  onNext: noop,
+  stageStart: 1,
+  stageEnd: 10,
+  barVisible: true,
+  onToggleBarVisible: noop,
+  onClose: noop,
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('HabitsDrawer action rows', () => {
+  it('fires onSelectMode("quickLog") and closes the drawer', () => {
+    const onSelectMode = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer {...baseProps} onSelectMode={onSelectMode} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Quick Log' }));
+    expect(onSelectMode).toHaveBeenCalledWith('quickLog');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onSelectMode("stats") and closes the drawer', () => {
+    const onSelectMode = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer {...baseProps} onSelectMode={onSelectMode} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Stats' }));
+    expect(onSelectMode).toHaveBeenCalledWith('stats');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onSelectMode("edit") and closes the drawer', () => {
+    const onSelectMode = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer {...baseProps} onSelectMode={onSelectMode} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Edit' }));
+    expect(onSelectMode).toHaveBeenCalledWith('edit');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onOpenAddHabit and closes the drawer', () => {
+    const onOpenAddHabit = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer {...baseProps} onOpenAddHabit={onOpenAddHabit} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Add Habit' }));
+    expect(onOpenAddHabit).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onOpenOnboarding and closes the drawer', () => {
+    const onOpenOnboarding = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer {...baseProps} onOpenOnboarding={onOpenOnboarding} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Energy Scaffolding' }));
+    expect(onOpenOnboarding).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('HabitsDrawer unlock-all confirm gating', () => {
+  it('labels the reveal row "Unlock All Habits" when nothing is unlocked', () => {
+    const { getByRole } = render(<HabitsDrawer {...baseProps} allRevealed={false} />);
+    expect(getByRole('button', { name: 'Unlock All Habits' })).toBeTruthy();
+  });
+
+  it('pressing "Unlock All Habits" opens a confirm dialog instead of firing the toggle', () => {
+    const onToggleReveal = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole, getByTestId } = render(
+      <HabitsDrawer
+        {...baseProps}
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+    expect(getByTestId('unlock-all-confirm')).toBeTruthy();
+    expect(onToggleReveal).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('confirming the dialog fires onToggleReveal once and closes the drawer', () => {
+    const onToggleReveal = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole, getByTestId } = render(
+      <HabitsDrawer
+        {...baseProps}
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+    fireEvent.press(getByTestId('unlock-all-confirm-button'));
+    expect(onToggleReveal).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelling does not fire onToggleReveal or close the drawer', () => {
+    const onToggleReveal = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole, getByTestId, queryByTestId } = render(
+      <HabitsDrawer
+        {...baseProps}
+        allRevealed={false}
+        onToggleReveal={onToggleReveal}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Unlock All Habits' }));
+    fireEvent.press(getByTestId('unlock-all-cancel'));
+    expect(onToggleReveal).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(queryByTestId('unlock-all-confirm')).toBeNull();
+  });
+
+  it('locking (allRevealed true) fires onToggleReveal directly with no dialog', () => {
+    const onToggleReveal = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole, queryByTestId } = render(
+      <HabitsDrawer {...baseProps} allRevealed onToggleReveal={onToggleReveal} onClose={onClose} />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Lock Unstarted Habits' }));
+    expect(onToggleReveal).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('unlock-all-confirm')).toBeNull();
+  });
+});
+
+describe('HabitsDrawer pagination section', () => {
+  it('shows the stage range as the visible label with the page position folded into its accessibility label', () => {
+    const { getByText } = render(
+      <HabitsDrawer {...baseProps} page={0} pageCount={2} stageStart={1} stageEnd={10} />,
+    );
+    const label = getByText('Stages 1–10');
+    expect(label.props.accessibilityLabel).toBe('Stages 1 to 10, page 1 of 2');
+  });
+
+  it('shows the second-lap stage range and position', () => {
+    const { getByText } = render(
+      <HabitsDrawer {...baseProps} page={1} pageCount={2} stageStart={11} stageEnd={20} />,
+    );
+    const label = getByText('Stages 11–20');
+    expect(label.props.accessibilityLabel).toBe('Stages 11 to 20, page 2 of 2');
+  });
+
+  it('disables Prev on the first page and enables Next', () => {
+    const { getByLabelText } = render(<HabitsDrawer {...baseProps} page={0} pageCount={3} />);
+    expect(getByLabelText('Previous page').props.accessibilityState).toEqual({ disabled: true });
+    expect(getByLabelText('Next page').props.accessibilityState).toEqual({ disabled: false });
+  });
+
+  it('disables Next on the last page and enables Prev', () => {
+    const { getByLabelText } = render(<HabitsDrawer {...baseProps} page={2} pageCount={3} />);
+    expect(getByLabelText('Previous page').props.accessibilityState).toEqual({ disabled: false });
+    expect(getByLabelText('Next page').props.accessibilityState).toEqual({ disabled: true });
+  });
+
+  it('disables both Prev and Next when there is only one page', () => {
+    const { getByLabelText } = render(<HabitsDrawer {...baseProps} page={0} pageCount={1} />);
+    expect(getByLabelText('Previous page').props.accessibilityState).toEqual({ disabled: true });
+    expect(getByLabelText('Next page').props.accessibilityState).toEqual({ disabled: true });
+  });
+
+  it('Prev fires onPrev without closing the drawer', () => {
+    const onPrev = jest.fn();
+    const onClose = jest.fn();
+    const { getByLabelText } = render(
+      <HabitsDrawer {...baseProps} page={1} pageCount={3} onPrev={onPrev} onClose={onClose} />,
+    );
+    fireEvent.press(getByLabelText('Previous page'));
+    expect(onPrev).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Next fires onNext without closing the drawer', () => {
+    const onNext = jest.fn();
+    const onClose = jest.fn();
+    const { getByLabelText } = render(
+      <HabitsDrawer {...baseProps} page={0} pageCount={3} onNext={onNext} onClose={onClose} />,
+    );
+    fireEvent.press(getByLabelText('Next page'));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('HabitsDrawer pagination-bar visibility toggle', () => {
+  it('labels the toggle "Hide page controls" when the bar is visible', () => {
+    const { getByRole } = render(<HabitsDrawer {...baseProps} barVisible />);
+    expect(getByRole('button', { name: 'Hide page controls' })).toBeTruthy();
+  });
+
+  it('labels the toggle "Show page controls" when the bar is hidden', () => {
+    const { getByRole } = render(<HabitsDrawer {...baseProps} barVisible={false} />);
+    expect(getByRole('button', { name: 'Show page controls' })).toBeTruthy();
+  });
+
+  it('fires onToggleBarVisible without closing the drawer', () => {
+    const onToggleBarVisible = jest.fn();
+    const onClose = jest.fn();
+    const { getByRole } = render(
+      <HabitsDrawer
+        {...baseProps}
+        barVisible
+        onToggleBarVisible={onToggleBarVisible}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByRole('button', { name: 'Hide page controls' }));
+    expect(onToggleBarVisible).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Habits/hooks/__tests__/usePaginationBarVisibility.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/usePaginationBarVisibility.test.tsx
@@ -1,0 +1,79 @@
+// Pins the load-once, fail-open-visible, and toggle-persists-inverse contract
+// of the pagination-bar visibility hook, with its storage module mocked so the
+// tests never touch AsyncStorage.
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('../../../../storage/paginationVisibilityStorage', () => ({
+  loadPaginationBarHidden: jest.fn(() => Promise.resolve(false)),
+  savePaginationBarHidden: jest.fn(() => Promise.resolve(undefined)),
+}));
+
+import {
+  loadPaginationBarHidden,
+  savePaginationBarHidden,
+} from '../../../../storage/paginationVisibilityStorage';
+import { usePaginationBarVisibility } from '../usePaginationBarVisibility';
+
+const mockLoad = loadPaginationBarHidden as jest.MockedFunction<typeof loadPaginationBarHidden>;
+const mockSave = savePaginationBarHidden as jest.MockedFunction<typeof savePaginationBarHidden>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('usePaginationBarVisibility', () => {
+  it('defaults to visible before the persisted flag resolves', () => {
+    mockLoad.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePaginationBarVisibility());
+    expect(result.current.barVisible).toBe(true);
+  });
+
+  it('hides the bar once a persisted hidden flag resolves true', async () => {
+    mockLoad.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => usePaginationBarVisibility());
+    await waitFor(() => expect(result.current.barVisible).toBe(false));
+  });
+
+  it('stays visible once a persisted hidden flag resolves false', async () => {
+    mockLoad.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePaginationBarVisibility());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+    expect(result.current.barVisible).toBe(true);
+  });
+
+  it('toggling hides the bar and persists the matching hidden flag', async () => {
+    mockLoad.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePaginationBarVisibility());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.toggleBarVisible();
+    });
+
+    expect(result.current.barVisible).toBe(false);
+    expect(mockSave).toHaveBeenCalledWith(true);
+  });
+
+  it('toggling twice shows the bar again and persists hidden=false', async () => {
+    mockLoad.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => usePaginationBarVisibility());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.toggleBarVisible();
+    });
+    act(() => {
+      result.current.toggleBarVisible();
+    });
+
+    expect(result.current.barVisible).toBe(true);
+    expect(mockSave).toHaveBeenLastCalledWith(false);
+  });
+
+  it('loads the persisted flag exactly once per mount', async () => {
+    mockLoad.mockResolvedValueOnce(false);
+    renderHook(() => usePaginationBarVisibility());
+    await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/features/Habits/hooks/useModalCoordinator.ts
+++ b/frontend/src/features/Habits/hooks/useModalCoordinator.ts
@@ -33,16 +33,13 @@ const INITIAL_STATE: ModalState = {
 };
 
 export interface ModalCoordinator extends ModalState {
-  menu: boolean;
   open: (_name: ModalName) => void;
   close: (_name: ModalName) => void;
   closeAll: () => void;
-  toggleMenu: () => void;
 }
 
 export const useModalCoordinator = (): ModalCoordinator => {
   const [modals, setModals] = useState<ModalState>(INITIAL_STATE);
-  const [menu, setMenu] = useState(false);
 
   const open = useCallback((name: ModalName) => {
     // BUG-FE-HABIT-008: previously this resolved to ``{ [name]: true }``
@@ -53,7 +50,6 @@ export const useModalCoordinator = (): ModalCoordinator => {
     // modals when the UX requires it; callers that need exclusivity
     // call ``closeAll`` first.
     setModals((prev) => ({ ...prev, [name]: true }));
-    setMenu(false);
   }, []);
 
   const close = useCallback((name: ModalName) => {
@@ -62,19 +58,12 @@ export const useModalCoordinator = (): ModalCoordinator => {
 
   const closeAll = useCallback(() => {
     setModals(INITIAL_STATE);
-    setMenu(false);
-  }, []);
-
-  const toggleMenu = useCallback(() => {
-    setMenu((prev) => !prev);
   }, []);
 
   return {
     ...modals,
-    menu,
     open,
     close,
     closeAll,
-    toggleMenu,
   };
 };

--- a/frontend/src/features/Habits/hooks/usePaginationBarVisibility.ts
+++ b/frontend/src/features/Habits/hooks/usePaginationBarVisibility.ts
@@ -1,0 +1,45 @@
+// Owns the show/hide state of the in-body pagination bar. Defaults to visible,
+// loads the persisted flag once on mount, and persists the inverse on toggle so
+// the next launch honours the last choice.
+import { useEffect, useState } from 'react';
+
+import {
+  loadPaginationBarHidden,
+  savePaginationBarHidden,
+} from '../../../storage/paginationVisibilityStorage';
+
+export interface PaginationBarVisibility {
+  /** Whether the in-body pagination bar should render. */
+  barVisible: boolean;
+  /** Flip visibility and persist the matching hidden flag. */
+  toggleBarVisible: () => void;
+}
+
+/** Track pagination-bar visibility, hydrating from and writing back to storage. */
+export function usePaginationBarVisibility(): PaginationBarVisibility {
+  const [barVisible, setBarVisible] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    loadPaginationBarHidden()
+      .then((hidden) => {
+        if (mounted) setBarVisible(!hidden);
+      })
+      .catch(() => {
+        // loadPaginationBarHidden already fails open; nothing to recover here.
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const toggleBarVisible = (): void => {
+    setBarVisible((prev) => {
+      const next = !prev;
+      void savePaginationBarHidden(!next);
+      return next;
+    });
+  };
+
+  return { barVisible, toggleBarVisible };
+}

--- a/frontend/src/storage/__tests__/paginationVisibilityStorage.test.ts
+++ b/frontend/src/storage/__tests__/paginationVisibilityStorage.test.ts
@@ -1,0 +1,76 @@
+// RED: paginationVisibilityStorage does not exist yet -- this import fails
+// until the implementation-specialist adds the module (mirrors
+// reflectionDismissalStorage.ts, but a single global flag rather than a
+// per-scope one).
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { savePaginationBarHidden, loadPaginationBarHidden } from '../paginationVisibilityStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('paginationVisibilityStorage', () => {
+  describe('savePaginationBarHidden', () => {
+    test('stores "true" under the pagination-hidden key', async () => {
+      await savePaginationBarHidden(true);
+
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/habits_pagination_hidden',
+        'true',
+      );
+    });
+
+    test('stores "false" when the bar is shown again', async () => {
+      await savePaginationBarHidden(false);
+
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/habits_pagination_hidden',
+        'false',
+      );
+    });
+
+    test('swallows a write error instead of rejecting', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      mockAsyncStorage.setItem.mockRejectedValueOnce(new Error('disk full'));
+
+      await expect(savePaginationBarHidden(true)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('loadPaginationBarHidden', () => {
+    test('fails open to false (visible) when nothing is stored', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+      const result = await loadPaginationBarHidden();
+      expect(result).toBe(false);
+    });
+
+    test('returns true only when the stored value is exactly "true"', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+      const result = await loadPaginationBarHidden();
+      expect(result).toBe(true);
+    });
+
+    test('treats any non-"true" stored value as visible', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('false');
+      const result = await loadPaginationBarHidden();
+      expect(result).toBe(false);
+    });
+
+    test('fails open to false on a storage read error rather than throwing', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('storage error'));
+      await expect(loadPaginationBarHidden()).resolves.toBe(false);
+    });
+  });
+});

--- a/frontend/src/storage/paginationVisibilityStorage.ts
+++ b/frontend/src/storage/paginationVisibilityStorage.ts
@@ -1,0 +1,36 @@
+// Persists whether the Habits screen's in-body pagination bar is hidden. A
+// single global flag (toggled from the header drawer) so the choice survives
+// relaunches. Mirrors ``reflectionDismissalStorage.ts``, but global rather than
+// per-scope.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@adepthood/habits_pagination_hidden';
+const FLAG_TRUE = 'true';
+
+/**
+ * Record whether the pagination bar is hidden. A write failure is warned and
+ * swallowed (never rejects) so a flaky disk cannot surface as an unhandled
+ * rejection at the fire-and-forget call site; the in-memory toggle stands.
+ */
+export async function savePaginationBarHidden(hidden: boolean): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, String(hidden));
+  } catch (err) {
+    console.warn('[paginationVisibilityStorage] failed to save hidden flag', err);
+  }
+}
+
+/**
+ * Whether the pagination bar was previously hidden. A storage read failure
+ * resolves ``false`` (show the bar rather than crash) so a flaky disk never
+ * permanently strands the pagination controls out of view.
+ */
+export async function loadPaginationBarHidden(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[paginationVisibilityStorage] failed to load hidden flag', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Relocates the Habits header overflow (kebab) menu and the stage pager into the shared `ScreenDrawer`, retiring the in-body overflow menu.

- **HabitsDrawer** (`frontend/src/features/Habits/components/HabitsDrawer.tsx`) — hosts the five mode/action rows (Quick Log, Stats, Edit, Add Habit, Energy Scaffolding), the unlock-all confirm gate, the Prev/Next stage pager with its stage-range label, and a show/hide toggle for the in-body pagination bar.
- **usePaginationBarVisibility** + **paginationVisibilityStorage** — persist the pagination-bar show/hide choice across relaunches. Both read and write paths fail open (warn + swallow), so a flaky disk never crashes the app or strands the controls out of view.
- **HabitsScreen** — renders the drawer and deletes the now-dead overflow-menu component, styles (`topBar`/`overflowMenuContainer`/`mobileMenu`), and the `useModalCoordinator` menu state.

## Test plan

- `./scripts/frontend/check-all.sh` — 4/4 green (ESLint, Prettier, tsc, Jest: 372 suites / 3903 tests).
- New tests: `HabitsDrawer.test.tsx`, `usePaginationBarVisibility.test.tsx`, `paginationVisibilityStorage.test.ts` (including save-failure fail-open), `HabitsPaginationVisibility.test.tsx`, plus updates to the existing Habits suites for the removed overflow menu.
- Gate 2.5 code review (code-review-orchestrator): fixed the MAJOR (unhandled save rejection → try/catch + test) and both MINORs (removed dead `scale` prop; added `drawer-pagination-*` testIDs).

> **Coverage caveat:** the repo-wide Jest baseline is ~85% statements / 79.5% branches and is pre-existing; this change does not regress it. CI owns the coverage gate.

Closes #1467
Refs #1465