### PR TITLE
refactor(habits): dead-code sweep, stale-comment fixes, and id-0 guard alignment

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -41,7 +41,7 @@ import {
 /** A tile that is not wired to log units keeps the star as a tooltip-only touch target. */
 const NOOP_LOG_UNIT: NonNullable<HabitTileProps['onLogUnit']> = () => {};
 
-/** Marker star size: a touch larger than the bar so it reads as a sitting marker. */
+/** Marker star size: tracks the bar's nominal thickness (spacing(2)) so it reads as a sitting marker. */
 const markerStarSize = (scale: number): number => spacing(2, scale);
 
 /** Round to at most two decimals and drop trailing zeros so the fraction reads cleanly. */
@@ -177,8 +177,6 @@ const HabitHeader = ({
   );
 };
 
-const TOTAL_HABITS = MAX_HABITS;
-
 /** Tile border thickness so the aptitude/stage color reads clearly at a glance. */
 export const TILE_BORDER_WIDTH = 3;
 
@@ -193,7 +191,7 @@ const habitGridChrome = (scale: number, gridGutter: number): number =>
 export const useTileLayout = () => {
   const { contentWidth, height, columns, scale, gridGutter } = useResponsive();
   const insets = useSafeAreaInsets();
-  const rows = columns === 2 ? TOTAL_HABITS / columns : TOTAL_HABITS;
+  const rows = columns === 2 ? MAX_HABITS / columns : MAX_HABITS;
   const chrome = habitGridChrome(scale, gridGutter);
   const bottomBarReserve = BOTTOM_TAB_BAR_CONTENT_HEIGHT + insets.bottom;
   const availableHeight = height - insets.top - bottomBarReserve - chrome;
@@ -464,7 +462,8 @@ const useHabitTileData = (habit: Habit, tz: string, stageColor: string) => {
     stretch: stretchMarker,
   } = getMarkerPositions(lowGoal, clearGoal, stretchGoal);
 
-  // SG is unconditionally visible (the prior ``hasCleared`` gate caused user-reported confusion).
+  // Each marker is visible whenever its tier's goal exists — the stretch marker is
+  // no longer gated on ``hasCleared`` (that gate caused user-reported confusion).
   // ``met`` is only computed when the goal exists — an absent tier has no goal to achieve.
   const markers: TileMarkerSpec[] = [
     {

--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -34,11 +34,6 @@ export const styles = StyleSheet.create({
   },
 
   // ===== Habit Tiles =====
-  icon: {
-    fontSize: 40,
-    marginTop: SPACING.sm,
-    marginBottom: SPACING.xs,
-  },
   iconLarge: {
     fontSize: 24,
   },
@@ -181,10 +176,6 @@ export const styles = StyleSheet.create({
   // ===== Icon Selector =====
   currentIcon: {
     fontSize: 24,
-  },
-  iconButtonText: {
-    color: COLORS.secondary,
-    fontWeight: '500',
   },
 
   // ===== Energy Container =====

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -28,15 +28,6 @@ export interface Habit {
   sort_order?: number | null;
 
   // --- Client-only fields (not from API) ---
-  /**
-   * Total progress toward the habit goals.
-   *
-   * This value is derived from the sum of all completion units
-   * recorded in the `completions` array and should not be set
-   * directly. It is kept optional to encourage calculating the
-   * current progress programmatically via `calculateTodaysProgress`.
-   */
-  progress?: number;
   completions?: Completion[];
   /** Device-local notification IDs managed by expo-notifications. */
   notificationIds?: string[];
@@ -215,7 +206,6 @@ export interface HabitsUIFlags {
   showEnergyCTA: boolean;
   showArchiveMessage: boolean;
   archiveEnergyCTA: () => void;
-  emojiHabitIndex: number | null;
 }
 
 export interface UseHabitsReturn {

--- a/frontend/src/features/Habits/__tests__/useHabits.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabits.test.ts
@@ -246,10 +246,4 @@ describe('useHabits', () => {
     expect(updated?.completions).toEqual([]);
     expect(updated?.start_date).toEqual(newDate);
   });
-
-  it('emojiHabitIndex tracks which habit is being edited', () => {
-    const { result } = renderHook(() => useHabits());
-
-    expect(result.current.ui.emojiHabitIndex).toBeNull();
-  });
 });

--- a/frontend/src/features/Habits/components/GoalModal.tsx
+++ b/frontend/src/features/Habits/components/GoalModal.tsx
@@ -842,7 +842,7 @@ const buildPendingGoalEdit = (
   habitId: number | undefined,
 ): PendingGoalEdit | null => {
   const goal = tier === 'low' ? tiers.lowGoal : tiers.clearGoal;
-  if (!goal || !habitId) return null;
+  if (!goal || habitId == null) return null;
   const stretchTarget = tiers.stretchGoal ? getGoalTarget(tiers.stretchGoal) : goal.target;
   const newTarget = Math.max(1, Math.round((percent / 100) * stretchTarget));
   const tierLabel = tier === 'low' ? 'Low Grit' : 'Clear Goal';
@@ -932,7 +932,8 @@ function useGoalConfirm(
     setPending(null);
   };
   const applyPending = () => {
-    if (pending && habitId) onUpdateGoal(habitId, { ...pending.goal, target: pending.newTarget });
+    if (pending && habitId != null)
+      onUpdateGoal(habitId, { ...pending.goal, target: pending.newTarget });
     setPending(null);
   };
   return { onConfirm, pending, cancelPending, applyPending };
@@ -1149,7 +1150,7 @@ const useLogState = (
   const [logDate, setLogDate] = useState<Date>(() => new Date());
 
   const handleLogUnit = () => {
-    if (!habit.id) return;
+    if (habit.id == null) return;
     const parsed = Number.parseFloat(logAmount);
     onLogUnit(habit.id, Number.isNaN(parsed) ? 1 : parsed, logDate);
     setLogAmount('1');

--- a/frontend/src/features/Habits/components/MissedDaysModal.tsx
+++ b/frontend/src/features/Habits/components/MissedDaysModal.tsx
@@ -122,12 +122,12 @@ const MissedDaysBody = ({
         <Calendar
           onDayPress={reset.onPick}
           markedDates={{
-            [selectedDateString ?? '']: {
+            [selectedDateString]: {
               selected: true,
               selectedColor: STAGE_COLORS[habit.stage],
             },
           }}
-          minDate={new Date().toISOString()}
+          minDate={toISODate(new Date())}
         />
       ) : (
         <MissedDaysActions

--- a/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/GoalModal.test.tsx
@@ -470,10 +470,19 @@ describe('GoalModal log-unit guards', () => {
     jest.clearAllMocks();
   });
 
-  it('skips logging when the habit has no id', () => {
-    const { getByText, props } = renderModal(makeHabit({ id: 0 }));
+  it('skips logging when the habit has no id (synthetic onboarding state)', () => {
+    const { getByText, props } = renderModal(makeHabit({ id: undefined as unknown as number }));
     fireEvent.press(getByText('Log Units'));
     expect(props.onLogUnit).not.toHaveBeenCalled();
+  });
+
+  it('logs when the habit id is 0 (falsy but a real id)', () => {
+    const { getByText, props } = renderModal(makeHabit({ id: 0 }));
+    fireEvent.press(getByText('Log Units'));
+    const calls = (props.onLogUnit as unknown as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [habitId] = calls[0] as [number, number, Date];
+    expect(habitId).toBe(0);
   });
 
   it('falls back to an amount of 1 when the log-amount field is non-numeric', () => {

--- a/frontend/src/features/Habits/components/parseEnergyValue.ts
+++ b/frontend/src/features/Habits/components/parseEnergyValue.ts
@@ -1,7 +1,7 @@
 /**
  * Pure parser for the energy-cost / energy-return text inputs in the
- * habit settings modal.  Lives in its own file so unit tests can import
- * without pulling in the RN component tree.
+ * habit settings and Add Habit modals.  Lives in its own file so unit
+ * tests can import without pulling in the RN component tree.
  *
  * BUG-FE-HABIT-201: the prior ``parseInt(text) || 0`` silently coerced
  * "foo", "1.5", "" all to ``0`` and accepted them as valid energy
@@ -9,9 +9,9 @@
  * cases so the caller can surface a validation error instead of writing
  * 0 to the planner.
  */
-// Bounds mirror those expressed in ``HabitSettingsModal``; kept here so
-// the parser stays a single source of truth across the input row + the
-// dedicated unit tests.
+// The -10..10 range is also spelled out in the user-facing validation
+// copy (``EnergyCostReturnEditor``'s ENERGY_VALIDATION_NOTE); keep the two
+// in sync.
 const ENERGY_MIN = -10;
 const ENERGY_MAX = 10;
 

--- a/frontend/src/features/Habits/constants.ts
+++ b/frontend/src/features/Habits/constants.ts
@@ -1,10 +1,11 @@
 /**
- * The habit ceiling: the maximum number of habits a user can track.
+ * The onboarding habit cap and Habits-grid sizing constant.
  *
  * Ten is a causally-coupled product constant — it simultaneously drives the
  * onboarding cap, the Habits list page size, and the tile-layout row divisor
  * (see `useTileLayout`). These must move together, so they all derive from this
- * single value rather than repeating the literal.
+ * single value rather than repeating the literal. The regular Add Habit flow is
+ * not capped here; the backend enforces a separate, higher per-user ceiling.
  */
 export const MAX_HABITS = 10;
 

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -54,7 +54,6 @@ export const useHabits = (): UseHabitsReturn => {
       showEnergyCTA: ui.showEnergyCTA,
       showArchiveMessage: ui.showArchiveMessage,
       archiveEnergyCTA: ui.archiveEnergyCTA,
-      emojiHabitIndex: ui.emojiHabitIndex,
     },
     setHabitsForTesting: storeSetHabits,
   };

--- a/frontend/src/features/Habits/services/habitManager.ts
+++ b/frontend/src/features/Habits/services/habitManager.ts
@@ -237,6 +237,15 @@ const resetHabitStart = (habit: Habit, newDate: Date): Habit => ({
   completions: [],
 });
 
+const buildTierGoals = (habitName: string, idFor: (tierIndex: number) => number) =>
+  GOAL_TIERS.map((t, ti) => ({
+    id: idFor(ti),
+    title: `${t.label} goal for ${habitName}`,
+    ...DEFAULT_GOAL_CONFIG,
+    tier: t.tier,
+    target: t.target,
+  }));
+
 const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
   newHabits.map((habit, index) => ({
     ...habit,
@@ -244,13 +253,7 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
     streak: 0,
     revealed: false,
     completions: [] as Habit['completions'],
-    goals: GOAL_TIERS.map((t, ti) => ({
-      id: index * 3 + ti + 1,
-      title: `${t.label} goal for ${habit.name}`,
-      ...DEFAULT_GOAL_CONFIG,
-      tier: t.tier,
-      target: t.target,
-    })),
+    goals: buildTierGoals(habit.name, (ti) => index * 3 + ti + 1),
   }));
 
 /**
@@ -262,22 +265,17 @@ const buildOnboardingHabits = (newHabits: OnboardingHabit[]) =>
 const buildAddedHabit = (input: AddHabitInput, existingCount: number): Habit => {
   const stage = stageAtIndex(existingCount);
   const tempId = -Date.now();
+  const name = input.name.trim();
   return {
     id: tempId,
     stage,
-    name: input.name.trim(),
+    name,
     icon: input.icon,
     streak: 0,
     energy_cost: input.energy_cost ?? 5,
     energy_return: input.energy_return ?? 5,
     start_date: new Date(),
-    goals: GOAL_TIERS.map((t, ti) => ({
-      id: tempId - ti - 1,
-      title: `${t.label} goal for ${input.name.trim()}`,
-      ...DEFAULT_GOAL_CONFIG,
-      tier: t.tier,
-      target: t.target,
-    })),
+    goals: buildTierGoals(name, (ti) => tempId - ti - 1),
     completions: [],
     revealed: false,
     sort_order: existingCount,
@@ -838,9 +836,8 @@ export const habitManager = {
 
   /**
    * Atomically update the shared unit fields across every tier goal of a
-   * habit (issue #289). One optimistic apply, one batch PUT, one rollback
-   * closure — replaces the GoalUnitEditor's three-call fan-out whose
-   * partial failure split tiers between old and new units server-side.
+   * habit: one optimistic apply, one batch PUT, one rollback closure — so a
+   * partial failure can never split tiers between old and new units.
    */
   updateGoalUnits: (
     habitId: number,
@@ -877,11 +874,9 @@ export const habitManager = {
     const prev = getHabits();
     const next = prev.map((h) => (h.id === updatedHabit.id ? updatedHabit : h));
     setHabits(next);
-    // BUG-FE-HABIT-005: serialize per-habit notification rescheduling and
-    // write the freshly-returned ids back onto the habit before
-    // persisting.  The previous ``void updateHabitNotifications(...)``
-    // discarded the return value, so a second rapid edit would still
-    // see the pre-first-edit ``notificationIds`` and double-schedule.
+    // Serialize per-habit notification rescheduling and write the freshly
+    // returned ids back onto the habit before persisting, so a rapid second
+    // edit reschedules against fresh ``notificationIds`` instead of double-scheduling.
     if (updatedHabit.id) void rescheduleAndPersist(updatedHabit);
     else void persistHabits(next);
     if (!updatedHabit.id) return;


### PR DESCRIPTION
## Summary

Round-2 low tidy-up sweep across the Habits feature (issue #1255). Every finding was re-verified at HEAD after recent Habits churn; one was found stale and skipped, one is deferred to its own issue, and the rest applied.

**Dead code removed** (grep-proven zero live references):
- `Habits.styles.ts`: dead `icon` and `iconButtonText` style keys.
- `Habits.types.ts`: dead client-only `Habit.progress` field + docstring.
- `useHabits.ts` / `Habits.types.ts`: redundant `emojiHabitIndex` exposure on the `useHabits` `ui` return (production reads it off `useHabitUI` directly); dropped the field and the test that only asserted the exposure.
- `MissedDaysModal.tsx`: unreachable `?? ''` fallback on a non-nullable `toISODate(...)` result.

**Behavior-adjacent fix (TDD-pinned with an id-0 fixture):**
- `GoalModal.tsx`: aligned the falsy-zero guards the file's own comment argues for — `handleLogUnit`, `buildPendingGoalEdit`, and `applyPending` now use `== null` / `!= null` so a habit with id 0 is treated as a real id instead of silently no-op'ing. (The reviewer flagged `applyPending` as a leftover truthy guard; it is now aligned so the whole marker-drag → confirm → apply path is consistent for id 0.)

**Comment / consistency tidy-up:**
- `MissedDaysModal.tsx`: normalized the calendar `minDate` to date-only (`toISODate(new Date())`) so "today" isn't excluded by the min compare.
- `parseEnergyValue.ts`: pointed the bounds comment at `EnergyCostReturnEditor`'s user-facing copy; noted the module also backs the Add Habit modal.
- `constants.ts`: reworded the `MAX_HABITS` summary (it's the onboarding/grid cap, not the per-user ceiling — the backend enforces a separate, higher one).
- `HabitTile.tsx`: inlined the single-use `TOTAL_HABITS` alias; corrected the stretch-marker "unconditionally visible" and marker-star "a touch larger than the bar" comments to match the code.
- `habitManager.ts`: extracted a `buildTierGoals` helper backing both the onboarding and added-habit builders (item #10's duplicated builders); collapsed two history-narrating comment blocks to intent-only.

**Skipped / deferred (noted per the issue's request to verify at HEAD):**
- **Item 5 (OnboardingModal `updateHabitEnergy` guards) — SKIPPED as stale.** The range guard and `Math.round` are NOT dead: the energy slider emits out-of-range and fractional values, and `OnboardingModal.energySliders.test.tsx` explicitly pins the clamp + round behavior. Removing them broke three tests, so the guards are kept.
- **Item 10's HabitTile tile-style builders — deferred to #1512** (that issue owns `getLockedTileStyle`/`buildUnlockedTileStyle`; this PR only does habitManager's `GOAL_TIERS` builder dedup, which #1512 itself confirms is separate).

## Test plan
- Added a RED→GREEN test in `GoalModal.test.tsx`: a habit with `id: 0` now logs (`onLogUnit` called with `0`); the existing no-id test was repointed to `id: undefined`.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, `tsc` strict, and all 4126 Jest tests pass.
- Gate 2.5 `code-review-orchestrator` verdict: CLEAN (its one non-blocking nit — the `applyPending` guard — is fixed in this PR).

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)