### PR TITLE
test(course): exercise a real stage change in the intro-refetch test

### DIFF
--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -567,12 +567,13 @@ describe('CourseScreen', () => {
       expect(getByTestId('stage-selector')).toBeTruthy();
     });
 
+    // Stage 2 is the default selection, so press stage 1 for a genuine change.
     await act(async () => {
-      fireEvent.press(getByTestId('stage-pill-2'));
+      fireEvent.press(getByTestId('stage-pill-1'));
     });
 
     await waitFor(() => {
-      expect(mockStageIntro).toHaveBeenCalledWith(2);
+      expect(mockStageIntro).toHaveBeenCalledWith(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the coverage-theater "refetches the intro when the stage changes" test in
`CourseScreen.test.tsx` (issue Item 1). The test pressed `stage-pill-2` while
stage 2 is already the default selection, making the press a no-op:
`handleStageSelect(2)` set the same value, React bailed the re-render,
`StageIntroCard`'s `useEffect([stageNumber])` never re-ran, and the asserted
`stageIntro(2)` call had already fired at mount — so the test stayed green even
if the stage-change refetch were broken.

The fix presses `stage-pill-1` (unlocked in the fixture) for a genuine 2 → 1
transition and asserts `stageIntro(1)`, so the test now exercises the refetch it
names and fails if `StageIntroCard`'s `stageNumber` effect dependency is dropped.

Item 2 (the "dead `useAppNavigation` mock") is intentionally **not** changed: it
is stale. Since PR #1532, `CourseScreen` calls `useScreenDrawer('Course')`, which
consumes `useAppNavigation`, so the mock is load-bearing (the maintainer comment
on the issue confirms this). Removing it would break the suite.

## Test plan

- Mutation-verified: dropping `stageNumber` from `StageIntroCard`'s effect deps
  makes the updated test fail at `expect(mockStageIntro).toHaveBeenCalledWith(1)`;
  restoring the dep makes it pass.
- `./scripts/frontend/check-all.sh` — lint, format, typecheck, and all 4136
  frontend tests pass.

Closes #1356