### PR TITLE
refactor(habits): remove fake SmoothSlider wrapper and fabricated animation props

### DIFF
--- a/frontend/src/features/Habits/components/OnboardingModal.tsx
+++ b/frontend/src/features/Habits/components/OnboardingModal.tsx
@@ -1,4 +1,4 @@
-import Slider, { type SliderProps } from '@react-native-community/slider';
+import Slider from '@react-native-community/slider';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   LayoutAnimation,
@@ -34,14 +34,6 @@ import { HABIT_NAME_MAX_LENGTH, validateAndAddHabit } from './onboardingValidati
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
-
-interface SmoothSliderProps extends SliderProps {
-  animateTransitions?: boolean;
-  animationType?: 'timing' | 'spring';
-  animationConfig?: Record<string, unknown>;
-}
-
-const SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>;
 
 const REVEAL_STAGGER_MS = 150;
 const REVEAL_SORT_PAUSE_MS = 500;
@@ -96,16 +88,13 @@ const EnergySliderTile = ({ habit, index, type, onValueChange }: EnergySliderTil
       </Text>
       <View style={styles.energySliderRow}>
         <View style={styles.energySliderContainer}>
-          <SmoothSlider
+          <Slider
             testID={`${type}-slider`}
             minimumValue={0}
             maximumValue={10}
             step={1}
             value={value}
             onValueChange={(v) => onValueChange(index, type, v)}
-            animateTransitions
-            animationType="timing"
-            animationConfig={{ duration: 150 }}
             minimumTrackTintColor={colors.secondary}
             maximumTrackTintColor={colors.mystical.glowLight}
             thumbTintColor={colors.secondary}

--- a/frontend/src/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/OnboardingModal.step2.test.tsx
@@ -62,7 +62,6 @@ describe('OnboardingModal cost step', () => {
   it('applies mystical slider styling', () => {
     const { getAllByTestId } = setupToCostStep();
     const slider = getAllByTestId('cost-slider')[0];
-    expect(slider.props.animateTransitions).toBe(true);
     expect(slider.props.minimumTrackTintColor).toBe(COLORS.secondary);
     expect(slider.props.thumbTintColor).toBe(COLORS.secondary);
   });


### PR DESCRIPTION
## Summary

`OnboardingModal.tsx` wrapped `@react-native-community/slider` in a
`SmoothSlider = Slider as React.ComponentType<SmoothSliderProps>` cast whose
`SmoothSliderProps` invented three props — `animateTransitions`,
`animationType`, `animationConfig`. The installed slider (v5.2.0) reads none of
them; they belong to a different, uninstalled package. The `as` cast smuggled
them past strict `tsc`, so the "smooth" animation the name and props advertised
was a silent no-op (a lying abstraction / hallucinated-API tell).

This PR removes the fake abstraction:

- Deletes the `SmoothSliderProps` interface and the `SmoothSlider` cast; the
  energy sliders now use `Slider` directly.
- Drops the three fabricated animation props from the slider usage.
- Removes the now-unused `SliderProps` import.

No animation was ever performed, so genuine behavior is identical. Real slider
props (`minimumValue`, `maximumValue`, `step`, `value`, `onValueChange`, tint
colors, style) are untouched. If smooth animation is genuinely wanted, it must
be implemented for real (e.g. `Animated`) in a follow-up.

## Test plan

- Retargeted `OnboardingModal.step2.test.tsx` to stop asserting the no-op
  `animateTransitions` prop while keeping the genuine tint-styling assertions.
- `OnboardingModal.energySliders.test.tsx` still passes — sliders render and
  update energy values.
- `./scripts/frontend/check-all.sh` green: ESLint, prettier, tsc (no new
  casts), and the full Jest suite (4055 tests) all pass.

Closes #1510