### PR TITLE
test(invitations): cover useInvitations per-id and unmount guards

### DIFF
--- a/frontend/src/features/Invitations/__tests__/useInvitations.test.tsx
+++ b/frontend/src/features/Invitations/__tests__/useInvitations.test.tsx
@@ -4,6 +4,31 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import type { Invitation } from '@/api';
 
+type RealUseState = (_initial: unknown) => [unknown, (_next: unknown) => void];
+
+// When armed, record every state dispatch so the unmount guard test can assert
+// that no dispatch reaches the hook after it has been torn down — the one signal
+// React 18 leaves observable (a post-unmount setState is otherwise a silent no-op).
+let mockUnmountTrackingArmed = false;
+const mockPostUnmountDispatches: unknown[] = [];
+
+function mockWrapUseState(realUseState: unknown): (_initial: unknown) => [unknown, unknown] {
+  const useStateFn = realUseState as RealUseState;
+  return (initial) => {
+    const [value, setValue] = useStateFn(initial);
+    const trackedSetValue = (next: unknown): void => {
+      if (mockUnmountTrackingArmed) mockPostUnmountDispatches.push(next);
+      setValue(next);
+    };
+    return [value, trackedSetValue];
+  };
+}
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react') as Record<string, unknown>;
+  return { ...actual, useState: mockWrapUseState(actual.useState) };
+});
+
 const mockList = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<Invitation[]>>;
 const mockDismiss = jest.fn() as jest.MockedFunction<
   (_id: number, _token?: string) => Promise<void>
@@ -38,6 +63,8 @@ beforeEach(() => {
   mockDismiss.mockReset();
   mockList.mockResolvedValue([]);
   mockDismiss.mockResolvedValue(undefined);
+  mockUnmountTrackingArmed = false;
+  mockPostUnmountDispatches.length = 0;
 });
 
 describe('useInvitations', () => {
@@ -91,5 +118,53 @@ describe('useInvitations', () => {
     });
 
     expect(result.current.invitations.map((i: Invitation) => i.id)).toEqual([4, 5]);
+  });
+
+  it('per-id guard: a second dismiss for the same in-flight id does not double-fire the API', async () => {
+    mockList.mockResolvedValue([invitation({ id: 6 }), invitation({ id: 7 })]);
+    let resolveDismiss: () => void = () => {};
+    mockDismiss.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDismiss = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useInvitations());
+    await waitFor(() => expect(result.current.invitations).toHaveLength(2));
+
+    await act(async () => {
+      void result.current.dismiss(6);
+      void result.current.dismiss(6);
+    });
+
+    expect(mockDismiss).toHaveBeenCalledWith(6);
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDismiss();
+    });
+  });
+
+  it('unmount guard: a late list resolution dispatches no state update on the dead hook', async () => {
+    // A post-unmount setState is a silent no-op in React 18, so asserting on
+    // `items` cannot distinguish the guard from its removal. Arm the state-
+    // dispatch tracker instead and assert the late resolution reaches no setter.
+    let resolveList: (_value: Invitation[]) => void = () => {};
+    mockList.mockReturnValue(
+      new Promise<Invitation[]>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useInvitations());
+    unmount();
+    mockUnmountTrackingArmed = true;
+
+    await act(async () => {
+      resolveList([invitation({ id: 8 })]);
+      await Promise.resolve();
+    });
+
+    expect(mockPostUnmountDispatches).toHaveLength(0);
+    expect(result.current.invitations).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds two mutation-killing tests for the previously untested defensive guards in `useInvitations` (the hook moved from `features/Today/` to `features/Invitations/` since this issue was filed; both guards still exist verbatim at HEAD and were both mutation-survivors before this change). Production code is unchanged.

1. **Per-id double-fire guard** (`useInvitations.ts` `if (pendingIdsRef.current.has(id)) return;`): a second `dismiss(id)` for the same in-flight id must not re-fire the API. The test issues two `dismiss(6)` calls before the first resolves and asserts `invitations.dismiss` was called exactly once. Removing the guard makes the API fire twice and the test fails.

2. **Unmount guard** (`useInvitations.ts` `if (mountedRef.current) setItems(loaded);`): a late `list()` resolution must dispatch no state update after teardown.

   Note on approach: in React 18 a `setState` on an unmounted component is a **silent no-op**, so a plain `items` assertion cannot distinguish the guard from its absence — verified empirically, and the sibling "gold standard" `useMettaReturn` unmount test (cited by the issue) is itself mutation-blind for the same reason. To make this test genuinely kill the mutant, it wraps `useState` via `jest.mock('react')` to record dispatches and asserts the late resolution reaches no setter after unmount. Removing the `mountedRef` guard makes `setItems` fire post-unmount and the test fails.

Both guards were verified by temporarily deleting each guard locally and confirming the corresponding test goes RED (the break was not committed); with both guards present the full frontend suite is green.

## Test plan

- `./scripts/frontend/check-all.sh` — lint, prettier, typecheck, and Jest (4120 tests) all pass.
- Mutation discipline: deleting the per-id guard fails the per-id test; deleting the unmount guard fails the unmount test; both restored → all green.

Closes #1203