### PR TITLE
fix(map): round formatMinutes before the hour threshold check

### DIFF
--- a/frontend/src/features/Map/__tests__/journeyNarrative.test.ts
+++ b/frontend/src/features/Map/__tests__/journeyNarrative.test.ts
@@ -86,6 +86,12 @@ describe('formatMinutes', () => {
     expect(formatMinutes(59.4)).toBe('59 min');
   });
 
+  it('promotes durations that round up to 60 minutes into the hours branch', () => {
+    expect(formatMinutes(59.5)).toBe('1 hr');
+    expect(formatMinutes(59.6)).toBe('1 hr');
+    expect(formatMinutes(59.99)).toBe('1 hr');
+  });
+
   it('switches to hours at the 60-minute boundary, singular at exactly 1 hour', () => {
     expect(formatMinutes(60)).toBe('1 hr');
   });

--- a/frontend/src/features/Map/journeyNarrative.ts
+++ b/frontend/src/features/Map/journeyNarrative.ts
@@ -35,11 +35,12 @@ const MINUTES_PER_HOUR = 60;
 
 /** Human-friendly duration: whole minutes under an hour, else rounded hours. */
 export const formatMinutes = (minutes: number): string => {
-  if (minutes >= MINUTES_PER_HOUR) {
+  const wholeMinutes = Math.round(minutes);
+  if (wholeMinutes >= MINUTES_PER_HOUR) {
     const hours = Math.round(minutes / MINUTES_PER_HOUR);
     return `${hours} hr${hours === 1 ? '' : 's'}`;
   }
-  return `${Math.round(minutes)} min`;
+  return `${wholeMinutes} min`;
 };
 
 /** Total sessions + total minutes + best habit streak, derived once. */


### PR DESCRIPTION
## Summary

`formatMinutes` (`frontend/src/features/Map/journeyNarrative.ts`) tested the
hour threshold on the **raw** value (`minutes >= 60`) but rounded the sub-hour
branch (`Math.round(minutes)`). For any duration in the half-open range
`[59.5, 60)` this rounded up to `60` while staying on the "minutes" branch,
rendering `"60 min"` — a value the function's own 60-minute → `"1 hr"` rule says
should never appear. `total_minutes` is a float end-to-end and feeds this
function directly in the stage-history modal, so the value is reachable.

The fix rounds once up front and compares the rounded minutes against the
threshold, so anything that rounds to `>= 60` minutes is promoted to the hours
branch. Hours-rounding behavior is unchanged (`90` → `"2 hrs"`, `89` → `"1 hr"`).

## Test plan

- Added a boundary regression test covering the `[59.5, 60)` gap
  (`59.5`, `59.6`, `59.99` → `"1 hr"`).
- Re-confirmed no regression: `59.4` → `"59 min"`, `60` → `"1 hr"`,
  `90` → `"2 hrs"`, `89` → `"1 hr"`, `0` → `"0 min"`.
- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4130
  tests).

Closes #1258