### PR TITLE
refactor(journal): extract HabitsStatTile data-loading into useHabitsSummary hook

### DIFF
--- a/frontend/src/features/Journal/HabitsStatTile.tsx
+++ b/frontend/src/features/Journal/HabitsStatTile.tsx
@@ -5,15 +5,12 @@
  */
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import StatTile from './StatTile';
+import { useHabitsSummary } from './useHabitsSummary';
 
-import { useAuth } from '@/context/AuthContext';
-import { countDoneToday, unlockedHabits } from '@/features/Habits/habitCounts';
-import { habitManager } from '@/features/Habits/services/habitManager';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
-import { useHabitStore } from '@/store/useHabitStore';
 
 type HabitsTileNav = BottomTabNavigationProp<RootTabParamList>;
 
@@ -71,24 +68,8 @@ export function describeHabits(
 
 const HabitsStatTile = (): React.JSX.Element => {
   const navigation = useNavigation<HabitsTileNav>();
-  const { userTimezone } = useAuth();
-  const habitsLoading = useHabitStore((state) => state.loading);
-  const habits = useHabitStore((state) => state.habits);
-
-  useEffect(() => {
-    void habitManager.loadHabits(userTimezone);
-  }, [userTimezone]);
-
-  // Unlock is governed solely by the persisted ``revealed`` flag, so the
-  // denominator no longer depends on the user's current stage.
-  const unlocked = unlockedHabits(habits);
-  const showSkeleton = habitsLoading && habits.length === 0;
-  const descriptor = describeHabits(
-    showSkeleton,
-    habits.length,
-    unlocked.length,
-    countDoneToday(unlocked, userTimezone),
-  );
+  const { showSkeleton, habitCount, unlockedCount, doneCount } = useHabitsSummary();
+  const descriptor = describeHabits(showSkeleton, habitCount, unlockedCount, doneCount);
 
   return (
     <StatTile

--- a/frontend/src/features/Journal/__tests__/useHabitsSummary.test.tsx
+++ b/frontend/src/features/Journal/__tests__/useHabitsSummary.test.tsx
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react-native';
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ userTimezone: 'UTC' }),
+}));
+
+const mockLoadHabits = jest.fn();
+jest.mock('@/features/Habits/services/habitManager', () => ({
+  habitManager: {
+    loadHabits: (...args: unknown[]) => mockLoadHabits(...args),
+  },
+}));
+
+import type { Habit } from '@/features/Habits/Habits.types';
+import { useHabitStore } from '@/store/useHabitStore';
+
+const { useHabitsSummary } = require('../useHabitsSummary');
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 1,
+  stage: 'Beige',
+  name: 'Test Habit',
+  icon: 'leaf',
+  streak: 0,
+  energy_cost: 5,
+  energy_return: 5,
+  start_date: new Date('2020-01-01T00:00:00Z'),
+  goals: [],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockLoadHabits.mockClear();
+  useHabitStore.setState({
+    loading: false,
+    habits: [],
+    habitsById: {},
+    habitOrder: [],
+    error: null,
+  });
+});
+
+describe('useHabitsSummary', () => {
+  it('calls habitManager.loadHabits with the user timezone on mount', () => {
+    renderHook(() => useHabitsSummary());
+    expect(mockLoadHabits).toHaveBeenCalledWith('UTC');
+  });
+
+  it('showSkeleton is true while loading with no habits yet', () => {
+    useHabitStore.setState({ loading: true, habits: [] });
+    const { result } = renderHook(() => useHabitsSummary());
+    expect(result.current.showSkeleton).toBe(true);
+  });
+
+  it('showSkeleton is false once habits are present even if loading is still true', () => {
+    useHabitStore.setState({ loading: true, habits: [makeHabit({ revealed: true })] });
+    const { result } = renderHook(() => useHabitsSummary());
+    expect(result.current.showSkeleton).toBe(false);
+  });
+
+  it('derives habitCount, unlockedCount, and doneCount from the store habits', () => {
+    const habits = [
+      makeHabit({
+        id: 1,
+        revealed: true,
+        completions: [{ id: 'c1', timestamp: new Date(), completed_units: 1 }],
+      }),
+      makeHabit({ id: 2, revealed: true }),
+      makeHabit({ id: 3, revealed: false }),
+    ];
+    useHabitStore.setState({ loading: false, habits });
+    const { result } = renderHook(() => useHabitsSummary());
+    expect(result.current).toEqual({
+      showSkeleton: false,
+      habitCount: 3,
+      unlockedCount: 2,
+      doneCount: 1,
+    });
+  });
+});

--- a/frontend/src/features/Journal/useHabitsSummary.ts
+++ b/frontend/src/features/Journal/useHabitsSummary.ts
@@ -1,0 +1,40 @@
+/**
+ * `useHabitsSummary` owns the "Today's habits" tile's data-loading: it triggers
+ * the habit fetch on mount, reads the habit-store slices, and assembles the
+ * plain counts the tile renders — keeping `HabitsStatTile` presentational,
+ * mirroring `useWeeklyProgress` for the practice bar.
+ */
+import { useEffect } from 'react';
+
+import { useAuth } from '@/context/AuthContext';
+import { countDoneToday, unlockedHabits } from '@/features/Habits/habitCounts';
+import { habitManager } from '@/features/Habits/services/habitManager';
+import { useHabitStore } from '@/store/useHabitStore';
+
+export interface HabitsSummary {
+  showSkeleton: boolean;
+  habitCount: number;
+  unlockedCount: number;
+  doneCount: number;
+}
+
+export function useHabitsSummary(): HabitsSummary {
+  const { userTimezone } = useAuth();
+  const habitsLoading = useHabitStore((state) => state.loading);
+  const habits = useHabitStore((state) => state.habits);
+
+  useEffect(() => {
+    void habitManager.loadHabits(userTimezone);
+  }, [userTimezone]);
+
+  // Unlock is governed solely by the persisted revealed flag.
+  const unlocked = unlockedHabits(habits);
+  const showSkeleton = habitsLoading && habits.length === 0;
+
+  return {
+    showSkeleton,
+    habitCount: habits.length,
+    unlockedCount: unlocked.length,
+    doneCount: countDoneToday(unlocked, userTimezone),
+  };
+}


### PR DESCRIPTION
## Summary
- Extract the Journal "Today's habits" tile's data-loading into a new `useHabitsSummary` hook, mirroring the sibling `PracticesStatTile`/`useWeeklyProgress` pattern (de-slop: Family 5 business-logic-in-wrong-tier + Family 12 architectural drift).
- `HabitsStatTile` is now a purely presentational tile: it consumes the hook's `{ showSkeleton, habitCount, unlockedCount, doneCount }` and renders the descriptor. The mount-time `habitManager.loadHabits` effect, the store-slice reads, and the count assembly all move into the hook.
- Pure refactor — rendered output is byte-identical, `habitCounts` stays pure/injected, and the existing `HabitsStatTile.test.tsx` passes unchanged.

## Test plan
- New `useHabitsSummary.test.tsx` (4 tests via `renderHook`): mount-time `loadHabits('UTC')`, both `showSkeleton` edge cases, and the derived `{ habitCount, unlockedCount, doneCount }` counts.
- Existing `HabitsStatTile.test.tsx` (9 tests) passes untouched — end-to-end behavior-parity evidence.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4035 jest tests).

Closes #1505
