### PR TITLE
feat(habits): long-press a tier star on the habit tile to fill-to-star and log units

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -29,12 +29,17 @@ import {
   isGoalAchieved,
   calculateTodaysProgress,
 } from './HabitUtils';
+import { useStarFill, type StarFillControls } from './hooks/useStarFill';
 import { longPressGestureStyle } from './longPressGestureStyle';
+import { STAR_LONG_PRESS_MS } from './starFill';
 import {
   TierMarkerOverlay,
   type MarkerInteraction,
   type TierMarkerSpec,
 } from './TierMarkerOverlay';
+
+/** A tile that is not wired to log units keeps the star as a tooltip-only touch target. */
+const NOOP_LOG_UNIT: NonNullable<HabitTileProps['onLogUnit']> = () => {};
 
 /** Marker star size: a touch larger than the bar so it reads as a sitting marker. */
 const markerStarSize = (scale: number): number => spacing(2, scale);
@@ -233,8 +238,8 @@ const TileTooltipText = ({
   </Text>
 );
 
-/** Every tile marker is a press-to-reveal-tooltip touch target (no drag on the tile). */
-const tileMarkerInteraction = (
+/** A quick tap on any marker reveals its tier-progress tooltip; no fill is armed. */
+const tooltipOnlyInteraction = (
   tier: TierType,
   setTooltip: (_v: TierType | null) => void,
 ): MarkerInteraction => ({
@@ -244,6 +249,46 @@ const tileMarkerInteraction = (
     onPressOut: () => setTooltip(null),
   },
 });
+
+/**
+ * A logging tile mirrors the goal modal's star behavior: a quick tap still shows
+ * the tooltip, but holding past the shared long-press delay arms the fill sweep
+ * toward that star and logs its delta on arrival; an early release reverts.
+ */
+const fillMarkerInteraction = (
+  tier: TierType,
+  setTooltip: (_v: TierType | null) => void,
+  starFill: StarFillControls,
+): MarkerInteraction => ({
+  Wrapper: TouchableOpacity,
+  interactionProps: {
+    onPressIn: () => setTooltip(tier),
+    onPressOut: () => {
+      setTooltip(null);
+      starFill.release();
+    },
+    onLongPress: () => starFill.begin(tier),
+    delayLongPress: STAR_LONG_PRESS_MS,
+    accessibilityRole: 'button',
+    accessibilityLabel: TIER_LABELS[tier],
+    accessibilityHint: `Hold to log your ${TIER_LABELS[tier]} for today.`,
+  },
+});
+
+/**
+ * Stars only arm the fill when the tile is actually wired to log units; without
+ * a real `onLogUnit` the marker stays tooltip-only so it never silently sweeps
+ * toward a no-op.
+ */
+const tileMarkerInteraction = (
+  tier: TierType,
+  setTooltip: (_v: TierType | null) => void,
+  starFill: StarFillControls,
+  hasLogUnit: boolean,
+): MarkerInteraction =>
+  hasLogUnit
+    ? fillMarkerInteraction(tier, setTooltip, starFill)
+    : tooltipOnlyInteraction(tier, setTooltip);
 
 interface ProgressBarProps {
   habit: Habit;
@@ -255,6 +300,8 @@ interface ProgressBarProps {
   tooltip: TierType | null;
   setTooltip: (_v: TierType | null) => void;
   tz: string;
+  starFill: StarFillControls;
+  hasLogUnit: boolean;
 }
 
 const COLOR_TRANSITION_MS = 400;
@@ -313,6 +360,43 @@ const AnimatedFill = ({ width, color, prevColor, fadeAnim, borderRadius }: Anima
   </>
 );
 
+interface TileMarkerLayerProps {
+  habit: Habit;
+  tz: string;
+  scale: number;
+  barHeight: number;
+  markers: TileMarkerSpec[];
+  tooltip: TierType | null;
+  setTooltip: (_v: TierType | null) => void;
+  starFill: StarFillControls;
+  hasLogUnit: boolean;
+}
+
+/** The tier-star overlay that sits atop the tile bar, wired for tap-tooltip and long-press fill. */
+const TileMarkerLayer = ({
+  habit,
+  tz,
+  scale,
+  barHeight,
+  markers,
+  tooltip,
+  setTooltip,
+  starFill,
+  hasLogUnit,
+}: TileMarkerLayerProps) => (
+  <TierMarkerOverlay<TileMarkerSpec>
+    markers={markers}
+    barHeight={barHeight}
+    starSize={markerStarSize(scale)}
+    tooltip={tooltip}
+    setTooltip={setTooltip}
+    markerTestIDPrefix="marker"
+    tooltipTestIDPrefix="tooltip"
+    renderTooltip={(m) => <TileTooltipText goal={m.goal} habit={habit} tz={tz} scale={scale} />}
+    resolveInteraction={(m) => tileMarkerInteraction(m.tier, setTooltip, starFill, hasLogUnit)}
+  />
+);
+
 const ProgressBar = ({
   habit,
   barHeight,
@@ -323,9 +407,10 @@ const ProgressBar = ({
   tooltip,
   setTooltip,
   tz,
+  starFill,
+  hasLogUnit,
 }: ProgressBarProps) => {
   const { fadeAnim, prevColor } = useColorTransition(progressBarColor);
-  const widthStyle: DimensionValue = `${progressPercentage}%`;
   const borderR = barHeight / 2;
 
   return (
@@ -340,25 +425,23 @@ const ProgressBar = ({
           }}
         >
           <AnimatedFill
-            width={widthStyle}
+            width={`${progressPercentage}%`}
             color={progressBarColor}
             prevColor={prevColor}
             fadeAnim={fadeAnim}
             borderRadius={borderR}
           />
         </View>
-        <TierMarkerOverlay<TileMarkerSpec>
-          markers={markers}
+        <TileMarkerLayer
+          habit={habit}
+          tz={tz}
+          scale={scale}
           barHeight={barHeight}
-          starSize={markerStarSize(scale)}
+          markers={markers}
           tooltip={tooltip}
           setTooltip={setTooltip}
-          markerTestIDPrefix="marker"
-          tooltipTestIDPrefix="tooltip"
-          renderTooltip={(m) => (
-            <TileTooltipText goal={m.goal} habit={habit} tz={tz} scale={scale} />
-          )}
-          resolveInteraction={(m) => tileMarkerInteraction(m.tier, setTooltip)}
+          starFill={starFill}
+          hasLogUnit={hasLogUnit}
         />
       </View>
     </View>
@@ -521,6 +604,7 @@ interface UnlockedTileProps {
   onOpenGoals?: () => void;
   onLongPress?: () => void;
   onIconPress?: () => void;
+  onLogUnit?: HabitTileProps['onLogUnit'];
   tz: string;
 }
 
@@ -542,16 +626,69 @@ const buildUnlockedTileStyle = (
   ...longPressGestureStyle,
 });
 
+interface TileProgressSectionProps {
+  habit: Habit;
+  tz: string;
+  scale: number;
+  barHeight: number;
+  progressPercentage: number;
+  progressBarColor: string;
+  markers: TileMarkerSpec[];
+  onLogUnit?: HabitTileProps['onLogUnit'];
+}
+
+/**
+ * The tile's progress bar plus its own tooltip state and the shared star-fill
+ * animation. The hook is always called (rules-of-hooks); a tile with no real
+ * logger gets a no-op, and `hasLogUnit` gates whether the stars ever arm the
+ * sweep. While a fill/revert runs the animated frame wins over the static
+ * percent, mirroring the goal modal's bar.
+ */
+const TileProgressSection = ({
+  habit,
+  tz,
+  scale,
+  barHeight,
+  progressPercentage,
+  progressBarColor,
+  markers,
+  onLogUnit,
+}: TileProgressSectionProps) => {
+  const [tooltip, setTooltip] = useState<TierType | null>(null);
+  const fill = useStarFill({
+    habit,
+    tz,
+    progressPercent: progressPercentage,
+    onLogUnit: onLogUnit ?? NOOP_LOG_UNIT,
+  });
+
+  return (
+    <ProgressBar
+      habit={habit}
+      barHeight={barHeight}
+      progressPercentage={fill.displayPercent ?? progressPercentage}
+      progressBarColor={progressBarColor}
+      markers={markers}
+      scale={scale}
+      tooltip={tooltip}
+      setTooltip={setTooltip}
+      tz={tz}
+      starFill={fill}
+      hasLogUnit={onLogUnit !== undefined}
+    />
+  );
+};
+
 const UnlockedTile = ({
   habit,
   stageColor,
   onOpenGoals,
   onLongPress,
   onIconPress,
+  onLogUnit,
   tz,
 }: UnlockedTileProps) => {
   const { scale, gridGutter, tileMinHeight, iconInline } = useTileLayout();
-  const [tooltip, setTooltip] = useState<TierType | null>(null);
   const { progressPercentage, progressBarColor, hasCompletedGoal, markers } = useHabitTileData(
     habit,
     tz,
@@ -578,16 +715,15 @@ const UnlockedTile = ({
         iconInline={iconInline}
         onIconPress={onIconPress}
       />
-      <ProgressBar
+      <TileProgressSection
         habit={habit}
+        tz={tz}
+        scale={scale}
         barHeight={barHeight}
         progressPercentage={progressPercentage}
         progressBarColor={progressBarColor}
         markers={markers}
-        scale={scale}
-        tooltip={tooltip}
-        setTooltip={setTooltip}
-        tz={tz}
+        onLogUnit={onLogUnit}
       />
     </TouchableOpacity>
   );
@@ -600,6 +736,7 @@ const HabitTileComponent = ({
   onLongPress,
   onIconPress,
   onUnlockHabit,
+  onLogUnit,
   tz = DEFAULT_TIMEZONE,
   stageColor,
   globalIndex = 0,
@@ -634,6 +771,7 @@ const HabitTileComponent = ({
       onOpenGoals={onOpenGoals ? () => onOpenGoals(habit) : undefined}
       onLongPress={onLongPress ? () => onLongPress(habit) : undefined}
       onIconPress={onIconPress ? () => onIconPress(globalIndex) : undefined}
+      onLogUnit={onLogUnit}
       tz={tz}
     />
   );

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -135,6 +135,8 @@ export interface HabitTileProps {
   onLongPress?: (_habit: Habit) => void;
   onIconPress?: (_index: number) => void;
   onUnlockHabit?: (_habitId: number) => void;
+  /** Long-press-a-star fill logging; ``date`` backfills a past day (omit for today). */
+  onLogUnit?: (_habitId: number, _amount: number, _date?: Date) => void;
   /**
    * IANA timezone used to bucket completions into the user's calendar day
    * for the progress bar / "Achieved Today" display. Defaults to UTC when

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -431,7 +431,7 @@ const useHabitTileRenderer = (
     actions,
     setSelectedHabit,
   );
-  const { unlockHabit } = actions;
+  const { unlockHabit, logUnit } = actions;
   const renderHabitTile = useCallback(
     ({ item, index }: { item: Habit; index: number }) => {
       // Unlock is governed solely by the persisted ``revealed`` flag — locked by
@@ -453,11 +453,12 @@ const useHabitTileRenderer = (
           onLongPress={handleLongPress}
           onIconPress={handleIconPress}
           onUnlockHabit={unlockHabit}
+          onLogUnit={logUnit}
           tz={tz}
         />
       );
     },
-    [pageOffset, tz, handleOpenGoals, handleLongPress, handleIconPress, unlockHabit],
+    [pageOffset, tz, handleOpenGoals, handleLongPress, handleIconPress, unlockHabit, logUnit],
   );
   return renderHabitTile;
 };

--- a/frontend/src/features/Habits/__tests__/HabitTileStarLongPress.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileStarLongPress.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { Goal, Habit } from '../Habits.types';
+import { HabitTile } from '../HabitTile';
+import { FULL_SWEEP_MS } from '../starFill';
+
+const HABIT_ID = 42;
+const STAGE_COLOR = '#4a3f35';
+
+const MARKER_LOW = 'marker-low';
+const MARKER_CLEAR = 'marker-clear';
+const MARKER_STRETCH = 'marker-stretch';
+const PROGRESS_FILL = 'progress-fill';
+const TOOLTIP_CLEAR = 'tooltip-clear';
+const TOOLTIP_STRETCH = 'tooltip-stretch';
+
+const makeGoal = (tier: 'low' | 'clear' | 'stretch', overrides: Partial<Goal> = {}): Goal => ({
+  id: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  title: `${tier} goal`,
+  tier,
+  target: tier === 'low' ? 1 : tier === 'clear' ? 2 : 3,
+  target_unit: 'units',
+  frequency: 1,
+  frequency_unit: 'per_day',
+  is_additive: true,
+  ...overrides,
+});
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: HABIT_ID,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: 'candle',
+  streak: 0,
+  energy_cost: 1,
+  energy_return: 2,
+  start_date: new Date('2025-01-01'),
+  goals: [makeGoal('low'), makeGoal('clear'), makeGoal('stretch')],
+  completions: [],
+  revealed: true,
+  ...overrides,
+});
+
+type TileProps = React.ComponentProps<typeof HabitTile>;
+type TilePropsWithLogUnit = TileProps & { onLogUnit: jest.Mock };
+
+const baseProps = (habit: Habit): TileProps => ({
+  habit,
+  stageColor: STAGE_COLOR,
+  onOpenGoals: jest.fn(),
+  onLongPress: jest.fn(),
+  tz: 'UTC',
+  globalIndex: 0,
+});
+
+const buildProps = (habit: Habit): TilePropsWithLogUnit => ({
+  ...baseProps(habit),
+  onLogUnit: jest.fn(),
+});
+
+const renderTile = (habit: Habit) => {
+  const props = buildProps(habit);
+  const utils = render(<HabitTile {...props} />);
+  return { ...utils, props };
+};
+
+const renderTileWithoutLogUnit = (habit: Habit) => {
+  const props = baseProps(habit);
+  const utils = render(<HabitTile {...props} />);
+  return { ...utils, props };
+};
+
+const advance = (ms: number): void => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+const fillWidth = (getByTestId: (_id: string) => { props: { style: { width: string } } }): number =>
+  parseFloat(getByTestId(PROGRESS_FILL).props.style.width);
+
+describe('HabitTile star long-press fill', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-03T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('arms the stretch star with the shared long-press delay and fills to it, logging the full delta', () => {
+    const { getByTestId, props } = renderTile(makeHabit());
+    const marker = getByTestId(MARKER_STRETCH);
+
+    expect(marker.props.accessibilityHint).toBe('Hold to log your Stretch Goal for today.');
+    expect(marker.props.accessibilityRole).toBe('button');
+    expect(marker.props.accessibilityLabel).toBe('Stretch Goal');
+
+    fireEvent(marker, 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledTimes(1);
+    expect(props.onLogUnit).toHaveBeenCalledWith(HABIT_ID, 3);
+  });
+
+  it('fills to the clear star and logs the clear delta', () => {
+    const { getByTestId, props } = renderTile(makeHabit());
+
+    fireEvent(getByTestId(MARKER_CLEAR), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(HABIT_ID, 2);
+  });
+
+  it('fills to the low star and logs the low delta', () => {
+    const { getByTestId, props } = renderTile(makeHabit());
+
+    fireEvent(getByTestId(MARKER_LOW), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(HABIT_ID, 1);
+  });
+
+  it('logs only the remaining units when the bar starts mid-way', () => {
+    const habit = makeHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 1 }],
+    });
+    const { getByTestId, props } = renderTile(habit);
+
+    fireEvent(getByTestId(MARKER_STRETCH), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(HABIT_ID, 2);
+  });
+
+  it('reverts to the starting position without logging when released early', () => {
+    const { getByTestId, props } = renderTile(makeHabit());
+    const marker = getByTestId(MARKER_STRETCH);
+
+    fireEvent(marker, 'longPress');
+    advance(FULL_SWEEP_MS / 3);
+    fireEvent(marker, 'pressOut');
+    advance(FULL_SWEEP_MS * 2);
+
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+    expect(fillWidth(getByTestId as never)).toBe(0);
+  });
+
+  it('does nothing when today already sits exactly on the pressed star', () => {
+    const habit = makeHabit({
+      completions: [{ id: 't-1', timestamp: new Date(), completed_units: 3 }],
+    });
+    const { getByTestId, props } = renderTile(habit);
+
+    fireEvent(getByTestId(MARKER_STRETCH), 'longPress');
+    advance(FULL_SWEEP_MS * 2);
+
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+    expect(fillWidth(getByTestId as never)).toBe(100);
+  });
+
+  it('shows the tooltip on a quick tap without arming a fill', () => {
+    const { getByTestId, queryByTestId, props } = renderTile(makeHabit());
+    const marker = getByTestId(MARKER_CLEAR);
+
+    fireEvent(marker, 'pressIn');
+    expect(getByTestId(TOOLTIP_CLEAR)).toBeTruthy();
+    fireEvent(marker, 'pressOut');
+    expect(queryByTestId(TOOLTIP_CLEAR)).toBeNull();
+
+    advance(FULL_SWEEP_MS * 2);
+    expect(props.onLogUnit).not.toHaveBeenCalled();
+  });
+
+  it('does not open the tile settings menu or the goal modal from a star long-press', () => {
+    const { getByTestId, props } = renderTile(makeHabit());
+
+    fireEvent(getByTestId(MARKER_STRETCH), 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLongPress).not.toHaveBeenCalled();
+    expect(props.onOpenGoals).not.toHaveBeenCalled();
+  });
+
+  it('stays tooltip-only with no throw when onLogUnit is not provided', () => {
+    const { getByTestId, queryByTestId } = renderTileWithoutLogUnit(makeHabit());
+    const marker = getByTestId(MARKER_STRETCH);
+
+    expect(() => {
+      fireEvent(marker, 'longPress');
+      advance(FULL_SWEEP_MS + 100);
+    }).not.toThrow();
+
+    fireEvent(marker, 'pressIn');
+    expect(getByTestId(TOOLTIP_STRETCH)).toBeTruthy();
+    fireEvent(marker, 'pressOut');
+    expect(queryByTestId(TOOLTIP_STRETCH)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Long-pressing any visible tier star (low / clear / stretch) on an **unlocked** habit tile now arms the same star-fill sweep the Goal modal already offers, so a tier's worth of progress can be logged in one gesture without opening the modal first:

- Holding a star for `STAR_LONG_PRESS_MS` (400ms) sweeps the tile bar toward that star; on arrival it logs the plan's `deltaUnits` via the same `logUnit` action the modal uses.
- Releasing before the sweep arrives reverts the bar to its starting percent and logs nothing (same `release()` semantics as the modal).
- A quick tap still shows the tier tooltip (existing `onPressIn`/`onPressOut` preserved).
- A star long-press does **not** bubble to the tile's `onLongPress` (settings modal) or `onPress` (goal modal) — RN's single-responder system stops the gesture at the inner star `TouchableOpacity`.
- Locked tiles are unchanged (no bar/stars; only the unlock dialog).
- While a sweep runs the tile bar renders `fill.displayPercent ?? staticPercent`, then hands back to the prop-derived percent, mirroring the modal's bar.

### Reuse, not fork
The tile calls the existing `useStarFill` / `computeStarFillPlan` machinery directly — nothing in them was modal-specific. `HabitTileProps` gains an optional `onLogUnit`, threaded from `useHabitTileRenderer` as the stable `actions.logUnit` reference (kept stable so `React.memo` on rows stays effective; the rendercount test still passes). When no logger is wired the stars stay tooltip-only, so they never silently arm a no-op sweep. The bar/tooltip/star-fill wiring was extracted into two small components (`TileMarkerLayer`, `TileProgressSection`) to keep each function A-grade.

### Scale reconciliation (the issue's flagged risk)
No rescale was needed. `getProgressPercentage` always normalizes today's progress against the **stretch** target internally (its `currentGoal` argument is only a no-stretch fallback) and already clamps, so the tile's static `progressPercentage` and `computeStarFillPlan.fromPercent` evaluate to the **same** value. The sweep therefore starts exactly where the tile bar already sits — no visual jump.

### Accessibility
Each armed star exposes `accessibilityRole="button"`, `accessibilityLabel` (the tier name), and an `accessibilityHint` ("Hold to log your {tier} for today.") so the hold affordance is announced rather than being gesture-only, following the existing hold-to-act hint pattern in the codebase.

## Test plan

- New `HabitTileStarLongPress.test.tsx` (9 tests, modeled on the modal's `GoalModal.starLongPress.test.tsx`): fill-to-star + correct `deltaUnits` for each of stretch/clear/low, mid-bar remainder, early-release revert with no log, already-on-star no-op, quick-tap tooltip, no bleed to the tile's settings/goal handlers, tooltip-only when `onLogUnit` is omitted, and the a11y role/label/hint.
- `./scripts/frontend/check-all.sh` passes: 4097 tests, ESLint (zero-warning), TypeScript strict, and Prettier all green.
- Existing tile suites (interactions, tooltip, rendercount, locked, fit, content-width) unchanged and passing.

Closes #1533