### PR TITLE
feat(navigation): retire the bottom tab bar — the drawer becomes primary navigation

### DIFF
--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -1,32 +1,21 @@
 // frontend/navigation/BottomTabs.tsx
 
-import {
-  BottomTabBar,
-  createBottomTabNavigator,
-  type BottomTabBarProps,
-} from '@react-navigation/bottom-tabs';
+import { createBottomTabNavigator, type BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  BookOpen,
-  Compass,
-  Flower2,
-  NotebookPen,
-  Settings,
-  Sprout,
-  type LucideIcon,
-} from 'lucide-react-native';
+import { Settings } from 'lucide-react-native';
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import { FeatureErrorBoundary } from '../components/FeatureErrorBoundary';
-import { accent, ink, SPACING, surface, touchTarget } from '../design/tokens';
+import { accent, SPACING, touchTarget } from '../design/tokens';
 import CourseScreen from '../features/Course/CourseScreen';
 import HabitsScreen from '../features/Habits/HabitsScreen';
 import JournalShelfScreen from '../features/Journal/JournalShelfScreen';
 import MapScreen from '../features/Map/MapScreen';
 import PracticeScreen from '../features/Practice/PracticeScreen';
 
+import { NAV_DESTINATIONS, type NavDestination } from './destinations';
 import type { RootStackParamList } from './RootStack';
 
 import { useAuth } from '@/context/AuthContext';
@@ -71,38 +60,21 @@ const CourseTab = withBoundary('Course', CourseScreen);
 const JournalTab = withBoundary('Journal', JournalShelfScreen);
 const MapTab = withBoundary('Map', MapScreen);
 
-const TAB_ICON_SIZE = 24;
-const TAB_ICON_STROKE = 2;
 const SETTINGS_ICON_SIZE = 24;
 
-/** Returns a tab-bar icon renderer with shared size/stroke for every entry. */
-const makeTabIcon =
-  (Icon: LucideIcon) =>
-  ({ color }: { color: string }): React.JSX.Element => (
-    <Icon color={color} size={TAB_ICON_SIZE} strokeWidth={TAB_ICON_STROKE} />
-  );
-
-type TabConfig = {
-  name: keyof RootTabParamList;
-  component: React.ComponentType<object>;
-  icon: LucideIcon;
+/** The single screen-component mapping, keyed by route so registry lookup is total. */
+const SCREEN_COMPONENT_BY_NAME: Readonly<
+  Record<keyof RootTabParamList, React.ComponentType<object>>
+> = {
+  Journal: JournalTab,
+  Habits: HabitsTab,
+  Practice: PracticeTab,
+  Course: CourseTab,
+  Map: MapTab,
 };
 
-/** Which depth-ring flag each optional tab depends on, keyed for the enable map. */
+/** Which depth-ring flag each optional route depends on, keyed for the enable map. */
 type RingKey = 'habits' | 'practices' | 'course';
-
-/** The three ring tabs, in the fixed order they slot between Journal and Map. */
-const RING_TABS: ReadonlyArray<{ key: RingKey; config: TabConfig }> = [
-  { key: 'habits', config: { name: 'Habits', component: HabitsTab, icon: Sprout } },
-  { key: 'practices', config: { name: 'Practice', component: PracticeTab, icon: Flower2 } },
-  { key: 'course', config: { name: 'Course', component: CourseTab, icon: BookOpen } },
-];
-
-/** Journal always leads; Map always trails — neither is ring-gated. */
-const LEADING_TABS: ReadonlyArray<TabConfig> = [
-  { name: 'Journal', component: JournalTab, icon: NotebookPen },
-];
-const TRAILING_TABS: ReadonlyArray<TabConfig> = [{ name: 'Map', component: MapTab, icon: Compass }];
 
 /** Route name of the always-present home the redirect falls back to. */
 const REDIRECT_TARGET = 'Journal' as const;
@@ -114,25 +86,30 @@ const RING_FLAG_BY_ROUTE: Readonly<Record<string, RingKey>> = {
   Course: 'course',
 };
 
-/** Live snapshot of the three ring flags, keyed to match ``RING_TABS``. */
+/** Live snapshot of the three ring flags, keyed to match the registry rings. */
 type RingEnabledMap = Record<RingKey, boolean>;
 
 /**
- * Subscribe to the three ring toggles and assemble the visible tab list in the
- * fixed order ``[Journal, ...enabledRings, Map]``. Reactive: a store flip
- * re-renders the caller with the tab added or removed live.
+ * Subscribe to the three ring toggles and derive the visible destination list
+ * from ``NAV_DESTINATIONS``, dropping any ring-gated route whose flag is off.
+ * The registry fixes the order ``[Journal, Habits, Practice, Course, Map]``.
+ * Reactive: a store flip re-renders the caller with the route added or removed.
  */
-const useEnabledTabs = (): { tabs: ReadonlyArray<TabConfig>; enabled: RingEnabledMap } => {
+const useVisibleDestinations = (): {
+  destinations: ReadonlyArray<NavDestination>;
+  enabled: RingEnabledMap;
+} => {
   const enabled: RingEnabledMap = {
     habits: useDepthPreferencesStore(selectEnableHabits),
     practices: useDepthPreferencesStore(selectEnablePractices),
     course: useDepthPreferencesStore(selectEnableCourse),
   };
 
-  const enabledRings = RING_TABS.filter((ring) => enabled[ring.key]).map((ring) => ring.config);
-  const tabs = [...LEADING_TABS, ...enabledRings, ...TRAILING_TABS];
+  const destinations = NAV_DESTINATIONS.filter(
+    (destination) => destination.ring === undefined || enabled[destination.ring],
+  );
 
-  return { tabs, enabled };
+  return { destinations, enabled };
 };
 
 /**
@@ -162,16 +139,15 @@ const useRingRedirect = (props: BottomTabBarProps, enabled: RingEnabledMap): voi
 };
 
 /**
- * The default bottom tab bar, augmented with the ring focus-redirect. Rendered
- * via ``Tab.Navigator``'s ``tabBar`` prop so it lives inside the navigator and
- * can read the tab navigator's focused route straight from ``props.state``.
+ * Ring focus-redirect host, mounted via ``Tab.Navigator``'s ``tabBar`` prop so it
+ * lives inside the navigator and can read the focused route from ``props.state``.
+ * Renders nothing — the drawer is primary navigation, so no bar is drawn and no
+ * bar height is reserved — while the redirect effect stays mounted.
  */
-const RingAwareTabBar = (
-  props: BottomTabBarProps & { enabled: RingEnabledMap },
-): React.JSX.Element => {
+const RingAwareTabBar = (props: BottomTabBarProps & { enabled: RingEnabledMap }): null => {
   const { enabled, ...tabBarProps } = props;
   useRingRedirect(tabBarProps, enabled);
-  return <BottomTabBar {...tabBarProps} />;
+  return null;
 };
 
 /** Fetch the current ring toggles once on mount, keyed off the auth token. */
@@ -203,12 +179,13 @@ const TabHeaderRight = ({ onSettings }: TabHeaderRightProps): React.JSX.Element 
 );
 
 /**
- * Application-wide bottom tab navigation.
- * Each tab corresponds to a major feature area.
+ * Application-wide navigation shell. The drawer is the primary way to move
+ * between feature areas, so this navigator draws no bottom bar; it hosts the
+ * registry-derived screens and the header Settings gear.
  */
 const BottomTabs = (): React.JSX.Element => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { tabs, enabled } = useEnabledTabs();
+  const { destinations, enabled } = useVisibleDestinations();
 
   useLoadDepthPreferences();
 
@@ -230,24 +207,10 @@ const BottomTabs = (): React.JSX.Element => {
     <Tab.Navigator
       initialRouteName={REDIRECT_TARGET}
       tabBar={renderTabBar}
-      screenOptions={{
-        // Warm tab bar (#803): raised paper ground + hairline top edge; active
-        // terracotta vs muted ink, both AA on the raised ground.
-        tabBarActiveTintColor: accent.primary,
-        tabBarInactiveTintColor: ink.muted,
-        // borderTopWidth is intentionally omitted — RN Navigation defaults it to
-        // StyleSheet.hairlineWidth; we only retint the existing edge.
-        tabBarStyle: { backgroundColor: surface.raised, borderTopColor: surface.hairline },
-        headerRight: renderHeaderRight,
-      }}
+      screenOptions={{ headerRight: renderHeaderRight }}
     >
-      {tabs.map(({ name, component, icon }) => (
-        <Tab.Screen
-          key={name}
-          name={name}
-          component={component}
-          options={{ tabBarIcon: makeTabIcon(icon) }}
-        />
+      {destinations.map(({ name }) => (
+        <Tab.Screen key={name} name={name} component={SCREEN_COMPONENT_BY_NAME[name]} />
       ))}
     </Tab.Navigator>
   );

--- a/frontend/src/navigation/__tests__/BottomTabs.test.tsx
+++ b/frontend/src/navigation/__tests__/BottomTabs.test.tsx
@@ -1,16 +1,9 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
+import { BottomTabBar } from '@react-navigation/bottom-tabs';
 import { NavigationContainer, type NavigationContainerRef } from '@react-navigation/native';
 import { act, render, waitFor } from '@testing-library/react-native';
-import {
-  BookOpen,
-  Compass,
-  Flower2,
-  LayoutGrid,
-  NotebookPen,
-  Settings,
-  Sprout,
-} from 'lucide-react-native';
+import { BookOpen, Compass, Flower2, NotebookPen, Settings, Sprout } from 'lucide-react-native';
 import React from 'react';
 
 jest.mock('expo-notifications', () => ({
@@ -71,7 +64,7 @@ jest.mock('@/store/useDepthPreferencesStore', () => ({
 // Auth mock — provides token for load-on-mount assertions.
 // ---------------------------------------------------------------------------
 
-// Variables inside jest.mock factories must start with "mock" (Jest hoisting rule).
+// The token the AuthContext mock returns; asserted by the load-on-mount tests.
 const mockToken = 'test-auth-token';
 
 jest.mock('@/context/AuthContext', () => ({
@@ -79,6 +72,7 @@ jest.mock('@/context/AuthContext', () => ({
 }));
 
 import BottomTabs, { type RootTabParamList } from '../BottomTabs';
+import { NAV_DESTINATIONS } from '../destinations';
 
 // ---------------------------------------------------------------------------
 // Reset mutable state between tests.
@@ -115,33 +109,6 @@ describe('BottomTabs', () => {
     expect(queryByText('Logout')).toBeNull();
   });
 
-  it('renders a lucide icon for each of the five tabs', () => {
-    const { UNSAFE_getAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    // The focused tab's icon may render more than once (active-state
-    // animation in @react-navigation/bottom-tabs); only assert each icon
-    // appears at least once, which is what makeTabIcon being invoked
-    // for every assembled tab (LEADING_TABS + rings + TRAILING_TABS) guarantees.
-    for (const Icon of [NotebookPen, Sprout, Flower2, BookOpen, Compass]) {
-      expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
-    }
-  });
-
-  it('no longer renders the Catalog tab (moved off the bottom nav)', () => {
-    const { UNSAFE_queryAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    // LayoutGrid was the Catalog tab icon; it must be absent now (5 tabs).
-    expect(UNSAFE_queryAllByType(LayoutGrid)).toHaveLength(0);
-  });
-
   it('opens into the Journal tab as the initial route', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
 
@@ -151,8 +118,7 @@ describe('BottomTabs', () => {
       </NavigationContainer>,
     );
 
-    // waitFor: the navigation state commits asynchronously, and polling inside
-    // act() also drains the tab bar's Animated update (else an act() warning).
+    // waitFor: the navigation state commits asynchronously.
     await waitFor(() => {
       expect(navRef.current?.getCurrentRoute()?.name).toBe('Journal');
     });
@@ -167,8 +133,7 @@ describe('BottomTabs', () => {
       </NavigationContainer>,
     );
 
-    // getRootState() (not a bare getState(), which can read undefined before
-    // commit) exposes routes[] in physical tab order; waitFor lets it commit.
+    // getRootState() exposes routes[] in physical tab order; waitFor lets it commit.
     await waitFor(() => {
       expect(navRef.current?.getRootState()?.routes?.[0]?.name).toBe('Journal');
     });
@@ -176,155 +141,148 @@ describe('BottomTabs', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Conditional ring tabs — store-gated tab visibility (RED suite).
+// Drawer is primary navigation — the bottom tab bar itself must not render.
 // ---------------------------------------------------------------------------
 
-describe('BottomTabs — conditional ring tabs: all-on regression', () => {
-  it('all five lucide tab icons render when all ring flags are true', () => {
-    // Store defaults to all-on; this is the regression guard for the five-tab set.
-    const { UNSAFE_getAllByType } = render(
+describe('BottomTabs — drawer is primary navigation (no tab bar)', () => {
+  it('renders no tab bar and no tab-bar icons; the settings gear still renders', () => {
+    const { UNSAFE_queryAllByType, getByTestId } = render(
       <NavigationContainer>
         <BottomTabs />
       </NavigationContainer>,
     );
 
+    expect(UNSAFE_queryAllByType(BottomTabBar)).toHaveLength(0);
+
     for (const Icon of [NotebookPen, Sprout, Flower2, BookOpen, Compass]) {
-      expect(UNSAFE_getAllByType(Icon).length).toBeGreaterThanOrEqual(1);
+      expect(UNSAFE_queryAllByType(Icon)).toHaveLength(0);
     }
+
+    expect(getByTestId('open-settings-button')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conditional ring tabs — store-gated route visibility, asserted on the
+// mounted route set rather than on tab-bar icons (no tab bar renders now).
+// ---------------------------------------------------------------------------
+
+describe('BottomTabs — conditional ring tabs: all-on regression', () => {
+  it('all five routes mount when all ring flags are true', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(['Journal', 'Habits', 'Practice', 'Course', 'Map']);
+    });
   });
 });
 
 describe('BottomTabs — conditional ring tabs: enable_habits=false', () => {
-  it('Sprout (Habits) icon is absent when enable_habits is false', () => {
+  it('route order excludes Habits when enable_habits is false', async () => {
     setMockState({ enable_habits: false });
 
-    const { UNSAFE_queryAllByType } = render(
-      <NavigationContainer>
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    expect(UNSAFE_queryAllByType(Sprout)).toHaveLength(0);
-  });
-
-  it('Journal/Map tabs still render when enable_habits is false', () => {
-    setMockState({ enable_habits: false });
-
-    const { UNSAFE_getAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    expect(UNSAFE_getAllByType(NotebookPen).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Compass).length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('Practice and Course tabs still render when only enable_habits is false', () => {
-    setMockState({ enable_habits: false });
-
-    const { UNSAFE_getAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    expect(UNSAFE_getAllByType(Flower2).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(BookOpen).length).toBeGreaterThanOrEqual(1);
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(['Journal', 'Practice', 'Course', 'Map']);
+    });
   });
 });
 
 describe('BottomTabs — conditional ring tabs: enable_practices=false', () => {
-  it('Flower2 (Practice) icon is absent when enable_practices is false', () => {
+  it('route order excludes Practice when enable_practices is false', async () => {
     setMockState({ enable_practices: false });
 
-    const { UNSAFE_queryAllByType } = render(
-      <NavigationContainer>
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    expect(UNSAFE_queryAllByType(Flower2)).toHaveLength(0);
-  });
-
-  it('Journal/Map/Habits/Course render when only enable_practices is false', () => {
-    setMockState({ enable_practices: false });
-
-    const { UNSAFE_getAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    expect(UNSAFE_getAllByType(NotebookPen).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Sprout).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(BookOpen).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Compass).length).toBeGreaterThanOrEqual(1);
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(['Journal', 'Habits', 'Course', 'Map']);
+    });
   });
 });
 
 describe('BottomTabs — conditional ring tabs: enable_course=false', () => {
-  it('BookOpen (Course) icon is absent when enable_course is false', () => {
+  it('route order excludes Course when enable_course is false', async () => {
     setMockState({ enable_course: false });
 
-    const { UNSAFE_queryAllByType } = render(
-      <NavigationContainer>
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    expect(UNSAFE_queryAllByType(BookOpen)).toHaveLength(0);
-  });
-
-  it('Journal/Map/Habits/Practice render when only enable_course is false', () => {
-    setMockState({ enable_course: false });
-
-    const { UNSAFE_getAllByType } = render(
-      <NavigationContainer>
-        <BottomTabs />
-      </NavigationContainer>,
-    );
-
-    expect(UNSAFE_getAllByType(NotebookPen).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Sprout).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Flower2).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Compass).length).toBeGreaterThanOrEqual(1);
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(['Journal', 'Habits', 'Practice', 'Map']);
+    });
   });
 });
 
 describe('BottomTabs — conditional ring tabs: all three rings off', () => {
-  it('only Journal/Map icons render when all ring flags are false', () => {
+  it('route order is Journal/Map only when all ring flags are false', async () => {
     setMockState({ enable_habits: false, enable_practices: false, enable_course: false });
 
-    const { UNSAFE_getAllByType, UNSAFE_queryAllByType } = render(
-      <NavigationContainer>
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    // Always-present tabs.
-    expect(UNSAFE_getAllByType(NotebookPen).length).toBeGreaterThanOrEqual(1);
-    expect(UNSAFE_getAllByType(Compass).length).toBeGreaterThanOrEqual(1);
-
-    // Gated tabs must be absent.
-    expect(UNSAFE_queryAllByType(Sprout)).toHaveLength(0);
-    expect(UNSAFE_queryAllByType(Flower2)).toHaveLength(0);
-    expect(UNSAFE_queryAllByType(BookOpen)).toHaveLength(0);
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(['Journal', 'Map']);
+    });
   });
 });
 
 describe('BottomTabs — conditional ring tabs: live enable', () => {
-  it('Sprout appears after enable_habits flips from false to true on re-render', () => {
+  it('routes include Habits after enable_habits flips from false to true on re-render', async () => {
     setMockState({ enable_habits: false });
 
-    const { UNSAFE_queryAllByType, rerender } = render(
-      <NavigationContainer>
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    const { rerender } = render(
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    // Sprout must be absent before the flag flips.
-    expect(UNSAFE_queryAllByType(Sprout)).toHaveLength(0);
+    // Habits must be absent before the flag flips.
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).not.toContain('Habits');
+    });
 
     // Flip the flag in the mutable mock state, then re-render the tree.
     act(() => {
@@ -332,12 +290,16 @@ describe('BottomTabs — conditional ring tabs: live enable', () => {
     });
 
     rerender(
-      <NavigationContainer>
+      <NavigationContainer ref={navRef}>
         <BottomTabs />
       </NavigationContainer>,
     );
 
-    expect(UNSAFE_queryAllByType(Sprout).length).toBeGreaterThanOrEqual(1);
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toContain('Habits');
+    });
   });
 });
 
@@ -500,6 +462,22 @@ describe('BottomTabs — conditional ring tabs: tab render order', () => {
       const routes = navRef.current?.getRootState()?.routes ?? [];
       const names = routes.map((r: { name: string }) => r.name);
       expect(names).toEqual(['Journal', 'Practice', 'Map']);
+    });
+  });
+
+  it('mounted route order equals the NAV_DESTINATIONS registry order (all rings on)', async () => {
+    const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
+
+    render(
+      <NavigationContainer ref={navRef}>
+        <BottomTabs />
+      </NavigationContainer>,
+    );
+
+    await waitFor(() => {
+      const routes = navRef.current?.getRootState()?.routes ?? [];
+      const names = routes.map((r: { name: string }) => r.name);
+      expect(names).toEqual(NAV_DESTINATIONS.map((d) => d.name));
     });
   });
 });


### PR DESCRIPTION
## Summary

The bottom tab bar no longer renders on any screen — the per-screen drawer's nav section (shipped in the two predecessor PRs of this epic) is now the sole top-level navigation, giving every screen its bottom edge back for content behind the single hamburger gesture. This is the final sub-issue of epic #1528.

- The tab navigator is **kept** (`createBottomTabNavigator`): its `tabBar` render prop now mounts a headless `RingAwareTabBar` that runs `useRingRedirect` and returns `null` instead of `<BottomTabBar/>`, so no bar draws and no bar height is reserved (preferred over `tabBarStyle: { display: 'none' }`, which still mounts the bar).
- `BottomTabs.tsx` derives its `Tab.Screen` list from the `NAV_DESTINATIONS` registry filtered by the live depth-ring flags, mapped to screen components through one total `Readonly<Record<keyof RootTabParamList, ComponentType>>`. Adding a destination is now **one registry entry + one component mapping** — the `RING_TABS`/`LEADING_TABS`/`TRAILING_TABS` triplet and its icon plumbing are gone.
- Unchanged: `RootTabParamList`, the `navigate('Tabs', { screen })` call sites (e.g. `SharePreviewScreen`), Journal as the initial route, the Settings gear `headerRight`, the per-screen drawer `headerLeft` hamburger, and the ring focus-redirect on disable (disabling the focused ring still redirects to Journal). State-retention and lazy-mount semantics are identical — the same five screens mount under the same names in the same order.

## Test plan

- `frontend/src/navigation/__tests__/BottomTabs.test.tsx` rewritten (TDD, RED → GREEN): asserts no `BottomTabBar` element and no tab-bar lucide icons render (Settings gear still does), the mounted route set/order is derived from `getRootState().routes` (registry-driven) across every ring-flag combination, and the focus-redirect / tab-count / no-Sangha / load-on-mount behaviors are preserved.
- `./scripts/frontend/check-all.sh` green locally: 4088 tests pass, ESLint + prettier + tsc (strict) clean. No suppressions.

## Follow-up (out of scope)

`frontend/src/features/Habits/HabitTile.tsx` still reserves `BOTTOM_TAB_BAR_CONTENT_HEIGHT` (49px) in its tile-density budget. With the bar gone this is now dead bottom padding — a cosmetic layout allowance the Habits grid could reclaim. It's deliberately deferred: this issue scopes to the navigation shell (`BottomTabs.tsx` + its test), and reclaiming it touches a documented density constant and its fit-test, better handled as its own small change.

Closes #1531
Refs #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)