### PR TITLE
refactor(backend): tidy up llm_pricing dead accessor + stale service-test comments (round 3)

### DIFF
--- a/backend/src/services/llm_pricing.py
+++ b/backend/src/services/llm_pricing.py
@@ -22,9 +22,10 @@ from decimal import Decimal
 
 logger = logging.getLogger(__name__)
 
-# One million — the denominator for provider rate cards.  ``Decimal``
-# constants are constructed via ``str`` so ``Decimal(1_000_000)`` does
-# not accidentally absorb float-precision noise — the literal is exact.
+# One million — the denominator for provider rate cards.  An int literal
+# is exact in ``Decimal``, so no string quoting is needed here; the module
+# reserves ``Decimal("...")`` for the fractional constants (e.g.
+# ``_COST_QUANTUM``) where a bare float literal would absorb precision noise.
 _TOKENS_PER_MILLION = Decimal(1000000)
 
 # Six decimal places of precision for stored cost — same scale used by

--- a/backend/src/services/llm_pricing.py
+++ b/backend/src/services/llm_pricing.py
@@ -81,11 +81,6 @@ MODEL_PRICING: dict[str, ModelPricing] = {
 }
 
 
-def get_model_pricing(model: str) -> ModelPricing | None:
-    """Return the :class:`ModelPricing` for ``model`` or ``None`` when unknown."""
-    return MODEL_PRICING.get(model)
-
-
 def estimate_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> Decimal | None:
     """Estimate the USD cost of a single LLM call as a quantised :class:`Decimal`.
 

--- a/backend/tests/services/test_contraction_service.py
+++ b/backend/tests/services/test_contraction_service.py
@@ -1,9 +1,12 @@
 """Integration tests for :mod:`services.contraction` -- read-only aggregate gathering.
 
-These tests FAIL until ``backend/src/services/contraction.py`` exists with the
-contract pinned below. That is the correct RED state for Gate 1.
+Exercises ``gather_contraction_aggregates`` against a live async session: it reads
+a user's habits, their additive goals, and recent goal completions, buckets the
+completions into user-local days, and derives each habit's consecutive unmet /
+unchecked day counts into a :class:`ContractionAggregates` snapshot -- issuing
+``SELECT`` statements only, never staging a write.
 
-Pinned service contract:
+Service contract:
   async def gather_contraction_aggregates(session, user_id, user_timezone="UTC")
       -> ContractionAggregates
 """

--- a/backend/tests/test_llm_pricing.py
+++ b/backend/tests/test_llm_pricing.py
@@ -18,7 +18,6 @@ from services.llm_pricing import (
     MODEL_PRICING,
     ModelPricing,
     estimate_cost_usd,
-    get_model_pricing,
 )
 
 
@@ -93,15 +92,15 @@ class TestEstimateCostUsd:
         assert int(cost.as_tuple().exponent) == -6
 
 
-class TestGetModelPricing:
+class TestModelPricingLookup:
     def test_returns_pricing_for_known_model(self) -> None:
-        pricing = get_model_pricing("gpt-4o-mini")
+        pricing = MODEL_PRICING.get("gpt-4o-mini")
         assert pricing is not None
         assert pricing.input_usd_per_million > 0
         assert pricing.output_usd_per_million > 0
 
     def test_returns_none_for_unknown_model(self) -> None:
-        assert get_model_pricing("unknown-model") is None
+        assert MODEL_PRICING.get("unknown-model") is None
 
 
 class TestModelPricingTable:
@@ -139,7 +138,7 @@ class TestAllowlistPricingReconciliation:
             model
             for spec in PROVIDER_REGISTRY.values()
             for model in spec.allowed_models
-            if get_model_pricing(model) is None
+            if MODEL_PRICING.get(model) is None
         )
         assert unpriced == [], f"allowlisted models missing a price: {unpriced}"
 


### PR DESCRIPTION
## Summary

De-slop round-3 tidy-up of the backend service layer + its tests. All three
findings from the issue were re-verified at HEAD and still present; each is
fixed in its own commit with no behavior change:

1. **Dead `get_model_pricing` accessor** (`services/llm_pricing.py`) — the public
   wrapper had zero production callers (`estimate_cost_usd` already read
   `MODEL_PRICING.get` directly, routing around it). Removed the pure passthrough
   and repointed the three `test_llm_pricing.py` references to `MODEL_PRICING.get`
   so there is a single lookup path.
2. **Misdescribing `_TOKENS_PER_MILLION` comment** (`services/llm_pricing.py`) —
   the comment claimed the constant is "constructed via `str`", but the line
   builds it from an int literal (already exact). Reworded to state the int is
   exact and that `str` quoting is reserved for the fractional constants where a
   float literal would drift. No code/arithmetic change.
3. **Stale RED-state TDD docstring** (`tests/services/test_contraction_service.py`)
   — the module docstring still asserted "These tests FAIL until ...
   contraction.py exists" (the RED state for Gate 1), but the service exists and
   the suite is green. Rewrote it to describe the live read-only aggregate-
   gathering contract the tests exercise today.

## Test plan

- `./scripts/backend/check-all.sh` — green (2618 passed, 2 skipped; coverage
  96.62%, `llm_pricing.py` at 100%).
- `xenon --max-absolute A --max-modules A --max-average A src` — passes.
- `radon mi` on both touched modules — grade A.
- `grep -rn get_model_pricing backend` — zero matches (fully removed).

Closes #1249