### PR TITLE
test(return): deflake useMettaReturn full-suite waitFor race

### DIFF
--- a/frontend/src/features/Return/__tests__/useMettaReturn.test.tsx
+++ b/frontend/src/features/Return/__tests__/useMettaReturn.test.tsx
@@ -100,8 +100,7 @@ describe('useMettaReturn', () => {
   it('loads state on mount and exposes eligible/weeks/arc', async () => {
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
-    expect(result.current.eligible).toBe(true);
+    await waitFor(() => expect(result.current.eligible).toBe(true));
     expect(result.current.weeks).toHaveLength(5);
     expect(result.current.arc).toBeNull();
   });
@@ -110,7 +109,7 @@ describe('useMettaReturn', () => {
     mockUseContractionSignalActive.mockReturnValue(false);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.eligible).toBe(true));
     expect(result.current.offerVisible).toBe(false);
   });
 
@@ -125,7 +124,7 @@ describe('useMettaReturn', () => {
     mockUseContractionSignalActive.mockReturnValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: false, arc: null }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.weeks).toHaveLength(5));
     expect(result.current.offerVisible).toBe(false);
   });
 
@@ -133,9 +132,8 @@ describe('useMettaReturn', () => {
     mockUseContractionSignalActive.mockReturnValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: arc() }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.arc).not.toBeNull());
     expect(result.current.offerVisible).toBe(false);
-    expect(result.current.arc).not.toBeNull();
   });
 
   it('dismissOffer hides the offer, calls the API, and persists the cache flag', async () => {
@@ -158,7 +156,7 @@ describe('useMettaReturn', () => {
     mockLoadDismissed.mockResolvedValue(false);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null, offer_dismissed: true }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.eligible).toBe(true));
     expect(result.current.offerVisible).toBe(false);
   });
 
@@ -167,7 +165,7 @@ describe('useMettaReturn', () => {
     mockLoadDismissed.mockResolvedValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null, offer_dismissed: true }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.eligible).toBe(true));
     expect(result.current.offerVisible).toBe(false);
   });
 
@@ -176,8 +174,7 @@ describe('useMettaReturn', () => {
     mockLoadDismissed.mockResolvedValue(true);
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null, offer_dismissed: false }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
-    expect(result.current.offerVisible).toBe(true);
+    await waitFor(() => expect(result.current.offerVisible).toBe(true));
   });
 
   it('falls back to the cached dismissal flag when state() rejects', async () => {
@@ -208,7 +205,7 @@ describe('useMettaReturn', () => {
     mockState.mockResolvedValue(stateResult({ eligible: true, arc: null }));
     mockStart.mockResolvedValue(arc({ week: 1, focus: 'self' }));
     const { result } = renderHook(() => useMettaReturn());
-    await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.eligible).toBe(true));
 
     await act(async () => {
       await result.current.start();


### PR DESCRIPTION
## Summary

Fixes the intermittent full-suite-only failures in
`frontend/src/features/Return/__tests__/useMettaReturn.test.tsx` (relocated
from `features/Today/` by #1246). The suite used
`await waitFor(() => expect(mockState).toHaveBeenCalledTimes(1))` as its settle
condition, but `mettaReturn.state()` is called **synchronously** inside the
mount effect, so that predicate passes on the very first poll — before the
resolving `.then` microtask has set `eligible`/`arc`/`weeks`/`dismissed`. Under
parallel-worker load the microtask lagged the poll, and the following
synchronous assertions read the initial unsettled state. That single idiom is
the shared root cause behind every reported symptom on this file
(`offerVisible is false when an arc already exists`, plus the `eligible`,
`arc`, and `offerVisible` variants noted in the issue comments and #1174).

The fix awaits the **actual settled value** each case pins (or a co-settled
signal set in the same state batch) rather than the mock call count:

- `arc`-existence case waits on `result.current.arc` being non-null.
- eligibility/dismissal cases wait on `result.current.eligible` (co-settled
  with `dismissed`/`weeks` in the same `.then`).
- the ineligible case waits on `weeks` loading (5) since `eligible` stays false.
- `offerVisible: true` cases wait directly on `offerVisible`.
- the `start` case now waits for the load to settle before starting, so the
  load's `.then` can no longer clobber the started arc.

The two state-rejection cases keep the call-count wait deliberately: a rejected
load has no positive settled state to await, and their asserted values equal the
initial defaults, so they cannot race.

No production code changed — the hook was already correct; only the tests'
synchronization was racy. The fixed tests still fail on regression: temporarily
dropping the `arc === null` guard from the hook's `offerVisible` fails the named
case, confirming the assertions still pin behavior.

Scope note: this PR covers only #1243. The unmount-guard mutation-survivor work
tracked in #1571 was not touched and remains open.

## Test plan

- Target suite passes 5/5 in isolation.
- Full parallel suite (`jest`, default `--maxWorkers`) green 3× — 4126/4126,
  `useMettaReturn.test.tsx` PASS each run.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, tests).
- Regression check: breaking the hook's `arc === null` guard fails
  `offerVisible is false when an arc already exists`, then reverted.

Closes #1243