### PR TITLE
docs(backend): correct stale _seed_startup_data docstring

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -259,17 +259,17 @@ install_trace_id_logging()
 
 
 async def _seed_startup_data(session: AsyncSession) -> None:
-    """Run the three idempotent seeders, with isolation and a stages prerequisite.
+    """Run the idempotent seeders, with isolation and a stages prerequisite.
 
-    ``seed_practices`` and ``seed_content`` both read from the seeded
+    Each dependent seeder (``seed_practices``, ``seed_practice_recipes``,
+    ``seed_content``, ``seed_goal_group_templates``) reads from the seeded
     ``CourseStage`` rows, so a ``seed_stages`` failure must short-circuit
     — otherwise the dependents run against an empty stages table and log
-    a misleading ``seed_complete inserted=0``. ``seed_practices`` and
-    ``seed_content`` are independent of each other, so each is isolated
-    in its own try/except: a failure in one (e.g. a new mode landing in
-    a CHECK constraint before the seed list catches up) must not starve
-    the other. Successes log the inserted count so a quiet deploy is
-    still verifiable from the boot log.
+    a misleading ``seed_complete inserted=0``. The dependents are
+    independent of each other, so each is isolated in its own try/except:
+    a failure in one (e.g. a new mode landing in a CHECK constraint before
+    the seed list catches up) must not starve the others. Successes log the
+    inserted count so a quiet deploy is still verifiable from the boot log.
     """
     try:
         inserted = await seed_stages(session)


### PR DESCRIPTION
## Summary

The `_seed_startup_data` docstring in `backend/src/main.py` claimed it runs
"the three idempotent seeders" and named only `seed_practices` and
`seed_content`, but the isolation loop actually runs **four** dependent seeders
(`practices`, `practice_recipes`, `content`, `goal_group_templates`) after the
`seed_stages` prerequisite. This corrects the stale/lying comment (Family 6):
the count is dropped in favor of "each dependent seeder" so it won't re-drift as
seeders are added, and the isolation rationale now covers all four dependents.

No behavior change — docstring only.

## Test plan

- `./scripts/backend/check-all.sh` — all 7 quality checks pass; 2619 tests
  passed, coverage 96.64% (≥90%).
- `xenon --max-absolute A --max-modules A --max-average A src` — exit 0;
  `radon mi src/main.py` — A.
- Verified at HEAD the loop iterates exactly four `(name, seeder)` tuples so the
  new docstring matches reality.

Closes #1383