### PR TITLE
fix(security): remove literal U+FEFF bytes from text_sanitize comment

### DIFF
--- a/backend/src/security/text_sanitize.py
+++ b/backend/src/security/text_sanitize.py
@@ -74,7 +74,7 @@ _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 # The pattern is built from codepoint constants so the source file itself
 # contains no invisible characters (Trojan-Source defense).  Ranges expand to
 # ``[lo-hi]``; the lone BOM gets a single ``chr`` so we don't emit a
-# redundant ``[﻿-﻿]`` range.
+# redundant ``[U+FEFF-U+FEFF]`` range.
 _ZERO_WIDTH_RANGES = (
     (0x200B, 0x200F),
     (0x202A, 0x202E),

--- a/backend/tests/security/test_text_sanitize.py
+++ b/backend/tests/security/test_text_sanitize.py
@@ -18,9 +18,11 @@ Trojan-Source codepoints (satisfies bandit B613 / ruff PLE2502).
 from __future__ import annotations
 
 import unicodedata
+from pathlib import Path
 
 import pytest
 
+import security.text_sanitize as text_sanitize_module
 from security import (
     DEFAULT_MAX_TEXT_LENGTH,
     TextTooLongError,
@@ -57,6 +59,11 @@ TAG_B = "\U000e0042"  # tag-encoded ASCII "B"
 CANCEL_TAG = "\U000e007f"  # CANCEL TAG -- range end
 VS17 = "\U000e0100"  # first variation-selector-supplement codepoint, one past the tag block
 IVS_BASE = "\u4e2d"  # CJK base char paired with VS17 in the scope-guard test
+
+# Unicode general category for invisible "Other, Format" codepoints -- the
+# class that the sanitizer strips (zero-width spaces/joiners, directional
+# marks, word joiner, BOM, Tags block).  Used by the source-hygiene guard.
+INVISIBLE_FORMAT_CATEGORY = "Cf"
 
 
 def _tag_encode(word: str) -> str:
@@ -403,3 +410,25 @@ class TestPromptInjectionPatterns:
         assert cleaned == "HelloIGNOREPREVIOUSINSTRUCTIONS"
         for char in zw:
             assert char not in cleaned
+
+
+class TestModuleSourceHygiene:
+    """The sanitizer module honors its own no-invisible-characters invariant.
+
+    ``text_sanitize`` builds its zero-width pattern from codepoint constants
+    precisely so the source file itself carries no literal invisible
+    characters (a Trojan-Source defense).  This guard pins that property: a
+    stray BOM or zero-width space reintroduced into the module source fails
+    here instead of silently contradicting the module's own contract.
+    """
+
+    def test_source_contains_no_invisible_characters(self) -> None:
+        """No character in the module source is an invisible format codepoint."""
+        source = Path(text_sanitize_module.__file__).read_text(encoding="utf-8")
+        offenders = sorted(
+            {char for char in source if unicodedata.category(char) == INVISIBLE_FORMAT_CATEGORY},
+        )
+        assert offenders == [], (
+            "text_sanitize.py source must contain no invisible format "
+            f"characters, found: {[f'U+{ord(c):04X}' for c in offenders]}"
+        )


### PR DESCRIPTION
## Summary

`backend/src/security/text_sanitize.py` is a Trojan-Source defense whose documented invariant is that *the source file itself contains no invisible characters*. A comment (line ~77) illustrating a redundant BOM range nonetheless carried two literal U+FEFF (BOM) bytes, silently contradicting the module's own contract — and every gate passed, so nothing caught it.

- Replaced the two literal U+FEFF bytes with the visible `U+FEFF` notation already used throughout the same comment block. No runtime-code change: the zero-width regex is still built from codepoint constants (`_ZERO_WIDTH_SINGLES = (0xFEFF,)` untouched).
- Added a `TestModuleSourceHygiene` regression guard that reads the module source and asserts it contains no Unicode category `Cf` (invisible format) codepoints, so a reintroduced BOM or zero-width space fails in review instead of silently.

The `Cf`-only scope is deliberate: source files legitimately contain category-`Cc` newlines/tabs, so widening the guard to `Cc` would false-positive on every line break; `Cf` precisely matches the reintroduced-invisible failure mode.

## Test plan

- `grep -P '[\x{FEFF}\x{200B}-\x{200D}]' backend/src/security/text_sanitize.py` is now empty.
- `./scripts/backend/check-all.sh` green (2619 passed, 96.56% coverage); ruff format/lint clean; `xenon` A-grade; `radon mi` A.
- New guard `TestModuleSourceHygiene::test_source_contains_no_invisible_characters` passes (and would fail if a `Cf` codepoint were reintroduced).

Closes #1379