### PR TITLE
fix(practice): drop duplicate interval-bell cue at session end

### DIFF
--- a/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
+++ b/frontend/src/features/Practice/components/__tests__/ActiveRitualSession.harvesters.test.ts
@@ -103,7 +103,7 @@ describe('ActiveRitualSession harvesters — interval_bell', () => {
     const state = fakeState({ elapsedMs: 5 * 60_000 });
     const wire = harvestMetadata(intervalBellConfig, state, null);
     const summary = harvestSummaryMetadata(intervalBellConfig, state, 0, null);
-    expect(wire).toEqual({ mode: 'interval_bell', intervals_struck: 2, total_intervals: 5 });
+    expect(wire).toEqual({ mode: 'interval_bell', intervals_struck: 2, total_intervals: 4 });
     expect(summary).toEqual(wire);
   });
 });

--- a/frontend/src/features/Practice/engine/__tests__/cues.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/cues.test.ts
@@ -122,7 +122,7 @@ describe('scheduledCues — metronome', () => {
 });
 
 describe('scheduledCues — interval_bell', () => {
-  it('expands interval_minutes=5 over duration=20 into 4 intervals + start + end, tagging the bell tone', () => {
+  it('expands interval_minutes=5 over duration=20 into 3 interior intervals + start + end, dropping the endpoint collision and tagging the bell tone', () => {
     const config: IntervalBellConfig = {
       mode: 'interval_bell',
       duration_minutes: 20,
@@ -131,13 +131,50 @@ describe('scheduledCues — interval_bell', () => {
     };
     const cues = scheduledCues(config);
     const intervalCues = cues.filter((c) => c.kind === 'interval_bell');
-    expect(intervalCues.map((c) => c.atMs)).toEqual([5 * MIN, 10 * MIN, 15 * MIN, 20 * MIN]);
+    expect(intervalCues.map((c) => c.atMs)).toEqual([5 * MIN, 10 * MIN, 15 * MIN]);
     expect(cues.filter((c) => c.kind === 'start_bell')).toHaveLength(1);
     expect(cues.filter((c) => c.kind === 'end_bell')).toHaveLength(1);
     // Interval cues carry the configured bell tone; boundary cues carry none.
     expect(intervalCues.every((c) => c.tone === 'bowl')).toBe(true);
     const boundaryCues = cues.filter((c) => c.kind !== 'interval_bell');
     expect(boundaryCues.every((c) => c.tone === undefined)).toBe(true);
+  });
+
+  it('schedules exactly one cue at the endpoint and it is the end_bell when the interval divides the duration', () => {
+    const cues = scheduledCues({
+      mode: 'interval_bell',
+      duration_minutes: 20,
+      interval_minutes: 5,
+      bell_tone: 'bowl',
+    });
+    const atEnd = cues.filter((c) => c.atMs === 20 * MIN);
+    expect(atEnd.map((c) => c.kind)).toEqual(['end_bell']);
+  });
+
+  it('keeps the final interval cue when the interval does not divide the duration', () => {
+    const cues = scheduledCues({
+      mode: 'interval_bell',
+      duration_minutes: 22,
+      interval_minutes: 5,
+      bell_tone: 'chime',
+    });
+    const intervalCues = cues.filter((c) => c.kind === 'interval_bell');
+    expect(intervalCues.map((c) => c.atMs)).toEqual([5 * MIN, 10 * MIN, 15 * MIN, 20 * MIN]);
+    const atEnd = cues.filter((c) => c.atMs === 22 * MIN);
+    expect(atEnd.map((c) => c.kind)).toEqual(['end_bell']);
+  });
+
+  it('emits only start and end when the interval equals the duration', () => {
+    const cues = scheduledCues({
+      mode: 'interval_bell',
+      duration_minutes: 10,
+      interval_minutes: 10,
+      bell_tone: 'gong',
+    });
+    expect(cues).toEqual([
+      { atMs: 0, kind: 'start_bell' },
+      { atMs: 10 * MIN, kind: 'end_bell' },
+    ]);
   });
 
   it('uses cue_offsets_minutes verbatim, tagging the tone (chime), and degrades to untoned start+end when neither offset field is set (gong)', () => {

--- a/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
+++ b/frontend/src/features/Practice/engine/__tests__/reducer.test.ts
@@ -103,7 +103,7 @@ describe('ritualReducer — metronome', () => {
 });
 
 describe('ritualReducer — interval_bell', () => {
-  it('fires 4 interval cues + start + end for interval_minutes=5 over 20 minutes', () => {
+  it('fires 3 interior interval cues + start + end for interval_minutes=5 over 20 minutes', () => {
     const config: IntervalBellConfig = {
       mode: 'interval_bell',
       duration_minutes: 20,
@@ -114,7 +114,7 @@ describe('ritualReducer — interval_bell', () => {
       { type: 'START', now: 0 },
       { type: 'TICK', now: 20 * MIN },
     ]);
-    expect(s.cuesStruck).toBe(6);
+    expect(s.cuesStruck).toBe(5);
     expect(s.status).toBe('complete');
   });
 

--- a/frontend/src/features/Practice/engine/__tests__/useRitualEngine.test.tsx
+++ b/frontend/src/features/Practice/engine/__tests__/useRitualEngine.test.tsx
@@ -86,7 +86,7 @@ describe('useRitualEngine', () => {
   it('tags an interval_bell cue with its configured tone while boundary cues stay single-arg', () => {
     const config: IntervalBellConfig = {
       mode: 'interval_bell',
-      duration_minutes: 1,
+      duration_minutes: 2,
       interval_minutes: 1,
       bell_tone: 'gong',
     };
@@ -97,9 +97,11 @@ describe('useRitualEngine', () => {
     expect(deps.audio.play).toHaveBeenNthCalledWith(1, 'start_bell');
 
     act(() => jest.advanceTimersByTime(60_000));
-    expect(result.current[0].status).toBe('complete');
     expect(deps.audio.play).toHaveBeenCalledWith('interval_bell', 'gong');
     expect(deps.audio.play).not.toHaveBeenCalledWith('interval_bell');
+
+    act(() => jest.advanceTimersByTime(60_000));
+    expect(result.current[0].status).toBe('complete');
   });
 
   it('pause/resume/cancel work and never emit a stray end_bell on cancel', () => {

--- a/frontend/src/features/Practice/engine/cues.ts
+++ b/frontend/src/features/Practice/engine/cues.ts
@@ -79,7 +79,7 @@ function computeIntervalOffsets(config: IntervalBellConfig, totalMs: number): re
   if (!interval || interval <= 0) return [];
   const intervalMs = interval * MS_PER_MINUTE;
   const out: number[] = [];
-  for (let t = intervalMs; t <= totalMs; t += intervalMs) out.push(t);
+  for (let t = intervalMs; t < totalMs; t += intervalMs) out.push(t);
   return out;
 }
 


### PR DESCRIPTION
## Summary

`computeIntervalOffsets` (`frontend/src/features/Practice/engine/cues.ts`) iterated the interval loop inclusive of the endpoint (`t <= totalMs`) while `cuesForIntervalBell` also pushes an explicit `end_bell` at `totalMs`. When the interval evenly divided the duration, an `interval_bell` and an `end_bell` were both scheduled at `totalMs` — `advanceCues` struck both in the same tick, producing a double haptic pulse at session end and inflating `cuesStruck` / `total_intervals` by one (Family 0 off-by-one boundary error).

The fix makes the interval loop exclusive of the endpoint (`t < totalMs`) so the final boundary is owned solely by the `end_bell`. Non-dividing schedules keep their legitimate last interior interval cue (e.g. `interval=5, duration=22` still emits an interval at 20 min).

## Test plan

- New boundary fixtures in `cues.test.ts` pin all three cases:
  - **interval divides duration** (`5/20`): exactly one cue at `totalMs`, and it is `end_bell`.
  - **interval does not divide duration** (`5/22`): the final interior interval at 20 min is retained; only `end_bell` sits at `totalMs`.
  - **interval equals duration** (`10/10`): only `start_bell` + `end_bell`.
- Updated the divide-evenly cases in `reducer.test.ts` (`cuesStruck` 6 → 5) and `ActiveRitualSession.harvesters.test.ts` (`total_intervals` 5 → 4) to the de-inflated counts, and re-based the `useRitualEngine` tone-tagging fixture off the degenerate `1/1` collision onto a non-colliding `2/1` schedule.
- `./scripts/frontend/check-all.sh`: lint, format, typecheck, and all 4166 Jest tests pass.

Closes #1392