### PR TITLE
refactor(frontend): drop dead AuthContext isLoading field and fix stale schema refs

### DIFF
--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -87,7 +87,6 @@ import { useWelcomeStore } from '@/store/useWelcomeStore';
 type MockAuth = {
   token: string | null;
   authStatus: AuthStatus;
-  isLoading: boolean;
   // ``userTimezone`` mirrors the production AuthContextValue default so a
   // navigator render at any auth state has a non-null TZ string available.
   userTimezone: string;
@@ -104,7 +103,6 @@ function buildAuth(overrides: Partial<MockAuth> = {}): MockAuth {
   return {
     token: null,
     authStatus: 'anonymous',
-    isLoading: false,
     userTimezone: 'UTC',
     setUserTimezone: jest.fn(),
     login: jest.fn(() => Promise.resolve()),
@@ -122,7 +120,6 @@ function mockAuthStatus(status: AuthStatus, token: string | null = null) {
     buildAuth({
       authStatus: status,
       token,
-      isLoading: status === 'loading',
     }),
   );
 }

--- a/frontend/src/__tests__/navigation/welcomeGate.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeGate.test.tsx
@@ -103,7 +103,6 @@ function mockAuthenticated() {
   jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
     token: 'jwt',
     authStatus: 'authenticated' as AuthStatus,
-    isLoading: false,
     userTimezone: 'UTC',
     setUserTimezone: jest.fn(),
     login: jest.fn(() => Promise.resolve()),

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -220,7 +220,6 @@ function mockAuthenticated(): void {
   jest.spyOn(AuthContextModule, 'useAuth').mockReturnValue({
     token: 'jwt',
     authStatus: 'authenticated' as AuthStatus,
-    isLoading: false,
     userTimezone: 'UTC',
     setUserTimezone: jest.fn(),
     login: jest.fn(() => Promise.resolve()),

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -60,8 +60,6 @@ type ConfirmReset = (_token: string, _newPassword: string) => Promise<void>;
 interface AuthContextValue {
   token: string | null;
   authStatus: AuthStatus;
-  /** Mirrors ``authStatus === 'loading'``. Kept for backwards compatibility. */
-  isLoading: boolean;
   /**
    * IANA timezone the server has on record for the authenticated user.
    * Populated from the `/auth/signup` / `/auth/login` / `/auth/refresh`
@@ -386,7 +384,7 @@ async function applyAuthResponse(response: AuthResponse, mutators: AuthMutators)
   mutators.setAuthStatus('authenticated');
 }
 
-/** Sentinel user_id in the backend's anti-enumeration duplicate-signup response (see schemas.ts:57, BUG-AUTH-002). */
+/** Sentinel user_id in the backend's anti-enumeration duplicate-signup response (see ``authResponseSchema`` in schemas.ts, BUG-AUTH-002). */
 const DUPLICATE_SIGNUP_SENTINEL_USER_ID = 0;
 
 /**
@@ -526,11 +524,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useLoadStoredToken(mutators);
 
   const actions = useAuthActions(mutators);
-  const isLoading = authStatus === 'loading';
 
   const value = useMemo(
-    () => ({ token, authStatus, isLoading, userTimezone, setUserTimezone, ...actions }),
-    [token, authStatus, isLoading, userTimezone, actions],
+    () => ({ token, authStatus, userTimezone, setUserTimezone, ...actions }),
+    [token, authStatus, userTimezone, actions],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -95,12 +95,12 @@ afterEach(() => {
 
 describe('AuthContext', () => {
   describe('initial state', () => {
-    it('starts with isLoading true while checking stored token', () => {
+    it('starts in the loading state while checking stored token', () => {
       // Never resolve loadToken so we stay in loading state
       mockLoadToken.mockReturnValue(new Promise(() => {}));
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      expect(result.current.isLoading).toBe(true);
+      expect(result.current.authStatus).toBe('loading');
       expect(result.current.token).toBeNull();
     });
 
@@ -108,7 +108,7 @@ describe('AuthContext', () => {
       mockLoadToken.mockResolvedValue(null);
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       expect(result.current.token).toBeNull();
     });
@@ -117,7 +117,7 @@ describe('AuthContext', () => {
       mockLoadToken.mockResolvedValue('stored-jwt');
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       expect(result.current.token).toBe('stored-jwt');
     });
@@ -126,7 +126,7 @@ describe('AuthContext', () => {
       mockLoadToken.mockResolvedValue('stored-jwt');
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       expect(mockSetTokenGetter).toHaveBeenCalled();
       // Call the registered getter to verify it returns the token
@@ -140,7 +140,7 @@ describe('AuthContext', () => {
       mockAuth.login.mockResolvedValue({ token: 'new-jwt', user_id: 1 });
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await act(async () => {
         await result.current.login('user@test.com', 'password123');
@@ -158,7 +158,7 @@ describe('AuthContext', () => {
       mockAuth.login.mockRejectedValue(new Error('Invalid credentials'));
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await expect(
         act(async () => {
@@ -176,7 +176,7 @@ describe('AuthContext', () => {
       mockAuth.signup.mockResolvedValue({ token: 'signup-jwt', user_id: 2 });
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await act(async () => {
         await result.current.signup('new@test.com', 'password123');
@@ -197,12 +197,12 @@ describe('AuthContext', () => {
       expect(result.current.token).toBe('signup-jwt');
     });
 
-    // BUG-AUTH-002: must not persist the user_id=0 anti-enumeration token (see schemas.ts:57).
+    // BUG-AUTH-002: must not persist the user_id=0 anti-enumeration token (see ``authResponseSchema`` in schemas.ts).
     it('rejects the anti-enumeration sentinel without persisting the token', async () => {
       mockAuth.signup.mockResolvedValue({ token: 'dummy-jwt', user_id: 0 });
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await expect(
         act(async () => {
@@ -422,13 +422,6 @@ describe('AuthContext', () => {
       });
       expect(result.current.authStatus).toBe('anonymous');
     });
-
-    it("isLoading mirrors authStatus === 'loading' for backwards compatibility", () => {
-      mockLoadToken.mockReturnValue(new Promise(() => {}));
-      const { result } = renderHook(() => useAuth(), { wrapper });
-      expect(result.current.isLoading).toBe(true);
-      expect(result.current.authStatus).toBe('loading');
-    });
   });
 
   describe('token expiration on startup', () => {
@@ -438,7 +431,7 @@ describe('AuthContext', () => {
 
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       expect(result.current.token).toBeNull();
       expect(mockClearToken).toHaveBeenCalled();
@@ -450,7 +443,7 @@ describe('AuthContext', () => {
 
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       expect(result.current.token).toBe('valid-jwt');
       expect(mockClearToken).not.toHaveBeenCalled();
@@ -635,7 +628,7 @@ describe('AuthContext', () => {
 
       const { result } = renderHook(() => useAuth(), { wrapper });
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       // Token should remain as-is when refresh fails
       expect(result.current.token).toBe('near-expiry-jwt');
@@ -928,7 +921,7 @@ describe('AuthContext', () => {
         timezone: 'America/Los_Angeles',
       });
       const { result } = renderHook(() => useAuth(), { wrapper });
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await act(async () => {
         await result.current.confirmPasswordReset('a'.repeat(43), 'new-password-123');
@@ -951,7 +944,7 @@ describe('AuthContext', () => {
         user_id: 7,
       });
       const { result } = renderHook(() => useAuth(), { wrapper });
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await act(async () => {
         await result.current.confirmPasswordReset('b'.repeat(43), 'longenough');
@@ -968,7 +961,7 @@ describe('AuthContext', () => {
       });
       mockAuth.confirmPasswordReset.mockRejectedValue(failure);
       const { result } = renderHook(() => useAuth(), { wrapper });
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await expect(
         act(async () => {

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -5,13 +5,11 @@ import React from 'react';
 
 type AuthStatus = 'loading' | 'authenticated' | 'reauth-required' | 'anonymous';
 
-// Control mock state per test. ``token`` + ``isLoading`` are kept so
-// legacy callers that still read them keep working; the navigator
-// itself now gates on ``authStatus`` (BUG-NAV-001 / BUG-NAV-002).
-let mockAuthState: { token: string | null; authStatus: AuthStatus; isLoading: boolean } = {
+// Control mock state per test. The navigator gates on ``authStatus``
+// (BUG-NAV-001 / BUG-NAV-002); ``token`` is kept for the routes that read it.
+let mockAuthState: { token: string | null; authStatus: AuthStatus } = {
   token: null,
   authStatus: 'anonymous',
-  isLoading: false,
 };
 
 jest.mock('@/context/AuthContext', () => ({
@@ -121,7 +119,7 @@ import App, { linking } from '@/App';
 import { useWelcomeStore } from '@/store/useWelcomeStore';
 
 beforeEach(() => {
-  mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
+  mockAuthState = { token: null, authStatus: 'anonymous' };
   // This suite asserts the auth-status → shell contract; the #836 first-run
   // welcome gate is exercised separately. Seed the flag as seen so an authed
   // render reaches the shell rather than the WelcomeScreen.
@@ -130,35 +128,35 @@ beforeEach(() => {
 
 describe('App auth flow', () => {
   it('shows auth screens when user is anonymous', () => {
-    mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
+    mockAuthState = { token: null, authStatus: 'anonymous' };
     const { getByText } = render(<App />);
 
     expect(getByText('LoginScreen')).toBeTruthy();
   });
 
   it('shows loading indicator while authStatus is loading', () => {
-    mockAuthState = { token: null, authStatus: 'loading', isLoading: true };
+    mockAuthState = { token: null, authStatus: 'loading' };
     const { getByTestId } = render(<App />);
 
     expect(getByTestId('auth-loading')).toBeTruthy();
   });
 
   it('shows main app when user is authenticated', () => {
-    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated', isLoading: false };
+    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated' };
     const { getByText } = render(<App />);
 
     expect(getByText('BottomTabs')).toBeTruthy();
   });
 
   it('does not show auth screens when authenticated', () => {
-    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated', isLoading: false };
+    mockAuthState = { token: 'valid-jwt', authStatus: 'authenticated' };
     const { queryByText } = render(<App />);
 
     expect(queryByText('LoginScreen')).toBeNull();
   });
 
   it('does not show main app when anonymous', () => {
-    mockAuthState = { token: null, authStatus: 'anonymous', isLoading: false };
+    mockAuthState = { token: null, authStatus: 'anonymous' };
     const { queryByText } = render(<App />);
 
     expect(queryByText('BottomTabs')).toBeNull();
@@ -167,7 +165,7 @@ describe('App auth flow', () => {
   // BUG-NAV-001: a 401 must not unmount the tabs. When authStatus is
   // 'reauth-required' we show BottomTabs *and* the ReauthSheet overlay.
   it('keeps BottomTabs mounted and shows ReauthSheet when reauth-required', () => {
-    mockAuthState = { token: null, authStatus: 'reauth-required', isLoading: false };
+    mockAuthState = { token: null, authStatus: 'reauth-required' };
     const { getByText } = render(<App />);
 
     expect(getByText('BottomTabs')).toBeTruthy();

--- a/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/LoginScreen.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 jest.mock('@/context/AuthContext', () => {
   const login = jest.fn(() => Promise.resolve());
   return {
-    useAuth: () => ({ login, isLoading: false, token: null }),
+    useAuth: () => ({ login, token: null }),
     _mockLogin: login,
   };
 });

--- a/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
@@ -16,7 +16,6 @@ jest.mock('@/context/AuthContext', () => ({
   useAuth: () => ({
     token: null,
     authStatus: 'reauth-required',
-    isLoading: false,
     login: mockLogin,
     signup: jest.fn(),
     logout: jest.fn(),

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 jest.mock('@/context/AuthContext', () => {
   const signup = jest.fn(() => Promise.resolve());
   return {
-    useAuth: () => ({ signup, isLoading: false, token: null }),
+    useAuth: () => ({ signup, token: null }),
     _mockSignup: signup,
   };
 });


### PR DESCRIPTION
## Summary

Two Low-severity de-slop items in `frontend/src/context/AuthContext.tsx` (Taxonomy Family 3 dead code + Family 6 stale comments), verified at HEAD:

- **Dead `isLoading` contract field** — removed from `AuthContextValue`, its derivation, and the provider memo. Word-boundary grep confirmed no production `useAuth()` consumer read it; every real `isLoading` in the tree belongs to unrelated contexts/hooks (`ApiKeyContext`, `useActivePractice`, `useWeeklyProgress`, …). The "backwards compatibility" docstring named no actual legacy caller. Auth-value test mocks and the `AuthContext` hook tests now gate on `authStatus` directly (the single source of truth; `isLoading === (authStatus === 'loading')`).
- **Stale cross-file line references** — `AuthContext.tsx` and `AuthContext.test.tsx` both pointed at `schemas.ts:57` (the `// Auth schemas` banner) rather than the real `authResponseSchema` sentinel logic (~20 lines lower). Now reference the symbol / `BUG-AUTH-002` marker instead of a line number that has already drifted.

No behavior, token lifecycle, or `authStatus` state-machine change — contract/comment hygiene only.

## Test plan

- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc strict, Jest: 4127 tests pass).
- `grep -rn "isLoading" frontend/src` shows no AuthContext-sourced `isLoading` (only unrelated `ApiKeyContext`/hook usages remain).
- Both stale `schemas.ts:57` references removed.

Closes #1269