### PR TITLE
test(map): remove dead StageService export and tighten redundant Map tests

### DIFF
--- a/frontend/src/features/Map/__tests__/waveGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/waveGeometry.test.ts
@@ -132,11 +132,9 @@ const pairPixelEndpoints = (
 
 describe('stageWavePoint', () => {
   it('rises upward: y strictly decreases as stageNumber climbs from 1 to 10', () => {
-    const ys = Array.from({ length: STAGE_COUNT }, (_, i) => stageWavePoint(i + 1).y);
     for (let stage = 2; stage <= STAGE_COUNT; stage += 1) {
       expect(stageWavePoint(stage).y).toBeLessThan(stageWavePoint(stage - 1).y);
     }
-    expect(ys).toHaveLength(STAGE_COUNT);
   });
 
   it('wobbles left for even (WE) stages and right for odd (I) stages, stages 1-8', () => {

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -300,17 +300,17 @@ describe('stageService', () => {
       return map;
     }
 
-    it('returns true when currentStage is STAGE_COUNT and stage-10 progress >= 1', () => {
-      const { isEndOfCycle } = require('../stageService');
-      const stagesByNumber = makeStagesByNumber({ 10: { progress: 1 } });
-      expect(isEndOfCycle(stagesByNumber, 10)).toBe(true);
-    });
-
-    it('returns true when stage-10 progress is exactly 1.0 and currentStage is 10', () => {
-      const { isEndOfCycle } = require('../stageService');
-      const stagesByNumber = makeStagesByNumber({ 10: { progress: 1.0 } });
-      expect(isEndOfCycle(stagesByNumber, 10)).toBe(true);
-    });
+    it.each([
+      [1, 'exactly at the completion threshold'],
+      [1.5, 'past the completion threshold'],
+    ])(
+      'returns true when currentStage is STAGE_COUNT and stage-10 progress is %s (%s)',
+      (progress) => {
+        const { isEndOfCycle } = require('../stageService');
+        const stagesByNumber = makeStagesByNumber({ 10: { progress } });
+        expect(isEndOfCycle(stagesByNumber, 10)).toBe(true);
+      },
+    );
 
     it('returns false when currentStage is 10 but stage-10 progress < 1', () => {
       const { isEndOfCycle } = require('../stageService');
@@ -363,8 +363,8 @@ describe('stageService', () => {
       expect(mockBeginAgainClient).toHaveBeenCalledTimes(1);
     });
 
-    it('sets cycleNumber from the response record', async () => {
-      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(2));
+    it.each([2, 3])('sets cycleNumber to the server-returned cycle_number %i', async (cycle) => {
+      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(cycle));
       mockList.mockResolvedValueOnce([makeApiStage(1)]);
       // The reload's calendar fetch reports the same server-side cycle.
       mockProgramCalendar.mockResolvedValueOnce({
@@ -372,7 +372,7 @@ describe('stageService', () => {
         calendar_stage: 1,
         calendar_week: 1,
         current_stage: 1,
-        cycle_number: 2,
+        cycle_number: cycle,
       });
       const { stageService } = require('../stageService');
       const { useStageStore } = require('../../../../store/useStageStore');
@@ -381,7 +381,7 @@ describe('stageService', () => {
         await stageService.beginAgain();
       });
 
-      expect(useStageStore.getState().cycleNumber).toBe(2);
+      expect(useStageStore.getState().cycleNumber).toBe(cycle);
     });
 
     it('reloads stages after setting cycleNumber', async () => {
@@ -412,27 +412,6 @@ describe('stageService', () => {
       // Failure short-circuits: no reload and no cycle bump from a bad response.
       expect(mockList).not.toHaveBeenCalled();
       expect(state.cycleNumber).toBe(1);
-    });
-
-    it('reflects cycle_number 3 when the server returns it', async () => {
-      mockBeginAgainClient.mockResolvedValueOnce(makeProgressRecord(3));
-      mockList.mockResolvedValueOnce([makeApiStage(1)]);
-      // The reload's calendar fetch reports the same server-side cycle.
-      mockProgramCalendar.mockResolvedValueOnce({
-        program_started_at: null,
-        calendar_stage: 1,
-        calendar_week: 1,
-        current_stage: 1,
-        cycle_number: 3,
-      });
-      const { stageService } = require('../stageService');
-      const { useStageStore } = require('../../../../store/useStageStore');
-
-      await act(async () => {
-        await stageService.beginAgain();
-      });
-
-      expect(useStageStore.getState().cycleNumber).toBe(3);
     });
   });
 });

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -119,5 +119,3 @@ export const stageService = {
     await stageService.loadStages(token);
   },
 };
-
-export type StageService = typeof stageService;


### PR DESCRIPTION
## Summary

De-slop tidy-up of the Map feature (`frontend/src/features/Map/`), closing the four findings that still reproduced at HEAD. Findings 5 and 6 from the issue were already resolved by the Map refactor (self-referential opacity pre-assertion restructured away) and the deletion of `TorusSpiralVisual`, so no changes were needed for them.

- **Dead type export** — deleted `export type StageService = typeof stageService;`; a word-boundary grep now shows zero hits (the earlier stale AC grep matched the unrelated `mockStageServiceModule` harness helper).
- **Redundant `isEndOfCycle` cases** — the `progress: 1` and `progress: 1.0` cases are the same numeric literal, so they were folded into an `it.each` whose second row (progress past the completion threshold) genuinely strengthens coverage: it kills the `>=`→`===` mutant that both identical originals were blind to (verified by a temporary in-worktree mutation).
- **Redundant `beginAgain` cycle cases** — the cycle-2 and cycle-3 tests were identical but for the literal; folded into one `it.each([2, 3])` that still asserts both dynamic values.
- **Tautological length assertion** — dropped the unused `ys` array and its `toHaveLength(STAGE_COUNT)` check in `waveGeometry.test.ts` (it tested `Array.from`, not `stageWavePoint`); the monotonic-decrease loop already exercises every stage point.

No net loss of behavioral coverage: every collapsed case is either identical to a survivor or replaced by a strictly stronger assertion.

## Test plan

- `./scripts/frontend/check-all.sh` — green (eslint, prettier, typecheck, 4125 tests pass).
- Mutation check: temporarily flipped `isEndOfCycle`'s `>=` to `===` inside the worktree and confirmed the new "past the completion threshold" row fails; restored before commit.

Closes #1215