### PR TITLE
fix(journal): honour blank-essay contract on the ResonanceEssayModal fetch path

### DIFF
--- a/frontend/src/features/Journal/ResonanceEssayModal.tsx
+++ b/frontend/src/features/Journal/ResonanceEssayModal.tsx
@@ -38,6 +38,9 @@ export interface ResonanceEssayModalProps {
 /** Stable no-op so the card's press-capture doesn't allocate a fn per render. */
 const NOOP = (): void => {};
 
+/** Shown when a fetch resolves an empty essay, so the user isn't stranded on a blank card. */
+const BLANK_ESSAY_MESSAGE = "This note's essay isn't ready yet.";
+
 interface EssayState {
   essay: string | null;
   loading: boolean;
@@ -74,8 +77,14 @@ function useEssay(
       .essay(note.id)
       .then((updated) => {
         if (!active) return;
-        setState({ essay: updated.essay, loading: false, error: null });
-        onLoadedRef.current?.(updated);
+        if (updated.essay) {
+          // Same blank-as-missing contract as the cached path above.
+          setState({ essay: updated.essay, loading: false, error: null });
+          onLoadedRef.current?.(updated);
+          return;
+        }
+        // Don't cache a blank essay back (it would re-fetch on every reopen).
+        setState({ essay: null, loading: false, error: BLANK_ESSAY_MESSAGE });
       })
       .catch((err: unknown) => {
         if (active) setState({ essay: null, loading: false, error: formatApiError(err) });

--- a/frontend/src/features/Journal/__tests__/ResonanceEssayModal.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ResonanceEssayModal.test.tsx
@@ -82,6 +82,18 @@ describe('ResonanceEssayModal', () => {
     expect(onClose).toHaveBeenCalledTimes(2);
   });
 
+  it('treats a blank fetched essay as a failure, offering retry instead of an empty body', async () => {
+    mockEssay.mockResolvedValue(note({ id: 4, essay: '' }));
+    const onEssayLoaded = jest.fn();
+    const { findByTestId, queryByTestId } = render(
+      <ResonanceEssayModal note={note()} onClose={jest.fn()} onEssayLoaded={onEssayLoaded} />,
+    );
+    await findByTestId('essay-retry');
+    expect(queryByTestId('essay-text')).toBeNull();
+    expect(onEssayLoaded).not.toHaveBeenCalled();
+    expect(mockEssay).toHaveBeenCalledTimes(1);
+  });
+
   it('shows a friendly error with retry, and retry refetches', async () => {
     mockEssay
       .mockRejectedValueOnce(new Error('boom'))


### PR DESCRIPTION
## Summary

`ResonanceEssayModal`'s `useEssay` guarded against a blank essay on the **cached** path (`if (note.essay)` — treat blank as missing) but not on the **fetch** path, which assigned `updated.essay` straight through. A fetched blank/`null` essay therefore:

- rendered an **empty `essay-text` body** — no spinner, no error, no retry — stranding the user on a blank card; and
- was cached back via `onEssayLoaded`, and because `if (note.essay)` is falsy for a blank string, the modal **re-fetched the same blank essay on every reopen**.

This applies the cached path's blank-as-missing contract to the fetch-success branch:

- a truthy fetched essay is set and cached as before;
- a blank/`null` fetched essay surfaces the existing retry affordance with a clear message ("This note's essay isn't ready yet.") — following the what/why/next/escape empty-state rubric — and is **not** cached, so reopening no longer loops on a bad blank.

Scope is limited to blank-essay handling: the essay API, the retry/error UI shape, and the caching mechanism are unchanged.

## Test plan

- Added a Jest case: a fetch that resolves `essay: ''` renders the `essay-retry` affordance, renders no `essay-text` body, does not call `onEssayLoaded`, and fetches exactly once (no auto-refetch loop).
- Confirmed RED against current code, then GREEN after the fix.
- `./scripts/frontend/check-all.sh` green: 4031 tests pass, lint/prettier/typecheck clean.

Closes #1504