### PR TITLE
test(backend): assert energy-plan offload concurrency deterministically

### DIFF
--- a/backend/tests/test_energy_api.py
+++ b/backend/tests/test_energy_api.py
@@ -9,7 +9,7 @@ which monkeypatch the service.
 from __future__ import annotations
 
 import asyncio
-import time
+import threading
 from datetime import date
 from http import HTTPStatus
 from typing import Any
@@ -103,24 +103,45 @@ async def test_keyed_requests_replay_identical_persisted_plan(
 async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) -> None:
     """BUG-INFRA-009: slow plan generation must not starve concurrent requests.
 
-    Replace ``build_energy_response`` (the CPU-bound step) with a sync sleep
-    that would block the loop for 300ms if run inline; ``get_or_create_persisted_plan``
-    runs it via ``asyncio.to_thread``, so two concurrent requests overlap and
-    finish in ~300ms, not ~600ms. ``_persist`` is stubbed to a no-op and the
-    habit lookup is stubbed so the test isolates the offload from the DB.
+    ``get_or_create_persisted_plan`` runs the CPU-bound ``build_energy_response``
+    via ``asyncio.to_thread``, so two concurrent requests must have their builds
+    in flight *at the same time* rather than serialised on the event loop. This
+    is asserted deterministically — not by a wall-clock budget: the stubbed build
+    performs a two-party handshake (a ``threading.Barrier``) so that each build
+    blocks until its sibling has also entered, then records peak overlap. If the
+    offload regressed to an inline call the loop would be blocked, only one build
+    could ever be in flight, the barrier would time out, and the request would
+    fail. ``_persist`` and the habit lookup are stubbed to isolate the offload
+    from the DB.
     """
     headers, _ = await _signup(async_client)
-    sleep_seconds = 0.3
+    expected_overlap = 2  # both concurrent requests build simultaneously
+    # Generous deadlock guard, not a speed budget: when the loop is *not* blocked
+    # the barrier releases the instant the sibling build enters (microseconds,
+    # independent of runner speed); this bound only trips if a regression forces
+    # the builds to run serially, so it is immune to slow-CI flake.
+    handshake_timeout_seconds = 10.0
     one_habit = [DomainHabit(id=1, name="Run", energy_cost=2, energy_return=5)]
     real_response = energy.build_energy_response(one_habit, date(2024, 1, 1))
+
+    both_builds_entered = threading.Barrier(expected_overlap, timeout=handshake_timeout_seconds)
+    concurrency_lock = threading.Lock()
+    active_builds = 0
+    peak_builds = 0
 
     async def _stub_resolve(
         _session: AsyncSession, _user_id: int, _payload: EnergyPlanRequest
     ) -> list[DomainHabit]:
         return one_habit
 
-    def _slow_build(_habits: list[DomainHabit], _start: date) -> EnergyPlanResponse:
-        time.sleep(sleep_seconds)
+    def _handshake_build(_habits: list[DomainHabit], _start: date) -> EnergyPlanResponse:
+        nonlocal active_builds, peak_builds
+        with concurrency_lock:
+            active_builds += 1
+            peak_builds = max(peak_builds, active_builds)
+        both_builds_entered.wait()  # blocks until the sibling build is also in flight
+        with concurrency_lock:
+            active_builds -= 1
         return real_response
 
     async def _noop_persist(
@@ -133,23 +154,22 @@ async def test_create_plan_does_not_block_event_loop(async_client: AsyncClient) 
 
     with (
         patch.object(energy_router, "resolve_trusted_habits", _stub_resolve),
-        patch.object(energy, "build_energy_response", _slow_build),
+        patch.object(energy, "build_energy_response", _handshake_build),
         patch.object(energy, "_persist", _noop_persist),
     ):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            start = time.perf_counter()
             results = await asyncio.gather(
                 ac.post("/v1/energy/plan", json=sample_payload(), headers=headers),
                 ac.post("/v1/energy/plan", json=sample_payload(), headers=headers),
             )
-            elapsed = time.perf_counter() - start
 
     for res in results:
         assert res.status_code == HTTPStatus.OK
 
-    assert elapsed < sleep_seconds * 1.8, (
-        f"expected concurrent energy requests to overlap; took {elapsed:.3f}s"
+    assert peak_builds == expected_overlap, (
+        f"expected {expected_overlap} energy builds in flight at once; "
+        f"peak overlap was {peak_builds} (event loop appears blocked)"
     )
 
 


### PR DESCRIPTION
## Summary

`test_create_plan_does_not_block_event_loop` asserted that two concurrent
energy-plan requests overlap by comparing wall-clock elapsed time against a
fixed budget (`elapsed < 0.3 * 1.8`). On a slow shared GitHub runner the same
code took 0.644s and failed CI on an unrelated diff (docstrings + a
pure-function move) — a pure flake, since wall-clock margins conflate "event
loop blocked" with "runner was slow."

This replaces the timing budget with a deterministic concurrency observation:

- The stubbed `build_energy_response` performs a two-party `threading.Barrier`
  handshake — each build blocks until its sibling has also entered, then records
  peak overlap under a lock. The barrier releasing proves both offloaded builds
  were in flight simultaneously (the second entered before the first exited).
- The assertion checks `peak_builds == 2`, with no wall-clock constant sensitive
  to runner speed. The barrier's 10s timeout is a deadlock guard, not a speed
  budget: in the passing path it releases in microseconds regardless of runner
  speed, and only trips if the offload regresses to a loop-blocking inline call.

## Test plan

- GREEN at HEAD: passes, ~0.22s.
- Mutation: temporarily replaced `await asyncio.to_thread(build_energy_response, ...)`
  with an inline `build_energy_response(...)` call — the test FAILS
  (`BrokenBarrierError`, only one build ever in flight). Reverted; not committed.
- Stability: ran 10x locally, 10/10 passed.
- `./scripts/backend/check-all.sh` green (2618 passed, coverage 96.51%);
  xenon A / radon MI A on the test file.

Closes #1574