### PR TITLE
fix(auth): serialize secure-store token writes to close a stale-token race

### DIFF
--- a/frontend/SECURITY.md
+++ b/frontend/SECURITY.md
@@ -28,6 +28,16 @@ web throws `TypeError`. The platform branch in `secureStringStore.ts`
 exists to prevent that crash; the alternative would be the auth flow
 failing end-to-end on every web load.
 
+### Concurrent write ordering
+
+Store mutations (`save`/`clear`) on both platforms run through a per-key
+serialized write lane (`serializedWrite.ts`, marker `BUG-FE-STORAGE-002`),
+so a stale proactive-refresh write issued before a subsequent login or
+logout can no longer settle _after_ it via keychain/`localStorage` latency
+and strand a stale token. Reads (`load`) stay unserialized. This is a
+storage-layer complement to the `expectedPriorToken` identity guards in
+`AuthContext.tsx`, which independently protect React state.
+
 ### The XSS-window risk
 
 A single successful XSS exploit on the web build yields **full account

--- a/frontend/src/storage/__tests__/secureStringStore.test.ts
+++ b/frontend/src/storage/__tests__/secureStringStore.test.ts
@@ -48,6 +48,22 @@ function makeStore() {
   return createSecureStringStore(TEST_KEY, TestEmptyError);
 }
 
+// Microtask rounds pumped so a serialized write chain enqueues each successive
+// write; generous because every write hops the FIFO chain several times.
+const MAX_DRAIN_ROUNDS = 50;
+
+// Commit deferred mock writes newest-first (a later write settling before an
+// earlier one), pumping microtasks so a serialized chain runs to completion. A
+// momentarily empty queue is not the end — a chained write may not be enqueued yet.
+async function drainNewestFirst(pending: Array<() => void>): Promise<void> {
+  for (let round = 0; round < MAX_DRAIN_ROUNDS; round += 1) {
+    await Promise.resolve();
+    if (pending.length === 0) continue;
+    const batch = pending.splice(0).reverse();
+    for (const commit of batch) commit();
+  }
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -130,5 +146,131 @@ describe('createSecureStringStore (web)', () => {
     const store = makeStore();
     await expect(store.load()).rejects.toThrow('read boom');
     expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('createSecureStringStore (native write ordering)', () => {
+  beforeEach(() => {
+    platformRef.value = 'ios';
+  });
+
+  test('a fresh save always wins over a stale save issued earlier', async () => {
+    let stored: string | null = null;
+    const pending: Array<() => void> = [];
+    mockSecureStore.setItemAsync.mockImplementation(
+      (_key: string, val: string) =>
+        new Promise<void>((resolve) => {
+          pending.push(() => {
+            stored = val;
+            resolve();
+          });
+        }),
+    );
+
+    const store = makeStore();
+    const pStale = store.save('stale-token');
+    const pFresh = store.save('fresh-token');
+
+    await drainNewestFirst(pending);
+    await Promise.all([pStale, pFresh]);
+
+    expect(stored).toBe('fresh-token');
+  });
+
+  test('a clear issued after a save is never overwritten by the save settling late', async () => {
+    let stored: string | null = null;
+    const pending: Array<() => void> = [];
+    mockSecureStore.setItemAsync.mockImplementation(
+      (_key: string, val: string) =>
+        new Promise<void>((resolve) => {
+          pending.push(() => {
+            stored = val;
+            resolve();
+          });
+        }),
+    );
+    mockSecureStore.deleteItemAsync.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pending.push(() => {
+            stored = null;
+            resolve();
+          });
+        }),
+    );
+
+    const store = makeStore();
+    const pSave = store.save('fresh-token');
+    const pClear = store.clear();
+
+    await drainNewestFirst(pending);
+    await Promise.all([pSave, pClear]);
+
+    expect(stored).toBeNull();
+  });
+
+  test('a held write on one key does not block a write on a different key', async () => {
+    const { createSecureStringStore } = loadSecureStringStore();
+    const storeA = createSecureStringStore('key-a', TestEmptyError);
+    const storeB = createSecureStringStore('key-b', TestEmptyError);
+
+    let resolveA: () => void = () => undefined;
+    mockSecureStore.setItemAsync.mockImplementation((key: string) =>
+      key === 'key-a'
+        ? new Promise<void>((resolve) => {
+            resolveA = resolve;
+          })
+        : Promise.resolve(),
+    );
+
+    const pA = storeA.save('a-value');
+    const pB = storeB.save('b-value');
+
+    await expect(pB).resolves.toBeUndefined();
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('key-b', 'b-value');
+
+    resolveA();
+    await pA;
+  });
+
+  test('a rejected save does not wedge the lane for the same key', async () => {
+    const store = makeStore();
+    mockSecureStore.setItemAsync.mockRejectedValueOnce(new Error('keychain write failed'));
+
+    await expect(store.save('will-fail')).rejects.toThrow('keychain write failed');
+
+    mockSecureStore.setItemAsync.mockResolvedValueOnce(undefined);
+    await store.save('recovers');
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenLastCalledWith(TEST_KEY, 'recovers');
+  });
+});
+
+describe('createSecureStringStore (web write ordering)', () => {
+  beforeEach(() => {
+    platformRef.value = 'web';
+  });
+
+  test('a fresh save always wins over a stale save issued earlier on web', async () => {
+    let stored: string | null = null;
+    const pending: Array<() => void> = [];
+    mockAsyncStorage.setItem.mockImplementation(
+      (_key: string, val: string) =>
+        new Promise<void>((resolve) => {
+          pending.push(() => {
+            stored = val;
+            resolve();
+          });
+        }),
+    );
+
+    const store = makeStore();
+    const pStale = store.save('stale-token');
+    const pFresh = store.save('fresh-token');
+
+    await drainNewestFirst(pending);
+    await Promise.all([pStale, pFresh]);
+
+    expect(stored).toBe('fresh-token');
   });
 });

--- a/frontend/src/storage/secureStringStore.ts
+++ b/frontend/src/storage/secureStringStore.ts
@@ -49,6 +49,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
 
+import { serialize } from './serializedWrite';
+
 // ``expo-secure-store`` v55 has no web implementation — its web module is
 // literally ``export default {}``, so calling ``SecureStore.setItemAsync``
 // throws ``TypeError: … is not a function``. On web we fall back to
@@ -83,16 +85,23 @@ export function createSecureStringStore(
       // value — bouncing the user to login, or producing a 401-guaranteed
       // empty Bearer header on the next call. Defence in depth at the store.
       const trimmed = value.trim();
+      // Reject empty/whitespace BEFORE the lane so a bad save never occupies a
+      // FIFO slot (and rejects without waiting behind a prior in-flight write).
       if (!trimmed) throw new EmptyErrorCtor();
-      if (isWeb) {
-        // BUG-FE-AUTH-007: web persists to localStorage — XSS risk accepted
-        // until the backend httpOnly-cookie session migration ships. See the
-        // file-header note. Reviewers: any new web persistence path MUST go
-        // through this same ``isWeb`` branch (or be replaced by a cookie).
-        await AsyncStorage.setItem(storageKey, trimmed);
-        return;
-      }
-      await SecureStore.setItemAsync(storageKey, trimmed);
+      // BUG-FE-STORAGE-002: serialize mutations per key so a stale save that
+      // settles late cannot clobber a fresher save/clear (e.g. a mid-await
+      // re-login writing the previous token over the new one).
+      await serialize(storageKey, async () => {
+        if (isWeb) {
+          // BUG-FE-AUTH-007: web persists to localStorage — XSS risk accepted
+          // until the backend httpOnly-cookie session migration ships. See the
+          // file-header note. Reviewers: any new web persistence path MUST go
+          // through this same ``isWeb`` branch (or be replaced by a cookie).
+          await AsyncStorage.setItem(storageKey, trimmed);
+          return;
+        }
+        await SecureStore.setItemAsync(storageKey, trimmed);
+      });
     },
 
     async load(): Promise<string | null> {
@@ -104,12 +113,16 @@ export function createSecureStringStore(
     },
 
     async clear(): Promise<void> {
-      if (isWeb) {
-        // BUG-FE-AUTH-007: web clears localStorage — see the file-header note.
-        await AsyncStorage.removeItem(storageKey);
-        return;
-      }
-      await SecureStore.deleteItemAsync(storageKey);
+      // BUG-FE-STORAGE-002: share the save lane so a clear cannot be undone by
+      // a save that was issued earlier but settles after it.
+      await serialize(storageKey, async () => {
+        if (isWeb) {
+          // BUG-FE-AUTH-007: web clears localStorage — see the file-header note.
+          await AsyncStorage.removeItem(storageKey);
+          return;
+        }
+        await SecureStore.deleteItemAsync(storageKey);
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

Closes a residual LOW-severity, security-labeled concurrency window on the native token store. On native, an awaited `saveToken(stale)` in the proactive-refresh path committed to the keychain *before* its post-save `expectedPriorToken` guard ran, so a logout→re-login interleaved inside that await could leave a stale token persisted in the keychain even though React state was correctly protected.

The fix routes `createSecureStringStore`'s `save`/`clear` through the existing per-key `serialize()` FIFO write lane (`frontend/src/storage/serializedWrite.ts`, already used by `habitStorage`). Writes now land in submission order, so the newer login/logout write — enqueued after the stale refresh write — deterministically wins. `load` stays unserialized; the trim/reject-empty guard stays outside the lane so a bad save never occupies a slot. The BYOK key store shares the factory but uses a distinct key, so it gets the same protection on an independent lane. The `expectedPriorToken` React-state guards in `AuthContext.tsx` are unchanged and complementary — no AuthContext change was needed.

## Test plan

- New deterministic interleaving tests in `frontend/src/storage/__tests__/secureStringStore.test.ts` (native fresh-wins, save-then-clear, web fresh-wins) using controlled deferred mock commits and a microtask-pump drain helper — no sleeps/timers.
- Verified RED: the three ordering tests fail against the unserialized implementation (stale value wins) and pass once writes are serialized.
- Regression backstops: distinct keys stay parallel; a rejected save does not wedge the lane.
- Gate 2 green locally: `./scripts/frontend/check-all.sh` (ESLint, Prettier, tsc, full Jest — 4125 tests) all pass.
- `frontend/SECURITY.md` updated with a concurrent-write-ordering note.

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)