### PR TITLE
feat(backend): UserUiFlags model + /ui-flags GET/PATCH endpoint

### DIFF
--- a/backend/migrations/versions/b4c5d6e7f8a1_add_user_ui_flags.py
+++ b/backend/migrations/versions/b4c5d6e7f8a1_add_user_ui_flags.py
@@ -1,0 +1,51 @@
+"""add user_ui_flags table
+
+Revision ID: b4c5d6e7f8a1
+Revises: a9b0c1d2e3f4
+Create Date: 2026-07-10 00:00:00.000000
+
+Adds ``useruiflags`` — one row per user recording lightweight one-time UI
+state (whether the welcome flow has been seen and whether the energy-scaffolding
+surface has been archived). ``upgrade`` creates the table with both boolean
+flags ``NOT NULL`` and a DB-level ``server_default`` of false (mirroring the
+model's ``server_default`` so ``alembic check`` stays drift-free), and a unique
+FK to ``user.id`` with ``ON DELETE CASCADE``. No rows are backfilled: existing
+users are provisioned on their first read. ``downgrade`` drops the table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4c5d6e7f8a1"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "a9b0c1d2e3f4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "useruiflags"
+
+
+def upgrade() -> None:
+    """Create ``useruiflags`` with both flags defaulting to false (no backfill)."""
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("has_seen_welcome", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "energy_scaffolding_archived",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``useruiflags`` table."""
+    op.drop_table(_TABLE_NAME)

--- a/backend/src/domain/ui_flags.py
+++ b/backend/src/domain/ui_flags.py
@@ -1,0 +1,42 @@
+"""Domain logic for provisioning and reading per-user UI flags."""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.user_ui_flags import UserUiFlags
+
+
+async def _get_ui_flags(session: AsyncSession, user_id: int) -> UserUiFlags | None:
+    """Fetch the user's :class:`UserUiFlags` row, or ``None``."""
+    result = await session.execute(select(UserUiFlags).where(col(UserUiFlags.user_id) == user_id))
+    return result.scalars().first()
+
+
+async def ensure_ui_flags(session: AsyncSession, user_id: int) -> UserUiFlags:
+    """Return the user's UI flags, provisioning an all-false row on first access.
+
+    Commits the new row before returning: a concurrent caller that loses the
+    SAVEPOINT race must re-read the winner's committed row, and ``get_session``
+    does not auto-commit. Because ``user_id`` is unique, a racing auto-provision
+    hits an ``IntegrityError`` and re-reads the winner's row. Mirrors
+    ``ensure_depth_preferences`` in ``depth_preferences.py``.
+    """
+    flags = await _get_ui_flags(session, user_id)
+    if flags is not None:
+        return flags
+    flags = UserUiFlags(user_id=user_id)
+    try:
+        async with session.begin_nested():
+            session.add(flags)
+        await session.commit()
+        await session.refresh(flags)
+    except IntegrityError as exc:
+        existing = await _get_ui_flags(session, user_id)
+        if existing is None:
+            msg = "UserUiFlags creation lost the race but the winner's row is missing"
+            raise RuntimeError(msg) from exc
+        return existing
+    return flags

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,6 +50,7 @@ from routers.promotions import router as promotions_router
 from routers.prompts import router as prompts_router
 from routers.reflections import router as reflections_router
 from routers.stages import router as stages_router
+from routers.ui_flags import router as ui_flags_router
 from routers.user_practices import router as user_practices_router
 from routers.users import router as users_router
 from seed_content import seed_content
@@ -448,6 +449,7 @@ app.include_router(goals_router)
 app.include_router(stages_router)
 app.include_router(users_router)
 app.include_router(depth_preferences_router)
+app.include_router(ui_flags_router)
 app.include_router(invitations_router)
 app.include_router(metta_return_router)
 

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -30,6 +30,7 @@ from .stage_progress import StageProgress
 from .user import User
 from .user_depth_preferences import UserDepthPreferences
 from .user_practice import UserPractice
+from .user_ui_flags import UserUiFlags
 from .wallet_audit import WalletAudit
 
 __all__ = [
@@ -64,5 +65,6 @@ __all__ = [
     "User",
     "UserDepthPreferences",
     "UserPractice",
+    "UserUiFlags",
     "WalletAudit",
 ]

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from .prompt_response import PromptResponse
     from .stage_progress import StageProgress
     from .user_depth_preferences import UserDepthPreferences
+    from .user_ui_flags import UserUiFlags
 
 
 def _default_reset_date() -> datetime:
@@ -129,6 +130,10 @@ class User(SQLModel, table=True):
     responses: list["PromptResponse"] = Relationship(back_populates="user")
     stage_progress: Optional["StageProgress"] = Relationship(back_populates="user")
     depth_preferences: Optional["UserDepthPreferences"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={"passive_deletes": True},
+    )
+    ui_flags: Optional["UserUiFlags"] = Relationship(
         back_populates="user",
         sa_relationship_kwargs={"passive_deletes": True},
     )

--- a/backend/src/models/user_ui_flags.py
+++ b/backend/src/models/user_ui_flags.py
@@ -1,0 +1,38 @@
+"""Per-user UI flags tracking one-time interface state."""
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Column
+from sqlmodel import Field, Relationship, SQLModel
+
+if TYPE_CHECKING:
+    from .user import User
+
+# Booleans default to disabled ("0") so a fresh user starts with no flags set;
+# rows are provisioned on first read rather than backfilled. The server_default
+# mirrors the migration end-state, keeping ``alembic check`` drift-free.
+_DISABLED_SERVER_DEFAULT = "0"
+
+
+class UserUiFlags(SQLModel, table=True):
+    """Per-user record of one-time UI state.
+
+    One row per user tracks lightweight interface flags: whether the welcome
+    flow has been seen and whether the energy-scaffolding surface has been
+    archived. Both flags default to ``False`` so a new account starts with a
+    clean slate; rows are created on first access rather than backfilled.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    has_seen_welcome: bool = Field(
+        default=False,
+        sa_column=Column(Boolean(), nullable=False, server_default=_DISABLED_SERVER_DEFAULT),
+    )
+    """Whether the user has seen the welcome flow."""
+    energy_scaffolding_archived: bool = Field(
+        default=False,
+        sa_column=Column(Boolean(), nullable=False, server_default=_DISABLED_SERVER_DEFAULT),
+    )
+    """Whether the user has archived the energy-scaffolding surface."""
+    user_id: int = Field(foreign_key="user.id", unique=True, ondelete="CASCADE")
+    user: "User" = Relationship(back_populates="ui_flags")

--- a/backend/src/routers/ui_flags.py
+++ b/backend/src/routers/ui_flags.py
@@ -1,0 +1,65 @@
+"""UI-flag endpoints for per-user one-time interface state.
+
+A user records lightweight interface flags — whether the welcome flow has been
+seen and whether the energy-scaffolding surface has been archived. The caller
+is resolved from their JWT, so only that user's own row is read or mutated: no
+``user_id`` is ever accepted from the body or path.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from domain.ui_flags import ensure_ui_flags
+from models.user_ui_flags import UserUiFlags
+from routers.auth import get_current_user
+from schemas.ui_flags import UiFlagsResponse, UiFlagsUpdate
+
+router = APIRouter(prefix="/ui-flags", tags=["ui-flags"])
+
+
+def _to_response(flags: UserUiFlags) -> UiFlagsResponse:
+    """Project a stored row onto the two-boolean response DTO."""
+    return UiFlagsResponse(
+        has_seen_welcome=flags.has_seen_welcome,
+        energy_scaffolding_archived=flags.energy_scaffolding_archived,
+    )
+
+
+@router.get("", response_model=UiFlagsResponse)
+async def get_ui_flags(
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> UiFlagsResponse:
+    """Return the caller's UI flags, provisioning all-false on first access.
+
+    Idempotent: repeated calls return the same state and never create a
+    duplicate row.
+    """
+    flags = await ensure_ui_flags(session, user_id)
+    return _to_response(flags)
+
+
+@router.patch("", response_model=UiFlagsResponse)
+async def update_ui_flags(
+    payload: UiFlagsUpdate,
+    user_id: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> UiFlagsResponse:
+    """Partially update the caller's UI flags and return the full new state.
+
+    Only the fields present in the request are applied; unspecified flags keep
+    their stored value. An empty body is rejected upstream (422) by
+    :class:`~schemas.ui_flags.UiFlagsUpdate`.
+    """
+    flags = await ensure_ui_flags(session, user_id)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(flags, field, value)
+    session.add(flags)
+    await session.commit()
+    await session.refresh(flags)
+    return _to_response(flags)

--- a/backend/src/schemas/ui_flags.py
+++ b/backend/src/schemas/ui_flags.py
@@ -1,0 +1,41 @@
+"""UI-flag schemas for per-user one-time interface state."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, model_validator
+
+
+class UiFlagsResponse(BaseModel):
+    """The two UI flags returned to the caller.
+
+    ``user_id`` is intentionally excluded — the caller already knows its own
+    identity from the JWT, and surfacing surrogate keys aids enumeration.
+    """
+
+    has_seen_welcome: bool
+    energy_scaffolding_archived: bool
+
+
+class UiFlagsUpdate(BaseModel):
+    """Partial update for the UI flags (PATCH).
+
+    Every field is optional; an empty payload is rejected (422) so a no-op
+    PATCH cannot reach the database. Only the fields the caller sets are
+    applied — unspecified flags keep their stored value.
+    """
+
+    has_seen_welcome: bool | None = None
+    energy_scaffolding_archived: bool | None = None
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self) -> Self:
+        provided = (
+            self.has_seen_welcome,
+            self.energy_scaffolding_archived,
+        )
+        if all(value is None for value in provided):
+            msg = "at least one field must be provided"
+            raise ValueError(msg)
+        return self

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2316,3 +2316,154 @@ def test_hier_reflection_migration_round_trip_on_sqlite(
     assert "reflection_level" in journal_cols_final
     assert "reflection_scope_key" in journal_cols_final
     assert _table_exists(db_url, "promotedquote")
+
+
+# -- useruiflags table migration round-trip -----------------------------------
+
+# down_revision is a9b0c1d2e3f4 (the promotedquote.stale migration, current head).
+_USER_UI_FLAGS_BASE_REVISION = "a9b0c1d2e3f4"  # pragma: allowlist secret
+_USER_UI_FLAGS_REVISION = "b4c5d6e7f8a1"  # pragma: allowlist secret
+
+
+def _bootstrap_user_table_for_ui_flags(sync_url: str) -> None:
+    """Pre-create a minimal ``user`` table with two seeded rows.
+
+    Mirrors the schema the ui-flags migration expects to find at
+    ``a9b0c1d2e3f4``. Two rows are seeded to prove the migration performs
+    no backfill even though existing users are present.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'alice@example.com')"))
+        conn.execute(text("INSERT INTO user (id, email) VALUES (2, 'bob@example.com')"))
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_user_ui_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite Alembic config positioned just before the ui-flags migration.
+
+    Bootstraps a minimal ``user`` table with two pre-existing rows and stamps
+    the DB at ``a9b0c1d2e3f4`` (the current chain head before this migration)
+    so the round-trip exercises only the new migration.
+    """
+    db_path = tmp_path / "user_ui_flags_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_user_table_for_ui_flags(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _USER_UI_FLAGS_BASE_REVISION)
+    return cfg
+
+
+def _ui_flags_row_count(db_url: str) -> int:
+    """Return the number of rows in ``useruiflags``."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            count: int = conn.execute(text("SELECT count(*) FROM useruiflags")).scalar_one()
+            return count
+    finally:
+        engine.dispose()
+
+
+def _insert_ui_flags_row_with_defaults(db_url: str, user_id: int) -> None:
+    """Insert a ``useruiflags`` row naming only ``user_id`` (raises on constraint violation)."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("INSERT INTO useruiflags (user_id) VALUES (:u)"),
+                {"u": user_id},
+            )
+    finally:
+        engine.dispose()
+
+
+def _ui_flags_row(db_url: str, user_id: int) -> dict[str, Any]:
+    """Fetch a single ``useruiflags`` row by ``user_id``."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT user_id, has_seen_welcome, energy_scaffolding_archived"
+                        " FROM useruiflags WHERE user_id = :u"
+                    ),
+                    {"u": user_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_user_ui_flags_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_user_ui_flags: Config,
+) -> None:
+    """Round-trip the ui-flags migration: upgrade creates an empty table; downgrade drops it.
+
+    Phase 1: upgrade creates ``useruiflags`` with zero rows despite two
+    pre-existing users -- the no-backfill design provisions rows only on
+    first GET, not via migration.
+    Phase 2: an insert naming only ``user_id`` proves both flag columns are
+    NOT NULL with a DB-level default of false.
+    Phase 3: a second insert for the same ``user_id`` violates the unique
+    constraint on that column.
+    Phase 4: downgrade drops the table entirely.
+    Phase 5: re-upgrade is idempotent -- the table is recreated empty.
+    """
+    cfg = alembic_sqlite_config_user_ui_flags
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade creates the table with zero rows (no backfill).
+    command.upgrade(cfg, _USER_UI_FLAGS_REVISION)
+    assert _table_exists(db_url, "useruiflags")
+    cols = _columns_of(db_url, "useruiflags")
+    assert {
+        "id",
+        "user_id",
+        "has_seen_welcome",
+        "energy_scaffolding_archived",
+    }.issubset(cols)
+    assert _ui_flags_row_count(db_url) == 0, (
+        "Existing users must not be backfilled; rows are provisioned on first GET."
+    )
+
+    # Phase 2: an insert naming only user_id proves both flags are NOT NULL
+    # with a DB-level default of false.
+    _insert_ui_flags_row_with_defaults(db_url, user_id=1)
+    row = _ui_flags_row(db_url, user_id=1)
+    assert bool(row["has_seen_welcome"]) is False
+    assert bool(row["energy_scaffolding_archived"]) is False
+
+    # Phase 3: user_id carries a unique constraint -- a second row for the
+    # same user is rejected.
+    with pytest.raises(IntegrityError):
+        _insert_ui_flags_row_with_defaults(db_url, user_id=1)
+
+    # Phase 4: downgrade drops the table entirely.
+    command.downgrade(cfg, _USER_UI_FLAGS_BASE_REVISION)
+    assert not _table_exists(db_url, "useruiflags")
+
+    # Phase 5: re-upgrade reproduces the empty table (idempotent cycle).
+    command.upgrade(cfg, _USER_UI_FLAGS_REVISION)
+    assert _table_exists(db_url, "useruiflags")
+    assert _ui_flags_row_count(db_url) == 0

--- a/backend/tests/test_ui_flags_api.py
+++ b/backend/tests/test_ui_flags_api.py
@@ -1,0 +1,202 @@
+"""Tests for GET /ui-flags and PATCH /ui-flags."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+_FLAGS_URL = "/ui-flags"
+
+# Both flag keys the response must carry.
+_FLAG_KEYS = ("has_seen_welcome", "energy_scaffolding_archived")
+
+
+async def _signup(client: AsyncClient, username: str = "uiflagsuser") -> dict[str, str]:
+    """Create an account and return auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    token = resp.json()["token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# GET — auto-provision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_auto_provisions_defaults(async_client: AsyncClient) -> None:
+    """Fresh user with no flags row gets 200 with both flags false."""
+    headers = await _signup(async_client)
+
+    resp = await async_client.get(_FLAGS_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    for key in _FLAG_KEYS:
+        assert body[key] is False, f"expected {key}=False, got {body[key]}"
+
+
+@pytest.mark.asyncio
+async def test_get_is_idempotent(async_client: AsyncClient) -> None:
+    """Calling GET twice returns identical all-false state (no duplicate/error)."""
+    headers = await _signup(async_client, "idem_flags")
+
+    first = await async_client.get(_FLAGS_URL, headers=headers)
+    second = await async_client.get(_FLAGS_URL, headers=headers)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert first.json() == second.json()
+    for key in _FLAG_KEYS:
+        assert second.json()[key] is False
+
+
+# ---------------------------------------------------------------------------
+# PATCH — partial update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_toggles_one_flag(async_client: AsyncClient) -> None:
+    """PATCH with one key flips that flag and leaves the other false."""
+    headers = await _signup(async_client, "one_flag")
+
+    resp = await async_client.patch(
+        _FLAGS_URL,
+        json={"has_seen_welcome": True},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    assert body["has_seen_welcome"] is True
+    assert body["energy_scaffolding_archived"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_partial_preserves_previous(async_client: AsyncClient) -> None:
+    """Second PATCH keeps the first flag true; both flags end up true."""
+    headers = await _signup(async_client, "two_patch_flags")
+
+    first_patch = await async_client.patch(
+        _FLAGS_URL,
+        json={"has_seen_welcome": True},
+        headers=headers,
+    )
+    assert first_patch.status_code == HTTPStatus.OK
+
+    second_patch = await async_client.patch(
+        _FLAGS_URL,
+        json={"energy_scaffolding_archived": True},
+        headers=headers,
+    )
+
+    assert second_patch.status_code == HTTPStatus.OK
+    body = second_patch.json()
+    assert body["has_seen_welcome"] is True
+    assert body["energy_scaffolding_archived"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_returns_both_keys(async_client: AsyncClient) -> None:
+    """PATCH response always includes both flag booleans."""
+    headers = await _signup(async_client, "full_resp_flags")
+
+    resp = await async_client.patch(
+        _FLAGS_URL,
+        json={"has_seen_welcome": True},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    for key in _FLAG_KEYS:
+        assert key in body, f"response missing key '{key}'"
+        assert isinstance(body[key], bool), f"expected bool for '{key}', got {type(body[key])}"
+
+
+# ---------------------------------------------------------------------------
+# Auth required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_requires_auth(async_client: AsyncClient) -> None:
+    """GET without a token returns 401."""
+    resp = await async_client.get(_FLAGS_URL)
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_get_invalid_token_returns_401(async_client: AsyncClient) -> None:
+    """GET with a malformed token returns 401."""
+    resp = await async_client.get(
+        _FLAGS_URL,
+        headers={"Authorization": "Bearer not.a.valid.token"},
+    )
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_patch_requires_auth(async_client: AsyncClient) -> None:
+    """PATCH without a token returns 401."""
+    resp = await async_client.patch(_FLAGS_URL, json={"has_seen_welcome": True})
+
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Caller-only isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_does_not_affect_other_user(async_client: AsyncClient) -> None:
+    """Toggling one user's flag leaves another user's flags all-false."""
+    alice_headers = await _signup(async_client, "alice_flags")
+    bob_headers = await _signup(async_client, "bob_flags")
+
+    # Alice marks the welcome flag seen.
+    patch = await async_client.patch(
+        _FLAGS_URL,
+        json={"has_seen_welcome": True},
+        headers=alice_headers,
+    )
+    assert patch.status_code == HTTPStatus.OK
+    assert patch.json()["has_seen_welcome"] is True
+
+    # Bob's flags are untouched; no user_id in the request body.
+    bob_resp = await async_client.get(_FLAGS_URL, headers=bob_headers)
+    assert bob_resp.status_code == HTTPStatus.OK
+    for key in _FLAG_KEYS:
+        assert bob_resp.json()[key] is False, f"Bob's {key} was mutated by Alice's PATCH"
+
+    # Alice's state is her own; re-GET confirms persistence.
+    alice_resp = await async_client.get(_FLAGS_URL, headers=alice_headers)
+    assert alice_resp.json()["has_seen_welcome"] is True
+
+
+# ---------------------------------------------------------------------------
+# Empty-body rejection (mirrors JournalEntryUpdate at-least-one guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_returns_422(async_client: AsyncClient) -> None:
+    """PATCH with no fields set is rejected so a no-op cannot reach the DB."""
+    headers = await _signup(async_client, "empty_flags")
+
+    resp = await async_client.patch(_FLAGS_URL, json={}, headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary

Adds per-user server-side persistence for two one-time UI dismissal flags — `has_seen_welcome` and `energy_scaffolding_archived` — so they survive logout and browser storage wipes (e.g. Brave clearing site data), instead of living only in device-local storage.

This is the FOUNDATION backend sub-issue of the server-ui-flags epic; the two frontend sub-issues (#1536, #1537) consume this endpoint's response shape.

- New `UserUiFlags` SQLModel table (`useruiflags`): `id`, unique cascading `user_id` FK, and two `NOT NULL` booleans defaulting to `false` (`server_default="0"` mirrored to the migration's `sa.false()` so `alembic check` stays drift-free).
- Alembic migration `b4c5d6e7f8a1` (chains off head `a9b0c1d2e3f4`) creates the table with **no backfill** — existing users are provisioned lazily on first read.
- JWT-scoped `/ui-flags` router: `GET` provisions an all-false row on first access (idempotent, no duplicate rows); `PATCH` partially updates only the fields present and returns the full new state; empty body → 422. Caller identity comes solely from the JWT — no `user_id` accepted from body or path.
- Mirrors the established depth-preferences vertical (model, `domain/` ensure-helper with SAVEPOINT/IntegrityError race handling, response + update DTOs, router mounted in `main.py`).

## Test plan

New `backend/tests/test_ui_flags_api.py` (10 tests) plus a migration round-trip test in `test_migrations.py`:

- `GET` auto-provisions both flags `false`; second `GET` is identical (no duplicate row).
- `PATCH` toggles one flag; partial `PATCH` preserves the other; response always carries both keys; `PATCH {}` → 422.
- Auth: missing token → 401, malformed token → 401.
- Cross-user isolation: one user's `PATCH` never mutates another's flags.
- Migration: upgrade/downgrade round-trip, `NOT NULL` default-false columns, unique `user_id`, and zero rows post-upgrade (locks in the no-backfill design).

Local gates: `scripts/backend/check-all.sh` green (ruff lint+format, mypy strict, bandit, complexity), full suite 2620 passed, coverage 96.63%, xenon A / radon A on the new modules, single alembic head, and Gate 2.5 self-review CLEAN.

Closes #1535
Refs #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)