### PR TITLE
refactor(settings): consolidate duplicated form style tokens into shared module

### DIFF
--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -13,13 +13,18 @@ import {
 
 import { BYOK_PROVIDERS, providerForKey } from './byokProviders';
 import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
-import { SETTINGS_BUTTON_PADDING } from './shared/settingsFormLayout';
+import {
+  SETTINGS_BUTTON_PADDING,
+  SETTINGS_CARD_LABEL_LETTER_SPACING,
+  SETTINGS_MONOSPACE_FONT,
+  settingsFormStyles,
+} from './shared/settingsFormLayout';
 import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useApiKey } from '@/context/ApiKeyContext';
-import { BORDER_RADIUS, SPACING, accent, colors, ink, surface } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, colors, ink, surface } from '@/design/tokens';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /**
@@ -183,8 +188,8 @@ interface ScreenBodyProps {
 
 const ScreenIntro = ({ apiKey }: { apiKey: string | null }): React.JSX.Element => (
   <>
-    <Text style={styles.title}>BotMason API Key</Text>
-    <Text style={styles.body}>
+    <Text style={settingsFormStyles.title}>BotMason API Key</Text>
+    <Text style={settingsFormStyles.body}>
       Bring your own API key from a supported provider. It is stored only on this device and sent
       with every BotMason request via the X-LLM-API-Key header. We never upload it to our servers.
     </Text>
@@ -198,7 +203,7 @@ const ScreenIntro = ({ apiKey }: { apiKey: string | null }): React.JSX.Element =
 
 const ProviderDirectory = (): React.JSX.Element => (
   <View style={styles.providerSection} testID="provider-directory">
-    <Text style={styles.inputLabel}>Supported providers</Text>
+    <Text style={settingsFormStyles.inputLabel}>Supported providers</Text>
     {BYOK_PROVIDERS.map((provider) => (
       <View key={provider.id} style={styles.providerRow}>
         <View style={styles.providerInfo}>
@@ -211,7 +216,7 @@ const ProviderDirectory = (): React.JSX.Element => (
           accessibilityLabel={`Get your ${provider.label} API key`}
           accessibilityRole="link"
         >
-          <Text style={styles.link}>Get your API key</Text>
+          <Text style={settingsFormStyles.link}>Get your API key</Text>
         </TouchableOpacity>
       </View>
     ))}
@@ -242,34 +247,36 @@ const ScreenFooter = ({
   <>
     <TouchableOpacity
       onPress={onSave}
-      style={[styles.button, styles.primaryButton]}
+      style={settingsFormStyles.primaryButton}
       disabled={submitting}
       testID="save-key-button"
       accessibilityLabel="Save API key"
       accessibilityRole="button"
       accessibilityState={{ disabled: submitting, busy: submitting }}
     >
-      <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save key'}</Text>
+      <Text style={settingsFormStyles.primaryButtonText}>
+        {submitting ? 'Saving…' : 'Save key'}
+      </Text>
     </TouchableOpacity>
     {onOpenTimezone && (
       <TouchableOpacity
         onPress={onOpenTimezone}
-        style={styles.linkRow}
+        style={settingsFormStyles.linkRow}
         testID="open-timezone-settings"
         accessibilityLabel="Time zone settings"
         accessibilityRole="link"
       >
-        <Text style={styles.link}>Time zone settings</Text>
+        <Text style={settingsFormStyles.link}>Time zone settings</Text>
       </TouchableOpacity>
     )}
     {onBack && (
       <TouchableOpacity
         onPress={onBack}
-        style={styles.linkRow}
+        style={settingsFormStyles.linkRow}
         accessibilityLabel="Go back"
         accessibilityRole="link"
       >
-        <Text style={styles.link}>Back</Text>
+        <Text style={settingsFormStyles.link}>Back</Text>
       </TouchableOpacity>
     )}
   </>
@@ -297,7 +304,7 @@ const ScreenBody = ({
     {apiKey && (
       <StoredKeyCard apiKey={apiKey} disabled={submitting} onRequestRemove={onRequestRemove} />
     )}
-    <Text style={styles.inputLabel}>{apiKey ? 'Replace key' : 'Add your key'}</Text>
+    <Text style={settingsFormStyles.inputLabel}>{apiKey ? 'Replace key' : 'Add your key'}</Text>
     <KeyInputRow
       draft={draft}
       reveal={reveal}
@@ -418,8 +425,6 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
   );
 }
 
-const MENLO_MONOSPACE = 'Menlo';
-const STORED_LABEL_LETTER_SPACING = 0.5;
 const PROVIDER_HINT_MARGIN_TOP = 2;
 
 const styles = StyleSheet.create({
@@ -428,13 +433,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: surface.canvas,
-  },
-  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md, color: ink.primary },
-  body: {
-    fontSize: 14,
-    color: ink.soft,
-    marginBottom: SPACING.xl,
-    lineHeight: 20,
   },
   storedCard: {
     borderWidth: 1,
@@ -448,11 +446,11 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: ink.muted,
     textTransform: 'uppercase',
-    letterSpacing: STORED_LABEL_LETTER_SPACING,
+    letterSpacing: SETTINGS_CARD_LABEL_LETTER_SPACING,
   },
   storedValue: {
     fontSize: 18,
-    fontFamily: MENLO_MONOSPACE,
+    fontFamily: SETTINGS_MONOSPACE_FONT,
     marginTop: SPACING.sm,
     marginBottom: SPACING.lg,
     color: ink.primary,
@@ -462,12 +460,6 @@ const styles = StyleSheet.create({
     color: ink.muted,
     marginBottom: SPACING.xl,
     fontStyle: 'italic',
-  },
-  inputLabel: {
-    fontSize: 14,
-    fontWeight: '600',
-    marginBottom: SPACING.sm,
-    color: ink.primary,
   },
   inputRow: { flexDirection: 'row', alignItems: 'stretch', marginBottom: SPACING.md },
   input: {
@@ -496,16 +488,12 @@ const styles = StyleSheet.create({
     padding: SETTINGS_BUTTON_PADDING,
     alignItems: 'center',
   },
-  primaryButton: { backgroundColor: accent.primary, marginTop: SPACING.xs },
-  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   destructiveButton: {
     backgroundColor: colors.destructive.background,
     borderWidth: 1,
     borderColor: colors.destructive.border,
   },
   destructiveButtonText: { color: colors.destructive.text, fontWeight: '600' },
-  linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
-  link: { color: accent.primary, fontWeight: '600' },
   providerSection: { marginBottom: SPACING.xl },
   providerRow: {
     flexDirection: 'row',

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -2,14 +2,18 @@ import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { SettingsFeedbackBanner } from './shared/SettingsFeedbackBanner';
-import { SETTINGS_BUTTON_PADDING } from './shared/settingsFormLayout';
+import {
+  SETTINGS_CARD_LABEL_LETTER_SPACING,
+  SETTINGS_MONOSPACE_FONT,
+  settingsFormStyles,
+} from './shared/settingsFormLayout';
 import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ApiError, users } from '@/api';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import { useAuth } from '@/context/AuthContext';
-import { BORDER_RADIUS, SPACING, accent, colors, ink, surface } from '@/design/tokens';
+import { BORDER_RADIUS, SPACING, ink, surface } from '@/design/tokens';
 import { detectDeviceTimezone } from '@/utils/dateUtils';
 
 /**
@@ -93,7 +97,7 @@ const ZoneInputSection = ({
   onUseDeviceZone,
 }: ZoneInputSectionProps): React.JSX.Element => (
   <>
-    <Text style={styles.inputLabel}>New time zone</Text>
+    <Text style={settingsFormStyles.inputLabel}>New time zone</Text>
     <TextInput
       style={styles.input}
       placeholder={EXAMPLE_ZONE}
@@ -127,23 +131,23 @@ const ScreenFooter = ({
   <>
     <TouchableOpacity
       onPress={onSave}
-      style={styles.primaryButton}
+      style={settingsFormStyles.primaryButton}
       disabled={submitting}
       testID="save-timezone-button"
       accessibilityLabel="Save time zone"
       accessibilityRole="button"
       accessibilityState={{ disabled: submitting, busy: submitting }}
     >
-      <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save'}</Text>
+      <Text style={settingsFormStyles.primaryButtonText}>{submitting ? 'Saving…' : 'Save'}</Text>
     </TouchableOpacity>
     {onBack && (
       <TouchableOpacity
         onPress={onBack}
-        style={styles.linkRow}
+        style={settingsFormStyles.linkRow}
         accessibilityLabel="Go back"
         accessibilityRole="link"
       >
-        <Text style={styles.link}>Back</Text>
+        <Text style={settingsFormStyles.link}>Back</Text>
       </TouchableOpacity>
     )}
   </>
@@ -158,8 +162,8 @@ const ScreenBody = ({
   onBack,
 }: ScreenBodyProps): React.JSX.Element => (
   <ScreenScaffold scroll testID="timezone-settings-screen">
-    <Text style={styles.title}>Time zone</Text>
-    <Text style={styles.body}>
+    <Text style={settingsFormStyles.title}>Time zone</Text>
+    <Text style={settingsFormStyles.body}>
       Streaks and daily stats count days in this time zone. Update it if you moved or if it was
       detected wrong at signup.
     </Text>
@@ -213,17 +217,7 @@ export default function TimezoneSettingsScreen({ navigation }: Props = {}): Reac
   );
 }
 
-const MENLO_MONOSPACE = 'Menlo';
-const CURRENT_LABEL_LETTER_SPACING = 0.5;
-
 const styles = StyleSheet.create({
-  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md, color: ink.primary },
-  body: {
-    fontSize: 14,
-    color: ink.soft,
-    marginBottom: SPACING.xl,
-    lineHeight: 20,
-  },
   currentCard: {
     borderWidth: 1,
     borderColor: surface.hairline,
@@ -236,18 +230,12 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: ink.muted,
     textTransform: 'uppercase',
-    letterSpacing: CURRENT_LABEL_LETTER_SPACING,
+    letterSpacing: SETTINGS_CARD_LABEL_LETTER_SPACING,
   },
   currentValue: {
     fontSize: 18,
-    fontFamily: MENLO_MONOSPACE,
+    fontFamily: SETTINGS_MONOSPACE_FONT,
     marginTop: SPACING.sm,
-    color: ink.primary,
-  },
-  inputLabel: {
-    fontSize: 14,
-    fontWeight: '600',
-    marginBottom: SPACING.sm,
     color: ink.primary,
   },
   input: {
@@ -270,14 +258,4 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.md,
   },
   secondaryButtonText: { fontSize: 14, color: ink.primary, fontWeight: '600' },
-  primaryButton: {
-    borderRadius: BORDER_RADIUS.md,
-    padding: SETTINGS_BUTTON_PADDING,
-    alignItems: 'center',
-    backgroundColor: accent.primary,
-    marginTop: SPACING.xs,
-  },
-  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
-  linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
-  link: { color: accent.primary, fontWeight: '600' },
 });

--- a/frontend/src/features/Settings/shared/settingsFormLayout.ts
+++ b/frontend/src/features/Settings/shared/settingsFormLayout.ts
@@ -1,4 +1,6 @@
-import { SPACING } from '@/design/tokens';
+import { StyleSheet } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, accent, colors, ink } from '@/design/tokens';
 
 /**
  * Vertical padding for the action buttons on the Settings form screens.
@@ -8,3 +10,49 @@ import { SPACING } from '@/design/tokens';
  * without a manual "keep in sync" comment.
  */
 export const SETTINGS_BUTTON_PADDING = SPACING.md + 2;
+
+/**
+ * Monospace face for rendering stored technical values (API keys, IANA zone
+ * names) on the Settings form screens.
+ */
+export const SETTINGS_MONOSPACE_FONT = 'Menlo';
+
+/**
+ * Letter spacing for the small uppercase card labels ("Stored on this device",
+ * "Current time zone") on the Settings form screens.
+ */
+export const SETTINGS_CARD_LABEL_LETTER_SPACING = 0.5;
+
+/**
+ * Style tokens shared verbatim by the API-key and time-zone settings forms.
+ *
+ * Consolidating them here keeps the two sibling screens in visual parity: a
+ * single edit updates both, so they can no longer drift silently. Screen-only
+ * tokens (input rows, card bodies, secondary/destructive buttons) stay local to
+ * each screen.
+ */
+export const settingsFormStyles = StyleSheet.create({
+  title: { fontSize: 22, fontWeight: '700', marginBottom: SPACING.md, color: ink.primary },
+  body: {
+    fontSize: 14,
+    color: ink.soft,
+    marginBottom: SPACING.xl,
+    lineHeight: 20,
+  },
+  inputLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: SPACING.sm,
+    color: ink.primary,
+  },
+  primaryButton: {
+    borderRadius: BORDER_RADIUS.md,
+    padding: SETTINGS_BUTTON_PADDING,
+    alignItems: 'center',
+    backgroundColor: accent.primary,
+    marginTop: SPACING.xs,
+  },
+  primaryButtonText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
+  linkRow: { marginTop: SPACING.xl, alignItems: 'center' },
+  link: { color: accent.primary, fontWeight: '600' },
+});


### PR DESCRIPTION
## Summary

`ApiKeySettingsScreen` and `TimezoneSettingsScreen` are sibling Settings forms whose logic was already de-duplicated into `shared/`, but their StyleSheet blocks and a couple of module constants were left copy-pasted verbatim — so a token edit had to be made in two places or the two screens would silently drift.

This moves the genuinely-shared tokens into the existing `frontend/src/features/Settings/shared/settingsFormLayout.ts` (whose docstring already promises the screens "stay in visual parity without a manual keep-in-sync comment"):

- New `settingsFormStyles` StyleSheet: `title`, `body`, `inputLabel`, `primaryButton`, `primaryButtonText`, `linkRow`, `link` — each was byte-identical in both screens.
- New constants `SETTINGS_MONOSPACE_FONT` (`'Menlo'`) and `SETTINGS_CARD_LABEL_LETTER_SPACING` (`0.5`), replacing the duplicated `MENLO_MONOSPACE` and the `STORED_LABEL_LETTER_SPACING` / `CURRENT_LABEL_LETTER_SPACING` pair.

Both screens now consume the shared tokens; only truly screen-specific styles (input rows, card bodies, secondary/destructive buttons) stay local. The ApiKey save button's prior `[button, primaryButton]` merge resolves to exactly the shared `primaryButton`'s five properties, and the base `button` style is retained locally for the destructive button.

Pure refactor — no JSX restructure, no visual change. The literals are kept as a shared style module (not new design tokens) because the design system's `typography` scale is a responsive serif set for the journal surface, not a fit for these fixed sans-serif Settings sizes.

Follow-up (out of scope here): `currentCard`/`storedCard` and `currentLabel`/`storedLabel` remain byte-identical across the two screens but were left local per this issue's stated scope (card styles stay local).

## Test plan

- `./scripts/frontend/check-all.sh` green: ESLint, prettier, tsc, and Jest (4128 tests, 397 suites) all pass — including the existing snapshot, confirming byte-identical rendering.
- Existing `ApiKeySettingsScreen` / `TimezoneSettingsScreen` tests unchanged and passing.

Closes #1268