### PR TITLE
feat(practice): add header drawer for catalog, customize, and create navigation

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -36,6 +36,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse } from '@/api';
+import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
@@ -51,8 +52,11 @@ import {
   touchTarget,
 } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
-import ActiveRitualSession from '@/features/Practice/components/ActiveRitualSession';
+import ActiveRitualSession, {
+  type ActiveRitualSessionHandle,
+} from '@/features/Practice/components/ActiveRitualSession';
 import { FrequencyBanner } from '@/features/Practice/components/FrequencyBanner';
+import PracticeDrawer from '@/features/Practice/components/PracticeDrawer';
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
 import { useAppRoute } from '@/navigation/hooks';
@@ -111,7 +115,56 @@ const PracticeScreen = (): React.JSX.Element => {
   const handleWriteReflection = useWriteReflection(active.effectiveName, active.practice);
   const refreshSignal = useFocusRefresh(active.refresh);
   const { banner } = usePracticeChrome(stageNumber, refreshSignal);
+  const drawer = useScreenDrawer('Practice');
+  const sessionRef = useRef<ActiveRitualSessionHandle>(null);
 
+  const hasActivePractice = Boolean(
+    active.activeUserPractice && active.practice && active.effectiveConfig,
+  );
+
+  return (
+    <>
+      <PracticeBody
+        active={active}
+        userTimezone={userTimezone}
+        weekly={weekly}
+        onWriteReflection={handleWriteReflection}
+        banner={banner}
+        stageNumber={stageNumber}
+        sessionRef={sessionRef}
+      />
+      <PracticeScreenDrawer
+        drawer={drawer}
+        hasActivePractice={hasActivePractice}
+        stageNumber={stageNumber}
+        practiceId={active.practice?.id}
+        onCustomize={() => sessionRef.current?.openConfigurator()}
+      />
+    </>
+  );
+};
+
+interface PracticeBodyProps {
+  active: ActivePracticeHook;
+  userTimezone: string;
+  weekly: WeeklyProgressHook;
+  onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
+  banner: React.JSX.Element;
+  stageNumber: number;
+  sessionRef: React.Ref<ActiveRitualSessionHandle>;
+}
+
+// Selects the screen body for the current load state: a loading/error
+// placeholder, the active session, or the empty state when no practice is set.
+const PracticeBody = ({
+  active,
+  userTimezone,
+  weekly,
+  onWriteReflection,
+  banner,
+  stageNumber,
+  sessionRef,
+}: PracticeBodyProps): React.JSX.Element => {
   if (active.isLoading) return <LoadingView />;
   if (active.error && !active.activeUserPractice) {
     return <ErrorView error={active.error} onRetry={active.refresh} />;
@@ -129,16 +182,50 @@ const PracticeScreen = (): React.JSX.Element => {
           userTimezone={userTimezone}
           weekly={weekly}
           onUserPracticeUpdated={active.updateActivePractice}
-          onWriteReflection={handleWriteReflection}
+          onWriteReflection={onWriteReflection}
           banner={banner}
           stageNumber={stageNumber}
+          sessionRef={sessionRef}
         />
       </ContentContainer>
     );
   }
-
   return <EmptyStateView stageNumber={stageNumber} />;
 };
+
+interface PracticeScreenDrawerProps {
+  drawer: ScreenDrawerState;
+  hasActivePractice: boolean;
+  stageNumber: number;
+  practiceId?: number;
+  onCustomize: () => void;
+}
+
+// The header drawer: catalog/customize/details/create actions in the active
+// state, browse/create when empty. Kept as its own component so the screen's
+// render stays small and the drawer wiring lives in one place.
+const PracticeScreenDrawer = ({
+  drawer,
+  hasActivePractice,
+  stageNumber,
+  practiceId,
+  onCustomize,
+}: PracticeScreenDrawerProps): React.JSX.Element => (
+  <ScreenDrawer
+    visible={drawer.isOpen}
+    onClose={drawer.close}
+    screenName="Practice"
+    title="Practice"
+  >
+    <PracticeDrawer
+      hasActivePractice={hasActivePractice}
+      stageNumber={stageNumber}
+      practiceId={practiceId}
+      onCustomize={onCustomize}
+      onClose={drawer.close}
+    />
+  </ScreenDrawer>
+);
 
 interface CatalogButtonProps {
   stageNumber: number;
@@ -203,6 +290,7 @@ interface ActiveSessionViewProps {
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
   banner: React.JSX.Element;
   stageNumber: number;
+  sessionRef?: React.Ref<ActiveRitualSessionHandle>;
 }
 
 const ActiveSessionView = ({
@@ -216,6 +304,7 @@ const ActiveSessionView = ({
   onWriteReflection,
   banner,
   stageNumber,
+  sessionRef,
 }: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
@@ -240,6 +329,7 @@ const ActiveSessionView = ({
         />
         <ActiveRitualSession
           key={`practice-${userPractice.id}`}
+          ref={sessionRef}
           userPractice={userPractice}
           effectiveName={effectiveName ?? practiceName}
           effectiveConfig={effectiveConfig}

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { useSyncExternalStore, type ReactElement } from 'react';
 
 import type { FrequencyResponse, PracticeItem, UserPractice } from '../../../api';
 
@@ -97,8 +98,22 @@ jest.mock('../../../context/AuthContext', () => ({
 const mockNavigate = jest.fn();
 const mockRootNavigate = jest.fn();
 const mockRouteParams: Record<string, unknown> = {};
+// PracticeScreen installs its header-left drawer toggle through
+// useAppNavigation (useScreenDrawer), which calls navigation.setOptions in a
+// layout effect on every mount -- without this mock every existing test below
+// would crash reading setOptions off an undefined navigation object. The store
+// relays the installed headerLeft into the same render tree as the screen so
+// the Modal-based drawer opens in-tree and its rows are pressable.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
 jest.mock('../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate }),
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
   useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: mockRouteParams }),
 }));
 
@@ -159,6 +174,23 @@ jest.mock('expo-haptics', () => ({
 // eslint-disable-next-line import/order
 const { render, waitFor, fireEvent, act, within } = require('@testing-library/react-native');
 const PracticeScreen = require('../PracticeScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so the
+// drawer opens in-tree and its rows are pressable.
+const PracticeScreenWithHeader = (): ReactElement => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <PracticeScreen />
+    </>
+  );
+};
 
 interface ModeFixture {
   label: string;
@@ -278,6 +310,8 @@ describe('PracticeScreen', () => {
     mockFrequency.mockResolvedValue(sampleFrequency);
     mockUserPracticesCreate.mockResolvedValue(sampleUserPractice());
     mockNavigate.mockClear();
+    mockSetOptions.mockClear();
+    mockRootNavigate.mockClear();
   });
 
   it('shows loading indicator initially', async () => {
@@ -778,5 +812,80 @@ describe('PracticeScreen', () => {
 
     const container = getByTestId('content-container');
     expect(within(container).getByTestId('practice-screen')).toBeTruthy();
+  });
+});
+
+describe('PracticeScreen header drawer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    mockFocusCallbacks.length = 0;
+    mockPracticesList.mockResolvedValue([samplePractice()]);
+    mockUserPracticesList.mockResolvedValue([]);
+    mockWeekCount.mockResolvedValue({ count: 2 });
+    mockInsights.mockRejectedValue(new Error('insights unavailable'));
+    mockFrequency.mockResolvedValue(sampleFrequency);
+    mockUserPracticesCreate.mockResolvedValue(sampleUserPractice());
+    mockNavigate.mockClear();
+    mockSetOptions.mockClear();
+    mockRootNavigate.mockClear();
+  });
+
+  it('opens the drawer and shows the full active-state row set, alongside the unchanged in-body controls', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, getByLabelText } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
+    expect(getByTestId('practice-drawer-change')).toBeTruthy();
+    expect(getByTestId('practice-drawer-browse')).toBeTruthy();
+    expect(getByTestId('practice-drawer-customize')).toBeTruthy();
+    expect(getByTestId('practice-drawer-details')).toBeTruthy();
+    expect(getByTestId('practice-drawer-create')).toBeTruthy();
+    // The in-body CatalogButton is not replaced by the drawer's rows.
+    expect(getByTestId('change-practice-button')).toBeTruthy();
+  });
+
+  it('opens the drawer and shows only the browse/create rows when there is no active practice, alongside the unchanged in-body CTA', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
+    expect(getByTestId('practice-drawer-browse')).toBeTruthy();
+    expect(getByTestId('practice-drawer-create')).toBeTruthy();
+    expect(queryByTestId('practice-drawer-change')).toBeNull();
+    expect(queryByTestId('practice-drawer-customize')).toBeNull();
+    expect(queryByTestId('practice-drawer-details')).toBeNull();
+    // The in-body empty-state CTA is not replaced by the drawer's rows.
+    expect(getByTestId('browse-catalog-button')).toBeTruthy();
+  });
+
+  it('pressing the drawer "Customize this practice" row opens the same configurator sheet as the gear', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, getByLabelText } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+    await act(async () => {
+      fireEvent.press(getByTestId('practice-drawer-customize'));
+    });
+
+    expect(getByTestId('ritual-configurator-sheet')).toBeTruthy();
+  });
+
+  it('pressing the drawer "Create a practice" row navigates via the root stack navigator', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, getByLabelText } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+    fireEvent.press(getByTestId('practice-drawer-create'));
+
+    expect(mockRootNavigate).toHaveBeenCalledWith('CreatePractice');
   });
 });

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -27,7 +27,15 @@
  *     tactile feedback and audible bells.
  */
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type {
@@ -121,38 +129,46 @@ interface ActiveSession {
   ) => Promise<void>;
 }
 
-export function ActiveRitualSession(props: ActiveRitualSessionProps): React.JSX.Element {
-  const [showConfigurator, setShowConfigurator] = useState(false);
-  const session = useActiveSession(props);
-  return (
-    <View testID="active-ritual-session">
-      <SessionCard
-        effectiveName={props.effectiveName}
-        onConfigure={() => setShowConfigurator(true)}
-        config={props.effectiveConfig}
-        state={session.state}
-        controls={session.controls}
-        tarotCardIndex={session.tarotCardIndex}
-        cardPick={session.cardPick}
-        onMindfulAnchorComplete={session.onMindfulAnchorComplete}
-        saveError={session.saveError}
-        onRandomBellMetadata={session.onRandomBellMetadata}
-      />
-      <RitualConfiguratorSheet
-        visible={showConfigurator}
-        userPracticeId={props.userPractice.id}
-        initialName={props.effectiveName}
-        initialConfig={props.effectiveConfig}
-        onClose={() => setShowConfigurator(false)}
-        onSaved={(next) => {
-          props.onUserPracticeUpdated(next);
-          setShowConfigurator(false);
-        }}
-      />
-      <SessionInsightModal session={session} onWriteReflection={props.onWriteReflection} />
-    </View>
-  );
+/** Imperative surface: lets a parent open the configurator sheet (e.g. from a header drawer). */
+export interface ActiveRitualSessionHandle {
+  openConfigurator: () => void;
 }
+
+export const ActiveRitualSession = forwardRef<ActiveRitualSessionHandle, ActiveRitualSessionProps>(
+  function ActiveRitualSession(props, ref): React.JSX.Element {
+    const [showConfigurator, setShowConfigurator] = useState(false);
+    const session = useActiveSession(props);
+    useImperativeHandle(ref, () => ({ openConfigurator: () => setShowConfigurator(true) }), []);
+    return (
+      <View testID="active-ritual-session">
+        <SessionCard
+          effectiveName={props.effectiveName}
+          onConfigure={() => setShowConfigurator(true)}
+          config={props.effectiveConfig}
+          state={session.state}
+          controls={session.controls}
+          tarotCardIndex={session.tarotCardIndex}
+          cardPick={session.cardPick}
+          onMindfulAnchorComplete={session.onMindfulAnchorComplete}
+          saveError={session.saveError}
+          onRandomBellMetadata={session.onRandomBellMetadata}
+        />
+        <RitualConfiguratorSheet
+          visible={showConfigurator}
+          userPracticeId={props.userPractice.id}
+          initialName={props.effectiveName}
+          initialConfig={props.effectiveConfig}
+          onClose={() => setShowConfigurator(false)}
+          onSaved={(next) => {
+            props.onUserPracticeUpdated(next);
+            setShowConfigurator(false);
+          }}
+        />
+        <SessionInsightModal session={session} onWriteReflection={props.onWriteReflection} />
+      </View>
+    );
+  },
+);
 
 interface SessionInsightModalProps {
   session: ActiveSession;

--- a/frontend/src/features/Practice/components/PracticeDrawer.tsx
+++ b/frontend/src/features/Practice/components/PracticeDrawer.tsx
@@ -1,0 +1,106 @@
+/**
+ * The Practice header-drawer body, rendered as ScreenDrawer children. Offers the
+ * catalog/customize/details/create actions in the active state and a pared-down
+ * browse/create pair when no practice is set for the stage.
+ */
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Compass, Info, Plus, RefreshCw, SlidersHorizontal } from 'lucide-react-native';
+import React from 'react';
+import { View } from 'react-native';
+
+import { DrawerItem } from '@/components/drawer';
+import { accent } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+/** Lucide glyph size in dp for the drawer's row icons. */
+const ICON_SIZE = 20;
+
+export interface PracticeDrawerProps {
+  hasActivePractice: boolean;
+  stageNumber: number;
+  practiceId?: number;
+  onCustomize: () => void;
+  onClose: () => void;
+}
+
+interface DrawerRow {
+  testID: string;
+  label: string;
+  Icon: typeof RefreshCw;
+  run: () => void;
+}
+
+/**
+ * Builds the ordered rows for the current state. The active state exposes the
+ * full set (change/browse/customize/details/create); the empty state offers only
+ * browse and create. "Practice details" appears only when a practiceId resolves.
+ */
+function usePracticeRows({
+  hasActivePractice,
+  stageNumber,
+  practiceId,
+  onCustomize,
+}: Omit<PracticeDrawerProps, 'onClose'>): DrawerRow[] {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const browse: DrawerRow = {
+    testID: 'practice-drawer-browse',
+    label: 'Browse all practices',
+    Icon: Compass,
+    run: () => navigation.navigate('Catalog', { stageNumber }),
+  };
+  const create: DrawerRow = {
+    testID: 'practice-drawer-create',
+    label: 'Create a practice',
+    Icon: Plus,
+    run: () => navigation.navigate('CreatePractice'),
+  };
+  if (!hasActivePractice) return [browse, create];
+  const rows: DrawerRow[] = [
+    {
+      testID: 'practice-drawer-change',
+      label: 'Change practice',
+      Icon: RefreshCw,
+      run: () => navigation.navigate('Catalog', { stageNumber }),
+    },
+    browse,
+    {
+      testID: 'practice-drawer-customize',
+      label: 'Customize this practice',
+      Icon: SlidersHorizontal,
+      run: onCustomize,
+    },
+  ];
+  if (practiceId !== undefined) {
+    rows.push({
+      testID: 'practice-drawer-details',
+      label: 'Practice details',
+      Icon: Info,
+      run: () => navigation.navigate('PracticeDetail', { practiceId }),
+    });
+  }
+  rows.push(create);
+  return rows;
+}
+
+/** The Practice header-drawer body: state-conditioned action rows. */
+export default function PracticeDrawer(props: PracticeDrawerProps): React.JSX.Element {
+  const { onClose } = props;
+  const rows = usePracticeRows(props);
+  return (
+    <View>
+      {rows.map((row) => (
+        <DrawerItem
+          key={row.testID}
+          testID={row.testID}
+          label={row.label}
+          icon={<row.Icon size={ICON_SIZE} color={accent.primary} />}
+          onPress={() => {
+            row.run();
+            onClose();
+          }}
+        />
+      ))}
+    </View>
+  );
+}

--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.handle.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.handle.test.tsx
@@ -1,0 +1,56 @@
+// RED: ActiveRitualSession is not yet a forwardRef component and does not
+// export ActiveRitualSessionHandle -- both fail to compile/resolve until the
+// implementation-specialist adds openConfigurator() via useImperativeHandle.
+import { describe, expect, it } from '@jest/globals';
+import { act, render } from '@testing-library/react-native';
+import React, { createRef } from 'react';
+
+import type { UserPractice } from '@/api';
+import ActiveRitualSession, {
+  type ActiveRitualSessionHandle,
+} from '@/features/Practice/components/ActiveRitualSession';
+import type { MeditationTimerConfig } from '@/features/Practice/engine/types';
+
+const userPractice: UserPractice = {
+  id: 10,
+  practice_id: 1,
+  stage_number: 1,
+  start_date: '2026-04-12',
+  end_date: null,
+};
+
+const config: MeditationTimerConfig = {
+  mode: 'meditation_timer',
+  duration_minutes: 10,
+  halfway_bell: true,
+};
+
+function renderSession(ref: React.Ref<ActiveRitualSessionHandle>) {
+  return render(
+    <ActiveRitualSession
+      ref={ref}
+      userPractice={userPractice}
+      effectiveName="Breath Awareness"
+      effectiveConfig={config}
+      userTimezone="UTC"
+      onSessionApply={() => {}}
+      onSessionRollback={() => {}}
+      onSessionCommitted={() => {}}
+      onUserPracticeUpdated={() => {}}
+      onWriteReflection={() => {}}
+    />,
+  );
+}
+
+describe('ActiveRitualSession imperative handle', () => {
+  it('opens the configurator sheet when openConfigurator is called via ref', () => {
+    const ref = createRef<ActiveRitualSessionHandle>();
+    const { getByTestId } = renderSession(ref);
+
+    act(() => {
+      ref.current?.openConfigurator();
+    });
+
+    expect(getByTestId('ritual-configurator-sheet')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Practice/components/__tests__/PracticeDrawer.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/PracticeDrawer.test.tsx
@@ -1,0 +1,141 @@
+// RED: PracticeDrawer does not exist yet -- this import fails until the
+// implementation-specialist adds the component. Specifies the Practice-tab
+// header-drawer body: catalog/customize/details/create rows for the active
+// state, and the pared-down browse/create pair for the no-active-practice
+// state.
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+// eslint-disable-next-line import/order
+const { fireEvent, render } = require('@testing-library/react-native');
+const PracticeDrawer = require('../PracticeDrawer').default;
+
+const noop = (..._args: unknown[]): void => {};
+
+const activeProps = {
+  hasActivePractice: true,
+  stageNumber: 3,
+  practiceId: 7,
+  onCustomize: noop,
+  onClose: noop,
+};
+
+const emptyProps = {
+  hasActivePractice: false,
+  stageNumber: 3,
+  onCustomize: noop,
+  onClose: noop,
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PracticeDrawer active state', () => {
+  it('renders the five active-state rows in order', () => {
+    const { getAllByRole } = render(<PracticeDrawer {...activeProps} />);
+    const rows = getAllByRole('button');
+    const labels = rows.map(
+      (r: { props: { accessibilityLabel: string } }) => r.props.accessibilityLabel,
+    );
+    expect(labels).toEqual([
+      'Change practice',
+      'Browse all practices',
+      'Customize this practice',
+      'Practice details',
+      'Create a practice',
+    ]);
+  });
+
+  it('pressing "Change practice" navigates to Catalog with the stage and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<PracticeDrawer {...activeProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('practice-drawer-change'));
+    expect(mockNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 3 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing "Browse all practices" navigates to Catalog with the stage and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<PracticeDrawer {...activeProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('practice-drawer-browse'));
+    expect(mockNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 3 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing "Customize this practice" calls onCustomize and closes the drawer', () => {
+    const onCustomize = jest.fn();
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <PracticeDrawer {...activeProps} onCustomize={onCustomize} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('practice-drawer-customize'));
+    expect(onCustomize).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('pressing "Practice details" navigates to PracticeDetail with the practiceId and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <PracticeDrawer {...activeProps} practiceId={42} onClose={onClose} />,
+    );
+    fireEvent.press(getByTestId('practice-drawer-details'));
+    expect(mockNavigate).toHaveBeenCalledWith('PracticeDetail', { practiceId: 42 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing "Create a practice" navigates to CreatePractice and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<PracticeDrawer {...activeProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('practice-drawer-create'));
+    expect(mockNavigate).toHaveBeenCalledWith('CreatePractice');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits "Practice details" when practiceId is undefined', () => {
+    const { queryByTestId } = render(<PracticeDrawer {...activeProps} practiceId={undefined} />);
+    expect(queryByTestId('practice-drawer-details')).toBeNull();
+  });
+
+  it('gives each row an accessibility label matching its visible text', () => {
+    const { getByLabelText, getByText } = render(<PracticeDrawer {...activeProps} />);
+    expect(getByLabelText('Customize this practice')).toBeTruthy();
+    expect(getByText('Customize this practice')).toBeTruthy();
+  });
+});
+
+describe('PracticeDrawer empty state (no active practice)', () => {
+  it('renders exactly the browse and create rows, and no active-only rows', () => {
+    const { getAllByRole, queryByTestId } = render(<PracticeDrawer {...emptyProps} />);
+    const rows = getAllByRole('button');
+    const labels = rows.map(
+      (r: { props: { accessibilityLabel: string } }) => r.props.accessibilityLabel,
+    );
+    expect(labels).toEqual(['Browse all practices', 'Create a practice']);
+    expect(queryByTestId('practice-drawer-change')).toBeNull();
+    expect(queryByTestId('practice-drawer-customize')).toBeNull();
+    expect(queryByTestId('practice-drawer-details')).toBeNull();
+  });
+
+  it('pressing "Browse all practices" navigates to Catalog with the stage and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<PracticeDrawer {...emptyProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('practice-drawer-browse'));
+    expect(mockNavigate).toHaveBeenCalledWith('Catalog', { stageNumber: 3 });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('pressing "Create a practice" navigates to CreatePractice and closes the drawer', () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(<PracticeDrawer {...emptyProps} onClose={onClose} />);
+    fireEvent.press(getByTestId('practice-drawer-create'));
+    expect(mockNavigate).toHaveBeenCalledWith('CreatePractice');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
+++ b/frontend/src/features/Practice/views/__tests__/calmSurfaceMigration.test.tsx
@@ -90,7 +90,7 @@ jest.mock('@react-navigation/native', () => {
 });
 
 jest.mock('../../../../navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: jest.fn() }),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
   useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: {} }),
 }));
 


### PR DESCRIPTION
## Summary

Adds the shared `ScreenDrawer` (from `@/components/drawer`, epic #1465) to the Practice tab via a header hamburger, left of the "Practice" title. This gives one consistent panel for practice navigation instead of scattered in-scroll buttons and nested sheets.

- **Active practice** — the drawer offers: **Change practice** (`Catalog`, seeded to the current stage), **Browse all practices** (same catalog), **Customize this practice** (opens the existing configurator sheet), **Practice details** (`PracticeDetail`, shown only when a `practiceId` resolves), and **Create a practice** (`CreatePractice`).
- **No active practice** — the drawer pares down to **Browse all practices** + **Create a practice**.
- Every row is a11y-labelled and closes the drawer on selection; the toggle announces its expanded state.

### Design notes
- **Customize wiring (Option A):** rather than lift the configurator's open-state into the screen (a controlled/uncontrolled hybrid) or fall back to navigating to `PracticeDetail` (redundant with the "Practice details" row), `ActiveRitualSession` now exposes an optional `openConfigurator()` handle via `forwardRef`/`useImperativeHandle`. The drawer's "Customize" and the in-session gear converge on the *same* `showConfigurator` sheet. The engine/mode dispatch is untouched; existing ref-less consumers/tests are unaffected.
- **In-body buttons kept:** the existing `change-practice-button` and `browse-catalog-button` `CatalogButton`s remain. Per #1468's acceptance criteria, removing them is a separate declutter decision — this change only *adds* navigation paths.
- The screen shell stays thin: drawer state lives in the shared `useScreenDrawer('Practice')` hook, the body-branch selection is extracted into a `PracticeBody` component, and the drawer body lives in a new `PracticeDrawer` component (mirrors the `HabitsDrawer` house pattern).

## Test plan
- New `PracticeDrawer` unit tests: active state renders all rows in order; empty state renders only browse + create; each row fires its navigation/`onCustomize` action then closes; the details row is omitted when `practiceId` is undefined; a11y labels present.
- New `ActiveRitualSession` handle test: `ref.openConfigurator()` opens the configurator sheet.
- `PracticeScreen` integration tests (in-tree headerLeft harness): the hamburger opens the drawer in both the active and empty states with the correct row sets, the in-body `CatalogButton`s survive, the drawer's "Customize" opens the same configurator sheet as the gear, and "Create a practice" routes through the root stack navigator.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and all 3919 Jest tests pass.

Closes #1468
Refs #1465 (epic — do not close)