### PR TITLE
refactor(course): drop dead viewer setters and fix a misleading footer doc

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -35,7 +35,8 @@ interface ChapterReaderProps {
   source: ChapterReaderSource;
   /** Title shown in the header until the live ``title`` from the manifest arrives. */
   fallbackTitle: string;
-  /** Render no footer — used for site resources, which aren't tracked. */
+  /** Optional footer rendered below the body — the content viewer passes its
+   *  mark-read / reflect actions; omitted for untracked site resources. */
   footer?: React.ReactNode;
   onBack: () => void;
 }

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -357,9 +357,7 @@ function useCourseViewer(selectedStage: number) {
 
   return {
     viewingItem,
-    setViewingItem,
     viewingResource,
-    setViewingResource,
     viewingIntro,
     handleContentPress,
     handleResourcePress,
@@ -516,20 +514,16 @@ const CourseScreenDrawer = ({
 };
 
 /** Stage-selector and drawer navigation callbacks. A drawer chapter tap switches
- *  to that chapter's stage, opens the reader (``handleContentPress`` already
- *  guards locked items — never a raw ``setViewingItem`` that would bypass the
- *  lock check), then closes the drawer. */
+ *  to that chapter's stage, opens the reader through ``handleContentPress`` (which
+ *  guards locked items), then closes the drawer. */
 function useCourseNavigation(
   setSelectedStage: (_stageNumber: number) => void,
   viewer: ReturnType<typeof useCourseViewer>,
   drawer: ScreenDrawerState,
 ) {
   const handleStageSelect = useCallback(
-    (stageNumber: number) => {
-      setSelectedStage(stageNumber);
-      viewer.setViewingItem(null);
-    },
-    [setSelectedStage, viewer],
+    (stageNumber: number) => setSelectedStage(stageNumber),
+    [setSelectedStage],
   );
 
   const handleChapterPress = useCallback(


### PR DESCRIPTION
## Summary

Low-severity Course tidy-up. This issue predates the Course drawer work (PR #1532 extracted `stageDisplay.ts` from `StageSelector`; drawer-nav PRs followed), so each of the four original findings was re-verified at HEAD before touching anything.

**Applied (findings that survived):**
- **Dead no-op + dead exported setters (`CourseScreen.tsx`).** Removed `viewer.setViewingItem(null)` from `handleStageSelect`: the stage selector renders only after the overlay early-return (`if (overlay !== null) return overlay;`), so `viewingItem` is provably already `null` when `handleStageSelect` fires — the call was a guaranteed no-op. Dropped `setViewingItem` and `setViewingResource` from the `useCourseViewer` return object (grep confirms zero external consumers after the no-op's removal). Also reworded the `useCourseNavigation` docstring so it no longer references the now-removed setter.
- **Misleading `footer` prop doc (`ChapterReader.tsx`).** The TSDoc said "Render no footer" while `ContentViewer` passes a real `<ViewerFooter onMarkRead/onReflect .../>`. Reworded to describe the prop.

**Skipped (already resolved at HEAD — noted per the fleet re-verify instruction):**
- **Stale `=== 1.0` comment.** `isCompleted` moved to `stageDisplay.ts` during the drawer extraction; its docstring already reads "progress reached 1.0" and the body uses a named `COMPLETE_PROGRESS` constant with `>=`. The stale phrasing (and its copy in the test comment) is gone.
- **Weak/misnamed StageSelector test.** The test was already renamed to `'shows checkmark for completed stages and the number for uncompleted ones'` and now asserts `within(pill1).getByText('✓')` plus the number branch — it fails under a mutation of the completed render branch. Redundant coverage requirement already met.

## Test plan
- `./scripts/frontend/check-all.sh` — lint, prettier, typecheck, and 4125 Jest tests all green.
- All pre-commit hooks pass.

Closes #1211