### PR TITLE
fix(frontend): guard ReauthSheet Android-back dismiss during in-flight login

### DIFF
--- a/frontend/src/features/Auth/ReauthSheet.tsx
+++ b/frontend/src/features/Auth/ReauthSheet.tsx
@@ -122,8 +122,11 @@ export function ReauthSheet(): React.JSX.Element {
   );
 
   const handleDismiss = useCallback(() => {
+    if (submitting) {
+      return;
+    }
     void dismissReauth();
-  }, [dismissReauth]);
+  }, [dismissReauth, submitting]);
 
   return (
     <Modal

--- a/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
@@ -99,8 +99,9 @@ describe('ReauthSheet', () => {
 
   // BUG-NAV-001 review follow-up: if dismiss fires while a login is in flight,
   // the login completion races the dismiss and can silently log the user back
-  // in after they chose to sign out. Disable the dismiss button while
-  // submitting so the race is impossible by construction.
+  // in after they chose to sign out. Both dismiss entry points guard on
+  // submitting — the disabled button here and the Android-back/onRequestClose
+  // path covered below.
   it('disables the dismiss button while a login is in flight', () => {
     const resolveLoginRef: { current: (() => void) | null } = { current: null };
     mockLogin.mockImplementationOnce(
@@ -124,6 +125,44 @@ describe('ReauthSheet', () => {
     expect(mockDismissReauth).not.toHaveBeenCalled();
 
     resolveLoginRef.current?.();
+  });
+
+  // Android hardware back fires the Modal's onRequestClose directly, bypassing
+  // the disabled dismiss button. It must honour the same in-flight guard so the
+  // login cannot be silently superseded by a mid-flight sign-out.
+  it('ignores Android-back (onRequestClose) while a login is in flight', () => {
+    const resolveLoginRef: { current: (() => void) | null } = { current: null };
+    mockLogin.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoginRef.current = () => resolve();
+        }),
+    );
+
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), 'a@b.co');
+    fireEvent.changeText(getByTestId('reauth-password'), 'pw'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    fireEvent(getByTestId('reauth-sheet'), 'requestClose');
+    expect(mockDismissReauth).not.toHaveBeenCalled();
+
+    resolveLoginRef.current?.();
+  });
+
+  it('honours Android-back (onRequestClose) once the login promise settles', async () => {
+    mockLogin.mockRejectedValueOnce(new Error('nope'));
+    const { getByTestId } = render(<ReauthSheet />);
+    fireEvent.changeText(getByTestId('reauth-email'), 'a@b.co');
+    fireEvent.changeText(getByTestId('reauth-password'), 'pw'); // pragma: allowlist secret
+    fireEvent.press(getByTestId('reauth-submit'));
+
+    await waitFor(() =>
+      expect(getByTestId('reauth-dismiss').props.accessibilityState?.disabled).toBe(false),
+    );
+
+    fireEvent(getByTestId('reauth-sheet'), 'requestClose');
+    expect(mockDismissReauth).toHaveBeenCalledTimes(1);
   });
 
   it('re-enables the dismiss button once the login promise settles', async () => {


### PR DESCRIPTION
## Summary

`ReauthSheet` disables the "Sign out instead" button while a login is in flight to prevent a sign-out from racing an in-flight re-login. But Android's hardware back fires the `Modal`'s `onRequestClose` directly, which called `handleDismiss` → `dismissReauth()` with **no `submitting` guard** — reopening the exact TOCTOU race the button guard exists to prevent: `dismissReauth` tears down the session (clears token + `resetAllStores` + `anonymous`) while the login concurrently re-authenticates, silently signing the user back in after they chose to sign out.

This adds the same in-flight guard to `handleDismiss` so both dismiss entry points (button and Android-back) are inert while `submitting`, and dismiss normally once the login promise settles. No change to button, login, or tear-down flows.

## Test plan

- New test fires the Modal's `requestClose` event during an in-flight login and asserts `dismissReauth` is **not** called (reproduces the old failure — verified RED before the fix).
- New test fires `requestClose` after the login promise settles and asserts `dismissReauth` **is** honored (user is never stranded).
- Existing ReauthSheet tests still pass; the stale "impossible by construction" comment was corrected to note both guarded paths.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4057 tests).

Closes #1514