### PR TITLE
refactor(journal): tidy SearchBar copy, tokens, and sync comment

### DIFF
--- a/frontend/src/features/Journal/SearchBar.tsx
+++ b/frontend/src/features/Journal/SearchBar.tsx
@@ -1,7 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
-import { accent, ink, radius, SPACING, surface } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  radius,
+  surface,
+  touchTarget,
+  uiType,
+} from '@/design/tokens';
 
 const DEBOUNCE_DELAY_MS = 300;
 
@@ -36,9 +46,9 @@ interface ExpandedSearchBarProps {
 
 /** The result line: "No results …" when a query came back empty, else the count. */
 function resultLine(searchQuery: string, resultCount: number): string {
-  return resultCount === 0
-    ? `No results for '${searchQuery}'`
-    : `${resultCount} results for '${searchQuery}'`;
+  if (resultCount === 0) return `No results for '${searchQuery}'`;
+  const noun = resultCount === 1 ? 'result' : 'results';
+  return `${resultCount} ${noun} for '${searchQuery}'`;
 }
 
 /** The warm-palette text field; owns its own accent-on-focus border. */
@@ -119,11 +129,8 @@ const SearchBar = ({ onSearch, resultCount, searchQuery }: SearchBarProps): Reac
   const [text, setText] = useState(searchQuery ?? '');
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // BUG-FE-JOURNAL-105: keep local ``text`` in sync with the controlling
-  // ``searchQuery`` prop.  Without this, a parent that programmatically
-  // resets the query (e.g. clearing on tab change) leaves the input
-  // showing the stale text -- and a pending debounce would then re-fire
-  // ``onSearch(stale)`` and clobber the parent's reset.
+  // Keep the local text in sync when the parent resets the searchQuery prop
+  // (e.g. clearing on tab change), so the field mirrors the controlled value.
   useEffect(() => {
     setText((current) => (current === (searchQuery ?? '') ? current : (searchQuery ?? '')));
   }, [searchQuery]);
@@ -188,51 +195,49 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   searchToggle: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    width: touchTarget.minimum,
+    height: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.circle,
     backgroundColor: surface.sunken,
     alignItems: 'center',
     justifyContent: 'center',
   },
   searchIcon: {
-    fontSize: 16,
+    ...uiType.button,
     color: ink.soft,
-    fontWeight: '600',
   },
   searchTextInput: {
     flex: 1,
     marginHorizontal: SPACING.sm,
-    height: 36,
+    height: touchTarget.minimum,
     paddingHorizontal: SPACING.md,
     borderRadius: radius.lg,
     borderWidth: 1,
     borderColor: surface.hairline,
     backgroundColor: surface.raised,
-    fontSize: 14,
+    fontSize: editorialType.note.fontSize,
     color: ink.primary,
   },
   searchTextInputFocused: {
     borderColor: accent.primary,
   },
   searchClear: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    width: touchTarget.minimum,
+    height: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.circle,
     backgroundColor: surface.sunken,
     alignItems: 'center',
     justifyContent: 'center',
   },
   searchClearText: {
-    fontSize: 14,
+    ...uiType.button,
     color: ink.soft,
-    fontWeight: '600',
   },
   searchResultCount: {
-    fontSize: 12,
+    ...editorialType.caption,
     color: ink.muted,
     marginTop: SPACING.xs,
-    marginLeft: 44,
+    marginLeft: touchTarget.minimum + SPACING.sm,
   },
 });
 

--- a/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
+++ b/frontend/src/features/Journal/__tests__/SearchBar.test.tsx
@@ -95,6 +95,14 @@ describe('SearchBar', () => {
     expect(getByText("5 results for 'test'")).toBeTruthy();
   });
 
+  it('uses the singular noun for exactly one result', () => {
+    const { getByTestId, getByText } = render(
+      <SearchBar onSearch={onSearch} resultCount={1} searchQuery="test" />,
+    );
+    fireEvent.press(getByTestId('search-toggle'));
+    expect(getByText("1 result for 'test'")).toBeTruthy();
+  });
+
   it('shows a "No results" line when a query comes back empty', () => {
     const { getByTestId, getByText } = render(
       <SearchBar onSearch={onSearch} resultCount={0} searchQuery="willow" />,


### PR DESCRIPTION
## Summary

De-slop tidy-up of `frontend/src/features/Journal/SearchBar.tsx`, bundling three corroborated Low findings in one file. All three were verified to still exist at HEAD before fixing.

1. **Grammatical result caption.** `resultLine` was unconditionally plural, so a single match rendered "1 results for 'x'". It now selects the noun conditionally: `result` for `1`, `results` otherwise (`0` and `>1` unchanged).
2. **Design-token sourcing.** Replaced the hardcoded touch-target and font-size literals (`36`/`18`/`16`/`14`/`12`/`44`) with Candle & Ink tokens, mirroring the co-located `JournalShelf.styles.ts`:
   - toggle/clear/input sizing → `touchTarget.minimum`; circular buttons → `BORDER_RADIUS.circle`.
   - glyph buttons (magnifier, clear ×) → `...uiType.button`; input text → `editorialType.note.fontSize`; result caption → `...editorialType.caption`.
   - the result-line indent, previously a silent `44` coupling (toggle width + gap), is now derived: `touchTarget.minimum + SPACING.sm`.
3. **Misleading sync comment.** Rewrote the `useEffect` comment to describe only what the effect does (keep local text in sync with the `searchQuery` prop) and dropped the unsupported "pending debounce clobber" claim and the dangling `BUG-FE-JOURNAL-105` tracker ID.

Scope note: the debounce/sync behavior, min-length gating, and count source are untouched (per the issue and #1145/#1146). A fourth item raised in the issue comment (the inert "Focus journal search" magnifier in the expanded bar) is an accessibility-behavior change outside this issue's Tasks/Acceptance Criteria, so it is left for a follow-up rather than expanded here.

## Test plan

- Added a Jest test asserting `resultCount={1}` renders "1 result for 'test'" (written RED first, confirmed failing on "1 results", then GREEN).
- `./scripts/frontend/check-all.sh` passes (ESLint, Prettier, tsc, 4126 Jest tests) with no new bare `36`/`18`/`16`/`14`/`12`/`44` literals in the StyleSheet.

Closes #1218