### PR TITLE
test(backend): tidy up dead test constant, stale comments, and subsumed seed_stages tests

### DIFF
--- a/backend/tests/test_lifespan_seeding.py
+++ b/backend/tests/test_lifespan_seeding.py
@@ -40,9 +40,9 @@ _EXPECTED_PRACTICE_COUNT = len(PRESET_PRACTICES)
 def _expected_content_count() -> int:
     """Rows the content seeder should produce in this environment.
 
-    Sourced from ``desired_content_records()`` — manifest chapters (none
-    in the test environment until a content pin is vendored).  Computed at
-    call time because the manifest is runtime data.
+    Sourced from ``desired_content_records()`` — the vendored manifest's
+    chapters plus site resources, which are present in the test environment.
+    Computed at call time because the manifest is runtime data.
     """
     return len(desired_content_records())
 

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -90,11 +90,6 @@ def test_missing_id_is_minted() -> None:
 
 _SANITY_MAX_TRACE_ID = 100
 
-# A 32-char UUID4 hex is the shape minted by ``_normalise_trace_id`` when the
-# inbound value is rejected.  Tests assert against this so a regression that
-# accidentally lets a hostile value through still trips the length check.
-_MINTED_LEN = 32
-
 
 def test_pathologically_long_id_is_rejected_and_replaced() -> None:
     """Values longer than the cap are silently replaced by a fresh UUID."""

--- a/backend/tests/test_seed_stages.py
+++ b/backend/tests/test_seed_stages.py
@@ -34,27 +34,6 @@ async def test_seed_stages_idempotent(db_session: AsyncSession) -> None:
     assert len(stages) == len(STAGE_DEFINITIONS)
 
 
-@pytest.mark.asyncio
-async def test_seed_stages_definitions_valid() -> None:
-    """All definitions should have the required fields."""
-    required_fields = {
-        "stage_number",
-        "title",
-        "subtitle",
-        "overview_url",
-        "category",
-        "aspect",
-        "spiral_dynamics_color",
-        "growing_up_stage",
-        "divine_gender_polarity",
-        "relationship_to_free_will",
-        "free_will_description",
-    }
-    for defn in STAGE_DEFINITIONS:
-        msg = f"Missing fields in stage {defn.get('stage_number')}"
-        assert required_fields.issubset(defn.keys()), msg
-
-
 # Golden values pinned from the pre-refactor STAGE_DEFINITIONS literal so a
 # migration to a curriculum-backed source cannot silently change behavior.
 _GOLDEN_STAGE_DEFINITIONS: list[dict[str, str | int]] = [
@@ -219,9 +198,3 @@ def test_stage_definitions_match_golden_values() -> None:
         for field in _GOLDEN_FIELDS:
             msg = f"stage {golden['stage_number']} field {field!r} mismatch"
             assert actual[field] == golden[field], msg
-
-
-def test_stage_definitions_overview_url_is_empty_for_all() -> None:
-    """overview_url golden value is the empty string for every stage."""
-    for defn in STAGE_DEFINITIONS:
-        assert defn["overview_url"] == ""


### PR DESCRIPTION
## Summary

De-slop tidy-up of three linter-invisible hygiene issues in backend-platform
test files (all verified still present at HEAD before acting):

1. **Dead `_MINTED_LEN` constant + lying comment** (`test_observability.py`) —
   removed. `grep -rn "_MINTED_LEN" backend/` now returns nothing; the actual
   length/shape assertions use `_SANITY_MAX_TRACE_ID` and an inline
   `re.fullmatch(r"[0-9a-f]{32}", ...)`.
2. **Stale `_expected_content_count` docstring** (`test_lifespan_seeding.py`) —
   rewrote the parenthetical that falsely claimed zero chapters in the test
   environment. The vendored manifest ships chapters + site resources, and the
   sibling assertion `len(contents) > 0` already asserts the opposite.
3. **Two subsumed seed_stages tests** (`test_seed_stages.py`) — deleted
   `test_seed_stages_definitions_valid` and
   `test_stage_definitions_overview_url_is_empty_for_all`. Both are strictly
   subsumed by `test_stage_definitions_match_golden_values`, which was
   re-verified at HEAD: `_GOLDEN_FIELDS` equals the old `required_fields` set
   field-for-field, `actual[field]` raises `KeyError` on a missing field
   (presence check) and asserts value equality for every stage, and every
   golden `overview_url` is `""` (so the empty-string check is already made).

No production source touched, no assertion weakened, and the surviving golden
test is kept.

## Test plan

- `./scripts/backend/check-all.sh` → all 7 checks pass; 2618 passed, 2 skipped;
  coverage **96.63%** (≥ 90% threshold, unchanged — the removed tests only read
  the already-exercised `STAGE_DEFINITIONS` constant, confirming subsumption
  rather than denting coverage).
- `xenon src/` and `radon mi src/ -n B` pass (CI-enforced; check-all omits them).
- Pre-commit hooks pass on push.

Closes #1200