### PR TITLE
fix(journal): list an entry's promotions so reopened highlights persist

### DIFF
--- a/backend/src/routers/promotions.py
+++ b/backend/src/routers/promotions.py
@@ -91,6 +91,31 @@ async def promote_quote(
     return _quote_response(quote)
 
 
+@router.get("/journal/{entry_id}/promotions", response_model=list[PromotedQuoteResponse])
+async def list_promotions(
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    entry: Annotated[JournalEntry, Depends(require_owned_journal_entry)],
+) -> list[PromotedQuoteResponse]:
+    """List every promoted quote anchored in the caller's own entry.
+
+    Ownership is enforced by ``require_owned_journal_entry`` (a missing,
+    soft-deleted, or foreign entry all resolve to 404). Results are scoped to
+    this entry and the caller, ordered by ``(anchor_start, id)``, and include
+    every quote regardless of status -- pending, folded, and stale -- so a
+    reopened entry can rehydrate all of its highlights.
+    """
+    result = await session.execute(
+        select(PromotedQuote)
+        .where(
+            PromotedQuote.source_entry_id == entry.id,
+            PromotedQuote.user_id == current_user,
+        )
+        .order_by(col(PromotedQuote.anchor_start), col(PromotedQuote.id))
+    )
+    return [_quote_response(quote) for quote in result.scalars().all()]
+
+
 async def _load_owned_quote(
     session: AsyncSession, promotion_id: int, user_id: int
 ) -> PromotedQuote | None:

--- a/backend/tests/test_promotions_api.py
+++ b/backend/tests/test_promotions_api.py
@@ -367,3 +367,152 @@ async def test_patch_promotion_rejects_empty_body_422(
 
     resp = await async_client.patch(f"/promotions/{quote.id}", json={}, headers=headers)
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── GET /journal/{entry_id}/promotions ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_requires_auth(async_client: AsyncClient) -> None:
+    """Unauthenticated callers get 401."""
+    resp = await async_client.get("/journal/1/promotions")
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_orders_by_anchor_start_then_id(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Returns a bare array ordered by (anchor_start, id), with no user_id leak."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "abcdefghijklmnopqrstuvwxyz")
+
+    # Seeded out of anchor order; two quotes share anchor_start=5 to pin the id tiebreak.
+    quote_c = await _seed_quote(db_session, user_id, entry.id, "j", anchor_start=9, anchor_end=10)
+    quote_a1 = await _seed_quote(db_session, user_id, entry.id, "f", anchor_start=5, anchor_end=6)
+    quote_a2 = await _seed_quote(db_session, user_id, entry.id, "g", anchor_start=5, anchor_end=6)
+    quote_b = await _seed_quote(db_session, user_id, entry.id, "b", anchor_start=1, anchor_end=2)
+
+    resp = await async_client.get(f"/journal/{entry.id}/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert isinstance(data, list)
+    assert [item["id"] for item in data] == [
+        quote_b.id,
+        quote_a1.id,
+        quote_a2.id,
+        quote_c.id,
+    ]
+    for item in data:
+        assert "user_id" not in item
+    assert data[0] == {
+        "id": quote_b.id,
+        "source_entry_id": entry.id,
+        "anchor_start": 1,
+        "anchor_end": 2,
+        "anchor_text": "b",
+        "pending": True,
+        "stale": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_includes_folded_quotes(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A quote already folded into a reflection is still listed, with pending False."""
+    headers, user_id = await _signup(async_client, db_session)
+    source_entry = await _seed_entry(db_session, user_id, "Source body text")
+    target_entry = await _seed_entry(
+        db_session,
+        user_id,
+        "Target reflection body",
+        tag=JournalTag.HIERARCHICAL_REFLECTION,
+        reflection_level="week",
+        reflection_scope_key="c1:w1",
+    )
+    quote = await _seed_quote(
+        db_session,
+        user_id,
+        source_entry.id,
+        "Source",
+        included_in_entry_id=target_entry.id,
+    )
+
+    resp = await async_client.get(f"/journal/{source_entry.id}/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert [item["id"] for item in data] == [quote.id]
+    assert data[0]["pending"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_empty_entry_returns_empty_list(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An entry with no promotions returns an empty array, not 404."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "No quotes taken from here")
+
+    resp = await async_client.get(f"/journal/{entry.id}/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_rejects_other_users_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Listing promotions on an entry owned by another user 404s (enumeration-safe).
+
+    Checks the ownership-dependency's detail body, not just the status code --
+    a route-not-found 404 would otherwise match by accident.
+    """
+    _owner_headers, owner_id = await _signup(async_client, db_session, username="alice")
+    other_headers, _other_id = await _signup(async_client, db_session, username="bob")
+    entry = await _seed_entry(db_session, owner_id, "Bob's private body text")
+    await _seed_quote(db_session, owner_id, entry.id, "Bob's")
+
+    resp = await async_client.get(f"/journal/{entry.id}/promotions", headers=other_headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "journal_entry_not_found"
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_rejects_missing_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A nonexistent entry id 404s with the ownership-dependency's detail body."""
+    headers, _user_id = await _signup(async_client, db_session)
+    resp = await async_client.get("/journal/999999/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "journal_entry_not_found"
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_rejects_soft_deleted_entry_404(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A soft-deleted entry is treated as gone, with the ownership-dependency's detail."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry = await _seed_entry(db_session, user_id, "Deleted body", deleted_at=datetime.now(UTC))
+
+    resp = await async_client.get(f"/journal/{entry.id}/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "journal_entry_not_found"
+
+
+@pytest.mark.asyncio
+async def test_list_promotions_isolated_by_entry(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A quote seeded on a different entry of the same user is not returned."""
+    headers, user_id = await _signup(async_client, db_session)
+    entry_a = await _seed_entry(db_session, user_id, "Entry A body")
+    entry_b = await _seed_entry(db_session, user_id, "Entry B body")
+    quote_a = await _seed_quote(db_session, user_id, entry_a.id, "Entry A")
+    await _seed_quote(db_session, user_id, entry_b.id, "Entry B")
+
+    resp = await async_client.get(f"/journal/{entry_a.id}/promotions", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert [item["id"] for item in resp.json()] == [quote_a.id]

--- a/frontend/src/api/__tests__/promotions.test.ts
+++ b/frontend/src/api/__tests__/promotions.test.ts
@@ -8,7 +8,7 @@
  * ``TypeError: promotions is undefined`` / ``is not a function`` until the
  * implementation-specialist adds the client to ``@/api/index``.
  */
-import { ApiError, promotions } from '../index';
+import { ApiError, ApiValidationError, promotions } from '../index';
 import type { PromotedQuote } from '../index';
 
 const mockFetch = jest.fn() as jest.Mock;
@@ -108,5 +108,29 @@ describe('promotions.setIncluded', () => {
     const [, init] = mockFetch.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({ included_in_entry_id: null });
     expect(result.pending).toBe(true);
+  });
+});
+
+describe('promotions.list', () => {
+  test('GETs /journal/{id}/promotions and resolves to the schema-parsed array', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse([quote({ id: 1, anchor_start: 1 }), quote({ id: 2, anchor_start: 9 })], 200),
+    );
+    const result = await promotions.list(7, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/7/promotions');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(result).toEqual([
+      expect.objectContaining({ id: 1, anchor_start: 1 }),
+      expect.objectContaining({ id: 2, anchor_start: 9 }),
+    ]);
+  });
+
+  test('rejects a malformed row (anchor_start as a string) via zod', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse([{ ...quote(), anchor_start: 'not-a-number' }], 200),
+    );
+    await expect(promotions.list(7, 'tok')).rejects.toBeInstanceOf(ApiValidationError);
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1321,7 +1321,8 @@ export interface PromoteQuoteSpan {
  * selected span into the corpus (may surface ``422 anchor_out_of_range`` /
  * ``422 quote_too_long`` as an ``ApiError``); ``remove`` un-promotes it; and
  * ``setIncluded`` folds a quote into another entry (or returns it to pending
- * with ``null``).
+ * with ``null``); ``list`` fetches every quote anchored in an entry so a
+ * reopened entry can rehydrate its highlights.
  */
 export const promotions = {
   /** Promote a reader-selected span of an entry into the corpus. */
@@ -1344,6 +1345,13 @@ export const promotions = {
       body: { included_in_entry_id: entryId },
       token,
       schema: promotedQuoteSchema as unknown as z.ZodType<PromotedQuote>,
+    });
+  },
+  /** List every quote anchored in ``entryId`` (ordered by anchor then id). */
+  list(entryId: number, token?: string): Promise<PromotedQuote[]> {
+    return request<PromotedQuote[]>(`/journal/${entryId}/promotions`, {
+      token,
+      schema: z.array(promotedQuoteSchema) as unknown as z.ZodType<PromotedQuote[]>,
     });
   },
 };

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -38,6 +38,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('@/navigation/hooks', () => ({

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenChord.test.tsx
@@ -43,6 +43,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('@/navigation/hooks', () => ({

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
@@ -38,6 +38,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 // useScreenDrawer installs the header-left toggle through useAppNavigation

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenLoadError.test.tsx
@@ -36,6 +36,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('@/navigation/hooks', () => ({

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -43,6 +43,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('@/navigation/hooks', () => ({

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -25,6 +25,9 @@ const mockPromote = jest.fn() as jest.MockedFunction<
   (_entryId: number, _span: { anchor_start: number; anchor_end: number }) => Promise<PromotedQuote>
 >;
 const mockRemovePromotion = jest.fn() as jest.MockedFunction<(_id: number) => Promise<void>>;
+const mockPromotionsList = jest.fn() as jest.MockedFunction<
+  (_entryId: number) => Promise<PromotedQuote[]>
+>;
 
 jest.mock('@/api', () => ({
   journal: {
@@ -48,6 +51,8 @@ jest.mock('@/api', () => ({
     remove: (...a: unknown[]) =>
       (mockRemovePromotion as unknown as (...x: unknown[]) => unknown)(...a),
     setIncluded: jest.fn(),
+    list: (...a: unknown[]) =>
+      (mockPromotionsList as unknown as (...x: unknown[]) => unknown)(...a),
   },
 }));
 
@@ -107,6 +112,8 @@ beforeEach(() => {
   mockCompletionList.mockResolvedValue({ items: [] });
   mockPromote.mockReset();
   mockRemovePromotion.mockReset();
+  mockPromotionsList.mockReset();
+  mockPromotionsList.mockResolvedValue([]);
   mockGet.mockResolvedValue(entry());
 });
 
@@ -237,5 +244,21 @@ describe('JournalEntryScreen -- removing a promoted quote', () => {
       fireEvent.press(removeButton);
     });
     expect(await screen.findByTestId('quote-highlight-90')).toBeTruthy();
+  });
+});
+
+describe('JournalEntryScreen -- reopening a finished entry hydrates promoted-quote highlights', () => {
+  it('renders every promoted quote returned by promotions.list', async () => {
+    mockGet.mockResolvedValue(entry({ status: 'finished' }));
+    mockPromotionsList.mockResolvedValue([
+      promotedQuote({ id: 12, anchor_start: 2, anchor_end: 6 }),
+      promotedQuote({ id: 34, anchor_start: 21, anchor_end: 24 }),
+    ]);
+    const { findByTestId } = renderScreen({ entryId: 7 });
+
+    expect(await findByTestId('journal-body-read')).toBeTruthy();
+    expect(await findByTestId('quote-highlight-12')).toBeTruthy();
+    expect(await findByTestId('quote-highlight-34')).toBeTruthy();
+    expect(mockPromotionsList).toHaveBeenCalledWith(7);
   });
 });

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenReflection.test.tsx
@@ -69,6 +69,7 @@ jest.mock('@/api', () => ({
     remove: jest.fn(),
     setIncluded: (...a: unknown[]) =>
       (mockSetIncluded as unknown as (...x: unknown[]) => unknown)(...a),
+    list: jest.fn(() => Promise.resolve([])),
   },
   reflections: {
     due: (...a: unknown[]) => (mockReflectionsDue as unknown as (...x: unknown[]) => unknown)(...a),

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenSuggestions.test.tsx
@@ -35,6 +35,12 @@ jest.mock('@/api', () => ({
     accept: jest.fn(),
     dismiss: jest.fn(),
   },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
 }));
 
 jest.mock('@/navigation/hooks', () => ({

--- a/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
@@ -22,6 +22,7 @@ const mockCreate = jest.fn() as jest.MockedFunction<
   (_entryId: number, _span: { anchor_start: number; anchor_end: number }) => Promise<PromotedQuote>
 >;
 const mockRemove = jest.fn() as jest.MockedFunction<(_id: number) => Promise<void>>;
+const mockList = jest.fn() as jest.MockedFunction<(_entryId: number) => Promise<PromotedQuote[]>>;
 
 jest.mock('@/api', () => {
   const actual = jest.requireActual('@/api') as Record<string, unknown>;
@@ -31,17 +32,18 @@ jest.mock('@/api', () => {
       create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
       remove: (...a: unknown[]) => (mockRemove as unknown as (...x: unknown[]) => unknown)(...a),
       setIncluded: jest.fn(),
+      list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
     },
   };
 });
 
-// RED: `usePromotions` does not exist yet -- this `require` fails with
-// "Cannot find module" until the implementation-specialist adds the hook.
 const { usePromotions } = require('../usePromotions');
 
 beforeEach(() => {
   mockCreate.mockReset();
   mockRemove.mockReset();
+  mockList.mockReset();
+  mockList.mockResolvedValue([]);
 });
 
 describe('usePromotions', () => {
@@ -128,5 +130,59 @@ describe('usePromotions', () => {
     });
     await waitFor(() => expect(result.current.quotes).toEqual([]));
     expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates its quote list from promotions.list on mount, sorted by anchor then id', async () => {
+    const hydrated = [quote({ id: 20, anchor_start: 15 }), quote({ id: 3, anchor_start: 1 })];
+    mockList.mockResolvedValue(hydrated);
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await waitFor(() =>
+      expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([3, 20]),
+    );
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(mockList).toHaveBeenCalledWith(7);
+  });
+
+  it('never calls promotions.list when entryId is 0 (unsaved entry)', async () => {
+    renderHook(() => usePromotions({ entryId: 0 }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('a hydration failure sets a non-blocking hint and leaves quotes empty', async () => {
+    mockList.mockRejectedValue(new ApiError(500, 'boom'));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await waitFor(() => expect(result.current.hint).toBeTruthy());
+    expect(result.current.quotes).toEqual([]);
+  });
+
+  it('does not drop a quote added via promote when hydration resolves after it', async () => {
+    let resolveList: (_value: PromotedQuote[]) => void = () => {};
+    mockList.mockReturnValue(
+      new Promise<PromotedQuote[]>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    mockCreate.mockResolvedValue(quote({ id: 9, anchor_start: 30, anchor_end: 49 }));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await act(async () => {
+      await result.current.promote(30, 49);
+    });
+    expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([9]);
+
+    await act(async () => {
+      resolveList([quote({ id: 3, anchor_start: 1, anchor_end: 2 })]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([3, 9]),
+    );
   });
 });

--- a/frontend/src/features/Journal/usePromotions.ts
+++ b/frontend/src/features/Journal/usePromotions.ts
@@ -8,7 +8,8 @@
  * it on error, guarding a double-tap per id (mirrors ``useResonance``'s
  * ``runDismiss``). One promote runs at a time so a double-tap can't double-post.
  */
-import { useCallback, useRef, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { promotions } from '@/api';
 import type { PromotedQuote } from '@/api';
@@ -31,14 +32,71 @@ export interface UsePromotionsResult {
   removePromotion: (_id: number) => Promise<void>;
 }
 
+/** The list's canonical order: by anchor offset, then id as a stable tiebreak. */
+function byAnchorThenId(a: PromotedQuote, b: PromotedQuote): number {
+  return a.anchor_start - b.anchor_start || a.id - b.id;
+}
+
 /** Re-insert a reverted quote, keeping the list ordered by anchor then id. */
 function insertSorted(quotes: PromotedQuote[], quote: PromotedQuote): PromotedQuote[] {
-  return [...quotes, quote].sort((a, b) => a.anchor_start - b.anchor_start || a.id - b.id);
+  return [...quotes, quote].sort(byAnchorThenId);
 }
 
 /** Drop the quote with ``id`` (a named helper so it isn't a nested callback). */
 function dropById(quotes: PromotedQuote[], id: number): PromotedQuote[] {
   return quotes.filter((q) => q.id !== id);
+}
+
+/**
+ * Union the fetched quotes into the current list by id, keeping the ordered
+ * invariant. A merge (rather than a blind replace) preserves a quote an
+ * in-flight ``promote`` already appended, and dedupes when the server echoes it.
+ */
+function mergeById(prev: PromotedQuote[], incoming: PromotedQuote[]): PromotedQuote[] {
+  const byId = new Map<number, PromotedQuote>(prev.map((q) => [q.id, q]));
+  for (const q of incoming) byId.set(q.id, q);
+  return [...byId.values()].sort(byAnchorThenId);
+}
+
+/** The sentinel for an unsaved entry — nothing to hydrate until it has a real id. */
+const UNSAVED_ENTRY_ID = 0;
+
+/**
+ * A state updater that unions the fetched quotes into the *latest* list. Named
+ * at module scope (not an inline updater) so the hydration effect stays flat,
+ * and functional so it can't clobber a concurrent optimistic add or removal.
+ */
+function mergeFetched(fetched: PromotedQuote[]): (_prev: PromotedQuote[]) => PromotedQuote[] {
+  return (prev) => mergeById(prev, fetched);
+}
+
+/**
+ * Rehydrate a reopened entry's quotes. Keyed by ``entryId`` and skipped for the
+ * unsaved-entry sentinel; the ``cancelled`` flag stops a slow response from
+ * setting state after unmount or an id change. Merges (never replaces) so a
+ * quote an in-flight ``promote`` already appended survives.
+ */
+function useHydrateOnOpen(
+  entryId: number,
+  setQuotes: Dispatch<SetStateAction<PromotedQuote[]>>,
+  setHint: (_hint: string | null) => void,
+): void {
+  useEffect(() => {
+    if (entryId <= UNSAVED_ENTRY_ID) return undefined;
+    let cancelled = false;
+    const hydrate = async (): Promise<void> => {
+      try {
+        const fetched = await promotions.list(entryId);
+        if (!cancelled) setQuotes(mergeFetched(fetched));
+      } catch (err) {
+        if (!cancelled) setHint(formatApiError(err));
+      }
+    };
+    void hydrate();
+    return () => {
+      cancelled = true;
+    };
+  }, [entryId, setQuotes, setHint]);
 }
 
 export function usePromotions({
@@ -55,6 +113,8 @@ export function usePromotions({
   // identity stable across every add/remove.
   const quotesRef = useRef(quotes);
   quotesRef.current = quotes;
+
+  useHydrateOnOpen(entryId, setQuotes, setHint);
 
   const promote = useCallback(
     async (start: number, end: number): Promise<void> => {


### PR DESCRIPTION
## Summary

Promoted-quote highlights previously rendered only for quotes created in the current read session. With no endpoint to list an entry's promotions, reopening the entry showed the body with **no** promoted-span highlights, even though the `PromotedQuote` rows persisted — the in-place visual anchor was lost to the user. Flagged as a non-blocking follow-up by the Gate 2.5 review of #1496.

- **Backend:** new owner-scoped `GET /journal/{entry_id}/promotions` in `routers/promotions.py`, returning the entry's promotions ordered by `(anchor_start, id)`. Ownership is gated by the existing `require_owned_journal_entry` dependency (missing / foreign / soft-deleted entries all resolve to a `404 journal_entry_not_found`) and the query is re-filtered by `user_id` as defense-in-depth. Folded (non-pending) and stale rows are included so every anchored span rehydrates. Reuses `_quote_response` (never serializes `user_id`).
- **Frontend:** `promotions.list(entryId)` added to the api client, and a `useHydrateOnOpen` effect in `usePromotions` that fetches on open (skipping the unsaved-entry sentinel `entryId === 0`) and merges the fetched quotes by id with a functional state updater, so a concurrent optimistic add/remove is never clobbered. No `JournalEntryScreen` change was needed — the read surface already renders highlights from the hydrated `quotes` list.

## Test plan

- **Backend** (`tests/test_promotions_api.py`): unauth `401`; ordering by `(anchor_start, id)` incl. the equal-anchor id tiebreak with no `user_id` leak; folded quote still returned (`pending False`); empty entry `→ []`; foreign / missing / soft-deleted entry `→ 404 journal_entry_not_found`; per-entry isolation.
- **Frontend**: `promotions.list` client (GET URL + schema-parsed array + zod rejection of a malformed row); `usePromotions` hydrate-on-mount sorted, no fetch for `entryId 0`, failure sets a warm hint, and a merge-by-id race that does not clobber an in-flight `promote`; a `JournalEntryScreen` reopen test asserting the promoted-span highlights render after load. Defensive `promotions.list` mocks added to sibling `JournalEntryScreen*` tests that render the screen.
- Gate 2 green locally: backend `pytest` 96.75% cov + xenon A + interrogate 95.7%; frontend eslint + tsc + jest (4015 tests).

## Follow-up (non-blocking, from Gate 2.5)

- Merge-on-hydrate could in principle resurrect an optimistically-removed quote if a `removePromotion` lands while `promotions.list` is still in flight. This is unreachable in the current app (the screen seeds no `initialQuotes`, so nothing is tappable before hydration); worth tracking if `initialQuotes` seeding is ever added — the fix is to exclude `removingIdsRef` ids from the merge.
- The frontend `promotedQuoteSchema` does not model the backend `stale` flag (pre-existing), so a rehydrated stale highlight can't yet be visually distinguished — a product/schema follow-up.

Closes #1497
Refs #1496