### PR TITLE
refactor(utils): remove orphaned dayLabel() and its lying docstring/tests

### DIFF
--- a/frontend/src/utils/__tests__/dateUtils.test.ts
+++ b/frontend/src/utils/__tests__/dateUtils.test.ts
@@ -5,7 +5,6 @@ import {
   addDaysInTZ,
   dayKeyInTZ,
   dayKeyToInstant,
-  dayLabel,
   detectDeviceTimezone,
   streakFromCompletions,
   subtractiveLongestStreakFromCompletions,
@@ -59,40 +58,6 @@ describe('dayKeyInTZ', () => {
   it('handles Pacific/Kiritimati lead (UTC+14)', () => {
     const moment = new Date('2026-06-14T18:00:00Z');
     expect(dayKeyInTZ(moment, 'Pacific/Kiritimati')).toBe('2026-06-15');
-  });
-});
-
-describe('dayLabel', () => {
-  // The weekday for a YYYY-MM-DD calendar day is independent of TZ -- 2026-
-  // 06-15 is a Monday everywhere on Earth.  These tests pin that the helper
-  // returns the canonical weekday for every zone (incl. UTC+14 where the
-  // older noon-anchor implementation returned the *next* day).
-  it('returns three-letter English weekday for UTC', () => {
-    expect(dayLabel('2026-06-15', 'UTC')).toBe('Mon');
-  });
-
-  it('is canonical across negative-offset zones (UTC-8 LA)', () => {
-    expect(dayLabel('2026-06-14', 'America/Los_Angeles')).toBe('Sun');
-    expect(dayLabel('2026-06-15', 'America/Los_Angeles')).toBe('Mon');
-  });
-
-  it('is canonical across positive-offset zones (UTC+14 Kiritimati)', () => {
-    // BUG-FE-HABIT-002 follow-on: an earlier noon-UTC anchor printed as
-    // the *next* day in UTC+13/+14 zones.  Calendar-day weekday is
-    // zone-independent so this test pins it.
-    expect(dayLabel('2026-06-15', 'Pacific/Kiritimati')).toBe('Mon');
-  });
-
-  it('is canonical for Pacific/Apia (UTC+13)', () => {
-    expect(dayLabel('2026-06-15', 'Pacific/Apia')).toBe('Mon');
-  });
-
-  it('is canonical for Pacific/Auckland (UTC+12 NZST)', () => {
-    expect(dayLabel('2026-06-15', 'Pacific/Auckland')).toBe('Mon');
-  });
-
-  it('returns empty string for malformed key (defensive)', () => {
-    expect(dayLabel('not-a-date', 'UTC')).toBe('');
   });
 });
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -92,43 +92,6 @@ export const dayKeyInTZ = (moment: Date | string, tz: string): string => {
 };
 
 /**
- * Render the human-friendly day-of-week label for a `YYYY-MM-DD` key.
- *
- * Used by stats charts so a Sunday-night Pacific completion is labeled
- * "Sun" (the user's perception) rather than "Mon" (UTC after midnight).
- * Returns three-letter English labels matching the backend's
- * `_DAY_LABELS` constant.
- *
- * Implementation note: the calendar weekday for a `YYYY-MM-DD` key is
- * canonical (2026-06-15 is a Monday everywhere — the weekday derives
- * from the date itself, not the user's clock).  The `tz` parameter is
- * accepted for API symmetry with the other helpers but is intentionally
- * unused: an earlier version that re-formatted in the user's zone gave
- * incorrect results in *both* directions — `T12:00:00Z` printed as the
- * next day in UTC+13/+14, while `T00:00:00Z` printed as the prior day
- * in negative-offset zones.  Treating the day-key's weekday as zone-
- * independent is the only formulation that's correct everywhere.
- */
-export const dayLabel = (dayKey: string, _tz: string): string => {
-  const [year, month, day] = dayKey.split('-').map((part) => Number.parseInt(part, 10));
-  if (
-    year === undefined ||
-    month === undefined ||
-    day === undefined ||
-    Number.isNaN(year) ||
-    Number.isNaN(month) ||
-    Number.isNaN(day)
-  ) {
-    return '';
-  }
-  const utcMidnight = new Date(Date.UTC(year, month - 1, day));
-  return new Intl.DateTimeFormat('en-US', {
-    weekday: 'short',
-    timeZone: 'UTC',
-  }).format(utcMidnight);
-};
-
-/**
  * Add `days` calendar days to `dayKey` and return the new `YYYY-MM-DD` key.
  *
  * Pure calendar math via `Date.UTC` rather than wall-clock arithmetic


### PR DESCRIPTION
## Summary

`dayLabel()` in `frontend/src/utils/dateUtils.ts` was orphaned production code with a lying docstring. The docstring claimed it was *"Used by stats charts so a Sunday-night Pacific completion is labeled 'Sun'…"*, but the stats charts render weekday labels from the backend-supplied `day_labels` (mapped in `features/Habits/HabitUtils.ts`), never from `dayLabel`.

Verified at HEAD (`260ae19c`) with a word-boundary grep: `\bdayLabel\b` across `frontend/src` matched only the definition and its own test file — zero inbound production edges, still orphaned despite recent Journal recency work.

This PR deletes:
- the `dayLabel` function and its 18-line docstring from `dateUtils.ts`
- the `describe('dayLabel', …)` test block and the `dayLabel` import from `dateUtils.test.ts`

Sibling exports (`dayKeyInTZ`, `addDaysInTZ`, `todayInUserTZ`, streak helpers) and the backend `day_labels` chart path are untouched.

## Test plan

- `grep -rn "\bdayLabel\b" frontend/src` → no matches (exit 1)
- `./scripts/frontend/check-all.sh` → lint, format, typecheck, and 4121 tests across 397 suites all pass
- Coverage holds: only dead code + its dead tests were removed (no covered lines lost)

Closes #1273