### PR TITLE
test(journal): collapse always-green "no chat UI" absence tests and tighten two loose/redundant assertions

### DIFF
--- a/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
@@ -12,7 +12,7 @@ import React from 'react';
  *   and the re-opener brings resources back (not a dead-end).
  * - Renders nothing when ``care`` is null.
  * - Meets the 44dp ``touchTarget.minimum`` on interactive elements.
- * - Carries no chat/bot affordances (no sender, avatar, reply testIDs).
+ * - Is a static reflection surface (no TextInput composer), not a chatbot.
  */
 import CareSupportNote from '../CareSupportNote';
 
@@ -64,6 +64,23 @@ function StyleSheetMin(node: { props: { style: unknown } }): number {
     minWidth?: number;
   };
   return Math.min(flat.minHeight ?? 0, flat.minWidth ?? 0);
+}
+
+type RenderedNode = {
+  type: string;
+  children: (RenderedNode | string)[] | null;
+};
+
+// Depth-first list of host-component type names (e.g. 'View', 'Text', 'TextInput').
+function hostTypes(node: RenderedNode | RenderedNode[] | string | null): string[] {
+  if (node === null) return [];
+  if (typeof node === 'string') return [];
+  if (Array.isArray(node)) return node.flatMap((child) => hostTypes(child));
+  const out: string[] = [node.type];
+  const children = node.children;
+  if (children === null) return out;
+  for (const child of children) out.push(...hostTypes(child));
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -243,28 +260,17 @@ describe('CareSupportNote — touch-target requirements', () => {
 });
 
 // ---------------------------------------------------------------------------
-// No chat/bot affordances
+// Static reflection surface — not a chat/bot composer
 // ---------------------------------------------------------------------------
 
-describe('CareSupportNote — no chat UI', () => {
-  it('does not render a sender testID', () => {
-    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
-    expect(queryByTestId('sender')).toBeNull();
-  });
-
-  it('does not render an avatar testID', () => {
-    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
-    expect(queryByTestId('avatar')).toBeNull();
-  });
-
-  it('does not render a reply testID', () => {
-    const { queryByTestId } = render(<CareSupportNote care={carePayload()} />);
-    expect(queryByTestId('reply')).toBeNull();
-  });
-
-  it('does not render a "Send" text element', () => {
-    const { queryByText } = render(<CareSupportNote care={carePayload()} />);
-    expect(queryByText('Send')).toBeNull();
+describe('CareSupportNote — not a chat surface', () => {
+  it('renders static content with no text-entry composer', () => {
+    const { toJSON } = render(<CareSupportNote care={carePayload()} />);
+    const types = hostTypes(toJSON());
+    // Guard the walker: the card really renders Text content.
+    expect(types).toContain('Text');
+    // A reply/chat composer would mount a TextInput; a reflection card never does.
+    expect(types).not.toContain('TextInput');
   });
 });
 

--- a/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
@@ -160,25 +160,31 @@ describe('ContractionReflectionNote — non-punitive intent', () => {
   });
 });
 
-describe('ContractionReflectionNote — no chat UI', () => {
-  it('does not render a sender testID', () => {
-    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
-    expect(queryByTestId('sender')).toBeNull();
-  });
+type RenderedNode = {
+  type: string;
+  children: (RenderedNode | string)[] | null;
+};
 
-  it('does not render an avatar testID', () => {
-    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
-    expect(queryByTestId('avatar')).toBeNull();
-  });
+// Depth-first list of host-component type names (e.g. 'View', 'Text', 'TextInput').
+function hostTypes(node: RenderedNode | RenderedNode[] | string | null): string[] {
+  if (node === null) return [];
+  if (typeof node === 'string') return [];
+  if (Array.isArray(node)) return node.flatMap((child) => hostTypes(child));
+  const out: string[] = [node.type];
+  const children = node.children;
+  if (children === null) return out;
+  for (const child of children) out.push(...hostTypes(child));
+  return out;
+}
 
-  it('does not render a reply testID', () => {
-    const { queryByTestId } = render(<ContractionReflectionNote contraction={contraction()} />);
-    expect(queryByTestId('reply')).toBeNull();
-  });
-
-  it('does not render a "Send" text element', () => {
-    const { queryByText } = render(<ContractionReflectionNote contraction={contraction()} />);
-    expect(queryByText('Send')).toBeNull();
+describe('ContractionReflectionNote — not a chat surface', () => {
+  it('renders static content with no text-entry composer', () => {
+    const { toJSON } = render(<ContractionReflectionNote contraction={contraction()} />);
+    const types = hostTypes(toJSON());
+    // Guard the walker: the note really renders Text content.
+    expect(types).toContain('Text');
+    // A reply/chat composer would mount a TextInput; a reflection note never does.
+    expect(types).not.toContain('TextInput');
   });
 });
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
@@ -269,36 +269,4 @@ describe('JournalEntryScreen — care-support surface placement (issue #891)', (
       jest.useRealTimers();
     }
   });
-
-  it('care-support IS a descendant of journal-screen (screen-level placement)', async () => {
-    jest.useFakeTimers();
-    try {
-      mockCreate.mockResolvedValue(entry({ id: 42 }));
-      mockGenerate.mockResolvedValue(resonancePayload(carePayload()));
-
-      const { getByTestId } = renderScreen(undefined, { autosaveDelayMs: 100 });
-
-      fireEvent.changeText(getByTestId('journal-body-input'), 'Today felt very dark.');
-      // Advance autosave debounce: create fires, entry gets id=42.
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(100);
-      });
-      // Advance idle timer: isIdle flips true, visible=true, button is findable.
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(DEFAULT_IDLE_DELAY_MS);
-      });
-
-      await act(async () => {
-        fireEvent.press(getByTestId('get-resonance-button'));
-        await Promise.resolve();
-      });
-
-      await waitFor(() => expect(getByTestId('care-support')).toBeTruthy());
-
-      // care-support must live somewhere under journal-screen.
-      expect(within(getByTestId('journal-screen')).queryByTestId('care-support')).toBeTruthy();
-    } finally {
-      jest.useRealTimers();
-    }
-  });
 });

--- a/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
@@ -158,11 +158,11 @@ describe('PrivacyTierControl — accessibility', () => {
     expect(intimateLabel.length).toBeGreaterThan(0);
   });
 
-  it('options carry role "radio" or "button" (segmented-control semantics)', () => {
+  it('every option carries the exact accessibilityRole "radio"', () => {
     const { getByTestId } = renderControl('personal');
-    const publicRole: string = getByTestId('privacy-tier-public').props.accessibilityRole;
-    // RNTL renders accessibilityRole as 'radio' or 'button' for segmented controls.
-    expect(['radio', 'button']).toContain(publicRole);
+    for (const tier of ['public', 'personal', 'intimate'] as const) {
+      expect(getByTestId(`privacy-tier-${tier}`).props.accessibilityRole).toBe('radio');
+    }
   });
 
   it('all touch targets meet the 44dp minimum', () => {


### PR DESCRIPTION
## Summary
De-slop of Taxonomy Family 9 (testing slop) in the Journal suite. Test-only; no production source changed.

- **Collapse 8 always-green absence tests → 1 meaningful check per component.** `CareSupportNote.test.tsx` and `ContractionReflectionNote.test.tsx` each asserted `queryByTestId('sender'|'avatar'|'reply')`/`queryByText('Send')` were null — testIDs/strings the components never emit, so no mutation could flip them. Replaced with a `hostTypes(toJSON())` walker asserting the tree renders `Text` (guards the walker) but no `TextInput` — the defining element a chat/reply composer would add. Mutation-verified: injecting a `TextInput` into the component turns the check red.
- **Tighten the loose role assertion.** `PrivacyTierControl.test.tsx` now pins the exact role `radio` across all three options (public/personal/intimate), replacing `expect(['radio','button']).toContain(publicRole)` which accepted either role and covered only the public option. A role swap now fails.
- **Drop the redundant placement assertion.** `JournalEntryScreenCare.test.tsx` no longer re-proves `care-support IS a descendant of journal-screen` (already established by the existence test); the load-bearing negative-placement tests (not in `journal-margin-column`, `journal-sheet`, or `journal-page`) are kept.

## Test plan
- `./scripts/frontend/check-all.sh` — ESLint, Prettier, tsc, and Jest all green (397 suites, 4128 tests).
- Mutation check: injected a `<TextInput>` into `CareSupportNote` → the new "not a chat surface" test failed as expected; reverted the component.

Closes #1266