### PR TITLE
refactor(map): de-slop tidy-up — no-op polarity ternary, dup history styles, redundant docs

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -143,14 +143,6 @@ const styles = StyleSheet.create({
     justifyContent: CENTER,
     paddingHorizontal: spacing(0.5),
   },
-  // Polarity is now carried by the sine-wave overlay, so the center cells stay
-  // transparent and let the wave read through the whole column.
-  cellFeminine: {
-    backgroundColor: 'transparent',
-  },
-  cellMasculine: {
-    backgroundColor: 'transparent',
-  },
   // --- The glass magnifier lens (the "you are here" box, grown up) ----------
   // A translucent pill floating over the center column. Width / height /
   // borderRadius and its transform are computed per-layout in the component;
@@ -586,7 +578,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: onShowcase.soft,
   },
-  historyLoading: {
+  historyStatus: {
     paddingVertical: spacing(1.5),
     alignItems: CENTER,
   },
@@ -596,10 +588,6 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
     paddingVertical: spacing(1),
     textAlign: CENTER,
-  },
-  historyError: {
-    paddingVertical: spacing(1.5),
-    alignItems: CENTER,
   },
   historyErrorText: {
     fontSize: 12,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -54,7 +54,7 @@ import {
 } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
 import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
-import { isLeftReturning, type StageData } from './stageData';
+import { type StageData } from './stageData';
 import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
 
@@ -282,7 +282,6 @@ const StageCenterCell = ({
     style={[
       styles.centerStageCell,
       showTopDivider ? styles.horizontalDivider : null,
-      isLeftReturning(display.stageNumber) ? styles.cellFeminine : styles.cellMasculine,
       locked ? styles.locked : null,
     ]}
     onPress={() => onPress(stage)}
@@ -629,7 +628,7 @@ const HistoryBody = ({
 
   if (loading) {
     return (
-      <View style={styles.historyLoading} testID="history-loading">
+      <View style={styles.historyStatus} testID="history-loading">
         <ActivityIndicator size="small" color={colors.text.light} />
       </View>
     );
@@ -638,7 +637,7 @@ const HistoryBody = ({
   // retry instead of the "begin this stage" empty copy.
   if (error) {
     return (
-      <View style={styles.historyError} testID="history-error">
+      <View style={styles.historyStatus} testID="history-error">
         <Text style={styles.historyErrorText}>Couldn&apos;t load your journey for this stage.</Text>
         <TouchableOpacity
           onPress={onRetry}

--- a/frontend/src/features/Map/hooks/useWheelBalance.ts
+++ b/frontend/src/features/Map/hooks/useWheelBalance.ts
@@ -1,11 +1,8 @@
-/** Fetch-on-mount wheel-of-wholeness balance; empty map on error reads all-thin. */
-
 import { useEffect, useState } from 'react';
 
 import { wheel } from '../../../api';
 import { clampProgress } from '../services/stageService';
 
-/** Fetch-on-mount wheel balance: fullness per stage, plus loading/error state. */
 export interface WheelBalanceState {
   /** Clamped 0..1 fullness keyed by stage number; ``{}`` on error/loading. */
   fullnessByStage: Record<number, number>;
@@ -17,7 +14,7 @@ export interface WheelBalanceState {
 const toFullnessByStage = (aspects: { stage_number: number; fullness: number }[]) =>
   Object.fromEntries(aspects.map((a) => [a.stage_number, clampProgress(a.fullness)]));
 
-/** Load the wheel balance once on mount; empty map + ``error`` on any failure. */
+/** Fetch-on-mount wheel-of-wholeness balance; empty map + ``error`` on failure reads all-thin. */
 export function useWheelBalance(): WheelBalanceState {
   const [fullnessByStage, setFullnessByStage] = useState<Record<number, number>>({});
   const [loading, setLoading] = useState(true);
@@ -31,8 +28,9 @@ export function useWheelBalance(): WheelBalanceState {
       // itself is unaffected by a failed wheel read.
       setError(err instanceof Error ? err.message : 'Failed to load wheel balance');
     };
-    // ``Promise.resolve`` wraps the call so a synchronous throw (not just a
-    // rejected promise) routes through the same all-thin fallback path.
+    // ``Promise.resolve`` wraps the call so a synchronous throw (e.g. a
+    // partially-available api module leaving ``wheel`` undefined) routes through
+    // the same all-thin fallback path as a rejected promise.
     Promise.resolve()
       .then(() => wheel.get())
       .then((balance) => {


### PR DESCRIPTION
## Summary

De-slop tidy-up of the Map feature (issue #1260, `de-slop`/`dead-code`/`priority-low`). Pure hygiene — no change to rendered output or behavior.

Verified all five original findings at HEAD (`b0863dc6`, after Map churn from #1545/#1562/#1577/#1585). Applied the three that still reproduce, one was already resolved upstream, and one turned out to be load-bearing (kept, with justification below).

- **Finding 1 (applied)** — Removed the byte-identical `cellFeminine`/`cellMasculine` styles and the `isLeftReturning(...)` ternary that selected between them in `StageCenterCell`. Polarity is carried by the `WaveOverlay`, so the center cells are always transparent; the branch was a no-op. Dropped the now-unused `isLeftReturning` import from `MapScreen.tsx` (still exported and used by `mapLayout`/`waveGeometry`).
- **Finding 2 (already resolved)** — The dead `isCurrent` prop on `StageTextBlock` was already removed by earlier Map work; `isCurrent` now drives real behavior elsewhere. No change needed.
- **Finding 3 (applied)** — Collapsed the identical `historyLoading`/`historyError` style objects into one shared `historyStatus` key, updating both call sites.
- **Finding 4 (kept — NOT over-defensive)** — The issue asked to replace `Promise.resolve().then(() => wheel.get())` with a bare `wheel.get()`, on the theory that `wheel.get()` can only ever reject (never throw synchronously) because `request()` is `async`. That analysis is incomplete: it misses that `wheel.get()` is a **property access on `wheel`**, and several Map suites (`MapRetry`, `MapJourney`, `MapScreenColdStart`, ...) mock `../../../api` with only `stages`, leaving `wheel` **undefined**. Reading `.get` off `undefined` is a **synchronous `TypeError`**, which the `Promise.resolve()` wrapper routes into `.catch(fail)` / the all-thin fallback. Removing the wrapper crashes 4 test suites (8 tests) at effect-commit time. The wrapper stays; its comment is corrected to describe the real defended-against condition rather than a vague "synchronous throw."
- **Finding 5 (applied)** — Reduced the three overlapping doc comments in `useWheelBalance.ts` (file header + interface doc + function doc, all restating the same idea) to one canonical function doc.

## Test plan

- `./scripts/frontend/check-all.sh` → all 4 gates green (ESLint, Prettier, tsc, Jest: 396 suites / 4130 tests passing).
- Existing `useWheelBalance` tests (resolve / loading / rejected-error all-thin fallback / all-zero) pass unchanged, confirming the error-degradation behavior is preserved.
- Map renders identically — the removed style branch selected between two transparent styles, and the two history styles were byte-identical.
- All pre-commit hooks pass.

Closes #1260