### PR TITLE
refactor(map): drop two subsumed dead RANK_OR_SHAME_PATTERNS entries

### DIFF
--- a/frontend/src/features/Map/__tests__/copyIntentRule.test.ts
+++ b/frontend/src/features/Map/__tests__/copyIntentRule.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { ranksOrShames } from './copyIntentRule';
+import { RANK_OR_SHAME_PATTERNS, countRankOrShameMatches, ranksOrShames } from './copyIntentRule';
 
 describe('ranksOrShames', () => {
   it.each([
@@ -42,5 +42,52 @@ describe('ranksOrShames', () => {
     ['Stage 10 / Emptiness'],
   ])('returns false for legal model vocabulary: %s', (copy) => {
     expect(ranksOrShames(copy)).toBe(false);
+  });
+});
+
+describe('RANK_OR_SHAME_PATTERNS coverage', () => {
+  const SOLE_MATCH_STRINGS: readonly string[] = [
+    "you're only at level 3",
+    'you are at level 4',
+    "you're at stage 3 of 10",
+    'you hold rank 5 this week',
+    'you are ranked among your peers',
+    'the leaderboard resets weekly',
+    'climb to unlock deeper practice',
+    'unlock the next tier of practice',
+    'reach the next to unlock more content',
+    'left behind again today',
+    'catch up to the others',
+    'she is ahead of you now',
+    "you're inferior to them",
+    'they are further along than you',
+    'keep your streak this week',
+    'the streak alive tonight',
+    'you lost your streak',
+    'you broke your streak yesterday',
+    "don't miss out on this moment",
+    "don't break the chain",
+    'this lasts forever now',
+    'just keep going no matter what',
+    'you must complete this today',
+    "don't lose your momentum",
+  ];
+
+  it.each(SOLE_MATCH_STRINGS.map((copy) => [copy]))(
+    'has a string matching exactly one pattern: %s',
+    (copy) => {
+      expect(countRankOrShameMatches(copy)).toBe(1);
+    },
+  );
+
+  it('provides one sole-match string per pattern', () => {
+    expect(SOLE_MATCH_STRINGS).toHaveLength(RANK_OR_SHAME_PATTERNS.length);
+  });
+
+  it('exercises every pattern via a sole-match string', () => {
+    const covered = RANK_OR_SHAME_PATTERNS.map((pattern) =>
+      SOLE_MATCH_STRINGS.some((copy) => pattern.test(copy)),
+    );
+    expect(covered.every(Boolean)).toBe(true);
   });
 });

--- a/frontend/src/features/Map/__tests__/copyIntentRule.ts
+++ b/frontend/src/features/Map/__tests__/copyIntentRule.ts
@@ -1,6 +1,6 @@
 /** Intent-rule predicate: ranking/shaming the person is banned, ascending model vocabulary is not. */
 
-const RANK_OR_SHAME_PATTERNS: readonly RegExp[] = [
+export const RANK_OR_SHAME_PATTERNS: readonly RegExp[] = [
   // Ranking the user against a fixed scale or each other.
   /you.?re only at level \d/i,
   /you are at level \d/i,
@@ -14,13 +14,11 @@ const RANK_OR_SHAME_PATTERNS: readonly RegExp[] = [
   /reach the next to unlock/i,
   // Behind/inferior/comparison framing.
   /\bbehind\b/i,
-  /fall(ing)? behind/i,
   /catch up/i,
   /ahead of you/i,
   /you.?re inferior/i,
   /further along than you/i,
   // Streak-shame / FOMO pressure.
-  /don.?t lose your streak/i,
   /keep your streak/i,
   /streak alive/i,
   /lost your streak/i,
@@ -36,4 +34,9 @@ const RANK_OR_SHAME_PATTERNS: readonly RegExp[] = [
 /** True when copy ranks or shames the person, per the balance-not-altitude intent rule. */
 export function ranksOrShames(copy: string): boolean {
   return RANK_OR_SHAME_PATTERNS.some((pattern) => pattern.test(copy));
+}
+
+/** Count of intent-rule patterns the copy trips, used to prove each pattern is uniquely exercised. */
+export function countRankOrShameMatches(copy: string): number {
+  return RANK_OR_SHAME_PATTERNS.filter((pattern) => pattern.test(copy)).length;
 }


### PR DESCRIPTION
## Summary

Removes two dead entries from `RANK_OR_SHAME_PATTERNS` — the shared test-only
content-safety guard (`frontend/src/features/Map/__tests__/copyIntentRule.ts`)
that enforces the "no gamified pressure / rank-or-shame" product principle
across Map and Return copy tests.

Both removed patterns are strictly subsumed and can never uniquely match, so
the guard's caught-set is provably unchanged:

- `/fall(ing)? behind/i` requires a literal space before `behind`, so every
  match also matches the retained `/\bbehind\b/i`.
- `/don.?t lose your streak/i` is a strict prefix-extension of the retained
  `/don.?t lose/i`.

Also exports the pattern list and adds a `countRankOrShameMatches` helper so a
new sole-match coverage test can pin every remaining pattern to exactly one
fixture — a string↔pattern bijection that self-enforces against re-adding dead
patterns (re-adding either removed entry breaks the length/exactly-one
assertions).

## Test plan

- Verified subsumption empirically with concrete fixtures before removal.
- New `RANK_OR_SHAME_PATTERNS coverage` block: each of the 24 remaining
  patterns has a sole-match string (`countRankOrShameMatches === 1`), string
  count equals pattern count, and every pattern is covered.
- Kept the existing `ranksOrShames` true-case fixtures `"don't fall behind"`
  and `"don't lose your streak today"` as regression anchors proving those
  strings still trip the guard after removal (via `\bbehind\b` / `don.?t lose`).
- Dependent consumers (`returnCopy.test.ts`, `mettaSessionCopy.test.ts`,
  `beginAgain.test.ts`) still pass — they import only the public predicate.
- Full `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and all
  4163 Jest tests pass.

Closes #1369