### PR TITLE
docs(frontend): document RadioOption adoption criteria (keep-local for four hand-rolled radios)

### DIFF
--- a/frontend/src/components/RadioOption.tsx
+++ b/frontend/src/components/RadioOption.tsx
@@ -1,3 +1,16 @@
+/**
+ * Shared radio primitive for exclusive-choice controls.
+ *
+ * Adoption criteria — a hand-rolled radio is a clean adopter only when every
+ * point below holds. When one does not, keep the control local rather than
+ * bending the primitive or weakening its a11y contract:
+ * - each option is a single TouchableOpacity wrapping exactly one Text label
+ *   (no icons, badges, description lines, or other child nodes);
+ * - the visible label doubles as the accessible name (they cannot differ);
+ * - selection is announced through accessibilityState `selected`, not `checked`;
+ * - the selected and unselected looks are expressed purely through the four
+ *   style props, with no runtime-injected theme colors.
+ */
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';


### PR DESCRIPTION
## Summary

Evaluates whether the four remaining hand-rolled `accessibilityRole="radio"` controls should adopt the shared `RadioOption`/`RadioGroup` primitive (`frontend/src/components/RadioOption.tsx`). The judgment: **all four stay local** — none is a clean drop-in, and forcing adoption would either destroy rendered output or weaken a11y semantics, both forbidden by the acceptance criteria.

The only code change is a concise **"Adoption criteria" module docstring** added to `RadioOption.tsx`, capturing the fitness template derived from the two existing clean adopters (Journal `AspectChordControl` + `PrivacyTierControl`). This makes the primitive's scope explicit so future controls can self-assess and de-slop passes do not re-litigate these decisions. Per the issue, the per-control keep-local rationale lives here in the PR body, not in code comments.

### Fitness template (a clean adopter meets all four)
- Each option is a single `TouchableOpacity` wrapping exactly one `<Text>{label}</Text>` (no icons, badges, or description lines).
- The visible label doubles as the accessible name (they cannot differ).
- Selection is announced via `accessibilityState.selected` (not `checked`).
- The selected/unselected look is expressed purely through the four style props, with no runtime-injected theme colors.

### Per-control evaluation — all keep-local

| Control | Verdict | Disqualifier |
|---|---|---|
| Practice `ModePicker` (`ModeRow`) | keep-local | Rich row body: icon + label/"New"-badge line + description Text. `RadioOption` renders only a single label, so adoption would drop that content. |
| Practice `MindfulAnchorView` (`OptionRow`) | keep-local | Uses `Pressable` (not `TouchableOpacity`), renders an optional description Text, and weaves runtime theme colors (`surface.*`) into its styles. The host-component swap alone breaks its snapshot's byte-identity. |
| Practice `CreatePracticeWizard` → `StageSelector` (radio variant, `components/StageSelector.tsx`) | keep-local | The accessible name (`"Stage 3"`) intentionally differs from the visible label (`"3"` / a `formatLabel` result); `RadioOption` forces `label === accessibleName`, which would regress the announced name. The chip is also shared with button-role variants. Already pinned by an existing test. |
| Habits `GoalModal` (`UnitChipRow` + `GoalDirectionRow`) | keep-local | Uses `accessibilityState={{ checked }}` — the intended radio announcement for VoiceOver/TalkBack — whereas `RadioOption` announces `selected`. Migrating would change the screen-reader output. Already pinned by an existing test. |

Note: the app now has two deliberate radio-announcement conventions (`selected` in `RadioOption`/adopters, `checked` in `GoalModal` with documented rationale). Harmonizing them, if ever desired, is a separate follow-up rather than part of this evaluation.

## Test plan

- No new tests: this is a docs-only change with no behavior change, and the two load-bearing divergences (`StageSelector` accessible-name independence, `GoalModal` `checked` state) are already guarded by existing tests that would break on migration — which is itself the evidence for keep-local.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, TypeScript, Jest: 396 suites / 4126 tests pass).

Closes #1237