### PR TITLE
test(map): strengthen two mislabeled MagnifierLens frost tests

### DIFF
--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -83,6 +83,14 @@ const soleCenterGlide = (timing: jest.SpyInstance): CenterGlideConfig => {
   return glide;
 };
 
+/**
+ * Count the frost-wash raises a spy saw. The frost-in animation is the only
+ * `Animated.timing` with a scalar `toValue: 1`; center glides target an XY
+ * object and the frost clear targets `0`.
+ */
+const frostRaiseCount = (timing: jest.SpyInstance): number =>
+  timing.mock.calls.filter(([, config]) => (config as { toValue?: unknown }).toValue === 1).length;
+
 /** Drive a full grant → move → release drag on the lens. */
 const drag = (
   tree: ReturnType<typeof create>,
@@ -250,8 +258,13 @@ describe('MagnifierLens', () => {
   it('glides with animation when reduced motion is off', () => {
     reducedMotionState.value = false;
     jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
     try {
       const { tree } = renderLens({ focusedStage: 1 });
+      act(() => {
+        jest.advanceTimersByTime(2000); // let the mount glide finish
+      });
+      timing.mockClear();
       act(() => {
         tree.update(
           <MagnifierLens
@@ -265,13 +278,11 @@ describe('MagnifierLens', () => {
           />,
         );
       });
-      // Caption follows immediately; the glide itself settles over time.
+      // Caption follows immediately; the glide raises the frost wash as it starts.
       expect(headlineText(tree)).toBe('Nondual');
-      act(() => {
-        jest.advanceTimersByTime(2000);
-      });
-      expect(tree.root.findByProps({ testID: 'magnifier-frost' })).toBeTruthy();
+      expect(frostRaiseCount(timing)).toBe(1);
     } finally {
+      timing.mockRestore();
       jest.useRealTimers();
     }
   });
@@ -327,22 +338,29 @@ describe('MagnifierLens', () => {
   it('raises the frost while a drag is live when reduced motion is off', () => {
     reducedMotionState.value = false;
     jest.useFakeTimers();
+    const timing = jest.spyOn(Animated, 'timing');
     try {
       const { tree, onSettleStage } = renderLens({ focusedStage: 1 });
       act(() => {
         jest.advanceTimersByTime(2000); // let the mount glide finish
       });
+      timing.mockClear();
       const lens = lensNode(tree);
       const start = lensCenterForStage(1, GRID_WIDTH, GRID_HEIGHT);
       const stage3Y = stageWavePoint(3).y * GRID_HEIGHT;
       act(() => {
         lens.props.onResponderGrant(touch(150, start.y));
         lens.props.onResponderMove(touch(150, stage3Y));
+      });
+      // A live drag raises the frost wash before any release-settle glide begins.
+      expect(frostRaiseCount(timing)).toBe(1);
+      act(() => {
         lens.props.onResponderRelease(touch(150, stage3Y));
         jest.advanceTimersByTime(2000);
       });
       expect(onSettleStage).toHaveBeenCalledWith(3);
     } finally {
+      timing.mockRestore();
       jest.useRealTimers();
     }
   });


### PR DESCRIPTION
## Summary

Two tests in `MagnifierLens.test.tsx` named the lens **frost** animation but never asserted it: "glides with animation when reduced motion is off" only checked that the unconditionally-rendered `magnifier-frost` node existed (plus a headline duplicate), and "raises the frost while a drag is live" only asserted `onSettleStage(3)` — a settle outcome already covered by the reduced-motion settle tests. Deleting the `raiseFrost` → `Animated.timing(frost, { toValue: 1 })` machinery left both green (de-slop Family 9: mislabeled tests / coverage theater).

This change spies `Animated.timing` (mirroring the existing settle-glide spy) and asserts the frost-in raise (`toValue: 1`, the only scalar timing target — center glides use an XY object, the frost clear uses `0`) fires under each named condition:

- **Focus glide:** after a `focusedStage` prop change, exactly one frost raise fires as the glide starts.
- **Live drag:** the frost raises mid-drag (asserted before release, so it is not the release-settle glide's raise), while the `onSettleStage(3)` outcome is retained as a secondary check.

A shared `frostRaiseCount` helper keeps both assertions terse. No production code changes; does not touch the `#1215`/`#1259` test items.

## Test plan

- `npx jest src/features/Map/__tests__/MagnifierLens.test.tsx` — 20 passed.
- `./scripts/frontend/check-all.sh` — lint, format, typecheck, full Jest suite (4137 tests) all green.
- **Mutation-verified:** temporarily neutering `raiseFrost` in `MagnifierLens.tsx` made **both** strengthened tests (and only those two) fail; restored afterward.

Closes #1362