### PR TITLE
feat(frontend): render DrawerNavSection at the top of every screen drawer

### DIFF
--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -12,7 +12,12 @@ import {
   type SiteResource,
   type Stage,
 } from '../../api';
-import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '../../components/drawer';
+import {
+  DrawerNavSection,
+  ScreenDrawer,
+  useScreenDrawer,
+  type ScreenDrawerState,
+} from '../../components/drawer';
 import { Celebration } from '../../components/feedback/Celebration';
 import { EmptyState } from '../../components/feedback/EmptyState';
 import { ContentContainer } from '../../components/layout/ContentContainer';
@@ -498,6 +503,7 @@ const CourseScreenDrawer = ({
   const { sections, retry } = useCourseDrawerContent(stages, drawer.isOpen);
   return (
     <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Course" title="Course">
+      <DrawerNavSection currentScreen="Course" onNavigate={drawer.close} />
       <CourseDrawer
         stages={stages}
         selectedStage={selectedStage}

--- a/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
@@ -3,9 +3,11 @@
 // drawer. Mirrors CourseDrawer.test.tsx's headerLeftStore harness, adding a
 // stable navigate spy so the shared nav rows have somewhere to route.
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { useSyncExternalStore, type ReactElement } from 'react';
 
 import type { ContentItem, CourseProgress, Stage } from '../../../api';
+import CourseScreen from '../CourseScreen';
 
 import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
 
@@ -96,10 +98,6 @@ jest.mock('react-native-safe-area-context', () => {
     useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
   };
 });
-
-// eslint-disable-next-line import/order
-const { render, waitFor, fireEvent } = require('@testing-library/react-native');
-const CourseScreen = require('../CourseScreen').default;
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
   headerLeftStore.listeners.add(onChange);

--- a/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
@@ -1,0 +1,182 @@
+/* eslint-env jest */
+// RED coverage for the shared DrawerNavSection wired into the Course header
+// drawer. Mirrors CourseDrawer.test.tsx's headerLeftStore harness, adding a
+// stable navigate spy so the shared nav rows have somewhere to route.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { useSyncExternalStore, type ReactElement } from 'react';
+
+import type { ContentItem, CourseProgress, Stage } from '../../../api';
+
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage',
+  subtitle: 'Subtitle',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const TEN_STAGES: Stage[] = Array.from({ length: 10 }, (_, index) => {
+  const stageNumber = index + 1;
+  return makeStage({
+    id: stageNumber,
+    stage_number: stageNumber,
+    title: `Stage ${stageNumber}`,
+    subtitle: `Subtitle ${stageNumber}`,
+    is_unlocked: stageNumber <= 3,
+    progress: 0,
+  });
+});
+
+const sampleProgress: CourseProgress = {
+  total_items: 1,
+  read_items: 0,
+  progress_percent: 0,
+  next_unlock_day: null,
+};
+
+const mockStagesList = jest.fn<(...a: unknown[]) => Promise<Stage[]>>();
+const mockStageContent = jest.fn<(stageNumber: number) => Promise<ContentItem[]>>();
+const mockStageProgress = jest.fn<(...a: unknown[]) => Promise<CourseProgress>>();
+
+jest.mock('../../../api', () => ({
+  stages: { listAll: (...a: unknown[]) => mockStagesList(...a) },
+  course: {
+    stageContentAll: (stageNumber: number) => mockStageContent(stageNumber),
+    stageProgress: (...a: unknown[]) => mockStageProgress(...a),
+    markRead: jest.fn(),
+    contentBody: () =>
+      Promise.resolve({ title: 'Chapter', content_type: 'chapter', body_markdown: 'x\n' }),
+    siteResources: () => Promise.resolve([]),
+    siteResourceBody: jest.fn(),
+    stageIntro: () => Promise.reject(new Error('content_not_found')),
+    stageIntroBody: jest.fn(),
+  },
+}));
+
+const mockNavigate = jest.fn();
+const mockRootNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockRootNavigate }),
+}));
+
+// CourseScreen installs its header-left drawer toggle through useAppNavigation
+// (useScreenDrawer), which calls navigation.setOptions in a layout effect on
+// every mount. The store relays the installed headerLeft into the same render
+// tree as the screen so the Modal-based drawer opens in-tree.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('../../../navigation/hooks', () => ({
+  useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: undefined }),
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: unknown }) =>
+      ReactMod.createElement(ReactMod.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// eslint-disable-next-line import/order
+const { render, waitFor, fireEvent } = require('@testing-library/react-native');
+const CourseScreen = require('../CourseScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so
+// the drawer opens in-tree and its rows are pressable.
+const CourseScreenWithHeader = (): ReactElement => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <CourseScreen />
+    </>
+  );
+};
+
+describe('Course header drawer nav section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    mockStagesList.mockResolvedValue(TEN_STAGES);
+    mockStageContent.mockResolvedValue([]);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+    useDepthPreferencesStore.setState({
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: true,
+    });
+  });
+
+  it("renders the nav section before the drawer's own rows, with a trailing divider", async () => {
+    const { getByTestId, getByLabelText, toJSON } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    await waitFor(() => expect(getByTestId('course-drawer-stage-1')).toBeTruthy());
+
+    expect(getByTestId('drawer-nav-Course')).toBeTruthy();
+    expect(getByTestId('drawer-nav-divider')).toBeTruthy();
+
+    // toJSON() embeds React elements with circular _owner refs; strip those.
+    const seen = new WeakSet();
+    const json = JSON.stringify(toJSON(), (key, value) => {
+      if (key === '_owner' || key === '_store') return undefined;
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return undefined;
+        seen.add(value);
+      }
+      return value;
+    });
+    const navIndex = json.indexOf('"testID":"drawer-nav-Course"');
+    const stageOneIndex = json.indexOf('"testID":"course-drawer-stage-1"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(stageOneIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(stageOneIndex);
+  });
+
+  it('marks the Course nav row selected', async () => {
+    const { getByTestId, getByLabelText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    expect(getByTestId('drawer-nav-Course').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('navigating to a different screen from the nav section closes the drawer', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    fireEvent.press(getByTestId('drawer-nav-Journal'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(queryByTestId('screen-drawer-panel')).toBeNull();
+  });
+});

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -36,7 +36,7 @@ import { useModalCoordinator } from './hooks/useModalCoordinator';
 import { usePagination } from './hooks/usePagination';
 import { usePaginationBarVisibility } from './hooks/usePaginationBarVisibility';
 
-import { ScreenDrawer, useScreenDrawer } from '@/components/drawer';
+import { DrawerNavSection, ScreenDrawer, useScreenDrawer } from '@/components/drawer';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 
 /** Habits per page — the ceiling that fills the screen 1-up on mobile and 2x5 on landscape/desktop. */
@@ -746,6 +746,7 @@ const HabitsScreenDrawer = ({
   const drawerRange = stageRangeForPage(pagination.page, HABITS_PER_PAGE);
   return (
     <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Habits" title="Habits">
+      <DrawerNavSection currentScreen="Habits" onNavigate={drawer.close} />
       <HabitsDrawer
         onSelectMode={state.handleSelectMode}
         onOpenOnboarding={() => modals.open('onboarding')}

--- a/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React, { useSyncExternalStore, type ReactElement } from 'react';
+
+// RED coverage for the shared DrawerNavSection wired into the Habits header
+// drawer. Mirrors PracticeScreenDrawerNav.test.tsx's headerLeftStore harness,
+// adding a stable navigate spy so the shared nav rows have somewhere to route.
+const mockNavigate = jest.fn();
+// HabitsScreen installs its header-left drawer toggle through
+// useAppNavigation (useScreenDrawer), which calls navigation.setOptions in a
+// layout effect on every mount. The store relays the installed headerLeft
+// into the same render tree as the screen so the Modal-based drawer opens
+// in-tree and its rows are pressable.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+}));
+
+jest.mock('../../../api', () => ({
+  habits: {
+    listAll: () => Promise.resolve([]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getStats: () =>
+      Promise.resolve({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+  },
+  goalCompletions: { create: jest.fn() },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: () => Promise.resolve({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  cancelScheduledNotificationAsync: jest.fn(),
+  getAllScheduledNotificationsAsync: () => Promise.resolve([]),
+  getExpoPushTokenAsync: () => Promise.resolve({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactModule = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({ __esModule: true, default: jest.fn(() => null) }));
+
+import HabitsScreen from '../HabitsScreen';
+
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so
+// the drawer opens in-tree and its rows are pressable.
+const HabitsScreenWithHeader = (): ReactElement => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <HabitsScreen />
+    </>
+  );
+};
+
+describe('Habits header drawer nav section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    useDepthPreferencesStore.setState({
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: true,
+    });
+  });
+
+  it("renders the nav section before the drawer's own rows, with a trailing divider", async () => {
+    const { getByTestId, getByLabelText, toJSON } = render(<HabitsScreenWithHeader />);
+    await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+
+    fireEvent.press(getByLabelText('Open Habits menu'));
+
+    expect(getByTestId('screen-drawer-panel')).toBeTruthy();
+    expect(getByTestId('drawer-nav-Habits')).toBeTruthy();
+    expect(getByTestId('drawer-nav-divider')).toBeTruthy();
+
+    // toJSON() embeds React elements with circular _owner refs; strip those.
+    const seen = new WeakSet();
+    const json = JSON.stringify(toJSON(), (key, value) => {
+      if (key === '_owner' || key === '_store') return undefined;
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return undefined;
+        seen.add(value);
+      }
+      return value;
+    });
+    const navIndex = json.indexOf('"testID":"drawer-nav-Habits"');
+    const quickLogIndex = json.indexOf('"Quick Log"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(quickLogIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(quickLogIndex);
+  });
+
+  it('marks the Habits nav row selected', async () => {
+    const { getByTestId, getByLabelText } = render(<HabitsScreenWithHeader />);
+    await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+
+    fireEvent.press(getByLabelText('Open Habits menu'));
+
+    expect(getByTestId('drawer-nav-Habits').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('navigating to a different screen from the nav section closes the drawer', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<HabitsScreenWithHeader />);
+    await waitFor(() => expect(mockSetOptions).toHaveBeenCalled());
+
+    fireEvent.press(getByLabelText('Open Habits menu'));
+    fireEvent.press(getByTestId('drawer-nav-Journal'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(queryByTestId('screen-drawer-panel')).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -22,7 +22,12 @@ import { groupByRecency, formatDate, type ShelfSection } from './recency';
 import { usePagedJournal } from './usePagedJournal';
 
 import type { JournalMessage } from '@/api';
-import { DrawerItem, ScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
+import {
+  DrawerItem,
+  DrawerNavSection,
+  ScreenDrawer,
+  type ScreenDrawerState,
+} from '@/components/drawer';
 import { accent, ink, radius, SPACING, surface, touchTarget, type } from '@/design/tokens';
 
 /** Row that starts a fresh, blank entry. */
@@ -287,6 +292,7 @@ export function JournalScreenDrawer({
       screenName="Journal"
       title="Journal"
     >
+      <DrawerNavSection currentScreen="Journal" onNavigate={drawer.close} />
       <JournalDrawer
         items={items}
         now={Date.now()}

--- a/frontend/src/features/Journal/__tests__/JournalScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreenDrawerNav.test.tsx
@@ -1,0 +1,115 @@
+/* eslint-env jest */
+// RED coverage for the shared DrawerNavSection wired into the Journal header
+// drawer. The nav rows do not exist yet in JournalScreenDrawer -- these
+// assertions pin the missing wiring so the implementation step has a target.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { JournalScreenDrawer } from '../JournalDrawer';
+
+import type { JournalListResponse } from '@/api';
+import { type ScreenDrawerState } from '@/components/drawer';
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+const mockNavigate = jest.fn();
+const mockClose = jest.fn();
+
+jest.mock('@/api', () => ({
+  journal: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
+}));
+
+function fakeDrawer(): ScreenDrawerState {
+  return { isOpen: true, open: jest.fn(), close: mockClose };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockList.mockResolvedValue({ items: [], total: 0, has_more: false });
+  useDepthPreferencesStore.setState({
+    enable_habits: true,
+    enable_practices: true,
+    enable_course: true,
+  });
+});
+
+describe('Journal header drawer nav section', () => {
+  it('renders the nav section before the New entry row, with a trailing divider', async () => {
+    const { getByTestId, toJSON } = render(
+      <JournalScreenDrawer
+        drawer={fakeDrawer()}
+        currentEntryId={null}
+        onSelectEntry={jest.fn()}
+        onNewEntry={jest.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+    expect(getByTestId('journal-drawer-new-entry')).toBeTruthy();
+
+    expect(getByTestId('drawer-nav-Journal')).toBeTruthy();
+    expect(getByTestId('drawer-nav-divider')).toBeTruthy();
+
+    const json = JSON.stringify(toJSON());
+    const navIndex = json.indexOf('"testID":"drawer-nav-Journal"');
+    const newEntryIndex = json.indexOf('"testID":"journal-drawer-new-entry"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(newEntryIndex);
+  });
+
+  it('marks the Journal nav row selected', async () => {
+    const { getByTestId } = render(
+      <JournalScreenDrawer
+        drawer={fakeDrawer()}
+        currentEntryId={null}
+        onSelectEntry={jest.fn()}
+        onNewEntry={jest.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+
+    expect(getByTestId('drawer-nav-Journal').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('navigating to a different screen from the nav section closes the drawer', async () => {
+    const { getByTestId } = render(
+      <JournalScreenDrawer
+        drawer={fakeDrawer()}
+        currentEntryId={null}
+        onSelectEntry={jest.fn()}
+        onNewEntry={jest.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+
+    fireEvent.press(getByTestId('drawer-nav-Map'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Map');
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('hides the Habits nav row while its depth ring is disabled, keeping the others visible', async () => {
+    useDepthPreferencesStore.setState({ enable_habits: false });
+    const { getByTestId, queryByTestId } = render(
+      <JournalScreenDrawer
+        drawer={fakeDrawer()}
+        currentEntryId={null}
+        onSelectEntry={jest.fn()}
+        onNewEntry={jest.fn()}
+      />,
+    );
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(1));
+
+    expect(getByTestId('drawer-nav-Journal')).toBeTruthy();
+    expect(queryByTestId('drawer-nav-Habits')).toBeNull();
+    expect(getByTestId('drawer-nav-Map')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -59,7 +59,12 @@ import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
 
 import { Button } from '@/components/Button';
-import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
+import {
+  DrawerNavSection,
+  ScreenDrawer,
+  useScreenDrawer,
+  type ScreenDrawerState,
+} from '@/components/drawer';
 import { Celebration } from '@/components/feedback/Celebration';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 import { colors } from '@/design/tokens';
@@ -1086,6 +1091,7 @@ const MapScreenDrawer = ({
   onSelectStage,
 }: MapScreenDrawerProps): React.JSX.Element => (
   <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Map" title="Map">
+    <DrawerNavSection currentScreen="Map" onNavigate={drawer.close} />
     <MapDrawer
       lookup={lookup}
       currentStage={currentStage}

--- a/frontend/src/features/Map/__tests__/MapScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawerNav.test.tsx
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+// RED coverage for the shared DrawerNavSection wired into the Map header
+// drawer. Mirrors MapScreenDrawer.test.tsx's harness.
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import MapScreen from '../MapScreen';
+
+import {
+  mockMakeStage,
+  mockMapState,
+  mockNavigate,
+  mockSetOptions,
+  resetMapMocks,
+} from './mapTestHarness';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../hooks/useWheelBalance', () =>
+  jest.requireActual('./mapTestHarness').mockWheelBalanceModule(),
+);
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => true,
+}));
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+jest.mock('../services/stageService', () =>
+  jest.requireActual('./mapTestHarness').mockStageServiceModule(),
+);
+jest.mock('../../../store/useStageStore', () =>
+  jest.requireActual('./mapTestHarness').mockStageStoreModule(),
+);
+
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+type HeaderLeftOptions = { headerLeft?: () => React.ReactElement };
+
+/** Grab the most recently installed headerLeft toggle element. */
+const lastHeaderLeftToggle = (): React.ReactElement => {
+  const calls = mockSetOptions.mock.calls;
+  const lastCall = calls[calls.length - 1] as [HeaderLeftOptions] | undefined;
+  if (!lastCall) throw new Error('setOptions was never called');
+  const headerLeft = lastCall[0].headerLeft;
+  if (!headerLeft) throw new Error('headerLeft was not installed');
+  return headerLeft();
+};
+
+/** Press the installed header-left toggle to open the drawer in-tree. */
+const openDrawer = (): void => {
+  const toggle = lastHeaderLeftToggle();
+  act(() => {
+    (toggle.props as { onPress: () => void }).onPress();
+  });
+};
+
+describe('Map header drawer nav section', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+    useDepthPreferencesStore.setState({
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: true,
+    });
+  });
+
+  it('renders the nav section before the stage legend, with a trailing divider', () => {
+    const tree = create(<MapScreen />);
+    openDrawer();
+
+    expect(tree.root.findByProps({ testID: 'drawer-nav-Map' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'drawer-nav-divider' })).toBeTruthy();
+
+    const json = JSON.stringify(tree.toJSON());
+    const navIndex = json.indexOf('"testID":"drawer-nav-Journal"');
+    const legendIndex = json.indexOf('"testID":"map-drawer-stage-1"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(legendIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(legendIndex);
+
+    act(() => tree.unmount());
+  });
+
+  it('marks the Map nav row selected', () => {
+    const tree = create(<MapScreen />);
+    openDrawer();
+
+    // findByProps returns the DrawerItem composite here, which carries the
+    // `selected` prop that drives its host's accessibilityState.selected.
+    const navRow = tree.root.findByProps({ testID: 'drawer-nav-Map' });
+    expect(navRow.props.selected).toBe(true);
+
+    act(() => tree.unmount());
+  });
+
+  it('tapping a non-current nav row navigates and closes the drawer', () => {
+    const tree = create(<MapScreen />);
+    openDrawer();
+
+    act(() => {
+      tree.root.findByProps({ testID: 'drawer-nav-Journal' }).props.onPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
+
+    act(() => tree.unmount());
+  });
+});

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -36,7 +36,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import WeeklyProgress from './WeeklyProgress';
 
 import type { PracticeSessionResponse } from '@/api';
-import { ScreenDrawer, useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
+import {
+  DrawerNavSection,
+  ScreenDrawer,
+  useScreenDrawer,
+  type ScreenDrawerState,
+} from '@/components/drawer';
 import { EmptyState } from '@/components/feedback/EmptyState';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
@@ -217,6 +222,7 @@ const PracticeScreenDrawer = ({
     screenName="Practice"
     title="Practice"
   >
+    <DrawerNavSection currentScreen="Practice" onNavigate={drawer.close} />
     <PracticeDrawer
       hasActivePractice={hasActivePractice}
       stageNumber={stageNumber}

--- a/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
@@ -1,11 +1,19 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-env jest */
 // RED coverage for the shared DrawerNavSection wired into the Practice header
 // drawer. Mirrors PracticeScreen.test.tsx's "header drawer" harness.
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
 import { useSyncExternalStore, type ReactElement } from 'react';
 
-import type { FrequencyResponse, PracticeItem, UserPractice } from '../../../api';
+import type {
+  FrequencyResponse,
+  PracticeInsightsResponse,
+  PracticeItem,
+  PracticeSessionResponse,
+  UserPractice,
+  WeekCountResponse,
+} from '../../../api';
+import PracticeScreen from '../PracticeScreen';
 
 import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
 
@@ -54,29 +62,45 @@ const sampleFrequency: FrequencyResponse = {
   banner_text: 'You are in the Beige frequency of APTITUDE.',
 };
 
-const mockPracticesList = (jest.fn() as any).mockResolvedValue([samplePractice()]);
-const mockUserPracticesList = (jest.fn() as any).mockResolvedValue([]);
-const mockUserPracticesCreate = (jest.fn() as any).mockResolvedValue(sampleUserPractice());
-const mockUserPracticesCustomize = (jest.fn() as any).mockResolvedValue(sampleUserPractice());
-const mockPracticeSessionsCreate = (jest.fn() as any).mockResolvedValue({
-  id: 100,
-  user_practice_id: 10,
-  duration_minutes: 10,
-  timestamp: '2026-04-12T10:30:00Z',
-  reflection: null,
-  mode: 'meditation_timer',
-  mode_metadata: null,
-  completed: true,
-  insight: null,
-});
-const mockWeekCount = (jest.fn() as any).mockResolvedValue({ count: 2 });
-const mockInsights = (jest.fn() as any).mockRejectedValue(new Error('insights unavailable'));
-const mockFrequency = (jest.fn() as any).mockResolvedValue(sampleFrequency);
+const mockPracticesList = jest
+  .fn<(...args: unknown[]) => Promise<PracticeItem[]>>()
+  .mockResolvedValue([samplePractice()]);
+const mockUserPracticesList = jest
+  .fn<(...args: unknown[]) => Promise<UserPractice[]>>()
+  .mockResolvedValue([]);
+const mockUserPracticesCreate = jest
+  .fn<(...args: unknown[]) => Promise<UserPractice>>()
+  .mockResolvedValue(sampleUserPractice());
+const mockUserPracticesCustomize = jest
+  .fn<(...args: unknown[]) => Promise<UserPractice>>()
+  .mockResolvedValue(sampleUserPractice());
+const mockPracticeSessionsCreate = jest
+  .fn<(...args: unknown[]) => Promise<PracticeSessionResponse>>()
+  .mockResolvedValue({
+    id: 100,
+    user_practice_id: 10,
+    duration_minutes: 10,
+    timestamp: '2026-04-12T10:30:00Z',
+    reflection: null,
+    mode: 'meditation_timer',
+    mode_metadata: null,
+    completed: true,
+    insight: null,
+  });
+const mockWeekCount = jest
+  .fn<(...args: unknown[]) => Promise<WeekCountResponse>>()
+  .mockResolvedValue({ count: 2 });
+const mockInsights = jest
+  .fn<(...args: unknown[]) => Promise<PracticeInsightsResponse>>()
+  .mockRejectedValue(new Error('insights unavailable'));
+const mockFrequency = jest
+  .fn<(...args: unknown[]) => Promise<FrequencyResponse>>()
+  .mockResolvedValue(sampleFrequency);
 
 jest.mock('../../../api', () => ({
   practices: {
     listAll: (...args: unknown[]) => mockPracticesList(...args),
-    get: jest.fn() as any,
+    get: jest.fn(),
   },
   userPractices: {
     create: (...args: unknown[]) => mockUserPracticesCreate(...args),
@@ -142,10 +166,10 @@ jest.mock('@react-navigation/native', () => {
 jest.mock('expo-av', () => ({
   Audio: {
     Sound: {
-      createAsync: (jest.fn() as any).mockResolvedValue({
+      createAsync: jest.fn<() => Promise<unknown>>().mockResolvedValue({
         sound: {
-          replayAsync: (jest.fn() as any).mockResolvedValue(undefined),
-          unloadAsync: (jest.fn() as any).mockResolvedValue(undefined),
+          replayAsync: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+          unloadAsync: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
           setOnPlaybackStatusUpdate: jest.fn(),
         },
       }),
@@ -154,20 +178,16 @@ jest.mock('expo-av', () => ({
 }));
 
 jest.mock('expo-keep-awake', () => ({
-  activateKeepAwakeAsync: (jest.fn() as any).mockResolvedValue(undefined),
+  activateKeepAwakeAsync: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
   deactivateKeepAwake: jest.fn(),
   useKeepAwake: jest.fn(),
 }));
 
 jest.mock('expo-haptics', () => ({
-  impactAsync: (jest.fn() as any).mockResolvedValue(undefined),
-  selectionAsync: (jest.fn() as any).mockResolvedValue(undefined),
+  impactAsync: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  selectionAsync: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
   ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
 }));
-
-// eslint-disable-next-line import/order
-const { render, waitFor, fireEvent } = require('@testing-library/react-native');
-const PracticeScreen = require('../PracticeScreen').default;
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
   headerLeftStore.listeners.add(onChange);

--- a/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
@@ -1,0 +1,244 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-env jest */
+// RED coverage for the shared DrawerNavSection wired into the Practice header
+// drawer. Mirrors PracticeScreen.test.tsx's "header drawer" harness.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { useSyncExternalStore, type ReactElement } from 'react';
+
+import type { FrequencyResponse, PracticeItem, UserPractice } from '../../../api';
+
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactMod = require('react');
+  const passthrough = ({ children }: { children: unknown }) =>
+    ReactMod.createElement(ReactMod.Fragment, null, children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+  };
+});
+
+const samplePractice = (overrides: Partial<PracticeItem> = {}): PracticeItem => ({
+  id: 1,
+  stage_number: 1,
+  name: 'Breath Awareness',
+  description: 'Focus on the breath to develop concentration.',
+  instructions: 'Sit comfortably and focus on your breathing.',
+  default_duration_minutes: 10,
+  submitted_by_user_id: null,
+  approved: true,
+  mode: 'meditation_timer',
+  mode_config: { mode: 'meditation_timer', duration_minutes: 10 },
+  ...overrides,
+});
+
+const sampleUserPractice = (overrides: Partial<UserPractice> = {}): UserPractice => ({
+  id: 10,
+  user_id: 1,
+  practice_id: 1,
+  stage_number: 1,
+  start_date: '2026-04-12',
+  end_date: null,
+  ...overrides,
+});
+
+const sampleFrequency: FrequencyResponse = {
+  stage_number: 1,
+  color: 'Beige',
+  aspect: 'Body',
+  practice_name: 'Breath Awareness',
+  practice_id: 1,
+  user_practice_id: 10,
+  banner_text: 'You are in the Beige frequency of APTITUDE.',
+};
+
+const mockPracticesList = (jest.fn() as any).mockResolvedValue([samplePractice()]);
+const mockUserPracticesList = (jest.fn() as any).mockResolvedValue([]);
+const mockUserPracticesCreate = (jest.fn() as any).mockResolvedValue(sampleUserPractice());
+const mockUserPracticesCustomize = (jest.fn() as any).mockResolvedValue(sampleUserPractice());
+const mockPracticeSessionsCreate = (jest.fn() as any).mockResolvedValue({
+  id: 100,
+  user_practice_id: 10,
+  duration_minutes: 10,
+  timestamp: '2026-04-12T10:30:00Z',
+  reflection: null,
+  mode: 'meditation_timer',
+  mode_metadata: null,
+  completed: true,
+  insight: null,
+});
+const mockWeekCount = (jest.fn() as any).mockResolvedValue({ count: 2 });
+const mockInsights = (jest.fn() as any).mockRejectedValue(new Error('insights unavailable'));
+const mockFrequency = (jest.fn() as any).mockResolvedValue(sampleFrequency);
+
+jest.mock('../../../api', () => ({
+  practices: {
+    listAll: (...args: unknown[]) => mockPracticesList(...args),
+    get: jest.fn() as any,
+  },
+  userPractices: {
+    create: (...args: unknown[]) => mockUserPracticesCreate(...args),
+    list: (...args: unknown[]) => mockUserPracticesList(...args),
+    customize: (...args: unknown[]) => mockUserPracticesCustomize(...args),
+  },
+  practiceSessions: {
+    create: (...args: unknown[]) => mockPracticeSessionsCreate(...args),
+    weekCount: (...args: unknown[]) => mockWeekCount(...args),
+    insights: (...args: unknown[]) => mockInsights(...args),
+  },
+  frequency: {
+    current: (...args: unknown[]) => mockFrequency(...args),
+  },
+}));
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', userTimezone: 'UTC' }),
+}));
+
+const mockNavigate = jest.fn();
+const mockRootNavigate = jest.fn();
+// PracticeScreen installs its header-left drawer toggle through
+// useAppNavigation (useScreenDrawer), which calls navigation.setOptions in a
+// layout effect on every mount. The store relays the installed headerLeft
+// into the same render tree as the screen so the Modal-based drawer opens
+// in-tree and its rows are pressable.
+const headerLeftStore: {
+  current: (() => ReactElement) | undefined;
+  listeners: Set<() => void>;
+} = { current: undefined, listeners: new Set() };
+const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
+  headerLeftStore.current = opts.headerLeft;
+  headerLeftStore.listeners.forEach((listener) => listener());
+});
+jest.mock('../../../navigation/hooks', () => ({
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+  useAppRoute: () => ({ key: 'Practice-test', name: 'Practice', params: {} }),
+}));
+
+const mockFocusCallbacks: Array<() => void | (() => void)> = [];
+jest.mock('@react-navigation/native', () => {
+  const reactMod = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    ...(jest.requireActual('@react-navigation/native') as object),
+    useNavigation: () => ({ navigate: mockRootNavigate }),
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      reactMod.useEffect(() => {
+        mockFocusCallbacks.push(cb);
+        const cleanup = cb();
+        return () => {
+          const index = mockFocusCallbacks.indexOf(cb);
+          if (index >= 0) mockFocusCallbacks.splice(index, 1);
+          if (typeof cleanup === 'function') cleanup();
+        };
+      }, [cb]);
+    },
+  };
+});
+
+jest.mock('expo-av', () => ({
+  Audio: {
+    Sound: {
+      createAsync: (jest.fn() as any).mockResolvedValue({
+        sound: {
+          replayAsync: (jest.fn() as any).mockResolvedValue(undefined),
+          unloadAsync: (jest.fn() as any).mockResolvedValue(undefined),
+          setOnPlaybackStatusUpdate: jest.fn(),
+        },
+      }),
+    },
+  },
+}));
+
+jest.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: (jest.fn() as any).mockResolvedValue(undefined),
+  deactivateKeepAwake: jest.fn(),
+  useKeepAwake: jest.fn(),
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: (jest.fn() as any).mockResolvedValue(undefined),
+  selectionAsync: (jest.fn() as any).mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+}));
+
+// eslint-disable-next-line import/order
+const { render, waitFor, fireEvent } = require('@testing-library/react-native');
+const PracticeScreen = require('../PracticeScreen').default;
+
+const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
+  headerLeftStore.listeners.add(onChange);
+  return () => headerLeftStore.listeners.delete(onChange);
+};
+
+// Renders the screen's headerLeft toggle in the same tree as the screen, so the
+// drawer opens in-tree and its rows are pressable.
+const PracticeScreenWithHeader = (): ReactElement => {
+  const headerLeft = useSyncExternalStore(subscribeHeaderLeft, () => headerLeftStore.current);
+  return (
+    <>
+      {headerLeft === undefined ? null : headerLeft()}
+      <PracticeScreen />
+    </>
+  );
+};
+
+describe('Practice header drawer nav section', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    mockFocusCallbacks.length = 0;
+    mockPracticesList.mockResolvedValue([samplePractice()]);
+    mockUserPracticesList.mockResolvedValue([]);
+    mockWeekCount.mockResolvedValue({ count: 2 });
+    mockInsights.mockRejectedValue(new Error('insights unavailable'));
+    mockFrequency.mockResolvedValue(sampleFrequency);
+    mockUserPracticesCreate.mockResolvedValue(sampleUserPractice());
+    useDepthPreferencesStore.setState({
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: true,
+    });
+  });
+
+  it("renders the nav section before the drawer's own rows, with a trailing divider", async () => {
+    const { getByTestId, getByLabelText, toJSON } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+
+    expect(getByTestId('drawer-nav-Practice')).toBeTruthy();
+    expect(getByTestId('drawer-nav-divider')).toBeTruthy();
+
+    const json = JSON.stringify(toJSON());
+    const navIndex = json.indexOf('"testID":"drawer-nav-Practice"');
+    const browseIndex = json.indexOf('"testID":"practice-drawer-browse"');
+    expect(navIndex).toBeGreaterThan(-1);
+    expect(browseIndex).toBeGreaterThan(-1);
+    expect(navIndex).toBeLessThan(browseIndex);
+  });
+
+  it('marks the Practice nav row selected', async () => {
+    const { getByTestId, getByLabelText } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+
+    expect(getByTestId('drawer-nav-Practice').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('navigating to a different screen from the nav section closes the drawer', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<PracticeScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Practice menu'));
+    fireEvent.press(getByTestId('drawer-nav-Journal'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(queryByTestId('screen-drawer-panel')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Prepends the shared `DrawerNavSection` to each screen drawer (Journal, Habits, Practice, Course, Map) as the **first child** of its `ScreenDrawer` panel, so the app's top-level destinations sit above every screen's own drawer rows, separated by the section's hairline divider. Each host passes its own `currentScreen` (rendered selected) and `onNavigate={drawer.close}`, so tapping a nav row navigates to that destination **and** closes the drawer.

- Two-line insertion per host (`import` + `<DrawerNavSection currentScreen="X" onNavigate={drawer.close} />`) in `CourseScreen.tsx`, `HabitsScreen.tsx`, `JournalDrawer.tsx`, `MapScreen.tsx`, `PracticeScreen.tsx`.
- Screen-specific drawer content, ordering, and a11y labels are unchanged below the divider; `BottomTabs.tsx` is untouched (the tab bar is retired in a follow-up).
- Ring-disabled destinations are hidden and update live on the next open (behavior inherited from `DrawerNavSection` / `NAV_DESTINATIONS`).

## Test plan

- Adds one Jest suite per drawer (`*ScreenDrawerNav.test.tsx`) asserting: nav section renders first (before the screen's own rows), divider present, current row marked selected, and a nav press navigates + closes the drawer. The Journal suite also covers the depth-ring-disabled hide path.
- `./scripts/frontend/check-all.sh` passes (ESLint, Prettier, tsc, Jest — 4092 tests).

Closes #1530
Refs #1528