### PR TITLE
refactor(journal): tidy dead re-exports, stale docstring, dup placeholder, NaN guard

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -66,6 +66,9 @@ export const AUTOSAVE_DELAY_MS = 1500;
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
 
+/** Body-field placeholder for a free-write with no prompt to echo. */
+const DEFAULT_BODY_PLACEHOLDER = 'Begin writing…';
+
 /** Fallback reason shown when resonance is gated off for an intimate entry. */
 const INTIMATE_RESONANCE_REASON = 'Intimate entries are kept private — resonance is paused.';
 
@@ -970,7 +973,7 @@ interface WritingColumnProps {
   finishing: boolean;
   /** Set (to {@link FINISH_ERROR_MESSAGE}) when the Finish write failed. */
   finishError: string | null;
-  bodyPlaceholder?: string;
+  bodyPlaceholder: string;
   /**
    * Disables the tier + chord controls until an existing entry's load settles
    * (still in flight or failed), so they never write against an unseen entry.
@@ -1092,7 +1095,7 @@ function WritingColumn({
   onFinish,
   finishing,
   finishError,
-  bodyPlaceholder = 'Begin writing…',
+  bodyPlaceholder,
   controlsDisabled,
   onBodySelectionChange,
 }: WritingColumnProps) {
@@ -1725,7 +1728,7 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
       reflectionScopeKey: p.reflectionScopeKey,
     },
     initialTitle,
-    bodyPlaceholder: p.promptQuestion ?? 'Begin writing…',
+    bodyPlaceholder: p.promptQuestion ?? DEFAULT_BODY_PLACEHOLDER,
   };
 }
 

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -1,10 +1,12 @@
 /**
  * ``JournalShelfScreen`` — the journal's landing surface, restyled as an
- * editorial library (#829): a warm ``ScreenScaffold`` + serif ``ScreenHeader``,
- * search on the warm palette, entries grouped by recency (This week / This month
- * / Earlier) as lifted paper tiles with a reading-time + "saved … ago" caption,
- * the weekly prompt promoted to its own band, and an inviting empty state with a
- * call to action. Tapping a page opens the entry screen by id.
+ * editorial library: a warm ``ScreenScaffold`` whose scrolling top matter stacks
+ * the ``JournalHero``, ``StatTileRow``, ``ReturnStack``, ``InvitationStack``, a
+ * serif ``ScreenHeader``, the weekly prompt, a ``ReflectionInvitationBand``, and
+ * ``SearchBar`` on the warm palette. Below it, entries group by recency (This
+ * week / This month / Earlier) as lifted paper tiles with a reading-time +
+ * "saved … ago" caption, over an inviting empty state with a call to action.
+ * Tapping a page opens the entry screen by id.
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';

--- a/frontend/src/features/Journal/__tests__/recency.test.ts
+++ b/frontend/src/features/Journal/__tests__/recency.test.ts
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+// Recency bucketing + absolute-date formatting shared by the shelf and its
+// header drawer. These pin the recency bands and the malformed-timestamp
+// handling so an unparseable API date buckets deterministically.
+import { describe, expect, it } from '@jest/globals';
+
+import type { JournalMessage } from '@/api';
+import { formatDate, groupByRecency } from '@/features/Journal/recency';
+
+const DAY_MS = 86_400_000;
+const ago = (days: number): string => new Date(Date.now() - days * DAY_MS).toISOString();
+
+function entry(id: number, timestamp: string): JournalMessage {
+  return {
+    id,
+    message: `Body of entry ${id}.`,
+    sender: 'user',
+    timestamp,
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+  };
+}
+
+describe('groupByRecency', () => {
+  it('sorts entries into This week / This month / Earlier bands', () => {
+    const now = Date.now();
+    const sections = groupByRecency([entry(1, ago(1)), entry(2, ago(10)), entry(3, ago(60))], now);
+
+    expect(sections.map((s) => s.title)).toEqual(['This week', 'This month', 'Earlier']);
+    expect(sections.map((s) => s.data[0]?.id)).toEqual([1, 2, 3]);
+  });
+
+  it('drops bands that have no entries', () => {
+    const now = Date.now();
+    const sections = groupByRecency([entry(1, ago(1))], now);
+
+    expect(sections.map((s) => s.title)).toEqual(['This week']);
+  });
+
+  it('buckets an unparseable timestamp into Earlier rather than by NaN accident', () => {
+    const now = Date.now();
+    const sections = groupByRecency([entry(1, 'not-a-date')], now);
+
+    expect(sections.map((s) => s.title)).toEqual(['Earlier']);
+    expect(sections[0]?.data[0]?.id).toBe(1);
+  });
+});
+
+describe('formatDate', () => {
+  it('renders an absolute Month D, YYYY label', () => {
+    expect(formatDate('2024-03-05T12:00:00.000Z')).toContain('2024');
+  });
+
+  it('returns an empty string for an unparseable timestamp', () => {
+    expect(formatDate('not-a-date')).toBe('');
+  });
+});

--- a/frontend/src/features/Journal/motion.ts
+++ b/frontend/src/features/Journal/motion.ts
@@ -8,8 +8,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { Animated } from 'react-native';
 
-export { usePressScale, PRESS_DURATION_MS, PRESS_SCALE } from '@/hooks/usePressScale';
-export type { PressScale } from '@/hooks/usePressScale';
+export { usePressScale, PRESS_SCALE } from '@/hooks/usePressScale';
 
 /** Sheet settle-in: a brief fade + a few-px lift into place. */
 export const SETTLE_DURATION_MS = 220;

--- a/frontend/src/features/Journal/recency.ts
+++ b/frontend/src/features/Journal/recency.ts
@@ -28,7 +28,9 @@ export function formatDate(timestamp: string): string {
 
 /** Bucket name for an entry's age relative to ``now`` (epoch ms). */
 function bucketFor(timestamp: string, now: number): string {
-  const age = (now - new Date(timestamp).getTime()) / MS_PER_DAY;
+  const ms = new Date(timestamp).getTime();
+  if (Number.isNaN(ms)) return 'Earlier';
+  const age = (now - ms) / MS_PER_DAY;
   if (age < WEEK_DAYS) return 'This week';
   if (age < MONTH_DAYS) return 'This month';
   return 'Earlier';


### PR DESCRIPTION
## Summary

De-slop bundle for the Journal feature (issue #1265). Four of the five filed
items survived verification at HEAD; all changes are behavior-preserving.

- **motion.ts** — dropped the dead `PRESS_DURATION_MS` and `PressScale` type
  re-exports (grep confirms no importer reaches either via `./motion`;
  `CompletionSuggestionNote` uses `ReturnType<typeof usePressScale>`, not the
  named type). Kept the live `usePressScale` / `PRESS_SCALE`.
- **JournalShelfScreen.tsx** — refreshed the stale module docstring so it
  matches the surfaces the shelf now renders (JournalHero, StatTileRow,
  ReturnStack, InvitationStack, ScreenHeader, weekly prompt,
  ReflectionInvitationBand, SearchBar), in render order.
- **JournalEntryScreen.tsx** — extracted the duplicated `'Begin writing…'`
  literal into one `DEFAULT_BODY_PLACEHOLDER` constant, made
  `WritingColumnProps.bodyPlaceholder` required (it is always supplied through
  `readEntrypoint → JournalPage → PageBodyColumn → WritingColumn`), and removed
  the unreachable default param.
- **recency.ts** — gave `bucketFor` an explicit `Number.isNaN` guard so a
  malformed timestamp buckets into `'Earlier'` deterministically, matching its
  sibling helpers `formatDate` / `savedAgo`. Behavior is unchanged (a `NaN` age
  already fell through to `'Earlier'` by accident) — the guard makes the intent
  explicit and is pinned by a new unit test.

### Skipped (stale at HEAD)

- **Item 4 (redundant `writeRefs` reconstruction)** — not applied. PR #1578's
  `useRefPersist` consolidation made the writer `refs` a fresh per-render object
  (spread at the `useDraftWriters` call site), so the `writeRefs` reconstruction
  in `useSaveRunner` / `useFinishWriter` is load-bearing: it projects the four
  stable refs into the memoized `useCallback` deps. Passing `refs` directly would
  force the unstable `refs` object into the dependency array (churning the
  writer every render) or require an eslint-disable. The current code is the
  correct pattern.

## Test plan

- Added `frontend/src/features/Journal/__tests__/recency.test.ts` pinning the
  recency bands, empty-band dropping, and the malformed-timestamp → `'Earlier'`
  behavior (plus `formatDate` label/empty cases).
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and Jest
  (397 suites / 4135 tests) all pass.

Closes #1265