### PR TITLE
test(habits): re-point HabitsScreen mocks from habits.list to listAll

### DIFF
--- a/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React, { useSyncExternalStore } from 'react';
 
+import type * as ApiModule from '../../../api';
 import HabitsScreen from '../HabitsScreen';
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
@@ -26,6 +27,7 @@ const HabitsScreenWithHeader = (): React.JSX.Element => {
 
 interface SettingsModalProps {
   visible: boolean;
+  habit: { id: number; name: string } | null;
 }
 
 const mockHabitSettingsModal = jest.fn((_props: SettingsModalProps) => null);
@@ -46,51 +48,59 @@ jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    list: () =>
-      Promise.resolve([
-        {
-          id: 1,
-          name: 'Meditate',
-          icon: '\u{1F9D8}',
-          stage: 'Beige',
-          streak: 0,
-          energy_cost: 1,
-          energy_return: 1,
-          start_date: new Date(2020, 0, 1),
-          goals: [
-            {
-              title: 'Low',
-              tier: 'low',
-              target: 1,
-              target_unit: 'u',
-              frequency: 1,
-              frequency_unit: 'per_day',
-              is_additive: true,
-            },
-          ],
-          completions: [],
-          revealed: true,
-        },
-      ]),
-    create: jest.fn(),
-    update: jest.fn(),
-    delete: jest.fn(),
-    getStats: () =>
-      Promise.resolve({
-        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-        values: [0, 0, 0, 0, 0, 0, 0],
-        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-        longest_streak: 0,
-        current_streak: 0,
-        total_completions: 0,
-        completion_rate: 0,
-        completion_dates: [],
-      }),
-  },
-  goalCompletions: { create: jest.fn() },
-}));
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      // The id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the
+      // settings-modal assertion fails if the screen falls back to the demo seed.
+      listAll: () =>
+        Promise.resolve([
+          {
+            id: 7,
+            name: 'Meditate',
+            icon: '\u{1F9D8}',
+            stage: 'Beige',
+            streak: 0,
+            energy_cost: 1,
+            energy_return: 1,
+            start_date: new Date(2020, 0, 1),
+            goals: [
+              {
+                title: 'Low',
+                tier: 'low',
+                target: 1,
+                target_unit: 'u',
+                frequency: 1,
+                frequency_unit: 'per_day',
+                is_additive: true,
+              },
+            ],
+            completions: [],
+            revealed: true,
+          },
+        ]),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      getStats: () =>
+        Promise.resolve({
+          day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+          values: [0, 0, 0, 0, 0, 0, 0],
+          completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+          longest_streak: 0,
+          current_streak: 0,
+          total_completions: 0,
+          completion_rate: 0,
+          completion_dates: [],
+        }),
+    },
+    goalCompletions: { create: jest.fn() },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
@@ -144,6 +154,8 @@ describe('Habits Edit-mode tile tap', () => {
       const calls = mockHabitSettingsModal.mock.calls;
       const last = calls[calls.length - 1]!;
       expect(last[0].visible).toBe(true);
+      // The modal opened for the mocked fixture habit, not a fallback tile.
+      expect(last[0].habit).toMatchObject({ id: 7, name: 'Meditate' });
     });
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, jest } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
+import type * as ApiModule from '../../../api';
 import HabitsScreen from '../HabitsScreen';
 
 const mockUpdateHabit = jest.fn((..._args: unknown[]) => Promise.resolve());
@@ -14,51 +15,59 @@ jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: jest.fn() }),
 }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    list: () =>
-      Promise.resolve([
-        {
-          id: 1,
-          name: 'Meditate',
-          icon: '\u{1F9D8}',
-          stage: 'Beige',
-          streak: 0,
-          energy_cost: 1,
-          energy_return: 1,
-          start_date: new Date(2020, 0, 1),
-          goals: [
-            {
-              title: 'Low',
-              tier: 'low',
-              target: 1,
-              target_unit: 'u',
-              frequency: 1,
-              frequency_unit: 'per_day',
-              is_additive: true,
-            },
-          ],
-          completions: [],
-          revealed: true,
-        },
-      ]),
-    create: jest.fn(),
-    update: (...args: unknown[]) => mockUpdateHabit(...args),
-    delete: jest.fn(),
-    getStats: () =>
-      Promise.resolve({
-        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-        values: [0, 0, 0, 0, 0, 0, 0],
-        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-        longest_streak: 0,
-        current_streak: 0,
-        total_completions: 0,
-        completion_rate: 0,
-        completion_dates: [],
-      }),
-  },
-  goalCompletions: { create: jest.fn() },
-}));
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      // The id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the
+      // update assertion fails if the screen ever falls back to the demo seed.
+      listAll: () =>
+        Promise.resolve([
+          {
+            id: 7,
+            name: 'Meditate',
+            icon: '\u{1F9D8}',
+            stage: 'Beige',
+            streak: 0,
+            energy_cost: 1,
+            energy_return: 1,
+            start_date: new Date(2020, 0, 1),
+            goals: [
+              {
+                title: 'Low',
+                tier: 'low',
+                target: 1,
+                target_unit: 'u',
+                frequency: 1,
+                frequency_unit: 'per_day',
+                is_additive: true,
+              },
+            ],
+            completions: [],
+            revealed: true,
+          },
+        ]),
+      create: jest.fn(),
+      update: (...args: unknown[]) => mockUpdateHabit(...args),
+      delete: jest.fn(),
+      getStats: () =>
+        Promise.resolve({
+          day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+          values: [0, 0, 0, 0, 0, 0, 0],
+          completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+          longest_streak: 0,
+          current_streak: 0,
+          total_completions: 0,
+          completion_rate: 0,
+          completion_dates: [],
+        }),
+    },
+    goalCompletions: { create: jest.fn() },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
@@ -102,7 +111,7 @@ describe('Habits icon-tap emoji picker', () => {
     fireEvent.press(getByTestId('emoji-picker-select'));
 
     await waitFor(() => expect(mockUpdateHabit).toHaveBeenCalledTimes(1));
-    expect(mockUpdateHabit.mock.calls[0]![0]).toBe(1);
+    expect(mockUpdateHabit.mock.calls[0]![0]).toBe(7);
     expect(mockUpdateHabit.mock.calls[0]![1]).toMatchObject({ icon: '\u{1F389}' });
 
     await waitFor(() => expect(queryByTestId('emoji-picker')).toBeNull());

--- a/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
@@ -16,7 +16,7 @@ import { useModalCoordinator } from '../hooks/useModalCoordinator';
 // Mock dependencies
 jest.mock('../../../api', () => ({
   habits: {
-    list: jest.fn(() => Promise.resolve([])),
+    listAll: jest.fn(() => Promise.resolve([])),
     create: jest.fn(() =>
       Promise.resolve({
         id: 100,

--- a/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React, { useSyncExternalStore } from 'react';
 
+import type * as ApiModule from '../../../api';
 import HabitsScreen from '../HabitsScreen';
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
@@ -41,51 +42,57 @@ jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    list: () =>
-      Promise.resolve([
-        {
-          id: 2,
-          name: 'Early Habit',
-          icon: '\u{1F331}',
-          stage: 'Beige',
-          streak: 0,
-          energy_cost: 1,
-          energy_return: 1,
-          start_date: new Date('2099-01-01'),
-          goals: [
-            {
-              title: 'Low',
-              tier: 'low',
-              target: 1,
-              target_unit: 'u',
-              frequency: 1,
-              frequency_unit: 'per_day',
-              is_additive: true,
-            },
-          ],
-          completions: [],
-          revealed: true,
-        },
-      ]),
-    create: jest.fn(),
-    update: jest.fn(),
-    delete: jest.fn(),
-    getStats: () =>
-      Promise.resolve({
-        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-        values: [0, 0, 0, 0, 0, 0, 0],
-        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-        longest_streak: 0,
-        current_streak: 0,
-        total_completions: 0,
-        completion_rate: 0,
-        completion_dates: [],
-      }),
-  },
-  goalCompletions: { create: jest.fn() },
-}));
+jest.mock('../../../api', () => {
+  // The load path maps API rows through the real toLocalHabit; keep it so the
+  // fixture below actually loads instead of throwing into the demo fallback.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      listAll: () =>
+        Promise.resolve([
+          {
+            id: 2,
+            name: 'Early Habit',
+            icon: '\u{1F331}',
+            stage: 'Beige',
+            streak: 0,
+            energy_cost: 1,
+            energy_return: 1,
+            start_date: new Date('2099-01-01'),
+            goals: [
+              {
+                title: 'Low',
+                tier: 'low',
+                target: 1,
+                target_unit: 'u',
+                frequency: 1,
+                frequency_unit: 'per_day',
+                is_additive: true,
+              },
+            ],
+            completions: [],
+            revealed: true,
+          },
+        ]),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      getStats: () =>
+        Promise.resolve({
+          day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+          values: [0, 0, 0, 0, 0, 0, 0],
+          completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+          longest_streak: 0,
+          current_streak: 0,
+          total_completions: 0,
+          completion_rate: 0,
+          completion_dates: [],
+        }),
+    },
+    goalCompletions: { create: jest.fn() },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
@@ -124,17 +131,25 @@ beforeEach(() => {
 
 describe('Habits drawer lock-unstarted toggle', () => {
   it('locks an early-unlocked habit via Lock Unstarted Habits', async () => {
-    const { getAllByTestId, getByText, getByLabelText, queryByText } = render(
+    const { getAllByTestId, getByText, getByLabelText, queryByText, queryByLabelText } = render(
       <HabitsScreenWithHeader />,
     );
 
     await waitFor(() => expect(getAllByTestId('habit-icon').length).toBeGreaterThan(0));
 
-    // All seeded habits are revealed, so the toggle offers the lock action.
+    // The mocked fixture — the revealed, future-start "Early Habit" — is what
+    // loaded, so it starts unlocked (no locked accessibility label yet).
+    expect(queryByLabelText('Early Habit locked')).toBeNull();
+
+    // The only seeded habit is revealed, so the toggle offers the lock action.
     fireEvent.press(getByLabelText('Open Habits menu'));
     fireEvent.press(getByText('Lock Unstarted Habits'));
 
     // Acting on a drawer row closes the drawer.
     await waitFor(() => expect(queryByText('Lock Unstarted Habits')).toBeNull());
+
+    // The zero-completion fixture habit is now locked — its tile re-renders as a
+    // locked tile carrying the "Early Habit locked" label.
+    await waitFor(() => expect(getByLabelText('Early Habit locked')).toBeTruthy());
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -23,10 +23,11 @@ const openHabitsDrawer = (): void => {
   });
 };
 
-// Mock the API so HabitsScreen loads instantly with an empty list (triggers fallback defaults)
+// Mock the API so HabitsScreen loads an empty list, which the loader seeds into
+// the demo fallback defaults that these responsive-grid assertions render against.
 jest.mock('../../../api', () => ({
   habits: {
-    list: (jest.fn() as any).mockResolvedValue([]),
+    listAll: (jest.fn() as any).mockResolvedValue([]),
     create: jest.fn() as any,
     update: jest.fn() as any,
     delete: jest.fn() as any,

--- a/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
@@ -16,7 +16,7 @@ jest.mock('@/navigation/hooks', () => ({
 // `@jest/globals`' `jest.fn().mockResolvedValue(...)`.
 jest.mock('../../../api', () => ({
   habits: {
-    list: () => Promise.resolve([]),
+    listAll: () => Promise.resolve([]),
     create: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -17,7 +17,7 @@ import { useHabits } from '../hooks/useHabits';
 
 jest.mock('../../../api', () => ({
   habits: {
-    list: jest.fn(() => Promise.resolve([])),
+    listAll: jest.fn(() => Promise.resolve([])),
     create: jest.fn(() => Promise.resolve({})),
     update: jest.fn(() => Promise.resolve({})),
     delete: jest.fn(() => Promise.resolve({})),

--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@/navigation/hooks', () => ({
 /* eslint-disable @typescript-eslint/no-explicit-any */
 jest.mock('../../../api', () => ({
   habits: {
-    list: (jest.fn() as any).mockResolvedValue([]),
+    listAll: (jest.fn() as any).mockResolvedValue([]),
     create: (jest.fn() as any).mockResolvedValue({}),
     update: jest.fn(),
     delete: jest.fn(),

--- a/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
+++ b/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React, { useSyncExternalStore } from 'react';
 
+import type * as ApiModule from '../../../api';
 import HabitsScreen from '../HabitsScreen';
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
@@ -44,54 +45,62 @@ jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
 
-jest.mock('../../../api', () => ({
-  habits: {
-    // One unlocked habit (past start_date) so the tile renders and is pressable.
-    list: () =>
-      Promise.resolve([
-        {
-          id: 1,
-          name: 'Meditate',
-          icon: '🧘',
-          stage: 'Beige',
-          streak: 0,
-          energy_cost: 1,
-          energy_return: 1,
-          start_date: new Date(2020, 0, 1),
-          goals: [
-            {
-              title: 'Low',
-              tier: 'low',
-              target: 1,
-              target_unit: 'u',
-              frequency: 1,
-              frequency_unit: 'per_day',
-              is_additive: true,
-            },
-          ],
-          completions: [],
-          revealed: true,
-        },
-      ]),
-    create: jest.fn(),
-    update: jest.fn(),
-    delete: jest.fn(),
-    getStats: (...args: unknown[]) => {
-      mockGetStats(...args);
-      return Promise.resolve({
-        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-        values: [0, 0, 0, 0, 0, 0, 0],
-        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
-        longest_streak: 0,
-        current_streak: 0,
-        total_completions: 0,
-        completion_rate: 0,
-        completion_dates: [],
-      });
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    habits: {
+      // One unlocked habit (past start_date) so the tile renders and is pressable.
+      // Its id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the
+      // getStats assertion fails if the screen ever falls back to the demo seed.
+      listAll: () =>
+        Promise.resolve([
+          {
+            id: 7,
+            name: 'Meditate',
+            icon: '🧘',
+            stage: 'Beige',
+            streak: 0,
+            energy_cost: 1,
+            energy_return: 1,
+            start_date: new Date(2020, 0, 1),
+            goals: [
+              {
+                title: 'Low',
+                tier: 'low',
+                target: 1,
+                target_unit: 'u',
+                frequency: 1,
+                frequency_unit: 'per_day',
+                is_additive: true,
+              },
+            ],
+            completions: [],
+            revealed: true,
+          },
+        ]),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      getStats: (...args: unknown[]) => {
+        mockGetStats(...args);
+        return Promise.resolve({
+          day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+          values: [0, 0, 0, 0, 0, 0, 0],
+          completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+          longest_streak: 0,
+          current_streak: 0,
+          total_completions: 0,
+          completion_rate: 0,
+          completion_dates: [],
+        });
+      },
     },
-  },
-  goalCompletions: { create: jest.fn() },
-}));
+    goalCompletions: { create: jest.fn() },
+  };
+});
 
 jest.mock('../../../context/AuthContext', () => ({
   useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
@@ -142,6 +151,6 @@ describe('Habits stats modal fetch dedup', () => {
     fireEvent.press(getAllByTestId('habit-tile')[0]!);
 
     await waitFor(() => expect(mockGetStats).toHaveBeenCalledTimes(1));
-    expect(mockGetStats).toHaveBeenCalledWith(1, 'test-token');
+    expect(mockGetStats).toHaveBeenCalledWith(7, 'test-token');
   });
 });

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -7,7 +7,7 @@ import { useHabits } from '../hooks/useHabits';
 // Mock dependencies
 jest.mock('../../../api', () => ({
   habits: {
-    list: jest.fn(() => Promise.resolve([])),
+    listAll: jest.fn(() => Promise.resolve([])),
     create: jest.fn(() => Promise.resolve({})),
     update: jest.fn(() => Promise.resolve({})),
     delete: jest.fn(() => Promise.resolve({})),


### PR DESCRIPTION
## Summary

A cluster of `HabitsScreen` tests mocked `habits.list`, but production loads habits through `habitsApi.listAll()`. With `listAll` undefined the load threw, `loadHabits` fell back to the demo `FALLBACK_HABITS` seed, and the tests' fixtures never reached the screen — they passed for the wrong reason (coverage theater).

This PR re-points every affected mock to `listAll` and re-verifies each test passes for the *intended* reason:

- Data-returning specs (`HabitsEmojiPicker`, `HabitsEditModeTile`, `StatsModal.fetch-dedup`, `HabitsLockUnstarted`) now spread the real api module via `jest.requireActual` so the load path's real `toLocalHabit` mapper resolves instead of throwing into the fallback.
- Assertions strengthened to depend on the fixture: distinct habit ids (`7`, not the fallback's `1`) for the emoji-picker update, edit-mode settings-modal, and stats fetch-dedup specs.
- `HabitsLockUnstarted` now actually loads its revealed, future-start "Early Habit" and verifies the drawer's *Lock Unstarted Habits* toggle re-locks it (the tile re-renders with the `Early Habit locked` label).
- Empty-list specs keep resolving `[]`, which is the genuine fresh-user fallback-seed path (`handleApiSuccess` seeds `FALLBACK_HABITS` when the api is empty and the store is fresh) — the intended behavior, so no assertion change.

Production code is unchanged.

## Test plan

- `./scripts/frontend/check-all.sh` — lint, prettier, typecheck, and full Jest suite all green (4055 tests).
- Mutation discipline: temporarily breaking each data path (removing the `requireActual` spread) drops the screen back to the `FALLBACK_HABITS` seed and fails the fixture-dependent assertion (id `7` → `1`), confirming the tests now genuinely consume their fixtures.

Closes #1509