### PR TITLE
refactor(frontend): drop the Journal tab's dead route-param surface

### DIFF
--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -946,10 +946,7 @@ const useStageNavigation = (onBeforeNavigate: () => void) => {
       onBeforeNavigate();
       InteractionManager.runAfterInteractions(() => {
         if (screen === 'Journal') {
-          navigation.navigate('Journal', {
-            tag: 'stage_reflection',
-            stageNumber: stage.stageNumber,
-          });
+          navigation.navigate('Journal');
         } else {
           navigation.navigate(screen, { stageNumber: stage.stageNumber });
         }

--- a/frontend/src/features/Map/__tests__/MapJourney.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapJourney.test.tsx
@@ -176,10 +176,7 @@ describe('MapScreen — journey narrative', () => {
 
     openStage(tree, 1);
     act(() => tree.root.findByProps({ testID: 'journal-link' }).props.onPress());
-    expect(mockNavigate).toHaveBeenCalledWith('Journal', {
-      tag: 'stage_reflection',
-      stageNumber: 1,
-    });
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
   });
 
   it('plays the Celebration when a stage newly completes', () => {

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -149,7 +149,7 @@ describe('MapScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('Course', { stageNumber: 1 });
   });
 
-  it('navigates to Journal with stage_reflection tag when Journal is tapped', () => {
+  it('navigates to the Journal tab when Journal is tapped', () => {
     const tree = create(<MapScreen />);
     act(() => {
       tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
@@ -157,10 +157,7 @@ describe('MapScreen', () => {
     act(() => {
       tree.root.findByProps({ testID: 'journal-link' }).props.onPress();
     });
-    expect(mockNavigate).toHaveBeenCalledWith('Journal', {
-      tag: 'stage_reflection',
-      stageNumber: 1,
-    });
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
   });
 
   it('closes modal when X is pressed', () => {

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -19,7 +19,6 @@ import {
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 
-import type { JournalTag } from '../api';
 import { FeatureErrorBoundary } from '../components/FeatureErrorBoundary';
 import { accent, ink, SPACING, surface, touchTarget } from '../design/tokens';
 import CourseScreen from '../features/Course/CourseScreen';
@@ -43,17 +42,7 @@ export type RootTabParamList = {
   Habits: undefined;
   Practice: { stageNumber?: number } | undefined;
   Course: { stageNumber?: number } | undefined;
-  Journal:
-    | {
-        tag?: JournalTag;
-        stageNumber?: number;
-        contentTitle?: string;
-        practiceSessionId?: number;
-        userPracticeId?: number;
-        practiceName?: string;
-        practiceDuration?: number;
-      }
-    | undefined;
+  Journal: undefined;
   Map: undefined;
 };
 

--- a/frontend/src/navigation/__tests__/hooks.test.tsx
+++ b/frontend/src/navigation/__tests__/hooks.test.tsx
@@ -52,17 +52,16 @@ describe('useAppRoute', () => {
     expect(result.params).toBeUndefined();
   });
 
-  it('returns a route with Journal params', () => {
+  it('returns a route with params for a parameterized screen', () => {
     const fakeRoute = {
-      key: 'Journal-abc',
-      name: 'Journal',
-      params: { practiceSessionId: 42, practiceName: 'Meditation' },
+      key: 'Course-abc',
+      name: 'Course',
+      params: { stageNumber: 5 },
     };
     mockUseRoute.mockReturnValue(fakeRoute);
 
-    const result = useAppRoute<'Journal'>();
+    const result = useAppRoute<'Course'>();
 
-    expect(result.params?.practiceSessionId).toBe(42);
-    expect(result.params?.practiceName).toBe('Meditation');
+    expect(result.params?.stageNumber).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary
- The `Journal` tab declared a 7-field route-param object (`tag`, `stageNumber`, `contentTitle`, `practiceSessionId`, `userPracticeId`, `practiceName`, `practiceDuration`) that `JournalShelfScreen` never read — the entire payload was silently dropped. This reduces the tab's param type to `undefined`, removing the dead surface.
- `contentTitle`/`practiceDuration` had zero producer and zero consumer anywhere; the practice-* fields belong to the separate `RootStack.JournalEntry` screen; and the `MapScreen` stage action now navigates to the Journal tab param-free.
- Chose deletion (issue Option B) over wiring the `stage_reflection` deep-link: the stage-specific intent is un-honorable in-scope (`journal.list` has a `tag` filter but no `stage_number`), and the stage-reflection feature already ships via the reflection invitation band's `JournalEntry` composer path (epics #1458/#1464, both closed). Runtime behavior is unchanged — the type system now blocks resurrecting the surface without a consumer.

## Test plan
- `npx jest src/features/Map/__tests__/MapScreen.test.tsx src/features/Map/__tests__/MapJourney.test.tsx src/navigation/__tests__/hooks.test.tsx` — RED before the impl (exact-arity `toHaveBeenCalledWith('Journal')`), GREEN after.
- `npx tsc --noEmit` — passes; enforces the removed param surface and the retargeted typed-route test.
- `./scripts/frontend/check-all.sh` — all 4 checks green (ESLint zero-warning, prettier, tsc, 4057 jest tests).

Closes #1515
