### PR TITLE
refactor(backend): services Low tidy-up round 2 — stale docstrings + compute_next_reset layering

### DIFF
--- a/backend/src/domain/dates.py
+++ b/backend/src/domain/dates.py
@@ -87,6 +87,20 @@ def ensure_aware(value: datetime) -> datetime:
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
+def compute_next_reset(now: datetime) -> datetime:
+    """Return the first moment of the calendar month following ``now`` in UTC.
+
+    Example: ``2026-04-15T12:34:56Z`` → ``2026-05-01T00:00:00Z``.  The result
+    is always timezone-aware (UTC) so it can be compared safely against
+    ``datetime.now(UTC)`` in SQL WHERE clauses.
+    """
+    utc = ensure_aware(now).astimezone(UTC)
+    year, month = utc.year, utc.month
+    if month == 12:  # noqa: PLR2004 - December rolls to January of next year
+        return datetime(year + 1, 1, 1, tzinfo=UTC)
+    return datetime(year, month + 1, 1, tzinfo=UTC)
+
+
 def now_in_tz(user_or_tz: _HasTimezone | str | None) -> datetime:
     """Return ``datetime.now`` in the user's IANA timezone.
 

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from sqlalchemy import Boolean, Column, DateTime, String
 from sqlmodel import Field, Relationship, SQLModel
 
-from services.usage import compute_next_reset
+from domain.dates import compute_next_reset
 
 if TYPE_CHECKING:
     from .habit import Habit

--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -1,8 +1,11 @@
 """BotMason AI service — LLM integration layer.
 
 Supports configurable LLM providers via environment variables. The service
-loads a system prompt from a file path or inline text and maintains
-conversation history context for coherent multi-turn chat.
+loads a system prompt from a file path or inline text and generates a single
+resonance reflection per call.  The ``conversation_history`` parameter on
+:func:`generate_response` is a retained seam, but the sole production caller
+(``services.marginalia``) always passes an empty history, so no multi-turn
+chat path exists today.
 """
 
 from __future__ import annotations

--- a/backend/src/services/usage.py
+++ b/backend/src/services/usage.py
@@ -13,9 +13,10 @@ atomic SQL statements around them without duplicating policy.
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
 
-from domain.dates import ensure_aware
+from domain.dates import compute_next_reset
+
+__all__ = ["DEFAULT_MONTHLY_CAP", "compute_next_reset", "get_monthly_cap"]
 
 # Default monthly cap when ``BOTMASON_MONTHLY_CAP`` is not set.  Chosen as a
 # conservative free-tier that covers a handful of reflections per day without
@@ -47,17 +48,3 @@ def get_monthly_cap() -> int:
     if parsed < _MIN_CAP:
         return DEFAULT_MONTHLY_CAP
     return parsed
-
-
-def compute_next_reset(now: datetime) -> datetime:
-    """Return the first moment of the calendar month following ``now`` in UTC.
-
-    Example: ``2026-04-15T12:34:56Z`` → ``2026-05-01T00:00:00Z``.  The result
-    is always timezone-aware (UTC) so it can be compared safely against
-    ``datetime.now(UTC)`` in SQL WHERE clauses.
-    """
-    utc = ensure_aware(now).astimezone(UTC)
-    year, month = utc.year, utc.month
-    if month == 12:  # noqa: PLR2004 - December rolls to January of next year
-        return datetime(year + 1, 1, 1, tzinfo=UTC)
-    return datetime(year, month + 1, 1, tzinfo=UTC)

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -325,10 +325,12 @@ async def add_balance(
     SQL statement — no lost-update window between read and write.
 
     BUG-BM-011: a ``WalletAudit`` row is staged for every successful
-    grant.  ``actor_user_id`` defaults to ``user_id`` for the legacy
-    "user tops up their own wallet" path, but the admin endpoint
-    overrides it with the granting admin's id so the audit row records
-    the actor distinct from the recipient.
+    grant.  ``actor_user_id`` defaults to ``user_id``, so the only
+    production caller -- an admin topping up their own wallet -- records
+    a ``self_grant`` (actor == recipient).  A distinct actor would be
+    logged as ``admin_grant``, a forward-looking seam reserved for a
+    future cross-user grant path (e.g. a Stripe webhook or referral
+    credit); no such caller exists yet.
     """
     result = await session.execute(
         update(User)

--- a/backend/tests/domain/test_dates.py
+++ b/backend/tests/domain/test_dates.py
@@ -21,6 +21,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from domain.dates import (
+    compute_next_reset,
     day_bounds_in_tz,
     ensure_aware,
     now_in_tz,
@@ -253,3 +254,20 @@ class TestYearAndLeapBoundaries:
         start, end = day_bounds_in_tz("UTC", date(2024, 2, 29))
         assert start.day == 29
         assert end.day == 1
+
+
+class TestComputeNextReset:
+    """``compute_next_reset`` returns first-of-next-month, UTC-aware."""
+
+    def test_mid_month(self) -> None:
+        result = compute_next_reset(datetime(2026, 4, 15, 12, 34, 56, tzinfo=UTC))
+        assert result == datetime(2026, 5, 1, tzinfo=UTC)
+
+    def test_december_rollover(self) -> None:
+        result = compute_next_reset(datetime(2026, 12, 31, 23, 59, 59, tzinfo=UTC))
+        assert result == datetime(2027, 1, 1, tzinfo=UTC)
+
+    def test_normalises_naive_input(self) -> None:
+        """A naive datetime is interpreted as UTC rather than crashing later."""
+        result = compute_next_reset(datetime(2026, 6, 15, 12, 0, 0))  # noqa: DTZ001
+        assert result == datetime(2026, 7, 1, tzinfo=UTC)

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import importlib
 import pathlib
-from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import ClassVar
 from unittest.mock import AsyncMock, patch
@@ -37,7 +36,6 @@ from services.botmason import (
 )
 from services.usage import (
     DEFAULT_MONTHLY_CAP,
-    compute_next_reset,
     get_monthly_cap,
 )
 
@@ -637,23 +635,6 @@ def test_get_monthly_cap_rejects_negative(monkeypatch: pytest.MonkeyPatch) -> No
 def test_get_monthly_cap_allows_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "0")
     assert get_monthly_cap() == 0
-
-
-def test_compute_next_reset_mid_month() -> None:
-    result = compute_next_reset(datetime(2026, 4, 15, 12, 34, 56, tzinfo=UTC))
-    assert result == datetime(2026, 5, 1, tzinfo=UTC)
-
-
-def test_compute_next_reset_december_rollover() -> None:
-    result = compute_next_reset(datetime(2026, 12, 31, 23, 59, 59, tzinfo=UTC))
-    assert result == datetime(2027, 1, 1, tzinfo=UTC)
-
-
-def test_compute_next_reset_normalises_naive_input() -> None:
-    # A naive datetime is interpreted as UTC rather than silently crashing on
-    # mismatched comparisons later.
-    result = compute_next_reset(datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC))
-    assert result == datetime(2026, 7, 1, tzinfo=UTC)
 
 
 # ── Issue #402: live-provider activation ────────────────────────────────


### PR DESCRIPTION
## Summary

Three small, linter-invisible service-layer items from the de-slopify scan, all verified still present at HEAD before acting:

1. **botmason.py module docstring** — advertised "conversation history context for coherent multi-turn chat", a feature retired when the chat endpoints were removed (the sole caller passes an empty history). Rewritten to describe single-shot resonance generation; the retained `conversation_history` seam is unchanged.
2. **`add_balance` docstring (wallet.py)** — claimed the admin endpoint records an actor distinct from the recipient, but the only production caller tops up its own wallet (`actor == user_id`, always `self_grant`). Corrected to match actual behaviour and note `admin_grant` is a forward-looking seam. The audit branch itself is unchanged.
3. **`compute_next_reset` layering inversion** — an ORM model (`models/user.py`) imported this pure calendar helper from `services/usage.py`, inverting the models → services direction. Moved it into `domain/dates.py` (its only dependency, `ensure_aware`, already lives there) and re-exported from `services/usage.py` so existing callers (`wallet.py`) are untouched. `models/user.py` now imports from `domain.dates`. Its unit tests moved to `tests/domain/test_dates.py` alongside the code; behaviour is unchanged (the naive-input test now passes a genuinely naive datetime to match the file convention and make its own comment honest).

No behaviour changes for items 1–2; item 3 is a pure-function relocation.

## Test plan

- `./scripts/backend/check-all.sh` — all 7 gates pass, 2618 passed / 2 skipped, 96.65% coverage.
- `xenon --max-absolute A --max-modules A --max-average A` on all touched files — A-grade.
- `radon mi` on `domain/dates.py` and `services/usage.py` — A.
- Relocated `compute_next_reset` tests pass in their new home; `wallet.py` exercises the re-export path.

Closes #1209