### PR TITLE
feat(map): Map screen drawer — stage legend, jump-to-stage, and journey summary

### DIFF
--- a/frontend/src/features/Map/MapDrawer.tsx
+++ b/frontend/src/features/Map/MapDrawer.tsx
@@ -1,0 +1,219 @@
+/**
+ * The Map header-drawer body: a compact legend of all ten stages rendered as
+ * ``ScreenDrawer`` children (the panel supplies the scroll surface, so this maps
+ * plain rows). Each row shows the stage's color swatch, persona/descriptor, and
+ * its wheel-of-wholeness balance read; the current stage is marked, and a locked
+ * stage carries a padlock plus its calendar unlock estimate. Tapping any row —
+ * locked or not — glides the magnifier lens to that stage and closes the drawer.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+
+import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
+import { useDaysUntilStage, useDerivedCurrentWeek } from '../../store/useProgramProgression';
+
+import { cycleLabel } from './beginAgain';
+import { journeyRead, unlockTimeline } from './journeyNarrative';
+import { STAGE_DISPLAY, type StageDisplay } from './mapLayout';
+import { isStageUnlocked } from './services/stageService';
+import { STAGE_COUNT, type StageData } from './stageData';
+import { balanceLabelSuffix, stageNodeLabel, THIN_FULLNESS } from './stageLegend';
+
+/** Glyph shown on a locked stage row. */
+const LOCKED_GLYPH = '🔒';
+/** Only the first pass earns no cycle caption; later passes name the cycle. */
+const SINGLE_CYCLE = 1;
+/** Diameter of the current-stage marker dot in dp. */
+const MARKER_SIZE = 10;
+/** Side of the square color swatch in dp. */
+const SWATCH_SIZE = 14;
+/** Dim factor applied to a locked stage row. */
+const LOCKED_ROW_OPACITY = 0.6;
+
+interface JourneySummaryProps {
+  currentStage: number;
+  cycleNumber: number;
+}
+
+/** The "Stage N of 10 · Week W" read plus, past the first pass, its cycle. */
+const JourneySummary = ({ currentStage, cycleNumber }: JourneySummaryProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const week = useDerivedCurrentWeek(1);
+  return (
+    <View testID="map-drawer-journey" style={styles.journey}>
+      <Text style={[type(width).body, styles.journeyText]}>
+        {journeyRead(currentStage, week, STAGE_COUNT)}
+      </Text>
+      {cycleNumber > SINGLE_CYCLE ? (
+        <Text style={[type(width).caption, styles.cycle]}>{cycleLabel(cycleNumber)}</Text>
+      ) : null}
+    </View>
+  );
+};
+
+/** "Unlocks in N days" estimate for a locked row, read from the calendar drip. */
+const UnlockRow = ({ stageNumber }: { stageNumber: number }): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  const daysUntil = useDaysUntilStage(stageNumber);
+  return (
+    <Text testID={`map-drawer-unlock-${stageNumber}`} style={[type(width).caption, styles.unlock]}>
+      {unlockTimeline(daysUntil)}
+    </Text>
+  );
+};
+
+interface LegendRowProps {
+  stageNumber: number;
+  display: StageDisplay;
+  fullness: number;
+  locked: boolean;
+  selected: boolean;
+  onSelectStage: (_stageNumber: number) => void;
+}
+
+/** One tappable legend row: swatch, persona/descriptor, balance read, and the
+ *  current-stage marker or a locked stage's padlock + unlock estimate. */
+const LegendRow = ({
+  stageNumber,
+  display,
+  fullness,
+  locked,
+  selected,
+  onSelectStage,
+}: LegendRowProps): React.JSX.Element => {
+  const { width } = useWindowDimensions();
+  return (
+    <TouchableOpacity
+      testID={`map-drawer-stage-${stageNumber}`}
+      accessibilityRole="button"
+      accessibilityLabel={stageNodeLabel(display, fullness)}
+      accessibilityState={{ selected }}
+      onPress={() => onSelectStage(stageNumber)}
+      style={[styles.row, selected ? styles.rowSelected : null, locked ? styles.rowLocked : null]}
+    >
+      <View
+        testID={`map-drawer-swatch-${stageNumber}`}
+        style={[styles.swatch, { backgroundColor: display.textColor }]}
+      />
+      <View style={styles.rowBody}>
+        <Text style={[type(width).label, styles.persona]} numberOfLines={1}>
+          {display.persona}
+        </Text>
+        <Text style={[type(width).caption, styles.descriptor]} numberOfLines={1}>
+          {display.descriptor}
+        </Text>
+        <Text style={[type(width).caption, styles.balanceRead]}>
+          {balanceLabelSuffix(fullness)}
+        </Text>
+        {locked ? <UnlockRow stageNumber={stageNumber} /> : null}
+      </View>
+      {selected ? (
+        <View testID={`map-drawer-current-${stageNumber}`} style={styles.currentMarker} />
+      ) : null}
+      {locked ? <Text style={styles.lockGlyph}>{LOCKED_GLYPH}</Text> : null}
+    </TouchableOpacity>
+  );
+};
+
+export interface MapDrawerProps {
+  /** Stage number → loaded StageData, for resolving each row's lock state. */
+  lookup: Readonly<Record<number, StageData | undefined>>;
+  /** The stage the journey currently rests on, marked selected in the list. */
+  currentStage: number;
+  /** Wheel-of-wholeness fullness (0..1) by stage; absent reads thin. */
+  fullnessByStage: Readonly<Record<number, number>>;
+  /** Which pass through the arc the user is on; past 1 it captions the cycle. */
+  cycleNumber: number;
+  /** Glide the magnifier lens to a stage and close the drawer. */
+  onSelectStage: (_stageNumber: number) => void;
+}
+
+/** The stage legend for the Map header drawer: one row per stage, ascending. */
+export default function MapDrawer({
+  lookup,
+  currentStage,
+  fullnessByStage,
+  cycleNumber,
+  onSelectStage,
+}: MapDrawerProps): React.JSX.Element {
+  const stageNumbers = Array.from({ length: STAGE_COUNT }, (_, i) => i + 1);
+  return (
+    <View testID="map-drawer">
+      <JourneySummary currentStage={currentStage} cycleNumber={cycleNumber} />
+      {stageNumbers.map((stageNumber) => {
+        const display = STAGE_DISPLAY[stageNumber];
+        if (!display) return null;
+        const stage = lookup[stageNumber];
+        return (
+          <LegendRow
+            key={stageNumber}
+            stageNumber={stageNumber}
+            display={display}
+            fullness={fullnessByStage[stageNumber] ?? THIN_FULLNESS}
+            locked={stage ? !isStageUnlocked(stage, currentStage) : true}
+            selected={stageNumber === currentStage}
+            onSelectStage={onSelectStage}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  journey: {
+    marginBottom: SPACING.md,
+    gap: SPACING.xs,
+  },
+  journeyText: {
+    color: ink.primary,
+    fontWeight: '600',
+  },
+  cycle: {
+    color: ink.muted,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: radius.sm,
+  },
+  rowSelected: {
+    backgroundColor: surface.sunken,
+  },
+  rowLocked: {
+    opacity: LOCKED_ROW_OPACITY,
+  },
+  swatch: {
+    width: SWATCH_SIZE,
+    height: SWATCH_SIZE,
+    borderRadius: radius.sm,
+  },
+  rowBody: {
+    flex: 1,
+  },
+  persona: {
+    color: ink.primary,
+  },
+  descriptor: {
+    color: ink.soft,
+  },
+  balanceRead: {
+    color: ink.muted,
+  },
+  unlock: {
+    color: ink.muted,
+  },
+  currentMarker: {
+    width: MARKER_SIZE,
+    height: MARKER_SIZE,
+    borderRadius: MARKER_SIZE / 2,
+    backgroundColor: accent.primary,
+  },
+  lockGlyph: {
+    color: ink.muted,
+  },
+});

--- a/frontend/src/features/Map/MapDrawer.tsx
+++ b/frontend/src/features/Map/MapDrawer.tsx
@@ -10,10 +10,10 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 
 import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
-import { useDaysUntilStage, useDerivedCurrentWeek } from '../../store/useProgramProgression';
+import { useDaysUntilStage } from '../../store/useProgramProgression';
 
-import { cycleLabel } from './beginAgain';
-import { journeyRead, unlockTimeline } from './journeyNarrative';
+import { useJourneySummary } from './hooks/useJourneySummary';
+import { unlockTimeline } from './journeyNarrative';
 import { STAGE_DISPLAY, type StageDisplay } from './mapLayout';
 import { isStageUnlocked } from './services/stageService';
 import { STAGE_COUNT, type StageData } from './stageData';
@@ -21,8 +21,6 @@ import { balanceLabelSuffix, stageNodeLabel, THIN_FULLNESS } from './stageLegend
 
 /** Glyph shown on a locked stage row. */
 const LOCKED_GLYPH = '🔒';
-/** Only the first pass earns no cycle caption; later passes name the cycle. */
-const SINGLE_CYCLE = 1;
 /** Diameter of the current-stage marker dot in dp. */
 const MARKER_SIZE = 10;
 /** Side of the square color swatch in dp. */
@@ -38,14 +36,12 @@ interface JourneySummaryProps {
 /** The "Stage N of 10 · Week W" read plus, past the first pass, its cycle. */
 const JourneySummary = ({ currentStage, cycleNumber }: JourneySummaryProps): React.JSX.Element => {
   const { width } = useWindowDimensions();
-  const week = useDerivedCurrentWeek(1);
+  const { read, cycleCaption } = useJourneySummary(currentStage, cycleNumber);
   return (
     <View testID="map-drawer-journey" style={styles.journey}>
-      <Text style={[type(width).body, styles.journeyText]}>
-        {journeyRead(currentStage, week, STAGE_COUNT)}
-      </Text>
-      {cycleNumber > SINGLE_CYCLE ? (
-        <Text style={[type(width).caption, styles.cycle]}>{cycleLabel(cycleNumber)}</Text>
+      <Text style={[type(width).body, styles.journeyText]}>{read}</Text>
+      {cycleCaption ? (
+        <Text style={[type(width).caption, styles.cycle]}>{cycleCaption}</Text>
       ) : null}
     </View>
   );

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -18,11 +18,7 @@ import type { HabitHistoryItem, PracticeHistoryItem, StageHistoryResponse } from
 import { stages as stagesApi } from '../../api';
 import { MAP_BACKGROUND_URI } from '../../constants/images';
 import { useAppNavigation } from '../../navigation/hooks';
-import {
-  useDaysUntilStage,
-  useDerivedCurrentStage,
-  useDerivedCurrentWeek,
-} from '../../store/useProgramProgression';
+import { useDaysUntilStage, useDerivedCurrentStage } from '../../store/useProgramProgression';
 import {
   selectCurrentStage,
   selectCycleNumber,
@@ -32,14 +28,14 @@ import {
   useStageStore,
 } from '../../store/useStageStore';
 
-import { BEGIN_AGAIN_COPY, cycleLabel } from './beginAgain';
+import { BEGIN_AGAIN_COPY } from './beginAgain';
 import { useBeginAgainGuard } from './hooks/useBeginAgainGuard';
+import { useJourneySummary } from './hooks/useJourneySummary';
 import { useStageAnchors } from './hooks/useStageAnchors';
 import type { UseStageAnchorsResult } from './hooks/useStageAnchors';
 import { useWheelBalance } from './hooks/useWheelBalance';
 import {
   formatMinutes,
-  journeyRead,
   progressionSentence,
   rankedStats,
   unlockTimeline,
@@ -58,7 +54,7 @@ import {
 } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
-import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
+import { isLeftReturning, type StageData } from './stageData';
 import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
 
@@ -824,9 +820,6 @@ const MapBackdrop = (): React.JSX.Element =>
     <View style={styles.backdrop} testID="map-background" pointerEvents="none" />
   );
 
-/** The first pass through the arc; cycles beyond it earn the subtle indicator. */
-const FIRST_CYCLE = 1;
-
 interface JourneyHeaderProps {
   currentStage: number;
   cycleNumber: number;
@@ -834,13 +827,13 @@ interface JourneyHeaderProps {
 
 /** Compact momentum read at the top of the Map: "Stage N of 10 · Week W". */
 const JourneyHeader = ({ currentStage, cycleNumber }: JourneyHeaderProps): React.JSX.Element => {
-  const week = useDerivedCurrentWeek(1);
+  const { read, cycleCaption } = useJourneySummary(currentStage, cycleNumber);
   return (
     <View style={styles.journeyHeader} testID="journey-read">
-      <Text style={styles.journeyReadText}>{journeyRead(currentStage, week, STAGE_COUNT)}</Text>
-      {cycleNumber > FIRST_CYCLE ? (
+      <Text style={styles.journeyReadText}>{read}</Text>
+      {cycleCaption ? (
         <Text style={styles.cycleIndicator} testID="cycle-indicator">
-          {cycleLabel(cycleNumber)}
+          {cycleCaption}
         </Text>
       ) : null}
     </View>

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -46,6 +46,7 @@ import {
 } from './journeyNarrative';
 import { MagnifierLens } from './MagnifierLens';
 import styles from './Map.styles';
+import MapDrawer from './MapDrawer';
 import {
   fitRightLabel,
   fittedTitleFontSize,
@@ -58,10 +59,11 @@ import {
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
 import { isLeftReturning, STAGE_COUNT, type StageData } from './stageData';
+import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
-import { FULLNESS_ALIVE_THRESHOLD } from './wheelBalance';
 
 import { Button } from '@/components/Button';
+import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
 import { Celebration } from '@/components/feedback/Celebration';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 import { colors } from '@/design/tokens';
@@ -73,15 +75,6 @@ type StageLookup = Readonly<Record<number, StageData | undefined>>;
 type FullnessLookup = Readonly<Record<number, number>>;
 
 const FULL_PROGRESS = 1;
-const THIN_FULLNESS = 0;
-
-/** Accessibility suffix appended to a node's label from its wheel fullness. */
-const balanceLabelSuffix = (fullness: number): string =>
-  fullness >= FULLNESS_ALIVE_THRESHOLD ? 'reads full' : 'reads thin';
-
-/** Full a11y label for a stage node: persona/descriptor plus the balance read. */
-const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
-  `${display.persona} - ${display.descriptor} - ${balanceLabelSuffix(fullness)}`;
 
 // --- Sub-components ---
 //
@@ -1084,7 +1077,38 @@ const CelebrationBanner = ({
   );
 };
 
+interface MapScreenDrawerProps {
+  drawer: ScreenDrawerState;
+  lookup: StageLookup;
+  currentStage: number;
+  fullnessByStage: FullnessLookup;
+  cycleNumber: number;
+  onSelectStage: (_stageNumber: number) => void;
+}
+
+/** The Map header drawer: a stage legend whose row tap glides the lens there. */
+const MapScreenDrawer = ({
+  drawer,
+  lookup,
+  currentStage,
+  fullnessByStage,
+  cycleNumber,
+  onSelectStage,
+}: MapScreenDrawerProps): React.JSX.Element => (
+  <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Map" title="Map">
+    <MapDrawer
+      lookup={lookup}
+      currentStage={currentStage}
+      fullnessByStage={fullnessByStage}
+      cycleNumber={cycleNumber}
+      onSelectStage={onSelectStage}
+    />
+  </ScreenDrawer>
+);
+
 interface MapContentProps {
+  drawer: ScreenDrawerState;
+  onDrawerSelectStage: (_stageNumber: number) => void;
   lookup: StageLookup;
   fullnessByStage: FullnessLookup;
   currentStage: number;
@@ -1134,19 +1158,47 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
         onClose={props.onCloseModal}
         onNavigate={props.onNavigate}
       />
+      <MapScreenDrawer
+        drawer={props.drawer}
+        lookup={props.lookup}
+        currentStage={props.currentStage}
+        fullnessByStage={props.fullnessByStage}
+        cycleNumber={props.cycleNumber}
+        onSelectStage={props.onDrawerSelectStage}
+      />
     </ContentContainer>
   </View>
 );
 
+/** Map header drawer: a row tap closes it and glides the lens to that stage. */
+const useMapDrawer = (
+  lens: LensFocus,
+): { drawer: ScreenDrawerState; onDrawerSelectStage: (_stageNumber: number) => void } => {
+  const drawer = useScreenDrawer('Map');
+  // A drawer row tap is a pure select-and-highlight: the map is not scrollable,
+  // so close the drawer and glide the magnifier lens to the tapped stage.
+  const onDrawerSelectStage = useCallback(
+    (stageNumber: number) => {
+      drawer.close();
+      lens.setFocusedStage(stageNumber);
+    },
+    [drawer, lens],
+  );
+  return { drawer, onDrawerSelectStage };
+};
+
+/** Read the five Map-relevant slices of the stage store in one place. */
+const useMapStageStore = () => ({
+  stages: useStageStore(selectStages),
+  loading: useStageStore(selectStagesLoading),
+  error: useStageStore(selectStagesError),
+  storeCurrentStage: useStageStore(selectCurrentStage),
+  cycleNumber: useStageStore(selectCycleNumber),
+});
+
 const MapScreen = (): React.JSX.Element => {
-  const stages = useStageStore(selectStages);
-  const loading = useStageStore(selectStagesLoading);
-  const error = useStageStore(selectStagesError);
-  const storeCurrentStage = useStageStore(selectCurrentStage);
-  const cycleNumber = useStageStore(selectCycleNumber);
-  // Prefer the date-driven stage when the master anchor is set; the
-  // server's count-based ``currentStage`` is the fallback for users who
-  // haven't picked an anchor yet.
+  const { stages, loading, error, storeCurrentStage, cycleNumber } = useMapStageStore();
+  // Prefer the date-driven stage; the server's count-based one is the fallback.
   const currentStage = useDerivedCurrentStage(storeCurrentStage);
   // Additive overlay: a failed/loading read leaves the map empty so every Aspect reads thin.
   const { fullnessByStage } = useWheelBalance();
@@ -1170,12 +1222,15 @@ const MapScreen = (): React.JSX.Element => {
   const handleNavigate = useStageNavigation(handleCloseModal);
   const celebration = useStageCompletionCelebration(stages, lookup);
   const lens = useLensFocus(currentStage, lookup, setActiveStage);
+  const { drawer, onDrawerSelectStage } = useMapDrawer(lens);
 
   if (loading && stages.length === 0) return <MapLoading />;
   if (error && stages.length === 0) return <MapError message={error} />;
 
   return (
     <MapContent
+      drawer={drawer}
+      onDrawerSelectStage={onDrawerSelectStage}
       lookup={lookup}
       fullnessByStage={fullnessByStage}
       currentStage={currentStage}

--- a/frontend/src/features/Map/__tests__/MapDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapDrawer.test.tsx
@@ -1,0 +1,337 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// Pure body suite for the Map header drawer's legend: ten stage rows ascending
+// (1 at top), the persona/descriptor/balance-read a11y label, the current-stage
+// marker, the locked-row unlock timeline, and the journey summary line.
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import { cycleLabel } from '../beginAgain';
+import { journeyRead, unlockTimeline } from '../journeyNarrative';
+import MapDrawer from '../MapDrawer';
+import { STAGE_DISPLAY } from '../mapLayout';
+import { STAGE_COUNT } from '../stageData';
+import type { StageData } from '../stageData';
+import { stageNodeLabel } from '../stageLegend';
+import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
+
+import { mockMakeStage, mockMapState, resetMapMockState } from './mapTestHarness';
+
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+
+type TestNode = { props: Record<string, unknown> };
+
+type Lookup = Readonly<Record<number, StageData | undefined>>;
+
+const buildLookup = (): Lookup => {
+  const lookup: Record<number, StageData> = {};
+  for (let n = 1; n <= STAGE_COUNT; n += 1) {
+    lookup[n] = mockMakeStage(n);
+  }
+  return lookup;
+};
+
+const requireDisplay = (stageNumber: number) => {
+  const display = STAGE_DISPLAY[stageNumber];
+  if (!display) throw new Error(`no STAGE_DISPLAY entry for stage ${stageNumber}`);
+  return display;
+};
+
+describe('MapDrawer', () => {
+  beforeEach(() => {
+    resetMapMockState();
+  });
+
+  it('renders ten stage rows in ascending order, stage 1 at the top', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const stageRowPattern = /^map-drawer-stage-\d+$/;
+    const rows = tree.root.findAll(
+      (n: TestNode) =>
+        typeof n.props.testID === 'string' && stageRowPattern.test(n.props.testID as string),
+    );
+    const order = [...new Set(rows.map((r: TestNode) => r.props.testID as string))];
+    expect(order).toEqual(
+      Array.from({ length: STAGE_COUNT }, (_, i) => `map-drawer-stage-${i + 1}`),
+    );
+  });
+
+  it('colors each stage swatch with STAGE_DISPLAY.textColor', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    for (const n of [1, 5, 10]) {
+      const swatch = tree.root.findByProps({ testID: `map-drawer-swatch-${n}` });
+      const flat = StyleSheet.flatten(swatch.props.style) as { backgroundColor?: string };
+      expect(flat.backgroundColor).toBe(requireDisplay(n).textColor);
+    }
+  });
+
+  it('shows persona and descriptor text for every stage', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    for (let n = 1; n <= STAGE_COUNT; n += 1) {
+      const display = requireDisplay(n);
+      expect(
+        tree.root.findAll((node: TestNode) => node.props.children === display.persona).length,
+      ).toBeGreaterThan(0);
+      expect(
+        tree.root.findAll((node: TestNode) => node.props.children === display.descriptor).length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('gives each row an accessibilityLabel matching stageNodeLabel', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{ 3: FULLNESS_ALIVE_THRESHOLD }}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-3' });
+    expect(row.props.accessibilityLabel).toBe(
+      stageNodeLabel(requireDisplay(3), FULLNESS_ALIVE_THRESHOLD),
+    );
+  });
+
+  it('gives each row accessibilityRole="button"', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-7' });
+    expect(row.props.accessibilityRole).toBe('button');
+  });
+
+  it('shows a reads-full caption when fullness meets the alive threshold', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{ 2: FULLNESS_ALIVE_THRESHOLD }}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-2' });
+    expect(row.findAll((n: TestNode) => n.props.children === 'reads full').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('shows a reads-thin caption when fullness is absent', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-4' });
+    expect(row.findAll((n: TestNode) => n.props.children === 'reads thin').length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('marks only the current stage row selected, with its current marker', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={5}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const currentRow = tree.root.findByProps({ testID: 'map-drawer-stage-5' });
+    expect(currentRow.props.accessibilityState).toEqual({ selected: true });
+    expect(tree.root.findByProps({ testID: 'map-drawer-current-5' })).toBeTruthy();
+
+    const otherRow = tree.root.findByProps({ testID: 'map-drawer-stage-6' });
+    expect(otherRow.props.accessibilityState).toEqual({ selected: false });
+  });
+
+  it('shows the lock glyph and pluralised unlock copy for a locked row', () => {
+    mockMapState.daysUntilStage = 5;
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-5' });
+    expect(row.findAll((n: TestNode) => n.props.children === '🔒').length).toBeGreaterThan(0);
+    const unlockLine = tree.root.findByProps({ testID: 'map-drawer-unlock-5' });
+    expect(unlockLine.props.children).toBe(unlockTimeline(5));
+  });
+
+  it('treats a stage missing from the lookup as locked', () => {
+    mockMapState.daysUntilStage = 3;
+    const lookup: Record<number, StageData> = {};
+    for (let n = 1; n <= STAGE_COUNT; n += 1) {
+      if (n !== 6) lookup[n] = mockMakeStage(n, { isUnlocked: true });
+    }
+    const tree = create(
+      <MapDrawer
+        lookup={lookup}
+        currentStage={STAGE_COUNT}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-6' });
+    expect(row.findAll((n: TestNode) => n.props.children === '🔒').length).toBeGreaterThan(0);
+    expect(tree.root.findByProps({ testID: 'map-drawer-unlock-6' })).toBeTruthy();
+  });
+
+  it('singularises "day" when exactly one day remains', () => {
+    mockMapState.daysUntilStage = 1;
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const unlockLine = tree.root.findByProps({ testID: 'map-drawer-unlock-8' });
+    expect(unlockLine.props.children).toBe(unlockTimeline(1));
+    expect(unlockLine.props.children).toBe('Unlocks in 1 day');
+  });
+
+  it('falls back to the no-anchor copy when no days-until value is set', () => {
+    mockMapState.daysUntilStage = null;
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const unlockLine = tree.root.findByProps({ testID: 'map-drawer-unlock-9' });
+    expect(unlockLine.props.children).toBe(unlockTimeline(null));
+    expect(unlockLine.props.children).toBe('Unlocks as your journey reaches it');
+  });
+
+  it('fires onSelectStage with the stage number when an unlocked row is tapped', () => {
+    const onSelectStage = jest.fn();
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={onSelectStage}
+      />,
+    );
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-2' }).props.onPress();
+    });
+    expect(onSelectStage).toHaveBeenCalledWith(2);
+  });
+
+  it('fires onSelectStage even for a locked row', () => {
+    const onSelectStage = jest.fn();
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={onSelectStage}
+      />,
+    );
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-8' }).props.onPress();
+    });
+    expect(onSelectStage).toHaveBeenCalledWith(8);
+  });
+
+  it('shows the journey summary line with journeyRead copy', () => {
+    mockMapState.derivedWeek = 4;
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={3}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const summary = tree.root.findByProps({ testID: 'map-drawer-journey' });
+    expect(
+      summary.findAll((n: TestNode) => n.props.children === journeyRead(3, 4, STAGE_COUNT)).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows the cycle label only when cycleNumber is greater than 1', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={2}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    expect(
+      tree.root.findAll((n: TestNode) => n.props.children === cycleLabel(2)).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('hides the cycle label when cycleNumber is 1', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    expect(tree.root.findAll((n: TestNode) => n.props.children === cycleLabel(1)).length).toBe(0);
+  });
+});

--- a/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
@@ -1,0 +1,166 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// Integration suite for the Map header drawer wired into MapScreen: the
+// header-left toggle installs via useScreenDrawer, opening it renders the
+// stage legend, and tapping a row closes the drawer and moves the magnifier
+// lens's focus to the tapped stage. Mirrors MapScreen.test.tsx's mock setup so
+// the same harness-driven stages/wheel/progression state applies.
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import MapScreen from '../MapScreen';
+
+import { mockMakeStage, mockMapState, mockSetOptions, resetMapMocks } from './mapTestHarness';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../hooks/useWheelBalance', () =>
+  jest.requireActual('./mapTestHarness').mockWheelBalanceModule(),
+);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => true,
+}));
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
+
+type TestNode = { props: Record<string, unknown> };
+type HeaderLeftOptions = { headerLeft?: () => React.ReactElement };
+
+const WAVE_LAYOUT_WIDTH = 300;
+const WAVE_LAYOUT_HEIGHT = 600;
+
+const fireGridLayout = (tree: ReturnType<typeof create>): void => {
+  act(() => {
+    tree.root.findByProps({ testID: 'map-grid' }).props.onLayout({
+      nativeEvent: { layout: { width: WAVE_LAYOUT_WIDTH, height: WAVE_LAYOUT_HEIGHT } },
+    });
+  });
+};
+
+/** Grab the most recently installed headerLeft toggle element. */
+const lastHeaderLeftToggle = (): React.ReactElement => {
+  const calls = mockSetOptions.mock.calls;
+  const lastCall = calls[calls.length - 1] as [HeaderLeftOptions] | undefined;
+  if (!lastCall) throw new Error('setOptions was never called');
+  const headerLeft = lastCall[0].headerLeft;
+  if (!headerLeft) throw new Error('headerLeft was not installed');
+  return headerLeft();
+};
+
+/** Press the installed header-left toggle to open the drawer in-tree. */
+const openDrawer = (): void => {
+  const toggle = lastHeaderLeftToggle();
+  act(() => {
+    (toggle.props as { onPress: () => void }).onPress();
+  });
+};
+
+describe('MapScreen header drawer', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('installs a header-left drawer toggle via useScreenDrawer', () => {
+    const tree = create(<MapScreen />);
+    expect(mockSetOptions).toHaveBeenCalled();
+    const toggle = lastHeaderLeftToggle();
+    // headerLeft returns an unrendered DrawerToggle element; its label lives on
+    // the TouchableOpacity it renders, so render it to assert the Map label.
+    let rendered: ReturnType<typeof create> | undefined;
+    act(() => {
+      rendered = create(toggle);
+    });
+    expect(rendered?.root.findByProps({ accessibilityLabel: 'Open Map menu' })).toBeTruthy();
+    act(() => rendered?.unmount());
+    act(() => tree.unmount());
+  });
+
+  it('renders the stage legend once the drawer toggle is pressed', () => {
+    const tree = create(<MapScreen />);
+    openDrawer();
+    expect(tree.root.findByProps({ testID: 'map-drawer' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'map-drawer-stage-1' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'map-drawer-stage-10' })).toBeTruthy();
+  });
+
+  it('installs the toggle but keeps the drawer unrendered until pressed', () => {
+    const tree = create(<MapScreen />);
+    expect(mockSetOptions).toHaveBeenCalled();
+    expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
+  });
+
+  it('tapping a drawer row closes the drawer and moves the lens focus to that stage', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    openDrawer();
+
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-3' }).props.onPress();
+    });
+
+    // Closing unmounts the drawer body (the Modal renders null when hidden).
+    expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
+    // The lens headline reflects the newly focused stage (stage 3's arrow label).
+    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
+    expect(headline.props.children).toBe('Self-Love');
+  });
+
+  it('tapping a locked drawer row still closes the drawer and refocuses the lens', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    openDrawer();
+
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-8' }).props.onPress();
+    });
+
+    // Closing unmounts the drawer body (the Modal renders null when hidden).
+    expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
+    // The lens headline reflects the newly focused stage (stage 8's arrow label).
+    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
+    expect(headline.props.children).toBe('Nondual');
+  });
+
+  it('does not open the stage-detail modal when a drawer row is tapped', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    openDrawer();
+
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-3' }).props.onPress();
+    });
+
+    expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
+  });
+
+  it('reflects the current cycle number in the drawer journey summary', () => {
+    // The top JourneyHeader also renders "Cycle 2" (testID cycle-indicator);
+    // scope the assertion to the drawer body so it pins the drawer's own copy.
+    mockMapState.cycleNumber = 2;
+    const tree = create(<MapScreen />);
+    openDrawer();
+    const drawer = tree.root.findByProps({ testID: 'map-drawer' });
+    const found = drawer.findAll((n: TestNode) => n.props.children === 'Cycle 2');
+    expect(found.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -3,7 +3,7 @@
 import type { StageData } from '../stageData';
 
 /**
- * Shared Jest scaffold for the six MapScreen-driven suites. Each suite keeps its
+ * Shared Jest scaffold for the MapScreen-driven suites. Each suite keeps its
  * own ``jest.mock(...)`` calls (so it controls exactly which modules it mocks)
  * and points every factory at a builder here via
  * ``jest.requireActual('./mapTestHarness')`` — the factory then references only
@@ -103,6 +103,8 @@ export function resetMapMockState(): void {
 
 /** Navigation spy asserted by the suites; the navigation mock reads it. */
 export const mockNavigate = jest.fn();
+/** ``navigation.setOptions`` spy — surfaces the drawer's installed ``headerLeft``. */
+export const mockSetOptions = jest.fn();
 /** ``stageService.loadStages`` spy. */
 export const mockLoadStages = jest.fn();
 /** ``stageService.beginAgain`` spy. */
@@ -112,6 +114,7 @@ export const mockBeginAgain = jest.fn();
 export function resetMapMocks(): void {
   resetMapMockState();
   mockNavigate.mockClear();
+  mockSetOptions.mockClear();
   mockLoadStages.mockClear();
   mockBeginAgain.mockClear();
 }
@@ -157,9 +160,14 @@ export function mockInteractionManagerModule() {
   };
 }
 
-/** ``navigation/hooks`` — surfaces the shared ``mockNavigate`` spy. */
+/**
+ * ``navigation/hooks`` — surfaces the shared ``mockNavigate`` / ``mockSetOptions``
+ * spies. ``setOptions`` is read by ``useScreenDrawer`` (a header-left toggle
+ * installed in a ``useLayoutEffect``); without it every screen that mounts a
+ * drawer would crash reading ``setOptions`` off an undefined navigation object.
+ */
 export function mockNavigationModule() {
-  return { useAppNavigation: () => ({ navigate: mockNavigate }) };
+  return { useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }) };
 }
 
 /** ``@react-navigation/bottom-tabs``. */

--- a/frontend/src/features/Map/__tests__/stageLegend.test.ts
+++ b/frontend/src/features/Map/__tests__/stageLegend.test.ts
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { STAGE_DISPLAY } from '../mapLayout';
+import { balanceLabelSuffix, stageNodeLabel, THIN_FULLNESS } from '../stageLegend';
+import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
+
+const requireDisplay = (stageNumber: number) => {
+  const display = STAGE_DISPLAY[stageNumber];
+  if (!display) throw new Error(`no STAGE_DISPLAY entry for stage ${stageNumber}`);
+  return display;
+};
+
+describe('balanceLabelSuffix', () => {
+  it('reads full at exactly the alive threshold', () => {
+    expect(balanceLabelSuffix(FULLNESS_ALIVE_THRESHOLD)).toBe('reads full');
+  });
+
+  it('reads full above the alive threshold', () => {
+    expect(balanceLabelSuffix(FULLNESS_ALIVE_THRESHOLD + 0.1)).toBe('reads full');
+  });
+
+  it('reads thin just below the alive threshold', () => {
+    expect(balanceLabelSuffix(FULLNESS_ALIVE_THRESHOLD - 0.01)).toBe('reads thin');
+  });
+
+  it('reads thin at zero fullness', () => {
+    expect(balanceLabelSuffix(0)).toBe('reads thin');
+  });
+});
+
+describe('stageNodeLabel', () => {
+  it('joins persona, descriptor, and a reads-full suffix at the threshold', () => {
+    const display = requireDisplay(3);
+    expect(stageNodeLabel(display, FULLNESS_ALIVE_THRESHOLD)).toBe(
+      `${display.persona} - ${display.descriptor} - reads full`,
+    );
+  });
+
+  it('joins persona, descriptor, and a reads-thin suffix below the threshold', () => {
+    const display = requireDisplay(1);
+    expect(stageNodeLabel(display, 0)).toBe(
+      `${display.persona} - ${display.descriptor} - reads thin`,
+    );
+  });
+});
+
+describe('THIN_FULLNESS', () => {
+  it('is the absent-fullness fallback of zero', () => {
+    expect(THIN_FULLNESS).toBe(0);
+  });
+});

--- a/frontend/src/features/Map/hooks/__tests__/useJourneySummary.test.tsx
+++ b/frontend/src/features/Map/hooks/__tests__/useJourneySummary.test.tsx
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import { renderHook } from '@testing-library/react-native';
+
+const mockDerivedWeek = jest.fn() as jest.Mock;
+jest.mock('../../../../store/useProgramProgression', () => ({
+  useDerivedCurrentWeek: (...args: unknown[]) => mockDerivedWeek(...args),
+}));
+
+import { cycleLabel } from '../../beginAgain';
+import { journeyRead } from '../../journeyNarrative';
+import { STAGE_COUNT } from '../../stageData';
+import { useJourneySummary } from '../useJourneySummary';
+
+beforeEach(() => {
+  mockDerivedWeek.mockReset();
+});
+
+describe('useJourneySummary', () => {
+  it('reads the shared journey sentence from the derived current week', () => {
+    mockDerivedWeek.mockReturnValue(14);
+    const { result } = renderHook(() => useJourneySummary(3, 1));
+
+    expect(result.current.read).toBe(journeyRead(3, 14, STAGE_COUNT));
+  });
+
+  it('derives the week with a fallback of 1', () => {
+    mockDerivedWeek.mockReturnValue(1);
+    renderHook(() => useJourneySummary(1, 1));
+
+    expect(mockDerivedWeek).toHaveBeenCalledWith(1);
+  });
+
+  it('omits the cycle caption on the first pass through the arc', () => {
+    mockDerivedWeek.mockReturnValue(1);
+    const { result } = renderHook(() => useJourneySummary(2, 1));
+
+    expect(result.current.cycleCaption).toBeNull();
+  });
+
+  it('captions the cycle past the first pass', () => {
+    mockDerivedWeek.mockReturnValue(5);
+    const { result } = renderHook(() => useJourneySummary(4, 3));
+
+    expect(result.current.cycleCaption).toBe(cycleLabel(3));
+  });
+});

--- a/frontend/src/features/Map/hooks/useJourneySummary.ts
+++ b/frontend/src/features/Map/hooks/useJourneySummary.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared journey read for the Map header and its drawer legend, so the two
+ * surfaces can never drift: identical week derivation, the same "Stage N of 10 ·
+ * Week W" sentence, and the same past-first-pass cycle caption. Each surface
+ * keeps its own styling; only the derived strings live here.
+ */
+
+import { useDerivedCurrentWeek } from '../../../store/useProgramProgression';
+import { cycleLabel } from '../beginAgain';
+import { journeyRead } from '../journeyNarrative';
+import { STAGE_COUNT } from '../stageData';
+
+/** The first pass through the arc earns no cycle caption; later passes name it. */
+const FIRST_CYCLE = 1;
+
+/** Fallback week before progression has a computed start date. */
+const FALLBACK_WEEK = 1;
+
+/** Derived journey strings shared by the Map header and the drawer legend. */
+export interface JourneySummaryRead {
+  /** "Stage N of 10 · Week W" progression sentence. */
+  read: string;
+  /** Cycle caption once past the first pass, else null. */
+  cycleCaption: string | null;
+}
+
+/** Computes the journey read + cycle caption for a stage and cycle number. */
+export function useJourneySummary(currentStage: number, cycleNumber: number): JourneySummaryRead {
+  const week = useDerivedCurrentWeek(FALLBACK_WEEK);
+  return {
+    read: journeyRead(currentStage, week, STAGE_COUNT),
+    cycleCaption: cycleNumber > FIRST_CYCLE ? cycleLabel(cycleNumber) : null,
+  };
+}

--- a/frontend/src/features/Map/stageLegend.ts
+++ b/frontend/src/features/Map/stageLegend.ts
@@ -1,0 +1,21 @@
+// frontend/features/Map/stageLegend.ts
+
+/**
+ * Accessibility-label helpers shared by the Map grid and its header drawer. A
+ * stage node reads as its persona, descriptor, and a wheel-of-wholeness balance
+ * suffix, so both surfaces announce the same label. Pure functions — no React.
+ */
+
+import type { StageDisplay } from './mapLayout';
+import { FULLNESS_ALIVE_THRESHOLD } from './wheelBalance';
+
+/** Fallback fullness for a stage with no wheel reading; it announces as thin. */
+export const THIN_FULLNESS = 0;
+
+/** Accessibility suffix appended to a node's label from its wheel fullness. */
+export const balanceLabelSuffix = (fullness: number): string =>
+  fullness >= FULLNESS_ALIVE_THRESHOLD ? 'reads full' : 'reads thin';
+
+/** Full a11y label for a stage node: persona/descriptor plus the balance read. */
+export const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
+  `${display.persona} - ${display.descriptor} - ${balanceLabelSuffix(fullness)}`;


### PR DESCRIPTION
## Summary

Adds the header-hamburger drawer to the Map tab, completing the "every screen has a drawer" consistency of epic #1465 (this is its last sub-issue). Rather than an action menu, the Map's drawer is a **legend of the territory** — the one orientation aid the visual map can't show without clutter:

- One row per stage (1–10, ascending): color swatch (`STAGE_DISPLAY.textColor`), persona/descriptor, and the same wheel-of-wholeness balance read the map's a11y label uses (`stageNodeLabel`, now shared).
- The current stage row is marked (`accessibilityState.selected` + a marker dot); locked stages show a padlock plus their calendar `"Unlocks in N days"` estimate (`useDaysUntilStage` + `unlockTimeline`).
- A compact journey summary (`"Stage N of 10 · Week W"`, plus the cycle label past the first pass) sits above the list.
- Every row is `accessibilityRole="button"` and labelled via the shared `stageNodeLabel`.

**Select + highlight, not scroll-to.** The Map grid is flex-fill, not a scrollable list, so per the issue's design defaults the "jump-to-stage" affordance is realized as **select-and-highlight**: tapping a row closes the drawer and glides the magnifier lens to that stage (`lens.setFocusedStage`). Rows stay tappable when locked, mirroring the map's own stage-text semantics.

The drawer renders from the same `useStageStore`/`useWheelBalance` selectors the map already reads — no independent fetch — and is a `Modal` that fully unmounts when closed, so it never forces map re-renders while shut. The `stageNodeLabel`/`balanceLabelSuffix` helpers were extracted into `stageLegend.ts` so the grid and the drawer announce identical labels.

## Test plan

- New `stageLegend.test.ts` — the extracted `balanceLabelSuffix` boundary + `stageNodeLabel` format.
- New `MapDrawer.test.tsx` — 10 rows ascending, swatch colors, persona/descriptor, a11y labels, full/thin fullness read, current-stage marker, locked-row padlock + unlock copy (N days / 1 day / no-anchor fallback), missing-stage-in-lookup → locked, row-tap fires `onSelectStage` (incl. locked), and the journey/cycle summary.
- New `MapScreenDrawer.test.tsx` — integration: header-left toggle installed via `useScreenDrawer`, opening renders the legend, a row tap closes the drawer and moves the lens focus (and does not open the stage-detail modal).
- Harness: added a shared `setOptions` spy so the six existing MapScreen suites survive the new `useScreenDrawer` wiring.
- `./scripts/frontend/check-all.sh` exits 0 — ESLint, prettier, `tsc --noEmit`, and all 4004 Jest tests pass.

Closes #1471
Refs #1465