### PR TITLE
refactor(journal): retire three corroborated duplications/orphans

### DIFF
--- a/frontend/src/features/Journal/EditConfirmDialog.tsx
+++ b/frontend/src/features/Journal/EditConfirmDialog.tsx
@@ -5,16 +5,11 @@
  * card over the dimmed, still-visible page.
  */
 import React from 'react';
-import { Modal, Pressable, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 
-import {
-  BORDER_RADIUS,
-  SPACING,
-  colors,
-  editorialType,
-  spacing,
-  touchTarget,
-} from '@/design/tokens';
+import JournalModalShell from './JournalModalShell';
+
+import { BORDER_RADIUS, colors, editorialType, spacing, touchTarget } from '@/design/tokens';
 
 export interface EditConfirmDialogProps {
   visible: boolean;
@@ -22,9 +17,6 @@ export interface EditConfirmDialogProps {
   onStartNew: () => void;
   onCancel: () => void;
 }
-
-/** No-op so the card's tap-capture doesn't allocate a function per render. */
-const NOOP = (): void => {};
 
 interface ChoiceProps {
   label: string;
@@ -55,51 +47,37 @@ function EditConfirmDialog({
   onCancel,
 }: EditConfirmDialogProps): React.JSX.Element {
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
-      <Pressable
-        style={styles.scrim}
-        onPress={onCancel}
-        testID="edit-confirm-scrim"
-        accessibilityLabel="Dismiss"
-      >
-        <Pressable style={styles.card} onPress={NOOP} testID="edit-confirm-dialog">
-          <Text style={styles.title}>Edit finished entry?</Text>
-          <Text style={styles.body}>
-            This entry has its resonance. Editing it may move or unsettle the margin notes — they’ll
-            re-anchor where they still fit and dim where they no longer do.
-          </Text>
-          <Choice
-            label="Edit"
-            onPress={onEdit}
-            a11y="Edit this entry"
-            testID="edit-confirm-edit"
-            primary
-          />
-          <Choice
-            label="Start new"
-            onPress={onStartNew}
-            a11y="Start a new entry"
-            testID="edit-confirm-start-new"
-          />
-          <Choice label="Cancel" onPress={onCancel} a11y="Cancel" testID="edit-confirm-cancel" />
-        </Pressable>
-      </Pressable>
-    </Modal>
+    <JournalModalShell
+      visible={visible}
+      onDismiss={onCancel}
+      scrimTestID="edit-confirm-scrim"
+      scrimLabel="Dismiss"
+      cardTestID="edit-confirm-dialog"
+    >
+      <Text style={styles.title}>Edit finished entry?</Text>
+      <Text style={styles.body}>
+        This entry has its resonance. Editing it may move or unsettle the margin notes — they’ll
+        re-anchor where they still fit and dim where they no longer do.
+      </Text>
+      <Choice
+        label="Edit"
+        onPress={onEdit}
+        a11y="Edit this entry"
+        testID="edit-confirm-edit"
+        primary
+      />
+      <Choice
+        label="Start new"
+        onPress={onStartNew}
+        a11y="Start a new entry"
+        testID="edit-confirm-start-new"
+      />
+      <Choice label="Cancel" onPress={onCancel} a11y="Cancel" testID="edit-confirm-cancel" />
+    </JournalModalShell>
   );
 }
 
 const styles = StyleSheet.create({
-  scrim: {
-    flex: 1,
-    backgroundColor: colors.mystical.overlay,
-    justifyContent: 'center',
-    paddingHorizontal: SPACING.xl,
-  },
-  card: {
-    padding: SPACING.xl,
-    borderRadius: BORDER_RADIUS.lg,
-    backgroundColor: colors.paper.background,
-  },
   title: {
     ...editorialType.title,
     color: colors.paper.ink,

--- a/frontend/src/features/Journal/JournalModalShell.tsx
+++ b/frontend/src/features/Journal/JournalModalShell.tsx
@@ -1,0 +1,72 @@
+/**
+ * ``JournalModalShell`` — the shared scrim/card modal shell for the Journal
+ * feature. Dims the still-visible page, dismisses on a scrim tap, and captures
+ * taps on the centred card so they don't bubble to the scrim. Callers supply the
+ * card's body and any extra card style (e.g. a maxHeight cap).
+ */
+import React from 'react';
+import { Modal, Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
+
+export interface JournalModalShellProps {
+  visible: boolean;
+  onDismiss: () => void;
+  scrimTestID: string;
+  scrimLabel: string;
+  modalTestID?: string;
+  cardTestID?: string;
+  cardStyle?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+/** Stable no-op so the card's tap-capture doesn't allocate a fn per render. */
+const NOOP = (): void => {};
+
+function JournalModalShell({
+  visible,
+  onDismiss,
+  scrimTestID,
+  scrimLabel,
+  modalTestID,
+  cardTestID,
+  cardStyle,
+  children,
+}: JournalModalShellProps): React.JSX.Element {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+      testID={modalTestID}
+    >
+      <Pressable
+        style={styles.scrim}
+        onPress={onDismiss}
+        testID={scrimTestID}
+        accessibilityLabel={scrimLabel}
+      >
+        <Pressable style={[styles.card, cardStyle]} onPress={NOOP} testID={cardTestID}>
+          {children}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrim: {
+    flex: 1,
+    backgroundColor: colors.mystical.overlay,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xl,
+  },
+  card: {
+    padding: SPACING.xl,
+    borderRadius: BORDER_RADIUS.lg,
+    backgroundColor: colors.paper.background,
+  },
+});
+
+export default JournalModalShell;

--- a/frontend/src/features/Journal/ResonanceEssayModal.tsx
+++ b/frontend/src/features/Journal/ResonanceEssayModal.tsx
@@ -8,8 +8,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  Modal,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -17,26 +15,18 @@ import {
   View,
 } from 'react-native';
 
+import JournalModalShell from './JournalModalShell';
+
 import { resonance } from '@/api';
 import type { Marginalia } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import {
-  BORDER_RADIUS,
-  SPACING,
-  colors,
-  editorialType,
-  spacing,
-  touchTarget,
-} from '@/design/tokens';
+import { colors, editorialType, spacing, touchTarget } from '@/design/tokens';
 
 export interface ResonanceEssayModalProps {
   note: Marginalia | null;
   onClose: () => void;
   onEssayLoaded?: (_note: Marginalia) => void;
 }
-
-/** Stable no-op so the card's press-capture doesn't allocate a fn per render. */
-const NOOP = (): void => {};
 
 /** Shown when a fetch resolves an empty essay, so the user isn't stranded on a blank card. */
 const BLANK_ESSAY_MESSAGE = "This note's essay isn't ready yet.";
@@ -125,58 +115,40 @@ function ResonanceEssayModal({
   const { essay, loading, error, retry } = useEssay(note, onEssayLoaded);
 
   return (
-    <Modal
+    <JournalModalShell
       visible={note != null}
-      transparent
-      animationType="fade"
-      onRequestClose={onClose}
-      testID="essay-modal"
+      onDismiss={onClose}
+      scrimTestID="essay-scrim"
+      scrimLabel="Dismiss essay"
+      modalTestID="essay-modal"
+      cardStyle={styles.essayCard}
     >
-      <Pressable
-        style={styles.scrim}
-        onPress={onClose}
-        testID="essay-scrim"
-        accessibilityLabel="Dismiss essay"
-      >
-        {/* Capture taps on the card so they don't bubble to the dismiss scrim. */}
-        <Pressable style={styles.card} onPress={NOOP}>
-          <View style={styles.header}>
-            <Text style={[styles.kind, { color: note ? colors.marginalia[note.kind] : undefined }]}>
-              {note?.kind}
-            </Text>
-            <TouchableOpacity
-              onPress={onClose}
-              accessibilityRole="button"
-              accessibilityLabel="Close"
-              testID="essay-close"
-            >
-              <Text style={styles.close}>×</Text>
-            </TouchableOpacity>
-          </View>
-          <Text style={styles.quote} testID="essay-quote">
-            “{note?.anchor_text}”
-          </Text>
-          <ScrollView contentContainerStyle={styles.bodyScroll}>
-            <EssayBody essay={essay} loading={loading} error={error} retry={retry} />
-          </ScrollView>
-        </Pressable>
-      </Pressable>
-    </Modal>
+      <View style={styles.header}>
+        <Text style={[styles.kind, { color: note ? colors.marginalia[note.kind] : undefined }]}>
+          {note?.kind}
+        </Text>
+        <TouchableOpacity
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Close"
+          testID="essay-close"
+        >
+          <Text style={styles.close}>×</Text>
+        </TouchableOpacity>
+      </View>
+      <Text style={styles.quote} testID="essay-quote">
+        “{note?.anchor_text}”
+      </Text>
+      <ScrollView contentContainerStyle={styles.bodyScroll}>
+        <EssayBody essay={essay} loading={loading} error={error} retry={retry} />
+      </ScrollView>
+    </JournalModalShell>
   );
 }
 
 const styles = StyleSheet.create({
-  scrim: {
-    flex: 1,
-    backgroundColor: colors.mystical.overlay,
-    justifyContent: 'center',
-    paddingHorizontal: SPACING.xl,
-  },
-  card: {
+  essayCard: {
     maxHeight: '80%',
-    padding: SPACING.xl,
-    borderRadius: BORDER_RADIUS.lg,
-    backgroundColor: colors.paper.background,
   },
   header: {
     flexDirection: 'row',

--- a/frontend/src/features/Journal/__tests__/JournalModalShell.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalModalShell.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import JournalModalShell from '../JournalModalShell';
+
+// Flattens an RN style prop (array or object) into a plain lookup object.
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style) as Record<string, unknown>;
+  }
+  return (style ?? {}) as Record<string, unknown>;
+}
+
+function renderShell(overrides: Record<string, unknown> = {}) {
+  const props = {
+    visible: true,
+    onDismiss: jest.fn(),
+    scrimTestID: 'shell-scrim',
+    scrimLabel: 'Dismiss',
+    children: <Text>Shell content</Text>,
+    ...overrides,
+  };
+  return { ...render(<JournalModalShell {...props} />), props };
+}
+
+describe('JournalModalShell', () => {
+  it('renders its children when visible', () => {
+    const { getByText } = renderShell();
+    expect(getByText('Shell content')).toBeTruthy();
+  });
+
+  it('fires onDismiss once when the scrim is pressed', () => {
+    const { getByTestId, props } = renderShell();
+    fireEvent.press(getByTestId('shell-scrim'));
+    expect(props.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onDismiss when the card is pressed', () => {
+    const { getByTestId, props } = renderShell({ cardTestID: 'shell-card' });
+    fireEvent.press(getByTestId('shell-card'));
+    expect(props.onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('carries the passed scrimTestID and accessibilityLabel on the scrim', () => {
+    const { getByTestId } = renderShell({ scrimTestID: 'custom-scrim', scrimLabel: 'Close this' });
+    const scrim = getByTestId('custom-scrim');
+    expect(scrim.props.accessibilityLabel).toBe('Close this');
+  });
+
+  it('omits modalTestID and cardTestID when they are not provided', () => {
+    const { queryByTestId } = renderShell();
+    expect(queryByTestId('shell-modal')).toBeNull();
+    expect(queryByTestId('shell-card')).toBeNull();
+  });
+
+  it('exposes modalTestID and cardTestID when they are provided', () => {
+    const { queryByTestId } = renderShell({ modalTestID: 'shell-modal', cardTestID: 'shell-card' });
+    expect(queryByTestId('shell-modal')).toBeTruthy();
+    expect(queryByTestId('shell-card')).toBeTruthy();
+  });
+
+  it('merges the passed cardStyle onto the card', () => {
+    const { getByTestId } = renderShell({
+      cardTestID: 'shell-card',
+      cardStyle: { maxHeight: 321 },
+    });
+    const card = getByTestId('shell-card');
+    expect(flattenStyle(card.props.style).maxHeight).toBe(321);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/buildAnchoredSegments.test.ts
@@ -1,12 +1,8 @@
 /* eslint-env jest */
 import { describe, it, expect } from '@jest/globals';
 
-// RED: `buildAnchoredSegments` does not exist on `../highlightSegments` yet --
-// this file fails with "Cannot find module" / "is not a function" until the
-// implementation-specialist adds it (highlightSegments.ts becomes a thin
-// wrapper around it; `buildHighlightSegments` stays byte-identical -- see
-// highlightSegments.test.ts, which is untouched).
-import { buildAnchoredSegments, buildHighlightSegments } from '../highlightSegments';
+// Segments the body against a merged note + promoted-quote anchor stream.
+import { buildAnchoredSegments } from '../highlightSegments';
 
 import type { Marginalia, PromotedQuote } from '@/api';
 
@@ -83,8 +79,7 @@ describe('buildAnchoredSegments', () => {
     const segments = buildAnchoredSegments(BODY, [n], [q]);
 
     const anchored = segments.filter((s) => s.note != null || s.quote != null);
-    // The note wins the tie; the overlapping quote is skipped by the same
-    // first-wins cursor-skip rule `buildHighlightSegments` already uses.
+    // The note wins the tie; the overlapping quote is skipped by the anchored path's own first-wins cursor-skip rule.
     expect(anchored).toHaveLength(1);
     expect(anchored[0]!.note?.id).toBe(1);
   });
@@ -137,12 +132,13 @@ describe('buildAnchoredSegments', () => {
     expect(segments.every((s) => s.note == null)).toBe(true);
   });
 
-  it('is a strict superset of buildHighlightSegments when there are no quotes', () => {
+  it('carries quote:null on every segment when there are no quotes', () => {
     const start = BODY.indexOf('the willow');
     const n = note({ id: 7, anchor_start: start, anchor_end: start + 'the willow'.length });
-    const legacy = buildHighlightSegments(BODY, [n]);
-    const anchored = buildAnchoredSegments(BODY, [n], []);
-    expect(anchored).toEqual(legacy.map((s) => ({ ...s, quote: null })));
+    const segments = buildAnchoredSegments(BODY, [n], []);
+    expect(segments.every((s) => s.quote === null)).toBe(true);
+    const anchored = segments.find((s) => s.note?.id === 7);
+    expect(anchored?.text).toBe('the willow');
   });
 });
 
@@ -153,7 +149,7 @@ function hasUnpairedSurrogate(text: string): boolean {
   return UNPAIRED_HIGH_SURROGATE.test(text) || UNPAIRED_LOW_SURROGATE.test(text);
 }
 
-// RED: anchors are code points, but slice() indexes UTF-16 code units, so a leading emoji drifts them.
+// Anchors are code points; slicing here must not drift or split a non-BMP character.
 describe('buildAnchoredSegments -- non-BMP (astral) code-point anchors', () => {
   const EMOJI = '\u{1F600}';
   // Code points: 0=emoji, 1..16="went for a daily" (16 chars), 17=' ', 18.."walk."

--- a/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
+++ b/frontend/src/features/Journal/__tests__/highlightSegments.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { describe, it, expect } from '@jest/globals';
 
-import { buildHighlightSegments } from '../highlightSegments';
+import { buildAnchoredSegments } from '../highlightSegments';
 
 import type { Marginalia } from '@/api';
 
@@ -25,19 +25,19 @@ function note(overrides: Partial<Marginalia>): Marginalia {
   };
 }
 
-describe('buildHighlightSegments', () => {
+describe('buildAnchoredSegments -- notes-only segmentation', () => {
   it('returns the whole body as one plain segment when there are no notes', () => {
-    const segments = buildHighlightSegments(BODY, []);
-    expect(segments).toEqual([{ start: 0, text: BODY, note: null }]);
+    const segments = buildAnchoredSegments(BODY, [], []);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null, quote: null }]);
   });
 
   it('splits the body at anchor boundaries', () => {
     const start = BODY.indexOf('the willow');
     const n = note({ id: 7, anchor_start: start, anchor_end: start + 'the willow'.length });
-    const segments = buildHighlightSegments(BODY, [n]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
 
     expect(segments).toHaveLength(3);
-    expect(segments[0]).toEqual({ start: 0, text: BODY.slice(0, start), note: null });
+    expect(segments[0]).toEqual({ start: 0, text: BODY.slice(0, start), note: null, quote: null });
     expect(segments[1]).toMatchObject({ start, text: 'the willow' });
     expect(segments[1]!.note?.id).toBe(7);
     expect(segments[2]!.note).toBeNull();
@@ -47,7 +47,7 @@ describe('buildHighlightSegments', () => {
 
   it('handles an anchor at the very start (no leading plain segment)', () => {
     const n = note({ id: 2, anchor_start: 0, anchor_end: 8 }); // "I walked"
-    const segments = buildHighlightSegments(BODY, [n]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
     expect(segments[0]!.note?.id).toBe(2);
     expect(segments[0]!.text).toBe('I walked');
   });
@@ -55,7 +55,7 @@ describe('buildHighlightSegments', () => {
   it('keeps the earliest of two overlapping anchors, deterministically', () => {
     const a = note({ id: 1, anchor_start: 2, anchor_end: 10 });
     const b = note({ id: 2, anchor_start: 5, anchor_end: 15 }); // overlaps a
-    const segments = buildHighlightSegments(BODY, [b, a]); // unsorted input
+    const segments = buildAnchoredSegments(BODY, [b, a], []); // unsorted input
     const highlighted = segments.filter((s) => s.note != null);
     expect(highlighted).toHaveLength(1);
     expect(highlighted[0]!.note?.id).toBe(1); // earliest start wins
@@ -63,7 +63,7 @@ describe('buildHighlightSegments', () => {
 
   it('drops anchors that fall outside the body', () => {
     const n = note({ id: 9, anchor_start: 100, anchor_end: 120 });
-    const segments = buildHighlightSegments(BODY, [n]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
     expect(segments.every((s) => s.note == null)).toBe(true);
   });
 
@@ -75,36 +75,36 @@ describe('buildHighlightSegments', () => {
       anchor_end: start + 'the willow'.length,
       status: 'stale',
     });
-    const segments = buildHighlightSegments(BODY, [stale]);
+    const segments = buildAnchoredSegments(BODY, [stale], []);
     expect(segments.every((s) => s.note == null)).toBe(true);
   });
 
   it('drops an anchor whose start is negative', () => {
     const n = note({ id: 10, anchor_start: -1, anchor_end: 4 });
-    const segments = buildHighlightSegments(BODY, [n]);
-    expect(segments).toEqual([{ start: 0, text: BODY, note: null }]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null, quote: null }]);
   });
 
   it('drops an empty anchor whose start equals its end', () => {
     const at = BODY.indexOf('willow');
     const n = note({ id: 11, anchor_start: at, anchor_end: at });
-    const segments = buildHighlightSegments(BODY, [n]);
-    expect(segments).toEqual([{ start: 0, text: BODY, note: null }]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
+    expect(segments).toEqual([{ start: 0, text: BODY, note: null, quote: null }]);
   });
 
   it('includes an anchor that ends exactly at the end of the body', () => {
     const end = BODY.length;
     const tail = 'bent.';
     const n = note({ id: 12, anchor_start: end - tail.length, anchor_end: end });
-    const segments = buildHighlightSegments(BODY, [n]);
+    const segments = buildAnchoredSegments(BODY, [n], []);
     const last = segments[segments.length - 1]!;
     expect(last.note?.id).toBe(12);
     expect(last.text).toBe(tail);
   });
 
   it('returns a single plain segment for an empty body', () => {
-    const segments = buildHighlightSegments('', []);
-    expect(segments).toEqual([{ start: 0, text: '', note: null }]);
+    const segments = buildAnchoredSegments('', [], []);
+    expect(segments).toEqual([{ start: 0, text: '', note: null, quote: null }]);
   });
 });
 
@@ -115,8 +115,7 @@ function hasUnpairedSurrogate(text: string): boolean {
   return UNPAIRED_HIGH_SURROGATE.test(text) || UNPAIRED_LOW_SURROGATE.test(text);
 }
 
-// RED: anchors are code points, but slice() indexes UTF-16 code units, so a leading emoji drifts them.
-describe('buildHighlightSegments -- non-BMP (astral) code-point anchors (marginalia)', () => {
+describe('buildAnchoredSegments -- non-BMP (astral) code-point anchors (marginalia, notes-only)', () => {
   const EMOJI = '\u{1F600}';
   const LEADING_EMOJI_BODY = `${EMOJI}went for a daily walk.`;
 
@@ -124,7 +123,7 @@ describe('buildHighlightSegments -- non-BMP (astral) code-point anchors (margina
     const start = 1; // code-point index right after the emoji, at "w"
     const end = 17; // code-point index right after "went for a daily"
     const n = note({ id: 7, anchor_start: start, anchor_end: end });
-    const segments = buildHighlightSegments(LEADING_EMOJI_BODY, [n]);
+    const segments = buildAnchoredSegments(LEADING_EMOJI_BODY, [n], []);
     const anchored = segments.find((s) => s.note?.id === 7);
     expect(anchored?.text).toBe('went for a daily');
   });
@@ -134,7 +133,7 @@ describe('buildHighlightSegments -- non-BMP (astral) code-point anchors (margina
     const start = 11; // code-point index of "w" in "walk"
     const end = 16; // the body's code-point length, including the trailing emoji
     const n = note({ id: 8, anchor_start: start, anchor_end: end });
-    const segments = buildHighlightSegments(tailBody, [n]);
+    const segments = buildAnchoredSegments(tailBody, [n], []);
     const anchored = segments.find((s) => s.note?.id === 8);
     expect(anchored).toBeDefined();
     expect(anchored?.text).toBe(`walk${EMOJI}`);
@@ -143,7 +142,7 @@ describe('buildHighlightSegments -- non-BMP (astral) code-point anchors (margina
   it('never produces a segment with a lone/unpaired surrogate', () => {
     const tailBody = `went for a walk${EMOJI}`;
     const n = note({ id: 8, anchor_start: 11, anchor_end: 16 });
-    const segments = buildHighlightSegments(tailBody, [n]);
+    const segments = buildAnchoredSegments(tailBody, [n], []);
     for (const segment of segments) {
       expect(hasUnpairedSurrogate(segment.text)).toBe(false);
     }

--- a/frontend/src/features/Journal/__tests__/optimisticRemove.test.ts
+++ b/frontend/src/features/Journal/__tests__/optimisticRemove.test.ts
@@ -1,0 +1,224 @@
+/* eslint-env jest */
+import { jest, describe, it, expect } from '@jest/globals';
+import type { Dispatch, SetStateAction } from 'react';
+
+import { optimisticRemove, type OptimisticRemoveDeps } from '../optimisticRemove';
+
+import { ApiError } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+
+interface Row {
+  id: number;
+}
+
+type RemoveFn = (_id: number) => Promise<unknown>;
+
+// Sorted re-insertion for reverting an optimistic removal.
+function reinsert(prev: Row[], item: Row): Row[] {
+  return [...prev, item].sort((a, b) => a.id - b.id);
+}
+
+// A remote-delete stub that resolves, typed to the helper's contract.
+function resolvedRemove(): jest.MockedFunction<RemoveFn> {
+  const fn = jest.fn() as jest.MockedFunction<RemoveFn>;
+  fn.mockResolvedValue(undefined);
+  return fn;
+}
+
+// A remote-delete stub that rejects with the given error.
+function rejectedRemove(err: unknown): jest.MockedFunction<RemoveFn> {
+  const fn = jest.fn() as jest.MockedFunction<RemoveFn>;
+  fn.mockRejectedValue(err);
+  return fn;
+}
+
+// A remote-delete stub whose promise the caller resolves by hand.
+function deferredRemove(): { fn: jest.MockedFunction<RemoveFn>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const fn = jest.fn() as jest.MockedFunction<RemoveFn>;
+  fn.mockReturnValue(
+    new Promise<void>((res) => {
+      resolve = res;
+    }),
+  );
+  return { fn, resolve: () => resolve() };
+}
+
+// A tiny setState-shaped harness backed by a plain closure variable.
+function makeHarness(initial: Row[]) {
+  let items: Row[] = initial;
+  const setItems = jest.fn((updater: Row[] | ((_prev: Row[]) => Row[])) => {
+    items = typeof updater === 'function' ? (updater as (_prev: Row[]) => Row[])(items) : updater;
+  }) as unknown as Dispatch<SetStateAction<Row[]>>;
+  return { getItems: () => items, setItems };
+}
+
+function baseDeps(overrides: Partial<OptimisticRemoveDeps<Row>> = {}): OptimisticRemoveDeps<Row> {
+  const harness = makeHarness([{ id: 1 }, { id: 2 }]);
+  return {
+    pendingIds: new Set<number>(),
+    current: harness.getItems(),
+    setItems: harness.setItems,
+    removeRemote: resolvedRemove(),
+    reinsert,
+    onError: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('optimisticRemove', () => {
+  it('removes the row optimistically before removeRemote resolves', async () => {
+    const removeRemote = deferredRemove();
+    const harness = makeHarness([{ id: 1 }, { id: 2 }]);
+    const pendingIds = new Set<number>();
+    const onError = jest.fn();
+
+    const promise = optimisticRemove(1, {
+      pendingIds,
+      current: harness.getItems(),
+      setItems: harness.setItems,
+      removeRemote: removeRemote.fn,
+      reinsert,
+      onError,
+    });
+
+    expect(harness.getItems()).toEqual([{ id: 2 }]);
+    expect(removeRemote.fn).toHaveBeenCalledWith(1);
+
+    removeRemote.resolve();
+    await promise;
+  });
+
+  it('reverts via reinsert and reports the formatted error on rejection', async () => {
+    const err = new ApiError(500, 'boom');
+    const removeRemote = rejectedRemove(err);
+    const harness = makeHarness([{ id: 1 }, { id: 2 }]);
+    const pendingIds = new Set<number>();
+    const onError = jest.fn();
+
+    await optimisticRemove(1, {
+      pendingIds,
+      current: harness.getItems(),
+      setItems: harness.setItems,
+      removeRemote,
+      reinsert,
+      onError,
+    });
+
+    expect(harness.getItems()).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(formatApiError(err));
+  });
+
+  it('is a no-op on a second call for the same id while the first is pending', async () => {
+    const removeRemote = deferredRemove();
+    const harness = makeHarness([{ id: 1 }]);
+    const pendingIds = new Set<number>();
+    const onError = jest.fn();
+    const deps = {
+      pendingIds,
+      current: harness.getItems(),
+      setItems: harness.setItems,
+      removeRemote: removeRemote.fn,
+      reinsert,
+      onError,
+    };
+
+    const first = optimisticRemove(1, deps);
+    const second = optimisticRemove(1, deps);
+    removeRemote.resolve();
+    await Promise.all([first, second]);
+
+    expect(removeRemote.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears pendingIds in finally on success', async () => {
+    const pendingIds = new Set<number>();
+    const deps = baseDeps({ pendingIds });
+
+    await optimisticRemove(1, deps);
+
+    expect(pendingIds.has(1)).toBe(false);
+  });
+
+  it('clears pendingIds in finally on rejection', async () => {
+    const pendingIds = new Set<number>();
+    const deps = baseDeps({ pendingIds, removeRemote: rejectedRemove(new ApiError(500, 'boom')) });
+
+    await optimisticRemove(1, deps);
+
+    expect(pendingIds.has(1)).toBe(false);
+  });
+
+  it('clears pendingIds in finally when the id is not present in current', async () => {
+    const harness = makeHarness([{ id: 2 }]);
+    const pendingIds = new Set<number>();
+    const removeRemote = resolvedRemove();
+    const onError = jest.fn();
+
+    await optimisticRemove(1, {
+      pendingIds,
+      current: harness.getItems(),
+      setItems: harness.setItems,
+      removeRemote,
+      reinsert,
+      onError,
+    });
+
+    expect(pendingIds.has(1)).toBe(false);
+    expect(removeRemote).toHaveBeenCalledWith(1);
+    expect(harness.getItems()).toEqual([{ id: 2 }]);
+  });
+
+  it('invokes beforeStart exactly once before the optimistic mutation', async () => {
+    const order: string[] = [];
+    let items: Row[] = [{ id: 1 }];
+    const setItems = jest.fn((updater: Row[] | ((_prev: Row[]) => Row[])) => {
+      order.push('setItems');
+      items = typeof updater === 'function' ? (updater as (_prev: Row[]) => Row[])(items) : updater;
+    }) as unknown as Dispatch<SetStateAction<Row[]>>;
+    const beforeStart = jest.fn(() => order.push('beforeStart'));
+    const removeRemote = resolvedRemove();
+    const onError = jest.fn();
+
+    await optimisticRemove(1, {
+      pendingIds: new Set<number>(),
+      current: items,
+      setItems,
+      removeRemote,
+      reinsert,
+      onError,
+      beforeStart,
+    });
+
+    expect(beforeStart).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['beforeStart', 'setItems']);
+  });
+
+  it('does not throw when beforeStart is omitted', async () => {
+    const deps = baseDeps();
+
+    await expect(optimisticRemove(1, deps)).resolves.toBeUndefined();
+  });
+
+  it('never calls onError or reinsert on the success path', async () => {
+    const harness = makeHarness([{ id: 1 }, { id: 2 }]);
+    const pendingIds = new Set<number>();
+    const onError = jest.fn();
+    const reinsertSpy = jest.fn(reinsert);
+    const removeRemote = resolvedRemove();
+
+    await optimisticRemove(1, {
+      pendingIds,
+      current: harness.getItems(),
+      setItems: harness.setItems,
+      removeRemote,
+      reinsert: reinsertSpy,
+      onError,
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(reinsertSpy).not.toHaveBeenCalled();
+    expect(harness.getItems()).toEqual([{ id: 2 }]);
+  });
+});

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -119,16 +119,3 @@ export function buildAnchoredSegments(
   if (segments.length === 0) segments.push({ start: 0, text: body, note: null, quote: null });
   return segments;
 }
-
-/**
- * The notes-only segmentation the read-mode highlight tree consumes. A thin
- * wrapper over {@link buildAnchoredSegments} (no quotes) that drops the quote
- * key, so its shape and behaviour stay exactly as before.
- */
-export function buildHighlightSegments(body: string, notes: Marginalia[]): HighlightSegment[] {
-  return buildAnchoredSegments(body, notes, []).map(({ start, text, note }) => ({
-    start,
-    text,
-    note,
-  }));
-}

--- a/frontend/src/features/Journal/optimisticRemove.ts
+++ b/frontend/src/features/Journal/optimisticRemove.ts
@@ -1,0 +1,39 @@
+/**
+ * ``optimisticRemove`` — the shared guarded optimistic-remove-with-revert
+ * primitive for Journal lists. Guards a double in-flight tap per id, drops the
+ * row up front, and re-inserts it (via the caller's ``reinsert``) if the remote
+ * delete rejects. The optional ``beforeStart`` hook lets a caller clear a hint
+ * before mutating; it runs exactly once, before the optimistic removal.
+ */
+import type { Dispatch, SetStateAction } from 'react';
+
+import { formatApiError } from '@/api/errorMessages';
+
+export interface OptimisticRemoveDeps<T extends { id: number }> {
+  pendingIds: Set<number>;
+  current: readonly T[];
+  setItems: Dispatch<SetStateAction<T[]>>;
+  removeRemote: (_id: number) => Promise<unknown>;
+  reinsert: (_prev: T[], _item: T) => T[];
+  onError: (_message: string) => void;
+  beforeStart?: () => void;
+}
+
+export async function optimisticRemove<T extends { id: number }>(
+  id: number,
+  deps: OptimisticRemoveDeps<T>,
+): Promise<void> {
+  if (deps.pendingIds.has(id)) return; // per-id guard
+  deps.pendingIds.add(id);
+  deps.beforeStart?.();
+  const removed = deps.current.find((row) => row.id === id);
+  deps.setItems((prev) => prev.filter((row) => row.id !== id)); // optimistic remove
+  try {
+    await deps.removeRemote(id);
+  } catch (err) {
+    if (removed) deps.setItems((prev) => deps.reinsert(prev, removed)); // revert
+    deps.onError(formatApiError(err));
+  } finally {
+    deps.pendingIds.delete(id);
+  }
+}

--- a/frontend/src/features/Journal/usePromotions.ts
+++ b/frontend/src/features/Journal/usePromotions.ts
@@ -4,12 +4,14 @@
  *
  * ``promote`` raises a reader-selected span into the corpus and appends the
  * returned quote on success; a failure maps to a warm, non-blocking hint and
- * appends nothing. ``removePromotion`` optimistically drops a quote and reverts
- * it on error, guarding a double-tap per id (mirrors ``useResonance``'s
- * ``runDismiss``). One promote runs at a time so a double-tap can't double-post.
+ * appends nothing. ``removePromotion`` drops a quote optimistically and reverts
+ * it on error via the shared optimistic-remove primitive. One promote runs at a
+ * time so a double-tap can't double-post.
  */
 import type { Dispatch, SetStateAction } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { optimisticRemove } from './optimisticRemove';
 
 import { promotions } from '@/api';
 import type { PromotedQuote } from '@/api';
@@ -40,11 +42,6 @@ function byAnchorThenId(a: PromotedQuote, b: PromotedQuote): number {
 /** Re-insert a reverted quote, keeping the list ordered by anchor then id. */
 function insertSorted(quotes: PromotedQuote[], quote: PromotedQuote): PromotedQuote[] {
   return [...quotes, quote].sort(byAnchorThenId);
-}
-
-/** Drop the quote with ``id`` (a named helper so it isn't a nested callback). */
-function dropById(quotes: PromotedQuote[], id: number): PromotedQuote[] {
-  return quotes.filter((q) => q.id !== id);
 }
 
 /**
@@ -133,21 +130,19 @@ export function usePromotions({
     [entryId],
   );
 
-  const removePromotion = useCallback(async (id: number): Promise<void> => {
-    if (removingIdsRef.current.has(id)) return;
-    removingIdsRef.current.add(id);
-    setHint(null);
-    const removed = quotesRef.current.find((q) => q.id === id);
-    setQuotes((prev) => dropById(prev, id)); // optimistic
-    try {
-      await promotions.remove(id);
-    } catch (err) {
-      if (removed) setQuotes((prev) => insertSorted(prev, removed)); // revert
-      setHint(formatApiError(err));
-    } finally {
-      removingIdsRef.current.delete(id);
-    }
-  }, []);
+  const removePromotion = useCallback(
+    (id: number): Promise<void> =>
+      optimisticRemove(id, {
+        pendingIds: removingIdsRef.current,
+        current: quotesRef.current,
+        setItems: setQuotes,
+        removeRemote: promotions.remove,
+        reinsert: insertSorted,
+        onError: setHint,
+        beforeStart: () => setHint(null),
+      }),
+    [],
+  );
 
   return { quotes, hint, promote, removePromotion };
 }

--- a/frontend/src/features/Journal/useResonance.ts
+++ b/frontend/src/features/Journal/useResonance.ts
@@ -18,6 +18,8 @@ import {
   type SetStateAction,
 } from 'react';
 
+import { optimisticRemove } from './optimisticRemove';
+
 import { completionSuggestions, resonance } from '@/api';
 import type {
   CareResponse,
@@ -161,7 +163,15 @@ function useSuggestions(routeEntryId: number | null, setError: SetError): Sugges
   );
 
   const dismissSuggestion = useCallback(
-    (id: number) => runDismiss(id, suggestions, { pendingIdsRef, setSuggestions, setError }),
+    (id: number) =>
+      optimisticRemove(id, {
+        pendingIds: pendingIdsRef.current,
+        current: suggestions,
+        setItems: setSuggestions,
+        removeRemote: completionSuggestions.dismiss,
+        reinsert: (prev, item) => mergeByIdSorted([item], prev),
+        onError: setError,
+      }),
     [suggestions, setError],
   );
 
@@ -191,34 +201,6 @@ async function runAccept(id: number, deps: AcceptDeps): Promise<void> {
     deps.setAcceptedCheckIns((prev) => ({ ...prev, [id]: result.check_in }));
   } catch (err) {
     deps.setError(formatApiError(err)); // row stays pending; user can retry
-  } finally {
-    deps.pendingIdsRef.current.delete(id);
-  }
-}
-
-interface DismissDeps {
-  pendingIdsRef: MutableRefObject<Set<number>>;
-  setSuggestions: Dispatch<SetStateAction<CompletionSuggestion[]>>;
-  setError: SetError;
-}
-
-/** Dismiss a suggestion: per-id guarded; optimistic remove, revert on error. */
-async function runDismiss(
-  id: number,
-  current: CompletionSuggestion[],
-  deps: DismissDeps,
-): Promise<void> {
-  if (deps.pendingIdsRef.current.has(id)) return;
-  deps.pendingIdsRef.current.add(id);
-  const dismissed = current.find((s) => s.id === id);
-  deps.setSuggestions((prev) => prev.filter((s) => s.id !== id)); // optimistic
-  try {
-    await completionSuggestions.dismiss(id);
-  } catch (err) {
-    if (dismissed) {
-      deps.setSuggestions((prev) => mergeByIdSorted([dismissed], prev)); // revert
-    }
-    deps.setError(formatApiError(err));
   } finally {
     deps.pendingIdsRef.current.delete(id);
   }


### PR DESCRIPTION
## Summary

De-slop cleanup of three corroborated Journal duplications/orphans (issue #1507). All three findings were re-verified live at HEAD before acting (the Journal feature changed heavily this week via #1538/#1546/#1548/#1550/#1551); each is a behavior-preserving refactor landed as its own commit.

1. **Shared modal shell.** `EditConfirmDialog` and `ResonanceEssayModal` repeated the same `NOOP` tap-capture, byte-identical `scrim` styles, a shared `card` style, and the same `Modal > scrim Pressable > card Pressable` structure. Extracted `JournalModalShell` and render both modals through it. testIDs, a11y labels, dismiss wiring, and the essay card's `maxHeight` cap are preserved (EditConfirmDialog keeps no Modal testID / no cardStyle; ResonanceEssayModal keeps `modalTestID="essay-modal"` and no card testID).

2. **Shared optimistic-remove-with-revert primitive.** `runDismiss` (`useResonance`) and `removePromotion` (`usePromotions`) implemented the same per-id-guarded, optimistic-remove, revert-on-error flow twice. Extracted a generic `optimisticRemove` helper parameterised by the re-insert semantics, the error sink, and an optional `beforeStart` hook (promotions clears its hint up front). The dismiss revert keeps its incoming-wins merge and the promotion revert its anchor-then-id insert, so double-tap guards and revert behaviour are unchanged. `promote`/`accept` were intentionally left as-is (different shape — forcing them would risk behaviour change).

3. **Retired orphaned `buildHighlightSegments`.** It had zero production importers (the read-mode tree calls `buildAnchoredSegments` directly), so its docstring claiming to be "the notes-only segmentation the read-mode highlight tree consumes" was false. Deleted the function and its docstring and retargeted its tests onto `buildAnchoredSegments`, preserving every assertion. The `HighlightSegment` interface is retained as `AnchoredSegment`'s base.

No user-visible behavior change. No API, dependency, or migration changes.

## Test plan

- New unit tests: `JournalModalShell.test.tsx` (children/dismiss/scrim-vs-card capture, optional testID presence/absence, cardStyle merge) and `optimisticRemove.test.ts` (optimistic-before-resolve, revert via `formatApiError`, double-tap no-op, `pendingIds` cleanup on every exit, `beforeStart` once-and-ordering, success path never reverts/errors).
- Existing modal and hook tests (`EditConfirmDialog`, `ResonanceEssayModal`, `useResonance`, `usePromotions`, `HighlightedBody`) pass **unchanged** — they are the behavior-parity contract.
- Segment tests retargeted onto `buildAnchoredSegments` with assertions preserved 1:1.
- Gate 2 green locally: ESLint (0 warnings), prettier, `tsc` strict, full Jest suite (4055 tests). Gate 2.5 self-review: CLEAN, no blockers.

Closes #1507