### PR TITLE
fix(storage): finish transient-read hardening — recentPractices + savePendingCheckIn RMW

### DIFF
--- a/frontend/src/storage/__tests__/habitStorage.test.ts
+++ b/frontend/src/storage/__tests__/habitStorage.test.ts
@@ -286,5 +286,36 @@ describe('habitStorage', () => {
       const queue = await loadPendingCheckIns();
       expect(queue).toEqual([]);
     });
+
+    test('aborts the write and preserves the stored queue on a transient RMW read', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('transient read'));
+
+      await expect(
+        savePendingCheckIn({ goal_id: 2, did_complete: true, timestamp: 't2' }),
+      ).resolves.toBeUndefined();
+
+      expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    test('self-heals corrupt queue JSON inside the RMW then writes the single new check-in', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockAsyncStorage.getItem.mockResolvedValueOnce('not valid json{{{');
+      const checkIn = { goal_id: 3, did_complete: true, timestamp: 't3' };
+
+      await savePendingCheckIn(checkIn);
+
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@adepthood/pending_checkins');
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/pending_checkins',
+        JSON.stringify([checkIn]),
+      );
+
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/frontend/src/storage/__tests__/jsonStore.test.ts
+++ b/frontend/src/storage/__tests__/jsonStore.test.ts
@@ -1,0 +1,82 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { getJsonArray, getJsonArrayForUpdate } from '../jsonStore';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+const KEY = 'some-key';
+
+interface Sample {
+  id: number;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getJsonArrayForUpdate', () => {
+  test('propagates a transient getItem rejection instead of swallowing it', async () => {
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('transient read'));
+
+    await expect(getJsonArrayForUpdate<Sample>(KEY)).rejects.toThrow('transient read');
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('self-heals corrupt JSON by clearing the key and resolving null', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('not valid json{{{');
+
+    const result = await getJsonArrayForUpdate<Sample>(KEY);
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+  });
+
+  test('self-heals a valid non-array payload by clearing the key and resolving null', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({}));
+
+    const result = await getJsonArrayForUpdate<Sample>(KEY);
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+  });
+
+  test('resolves null on a missing key without clearing anything', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+    const result = await getJsonArrayForUpdate<Sample>(KEY);
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('resolves the parsed array on a valid payload', async () => {
+    const stored: Sample[] = [{ id: 1 }, { id: 2 }];
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(stored));
+
+    const result = await getJsonArrayForUpdate<Sample>(KEY);
+    expect(result).toEqual(stored);
+  });
+});
+
+describe('getJsonArray (shared parse-heal guard)', () => {
+  test('a transient getItem rejection resolves null without clearing the key', async () => {
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('transient read'));
+
+    const result = await getJsonArray<Sample>(KEY);
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('corrupt JSON resolves null and clears the key', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('not valid json{{{');
+
+    const result = await getJsonArray<Sample>(KEY);
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(KEY);
+  });
+});

--- a/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
+++ b/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, jest */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  loadRecentPractices,
+  recordRecentPractice,
+  MAX_RECENT_PRACTICES,
+  type RecentPractice,
+} from '../recentPracticesStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+const STORAGE_KEY = '@adepthood/recent_practices';
+
+function makePractice(id: number): RecentPractice {
+  return { id, name: `Practice ${id}`, mode: 'guided', durationMinutes: 10 };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('loadRecentPractices', () => {
+  test('returns an empty list when nothing is stored', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+    const result = await loadRecentPractices();
+    expect(result).toEqual([]);
+  });
+
+  test('returns the stored list, filtering bad entries and slicing to the max', async () => {
+    const valid = Array.from({ length: MAX_RECENT_PRACTICES + 2 }, (_, i) => makePractice(i + 1));
+    const badEntry = { id: 999, name: 'Missing duration' };
+    const stored = [...valid, badEntry];
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(stored));
+
+    const result = await loadRecentPractices();
+    expect(result).toHaveLength(MAX_RECENT_PRACTICES);
+    expect(result).toEqual(valid.slice(0, MAX_RECENT_PRACTICES));
+  });
+
+  test('a transient getItem rejection returns an empty list without clearing the key', async () => {
+    mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('transient read'));
+
+    const result = await loadRecentPractices();
+    expect(result).toEqual([]);
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test('self-heals corrupt JSON by clearing the key', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce('not valid json{{{');
+
+    const result = await loadRecentPractices();
+    expect(result).toEqual([]);
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+  });
+
+  test('sanitizes a valid non-array payload to an empty list without clearing the key', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({}));
+
+    const result = await loadRecentPractices();
+    expect(result).toEqual([]);
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordRecentPractice', () => {
+  test('prepends a new entry and persists it', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+
+    await recordRecentPractice(makePractice(1));
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      STORAGE_KEY,
+      JSON.stringify([makePractice(1)]),
+    );
+  });
+
+  test('dedupes by id, moving an existing entry to the front', async () => {
+    const existing = [makePractice(1), makePractice(2), makePractice(3)];
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(existing));
+
+    await recordRecentPractice(makePractice(2));
+
+    const stored = mockAsyncStorage.setItem.mock.calls[0]![1] as string;
+    const parsed = JSON.parse(stored) as RecentPractice[];
+    expect(parsed.map((p) => p.id)).toEqual([2, 1, 3]);
+  });
+
+  test('slices to MAX_RECENT_PRACTICES when prepending would overflow', async () => {
+    const existing = Array.from({ length: MAX_RECENT_PRACTICES }, (_, i) => makePractice(i + 1));
+    mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(existing));
+
+    await recordRecentPractice(makePractice(999));
+
+    const stored = mockAsyncStorage.setItem.mock.calls[0]![1] as string;
+    const parsed = JSON.parse(stored) as RecentPractice[];
+    expect(parsed).toHaveLength(MAX_RECENT_PRACTICES);
+    expect(parsed[0]!.id).toBe(999);
+    expect(parsed.map((p) => p.id)).not.toContain(MAX_RECENT_PRACTICES);
+  });
+});

--- a/frontend/src/storage/habitStorage.ts
+++ b/frontend/src/storage/habitStorage.ts
@@ -2,7 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import type { Habit } from '../features/Habits/Habits.types';
 
-import { getJsonArray } from './jsonStore';
+import { getJsonArray, getJsonArrayForUpdate } from './jsonStore';
 import { serialize } from './serializedWrite';
 
 const STORAGE_KEY = '@adepthood/habits';
@@ -48,7 +48,7 @@ export async function clearHabits(): Promise<void> {
 /**
  * BUG-FE-STORAGE-002: append a check-in to the pending queue under a
  * serialized write lane. AsyncStorage offers no transactional RMW, so
- * two concurrent appenders that both hit `loadPendingCheckIns` before
+ * two concurrent appenders that both read the queue before
  * either calls `setItem` would each write a single-item array,
  * silently losing one of the user's check-ins. Funnelling every write
  * to `PENDING_CHECKINS_KEY` through `serialize(...)` makes the
@@ -56,7 +56,19 @@ export async function clearHabits(): Promise<void> {
  */
 export async function savePendingCheckIn(checkIn: PendingCheckIn): Promise<void> {
   await serialize(PENDING_CHECKINS_KEY, async () => {
-    const existing = await loadPendingCheckIns();
+    let result: PendingCheckIn[] | null;
+    try {
+      result = await getJsonArrayForUpdate<PendingCheckIn>(PENDING_CHECKINS_KEY);
+    } catch (err: unknown) {
+      // A transient read must abort the write; falling back to [] here would
+      // overwrite an intact on-disk queue with a single-item array.
+      console.warn(
+        '[storage] transient read during pending check-in append, aborting write to preserve queue',
+        err,
+      );
+      return;
+    }
+    const existing = result ?? [];
     existing.push(checkIn);
     await AsyncStorage.setItem(PENDING_CHECKINS_KEY, JSON.stringify(existing));
   });

--- a/frontend/src/storage/jsonStore.ts
+++ b/frontend/src/storage/jsonStore.ts
@@ -31,14 +31,7 @@ export async function resetCorruptKey(key: string, err: unknown): Promise<void> 
  * `try` whose `catch` clears the key — silently deletes good data on a
  * momentary read blip, which is the bug this helper exists to prevent.
  */
-export async function getJsonArray<T>(key: string): Promise<T[] | null> {
-  let raw: string | null;
-  try {
-    raw = await AsyncStorage.getItem(key);
-  } catch (err: unknown) {
-    console.warn(`[storage] transient read error for ${key}, keeping stored data`, err);
-    return null;
-  }
+async function parseJsonArrayOrHeal<T>(key: string, raw: string | null): Promise<T[] | null> {
   if (raw === null) return null;
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -51,4 +44,30 @@ export async function getJsonArray<T>(key: string): Promise<T[] | null> {
     await resetCorruptKey(key, err);
     return null;
   }
+}
+
+export async function getJsonArray<T>(key: string): Promise<T[] | null> {
+  let raw: string | null;
+  try {
+    raw = await AsyncStorage.getItem(key);
+  } catch (err: unknown) {
+    console.warn(`[storage] transient read error for ${key}, keeping stored data`, err);
+    return null;
+  }
+  return parseJsonArrayOrHeal<T>(key, raw);
+}
+
+/**
+ * Read a JSON array as the read leg of a read-modify-write.
+ *
+ * Unlike `getJsonArray`, a transient `getItem` rejection is NOT swallowed —
+ * it PROPAGATES to the caller. `getJsonArray` is a fail-safe read that
+ * returns `null` on a momentary blip; an RMW caller must instead abort its
+ * write on that blip, because falling back to an empty array would clobber
+ * intact stored data with the write's fallback. Corrupt JSON and a valid
+ * non-array payload still self-heal to `null`; a missing key returns `null`.
+ */
+export async function getJsonArrayForUpdate<T>(key: string): Promise<T[] | null> {
+  const raw = await AsyncStorage.getItem(key);
+  return parseJsonArrayOrHeal<T>(key, raw);
 }

--- a/frontend/src/storage/recentPracticesStorage.ts
+++ b/frontend/src/storage/recentPracticesStorage.ts
@@ -37,9 +37,20 @@ function sanitize(value: unknown): RecentPractice[] {
 
 /** Read the recent-practice list; self-heals (returns []) on missing/corrupt data. */
 export async function loadRecentPractices(): Promise<RecentPractice[]> {
+  let raw: string | null;
   try {
-    const raw = await AsyncStorage.getItem(RECENT_PRACTICES_KEY);
-    if (raw === null) return [];
+    raw = await AsyncStorage.getItem(RECENT_PRACTICES_KEY);
+  } catch (err) {
+    // A transient read leaves the stored list intact for a later retry;
+    // clearing here would delete good data on a momentary blip.
+    console.warn(
+      `[storage] transient read error for ${RECENT_PRACTICES_KEY}, keeping stored data`,
+      err,
+    );
+    return [];
+  }
+  if (raw === null) return [];
+  try {
     return sanitize(JSON.parse(raw));
   } catch (err) {
     await resetCorruptKey(RECENT_PRACTICES_KEY, err);


### PR DESCRIPTION
## Summary

Finishes the transient-read hardening started for `getJsonArray` (the transient-IO-vs-corrupt-JSON split). Two AsyncStorage read-modify-write sites still silently clobbered intact stored data when an internal read failed **transiently** (an Android SQLite hiccup / disk pressure — not corruption):

- **`recentPracticesStorage.loadRecentPractices`** wrapped `getItem` and `JSON.parse` in one `try` whose `catch` cleared the key, so a momentary read blip deleted the recent-practice list. Split into a two-try shape: a transient `getItem` rejection now returns `[]` **without** clearing; only a genuine `JSON.parse` failure self-heals via `resetCorruptKey`. The `sanitize`-without-clear semantics for a valid non-array payload are preserved (not a drop-in `getJsonArray` adoption).
- **`savePendingCheckIn`'s serialized RMW** read the queue through `getJsonArray`, which swallows a transient read to `null` → `[]`; the append then wrote a single-item array over the intact on-disk queue. It now reads via the new `getJsonArrayForUpdate` inside the existing `serialize()` lane and **aborts the write** (`console.warn` + `return`, `setItem` never called) on a transient read, preserving the stored queue. The promise still resolves, so the `void savePendingCheckIn(...)` call site sees no new unhandled rejection. Corrupt JSON still self-heals then writes the single new check-in.

Adds `getJsonArrayForUpdate<T>` to `jsonStore` — the RMW read leg that **propagates** a transient `getItem` rejection (vs `getJsonArray`, which swallows it) while still self-healing corrupt/non-array JSON to `null`. The shared parse/heal body is factored into a private helper so `getJsonArray` behavior is unchanged. Reuses the existing `serialize()` per-key write lane rather than introducing a new primitive.

## Test plan

- New `frontend/src/storage/__tests__/jsonStore.test.ts` covering `getJsonArrayForUpdate` (transient rejection propagates with no `removeItem`; corrupt/non-array self-heal to `null`; missing → `null`; valid array) plus a guard on `getJsonArray`'s unchanged split.
- New `frontend/src/storage/__tests__/recentPracticesStorage.test.ts` (module was untested): transient rejection → `[]` without clearing (RED anchor); corrupt JSON self-heal; valid non-array → `[]` without clearing; `recordRecentPractice` dedupe/prepend/slice.
- Extended `habitStorage.test.ts`: transient RMW read aborts the write (`setItem` never called, resolves) — RED anchor; corrupt queue JSON self-heals then writes `[checkIn]`.
- Tests are deterministic (`mockRejectedValueOnce`/`mockResolvedValueOnce`, no sleeps) and fail against the pre-fix implementation.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, full Jest suite — 4136 tests).

Follow-up (out of scope): `recordRecentPractice` still does an unserialized RMW — same clobber class, lower stakes — tracked in #1594.

Closes #1298