### PR TITLE
fix(frontend): welcome intro shows once per account via server /ui-flags hydration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,7 +142,8 @@ function AuthNavigator() {
  * false, so the shell renders without a flash.
  */
 function WelcomeGate(): React.JSX.Element {
-  const { isFirstRun, markSeen } = useFirstRun();
+  const { token } = useAuth();
+  const { isFirstRun, markSeen } = useFirstRun(token);
   if (isFirstRun) {
     return <WelcomeScreen onComplete={markSeen} onBegin={markSeen} />;
   }

--- a/frontend/src/__tests__/navigation/welcomeGate.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeGate.test.tsx
@@ -78,13 +78,26 @@ jest.mock('@/storage/welcomeStorage', () => ({
   clearHasSeenWelcome: jest.fn(() => Promise.resolve()),
 }));
 
-import { render, act } from '@testing-library/react-native';
+// A never-settling GET keeps the store gated on the local-cache fallback for
+// tests that drive useWelcomeStore state directly.
+jest.mock('@/api', () => ({
+  __esModule: true,
+  uiFlags: {
+    get: jest.fn(() => new Promise(() => undefined)),
+    update: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { render, act, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
+import { uiFlags } from '@/api';
 import { RootNavigator } from '@/App';
 import * as AuthContextModule from '@/context/AuthContext';
 import type { AuthStatus } from '@/context/AuthContext';
 import { useWelcomeStore } from '@/store/useWelcomeStore';
+
+const mockUiFlagsGet = jest.mocked(uiFlags.get);
 
 function mockAuthenticated() {
   jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
@@ -151,5 +164,52 @@ describe('WelcomeGate → Journal shell (regression locks)', () => {
     const { getByTestId, queryByTestId } = render(<RootNavigator />);
     expect(getByTestId('root-stack')).toBeTruthy();
     expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+});
+
+// End-to-end through the real useFirstRun hook (not a setState bypass) so the
+// server round-trip actually drives the gate.
+describe('WelcomeGate — server hydration', () => {
+  beforeEach(() => {
+    act(() => useWelcomeStore.setState({ hasSeenWelcome: null }));
+  });
+
+  it('does not flash the welcome while the server GET is still pending', () => {
+    mockUiFlagsGet.mockReturnValueOnce(
+      new Promise<{ has_seen_welcome: boolean; energy_scaffolding_archived: boolean }>(
+        () => undefined,
+      ),
+    );
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+    // Pins that hydration is server-driven, not just the stay-closed no-flash.
+    expect(mockUiFlagsGet).toHaveBeenCalledWith('jwt');
+  });
+
+  it('returning user (server has_seen_welcome=true, empty local cache) lands on root-stack', async () => {
+    mockUiFlagsGet.mockResolvedValueOnce({
+      has_seen_welcome: true,
+      energy_scaffolding_archived: false,
+    });
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    await waitFor(() => expect(mockUiFlagsGet).toHaveBeenCalledWith('jwt'));
+    expect(getByTestId('root-stack')).toBeTruthy();
+    expect(queryByTestId('welcome-screen')).toBeNull();
+  });
+
+  it('first-run (server has_seen_welcome=false) shows Welcome; markSeen closes it', async () => {
+    mockUiFlagsGet.mockResolvedValueOnce({
+      has_seen_welcome: false,
+      energy_scaffolding_archived: false,
+    });
+    const { getByTestId, queryByTestId } = render(<RootNavigator />);
+    await waitFor(() => expect(getByTestId('welcome-screen')).toBeTruthy());
+    expect(queryByTestId('root-stack')).toBeNull();
+
+    act(() => useWelcomeStore.getState().markWelcomeSeen());
+
+    expect(queryByTestId('welcome-screen')).toBeNull();
+    expect(getByTestId('root-stack')).toBeTruthy();
   });
 });

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -160,6 +160,16 @@ jest.mock('@/storage/welcomeStorage', () => ({
   clearHasSeenWelcome: jest.fn(() => Promise.resolve()),
 }));
 
+// A never-settling GET falls through to the local-cache mock above so this
+// file's direct useWelcomeStore.setState scenarios are unaffected.
+jest.mock('@/api', () => ({
+  __esModule: true,
+  uiFlags: {
+    get: jest.fn(() => new Promise(() => undefined)),
+    update: jest.fn(() => new Promise(() => undefined)),
+  },
+}));
+
 // ─── FeatureErrorBoundary — transparent pass-through ─────────────────────────
 jest.mock('@/components/FeatureErrorBoundary', () => {
   const React = require('react');

--- a/frontend/src/api/__tests__/uiFlags-api.test.ts
+++ b/frontend/src/api/__tests__/uiFlags-api.test.ts
@@ -1,0 +1,97 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import { ApiError, ApiValidationError, uiFlags } from '../index';
+import type { UiFlags } from '../index';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+const ALL_SEEN: UiFlags = {
+  has_seen_welcome: true,
+  energy_scaffolding_archived: false,
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('uiFlags.get', () => {
+  test('GETs /ui-flags (no trailing slash) with the bearer token and returns the parsed body', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse(ALL_SEEN));
+    const result = await uiFlags.get('tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/ui-flags');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer tok');
+    expect(result.has_seen_welcome).toBe(true);
+    expect(result.energy_scaffolding_archived).toBe(false);
+  });
+
+  test('surfaces a 401 as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unauthorized' }, 401));
+    const err = await uiFlags.get('bad-tok').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(401);
+  });
+
+  test('rejects a malformed payload (non-boolean field) with ApiValidationError', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        has_seen_welcome: 'yes',
+        energy_scaffolding_archived: false,
+      }),
+    );
+    await expect(uiFlags.get('tok')).rejects.toBeInstanceOf(ApiValidationError);
+  });
+
+  test('strips unknown keys from the response', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({
+        has_seen_welcome: true,
+        energy_scaffolding_archived: false,
+        unexpected_field: 'should be stripped',
+      }),
+    );
+    const result = await uiFlags.get('tok');
+    expect(result).toEqual(ALL_SEEN);
+    expect((result as Record<string, unknown>).unexpected_field).toBeUndefined();
+  });
+});
+
+describe('uiFlags.update', () => {
+  test('PATCHes /ui-flags with the partial body verbatim and returns the full echo', async () => {
+    const fullResponse: UiFlags = {
+      has_seen_welcome: true,
+      energy_scaffolding_archived: false,
+    };
+    mockFetch.mockReturnValueOnce(jsonResponse(fullResponse));
+
+    const result = await uiFlags.update({ has_seen_welcome: true }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/ui-flags');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toEqual({ has_seen_welcome: true });
+    expect(result.has_seen_welcome).toBe(true);
+    expect(result.energy_scaffolding_archived).toBe(false);
+  });
+
+  test('surfaces a 422 (empty body rejection) as an ApiError', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'unprocessable_entity' }, 422));
+    await expect(uiFlags.update({}, 'tok')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 422,
+    });
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,6 +34,7 @@ import {
   stageProgressRecordSchema,
   stageSchema,
   timezoneReadSchema,
+  uiFlagsSchema,
   wheelBalanceSchema,
   type AcceptSuggestionResultT,
   type CareKindT,
@@ -44,6 +45,7 @@ import {
   type ContractionVariantT,
   type CompletionTargetTypeT,
   type DepthPreferencesT,
+  type UiFlagsT,
   type InvitationT,
   type journalTagSchema,
   type MettaReturnStateT,
@@ -2602,6 +2604,43 @@ export const depthPreferences = {
       body: partial,
       token,
       schema: depthPreferencesResponseSchema,
+    });
+  },
+};
+
+// Per-account UI flags (server-owned one-time UI state, e.g. hasSeenWelcome)
+
+/** Full UI-flags state (mirrors the backend response). */
+export type UiFlags = UiFlagsT;
+
+/** Partial update body — only the flipped flags are sent. */
+export type UiFlagsUpdate = Partial<UiFlags>;
+
+// Responses are validated via ``uiFlagsSchema`` so a mis-shaped payload (e.g. a
+// non-boolean flag) raises ApiValidationError rather than silently corrupting a
+// flag. The route has no trailing slash — the backend serves ``/ui-flags``
+// directly (no 307 redirect).
+const uiFlagsResponseSchema = uiFlagsSchema as unknown as z.ZodType<UiFlags>;
+
+export const uiFlags = {
+  /** Read the caller's current UI flags. */
+  get(token?: string): Promise<UiFlags> {
+    return request<UiFlags>('/ui-flags', {
+      token,
+      schema: uiFlagsResponseSchema,
+    });
+  },
+  /**
+   * Flip one or more flags. The partial is sent verbatim; the server echoes the
+   * FULL state back, so callers get the authoritative post-update snapshot
+   * rather than the subset they sent.
+   */
+  update(partial: UiFlagsUpdate, token?: string): Promise<UiFlags> {
+    return request<UiFlags>('/ui-flags', {
+      method: 'PATCH',
+      body: partial,
+      token,
+      schema: uiFlagsResponseSchema,
     });
   },
 };

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -731,6 +731,20 @@ export const depthPreferencesSchema = z.object({
 export type DepthPreferencesT = z.infer<typeof depthPreferencesSchema>;
 
 // ---------------------------------------------------------------------------
+// UI flags (per-account, server-owned one-time UI state)
+// ---------------------------------------------------------------------------
+
+// Per-account UI flags (mirrors the backend ``UiFlags``). Plain object, not
+// ``.strict()``, so unknown keys are stripped and an additive backend field
+// cannot fail a client build; a non-boolean field raises ApiValidationError.
+export const uiFlagsSchema = z.object({
+  has_seen_welcome: z.boolean(),
+  energy_scaffolding_archived: z.boolean(),
+});
+
+export type UiFlagsT = z.infer<typeof uiFlagsSchema>;
+
+// ---------------------------------------------------------------------------
 // Wheel-of-wholeness balance (Map balance reading)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/store/__tests__/useWelcomeStore.test.tsx
+++ b/frontend/src/store/__tests__/useWelcomeStore.test.tsx
@@ -7,10 +7,32 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(() => Promise.resolve()),
 }));
 
+// useFirstRun is server-first, falling back to the local cache above only when
+// the GET rejects.
+jest.mock('@/api', () => ({
+  __esModule: true,
+  uiFlags: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
 const mockAsyncStorage = jest.requireMock('@react-native-async-storage/async-storage') as {
   setItem: jest.Mock<(_key: string, _value: string) => Promise<void>>;
   getItem: jest.Mock<(_key: string) => Promise<string | null>>;
   removeItem: jest.Mock<(_key: string) => Promise<void>>;
+};
+
+interface MockUiFlagsState {
+  has_seen_welcome: boolean;
+  energy_scaffolding_archived: boolean;
+}
+
+const mockUiFlags = (jest.requireMock('@/api') as { uiFlags: unknown }).uiFlags as {
+  get: jest.Mock<(_token?: string) => Promise<MockUiFlagsState>>;
+  update: jest.Mock<
+    (_partial: Partial<MockUiFlagsState>, _token?: string) => Promise<MockUiFlagsState>
+  >;
 };
 
 import { useFirstRun, useWelcomeStore } from '../useWelcomeStore';
@@ -18,6 +40,14 @@ import { useFirstRun, useWelcomeStore } from '../useWelcomeStore';
 beforeEach(() => {
   jest.clearAllMocks();
   mockAsyncStorage.getItem.mockResolvedValue(null);
+  // Default: no server hydration source, so `useFirstRun` falls back to the
+  // local cache exactly as before this issue landed. Individual tests below
+  // override with a resolved value to exercise the server-first path.
+  mockUiFlags.get.mockRejectedValue(new Error('no server hydration configured'));
+  mockUiFlags.update.mockResolvedValue({
+    has_seen_welcome: true,
+    energy_scaffolding_archived: false,
+  });
   act(() => {
     useWelcomeStore.setState({ hasSeenWelcome: null });
   });
@@ -56,5 +86,79 @@ describe('useWelcomeStore.reset', () => {
     });
     expect(useWelcomeStore.getState().hasSeenWelcome).toBeNull();
     expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/has_seen_welcome');
+  });
+
+  // Regression guard: reset() must stay a purely local wipe. Routing it through
+  // uiFlags.update would flip has_seen_welcome back to false server-side on
+  // every logout, replaying the welcome intro for every account on the device.
+  it('never calls uiFlags.update', () => {
+    act(() => {
+      useWelcomeStore.getState().hydrateHasSeenWelcome(true);
+      useWelcomeStore.getState().reset();
+    });
+    expect(mockUiFlags.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('useFirstRun — server hydration', () => {
+  it('hydrates false and re-seeds the local cache when the server reports true', async () => {
+    mockUiFlags.get.mockResolvedValueOnce({
+      has_seen_welcome: true,
+      energy_scaffolding_archived: false,
+    });
+    const { result } = renderHook(() => useFirstRun('server-tok'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.isFirstRun).toBe(false);
+    // Brave-wipe scenario: local cache is empty, but the server is the
+    // source of truth, so the local cache is re-seeded to match it.
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('@adepthood/has_seen_welcome', 'true');
+  });
+
+  it('hydrates true and clears the local cache when the server reports false', async () => {
+    mockUiFlags.get.mockResolvedValueOnce({
+      has_seen_welcome: false,
+      energy_scaffolding_archived: false,
+    });
+    const { result } = renderHook(() => useFirstRun('server-tok'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.isFirstRun).toBe(true);
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/has_seen_welcome');
+  });
+
+  it('falls back to the local cache when the server GET rejects', async () => {
+    mockUiFlags.get.mockRejectedValueOnce(new Error('network unreachable'));
+    mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+    const { result } = renderHook(() => useFirstRun('server-tok'));
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.isFirstRun).toBe(false);
+    // Pins that the server path was actually attempted (with the token) before
+    // the fallback ran, not that the hook skipped straight to local storage.
+    expect(mockUiFlags.get).toHaveBeenCalledWith('server-tok');
+  });
+
+  it('markSeen flips state synchronously and fires uiFlags.update with the token, best-effort', async () => {
+    mockUiFlags.get.mockRejectedValueOnce(new Error('network unreachable'));
+    const { result } = renderHook(() => useFirstRun('server-tok'));
+    await waitFor(() => expect(result.current.isFirstRun).toBe(true));
+
+    act(() => result.current.markSeen());
+
+    expect(result.current.isFirstRun).toBe(false);
+    expect(mockUiFlags.update).toHaveBeenCalledWith({ has_seen_welcome: true }, 'server-tok');
+  });
+
+  it('markSeen state stays true and warns when uiFlags.update rejects', async () => {
+    mockUiFlags.get.mockRejectedValueOnce(new Error('network unreachable'));
+    mockUiFlags.update.mockRejectedValueOnce(new Error('server unreachable'));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useFirstRun('server-tok'));
+    await waitFor(() => expect(result.current.isFirstRun).toBe(true));
+
+    act(() => result.current.markSeen());
+    expect(result.current.isFirstRun).toBe(false);
+
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    warnSpy.mockRestore();
   });
 });

--- a/frontend/src/store/useWelcomeStore.ts
+++ b/frontend/src/store/useWelcomeStore.ts
@@ -1,8 +1,12 @@
-// First-run state for the program welcome (issue #836). Backed by AsyncStorage
-// so the editorial intro shows exactly once; returning users are never gated.
-import { useEffect } from 'react';
+// First-run state for the program welcome (issue #836). The SERVER owns the
+// per-account ``has_seen_welcome`` flag after login; AsyncStorage is only an
+// offline/latency cache. On mount we hydrate from ``GET /ui-flags`` and re-seed
+// the local cache to match, falling back to the cache when the server is
+// unreachable. This keeps the intro per-account instead of per-device.
+import { useCallback, useEffect } from 'react';
 import { create } from 'zustand';
 
+import { uiFlags } from '../api';
 import {
   clearHasSeenWelcome,
   loadHasSeenWelcome,
@@ -18,8 +22,8 @@ export interface WelcomeStoreState {
   hasSeenWelcome: boolean | null;
   // Seed from storage on boot without re-writing it.
   hydrateHasSeenWelcome: (_seen: boolean) => void;
-  // Mark the welcome complete (Begin or Skip) and persist it.
-  markWelcomeSeen: () => void;
+  // Mark the welcome complete (Begin or Skip); persists local + syncs server.
+  markWelcomeSeen: (_token?: string) => void;
   // BUG-FE-STATE-001: wipe on logout. Also clears persisted storage.
   reset: () => void;
 }
@@ -35,15 +39,30 @@ const persistAsync = (seen: boolean): void => {
   });
 };
 
+// Server is source of truth after login; fall back to the local cache only when
+// the GET rejects (offline / 401). Kept flat to stay well under the cognitive
+// complexity budget.
+async function resolveHasSeenWelcome(token?: string): Promise<boolean> {
+  try {
+    const flags = await uiFlags.get(token);
+    return flags.has_seen_welcome;
+  } catch {
+    return loadHasSeenWelcome();
+  }
+}
+
 export const useWelcomeStore = create<WelcomeStoreState>((set) => ({
   ...INITIAL_STATE,
 
   hydrateHasSeenWelcome: (seen) => {
     set({ hasSeenWelcome: seen });
   },
-  markWelcomeSeen: () => {
+  markWelcomeSeen: (token) => {
     set({ hasSeenWelcome: true });
     persistAsync(true);
+    uiFlags.update({ has_seen_welcome: true }, token).catch((err) => {
+      console.warn('[useWelcomeStore] failed to sync welcome flag', err);
+    });
   },
   reset: () => {
     set({ ...INITIAL_STATE });
@@ -66,26 +85,35 @@ export interface FirstRun {
 }
 
 /**
- * First-run gate for the program welcome. Hydrates the persisted flag on mount,
- * then reports whether the editorial intro should show. ``isFirstRun`` is
- * ``true`` exactly when the flag has resolved to unset; it flips to ``false``
- * the moment ``markSeen`` runs, so the welcome shows once and never again.
+ * First-run gate for the program welcome. On mount it hydrates the flag from the
+ * server (``GET /ui-flags``, source of truth after login), re-seeding the local
+ * cache both directions, and falls back to that cache when the server is
+ * unreachable. ``isFirstRun`` is ``true`` exactly when the flag resolves to
+ * unset; it flips to ``false`` the moment ``markSeen`` runs, so the welcome
+ * shows once per account and never again.
  */
-export function useFirstRun(): FirstRun {
+export function useFirstRun(token?: string | null): FirstRun {
+  const normalizedToken = token ?? undefined;
   const hasSeenWelcome = useWelcomeStore((s) => s.hasSeenWelcome);
   const hydrate = useWelcomeStore((s) => s.hydrateHasSeenWelcome);
-  const markSeen = useWelcomeStore((s) => s.markWelcomeSeen);
+  const markWelcomeSeen = useWelcomeStore((s) => s.markWelcomeSeen);
 
   useEffect(() => {
     if (hasSeenWelcome !== null) return;
     let cancelled = false;
-    void loadHasSeenWelcome().then((seen) => {
-      if (!cancelled) hydrate(seen);
+    void resolveHasSeenWelcome(normalizedToken).then((seen) => {
+      if (cancelled) return;
+      hydrate(seen);
+      persistAsync(seen);
     });
     return () => {
       cancelled = true;
     };
-  }, [hasSeenWelcome, hydrate]);
+  }, [hasSeenWelcome, hydrate, normalizedToken]);
+
+  const markSeen = useCallback(() => {
+    markWelcomeSeen(normalizedToken);
+  }, [markWelcomeSeen, normalizedToken]);
 
   return {
     isFirstRun: hasSeenWelcome === false,


### PR DESCRIPTION
## Summary

The program welcome intro replayed on every login because `hasSeenWelcome` lived only in browser localStorage — wiped whenever Brave clears site data — and `useWelcomeStore.reset()` actively cleared it on every logout (BUG-FE-STATE-001 shared-device hygiene). This makes the flag per-**account** instead of per-device:

- `useFirstRun(token)` now hydrates from the backend `GET /ui-flags` (source of truth after login) and falls back to the local AsyncStorage cache only when the server is unreachable/401. On resolve it re-seeds the cache both directions.
- `markWelcomeSeen(token)` writes local optimistically and best-effort `PATCH /ui-flags { has_seen_welcome: true }` (console.warn on failure, matching the existing `persistAsync` style).
- New `uiFlags` API client + `uiFlagsSchema` mirror the existing `depthPreferences` precedent. The shared schema deliberately carries **both** `has_seen_welcome` and `energy_scaffolding_archived` so the sibling energy-scaffolding issue reuses the same client/schema untouched.
- The BUG-FE-STATE-001 logout wipe of local state is preserved unchanged — correctness now comes from server re-hydration on next login. The no-flash contract (gate stays closed while `hasSeenWelcome === null`) is preserved.

Local AsyncStorage remains an offline/latency cache; the server is authoritative after login.

## Test plan

- New `uiFlags` API client tests: GET/PATCH hit `/ui-flags` (no trailing slash) with the bearer token, validate the response, strip unknown keys, and raise `ApiValidationError` on a mis-shaped payload.
- Store/hook tests: server `true` → hydrate true + re-seed cache (the Brave-wipe scenario); server `false` → hydrate false + clear cache; GET reject → fall back to local cache; `markWelcomeSeen` fires `PATCH` and warns on rejection; explicit regression guard that `reset()` stays a purely local wipe and never PATCHes the server.
- Navigation tests: no-flash while the server GET is pending; returning user (server true, empty cache) lands on the shell; first-run user sees the intro and `markSeen` closes it.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, full Jest suite — 4112 tests passing).

Closes #1536
Refs #1534