### PR TITLE
refactor(design): drop dead elevation/shadows.glow tokens and fix contrast comments

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -231,7 +231,6 @@ describe('design tokens', () => {
       expect(shadows.small.elevation).toBe(2);
       expect(shadows.medium.elevation).toBe(3);
       expect(shadows.large.elevation).toBe(5);
-      expect(shadows.glow.elevation).toBe(5);
     });
 
     it('includes shadow properties for each level', () => {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -40,7 +40,7 @@ export const colors = {
     // headings where AAA isn't required and the softer hue reads nicer.
     primary: '#333333',
     secondary: '#666666',
-    secondaryAccessible: '#555555', // 7.22:1 on #f8f8f8 — AAA normal text
+    secondaryAccessible: '#555555', // 7.02:1 on #f8f8f8 — AAA normal text
     tertiary: '#999999',
     tertiaryAccessible: '#707070', // 5.25:1 on #f8f8f8 — AA normal text
     light: '#ffffff',
@@ -335,13 +335,6 @@ export const shadows = {
     shadowRadius: 4,
     elevation: 5,
   },
-  glow: {
-    shadowColor: colors.paper.ink,
-    shadowOffset: { width: 0, height: 3 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 5,
-  },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -372,7 +365,7 @@ export const tileDensity = { paddingV: 0.5, barGap: 0.5 } as const;
 /** React Navigation's default bottom tab-bar content height; bump if the tab bar is restyled taller. */
 export const BOTTOM_TAB_BAR_CONTENT_HEIGHT = 49;
 
-/** WCAG-AA on the white modal card: #555 = 7.22:1 on #ffffff (AAA normal). */
+/** WCAG-AA on the white modal card: #555 = 7.46:1 on #ffffff (AAA normal). */
 export const CHART_AXIS_LABEL_COLOR = '#555555';
 
 export const CHART_STYLE = {
@@ -384,12 +377,6 @@ export const CHART_STYLE = {
 } as const;
 
 export const breakpoints = { xs: 0, sm: 360, md: 600, lg: 900, xl: 1200 } as const;
-
-export const elevation = {
-  sm: 1,
-  md: 3,
-  lg: 6,
-} as const;
 
 /** Responsive font sizes based on viewport width. */
 export const typography = (width: number) => {


### PR DESCRIPTION
## Summary

De-slop of the Candle & Ink token module (`frontend/src/design/tokens.ts`), the design system's single source of truth.

- **Removed dead `elevation` scale** (`{ sm: 1, md: 3, lg: 6 }`) — no importers anywhere in `frontend/src`; Android elevation is already carried by `shadows.*` / `paperShadow.*` / `surfaceShadow.*`.
- **Removed dead + duplicate `shadows.glow`** — byte-for-byte identical to `shadows.large`, with no production consumer. Also dropped the single orphaned change-detector assertion for it in `tokens.test.ts`.
- **Corrected two copy-pasted `7.22:1` contrast comments** for `#555555` to their true per-background WCAG ratios:
  - `secondaryAccessible` → `7.02:1 on #f8f8f8` (recomputed; still AAA normal text)
  - `CHART_AXIS_LABEL_COLOR` → `7.46:1 on #ffffff` (WebAIM-confirmed; still AAA normal text)

### Deviation from the issue: `transparentLight` retained

The issue also asked to delete `colors.mystical.transparentLight`. That token is **no longer dead** — since the issue was filed it gained a real consumer at `frontend/src/features/Map/Map.styles.ts:171` (`backgroundColor: colors.mystical.transparentLight`). Per the "a token that gained a consumer stays" rule, it and its `tokens.test.ts` assertion are left untouched.

## Test plan

- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, `tsc --noEmit`, and Jest (4127 tests) all pass.
- Verified zero residual references to `shadows.glow`, the `elevation` const, or the `7.22` string across `frontend/src` after the change.
- No surviving token lost coverage; the only removed assertion covered the deleted `shadows.glow`.

Closes #1272