### PR TITLE
feat(course): Course screen drawer with stage-grouped chapter list

### DIFF
--- a/frontend/src/features/Course/CourseDrawer.tsx
+++ b/frontend/src/features/Course/CourseDrawer.tsx
@@ -1,0 +1,385 @@
+/**
+ * The Course header-drawer body: a stage-grouped table of contents rendered as
+ * ``ScreenDrawer`` children (the panel already supplies the scroll surface, so
+ * this maps plain sections rather than nesting its own list).
+ *
+ * Chapter content for each unlocked stage is fetched lazily and independently
+ * the first time the drawer opens, cached across reopens, and a per-section
+ * failure surfaces an inline retry row instead of blanking that stage while its
+ * siblings keep their chapters (audit-ux-04 pattern).
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+import { course as courseApi, type ContentItem, type Stage } from '../../api';
+import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
+
+import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
+
+/** Glyph shown on a completed stage header. */
+const COMPLETED_GLYPH = '✓';
+/** Glyph shown on a locked stage header or chapter row. */
+const LOCKED_GLYPH = '🔒';
+/** Copy for the inline per-section retry row after a failed fetch. */
+const RETRY_LABEL = 'Content failed to load. Tap to retry.';
+/** Dim factor applied to a locked chapter row. */
+const LOCKED_ROW_OPACITY = 0.5;
+
+/** Load state for one stage's chapter list within the drawer. */
+type DrawerSection =
+  | { readonly status: 'loading' }
+  | { readonly status: 'loaded'; readonly items: ContentItem[] }
+  | { readonly status: 'error' };
+
+/** Per-stage-number load state, keyed by stage number. */
+export type DrawerSections = Readonly<Record<number, DrawerSection | undefined>>;
+
+/**
+ * Lazily load each unlocked stage's chapters the first time the drawer opens,
+ * caching the results so reopening never refetches. Each stage loads on its own
+ * promise so a slow or failing stage never blocks its siblings, and a per-stage
+ * sequence guard drops stale responses (unmount or a retry supersedes them).
+ *
+ * This hook lives above the drawer panel (which unmounts when closed) so its
+ * cache survives close/reopen. It assumes ``stages`` is effectively static for
+ * the life of the mount: the first open latches the set of stages to load, so a
+ * stage that becomes unlocked afterward would need a remount to fetch.
+ */
+export function useCourseDrawerContent(
+  stages: Stage[],
+  isOpen: boolean,
+): { sections: DrawerSections; retry: (_stageNumber: number) => void } {
+  const [sections, setSections] = useState<Record<number, DrawerSection>>({});
+  const requestSeq = useRef<Record<number, number>>({});
+  const mountedRef = useRef(true);
+  const hasOpened = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const loadStage = useCallback((stageNumber: number) => {
+    const seq = (requestSeq.current[stageNumber] ?? 0) + 1;
+    requestSeq.current[stageNumber] = seq;
+    const isLatest = (): boolean => mountedRef.current && requestSeq.current[stageNumber] === seq;
+    setSections((prev) => ({ ...prev, [stageNumber]: { status: 'loading' } }));
+    void courseApi
+      .stageContentAll(stageNumber)
+      .then((items) => {
+        if (isLatest()) {
+          setSections((prev) => ({ ...prev, [stageNumber]: { status: 'loaded', items } }));
+        }
+      })
+      .catch((err: unknown) => {
+        // A per-section failure must not blank the drawer: flag only this stage
+        // so it shows an inline retry while siblings keep their chapters.
+        console.error('Failed to load drawer stage content:', err);
+        if (isLatest()) {
+          setSections((prev) => ({ ...prev, [stageNumber]: { status: 'error' } }));
+        }
+      });
+  }, []);
+
+  const unlockedStageNumbers = useMemo(
+    () => stages.filter((s) => s.is_unlocked).map((s) => s.stage_number),
+    [stages],
+  );
+
+  useEffect(() => {
+    if (!isOpen || hasOpened.current) return;
+    hasOpened.current = true;
+    for (const stageNumber of unlockedStageNumbers) {
+      loadStage(stageNumber);
+    }
+  }, [isOpen, unlockedStageNumbers, loadStage]);
+
+  return { sections, retry: loadStage };
+}
+
+/** Resolve the status glyph for a stage header, or null for an open stage. */
+function headerGlyph(unlocked: boolean, completed: boolean): string | null {
+  if (completed) return COMPLETED_GLYPH;
+  if (!unlocked) return LOCKED_GLYPH;
+  return null;
+}
+
+interface StageHeaderProps {
+  stageNumber: number;
+  title: string;
+  color: string;
+  unlocked: boolean;
+  completed: boolean;
+  isSelected: boolean;
+}
+
+/** A stage's colored section header, marked completed / locked / selected. */
+const StageHeader = ({
+  stageNumber,
+  title,
+  color,
+  unlocked,
+  completed,
+  isSelected,
+}: StageHeaderProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const glyph = headerGlyph(unlocked, completed);
+  return (
+    <View
+      testID={`course-drawer-stage-${stageNumber}`}
+      accessibilityState={{ disabled: !unlocked, selected: isSelected }}
+      style={[styles.stageHeader, { backgroundColor: color }]}
+    >
+      <Text style={[type(width).label, styles.stageHeaderTitle]} numberOfLines={1}>
+        {title}
+      </Text>
+      {glyph === null ? null : (
+        <Text style={[type(width).body, styles.stageHeaderGlyph]}>{glyph}</Text>
+      )}
+    </View>
+  );
+};
+
+interface ChapterRowProps {
+  stageNumber: number;
+  item: ContentItem;
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+}
+
+/** A single chapter row; a locked chapter is disabled and non-navigable. */
+const ChapterRow = ({ stageNumber, item, onChapterPress }: ChapterRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const locked = item.is_locked;
+  return (
+    <TouchableOpacity
+      testID={`course-drawer-chapter-${item.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={locked ? `${item.title}, locked` : item.title}
+      accessibilityState={{ disabled: locked }}
+      disabled={locked}
+      onPress={() => {
+        if (locked) return;
+        onChapterPress(stageNumber, item);
+      }}
+      style={[styles.chapterRow, locked && styles.chapterRowLocked]}
+    >
+      <Text style={[type(width).body, styles.chapterRowLabel]} numberOfLines={1}>
+        {item.title}
+      </Text>
+      {locked ? <Text style={styles.chapterRowGlyph}>{LOCKED_GLYPH}</Text> : null}
+    </TouchableOpacity>
+  );
+};
+
+interface RetryRowProps {
+  stageNumber: number;
+  onRetry: (_stageNumber: number) => void;
+}
+
+/** Inline retry affordance shown when a single stage's fetch failed. */
+const RetryRow = ({ stageNumber, onRetry }: RetryRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  return (
+    <TouchableOpacity
+      testID={`course-drawer-retry-${stageNumber}`}
+      accessibilityRole="button"
+      accessibilityLabel={`Retry loading stage ${stageNumber}`}
+      onPress={() => onRetry(stageNumber)}
+      style={styles.retryRow}
+    >
+      <Text style={[type(width).body, styles.retryRowText]}>{RETRY_LABEL}</Text>
+    </TouchableOpacity>
+  );
+};
+
+interface StageSectionBodyProps {
+  stageNumber: number;
+  section: DrawerSection | undefined;
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+  onRetry: (_stageNumber: number) => void;
+}
+
+/** The rows below an unlocked stage header: chapters, a retry, or a spinner. */
+const StageSectionBody = ({
+  stageNumber,
+  section,
+  onChapterPress,
+  onRetry,
+}: StageSectionBodyProps): React.JSX.Element => {
+  if (section?.status === 'error') {
+    return <RetryRow stageNumber={stageNumber} onRetry={onRetry} />;
+  }
+  if (section?.status === 'loaded') {
+    return (
+      <View>
+        {section.items.map((item) => (
+          <ChapterRow
+            key={item.id}
+            stageNumber={stageNumber}
+            item={item}
+            onChapterPress={onChapterPress}
+          />
+        ))}
+      </View>
+    );
+  }
+  return (
+    <ActivityIndicator
+      testID={`course-drawer-loading-${stageNumber}`}
+      size="small"
+      color={accent.primary}
+      style={styles.sectionLoading}
+    />
+  );
+};
+
+interface StageSectionProps {
+  stageNumber: number;
+  stageById: Map<number, Stage>;
+  section: DrawerSection | undefined;
+  isSelected: boolean;
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+  onRetry: (_stageNumber: number) => void;
+}
+
+/** One stage: a header plus, when unlocked, its lazily-loaded chapter rows. */
+const StageSection = ({
+  stageNumber,
+  stageById,
+  section,
+  isSelected,
+  onChapterPress,
+  onRetry,
+}: StageSectionProps): React.JSX.Element => {
+  const unlocked = isUnlocked(stageNumber, stageById);
+  const completed = isCompleted(stageNumber, stageById);
+  const title = stageById.get(stageNumber)?.title ?? `Stage ${stageNumber}`;
+  return (
+    <View style={styles.section}>
+      <StageHeader
+        stageNumber={stageNumber}
+        title={title}
+        color={getStageColor(stageNumber, stageById)}
+        unlocked={unlocked}
+        completed={completed}
+        isSelected={isSelected}
+      />
+      {unlocked ? (
+        <StageSectionBody
+          stageNumber={stageNumber}
+          section={section}
+          onChapterPress={onChapterPress}
+          onRetry={onRetry}
+        />
+      ) : null}
+    </View>
+  );
+};
+
+export interface CourseDrawerProps {
+  /** Every stage in the course; the drawer renders one section per stage. */
+  stages: Stage[];
+  /** The stage currently shown on the screen, marked selected in the list. */
+  selectedStage: number;
+  /** Per-stage chapter load state, owned by :func:`useCourseDrawerContent`. */
+  sections: DrawerSections;
+  /** Select a stage, open the chapter, and close the drawer. */
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+  /** Refetch a single failed stage's chapters. */
+  onRetry: (_stageNumber: number) => void;
+}
+
+/** The stage-grouped table of contents for the Course header drawer. */
+export default function CourseDrawer({
+  stages,
+  selectedStage,
+  sections,
+  onChapterPress,
+  onRetry,
+}: CourseDrawerProps): React.JSX.Element {
+  const stageById = useMemo(() => new Map(stages.map((s) => [s.stage_number, s])), [stages]);
+  const stageNumbers = Array.from({ length: totalStageCount(stages) }, (_, i) => i + 1);
+  return (
+    <View testID="course-drawer">
+      {stageNumbers.map((stageNumber) => (
+        <StageSection
+          key={stageNumber}
+          stageNumber={stageNumber}
+          stageById={stageById}
+          section={sections[stageNumber]}
+          isSelected={stageNumber === selectedStage}
+          onChapterPress={onChapterPress}
+          onRetry={onRetry}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: SPACING.sm,
+  },
+  stageHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+    marginTop: SPACING.sm,
+    borderRadius: radius.sm,
+  },
+  stageHeaderTitle: {
+    flex: 1,
+    color: surface.canvas,
+    fontWeight: '700',
+  },
+  stageHeaderGlyph: {
+    color: surface.canvas,
+  },
+  sectionLoading: {
+    alignSelf: 'flex-start',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+  },
+  chapterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  chapterRowLocked: {
+    opacity: LOCKED_ROW_OPACITY,
+  },
+  chapterRowLabel: {
+    flex: 1,
+    color: ink.primary,
+  },
+  chapterRowGlyph: {
+    color: ink.muted,
+  },
+  retryRow: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  retryRowText: {
+    color: accent.primary,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -12,6 +12,7 @@ import {
   type SiteResource,
   type Stage,
 } from '../../api';
+import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '../../components/drawer';
 import { Celebration } from '../../components/feedback/Celebration';
 import { EmptyState } from '../../components/feedback/EmptyState';
 import { ContentContainer } from '../../components/layout/ContentContainer';
@@ -28,6 +29,7 @@ import ChapterReader from './ChapterReader';
 import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
+import CourseDrawer, { useCourseDrawerContent } from './CourseDrawer';
 import SiteResourcesPanel from './SiteResourcesPanel';
 import StageIntroCard from './StageIntroCard';
 import StageSelector from './StageSelector';
@@ -478,17 +480,73 @@ const StagePanel = ({
   );
 };
 
-const CourseScreen = (): React.JSX.Element => {
-  const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
-  const stageContent = useStageContent(selectedStage, allStages.length > 0);
-  const viewer = useCourseViewer(selectedStage);
+interface CourseScreenDrawerProps {
+  drawer: ScreenDrawerState;
+  stages: Stage[];
+  selectedStage: number;
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+}
 
+/** The Course header drawer: a stage-grouped table of contents whose chapter
+ *  content loads lazily above the panel so the cache survives close/reopen. */
+const CourseScreenDrawer = ({
+  drawer,
+  stages,
+  selectedStage,
+  onChapterPress,
+}: CourseScreenDrawerProps): React.JSX.Element => {
+  const { sections, retry } = useCourseDrawerContent(stages, drawer.isOpen);
+  return (
+    <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Course" title="Course">
+      <CourseDrawer
+        stages={stages}
+        selectedStage={selectedStage}
+        sections={sections}
+        onChapterPress={onChapterPress}
+        onRetry={retry}
+      />
+    </ScreenDrawer>
+  );
+};
+
+/** Stage-selector and drawer navigation callbacks. A drawer chapter tap switches
+ *  to that chapter's stage, opens the reader (``handleContentPress`` already
+ *  guards locked items — never a raw ``setViewingItem`` that would bypass the
+ *  lock check), then closes the drawer. */
+function useCourseNavigation(
+  setSelectedStage: (_stageNumber: number) => void,
+  viewer: ReturnType<typeof useCourseViewer>,
+  drawer: ScreenDrawerState,
+) {
   const handleStageSelect = useCallback(
     (stageNumber: number) => {
       setSelectedStage(stageNumber);
       viewer.setViewingItem(null);
     },
     [setSelectedStage, viewer],
+  );
+
+  const handleChapterPress = useCallback(
+    (stageNumber: number, item: ContentItem) => {
+      setSelectedStage(stageNumber);
+      viewer.handleContentPress(item);
+      drawer.close();
+    },
+    [setSelectedStage, viewer, drawer],
+  );
+
+  return { handleStageSelect, handleChapterPress };
+}
+
+const CourseScreen = (): React.JSX.Element => {
+  const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
+  const stageContent = useStageContent(selectedStage, allStages.length > 0);
+  const viewer = useCourseViewer(selectedStage);
+  const drawer = useScreenDrawer('Course');
+  const { handleStageSelect, handleChapterPress } = useCourseNavigation(
+    setSelectedStage,
+    viewer,
+    drawer,
   );
 
   const overlay = renderOverlay(viewer, stageContent.handleMarkRead);
@@ -523,6 +581,12 @@ const CourseScreen = (): React.JSX.Element => {
           selectedStageData={selectedStageData}
           stageContent={stageContent}
           viewer={viewer}
+        />
+        <CourseScreenDrawer
+          drawer={drawer}
+          stages={allStages}
+          selectedStage={selectedStage}
+          onChapterPress={handleChapterPress}
         />
       </ContentContainer>
     </SafeAreaView>

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -2,40 +2,14 @@ import React from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
 import type { Stage } from '../../api';
-import { STAGE_ORDER, resolveStageColor } from '../../design/tokens';
 
 import styles from './Course.styles';
-
-/** Derive the total number of stage pills from the API response. */
-function totalStageCount(stages: Stage[]): number {
-  if (stages.length === 0) return 0;
-  return Math.max(...stages.map((s) => s.stage_number));
-}
+import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
 
 interface StageSelectorProps {
   stages: Stage[];
   selectedStage: number;
   onSelectStage: (_stageNumber: number) => void;
-}
-
-/** Get the spiral dynamics color for a stage number (1-indexed). */
-function getStageColor(stageNumber: number, stageById: Map<number, Stage>): string {
-  // Prefer the stage's own API color; fall back to its progression-order name
-  // when the API omits that stage number. The shared resolver handles the
-  // neutral fallback for missing or unrecognized names.
-  const name = stageById.get(stageNumber)?.spiral_dynamics_color ?? STAGE_ORDER[stageNumber - 1];
-  return resolveStageColor(name);
-}
-
-/** Determine if a stage is unlocked based on API data. */
-function isUnlocked(stageNumber: number, stageById: Map<number, Stage>): boolean {
-  return stageById.get(stageNumber)?.is_unlocked ?? false;
-}
-
-/** Determine if a stage has been completed (progress === 1.0). */
-function isCompleted(stageNumber: number, stageById: Map<number, Stage>): boolean {
-  const stage = stageById.get(stageNumber);
-  return stage != null && stage.progress >= 1.0;
 }
 
 interface StagePillProps {

--- a/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
@@ -1,0 +1,366 @@
+/* eslint-env jest */
+// The Course header drawer: a scrollable, stage-grouped table of contents.
+// Chapter content for unlocked stages is fetched lazily (per-stage) the first
+// time the drawer opens, cached across reopens, and shows an inline retry row
+// on a per-section failure (audit-ux-04 pattern).
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { useSyncExternalStore, type ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+
+import type { ContentItem, CourseProgress, Stage } from '../../../api';
+import { resolveStageColor, STAGE_ORDER } from '../../../design/tokens';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage',
+  subtitle: 'Subtitle',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const chapterItem = (
+  id: number,
+  title: string,
+  overrides: Partial<ContentItem> = {},
+): ContentItem => ({
+  id,
+  title,
+  content_type: 'chapter',
+  release_day: 0,
+  url: null,
+  is_locked: false,
+  is_read: false,
+  ...overrides,
+});
+
+// Ten stages: 1-3 unlocked (stage 2 completed at progress 1.0), 4-10 locked.
+// STAGE_ORDER supplies ten distinct, recognized Spiral-Dynamics color names so
+// each header's resolved color is independently checkable.
+const TEN_STAGES: Stage[] = STAGE_ORDER.map((colorName, index) => {
+  const stageNumber = index + 1;
+  const unlocked = stageNumber <= 3;
+  const progress = stageNumber === 2 ? 1 : stageNumber === 1 ? 0.4 : stageNumber === 3 ? 0.5 : 0;
+  return makeStage({
+    id: stageNumber,
+    stage_number: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    spiral_dynamics_color: colorName,
+    is_unlocked: unlocked,
+    progress,
+  });
+});
+
+// Distinct chapter titles per stage, so grouping is independently checkable.
+// Stage 2 (the initially-selected stage) carries a locked chapter to pin the
+// "locked chapter row inside an unlocked stage" behavior. Stage 4 (locked)
+// carries a fixture too, so a wrongly-fetched locked section would be
+// detectable -- correct behavior never fetches it, so its title never shows.
+const contentByStage: Record<number, ContentItem[]> = {
+  1: [chapterItem(101, 'Stage 1 Chapter A')],
+  2: [
+    chapterItem(201, 'Stage 2 Chapter A'),
+    chapterItem(202, 'Stage 2 Chapter B', { is_locked: true }),
+  ],
+  3: [chapterItem(301, 'Stage 3 Chapter A')],
+  4: [chapterItem(401, 'Stage 4 Secret Chapter')],
+};
+
+const sampleProgress: CourseProgress = {
+  total_items: 1,
+  read_items: 0,
+  progress_percent: 0,
+  next_unlock_day: null,
+};
+
+const mockStagesList = jest.fn<(...a: unknown[]) => Promise<Stage[]>>();
+const mockStageContent = jest.fn<(stageNumber: number, token?: string) => Promise<ContentItem[]>>();
+const mockStageProgress = jest.fn<(...a: unknown[]) => Promise<CourseProgress>>();
+
+jest.mock('../../../api', () => ({
+  stages: { listAll: (...a: unknown[]) => mockStagesList(...a) },
+  course: {
+    stageContentAll: (stageNumber: number) => mockStageContent(stageNumber),
+    stageProgress: (...a: unknown[]) => mockStageProgress(...a),
+    markRead: jest.fn(),
+    contentBody: () =>
+      Promise.resolve({ title: 'Chapter', content_type: 'chapter', body_markdown: 'x\n' }),
+    siteResources: () => Promise.resolve([]),
+    siteResourceBody: jest.fn(),
+    // No intro in these drawer scenarios -- keep the intro card hidden.
+    stageIntro: () => Promise.reject(new Error('content_not_found')),
+    stageIntroBody: jest.fn(),
+  },
+}));
+
+const mockRootNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockRootNavigate }),
+}));
+
+// CourseScreen installs its header-left drawer toggle through useAppNavigation
+// (useScreenDrawer), which calls navigation.setOptions in a layout effect on
+// every mount. The store relays the installed headerLeft into the same render
+// tree as the screen so the Modal-based drawer opens in-tree and its rows are
+// pressable.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('../../../navigation/hooks', () => ({
+  useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: mockSetOptions }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: unknown }) =>
+      ReactMod.createElement(ReactMod.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// eslint-disable-next-line import/order
+const { render, waitFor, fireEvent, act, within } = require('@testing-library/react-native');
+const CourseScreen = require('../CourseScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so
+// the drawer opens in-tree and its rows are pressable.
+const CourseScreenWithHeader = (): ReactElement => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <CourseScreen />
+    </>
+  );
+};
+
+describe('Course header drawer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    mockStagesList.mockResolvedValue(TEN_STAGES);
+    mockStageContent.mockImplementation((stageNumber: number) =>
+      Promise.resolve(contentByStage[stageNumber] ?? []),
+    );
+    mockStageProgress.mockResolvedValue(sampleProgress);
+  });
+
+  it('installs a header-left drawer toggle and opens the drawer on press', async () => {
+    const { getByTestId, getByLabelText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    expect(mockSetOptions).toHaveBeenCalled();
+    const setOptionsCalls = mockSetOptions.mock.calls;
+    const lastCall = setOptionsCalls[setOptionsCalls.length - 1];
+    if (lastCall === undefined) throw new Error('setOptions was never called');
+    expect(lastCall[0].headerLeft).toBeDefined();
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    expect(getByTestId('screen-drawer')).toBeTruthy();
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
+  });
+
+  it('groups chapters under ten colored stage headers, marking completed and locked stages', async () => {
+    const { getByTestId, getByLabelText, getByText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    await waitFor(() => {
+      for (let n = 1; n <= 10; n += 1) {
+        expect(getByTestId(`course-drawer-stage-${n}`)).toBeTruthy();
+      }
+    });
+
+    // Unlocked stages show their own chapter titles. Stage 2 is the selected
+    // stage, so its chapter also renders in the body panel -- scope the check to
+    // the drawer row so the assertion is unambiguous.
+    expect(getByText('Stage 1 Chapter A')).toBeTruthy();
+    expect(
+      within(getByTestId('course-drawer-chapter-201')).getByText('Stage 2 Chapter A'),
+    ).toBeTruthy();
+    expect(getByText('Stage 3 Chapter A')).toBeTruthy();
+
+    // Stage 2 is completed; stage 4 is locked.
+    expect(within(getByTestId('course-drawer-stage-2')).getByText('✓')).toBeTruthy();
+    expect(within(getByTestId('course-drawer-stage-4')).getByText('🔒')).toBeTruthy();
+
+    // The header's color equals the shared resolver applied to the stage's own API color.
+    const stage1Style = StyleSheet.flatten(getByTestId('course-drawer-stage-1').props.style) ?? {};
+    expect((stage1Style as { backgroundColor?: string }).backgroundColor).toBe(
+      resolveStageColor('Beige'),
+    );
+    const stage3Style = StyleSheet.flatten(getByTestId('course-drawer-stage-3').props.style) ?? {};
+    expect((stage3Style as { backgroundColor?: string }).backgroundColor).toBe(
+      resolveStageColor('Red'),
+    );
+  });
+
+  it('renders a locked stage header as disabled and never fetches or selects it on press', async () => {
+    const { getByTestId, getByLabelText, queryByText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    await waitFor(() => expect(getByTestId('course-drawer-stage-4')).toBeTruthy());
+
+    const header4 = getByTestId('course-drawer-stage-4');
+    expect(header4.props.accessibilityState.disabled).toBe(true);
+
+    const stageContentCallCount = mockStageContent.mock.calls.length;
+    const stageProgressCallCount = mockStageProgress.mock.calls.length;
+
+    fireEvent.press(header4);
+
+    expect(mockStageContent.mock.calls.length).toBe(stageContentCallCount);
+    expect(mockStageProgress.mock.calls.length).toBe(stageProgressCallCount);
+    expect(mockStageContent.mock.calls.some((call) => call[0] === 4)).toBe(false);
+    // Its content is never rendered -- correct behavior never fetches a locked section.
+    expect(queryByText('Stage 4 Secret Chapter')).toBeNull();
+  });
+
+  it('tapping a chapter in a different stage selects it, opens the viewer, closes the drawer, and refetches', async () => {
+    const { getByTestId, getByLabelText, getByText, queryByTestId } = render(
+      <CourseScreenWithHeader />,
+    );
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+    await waitFor(() => expect(mockStageContent).toHaveBeenCalledWith(2));
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    await waitFor(() => expect(getByText('Stage 1 Chapter A')).toBeTruthy());
+
+    mockStageContent.mockClear();
+    mockStageProgress.mockClear();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('course-drawer-chapter-101'));
+    });
+
+    await waitFor(() => expect(getByTestId('chapter-reader')).toBeTruthy());
+    expect(queryByTestId('screen-drawer')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockStageContent).toHaveBeenCalledWith(1);
+      expect(mockStageProgress).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('a locked chapter row is disabled and pressing it opens nothing, keeping the drawer open', async () => {
+    const { getByTestId, getByLabelText, getByText, queryByTestId } = render(
+      <CourseScreenWithHeader />,
+    );
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    await waitFor(() => expect(getByText('Stage 2 Chapter B')).toBeTruthy());
+
+    const lockedRow = getByTestId('course-drawer-chapter-202');
+    expect(lockedRow.props.accessibilityState.disabled).toBe(true);
+
+    fireEvent.press(lockedRow);
+
+    expect(queryByTestId('chapter-reader')).toBeNull();
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
+  });
+
+  it('fetches content lazily per unlocked stage only when the drawer first opens, and caches across reopens', async () => {
+    const { getByTestId, getByLabelText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+    await waitFor(() => expect(mockStageContent).toHaveBeenCalledWith(2));
+
+    // Before opening: only the initially-selected stage was fetched.
+    const stagesFetchedBeforeOpen = new Set(mockStageContent.mock.calls.map((call) => call[0]));
+    expect(stagesFetchedBeforeOpen).toEqual(new Set([2]));
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    await waitFor(() => {
+      const fetched = new Set(mockStageContent.mock.calls.map((call) => call[0]));
+      expect(fetched.has(1)).toBe(true);
+      expect(fetched.has(2)).toBe(true);
+      expect(fetched.has(3)).toBe(true);
+    });
+
+    const fetchedAfterOpen = new Set(mockStageContent.mock.calls.map((call) => call[0]));
+    for (let n = 4; n <= 10; n += 1) {
+      expect(fetchedAfterOpen.has(n)).toBe(false);
+    }
+
+    const callCountAfterOpen = mockStageContent.mock.calls.length;
+
+    await act(async () => {
+      fireEvent.press(getByTestId('screen-drawer-scrim'));
+    });
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    expect(mockStageContent.mock.calls.length).toBe(callCountAfterOpen);
+  });
+
+  it('shows a per-section retry when exactly one unlocked stage fails, and retry reloads only that stage', async () => {
+    let stage3ShouldFail = true;
+    mockStageContent.mockImplementation((stageNumber: number) => {
+      if (stageNumber === 3 && stage3ShouldFail) {
+        stage3ShouldFail = false;
+        return Promise.reject(new Error('stage 3 fetch failed'));
+      }
+      return Promise.resolve(contentByStage[stageNumber] ?? []);
+    });
+
+    const { getByTestId, getByLabelText, getByText, queryByText, queryByTestId } = render(
+      <CourseScreenWithHeader />,
+    );
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    await waitFor(() => expect(getByTestId('course-drawer-retry-3')).toBeTruthy());
+    // Sibling sections still render their chapters. Stage 2 is the selected
+    // stage, so scope its check to the drawer row to stay unambiguous.
+    expect(getByText('Stage 1 Chapter A')).toBeTruthy();
+    expect(
+      within(getByTestId('course-drawer-chapter-201')).getByText('Stage 2 Chapter A'),
+    ).toBeTruthy();
+    expect(queryByText('Stage 3 Chapter A')).toBeNull();
+
+    const stage1CallsBefore = mockStageContent.mock.calls.filter((c) => c[0] === 1).length;
+    const stage2CallsBefore = mockStageContent.mock.calls.filter((c) => c[0] === 2).length;
+    const stage3CallsBefore = mockStageContent.mock.calls.filter((c) => c[0] === 3).length;
+    expect(stage3CallsBefore).toBe(1);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('course-drawer-retry-3'));
+    });
+
+    await waitFor(() => expect(getByText('Stage 3 Chapter A')).toBeTruthy());
+    expect(queryByTestId('course-drawer-retry-3')).toBeNull();
+
+    expect(mockStageContent.mock.calls.filter((c) => c[0] === 1).length).toBe(stage1CallsBefore);
+    expect(mockStageContent.mock.calls.filter((c) => c[0] === 2).length).toBe(stage2CallsBefore);
+    expect(mockStageContent.mock.calls.filter((c) => c[0] === 3).length).toBe(
+      stage3CallsBefore + 1,
+    );
+  });
+});

--- a/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseErrorStates.test.tsx
@@ -61,9 +61,13 @@ jest.mock('../../../api', () => ({
   },
 }));
 
+// CourseScreen installs its header-left drawer toggle through useAppNavigation
+// (useScreenDrawer), which calls navigation.setOptions in a layout effect on
+// every mount -- without this mock every test below would crash reading
+// setOptions off an undefined navigation object.
 jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
-  useAppNavigation: () => ({ navigate: jest.fn() }),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
 }));
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -142,9 +142,13 @@ jest.mock('../../../api', () => ({
 }));
 
 const mockNavigate = jest.fn() as any;
+// CourseScreen installs its header-left drawer toggle through useAppNavigation
+// (useScreenDrawer), which calls navigation.setOptions in a layout effect on
+// every mount -- without this mock every test below would crash reading
+// setOptions off an undefined navigation object.
 jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
-  useAppNavigation: () => ({ navigate: mockNavigate }),
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
 }));
 // The reflect action now pushes the root-stack JournalEntry via useNavigation.
 jest.mock('@react-navigation/native', () => ({

--- a/frontend/src/features/Course/__tests__/CourseScreenUnmatchedStage.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenUnmatchedStage.test.tsx
@@ -53,9 +53,13 @@ jest.mock('../../../api', () => ({
 }));
 
 // Route requests stage 99, which is not in the loaded stage list.
+// CourseScreen installs its header-left drawer toggle through useAppNavigation
+// (useScreenDrawer), which calls navigation.setOptions in a layout effect on
+// every mount -- without this mock every test below would crash reading
+// setOptions off an undefined navigation object.
 jest.mock('../../../navigation/hooks', () => ({
   useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: { stageNumber: 99 } }),
-  useAppNavigation: () => ({ navigate: jest.fn() }),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
 }));
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),

--- a/frontend/src/features/Course/__tests__/stageDisplay.test.ts
+++ b/frontend/src/features/Course/__tests__/stageDisplay.test.ts
@@ -1,0 +1,98 @@
+/* eslint-env jest */
+// Direct unit tests for the stage-display helpers extracted from
+// StageSelector so the drawer's stage grouping can reuse the same
+// color/lock/completion rules without duplicating them.
+import { describe, it, expect } from '@jest/globals';
+
+import type { Stage } from '../../../api';
+import { colors, resolveStageColor, STAGE_ORDER } from '../../../design/tokens';
+import { getStageColor, isCompleted, isUnlocked, totalStageCount } from '../stageDisplay';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage',
+  subtitle: 'Subtitle',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+describe('totalStageCount', () => {
+  it('returns 0 for an empty stage list', () => {
+    expect(totalStageCount([])).toBe(0);
+  });
+
+  it('returns the max stage_number across the list, regardless of order', () => {
+    const stages = [
+      makeStage({ stage_number: 2 }),
+      makeStage({ stage_number: 5 }),
+      makeStage({ stage_number: 1 }),
+    ];
+    expect(totalStageCount(stages)).toBe(5);
+  });
+});
+
+describe('getStageColor', () => {
+  it("uses the stage's own API spiral_dynamics_color when present", () => {
+    const stage = makeStage({ stage_number: 3, spiral_dynamics_color: 'Red' });
+    const stageById = new Map([[3, stage]]);
+    expect(getStageColor(3, stageById)).toBe(resolveStageColor('Red'));
+  });
+
+  it('falls back to the STAGE_ORDER position when the stage is missing from the map', () => {
+    const stageById = new Map<number, Stage>();
+    expect(getStageColor(2, stageById)).toBe(resolveStageColor(STAGE_ORDER[1]));
+  });
+
+  it('falls back to the neutral color for an unrecognized color name', () => {
+    const stage = makeStage({ stage_number: 1, spiral_dynamics_color: 'Mauve' });
+    const stageById = new Map([[1, stage]]);
+    expect(getStageColor(1, stageById)).toBe(colors.neutral);
+  });
+});
+
+describe('isUnlocked', () => {
+  it('returns false when the stage is missing from the map', () => {
+    expect(isUnlocked(1, new Map())).toBe(false);
+  });
+
+  it('reflects is_unlocked: true from the stage data', () => {
+    const stage = makeStage({ stage_number: 4, is_unlocked: true });
+    expect(isUnlocked(4, new Map([[4, stage]]))).toBe(true);
+  });
+
+  it('reflects is_unlocked: false from the stage data', () => {
+    const stage = makeStage({ stage_number: 4, is_unlocked: false });
+    expect(isUnlocked(4, new Map([[4, stage]]))).toBe(false);
+  });
+});
+
+describe('isCompleted', () => {
+  it('returns false when the stage is missing from the map', () => {
+    expect(isCompleted(1, new Map())).toBe(false);
+  });
+
+  it('returns true at exactly progress 1.0 (boundary)', () => {
+    const stage = makeStage({ stage_number: 1, progress: 1.0 });
+    expect(isCompleted(1, new Map([[1, stage]]))).toBe(true);
+  });
+
+  it('returns false just under progress 1.0', () => {
+    const stage = makeStage({ stage_number: 1, progress: 0.99 });
+    expect(isCompleted(1, new Map([[1, stage]]))).toBe(false);
+  });
+
+  it('returns false at progress 0', () => {
+    const stage = makeStage({ stage_number: 1, progress: 0 });
+    expect(isCompleted(1, new Map([[1, stage]]))).toBe(false);
+  });
+});

--- a/frontend/src/features/Course/stageDisplay.ts
+++ b/frontend/src/features/Course/stageDisplay.ts
@@ -1,0 +1,37 @@
+/**
+ * Stage-display helpers shared by the Course stage selector and the header
+ * drawer's table of contents. Colocated here so the pill row and the drawer's
+ * stage grouping apply identical color/lock/completion rules without either
+ * side redefining them.
+ */
+import type { Stage } from '../../api';
+import { STAGE_ORDER, resolveStageColor } from '../../design/tokens';
+
+/** Progress value at which a stage counts as fully completed. */
+const COMPLETE_PROGRESS = 1;
+
+/** Derive the total number of stages from the API response (the max number). */
+export function totalStageCount(stages: Stage[]): number {
+  if (stages.length === 0) return 0;
+  return Math.max(...stages.map((s) => s.stage_number));
+}
+
+/** Resolve the Spiral-Dynamics color for a stage number (1-indexed). */
+export function getStageColor(stageNumber: number, stageById: Map<number, Stage>): string {
+  // Prefer the stage's own API color; fall back to its progression-order name
+  // when the API omits that stage number. The shared resolver handles the
+  // neutral fallback for missing or unrecognized names.
+  const name = stageById.get(stageNumber)?.spiral_dynamics_color ?? STAGE_ORDER[stageNumber - 1];
+  return resolveStageColor(name);
+}
+
+/** Determine whether a stage is unlocked based on API data. */
+export function isUnlocked(stageNumber: number, stageById: Map<number, Stage>): boolean {
+  return stageById.get(stageNumber)?.is_unlocked ?? false;
+}
+
+/** Determine whether a stage has been completed (progress reached 1.0). */
+export function isCompleted(stageNumber: number, stageById: Map<number, Stage>): boolean {
+  const stage = stageById.get(stageNumber);
+  return stage != null && stage.progress >= COMPLETE_PROGRESS;
+}


### PR DESCRIPTION
## Summary

Adds a header-hamburger `ScreenDrawer` to the Course tab presenting a scrollable, stage-grouped table of contents, so any chapter is two taps away instead of stage-pill-plus-scroll hunting.

- A header-left hamburger (via the shared `useScreenDrawer('Course')`) opens a drawer on the Course tab.
- The drawer lists all ten stages as colored section headers (via `resolveStageColor`), honoring each stage's `is_unlocked`/completed state with the same completed-over-locked glyph priority as the existing `StagePill`.
- Tapping a chapter selects that stage (`setSelectedStage`), opens the content item through the lock-guarded content handler, and closes the drawer.
- Locked stage headers and locked chapter rows render disabled (`accessibilityState.disabled` + `disabled`), matching the pill behavior.
- Chapter content loads lazily per unlocked stage the first time the drawer opens and is cached across reopens — no eager fetch of all ten stages at mount. A single stage's fetch failure surfaces an inline retry row without blanking its siblings (audit-ux-04 pattern).
- The stage color/lock/completion helpers are extracted from `StageSelector` into a shared `stageDisplay` module so the pill row and the drawer apply identical rules without duplication; the horizontal `StageSelector` pills are otherwise unchanged.

## Test plan

- `frontend/src/features/Course/__tests__/CourseDrawer.test.tsx` — new suite covering drawer open, ten colored/marked stage headers, chapter grouping, locked-stage/locked-row disabled behavior, cross-stage chapter tap (select + open + close + refetch), lazy per-unlocked-stage fetch with cross-reopen caching, and per-section retry.
- `frontend/src/features/Course/__tests__/stageDisplay.test.ts` — new unit tests for the extracted `totalStageCount`/`getStageColor`/`isUnlocked`/`isCompleted` helpers.
- Existing `StageSelector`, `CourseScreen`, and Course error-state suites re-verified unchanged pill behavior.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, TypeScript, and the full Jest suite (3938 tests) all pass.

Closes #1469
Refs #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)