### PR TITLE
fix(course): reconcile ContentCard content_type map with backend

### DIFF
--- a/frontend/src/features/Course/ContentCard.tsx
+++ b/frontend/src/features/Course/ContentCard.tsx
@@ -6,22 +6,41 @@ import { colors, surface } from '../../design/tokens';
 
 import styles from './Course.styles';
 
-/** Map content_type to a representative icon character. */
-const CONTENT_TYPE_ICONS: Record<string, string> = {
-  essay: '📖',
-  prompt: '💬',
-  video: '▶',
+interface ContentTypeStyle {
+  icon: string;
+  color: string;
+}
+
+/**
+ * Single source of truth for per-content_type presentation. Icon and background
+ * live in one entry so they cannot drift apart, and the keys track the
+ * content_type values the backend actually serves (production ships `chapter`;
+ * `essay`/`prompt`/`video` are creatable via the course authoring endpoint).
+ */
+const CONTENT_TYPE_STYLES: Record<string, ContentTypeStyle> = {
+  chapter: { icon: '📚', color: colors.tier.stretch },
+  essay: { icon: '📖', color: colors.mystical.glowPurple },
+  prompt: { icon: '💬', color: colors.tier.clear },
+  video: { icon: '▶', color: colors.tier.low },
 };
 
-/** Background color by content type. */
-const CONTENT_TYPE_COLORS: Record<string, string> = {
-  essay: colors.mystical.glowPurple,
-  prompt: colors.tier.clear,
-  video: colors.tier.low,
+const DEFAULT_STYLE: ContentTypeStyle = { icon: '📄', color: surface.sunken };
+
+const getSubtitle = (item: ContentItem): string => {
+  if (item.is_locked) {
+    return `Unlocks on day ${item.release_day}`;
+  }
+  if (item.is_read) {
+    return 'Completed';
+  }
+  return item.content_type.charAt(0).toUpperCase() + item.content_type.slice(1);
 };
 
-const DEFAULT_ICON = '📄';
-const DEFAULT_COLOR = surface.sunken;
+const getStatusIndicator = (item: ContentItem): string => {
+  if (item.is_locked) return '🔒';
+  if (item.is_read) return '✓';
+  return '›';
+};
 
 interface ContentCardProps {
   item: ContentItem;
@@ -29,24 +48,7 @@ interface ContentCardProps {
 }
 
 const ContentCard = ({ item, onPress }: ContentCardProps): React.JSX.Element => {
-  const icon = CONTENT_TYPE_ICONS[item.content_type] ?? DEFAULT_ICON;
-  const iconBg = CONTENT_TYPE_COLORS[item.content_type] ?? DEFAULT_COLOR;
-
-  const getSubtitle = (): string => {
-    if (item.is_locked) {
-      return `Unlocks on day ${item.release_day}`;
-    }
-    if (item.is_read) {
-      return 'Completed';
-    }
-    return item.content_type.charAt(0).toUpperCase() + item.content_type.slice(1);
-  };
-
-  const getStatusIndicator = (): string => {
-    if (item.is_locked) return '🔒';
-    if (item.is_read) return '✓';
-    return '›';
-  };
+  const { icon, color: iconBg } = CONTENT_TYPE_STYLES[item.content_type] ?? DEFAULT_STYLE;
 
   return (
     <TouchableOpacity
@@ -65,17 +67,20 @@ const ContentCard = ({ item, onPress }: ContentCardProps): React.JSX.Element => 
         item.is_read && styles.contentCardRead,
       ]}
     >
-      <View style={[styles.contentCardIcon, { backgroundColor: iconBg }]}>
+      <View
+        testID={`content-card-icon-${item.id}`}
+        style={[styles.contentCardIcon, { backgroundColor: iconBg }]}
+      >
         <Text style={styles.contentCardIconText}>{icon}</Text>
       </View>
       <View style={styles.contentCardBody}>
         <Text style={styles.contentCardTitle} numberOfLines={1}>
           {item.title}
         </Text>
-        <Text style={styles.contentCardSubtitle}>{getSubtitle()}</Text>
+        <Text style={styles.contentCardSubtitle}>{getSubtitle(item)}</Text>
       </View>
       <View style={styles.contentCardStatus}>
-        <Text style={styles.contentCardStatusText}>{getStatusIndicator()}</Text>
+        <Text style={styles.contentCardStatusText}>{getStatusIndicator(item)}</Text>
       </View>
     </TouchableOpacity>
   );

--- a/frontend/src/features/Course/__tests__/ContentCard.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentCard.test.tsx
@@ -2,9 +2,16 @@
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, fireEvent } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 
 import type { ContentItem } from '../../../api';
+import { colors, surface } from '../../../design/tokens';
 import ContentCard from '../ContentCard';
+
+const DEFAULT_ICON = '📄';
+
+const iconBackground = (style: unknown): unknown =>
+  (StyleSheet.flatten(style as never) as { backgroundColor?: unknown }).backgroundColor;
 
 const makeItem = (overrides: Partial<ContentItem> = {}): ContentItem => ({
   id: 1,
@@ -46,6 +53,28 @@ describe('ContentCard', () => {
     const item = makeItem({ content_type: 'video' });
     const { getByText } = render(<ContentCard item={item} onPress={onPress} />);
     expect(getByText('▶')).toBeTruthy();
+  });
+
+  it('shows a non-default icon for the production chapter content type', () => {
+    const item = makeItem({ content_type: 'chapter' });
+    const { getByText, queryByText } = render(<ContentCard item={item} onPress={onPress} />);
+    expect(getByText('📚')).toBeTruthy();
+    expect(queryByText(DEFAULT_ICON)).toBeNull();
+  });
+
+  it('gives the chapter icon badge a non-default themed background', () => {
+    const item = makeItem({ id: 42, content_type: 'chapter' });
+    const { getByTestId } = render(<ContentCard item={item} onPress={onPress} />);
+    const background = iconBackground(getByTestId('content-card-icon-42').props.style);
+    expect(background).toBe(colors.tier.stretch);
+    expect(background).not.toBe(surface.sunken);
+  });
+
+  it('falls back to the default icon and background for an unknown content type', () => {
+    const item = makeItem({ id: 7, content_type: 'mystery' });
+    const { getByText, getByTestId } = render(<ContentCard item={item} onPress={onPress} />);
+    expect(getByText(DEFAULT_ICON)).toBeTruthy();
+    expect(iconBackground(getByTestId('content-card-icon-7').props.style)).toBe(surface.sunken);
   });
 
   it('shows unlock date for locked items', () => {


### PR DESCRIPTION
## Summary
Production course content ships `content_type: "chapter"` for all 209 seeded items, but `ContentCard`'s icon/color maps were keyed only on `essay | prompt | video`. Every real card therefore fell through to the generic default icon (📄), and the type-specific iconography never rendered.

- Unified `CONTENT_TYPE_ICONS` + `CONTENT_TYPE_COLORS` into a single `CONTENT_TYPE_STYLES` map so the icon and its background can no longer drift apart (one entry per type, shared key set).
- Added the production `chapter` type with a Candle & Ink icon (📚) and themed background (`colors.tier.stretch`). Kept `essay`/`prompt`/`video`, which remain creatable via the course authoring endpoint.
- Hoisted the two pure `getSubtitle`/`getStatusIndicator` helpers to module scope (keeps the component under the max-lines lint gate and makes them independently testable).
- Added a `content-card-icon-<id>` testID on the icon badge so a test can pin its background.

## Test plan
- `frontend/src/features/Course/__tests__/ContentCard.test.tsx`: new tests assert the production `chapter` type renders the non-default 📚 icon and `colors.tier.stretch` background, and that an unknown type falls back to the default icon + `surface.sunken`. RED before the map change, GREEN after.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4129 tests).

Closes #1257