### PR TITLE
fix(map): reconcile stage descriptors with canonical archetype copy

### DIFF
--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -21,6 +21,22 @@ const HEX_COLOR = /^#[\da-f]{6}$/i;
 const ALL_STAGES = Array.from({ length: STAGE_COUNT }, (_, i) => STAGE_COUNT - i);
 const MAX_RIGHT_LABEL_LINE_LENGTH = 9;
 
+// The canonical archetype word for each stage, mirroring the backend's
+// Stage.title in archetypal_wavelength.json. The Map descriptor is a second
+// copy of this vocabulary, so it must not drift from the source of truth.
+const CANONICAL_DESCRIPTOR: Readonly<Record<number, string>> = {
+  1: 'Survival',
+  2: 'Magick',
+  3: 'Power',
+  4: 'Conformity',
+  5: 'Achievist',
+  6: 'Pluralist',
+  7: 'Integrative',
+  8: 'Nondual',
+  9: 'Effortless Being',
+  10: 'Pure Awareness',
+};
+
 /** WCAG relative luminance of a #rrggbb color. */
 const luminance = (hex: string): number => {
   const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
@@ -71,6 +87,12 @@ describe('mapLayout', () => {
       expect(display?.descriptor).toBeTruthy();
       expect(display?.practice).toBeTruthy();
       expect(display?.textColor).toMatch(HEX_COLOR);
+    });
+  });
+
+  it('matches each stage descriptor to the canonical backend archetype word', () => {
+    ALL_STAGES.forEach((stageNumber) => {
+      expect(requireDisplay(stageNumber).descriptor).toBe(CANONICAL_DESCRIPTOR[stageNumber]);
     });
   });
 

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -179,7 +179,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
   8: {
     stageNumber: 8,
     persona: 'Adept',
-    descriptor: 'Nonduality',
+    descriptor: 'Nondual',
     practice: 'Deep Intuition',
     arrowLabel: 'Nondual',
     textColor: '#6d92a6',
@@ -197,7 +197,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
   6: {
     stageNumber: 6,
     persona: 'Shadow Glorifier',
-    descriptor: 'Pluralistic',
+    descriptor: 'Pluralist',
     practice: 'Shadow Work',
     arrowLabel: 'Embodied',
     textColor: '#7cb273',
@@ -206,7 +206,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
   5: {
     stageNumber: 5,
     persona: 'Status Seeker',
-    descriptor: 'Achievest',
+    descriptor: 'Achievist',
     practice: 'Wim Hof Method',
     arrowLabel: 'Intellectual',
     textColor: '#dc9a5b',
@@ -233,7 +233,7 @@ export const STAGE_DISPLAY: Readonly<Record<number, StageDisplay>> = {
   2: {
     stageNumber: 2,
     persona: 'Pleasure Seeker',
-    descriptor: 'Magic',
+    descriptor: 'Magick',
     practice: 'Divination',
     arrowLabel: 'Receptivity',
     textColor: '#5d4e9e',


### PR DESCRIPTION
## Summary
The Map's `STAGE_DISPLAY[n].descriptor` in `frontend/src/features/Map/mapLayout.ts` was a second, hardcoded copy of each stage's archetype word, and four values had drifted from the backend's canonical `Stage.title` in `backend/src/curriculum/archetypal_wavelength.json`:

| stage | was | now (canonical) | reason |
|-------|-----|-----------------|--------|
| 5 | `Achievest` | `Achievist` | misspelling — not an English word; the only `grep` hit for "Achievest" |
| 2 | `Magic` | `Magick` | accidental drop of the deliberate "k" spelling |
| 6 | `Pluralistic` | `Pluralist` | canonical short form |
| 8 | `Nonduality` | `Nondual` | canonical form; also matches the record's own `arrowLabel: 'Nondual'` |

All ten descriptors now match the backend titles exactly, removing the drifted second source of truth. This copy renders in the Map left column, the stage a11y label (`MapScreen.tsx`), and the magnifier-lens caption (`magnifierGeometry.ts`) — all now show the canonical spelling. Scope is copy-only; `STAGE_DISPLAY` is not restructured into a backend-fed source.

Sibling descriptors for stages 6 and 8 were reconciled to the canonical short form rather than kept as long-forms, because the six already-matching descriptors show the field is meant to mirror the backend title, and stage 8's `arrowLabel` already used `Nondual` (intra-record inconsistency now resolved).

## Test plan
- Added a regression test in `frontend/src/features/Map/__tests__/mapLayout.test.ts` pinning every stage descriptor to its canonical archetype word (`CANONICAL_DESCRIPTOR` map over all 10 stages).
- `grep -rn "Achievest" frontend/src` returns no hits.
- `./scripts/frontend/check-all.sh` green: ESLint, prettier, tsc, and all 4137 Jest tests pass.

Closes #1360