### PR TITLE
fix(journal): use Unicode code-point offsets for quote/marginalia anchors

### DIFF
--- a/backend/src/routers/promotions.py
+++ b/backend/src/routers/promotions.py
@@ -45,9 +45,11 @@ def _quote_response(quote: PromotedQuote) -> PromotedQuoteResponse:
 def _slice_anchor_text(entry: JournalEntry, payload: PromoteQuoteCreate) -> str:
     """Slice + sanitize the anchored span from the persisted body.
 
-    The span is validated against the *server-held* body (never client text): an
-    end past the body length is 422 ``anchor_out_of_range``, and a normalized
-    span longer than the plaintext cap is 422 ``quote_too_long``.
+    Offsets are Unicode code points (Python string indexing is code-point-based),
+    which is the anchor API's contract. The span is validated against the
+    *server-held* body (never client text): an end past the body length is 422
+    ``anchor_out_of_range``, and a normalized span longer than the plaintext cap
+    is 422 ``quote_too_long``.
     """
     if payload.anchor_end > len(entry.message):
         raise unprocessable("anchor_out_of_range")

--- a/backend/tests/test_detection_service.py
+++ b/backend/tests/test_detection_service.py
@@ -169,6 +169,30 @@ async def test_caps_at_max_hits() -> None:
     assert len(hits) == MAX_HITS
 
 
+@pytest.mark.asyncio
+async def test_anchors_round_trip_through_an_emoji_containing_body() -> None:
+    """Every resolved anchor's [start:end) code-point slice matches the anchored phrase.
+
+    Python string indexing is code-point-native, so a leading astral (emoji)
+    character never desyncs an offset the way UTF-16 code-unit indexing would --
+    this pins that round-trip as a regression guard.
+    """
+    body = (
+        "\U0001f600This morning I meditated for twenty minutes by the window. "
+        "Later I went for a run along the river."
+    )
+    llm = FakeLLM(
+        _hits_json(
+            {"index": 0, "quote": "I meditated for twenty minutes"},
+            {"index": 1, "quote": "I went for a run along the river"},
+        )
+    )
+    hits = await detect_completions(body, candidates=_CANDIDATES, llm=llm)
+    assert len(hits) == 2
+    for hit in hits:
+        assert body[hit.anchor_start : hit.anchor_end] == hit.anchor_text
+
+
 def test_prompt_excludes_intentions_and_avoidance() -> None:
     """The prompt forbids counting planned/avoided items, not just completed ones."""
     prompt = build_detection_prompt(_BODY, _CANDIDATES)

--- a/backend/tests/test_marginalia_reanchoring.py
+++ b/backend/tests/test_marginalia_reanchoring.py
@@ -58,6 +58,19 @@ def test_empty_anchor_text_is_stale() -> None:
     assert out.stale is True
 
 
+def test_reanchor_round_trips_with_a_preceding_emoji() -> None:
+    """A body with a leading astral (emoji) character still round-trips exactly.
+
+    Python string indexing is code-point-native, so this pins the backend's
+    existing correct behavior as a regression guard.
+    """
+    emoji_body = "\U0001f600" + _BODY
+    start = emoji_body.index(_ANCHOR)
+    out = reanchor_one(_ANCHOR, start, emoji_body)
+    assert out.stale is False
+    assert emoji_body[out.anchor_start : out.anchor_end] == _ANCHOR
+
+
 async def _signup(client: AsyncClient, username: str = "anchor") -> tuple[dict[str, str], int]:
     resp = await client.post(
         "/auth/signup",

--- a/backend/tests/test_promotions_api.py
+++ b/backend/tests/test_promotions_api.py
@@ -209,6 +209,66 @@ async def test_promote_rejects_inverted_span_422(
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
+# ── Unicode code-point offsets (regression guard; Python indexing is code-point-native) ──
+
+_EMOJI = "\U0001f600"
+
+
+@pytest.mark.asyncio
+async def test_promote_slices_exact_phrase_after_leading_emoji(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A code-point span after a leading astral character slices exactly."""
+    headers, user_id = await _signup(async_client, db_session)
+    body = f"{_EMOJI}went for a daily walk."
+    entry = await _seed_entry(db_session, user_id, body)
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 1, "anchor_end": 17},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["anchor_text"] == "went for a daily"
+
+
+@pytest.mark.asyncio
+async def test_promote_accepts_anchor_end_at_code_point_length_of_emoji_final_body(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An anchor_end equal to the body's code-point length (trailing emoji) is accepted."""
+    headers, user_id = await _signup(async_client, db_session)
+    body = f"went for a walk{_EMOJI}"
+    entry = await _seed_entry(db_session, user_id, body)
+    assert len(body) == 16
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 11, "anchor_end": len(body)},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    assert resp.json()["anchor_text"] == f"walk{_EMOJI}"
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_anchor_end_one_past_code_point_length_422(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An anchor_end one past the body's code-point length is anchor_out_of_range."""
+    headers, user_id = await _signup(async_client, db_session)
+    body = f"went for a walk{_EMOJI}"
+    entry = await _seed_entry(db_session, user_id, body)
+
+    resp = await async_client.post(
+        f"/journal/{entry.id}/promote",
+        json={"anchor_start": 11, "anchor_end": len(body) + 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "anchor_out_of_range"
+
+
 # ── DELETE /promotions/{id} ──────────────────────────────────────────────
 
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1188,7 +1188,9 @@ export interface Marginalia {
   id: number;
   journal_entry_id: number;
   kind: MarginaliaKind;
+  /** Anchor start as a Unicode code-point offset into the body (end-exclusive pair). */
   anchor_start: number;
+  /** Anchor end as a Unicode code-point offset into the body (end-exclusive). */
   anchor_end: number;
   anchor_text: string;
   note: string;
@@ -1310,7 +1312,12 @@ export const journal = {
   },
 };
 
-/** The char-offset span a reader selected to promote (end-exclusive). */
+/**
+ * The span a reader selected to promote, in Unicode code-point offsets
+ * (end-exclusive) — the anchor API's unit, matching the code-point-native
+ * backend. Callers converting a native UTF-16 TextInput selection must map it to
+ * code points first (see ``features/Journal/codePoints``).
+ */
 export interface PromoteQuoteSpan {
   anchor_start: number;
   anchor_end: number;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -34,7 +34,7 @@ import MarginNote from './MarginNote';
 import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
-import QuoteSelectionSurface from './QuoteSelectionSurface';
+import QuoteSelectionSurface, { type CodePointSpan } from './QuoteSelectionSurface';
 import ReflectionSourcesPanel from './ReflectionSourcesPanel';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { usePromotions } from './usePromotions';
@@ -1180,7 +1180,7 @@ interface QuotePromotion {
   removeTargetId: number | null;
   startSelecting: () => void;
   cancelSelecting: () => void;
-  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onSelectionChange: (_span: CodePointSpan) => void;
   confirmSelection: () => Promise<void>;
   onQuotePress: (_quote: PromotedQuote) => void;
   confirmRemove: () => void;
@@ -1203,8 +1203,10 @@ function useQuoteInteraction(
     setSelecting(true);
   }, []);
   const cancelSelecting = useCallback(() => setSelecting(false), []);
-  const onSelectionChange = useCallback((e: SelectionChangeEvent) => {
-    selectionRef.current = e.nativeEvent.selection;
+  // The surface converts the native UTF-16 selection to a code-point span; store
+  // it verbatim so ``confirmSelection`` posts anchors in the API's code-point unit.
+  const onSelectionChange = useCallback((span: CodePointSpan) => {
+    selectionRef.current = span;
   }, []);
   // A collapsed/empty selection (a caret tap, no highlighted span) can't be
   // promoted — stay in selection mode rather than post a span the server would

--- a/frontend/src/features/Journal/QuoteSelectionSurface.tsx
+++ b/frontend/src/features/Journal/QuoteSelectionSurface.tsx
@@ -7,7 +7,7 @@
  * ``ReflectionSourcesPanel``; ``testID`` prefixes every element so more than one
  * surface can coexist on a page.
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Text,
   TextInput,
@@ -17,19 +17,51 @@ import {
   type TextInputSelectionChangeEventData,
 } from 'react-native';
 
+import { utf16ToCodePoint } from './codePoints';
 import styles from './JournalEntry.styles';
 
 type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
+
+/**
+ * A selection span in Unicode code-point offsets (the anchor API's unit),
+ * end-exclusive. This is the single conversion boundary between the native
+ * TextInput's UTF-16 selection and the code-point anchors both send flows post.
+ */
+export interface CodePointSpan {
+  start: number;
+  end: number;
+}
 
 /** Prefix for the surface's testIDs; the read-mode flow relies on this default. */
 const DEFAULT_TEST_ID = 'quote-select';
 
 export interface QuoteSelectionSurfaceProps {
   body: string;
-  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  /** Emits the selection as a code-point span (already converted from UTF-16). */
+  onSelectionChange: (_span: CodePointSpan) => void;
   onConfirm: () => Promise<void>;
   onCancel: () => void;
   testID?: string;
+}
+
+/**
+ * Adapt the native UTF-16 selection event into a code-point span emitter — the
+ * single conversion boundary, lifted out of the component so its body stays lean.
+ */
+function useCodePointSelection(
+  body: string,
+  onSelectionChange: (_span: CodePointSpan) => void,
+): (_event: SelectionChangeEvent) => void {
+  return useCallback(
+    (event: SelectionChangeEvent) => {
+      const { start, end } = event.nativeEvent.selection;
+      onSelectionChange({
+        start: utf16ToCodePoint(body, start),
+        end: utf16ToCodePoint(body, end),
+      });
+    },
+    [body, onSelectionChange],
+  );
 }
 
 function QuoteSelectionSurface({
@@ -39,6 +71,8 @@ function QuoteSelectionSurface({
   onCancel,
   testID = DEFAULT_TEST_ID,
 }: QuoteSelectionSurfaceProps): React.JSX.Element {
+  const handleSelectionChange = useCodePointSelection(body, onSelectionChange);
+
   return (
     <View>
       <TextInput
@@ -49,7 +83,7 @@ function QuoteSelectionSurface({
         showSoftInputOnFocus={false}
         caretHidden
         scrollEnabled={false}
-        onSelectionChange={onSelectionChange}
+        onSelectionChange={handleSelectionChange}
         accessibilityLabel="Select a passage to promote"
         testID={`${testID}-input`}
       />

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -22,11 +22,9 @@ import {
   TouchableOpacity,
   View,
   useWindowDimensions,
-  type NativeSyntheticEvent,
-  type TextInputSelectionChangeEventData,
 } from 'react-native';
 
-import QuoteSelectionSurface from './QuoteSelectionSurface';
+import QuoteSelectionSurface, { type CodePointSpan } from './QuoteSelectionSurface';
 import { sourceAttribution } from './reflectionCopy';
 
 import type { PromoteQuoteSpan, PromotedQuoteSummary, ReflectionSourceItem } from '@/api';
@@ -59,8 +57,6 @@ const INCLUDED_ROW_OPACITY = 0.5;
 /** Warm, declinable copy when a re-promotion didn't take; invites a calm retry. */
 const PROMOTE_FAILURE_HINT =
   'That selection didn’t quite take — you can try again whenever you like.';
-
-type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
 
 export interface ReflectionSourcesPanelProps {
   items: ReflectionSourceItem[];
@@ -198,7 +194,7 @@ interface RowPromoteControls {
   /** True when re-promotion is available at all (the parent wired a handler). */
   canPromote: boolean;
   onStartSelecting: () => void;
-  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onSelectionChange: (_span: CodePointSpan) => void;
   onConfirm: () => Promise<void>;
   onCancel: () => void;
 }
@@ -298,7 +294,7 @@ type PromoteSpanHandler = (
 interface RowSelection {
   selectingKey: string | null;
   promoteFailedKey: string | null;
-  onSelectionChange: (_e: SelectionChangeEvent) => void;
+  onSelectionChange: (_span: CodePointSpan) => void;
   startSelecting: (_key: string) => void;
   cancelSelecting: () => void;
   confirmSelection: (_item: ReflectionSourceItem, _key: string) => Promise<void>;
@@ -322,8 +318,10 @@ function useRowSelection(onPromoteSpan?: PromoteSpanHandler): RowSelection {
 
   const cancelSelecting = useCallback(() => setSelectingKey(null), []);
 
-  const onSelectionChange = useCallback((event: SelectionChangeEvent) => {
-    selectionRef.current = event.nativeEvent.selection;
+  // The surface hands back an already-converted code-point span; store it so the
+  // confirm handler posts anchors in the API's code-point unit.
+  const onSelectionChange = useCallback((span: CodePointSpan) => {
+    selectionRef.current = span;
   }, []);
 
   const confirmSelection = useCallback(

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -206,6 +206,29 @@ describe('JournalEntryScreen -- promote-a-quote affordance', () => {
   });
 });
 
+// RED: anchors are code points, but the TextInput reports UTF-16 offsets, so a leading emoji drifts them.
+describe('JournalEntryScreen -- promote-a-quote code-point anchors (non-BMP)', () => {
+  const EMOJI = '\u{1F600}';
+  const EMOJI_BODY = `${EMOJI}went for a daily walk.`;
+
+  it('converts a UTF-16 selection over an emoji-led body to code-point anchor offsets', async () => {
+    mockGet.mockResolvedValue(entry({ message: EMOJI_BODY }));
+    mockPromote.mockResolvedValue(
+      promotedQuote({ anchor_start: 1, anchor_end: 17, anchor_text: 'went for a daily' }),
+    );
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    // The one leading astral char shifts every later UTF-16 offset by +1 vs its code-point index.
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 18 } } });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+    expect(mockPromote).toHaveBeenCalledWith(7, { anchor_start: 1, anchor_end: 17 });
+  });
+});
+
 describe('JournalEntryScreen -- removing a promoted quote', () => {
   async function promoteOne(screen: ReturnType<typeof renderScreen>): Promise<void> {
     mockPromote.mockResolvedValue(promotedQuote({ id: 90 }));

--- a/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
@@ -274,6 +274,33 @@ describe('ReflectionSourcesPanel -- in-panel re-promotion selection surface', ()
   });
 });
 
+// RED: anchors are code points, but the shared surface's TextInput reports UTF-16 offsets.
+describe('ReflectionSourcesPanel -- in-panel re-promotion code-point anchors (non-BMP)', () => {
+  const EMOJI = '\u{1F600}';
+  const EMOJI_BODY = `${EMOJI}went for a daily walk.`;
+
+  it('converts a UTF-16 selection over an emoji-led body to code-point anchor offsets', async () => {
+    const onPromoteSpan = jest.fn(() => Promise.resolve(true));
+    const sourceItem = item({ id: 1, body: EMOJI_BODY });
+    const { getByTestId } = render(
+      <ReflectionSourcesPanel
+        items={[sourceItem]}
+        onInsertQuote={jest.fn()}
+        onPromoteSpan={onPromoteSpan}
+      />,
+    );
+    fireEvent.press(getByTestId('entry-source-1'));
+    fireEvent.press(getByTestId('source-promote-entry-1'));
+    const input = getByTestId('source-select-entry-1-input');
+    // The one leading astral char shifts every later UTF-16 offset by +1 vs its code-point index.
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 18 } } });
+    await act(async () => {
+      fireEvent.press(getByTestId('source-select-entry-1-confirm'));
+    });
+    expect(onPromoteSpan).toHaveBeenCalledWith(sourceItem, { anchor_start: 1, anchor_end: 17 });
+  });
+});
+
 // RED: `onInsertQuote`'s Promise<boolean> result is not yet reconciled with the dim.
 describe('ReflectionSourcesPanel -- dim reconciles with a failed fold-in', () => {
   it('reverts the dim when onInsertQuote resolves false, and a second press re-fires it', async () => {

--- a/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
@@ -145,3 +145,47 @@ describe('buildAnchoredSegments', () => {
     expect(anchored).toEqual(legacy.map((s) => ({ ...s, quote: null })));
   });
 });
+
+// True when a slice cut a non-BMP (astral) character in half, leaving a lone surrogate.
+const UNPAIRED_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+const UNPAIRED_LOW_SURROGATE = /(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+function hasUnpairedSurrogate(text: string): boolean {
+  return UNPAIRED_HIGH_SURROGATE.test(text) || UNPAIRED_LOW_SURROGATE.test(text);
+}
+
+// RED: anchors are code points, but slice() indexes UTF-16 code units, so a leading emoji drifts them.
+describe('buildAnchoredSegments -- non-BMP (astral) code-point anchors', () => {
+  const EMOJI = '\u{1F600}';
+  // Code points: 0=emoji, 1..16="went for a daily" (16 chars), 17=' ', 18.."walk."
+  const LEADING_EMOJI_BODY = `${EMOJI}went for a daily walk.`;
+
+  it('slices the exact anchored phrase after a leading emoji using code-point offsets', () => {
+    const start = 1; // code-point index right after the emoji, at "w"
+    const end = 17; // code-point index right after "went for a daily"
+    const q = quote({ id: 55, anchor_start: start, anchor_end: end });
+    const segments = buildAnchoredSegments(LEADING_EMOJI_BODY, [], [q]);
+    const anchored = segments.find((s) => s.quote?.id === 55);
+    expect(anchored?.text).toBe('went for a daily');
+  });
+
+  it('renders an anchor whose end equals the code-point length of an emoji-final body', () => {
+    // Code points: 0.."went for a walk" (15 chars), 15=emoji; length=16.
+    const tailBody = `went for a walk${EMOJI}`;
+    const start = 11; // code-point index of "w" in "walk"
+    const end = 16; // the body's code-point length, including the trailing emoji
+    const q = quote({ id: 77, anchor_start: start, anchor_end: end });
+    const segments = buildAnchoredSegments(tailBody, [], [q]);
+    const anchored = segments.find((s) => s.quote?.id === 77);
+    expect(anchored).toBeDefined();
+    expect(anchored?.text).toBe(`walk${EMOJI}`);
+  });
+
+  it('never produces a segment with a lone/unpaired surrogate', () => {
+    const tailBody = `went for a walk${EMOJI}`;
+    const q = quote({ id: 77, anchor_start: 11, anchor_end: 16 });
+    const segments = buildAnchoredSegments(tailBody, [], [q]);
+    for (const segment of segments) {
+      expect(hasUnpairedSurrogate(segment.text)).toBe(false);
+    }
+  });
+});

--- a/frontend/src/features/Journal/__tests__/codePoints.test.ts
+++ b/frontend/src/features/Journal/__tests__/codePoints.test.ts
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+// RED: `codePoints.ts` doesn't exist yet -- pins utf16ToCodePoint(text, i) as count(text.slice(0, i)).
+import { utf16ToCodePoint } from '../codePoints';
+
+describe('utf16ToCodePoint', () => {
+  it('is the identity for a pure-ASCII string', () => {
+    const text = 'hello world';
+    expect(utf16ToCodePoint(text, 5)).toBe(5);
+  });
+
+  it('returns 0 for a UTF-16 index of 0, even over an astral-led body', () => {
+    expect(utf16ToCodePoint('\u{1F600}hello', 0)).toBe(0);
+  });
+
+  it('subtracts one for an index positioned right after one leading astral char', () => {
+    const text = '\u{1F600}hello';
+    // The emoji is a 2-unit surrogate pair; index 2 sits right after it, before "h".
+    expect(utf16ToCodePoint(text, 2)).toBe(1);
+  });
+
+  it('shifts by the count of leading astral characters', () => {
+    const text = '\u{1F600}\u{1F601}\u{1F602}hello';
+    // Three leading emoji (2 UTF-16 units each = 6 units), then "he" (2 more).
+    expect(utf16ToCodePoint(text, 8)).toBe(5);
+  });
+
+  it('clamps to the code-point length when the index sits exactly at the end', () => {
+    const text = '\u{1F600}hi';
+    expect(utf16ToCodePoint(text, text.length)).toBe(3);
+  });
+
+  it('clamps to the code-point length when the index is past the end, without throwing', () => {
+    const text = '\u{1F600}hi';
+    expect(() => utf16ToCodePoint(text, text.length + 50)).not.toThrow();
+    expect(utf16ToCodePoint(text, text.length + 50)).toBe(3);
+  });
+
+  it('returns a deterministic count for an index landing mid-surrogate-pair', () => {
+    const text = '\u{1F600}abc';
+    // text.slice(0, 1) is the lone high surrogate, which iterates as one element.
+    expect(utf16ToCodePoint(text, 1)).toBe(1);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
@@ -107,3 +107,45 @@ describe('buildHighlightSegments', () => {
     expect(segments).toEqual([{ start: 0, text: '', note: null }]);
   });
 });
+
+// True when a slice cut a non-BMP (astral) character in half, leaving a lone surrogate.
+const UNPAIRED_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+const UNPAIRED_LOW_SURROGATE = /(?:^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+function hasUnpairedSurrogate(text: string): boolean {
+  return UNPAIRED_HIGH_SURROGATE.test(text) || UNPAIRED_LOW_SURROGATE.test(text);
+}
+
+// RED: anchors are code points, but slice() indexes UTF-16 code units, so a leading emoji drifts them.
+describe('buildHighlightSegments -- non-BMP (astral) code-point anchors (marginalia)', () => {
+  const EMOJI = '\u{1F600}';
+  const LEADING_EMOJI_BODY = `${EMOJI}went for a daily walk.`;
+
+  it('slices the exact anchored phrase after a leading emoji using code-point offsets', () => {
+    const start = 1; // code-point index right after the emoji, at "w"
+    const end = 17; // code-point index right after "went for a daily"
+    const n = note({ id: 7, anchor_start: start, anchor_end: end });
+    const segments = buildHighlightSegments(LEADING_EMOJI_BODY, [n]);
+    const anchored = segments.find((s) => s.note?.id === 7);
+    expect(anchored?.text).toBe('went for a daily');
+  });
+
+  it('renders an anchor whose end equals the code-point length of an emoji-final body', () => {
+    const tailBody = `went for a walk${EMOJI}`;
+    const start = 11; // code-point index of "w" in "walk"
+    const end = 16; // the body's code-point length, including the trailing emoji
+    const n = note({ id: 8, anchor_start: start, anchor_end: end });
+    const segments = buildHighlightSegments(tailBody, [n]);
+    const anchored = segments.find((s) => s.note?.id === 8);
+    expect(anchored).toBeDefined();
+    expect(anchored?.text).toBe(`walk${EMOJI}`);
+  });
+
+  it('never produces a segment with a lone/unpaired surrogate', () => {
+    const tailBody = `went for a walk${EMOJI}`;
+    const n = note({ id: 8, anchor_start: 11, anchor_end: 16 });
+    const segments = buildHighlightSegments(tailBody, [n]);
+    for (const segment of segments) {
+      expect(hasUnpairedSurrogate(segment.text)).toBe(false);
+    }
+  });
+});

--- a/frontend/src/features/Journal/codePoints.ts
+++ b/frontend/src/features/Journal/codePoints.ts
@@ -1,0 +1,25 @@
+/**
+ * Bridge between the two ways JavaScript counts string positions and the one the
+ * anchor API uses.
+ *
+ * A React Native ``TextInput`` reports its selection in UTF-16 code units, but
+ * the promoted-quote / marginalia anchor contract is defined in Unicode CODE
+ * POINTS (matching the code-point-native backend). Those two agree for BMP text
+ * yet drift by one unit per astral character (emoji, rare CJK): a single leading
+ * emoji shifts every later UTF-16 offset by +1 versus its code-point index. This
+ * helper is the single place that reconciles them.
+ */
+
+/**
+ * Count the Unicode code points in ``text.slice(0, utf16Index)``.
+ *
+ * The result is the code-point offset that corresponds to a UTF-16 selection
+ * boundary. A negative index clamps to 0; an index at or past the end clamps to
+ * the string's code-point length; a mid-surrogate index counts the lone
+ * surrogate as one element (exactly per the ``slice(0, i)`` definition). Never
+ * throws.
+ */
+export function utf16ToCodePoint(text: string, utf16Index: number): number {
+  const bounded = Math.max(0, Math.min(utf16Index, text.length));
+  return Array.from(text.slice(0, bounded)).length;
+}

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -6,7 +6,7 @@
 import type { Marginalia, PromotedQuote } from '@/api';
 
 export interface HighlightSegment {
-  /** Character offset of this segment in the body (stable, unique → React key). */
+  /** Code-point offset of this segment in the body (stable, unique → React key). */
   start: number;
   text: string;
   /** The note whose anchor this segment is, or null for plain text. */
@@ -33,15 +33,19 @@ interface Anchor {
   quote: PromotedQuote | null;
 }
 
-/** An anchor is drawn only if it falls inside the body and is non-empty. */
-function inRange(body: string, start: number, end: number): boolean {
-  return start >= 0 && end <= body.length && start < end;
+/**
+ * An anchor is drawn only if it falls inside the body and is non-empty. Anchor
+ * offsets are Unicode code points, so the bound is the body's code-point length
+ * (``length``), not its UTF-16 code-unit length.
+ */
+function inRange(length: number, start: number, end: number): boolean {
+  return start >= 0 && end <= length && start < end;
 }
 
 /** Live (non-stale), in-range note anchors — stale notes are not drawn inline. */
-function noteAnchors(body: string, notes: Marginalia[]): Anchor[] {
+function noteAnchors(length: number, notes: Marginalia[]): Anchor[] {
   return notes
-    .filter((n) => n.status !== 'stale' && inRange(body, n.anchor_start, n.anchor_end))
+    .filter((n) => n.status !== 'stale' && inRange(length, n.anchor_start, n.anchor_end))
     .map((n) => ({
       start: n.anchor_start,
       end: n.anchor_end,
@@ -53,9 +57,9 @@ function noteAnchors(body: string, notes: Marginalia[]): Anchor[] {
 }
 
 /** In-range quote anchors (quotes have no stale status to filter on). */
-function quoteAnchors(body: string, quotes: PromotedQuote[]): Anchor[] {
+function quoteAnchors(length: number, quotes: PromotedQuote[]): Anchor[] {
   return quotes
-    .filter((q) => inRange(body, q.anchor_start, q.anchor_end))
+    .filter((q) => inRange(length, q.anchor_start, q.anchor_end))
     .map((q) => ({
       start: q.anchor_start,
       end: q.anchor_end,
@@ -67,8 +71,8 @@ function quoteAnchors(body: string, quotes: PromotedQuote[]): Anchor[] {
 }
 
 /** Merge + sort by (anchor_start, note-before-quote at equal start, then id). */
-function usableAnchors(body: string, notes: Marginalia[], quotes: PromotedQuote[]): Anchor[] {
-  return [...noteAnchors(body, notes), ...quoteAnchors(body, quotes)].sort(
+function usableAnchors(length: number, notes: Marginalia[], quotes: PromotedQuote[]): Anchor[] {
+  return [...noteAnchors(length, notes), ...quoteAnchors(length, quotes)].sort(
     (a, b) => a.start - b.start || a.order - b.order || a.id - b.id,
   );
 }
@@ -78,34 +82,39 @@ function usableAnchors(body: string, notes: Marginalia[], quotes: PromotedQuote[
  * first-wins cursor-skip rule as the notes-only path resolves overlaps: the
  * earliest-starting anchor wins and any anchor overlapping a committed range is
  * skipped.
+ *
+ * All slicing happens in CODE-POINT space (``chars``), matching the anchor
+ * contract, so a non-BMP character (emoji / astral) never shifts a boundary or
+ * gets cut mid-surrogate.
  */
 export function buildAnchoredSegments(
   body: string,
   notes: Marginalia[],
   quotes: PromotedQuote[],
 ): AnchoredSegment[] {
+  const chars = Array.from(body);
   const segments: AnchoredSegment[] = [];
   let cursor = 0;
-  for (const anchor of usableAnchors(body, notes, quotes)) {
+  for (const anchor of usableAnchors(chars.length, notes, quotes)) {
     if (anchor.start < cursor) continue; // overlaps a committed range — skip it
     if (anchor.start > cursor) {
       segments.push({
         start: cursor,
-        text: body.slice(cursor, anchor.start),
+        text: chars.slice(cursor, anchor.start).join(''),
         note: null,
         quote: null,
       });
     }
     segments.push({
       start: anchor.start,
-      text: body.slice(anchor.start, anchor.end),
+      text: chars.slice(anchor.start, anchor.end).join(''),
       note: anchor.note,
       quote: anchor.quote,
     });
     cursor = anchor.end;
   }
-  if (cursor < body.length) {
-    segments.push({ start: cursor, text: body.slice(cursor), note: null, quote: null });
+  if (cursor < chars.length) {
+    segments.push({ start: cursor, text: chars.slice(cursor).join(''), note: null, quote: null });
   }
   if (segments.length === 0) segments.push({ start: 0, text: body, note: null, quote: null });
   return segments;


### PR DESCRIPTION
## Summary

Quote promotion and the marginalia render path assumed JS UTF-16 string offsets and Python code-point offsets agree. They diverge for any character outside the Basic Multilingual Plane (emoji, some CJK extensions): JS counts a surrogate pair as two code units while Python counts one code point, so an anchor computed on one side mis-sliced on the other. A body with an emoji before the selected span drifted the persisted `anchor_text` or split a surrogate pair.

This pins the anchor API contract to **Unicode code points** (the unit Python already uses natively) and converts at the single frontend boundary:

- Add `utf16ToCodePoint` (`frontend/src/features/Journal/codePoints.ts`) — the code-point count of a UTF-16 prefix; clamped, non-throwing, dependency-free.
- `QuoteSelectionSurface` converts the native UTF-16 `TextInput` selection to a code-point span before emitting it, so both the read-mode promote flow and the in-panel re-promotion flow post code-point anchors.
- `buildAnchoredSegments` segments in code-point space (`Array.from` + slice/join, bounded by code-point length), so a non-BMP character never shifts a boundary or gets cut mid-surrogate; the notes-only marginalia path inherits the fix.
- Backend logic is unchanged — Python string indexing is already code-point based; only a clarifying docstring is added on `_slice_anchor_text`.

## Test plan

- New `codePoints.test.ts`: ASCII identity, leading-emoji shift, index 0, past-end clamp, mid-surrogate determinism.
- Extended `buildAnchoredSegments` / `highlightSegments` tests: a code-point anchor over an emoji-bearing body renders the exact phrase (previously drifted); emoji-final in-range anchors render; no segment emits a lone surrogate; notes-only path covered.
- Extended `JournalEntryScreenPromotions` + `ReflectionSourcesPanel` tests: a UTF-16 selection over an emoji body posts code-point anchors to the promote/re-promote handlers.
- Backend emoji round-trips in `test_promotions_api` (promote + out-of-range guard), `test_detection_service`, and `test_marginalia_reanchoring` pin the already-correct code-point contract.
- Gate 2 green locally: frontend check-all (ESLint, prettier, tsc, 4030 jest tests) and backend check-all (2600 tests, 96.67% coverage, xenon A / radon MI ≥ B) all pass.

Closes #1498