### PR TITLE
feat(journal): Journal drawer listing past entries for quick navigation

### DIFF
--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -1,0 +1,342 @@
+/**
+ * The Journal header-drawer body: a New-entry row pinned on top, then the user's
+ * past entries grouped by recency (This week / This month / Earlier, newest
+ * first, empty bands dropped), a tappable "Load older entries" row, and a
+ * spinner / error+retry while the first page loads.
+ *
+ * Entries are fetched lazily on the drawer's first open via the co-located
+ * ``useJournalDrawerEntries`` hook, which lives above the ``ScreenDrawer`` panel
+ * so its cache survives close/reopen (mirrors ``useCourseDrawerContent``).
+ */
+import React, { useCallback, useEffect, useRef } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+import { groupByRecency, formatDate, type ShelfSection } from './recency';
+import { usePagedJournal } from './usePagedJournal';
+
+import type { JournalMessage } from '@/api';
+import { DrawerItem, ScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
+import { accent, ink, radius, SPACING, surface, touchTarget, type } from '@/design/tokens';
+
+/** Row that starts a fresh, blank entry. */
+const NEW_ENTRY_LABEL = 'New entry';
+/** Row that fetches and appends the next page of older entries. */
+const LOAD_MORE_LABEL = 'Load older entries';
+/** Fallback label for an entry saved without a title. */
+const UNTITLED_LABEL = 'Untitled';
+/** Copy shown when the entry fetch failed, above the retry row. */
+const ERROR_LABEL = 'We could not load your entries.';
+/** Retry affordance shown alongside the error copy. */
+const RETRY_LABEL = 'Tap to retry';
+
+/**
+ * Fetch the drawer's entries lazily on its first open and cache them across
+ * close/reopen. The first fetch pulls page 0; ``loadMore`` appends the next page
+ * (offset = current count) and is guarded so a concurrent or duplicate press is
+ * a no-op; ``retry`` refetches page 0 after a failure.
+ *
+ * The hook must be mounted above the ``ScreenDrawer`` panel (which unmounts when
+ * closed) so its cache outlives a close/reopen — the first open latches the fetch
+ * via ``hasOpened`` and never refires it.
+ */
+export function useJournalDrawerEntries(isOpen: boolean): {
+  items: JournalMessage[];
+  loading: boolean;
+  error: boolean;
+  hasMore: boolean;
+  loadMore: () => void;
+  retry: () => void;
+} {
+  const { items, hasMore, loading, error, load } = usePagedJournal();
+  const hasOpened = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen || hasOpened.current) return;
+    hasOpened.current = true;
+    void load(undefined, 0);
+  }, [isOpen, load]);
+
+  const loadMore = useCallback(() => {
+    // Ignore a press while a page is already in flight or none remain.
+    if (hasMore && !loading) void load(undefined, items.length);
+  }, [hasMore, loading, load, items.length]);
+
+  const retry = useCallback(() => {
+    void load(undefined, 0);
+  }, [load]);
+
+  return { items, loading, error: error !== null, hasMore, loadMore, retry };
+}
+
+/** Full-panel spinner shown before the first page of entries resolves. */
+function DrawerLoading(): React.JSX.Element {
+  return (
+    <ActivityIndicator
+      testID="journal-drawer-loading"
+      size="small"
+      color={accent.primary}
+      style={styles.loading}
+    />
+  );
+}
+
+/** Error copy plus a retry row shown when the entry fetch failed. */
+function DrawerError({ onRetry }: { onRetry: () => void }): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  return (
+    <View testID="journal-drawer-error" style={styles.errorBlock}>
+      <Text style={[type(width).body, styles.errorText]}>{ERROR_LABEL}</Text>
+      <DrawerItem testID="journal-drawer-retry" label={RETRY_LABEL} onPress={onRetry} />
+    </View>
+  );
+}
+
+interface EntryRowProps {
+  entry: JournalMessage;
+  selected: boolean;
+  onPress: (_id: number) => void;
+}
+
+/** One entry row: title (or "Untitled") + its saved date, selectable + tappable. */
+const EntryRow = ({ entry, selected, onPress }: EntryRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const label = entry.title?.trim() ? entry.title : UNTITLED_LABEL;
+  const dateText = formatDate(entry.timestamp);
+  // Drop the separator when the date is unparseable so the label never trails a
+  // bare comma.
+  const a11yLabel = dateText ? `${label}, ${dateText}` : label;
+  return (
+    <TouchableOpacity
+      testID={`journal-drawer-entry-${entry.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel}
+      accessibilityState={{ selected }}
+      onPress={() => onPress(entry.id)}
+      style={[styles.entryRow, selected && styles.entryRowSelected]}
+    >
+      <Text style={[type(width).body, styles.entryLabel]} numberOfLines={1}>
+        {label}
+      </Text>
+      <Text style={[type(width).caption, styles.entryDate]}>{dateText}</Text>
+    </TouchableOpacity>
+  );
+};
+
+interface RecencySectionProps {
+  section: ShelfSection;
+  currentEntryId?: number | null;
+  onRowPress: (_id: number) => void;
+}
+
+/** A recency band heading above its newest-first entry rows. */
+const RecencySection = ({
+  section,
+  currentEntryId,
+  onRowPress,
+}: RecencySectionProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  return (
+    <View style={styles.section}>
+      <Text style={[type(width).label, styles.sectionHeading]} accessibilityRole="header">
+        {section.title}
+      </Text>
+      {section.data.map((entry) => (
+        <EntryRow
+          key={entry.id}
+          entry={entry}
+          selected={entry.id === currentEntryId}
+          onPress={onRowPress}
+        />
+      ))}
+    </View>
+  );
+};
+
+interface DrawerBodyProps {
+  sections: ShelfSection[];
+  loading: boolean;
+  error: boolean;
+  hasMore: boolean;
+  currentEntryId?: number | null;
+  onRowPress: (_id: number) => void;
+  onLoadMore: () => void;
+  onRetry: () => void;
+}
+
+/** The rows below the pinned New-entry row: spinner, error, or the grouped list. */
+function DrawerBody({
+  sections,
+  loading,
+  error,
+  hasMore,
+  currentEntryId,
+  onRowPress,
+  onLoadMore,
+  onRetry,
+}: DrawerBodyProps): React.JSX.Element {
+  if (error) return <DrawerError onRetry={onRetry} />;
+  // Only the first load blanks the list; a "load more" keeps the entries visible.
+  if (loading && sections.length === 0) return <DrawerLoading />;
+  return (
+    <View>
+      {sections.map((section) => (
+        <RecencySection
+          key={section.title}
+          section={section}
+          currentEntryId={currentEntryId}
+          onRowPress={onRowPress}
+        />
+      ))}
+      {hasMore ? (
+        <DrawerItem
+          testID="journal-drawer-load-more"
+          label={LOAD_MORE_LABEL}
+          onPress={onLoadMore}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+export interface JournalDrawerProps {
+  /** The entries to group and render (newest-first, per the API order). */
+  items: JournalMessage[];
+  /** Epoch ms used to bucket entries into recency bands. */
+  now: number;
+  /** True until the first page resolves; drives the spinner. */
+  loading: boolean;
+  /** True when the entry fetch failed; drives the error + retry state. */
+  error: boolean;
+  /** Whether an older page remains to load. */
+  hasMore: boolean;
+  /** The entry currently shown on-screen, highlighted in the list (or none). */
+  currentEntryId?: number | null;
+  /** Open the tapped entry. */
+  onRowPress: (_id: number) => void;
+  /** Start a fresh, blank entry. */
+  onNewEntry: () => void;
+  /** Fetch and append the next older page. */
+  onLoadMore: () => void;
+  /** Refetch the first page after a failure. */
+  onRetry: () => void;
+}
+
+/** The Journal header drawer's contents: New entry, then the grouped entry list. */
+export default function JournalDrawer({
+  items,
+  now,
+  loading,
+  error,
+  hasMore,
+  currentEntryId,
+  onRowPress,
+  onNewEntry,
+  onLoadMore,
+  onRetry,
+}: JournalDrawerProps): React.JSX.Element {
+  const sections = groupByRecency(items, now);
+  return (
+    <View testID="journal-drawer">
+      <DrawerItem testID="journal-drawer-new-entry" label={NEW_ENTRY_LABEL} onPress={onNewEntry} />
+      <DrawerBody
+        sections={sections}
+        loading={loading}
+        error={error}
+        hasMore={hasMore}
+        currentEntryId={currentEntryId}
+        onRowPress={onRowPress}
+        onLoadMore={onLoadMore}
+        onRetry={onRetry}
+      />
+    </View>
+  );
+}
+
+export interface JournalScreenDrawerProps {
+  /** The screen's drawer open/close state (from ``useScreenDrawer``). */
+  drawer: ScreenDrawerState;
+  /** The entry currently shown on-screen, highlighted in the list (or none). */
+  currentEntryId?: number | null;
+  /** Open the tapped entry, then close the drawer. */
+  onSelectEntry: (_id: number) => void;
+  /** Start a fresh entry, then close the drawer. */
+  onNewEntry: () => void;
+}
+
+/** The Journal header drawer wired to its lazy, cache-above-the-panel entry fetch. */
+export function JournalScreenDrawer({
+  drawer,
+  currentEntryId,
+  onSelectEntry,
+  onNewEntry,
+}: JournalScreenDrawerProps): React.JSX.Element {
+  const { items, loading, error, hasMore, loadMore, retry } = useJournalDrawerEntries(
+    drawer.isOpen,
+  );
+  return (
+    <ScreenDrawer
+      visible={drawer.isOpen}
+      onClose={drawer.close}
+      screenName="Journal"
+      title="Journal"
+    >
+      <JournalDrawer
+        items={items}
+        now={Date.now()}
+        loading={loading}
+        error={error}
+        hasMore={hasMore}
+        currentEntryId={currentEntryId}
+        onRowPress={onSelectEntry}
+        onNewEntry={onNewEntry}
+        onLoadMore={loadMore}
+        onRetry={retry}
+      />
+    </ScreenDrawer>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    alignSelf: 'flex-start',
+    paddingVertical: SPACING.sm,
+  },
+  errorBlock: {
+    paddingVertical: SPACING.sm,
+    gap: SPACING.xs,
+  },
+  errorText: {
+    color: ink.muted,
+  },
+  section: {
+    marginBottom: SPACING.sm,
+  },
+  sectionHeading: {
+    color: ink.muted,
+    marginTop: SPACING.sm,
+    marginBottom: SPACING.xs,
+  },
+  entryRow: {
+    minHeight: touchTarget.minimum,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: radius.sm,
+  },
+  entryRowSelected: {
+    backgroundColor: surface.sunken,
+  },
+  entryLabel: {
+    color: ink.primary,
+  },
+  entryDate: {
+    color: ink.muted,
+  },
+});

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -28,6 +28,7 @@ import ContractionReflectionNote from './ContractionReflectionNote';
 import EditConfirmDialog from './EditConfirmDialog';
 import GetResonanceButton, { shouldShowResonance } from './GetResonanceButton';
 import HighlightedBody from './HighlightedBody';
+import { JournalScreenDrawer } from './JournalDrawer';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
@@ -52,6 +53,7 @@ import type {
   ReflectionLevel,
 } from '@/api';
 import { Button } from '@/components/Button';
+import { useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
 import { colors } from '@/design/tokens';
 import { useIdle } from '@/hooks/useIdle';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -1833,20 +1835,84 @@ function ReflectionComposer({
   );
 }
 
+interface EntryScreenDrawer {
+  drawer: ScreenDrawerState;
+  onSelectEntry: (_id: number) => void;
+  onNewEntry: () => void;
+}
+
+/**
+ * The header drawer wired for the entry screen. It latches its entry id at mount,
+ * so a row tap and New entry must ``push`` a fresh screen (not ``navigate`` in
+ * place, which would keep the current, already-loaded entry).
+ */
+function useEntryScreenDrawer(navigation: ScreenNavigation): EntryScreenDrawer {
+  const drawer = useScreenDrawer('Journal');
+  const onSelectEntry = useCallback(
+    (entryId: number) => {
+      navigation.push('JournalEntry', { entryId });
+      drawer.close();
+    },
+    [navigation, drawer],
+  );
+  const onNewEntry = useCallback(() => {
+    navigation.push('JournalEntry');
+    drawer.close();
+  }, [navigation, drawer]);
+  return { drawer, onSelectEntry, onNewEntry };
+}
+
+/** The screen's floating layers: the essay modal, the edit-confirm dialog, and
+ *  the header drawer — grouped so the screen component stays under the line cap. */
+function EntryOverlays({
+  modal,
+  editGate,
+  entryDrawer,
+  currentEntryId,
+}: {
+  modal: Controller['modal'];
+  editGate: Controller['editGate'];
+  entryDrawer: EntryScreenDrawer;
+  currentEntryId: number | null;
+}): React.JSX.Element {
+  return (
+    <>
+      <ResonanceEssayModal
+        note={modal.openNote}
+        onClose={modal.onCloseNote}
+        onEssayLoaded={modal.onEssayLoaded}
+      />
+      <EditConfirmDialog
+        visible={editGate.confirmOpen}
+        onEdit={editGate.confirmEdit}
+        onStartNew={editGate.startNew}
+        onCancel={editGate.cancelEdit}
+      />
+      <JournalScreenDrawer
+        drawer={entryDrawer.drawer}
+        currentEntryId={currentEntryId}
+        onSelectEntry={entryDrawer.onSelectEntry}
+        onNewEntry={entryDrawer.onNewEntry}
+      />
+    </>
+  );
+}
+
 function JournalEntryScreen({
   route,
   navigation,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
   const { ctx, initialTitle, bodyPlaceholder } = readEntrypoint(route.params);
+  const currentEntryId = route.params?.entryId ?? null;
+  const entryDrawer = useEntryScreenDrawer(navigation);
   const ctl = useJournalEntryController(
-    route.params?.entryId ?? null,
+    currentEntryId,
     autosaveDelayMs,
     navigation,
     ctx,
     initialTitle,
   );
-  const { editGate, modal } = ctl;
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">
       {/* Screen-level care surface (NORTH-STAR §10): a sibling ABOVE the page,
@@ -1870,16 +1936,11 @@ function JournalEntryScreen({
         disabled={ctl.resonanceDisabled}
         onPress={ctl.resonance.requestResonance}
       />
-      <ResonanceEssayModal
-        note={modal.openNote}
-        onClose={modal.onCloseNote}
-        onEssayLoaded={modal.onEssayLoaded}
-      />
-      <EditConfirmDialog
-        visible={editGate.confirmOpen}
-        onEdit={editGate.confirmEdit}
-        onStartNew={editGate.startNew}
-        onCancel={editGate.cancelEdit}
+      <EntryOverlays
+        modal={ctl.modal}
+        editGate={ctl.editGate}
+        entryDrawer={entryDrawer}
+        currentEntryId={currentEntryId}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -8,22 +8,25 @@
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Animated, SectionList, Text, TouchableOpacity, View } from 'react-native';
 import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 
+import { JournalScreenDrawer } from './JournalDrawer';
 import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
 import { promptTitleForWeek } from './promptTitle';
+import { formatDate, groupByRecency, type ShelfSection } from './recency';
 import ReflectionInvitationBand from './ReflectionInvitationBand';
 import SearchBar from './SearchBar';
 import StatTileRow from './StatTileRow';
+import { usePagedJournal } from './usePagedJournal';
 
-import { journal, prompts } from '@/api';
+import { prompts } from '@/api';
 import type { JournalMessage, PromptDetail } from '@/api';
-import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
+import { useScreenDrawer } from '@/components/drawer';
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { ScreenHeader } from '@/components/layout/ScreenHeader';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
@@ -34,11 +37,9 @@ import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentWeek } from '@/store/useProgramProgression';
 import { MS_PER_DAY } from '@/utils/dateUtils';
 
-const PAGE_SIZE = 20;
 const SEARCH_MIN_LENGTH = 3;
 const SEARCH_MAX_LENGTH = 64; // mirrors the backend JOURNAL_SEARCH_MAX_LENGTH guard
 const EXCERPT_MAX = 140;
-const WEEK_DAYS = 7;
 const MONTH_DAYS = 30;
 const WORDS_PER_MINUTE = 200;
 
@@ -47,38 +48,9 @@ const FIRST_PROMPT = 'What brought you here?';
 
 type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
 
-interface ShelfSection {
-  title: string;
-  data: JournalMessage[];
-}
-
-function formatDate(timestamp: string): string {
-  const date = new Date(timestamp);
-  if (Number.isNaN(date.getTime())) return '';
-  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
-}
-
 function excerpt(body: string): string {
   const flat = body.replace(/\s+/g, ' ').trim();
   return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
-}
-
-const RECENCY_ORDER = ['This week', 'This month', 'Earlier'] as const;
-
-/** Bucket name for an entry's age relative to ``now`` (epoch ms). */
-function bucketFor(timestamp: string, now: number): string {
-  const age = (now - new Date(timestamp).getTime()) / MS_PER_DAY;
-  if (age < WEEK_DAYS) return 'This week';
-  if (age < MONTH_DAYS) return 'This month';
-  return 'Earlier';
-}
-
-/** Group entries into recency sections, dropping any section with no entries. */
-function groupByRecency(items: JournalMessage[], now: number): ShelfSection[] {
-  return RECENCY_ORDER.map((title) => ({
-    title,
-    data: items.filter((item) => bucketFor(item.timestamp, now) === title),
-  })).filter((section) => section.data.length > 0);
 }
 
 /** Estimated reading time in whole minutes (≥1). */
@@ -131,34 +103,8 @@ function isSearchable(next: string): boolean {
 
 /** Loads the shelf with offset paging + debounced search (via SearchBar). */
 function useShelf(): ShelfState {
-  const [items, setItems] = useState<JournalMessage[]>([]);
-  const [total, setTotal] = useState(0);
+  const { items, total, hasMore, loading, error, load } = usePagedJournal();
   const [query, setQuery] = useState('');
-  const [hasMore, setHasMore] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const requestSeq = useRef(0);
-
-  const load = useCallback(async (search: string | undefined, offset: number) => {
-    // Only the newest in-flight request may settle; stale ones are dropped.
-    const requestId = (requestSeq.current += 1);
-    const isLatest = () => requestId === requestSeq.current;
-    setLoading(true);
-    setError(null);
-    try {
-      const page = await journal.list({ search, limit: PAGE_SIZE, offset });
-      if (!isLatest()) return;
-      setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
-      setTotal(page.total);
-      setHasMore(page.has_more);
-    } catch (err) {
-      // Surface the failure so a cold-start network error isn't mistaken for an
-      // empty shelf; the current items (if any) stay in place for retry.
-      if (isLatest()) setError(formatApiError(err));
-    } finally {
-      if (isLatest()) setLoading(false);
-    }
-  }, []);
 
   useEffect(() => {
     void load(undefined, 0);
@@ -415,13 +361,42 @@ function renderSectionHeader({
   return <SectionHeading title={section.title} />;
 }
 
-function JournalShelfScreen(): React.JSX.Element {
-  const navigation = useNavigation<ShelfNavigation>();
-  const { items, total, loading, error, query, hasMore, onSearch, loadMore } = useShelf();
-  const prompt = usePrompt();
-  const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
-  const nav = useShelfNavigation(navigation, prompt, week);
-  const now = Date.now();
+interface ShelfDrawer {
+  drawer: ReturnType<typeof useScreenDrawer>;
+  onSelectEntry: (_id: number) => void;
+  onNewEntry: () => void;
+}
+
+/** The header drawer's open state plus its open-then-close row callbacks. From
+ *  the shelf a row tap navigates (not pushes) to the entry, then closes. */
+function useShelfDrawer(nav: ShelfNav): ShelfDrawer {
+  const drawer = useScreenDrawer('Journal');
+  const onSelectEntry = useCallback(
+    (entryId: number) => {
+      nav.openEntry(entryId);
+      drawer.close();
+    },
+    [nav, drawer],
+  );
+  const onNewEntry = useCallback(() => {
+    nav.newEntry();
+    drawer.close();
+  }, [nav, drawer]);
+  return { drawer, onSelectEntry, onNewEntry };
+}
+
+interface ShelfBodyProps {
+  shelf: ShelfState;
+  nav: ShelfNav;
+  prompt: PromptDetail | null;
+  week: number;
+  now: number;
+}
+
+/** The shelf's scrolling list surface (top matter, recency sections, paging) —
+ *  split out so the screen component stays under the line cap. */
+function ShelfBody({ shelf, nav, prompt, week, now }: ShelfBodyProps): React.JSX.Element {
+  const { items, total, loading, error, query, hasMore, onSearch, loadMore } = shelf;
   const sections = groupByRecency(items, now);
   const searching = query.length >= SEARCH_MIN_LENGTH;
   const resultCount = searching ? total : undefined;
@@ -431,38 +406,57 @@ function JournalShelfScreen(): React.JSX.Element {
   );
 
   return (
+    <SectionList
+      style={styles.list}
+      testID="journal-shelf-list"
+      sections={sections}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={renderItem}
+      renderSectionHeader={renderSectionHeader}
+      stickySectionHeadersEnabled={false}
+      ListHeaderComponent={
+        <ShelfTopMatter
+          prompt={prompt}
+          week={week}
+          onPrompt={nav.openPrompt}
+          onNew={nav.newEntry}
+          onSearch={onSearch}
+          query={query}
+          resultCount={resultCount}
+        />
+      }
+      ListEmptyComponent={
+        <ShelfEmpty
+          loading={loading}
+          error={error}
+          searching={searching}
+          onNew={nav.newEntry}
+          onFirstPrompt={nav.openWithPrompt}
+        />
+      }
+      onEndReached={hasMore ? loadMore : undefined}
+      onEndReachedThreshold={0.4}
+      contentContainerStyle={styles.listContent}
+    />
+  );
+}
+
+function JournalShelfScreen(): React.JSX.Element {
+  const navigation = useNavigation<ShelfNavigation>();
+  const shelf = useShelf();
+  const prompt = usePrompt();
+  const week = useDerivedCurrentWeek(prompt?.week_number ?? 1);
+  const nav = useShelfNavigation(navigation, prompt, week);
+  const shelfDrawer = useShelfDrawer(nav);
+  const now = Date.now();
+
+  return (
     <ScreenScaffold testID="journal-shelf">
-      <SectionList
-        style={styles.list}
-        testID="journal-shelf-list"
-        sections={sections}
-        keyExtractor={(item) => String(item.id)}
-        renderItem={renderItem}
-        renderSectionHeader={renderSectionHeader}
-        stickySectionHeadersEnabled={false}
-        ListHeaderComponent={
-          <ShelfTopMatter
-            prompt={prompt}
-            week={week}
-            onPrompt={nav.openPrompt}
-            onNew={nav.newEntry}
-            onSearch={onSearch}
-            query={query}
-            resultCount={resultCount}
-          />
-        }
-        ListEmptyComponent={
-          <ShelfEmpty
-            loading={loading}
-            error={error}
-            searching={searching}
-            onNew={nav.newEntry}
-            onFirstPrompt={nav.openWithPrompt}
-          />
-        }
-        onEndReached={hasMore ? loadMore : undefined}
-        onEndReachedThreshold={0.4}
-        contentContainerStyle={styles.listContent}
+      <ShelfBody shelf={shelf} nav={nav} prompt={prompt} week={week} now={now} />
+      <JournalScreenDrawer
+        drawer={shelfDrawer.drawer}
+        onSelectEntry={shelfDrawer.onSelectEntry}
+        onNewEntry={shelfDrawer.onNewEntry}
       />
     </ScreenScaffold>
   );

--- a/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
@@ -1,0 +1,340 @@
+/* eslint-env jest */
+// The Journal header-drawer body: a New-entry row on top, then past entries
+// grouped by recency (newest-first, empty sections dropped), a tappable
+// "Load older entries" row, and loading/error+retry states. Entries are
+// fetched lazily on first open via the co-located useJournalDrawerEntries
+// hook, which lives above the ScreenDrawer panel so its cache survives
+// close/reopen (mirrors useCourseDrawerContent in Course/CourseDrawer.tsx).
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React, { useState } from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import type { JournalListResponse, JournalMessage } from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+const { default: JournalDrawer, useJournalDrawerEntries } = require('../JournalDrawer');
+
+const DAY_MS = 86_400_000;
+const ago = (days: number): string => new Date(Date.now() - days * DAY_MS).toISOString();
+
+function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id,
+    message: `Body of entry ${id}.`,
+    sender: 'user',
+    timestamp: ago(1),
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: `Entry ${id}`,
+    status: 'finished',
+    updated_at: ago(1),
+    ...overrides,
+  };
+}
+
+function page(items: JournalMessage[], hasMore = false): JournalListResponse {
+  return { items, total: items.length, has_more: hasMore };
+}
+
+// Mirrors JournalShelfScreen's formatDate exactly, so the assertions below pin
+// the drawer's date text without hardcoding a locale-specific literal.
+function formatDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+interface DrawerHarness {
+  items: JournalMessage[];
+  loading: boolean;
+  error: boolean;
+  hasMore: boolean;
+  currentEntryId?: number | null;
+  onRowPress?: (_id: number) => void;
+  onNewEntry?: () => void;
+}
+
+function renderDrawer(props: Partial<DrawerHarness> = {}) {
+  const onRowPress = props.onRowPress ?? jest.fn();
+  const onNewEntry = props.onNewEntry ?? jest.fn();
+  const onLoadMore = jest.fn();
+  const onRetry = jest.fn();
+  const result = render(
+    <JournalDrawer
+      items={props.items ?? []}
+      now={Date.now()}
+      loading={props.loading ?? false}
+      error={props.error ?? false}
+      hasMore={props.hasMore ?? false}
+      currentEntryId={props.currentEntryId}
+      onRowPress={onRowPress}
+      onNewEntry={onNewEntry}
+      onLoadMore={onLoadMore}
+      onRetry={onRetry}
+    />,
+  );
+  return { ...result, onRowPress, onNewEntry, onLoadMore, onRetry };
+}
+
+describe('JournalDrawer (presentational)', () => {
+  it('groups entries under recency headings and drops empty sections', () => {
+    const items = [
+      entry(1, { timestamp: ago(1) }), // This week
+      entry(2, { timestamp: ago(10) }), // This month
+      entry(3, { timestamp: ago(60) }), // Earlier
+    ];
+    const { getByText } = renderDrawer({ items });
+    expect(getByText('This week')).toBeTruthy();
+    expect(getByText('This month')).toBeTruthy();
+    expect(getByText('Earlier')).toBeTruthy();
+  });
+
+  it('drops a recency heading with no entries in it', () => {
+    const items = [entry(1, { timestamp: ago(1) })];
+    const { queryByText } = renderDrawer({ items });
+    expect(queryByText('This month')).toBeNull();
+    expect(queryByText('Earlier')).toBeNull();
+  });
+
+  it('renders entry rows in the order they are given (newest-first)', () => {
+    const items = [entry(3), entry(2), entry(1)];
+    const { getAllByTestId } = renderDrawer({ items });
+    const ids = getAllByTestId(/^journal-drawer-entry-\d+$/).map((n) => n.props.testID as string);
+    expect(ids).toEqual([
+      'journal-drawer-entry-3',
+      'journal-drawer-entry-2',
+      'journal-drawer-entry-1',
+    ]);
+  });
+
+  it('falls back to "Untitled" for a blank title', () => {
+    const items = [entry(1, { title: null })];
+    const { getByText } = renderDrawer({ items });
+    expect(getByText('Untitled')).toBeTruthy();
+  });
+
+  it('gives an untitled row an accessibility label containing "Untitled" and its date', () => {
+    const ts = ago(1);
+    const items = [entry(1, { title: null, timestamp: ts })];
+    const { getByTestId } = renderDrawer({ items });
+    const label = String(getByTestId('journal-drawer-entry-1').props.accessibilityLabel ?? '');
+    expect(label).toContain('Untitled');
+    expect(label).toContain(formatDate(ts));
+  });
+
+  it('gives a titled row an accessibility label containing both the title and its date', () => {
+    const ts = ago(1);
+    const items = [entry(1, { title: 'Morning pages', timestamp: ts })];
+    const { getByTestId } = renderDrawer({ items });
+    const label = String(getByTestId('journal-drawer-entry-1').props.accessibilityLabel ?? '');
+    expect(label).toContain('Morning pages');
+    expect(label).toContain(formatDate(ts));
+  });
+
+  it('renders a New entry row above every section and entries', () => {
+    const items = [entry(1, { timestamp: ago(1) })];
+    const { getAllByTestId } = renderDrawer({ items });
+    const testIDs = getAllByTestId(/^(journal-drawer-new-entry|journal-drawer-entry-\d+)$/).map(
+      (n) => n.props.testID as string,
+    );
+    expect(testIDs[0]).toBe('journal-drawer-new-entry');
+  });
+
+  it('fires onNewEntry when the New entry row is pressed', () => {
+    const { getByTestId, onNewEntry } = renderDrawer({ items: [] });
+    fireEvent.press(getByTestId('journal-drawer-new-entry'));
+    expect(onNewEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onRowPress with the tapped entry id', () => {
+    const items = [entry(5), entry(6)];
+    const { getByTestId, onRowPress } = renderDrawer({ items });
+    fireEvent.press(getByTestId('journal-drawer-entry-6'));
+    expect(onRowPress).toHaveBeenCalledWith(6);
+    expect(onRowPress).not.toHaveBeenCalledWith(5);
+  });
+
+  it('marks the current entry row selected and leaves the others unselected', () => {
+    const items = [entry(1), entry(2)];
+    const { getByTestId } = renderDrawer({ items, currentEntryId: 2 });
+    expect(getByTestId('journal-drawer-entry-2').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('journal-drawer-entry-1').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('selects nothing when no current entry id is given (the shelf mount)', () => {
+    const items = [entry(1), entry(2)];
+    const { getByTestId } = renderDrawer({ items, currentEntryId: null });
+    expect(getByTestId('journal-drawer-entry-1').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('journal-drawer-entry-2').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('shows the "Load older entries" row only when hasMore is true', () => {
+    const items = [entry(1)];
+    const withMore = renderDrawer({ items, hasMore: true });
+    expect(withMore.getByTestId('journal-drawer-load-more')).toBeTruthy();
+    const withoutMore = renderDrawer({ items, hasMore: false });
+    expect(withoutMore.queryByTestId('journal-drawer-load-more')).toBeNull();
+  });
+
+  it('fires onLoadMore when the load-more row is pressed', () => {
+    const items = [entry(1)];
+    const { getByTestId, onLoadMore } = renderDrawer({ items, hasMore: true });
+    fireEvent.press(getByTestId('journal-drawer-load-more'));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a loading spinner and no entry rows while loading', () => {
+    const { getByTestId, queryByTestId } = renderDrawer({ items: [], loading: true });
+    expect(getByTestId('journal-drawer-loading')).toBeTruthy();
+    expect(queryByTestId(/^journal-drawer-entry-\d+$/)).toBeNull();
+  });
+
+  it('still offers the New entry row while loading', () => {
+    const { getByTestId } = renderDrawer({ items: [], loading: true });
+    expect(getByTestId('journal-drawer-new-entry')).toBeTruthy();
+  });
+
+  it('shows an error state with a retry affordance when the fetch failed', () => {
+    const { getByTestId } = renderDrawer({ items: [], error: true });
+    expect(getByTestId('journal-drawer-error')).toBeTruthy();
+    expect(getByTestId('journal-drawer-retry')).toBeTruthy();
+  });
+
+  it('fires onRetry when the retry row is pressed', () => {
+    const { getByTestId, onRetry } = renderDrawer({ items: [], error: true });
+    fireEvent.press(getByTestId('journal-drawer-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Wiring: the co-located useJournalDrawerEntries hook, mounted the same way
+// the real screens will use it -- called unconditionally above the panel, with
+// the panel itself only mounted while open (a ScreenDrawer Modal renders no
+// children when closed, so this is the only way to prove the cache survives
+// close/reopen without depending on ScreenDrawer or navigation at all).
+function Harness(): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const { items, loading, error, hasMore, loadMore, retry } = useJournalDrawerEntries(isOpen);
+  return (
+    <View>
+      <TouchableOpacity testID="harness-open" onPress={() => setIsOpen(true)} />
+      <TouchableOpacity testID="harness-close" onPress={() => setIsOpen(false)} />
+      {isOpen ? (
+        <JournalDrawer
+          items={items}
+          now={Date.now()}
+          loading={loading}
+          error={error}
+          hasMore={hasMore}
+          onRowPress={() => undefined}
+          onNewEntry={() => undefined}
+          onLoadMore={loadMore}
+          onRetry={retry}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+describe('useJournalDrawerEntries (wiring)', () => {
+  beforeEach(() => {
+    mockList.mockReset();
+  });
+
+  it('does not fetch until the drawer is opened for the first time', () => {
+    mockList.mockResolvedValue(page([]));
+    render(<Harness />);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('shows the loading state before the first fetch resolves', async () => {
+    let resolveFetch: (_v: JournalListResponse) => void = () => undefined;
+    mockList.mockReturnValue(
+      new Promise<JournalListResponse>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const { getByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() => expect(getByTestId('journal-drawer-loading')).toBeTruthy());
+    await act(async () => {
+      resolveFetch(page([entry(1)]));
+    });
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+  });
+
+  it('fetches once on first open and caches across close/reopen', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('harness-close'));
+    });
+    expect(queryByTestId('journal-drawer-entry-1')).toBeNull();
+
+    fireEvent.press(getByTestId('harness-open'));
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+    expect(mockList).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error and retry when the fetch rejects, and retry refetches', async () => {
+    mockList.mockRejectedValueOnce(new Error('network down'));
+    const { getByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() => expect(getByTestId('journal-drawer-error')).toBeTruthy());
+
+    mockList.mockResolvedValueOnce(page([entry(1)]));
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-retry'));
+    });
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+  });
+
+  it('fetches the first page at offset 0 when the drawer first opens', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { getByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() =>
+      expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ offset: 0 })),
+    );
+  });
+
+  it('fetches the next offset and appends older entries when Load older is pressed', async () => {
+    const firstPageItems = Array.from({ length: 20 }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValueOnce(page(firstPageItems, true));
+    const { getByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() => expect(getByTestId('journal-drawer-load-more')).toBeTruthy());
+
+    mockList.mockResolvedValueOnce(page([entry(21)], false));
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-load-more'));
+    });
+
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-21')).toBeTruthy());
+    expect(mockList).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 20 }));
+    // The first page's entries are still present -- Load older appends.
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+  });
+
+  it('hides Load older once the last page reports has_more: false', async () => {
+    mockList.mockResolvedValue(page([entry(1)], false));
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    fireEvent.press(getByTestId('harness-open'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+    expect(queryByTestId('journal-drawer-load-more')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -40,6 +40,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
@@ -53,6 +53,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -45,6 +45,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
@@ -52,6 +52,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
@@ -1,0 +1,177 @@
+/* eslint-env jest */
+// The Journal header drawer mounted from JournalEntryScreen: the current entry
+// is highlighted, and both a row tap and New entry push (not navigate) --
+// JournalEntryScreen latches its entry id at mount, so navigating "in place"
+// with the current route would not reload the new entry.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useSyncExternalStore, type ReactElement } from 'react';
+
+import type { JournalListResponse, JournalMessage } from '@/api';
+
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+const mockResonanceList = jest.fn() as jest.MockedFunction<
+  (_id: number) => Promise<{ items: unknown[] }>
+>;
+const mockJournalList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+    list: (...a: unknown[]) => (mockJournalList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+  prompts: { respond: jest.fn() },
+  resonance: {
+    list: (...a: unknown[]) => (mockResonanceList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+// useScreenDrawer installs the header-left toggle through useAppNavigation
+// (a hook, unrelated to the navigation PROP JournalEntryScreen receives),
+// so it needs its own stubbed setOptions the way CourseScreen's drawer tests
+// stub it -- the relayed headerLeft renders the toggle in-tree.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: mockSetOptions }),
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'An existing page about rivers.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'draft',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function page(items: JournalMessage[], hasMore = false): JournalListResponse {
+  return { items, total: items.length, has_more: hasMore };
+}
+
+interface EntryScreenWithHeaderProps {
+  navigation: { navigate: jest.Mock; goBack: jest.Mock; push: jest.Mock };
+  route: { key: string; name: 'JournalEntry'; params?: { entryId?: number } };
+}
+
+function EntryScreenWithHeader({ navigation, route }: EntryScreenWithHeaderProps): ReactElement {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <JournalEntryScreen navigation={navigation} route={route} />
+    </>
+  );
+}
+
+function renderScreen(entryId?: number) {
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const route = {
+    key: 'k',
+    name: 'JournalEntry' as const,
+    params: entryId ? { entryId } : undefined,
+  };
+  const result = render(<EntryScreenWithHeader navigation={navigation} route={route} />);
+  return { ...result, navigation };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  headerLeftStore.current = undefined;
+  headerLeftStore.listeners.clear();
+  mockGet.mockResolvedValue(entry());
+  mockCreate.mockResolvedValue(entry({ id: 42 }));
+  mockUpdate.mockResolvedValue(entry({ id: 42 }));
+  mockResonanceList.mockResolvedValue({ items: [] });
+  mockJournalList.mockResolvedValue(page([]));
+});
+
+describe('Journal header drawer from JournalEntryScreen', () => {
+  it('installs a header-left drawer toggle and opens the drawer on press', async () => {
+    const { getByTestId, getByLabelText } = renderScreen(7);
+    await waitFor(() => expect(getByTestId('journal-title-input')).toBeTruthy());
+    expect(mockSetOptions).toHaveBeenCalled();
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    expect(getByTestId('screen-drawer')).toBeTruthy();
+  });
+
+  it('highlights the row for the current entry (from route.params.entryId)', async () => {
+    mockJournalList.mockResolvedValue(page([entry({ id: 7 }), entry({ id: 8, title: 'Other' })]));
+    const { getByTestId, getByLabelText } = renderScreen(7);
+    await waitFor(() => expect(getByTestId('journal-title-input')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-7')).toBeTruthy());
+
+    expect(getByTestId('journal-drawer-entry-7').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('journal-drawer-entry-8').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('pushes (not navigates) to the tapped entry and closes the drawer', async () => {
+    mockJournalList.mockResolvedValue(page([entry({ id: 7 }), entry({ id: 9, title: 'Other' })]));
+    const { getByTestId, getByLabelText, navigation, queryByTestId } = renderScreen(7);
+    await waitFor(() => expect(getByTestId('journal-title-input')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-9')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-entry-9'));
+    });
+
+    expect(navigation.push).toHaveBeenCalledWith('JournalEntry', { entryId: 9 });
+    expect(navigation.navigate).not.toHaveBeenCalledWith('JournalEntry', { entryId: 9 });
+    expect(queryByTestId('screen-drawer')).toBeNull();
+  });
+
+  it('pushes a blank entry from New entry and closes the drawer', async () => {
+    const { getByTestId, getByLabelText, navigation, queryByTestId } = renderScreen(7);
+    await waitFor(() => expect(getByTestId('journal-title-input')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-new-entry')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-new-entry'));
+    });
+
+    expect(navigation.push).toHaveBeenCalledWith('JournalEntry');
+    expect(queryByTestId('screen-drawer')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenFinish.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenFinish.test.tsx
@@ -35,6 +35,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // Comfortably longer than the shelf's EXCERPT_MAX (140 chars) and multi-paragraph,

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
@@ -38,6 +38,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // The exact copy the load-error banner must render (substring-matched below so

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -45,6 +45,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -51,6 +51,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 const BODY = 'A page about a daily run to the river and back.';

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
@@ -146,6 +146,11 @@ jest.mock('../ReflectionSourcesPanel', () => {
   return { __esModule: true, default: Stub };
 });
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
@@ -37,6 +37,11 @@ jest.mock('@/api', () => ({
   },
 }));
 
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 
 function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@react-navigation/native', () => {
     useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
   };
   return {
-    useNavigation: () => ({ navigate: mockNavigate }),
+    useNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
     // Run the focus callback on mount (and its cleanup on unmount) — enough to
     // exercise the prompt re-fetch in these render-once tests.
     useFocusEffect: (cb: () => undefined | (() => void)) => react.useEffect(cb, []),

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreenDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreenDrawer.test.tsx
@@ -1,0 +1,213 @@
+/* eslint-env jest */
+// The Journal header drawer mounted from JournalShelfScreen: the toggle is
+// installed via useScreenDrawer, entries fetch lazily on first open (the
+// shelf's own initial journal.list call must not be mistaken for the
+// drawer's), reopening is cached, and a row tap navigates (not pushes --
+// unlike the entry-screen mount point) and closes the drawer.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { useSyncExternalStore, type ReactElement } from 'react';
+
+import type { JournalListResponse, JournalMessage, PromptDetail } from '@/api';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+const mockPromptCurrent = jest.fn() as jest.MockedFunction<() => Promise<PromptDetail>>;
+const mockNavigate = jest.fn();
+
+jest.mock('@/api', () => ({
+  journal: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    update: jest.fn(),
+  },
+  prompts: {
+    current: (...a: unknown[]) =>
+      (mockPromptCurrent as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+
+jest.mock('@react-navigation/native', () => {
+  const react = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    useNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+    useFocusEffect: (cb: () => undefined | (() => void)) => react.useEffect(cb, []),
+  };
+});
+
+jest.mock('../SearchBar', () => {
+  const { TextInput } = require('react-native');
+  const Stub = ({ onSearch }: { onSearch: (_q: string) => void }) => (
+    <TextInput testID="shelf-search" onChangeText={onSearch} />
+  );
+  return { __esModule: true, default: Stub };
+});
+jest.mock('../StatTileRow', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="stat-tile-row-stub" />;
+  return { __esModule: true, default: Stub };
+});
+jest.mock('@/features/Return/ReturnStack', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="return-stack-stub" />;
+  return { __esModule: true, default: Stub };
+});
+jest.mock('@/features/Invitations/InvitationStack', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="invitation-stack-stub" />;
+  return { __esModule: true, default: Stub };
+});
+
+const JournalShelfScreen = require('../JournalShelfScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+function ShelfScreenWithHeader(): ReactElement {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <JournalShelfScreen />
+    </>
+  );
+}
+
+function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id,
+    message: `Body of entry ${id}.`,
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: `Entry ${id}`,
+    status: 'finished',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function page(items: JournalMessage[], hasMore = false): JournalListResponse {
+  return { items, total: items.length, has_more: hasMore };
+}
+
+function prompt(overrides: Partial<PromptDetail> = {}): PromptDetail {
+  return {
+    week_number: 3,
+    question: 'What did you notice this week?',
+    has_responded: true,
+    response: null,
+    timestamp: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  headerLeftStore.current = undefined;
+  headerLeftStore.listeners.clear();
+  mockList.mockResolvedValue(page([entry(1)]));
+  mockPromptCurrent.mockResolvedValue(prompt());
+});
+
+describe('Journal header drawer from JournalShelfScreen', () => {
+  it('installs a header-left drawer toggle and opens the drawer on press', async () => {
+    const { getByTestId, getByLabelText } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+    expect(mockSetOptions).toHaveBeenCalled();
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    expect(getByTestId('screen-drawer')).toBeTruthy();
+  });
+
+  it('adds no drawer journal.list call on mount -- only the shelf load fires', async () => {
+    const { getByTestId } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+    expect(mockList).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches entries once when the drawer first opens', async () => {
+    const { getByTestId, getByLabelText } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+
+    expect(mockList).toHaveBeenCalledTimes(2); // 1 shelf load + 1 drawer open
+  });
+
+  it('does not refetch when the drawer is closed and reopened', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+    const callsAfterFirstOpen = mockList.mock.calls.length;
+
+    await act(async () => {
+      fireEvent.press(getByTestId('screen-drawer-scrim'));
+    });
+    expect(queryByTestId('screen-drawer')).toBeNull();
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+    expect(mockList).toHaveBeenCalledTimes(callsAfterFirstOpen);
+  });
+
+  it('navigates (not pushes) to the tapped entry and closes the drawer', async () => {
+    mockList.mockResolvedValue(page([entry(1), entry(2)]));
+    const { getByTestId, getByLabelText, queryByTestId } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-2')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-entry-2'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry', { entryId: 2 });
+    expect(queryByTestId('screen-drawer')).toBeNull();
+  });
+
+  it('selects no row (the shelf has no current entry)', async () => {
+    mockList.mockResolvedValue(page([entry(1)]));
+    const { getByTestId, getByLabelText } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-entry-1')).toBeTruthy());
+
+    expect(getByTestId('journal-drawer-entry-1').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('starts a blank entry and closes the drawer from New entry', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-drawer-new-entry')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-new-entry'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry');
+    expect(queryByTestId('screen-drawer')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/recency.ts
+++ b/frontend/src/features/Journal/recency.ts
@@ -1,0 +1,43 @@
+/**
+ * Recency bucketing + absolute date formatting for journal entries, shared by
+ * the shelf and its header drawer so both group and label entries identically.
+ */
+import type { JournalMessage } from '@/api';
+import { MS_PER_DAY } from '@/utils/dateUtils';
+
+/** Days within which an entry counts as "This week". */
+const WEEK_DAYS = 7;
+/** Days within which an entry counts as "This month". */
+const MONTH_DAYS = 30;
+
+/** The recency bands, in display order. */
+const RECENCY_ORDER = ['This week', 'This month', 'Earlier'] as const;
+
+/** One recency band and the entries that fall in it. */
+export interface ShelfSection {
+  title: string;
+  data: JournalMessage[];
+}
+
+/** Absolute "Month D, YYYY" label for a timestamp; '' for an unparseable one. */
+export function formatDate(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+/** Bucket name for an entry's age relative to ``now`` (epoch ms). */
+function bucketFor(timestamp: string, now: number): string {
+  const age = (now - new Date(timestamp).getTime()) / MS_PER_DAY;
+  if (age < WEEK_DAYS) return 'This week';
+  if (age < MONTH_DAYS) return 'This month';
+  return 'Earlier';
+}
+
+/** Group entries into recency sections, dropping any section with no entries. */
+export function groupByRecency(items: JournalMessage[], now: number): ShelfSection[] {
+  return RECENCY_ORDER.map((title) => ({
+    title,
+    data: items.filter((item) => bucketFor(item.timestamp, now) === title),
+  })).filter((section) => section.data.length > 0);
+}

--- a/frontend/src/features/Journal/usePagedJournal.ts
+++ b/frontend/src/features/Journal/usePagedJournal.ts
@@ -1,0 +1,59 @@
+/**
+ * Offset-paged journal fetch shared by the shelf list and the header drawer.
+ *
+ * Owns the entry page state (items / total / hasMore / loading / error) and a
+ * single ``load`` that either replaces (offset 0) or appends (offset > 0). A
+ * request-sequence guard drops every response but the newest, so overlapping
+ * loads never race and a stale page never clobbers a fresher one.
+ */
+import { useCallback, useRef, useState } from 'react';
+
+import { journal } from '@/api';
+import type { JournalMessage } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+
+/** Entries fetched per page; also the offset step for "load more". */
+export const PAGE_SIZE = 20;
+
+export interface PagedJournal {
+  items: JournalMessage[];
+  total: number;
+  hasMore: boolean;
+  loading: boolean;
+  error: string | null;
+  /** Fetch ``offset``'s page: offset 0 replaces the list, otherwise appends. */
+  load: (_search: string | undefined, _offset: number) => Promise<void>;
+}
+
+/** Offset-paged fetch with a stale-response guard; the caller layers intent on top. */
+export function usePagedJournal(): PagedJournal {
+  const [items, setItems] = useState<JournalMessage[]>([]);
+  const [total, setTotal] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestSeq = useRef(0);
+
+  const load = useCallback(async (search: string | undefined, offset: number) => {
+    // Only the newest in-flight request may settle; stale ones are dropped.
+    const requestId = (requestSeq.current += 1);
+    const isLatest = () => requestId === requestSeq.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const page = await journal.list({ search, limit: PAGE_SIZE, offset });
+      if (!isLatest()) return;
+      setItems((prev) => (offset === 0 ? page.items : [...prev, ...page.items]));
+      setTotal(page.total);
+      setHasMore(page.has_more);
+    } catch (err) {
+      // Surface the failure so a cold-start network error isn't mistaken for an
+      // empty list; the current items (if any) stay in place for retry.
+      if (isLatest()) setError(formatApiError(err));
+    } finally {
+      if (isLatest()) setLoading(false);
+    }
+  }, []);
+
+  return { items, total, hasMore, loading, error, load };
+}


### PR DESCRIPTION
## Summary

Adds the shared header-hamburger `ScreenDrawer` to the Journal surfaces with a scrollable list of past entries — like the chat list in a Claude side panel — so any past entry is reachable without scrolling the shelf, including from inside an open entry.

- A header hamburger opens the drawer on the Journal tab (`JournalShelfScreen`) and on the pushed `JournalEntryScreen` (where it earns its keep — the shelf already lists entries).
- Drawer rows show entry title (or `Untitled`) + date, newest-first, grouped by the shelf's existing recency sections (This week / This month / Earlier); tapping one navigates to that entry and closes the drawer.
- A "New entry" row at the top opens a blank entry; the current entry is highlighted when the drawer is opened from `JournalEntryScreen`.
- All rows are a11y-labeled with title + date.

### Design notes / decisions
- **Shared extraction, not duplication.** The shelf's recency grouping moved to `recency.ts` and its paged-fetch core to `usePagedJournal.ts`; both `useShelf` (which layers search on top) and the new drawer hook `useJournalDrawerEntries` consume the same fetch core, so grouping and paging stay identical to the shelf. The extraction is behavior-preserving — the existing shelf suite passes unchanged.
- **Lazy fetch, cached across reopens.** The drawer fetches on first open only (the `ScreenDrawer` Modal unmounts its children when closed), mirroring the Course drawer's `useCourseDrawerContent` pattern. Opening the drawer adds no `journal.list` call on shelf mount.
- **Paging is a "Load older entries" row, not `onEndReached`.** The shared `ScreenDrawer` owns its own `ScrollView` (and must not be modified by this issue), so infinite scroll is realized as a tappable load-more row that fetches the next page and appends.
- **Entry-screen navigation uses `navigation.push`.** `JournalEntryScreen` latches its entry id at mount, so navigating in place would not reload; rows and the New-entry row `push` a fresh entry screen from that mount point (the shelf keeps `navigate`).
- **`headerLeft` replaces the back chevron on the pushed entry screen.** `useScreenDrawer` installs the hamburger as `headerLeft`; on the pushed entry screen this displaces the native back chevron. This is intentional given the issue mandates that mount point and the drawer module is consume-only — back remains available via gesture/hardware back, and the drawer is the in-screen navigation affordance.
- No search box in the drawer v1 — the shelf's `SearchBar` remains the search surface.

## Test plan
- New suites: `JournalDrawer.test.tsx` (recency grouping, newest-first, Untitled+date fallback, a11y labels, New-entry row, row-tap callback + close, current-entry highlight, load-more visibility/append, loading + error/retry), `JournalShelfScreenDrawer.test.tsx` and `JournalEntryScreenDrawer.test.tsx` (both mount points, lazy fetch, `navigate` vs `push`).
- Existing `JournalShelfScreen.test.tsx` (grouping/paging/search) and all 10 `JournalEntryScreen*` suites pass unchanged (only additive nav-hook mocks added).
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and the full Jest suite (3973 tests).

Closes #1470
Refs #1465