### PR TITLE
refactor(backend): services Low tidy-up round 5 (wallet/checkin/botmason/contraction)

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -202,9 +202,9 @@ def get_provider() -> str:
     return os.getenv("BOTMASON_PROVIDER", "stub")
 
 
-def provider_requires_api_key(provider: str | None = None) -> bool:
+def provider_requires_api_key() -> bool:
     """Return True when the selected provider needs an API key to function."""
-    return (provider or get_provider()) in PROVIDER_REGISTRY
+    return get_provider() in PROVIDER_REGISTRY
 
 
 # Prefix rules derived from the registry — a dict keeps

--- a/backend/src/services/checkin.py
+++ b/backend/src/services/checkin.py
@@ -277,10 +277,9 @@ async def current_check_in(session: AsyncSession, ctx: CheckInContext) -> CheckI
     """
     goal_id = cast("int", ctx.goal.id)
     subtractive = await _subtractive_context_for_goal(session, ctx.habit, ctx.goal)
-    streak = await compute_consecutive_streak(
+    return await _idempotent_already_logged_response(
         session, goal_id, ctx.user_id, ctx.user_timezone, subtractive
     )
-    return CheckInResult(streak=streak, milestones=[], reason_code="already_logged_today")
 
 
 async def record_goal_completion(

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -6,9 +6,13 @@ The BotMason wallet has two buckets:
   rolls over at the start of every calendar month.
 - ``offering_balance`` — paid / gifted credits with no expiry.
 
-Every mutation in this module is expressed as a single atomic SQL statement
-(``UPDATE … WHERE … RETURNING``) so concurrent requests can never overspend
-either bucket.  The router layer is responsible for translating ``None``
+The spend and grant mutations are each expressed as a single atomic SQL
+statement (``UPDATE … WHERE … RETURNING``) so concurrent requests can never
+overspend either bucket.  The monthly-usage reset is the exception: it reads
+the row first (to snapshot the pre-reset count for the audit log) and then
+issues a guarded ``UPDATE … WHERE monthly_reset_date <= now`` without a
+``RETURNING`` clause — the ``WHERE`` predicate still makes the reset
+exactly-once.  The router layer is responsible for translating ``None``
 returns into HTTP errors; the service only reports capacity outcomes.
 
 Every mutation also stages a :class:`models.WalletAudit` row recording
@@ -24,8 +28,9 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any, cast
 
-from sqlalchemy import update
+from sqlalchemy import CursorResult, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -175,7 +180,7 @@ async def reset_monthly_usage_if_due(
         .values(monthly_messages_used=0, monthly_reset_date=next_reset)
         .execution_options(synchronize_session=False)
     )
-    if not result.rowcount:  # type: ignore[attr-defined]
+    if not cast("CursorResult[Any]", result).rowcount:
         return
     logger.info(
         "Monthly usage reset for user_id=%s, next_reset=%s",

--- a/backend/tests/services/test_contraction_service.py
+++ b/backend/tests/services/test_contraction_service.py
@@ -153,8 +153,11 @@ async def test_healthy_habit_is_not_flagged(db_session: AsyncSession) -> None:
 
     matching = [h for h in aggregates.habits if h.habit_id == habit_id]
     assert matching
-    assert matching[0].consecutive_unmet_days < FOUNDATION_UNMET_CONSECUTIVE_DAYS
-    assert matching[0].consecutive_unchecked_days < FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+    # Five days of met completions: today is present-and-met, so both walks in
+    # ``_consecutive_days`` break on day 0. Pin the exact zero counts rather
+    # than a loose ``< THRESHOLD`` so a miscount that stays under the gate fails.
+    assert matching[0].consecutive_unmet_days == 0
+    assert matching[0].consecutive_unchecked_days == 0
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +180,10 @@ async def test_brand_new_habit_is_not_reported_unchecked(db_session: AsyncSessio
 
     matching = [h for h in aggregates.habits if h.habit_id == habit_id]
     assert matching
-    assert matching[0].consecutive_unchecked_days < FOUNDATION_UNCHECKED_CONSECUTIVE_DAYS
+    # start_date is today - 2 days, so ``earliest`` clamps the unchecked walk to
+    # today, -1, -2 (three days) before it crosses the habit's start. Pin the
+    # exact count so a miscount that stays under the gate is caught.
+    assert matching[0].consecutive_unchecked_days == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Round-5 backend de-slop tidy-up of the `services` layer. Five distinct,
linter-invisible residues fixed; the sixth finding was already resolved by a
prior round and is skipped with evidence below.

- **wallet.py docstring** — the module docstring claimed *every* mutation is a
  single atomic `UPDATE … WHERE … RETURNING`, but `reset_monthly_usage_if_due`
  does a `SELECT`-then-guarded-`UPDATE` with no `RETURNING`. Narrowed the claim
  to spend/grant mutations and described the reset path accurately.
- **wallet.py `type: ignore` → `cast`** — replaced the lone unjustified
  `# type: ignore[attr-defined]` on `result.rowcount` with the repo's
  `cast("CursorResult[Any]", result).rowcount` idiom (matches `energy.py`). No
  suppression added elsewhere; mypy stays green.
- **checkin.py delegation** — `current_check_in` now delegates to the existing
  `_idempotent_already_logged_response` helper instead of re-inlining the
  identical `CheckInResult` shape. Pure delegation, no behavior change.
- **contraction tests** — two loose `< THRESHOLD` asserts tightened to the exact
  counts the `_consecutive_days` walk produces (healthy: `unmet == 0`,
  `unchecked == 0`; brand-new: `unchecked == 3`).
- **botmason.py unused param** — dropped the speculative `provider: str | None`
  parameter from `provider_requires_api_key()`; the sole caller passes nothing
  and it is not part of any Protocol/ABC.

**Skipped (already resolved):** Finding 5 (orphaned key-prefix comment at
`botmason.py:51-52`) no longer exists at HEAD — a prior de-slop round removed it;
the current lines are a legit `_MAX_PROMPT_FILE_SIZE` comment, and the surviving
key-prefix notes (lines ~105/291) accurately describe live code.

## Test plan

- `./scripts/backend/check-all.sh` → all 7 checks pass; coverage 96.64%
  (wallet 100%, checkin 99%).
- `mypy src` green (cast idiom verified).
- `xenon --max-absolute A --max-modules A --max-average A src` → A-grade;
  `radon mi` all-A on touched modules.
- Contraction exact-count asserts traced against `_consecutive_days` and pass.

Closes #1386