### PR TITLE
fix(frontend): persist energy-scaffolding CTA archived flag via server /ui-flags

### DIFF
--- a/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
@@ -54,6 +54,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       // The id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the
       // settings-modal assertion fails if the screen falls back to the demo seed.

--- a/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEmojiPicker.test.tsx
@@ -21,6 +21,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       // The id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the
       // update assertion fails if the screen ever falls back to the demo seed.

--- a/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitsIntegration.test.ts
@@ -44,6 +44,11 @@ jest.mock('../../../api', () => ({
   goals: {
     update: jest.fn(() => Promise.resolve({})),
   },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: jest.fn(() => Promise.reject(new Error('no server hydration configured'))),
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
@@ -48,6 +48,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       listAll: () =>
         Promise.resolve([

--- a/frontend/src/features/Habits/__tests__/HabitsPaginationVisibility.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsPaginationVisibility.test.tsx
@@ -53,6 +53,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       listAll: jest.fn() as any,
       create: jest.fn() as any,

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -43,6 +43,17 @@ jest.mock('../../../api', () => ({
     }),
   },
   goalCompletions: { create: jest.fn() as any },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: (jest.fn() as any).mockResolvedValue({
+      has_seen_welcome: false,
+      energy_scaffolding_archived: false,
+    }),
+    update: (jest.fn() as any).mockResolvedValue({
+      has_seen_welcome: false,
+      energy_scaffolding_archived: true,
+    }),
+  },
 }));
 
 jest.mock('../../../context/AuthContext', () => ({

--- a/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
@@ -42,6 +42,11 @@ jest.mock('../../../api', () => ({
       }),
   },
   goalCompletions: { create: jest.fn() },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: () => Promise.reject(new Error('no server hydration configured')),
+    update: jest.fn(),
+  },
 }));
 
 jest.mock('../../../context/AuthContext', () => ({

--- a/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../../api', () => ({
       }),
   },
   goalCompletions: { create: jest.fn() },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: () => Promise.reject(new Error('no server hydration configured')),
+    update: jest.fn(),
+  },
 }));
 
 jest.mock('../../../context/AuthContext', () => ({

--- a/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsSecondLap.test.tsx
@@ -51,6 +51,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       listAll: jest.fn() as any,
       create: jest.fn() as any,

--- a/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsStageColors.test.tsx
@@ -50,6 +50,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       listAll: jest.fn() as any,
       create: jest.fn() as any,

--- a/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingFlow.test.tsx
@@ -28,6 +28,11 @@ jest.mock('../../../api', () => ({
   goals: {
     update: jest.fn(() => Promise.resolve({})),
   },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: jest.fn(() => Promise.reject(new Error('no server hydration configured'))),
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -31,6 +31,11 @@ jest.mock('../../../api', () => ({
     }),
   },
   goalCompletions: { create: jest.fn() },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: (jest.fn() as any).mockRejectedValue(new Error('no server hydration configured')),
+    update: jest.fn(),
+  },
 }));
 /* eslint-enable @typescript-eslint/no-explicit-any */
 

--- a/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
+++ b/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
@@ -51,6 +51,21 @@ jest.mock('../../../api', () => {
   const actual: typeof ApiModule = jest.requireActual('../../../api');
   return {
     ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
     habits: {
       // One unlocked habit (past start_date) so the tile renders and is pressable.
       // Its id is deliberately distinct from FALLBACK_HABITS[0].id (1) so the

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -20,6 +20,11 @@ jest.mock('../../../api', () => ({
   goals: {
     update: jest.fn(() => Promise.resolve({})),
   },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: jest.fn(() => Promise.reject(new Error('no server hydration configured'))),
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../../storage/habitStorage', () => ({

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitActions.test.tsx
@@ -41,6 +41,11 @@ jest.mock('../../../../api', () => {
     goals: {
       update: jest.fn(() => Promise.resolve({})),
     },
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() => Promise.reject(new Error('no server hydration configured'))),
+      update: jest.fn(() => Promise.resolve({})),
+    },
   };
 });
 

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitUI.test.ts
@@ -11,6 +11,16 @@ jest.mock('../../../../storage/energyScaffoldingStorage', () => ({
   saveEnergyScaffoldingArchived: jest.fn(() => Promise.resolve(undefined)),
 }));
 
+// useHabitUI is server-first, falling back to the local cache above only when
+// the GET rejects.
+jest.mock('@/api', () => ({
+  __esModule: true,
+  uiFlags: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
 import {
   loadEnergyScaffoldingArchived,
   saveEnergyScaffoldingArchived,
@@ -24,9 +34,29 @@ const mockSave = saveEnergyScaffoldingArchived as jest.MockedFunction<
   typeof saveEnergyScaffoldingArchived
 >;
 
+interface MockUiFlagsState {
+  has_seen_welcome: boolean;
+  energy_scaffolding_archived: boolean;
+}
+
+const mockUiFlags = (jest.requireMock('@/api') as { uiFlags: unknown }).uiFlags as {
+  get: jest.Mock<(_token?: string) => Promise<MockUiFlagsState>>;
+  update: jest.Mock<
+    (_partial: Partial<MockUiFlagsState>, _token?: string) => Promise<MockUiFlagsState>
+  >;
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
+  // Default: no server hydration source, so the hook falls back to the local
+  // cache exactly as before this issue landed. Individual tests below override
+  // with a resolved value to exercise the server-first path.
+  mockUiFlags.get.mockRejectedValue(new Error('no server hydration configured'));
+  mockUiFlags.update.mockResolvedValue({
+    has_seen_welcome: true,
+    energy_scaffolding_archived: true,
+  });
 });
 
 afterEach(() => {
@@ -76,5 +106,91 @@ describe('useHabitUI — energy scaffolding CTA', () => {
       jest.advanceTimersByTime(3000);
     });
     expect(result.current.showArchiveMessage).toBe(false);
+  });
+
+  describe('server-first hydration', () => {
+    it('server wins over a wiped local cache: archived server flag hides the CTA', async () => {
+      mockLoad.mockResolvedValueOnce(false);
+      mockUiFlags.get.mockResolvedValueOnce({
+        has_seen_welcome: false,
+        energy_scaffolding_archived: true,
+      });
+      const { result } = renderHook(() => useHabitUI('server-tok'));
+      await waitFor(() => expect(mockUiFlags.get).toHaveBeenCalledWith('server-tok'));
+      await waitFor(() => expect(result.current.showEnergyCTA).toBe(false));
+    });
+
+    it('reveals the CTA for a first-time user when both server and local report unarchived', async () => {
+      mockLoad.mockResolvedValueOnce(false);
+      mockUiFlags.get.mockResolvedValueOnce({
+        has_seen_welcome: false,
+        energy_scaffolding_archived: false,
+      });
+      const { result } = renderHook(() => useHabitUI('server-tok'));
+      await waitFor(() => expect(mockUiFlags.get).toHaveBeenCalledWith('server-tok'));
+      await waitFor(() => expect(result.current.showEnergyCTA).toBe(true));
+    });
+
+    it('re-seeds the local cache with the server-resolved value after hydration', async () => {
+      mockUiFlags.get.mockResolvedValueOnce({
+        has_seen_welcome: false,
+        energy_scaffolding_archived: true,
+      });
+      renderHook(() => useHabitUI('server-tok'));
+      await waitFor(() => expect(mockSave).toHaveBeenCalledWith(true));
+    });
+
+    it('falls back to the local cache when the server GET rejects', async () => {
+      mockUiFlags.get.mockRejectedValueOnce(new Error('network unreachable'));
+      mockLoad.mockResolvedValueOnce(true);
+      const { result } = renderHook(() => useHabitUI('server-tok'));
+      // Pins that the server path was actually attempted (with the token) before
+      // the fallback ran, not that the hook skipped straight to local storage.
+      await waitFor(() => expect(mockUiFlags.get).toHaveBeenCalledWith('server-tok'));
+      await waitFor(() => expect(result.current.showEnergyCTA).toBe(false));
+    });
+  });
+
+  describe('archive PATCHes the server, best-effort', () => {
+    it('archiveEnergyCTA syncs the server flag with the token after hydration', async () => {
+      mockUiFlags.get.mockResolvedValueOnce({
+        has_seen_welcome: false,
+        energy_scaffolding_archived: false,
+      });
+      const { result } = renderHook(() => useHabitUI('server-tok'));
+      await waitFor(() => expect(result.current.showEnergyCTA).toBe(true));
+
+      act(() => {
+        result.current.archiveEnergyCTA();
+      });
+
+      expect(result.current.showEnergyCTA).toBe(false);
+      expect(result.current.showArchiveMessage).toBe(true);
+      expect(mockSave).toHaveBeenCalledWith(true);
+      expect(mockUiFlags.update).toHaveBeenCalledWith(
+        { energy_scaffolding_archived: true },
+        'server-tok',
+      );
+    });
+
+    it('stays hidden and warns when the PATCH rejects', async () => {
+      mockUiFlags.get.mockResolvedValueOnce({
+        has_seen_welcome: false,
+        energy_scaffolding_archived: false,
+      });
+      mockUiFlags.update.mockRejectedValueOnce(new Error('server unreachable'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const { result } = renderHook(() => useHabitUI('server-tok'));
+      await waitFor(() => expect(result.current.showEnergyCTA).toBe(true));
+
+      act(() => {
+        result.current.archiveEnergyCTA();
+      });
+      expect(result.current.showEnergyCTA).toBe(false);
+
+      await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/frontend/src/features/Habits/hooks/useHabitUI.ts
+++ b/frontend/src/features/Habits/hooks/useHabitUI.ts
@@ -7,8 +7,22 @@ import {
 import { selectHabitById, useHabitStore } from '../../../store/useHabitStore';
 import type { Habit, HabitScreenMode } from '../Habits.types';
 
+import { uiFlags } from '@/api';
+
 /** Toast dismissal delay for the archive-CTA acknowledgement message. */
 const ARCHIVE_MESSAGE_DURATION_MS = 3000;
+
+// Server is source of truth after login (account-scoped ``GET /ui-flags``); the
+// local cache is only an offline fallback when the GET rejects. Kept flat to
+// stay well under the cognitive-complexity budget.
+async function resolveEnergyArchived(token?: string): Promise<boolean> {
+  try {
+    const flags = await uiFlags.get(token);
+    return flags.energy_scaffolding_archived;
+  } catch {
+    return loadEnergyScaffoldingArchived();
+  }
+}
 
 export interface HabitUIState {
   /** Currently selected habit, derived from the store by ID. */
@@ -32,21 +46,25 @@ export interface HabitUIState {
  * only `selectedHabitId` here; the habit is resolved via a selector so that
  * updates to the store propagate automatically — no stale closures.
  */
-export const useHabitUI = (): HabitUIState => {
+export const useHabitUI = (token?: string | null): HabitUIState => {
+  const normalizedToken = token ?? undefined;
   const [selectedHabitId, setSelectedHabitId] = useState<number | null>(null);
   const selectedHabit = useHabitStore(selectHabitById(selectedHabitId)) ?? null;
   const [mode, setMode] = useState<HabitScreenMode>('normal');
   const [emojiHabitIndex, setEmojiHabitIndex] = useState<number | null>(null);
   // Start hidden so a previously-archived CTA never flashes before the async
-  // storage read resolves; the effect reveals it only when it isn't archived.
+  // read resolves; the effect reveals it only when it isn't archived.
   const [showEnergyCTA, setShowEnergyCTA] = useState(false);
   const [showArchiveMessage, setShowArchiveMessage] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    loadEnergyScaffoldingArchived()
+    resolveEnergyArchived(normalizedToken)
       .then((archived) => {
-        if (!cancelled) setShowEnergyCTA(!archived);
+        if (cancelled) return;
+        setShowEnergyCTA(!archived);
+        // Re-seed the offline cache so it matches the server-resolved value.
+        saveEnergyScaffoldingArchived(archived).catch(console.warn);
       })
       .catch((err: unknown) => {
         console.warn('[useHabitUI] failed to load energy-CTA archived state', err);
@@ -54,7 +72,7 @@ export const useHabitUI = (): HabitUIState => {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [normalizedToken]);
 
   const setSelectedHabit = useCallback((habit: Habit | null) => {
     setSelectedHabitId(habit?.id ?? null);
@@ -67,7 +85,10 @@ export const useHabitUI = (): HabitUIState => {
     saveEnergyScaffoldingArchived(true).catch((err: unknown) => {
       console.warn('[useHabitUI] failed to persist energy-CTA archived state', err);
     });
-  }, []);
+    uiFlags.update({ energy_scaffolding_archived: true }, normalizedToken).catch((err: unknown) => {
+      console.warn('[useHabitUI] failed to sync energy-CTA archived state', err);
+    });
+  }, [normalizedToken]);
 
   return {
     selectedHabit,

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -36,8 +36,8 @@ export const useHabits = (): UseHabitsReturn => {
   const error = useHabitStore((s) => s.error);
   const storeSetHabits = useHabitStore((s) => s.setHabits);
   const { showToast } = useToast();
-  const { userTimezone } = useAuth();
-  const ui = useHabitUI();
+  const { userTimezone, token } = useAuth();
+  const ui = useHabitUI(token);
   useBootstrapHabits(userTimezone);
   const actions = useHabitActions(ui, showToast, userTimezone);
 

--- a/frontend/src/store/__tests__/storeIntegration.test.ts
+++ b/frontend/src/store/__tests__/storeIntegration.test.ts
@@ -22,6 +22,11 @@ jest.mock('../../api', () => ({
   goalCompletions: {
     create: jest.fn(() => Promise.resolve({ streak: 1, milestones: [], reason_code: 'ok' })),
   },
+  // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+  uiFlags: {
+    get: jest.fn(() => Promise.reject(new Error('no server hydration configured'))),
+    update: jest.fn(() => Promise.resolve({})),
+  },
 }));
 
 jest.mock('../../storage/habitStorage', () => ({


### PR DESCRIPTION
## Summary

The Habits energy-scaffolding CTA dismissal lived only in browser `localStorage` (`@adepthood/energy_scaffolding_archived`), so any browser that clears site data — e.g. Brave with "Clear cookies and site data when you close all windows" — resurrected the declined invitation on every login, contradicting the "resonant, declinable invitations, never gamified pressure" principle.

This makes the archived flag per-account server state, mirroring the sibling welcome-flag fix:

- `useHabitUI` now takes a `token` (threaded from `useHabits` via `useAuth()`) and hydrates the archived flag **server-first** from `GET /ui-flags`, falling back to the local cache only when the GET rejects, then re-seeds the local cache from the resolved value.
- `archiveEnergyCTA` stays optimistic — hide immediately + local save — and additionally `PATCH /ui-flags { energy_scaffolding_archived: true }` best-effort (`console.warn` on failure).
- The no-flash guarantee is preserved: `showEnergyCTA` starts hidden until hydration resolves.
- Local storage stays the offline cache and stays out of the logout wipe; account state is now the source of truth (an intentional device-to-account scoping change sanctioned by the epic). Reuses the existing `uiFlags` client + `uiFlagsSchema` (no duplication, no schema reshape).

This is the last sub-issue of the epic; merging it completes #1534.

## Test plan

- `useHabitUI.test.ts`: server wins over a wiped local cache (archived server flag keeps CTA hidden after fresh login); first-time user still sees the CTA; archive PATCHes `{ energy_scaffolding_archived: true }` with the token; offline GET-reject falls back to the local cache; local cache re-seeded from the server value; PATCH-reject keeps the CTA hidden and warns.
- Added the `uiFlags` mock to sibling Habits/store suites that render `useHabits`, since the hook now calls `uiFlags.get` on mount.
- Full `scripts/frontend/check-all.sh` green: ESLint (zero warnings), prettier, `tsc --noEmit`, and the entire Jest suite (4118 tests).

Closes #1537
Refs #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)