### PR TITLE
refactor(frontend): tidy dead exported surface and coverage-theater tests

### DIFF
--- a/frontend/src/context/NetworkStatusContext.tsx
+++ b/frontend/src/context/NetworkStatusContext.tsx
@@ -18,12 +18,10 @@ import { setNetworkOnlineGetter } from '@/api';
 
 interface NetworkStatusContextValue {
   isOnline: boolean;
-  isInternetReachable: boolean | null;
 }
 
 const NetworkStatusContext = createContext<NetworkStatusContextValue>({
   isOnline: true,
-  isInternetReachable: null,
 });
 
 /**
@@ -39,7 +37,6 @@ function isStateOnline(state: NetInfoState): boolean {
 
 export function NetworkStatusProvider({ children }: { children: React.ReactNode }) {
   const [isOnline, setIsOnline] = useState(true);
-  const [isInternetReachable, setIsInternetReachable] = useState<boolean | null>(null);
   const onlineRef = useRef(true);
   onlineRef.current = isOnline;
 
@@ -49,7 +46,6 @@ export function NetworkStatusProvider({ children }: { children: React.ReactNode 
 
     const handleChange = (state: NetInfoState): void => {
       setIsOnline(isStateOnline(state));
-      setIsInternetReachable(state.isInternetReachable);
     };
 
     // Seed once, then subscribe for deltas.
@@ -66,7 +62,7 @@ export function NetworkStatusProvider({ children }: { children: React.ReactNode 
     };
   }, []);
 
-  const value = useMemo(() => ({ isOnline, isInternetReachable }), [isOnline, isInternetReachable]);
+  const value = useMemo(() => ({ isOnline }), [isOnline]);
 
   return <NetworkStatusContext.Provider value={value}>{children}</NetworkStatusContext.Provider>;
 }

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -827,7 +827,6 @@ describe('AuthContext', () => {
   // the device doesn't inherit the previous user's data.
   describe('logout clears all user state (BUG-FE-STATE-001)', () => {
     it('calls resetAllStores from the registry on explicit logout', async () => {
-      const { resetAllStores } = require('@/store/registry');
       const resetSpy = jest.spyOn(require('@/store/registry'), 'resetAllStores');
       mockLoadToken.mockResolvedValue('jwt');
       const { result } = renderHook(() => useAuth(), { wrapper });
@@ -838,7 +837,6 @@ describe('AuthContext', () => {
       });
 
       expect(resetSpy).toHaveBeenCalledTimes(1);
-      expect(typeof resetAllStores).toBe('function');
       resetSpy.mockRestore();
     });
 

--- a/frontend/src/features/Auth/ForgotPasswordScreen.tsx
+++ b/frontend/src/features/Auth/ForgotPasswordScreen.tsx
@@ -14,7 +14,7 @@ const FORGOT_FALLBACK =
   "We couldn't reach the server. Check your connection, then try again in a moment.";
 
 interface Props {
-  navigation: { navigate: (_screen: string) => void; goBack: () => void };
+  navigation: { navigate: (_screen: string) => void };
 }
 
 interface ForgotFieldsProps {

--- a/frontend/src/features/Auth/__tests__/ForgotPasswordScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ForgotPasswordScreen.test.tsx
@@ -16,7 +16,7 @@ const { _mockRequestPasswordReset: mockRequest } = require('@/api') as any;
 
 import ForgotPasswordScreen from '../ForgotPasswordScreen';
 
-const navigation = { navigate: jest.fn(), goBack: jest.fn() };
+const navigation = { navigate: jest.fn() };
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
+++ b/frontend/src/features/Auth/__tests__/ReauthSheet.test.tsx
@@ -47,9 +47,9 @@ describe('ReauthSheet', () => {
     expect(getByTestId('reauth-dismiss')).toBeTruthy();
   });
 
-  it('calls login(email.trim(), password) when submit is pressed', async () => {
+  it('calls login with the canonicalized (trimmed + lowercased) email', async () => {
     const { getByTestId } = render(<ReauthSheet />);
-    fireEvent.changeText(getByTestId('reauth-email'), '  user@example.com  ');
+    fireEvent.changeText(getByTestId('reauth-email'), '  User@Example.COM  ');
     fireEvent.changeText(getByTestId('reauth-password'), 'secret'); // pragma: allowlist secret
     fireEvent.press(getByTestId('reauth-submit'));
 

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -12,7 +12,7 @@ import {
 
 // Cap the form width so fields don't stretch edge-to-edge on laptop/desktop
 // browsers; on phones the screen is narrower so it has no effect.
-export const FORM_MAX_WIDTH = 480;
+const FORM_MAX_WIDTH = 480;
 
 // The serif type ramp is responsive (scales with viewport width); the auth
 // screens are full-bleed editorial covers, so resolve at the widest step so the

--- a/frontend/src/features/Auth/useAuthSubmit.ts
+++ b/frontend/src/features/Auth/useAuthSubmit.ts
@@ -14,7 +14,7 @@ import { formatApiError } from '@/api/errorMessages';
  * makes a synchronous second ``run()`` a no-op until the first settles.
  */
 
-export interface AuthSubmit {
+interface AuthSubmit {
   submitting: boolean;
   error: string | null;
   setError: Dispatch<SetStateAction<string | null>>;

--- a/frontend/src/features/Settings/__tests__/SupportCareScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/SupportCareScreen.test.tsx
@@ -151,29 +151,3 @@ describe('SupportCareScreen — limits line', () => {
     expect(getByText('This complements professional care — it does not replace it.')).toBeTruthy();
   });
 });
-
-// ---------------------------------------------------------------------------
-// No chatbot chrome
-// ---------------------------------------------------------------------------
-
-describe('SupportCareScreen — no chatbot chrome', () => {
-  it('does not render testID "sender"', () => {
-    const { queryByTestId } = render(<SupportCareScreen />);
-    expect(queryByTestId('sender')).toBeNull();
-  });
-
-  it('does not render testID "avatar"', () => {
-    const { queryByTestId } = render(<SupportCareScreen />);
-    expect(queryByTestId('avatar')).toBeNull();
-  });
-
-  it('does not render testID "reply"', () => {
-    const { queryByTestId } = render(<SupportCareScreen />);
-    expect(queryByTestId('reply')).toBeNull();
-  });
-
-  it('does not render a "Send" text element', () => {
-    const { queryByText } = render(<SupportCareScreen />);
-    expect(queryByText('Send')).toBeNull();
-  });
-});

--- a/frontend/src/features/Welcome/WelcomeScreen.tsx
+++ b/frontend/src/features/Welcome/WelcomeScreen.tsx
@@ -168,7 +168,6 @@ export const WelcomeScreen = ({ onComplete, onBegin }: WelcomeScreenProps): Reac
         pagingEnabled
         showsHorizontalScrollIndicator={false}
         onMomentumScrollEnd={onScroll}
-        scrollEventThrottle={16}
         testID="welcome-pager"
       >
         {WELCOME_PANELS.map((panel, index) => (

--- a/frontend/src/features/Welcome/welcomeContent.ts
+++ b/frontend/src/features/Welcome/welcomeContent.ts
@@ -20,7 +20,7 @@ export interface WelcomePanel {
  * "you choose your depth" ethos is visible before any entry is written — no
  * extra panel, no gate.
  */
-export const WELCOME_PRIVACY_NOTE =
+const WELCOME_PRIVACY_NOTE =
   'Your journal is yours — you choose each entry’s privacy, and anything you mark Intimate never leaves for AI.';
 
 /** The five APTITUDE pillars introduced on the second panel. */

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -19,18 +19,6 @@ import type { ReflectionLevel } from '@/api';
 import { accent, fonts, ink } from '@/design/tokens';
 import type { ModeConfig } from '@/features/Practice/engine/types';
 
-/**
- * Root stack for the authenticated app. Hosts the bottom-tabs shell plus
- * modal-style screens (e.g. BYOK API key settings, the practice share
- * preview screen deep-linked from another app) that should not live
- * inside any single tab.
- *
- * ``Tabs`` is typed as ``NavigatorScreenParams<RootTabParamList>`` (not
- * ``undefined``) so screens nested under it -- e.g. ``SharePreviewScreen``
- * forwarding the recipient back to the Practice tab after a successful
- * import -- can pass ``{ screen, params }`` through ``navigation.navigate``
- * with full type safety.
- */
 export interface CreatePracticePrefill {
   config: ModeConfig;
   name?: string;
@@ -75,6 +63,18 @@ const NAV_SCREEN_OPTIONS = {
   headerTitleStyle: { fontFamily: fonts.serif, color: ink.primary },
 } as const;
 
+/**
+ * Root stack for the authenticated app. Hosts the bottom-tabs shell plus
+ * modal-style screens (e.g. BYOK API key settings, the practice share
+ * preview screen deep-linked from another app) that should not live
+ * inside any single tab.
+ *
+ * ``Tabs`` is typed as ``NavigatorScreenParams<RootTabParamList>`` (not
+ * ``undefined``) so screens nested under it -- e.g. ``SharePreviewScreen``
+ * forwarding the recipient back to the Practice tab after a successful
+ * import -- can pass ``{ screen, params }`` through ``navigation.navigate``
+ * with full type safety.
+ */
 const RootStack = (): React.JSX.Element => (
   <Stack.Navigator screenOptions={NAV_SCREEN_OPTIONS}>
     <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />

--- a/frontend/src/navigation/__tests__/hooks.test.tsx
+++ b/frontend/src/navigation/__tests__/hooks.test.tsx
@@ -11,57 +11,20 @@ jest.mock('@react-navigation/native', () => ({
 
 import { useAppNavigation, useAppRoute } from '../hooks';
 
-describe('useAppNavigation', () => {
-  it('returns a typed BottomTabNavigationProp', () => {
-    const fakeNav = { navigate: jest.fn(), goBack: jest.fn() };
-    mockUseNavigation.mockReturnValue(fakeNav);
+// These wrappers only narrow React Navigation's hooks at compile time; their
+// sole runtime behavior is delegating to the underlying hook, so that is all
+// these tests exercise. The generic typing is verified by the type-checker,
+// not here.
+describe('navigation typed hooks', () => {
+  it('useAppNavigation delegates to React Navigation useNavigation', () => {
+    useAppNavigation();
 
-    const result = useAppNavigation();
-
-    expect(result).toBe(fakeNav);
-    expect(result.navigate).toBeDefined();
-  });
-});
-
-describe('useAppRoute', () => {
-  it('returns a typed route for a given screen name', () => {
-    const fakeRoute = {
-      key: 'Practice-abc',
-      name: 'Practice',
-      params: { stageNumber: 3 },
-    };
-    mockUseRoute.mockReturnValue(fakeRoute);
-
-    const result = useAppRoute<'Practice'>();
-
-    expect(result).toBe(fakeRoute);
-    expect(result.params?.stageNumber).toBe(3);
+    expect(mockUseNavigation).toHaveBeenCalledTimes(1);
   });
 
-  it('returns a route with undefined params for screens without params', () => {
-    const fakeRoute = {
-      key: 'Habits-abc',
-      name: 'Habits',
-      params: undefined,
-    };
-    mockUseRoute.mockReturnValue(fakeRoute);
+  it('useAppRoute delegates to React Navigation useRoute', () => {
+    useAppRoute<'Practice'>();
 
-    const result = useAppRoute<'Habits'>();
-
-    expect(result).toBe(fakeRoute);
-    expect(result.params).toBeUndefined();
-  });
-
-  it('returns a route with params for a parameterized screen', () => {
-    const fakeRoute = {
-      key: 'Course-abc',
-      name: 'Course',
-      params: { stageNumber: 5 },
-    };
-    mockUseRoute.mockReturnValue(fakeRoute);
-
-    const result = useAppRoute<'Course'>();
-
-    expect(result.params?.stageNumber).toBe(5);
+    expect(mockUseRoute).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Round-2 frontend-entry Low tidy-up (mirrors #1143). Removes small dead exported surface and replaces/removes coverage-theater tests. Every item was re-verified at HEAD (word-boundary grepped before deletion); the optional cross-context DRY extraction (comment item 7) was deliberately left out to keep this surgical.

Dead exported surface:
- `NetworkStatusContext`: drop the unsubscribed `isInternetReachable` context field, state, setter, and memo dep — `isOnline` is the only live signal; `isStateOnline` still reads the raw NetInfo snapshot field.
- `ForgotPasswordScreen`: drop the never-called `goBack` from the Props type + its test stub.
- `auth.styles`: un-export module-local `FORM_MAX_WIDTH`.
- `welcomeContent`: un-export module-local `WELCOME_PRIVACY_NOTE`.
- `useAuthSubmit`: un-export the `AuthSubmit` return-type interface (no external importer).
- `WelcomeScreen`: remove the no-op `scrollEventThrottle` (only `onMomentumScrollEnd` is wired, never `onScroll`).
- `RootStack`: move the root-stack docstring off the unrelated `CreatePracticePrefill` interface onto `const RootStack`.

Test quality:
- `AuthContext.test`: drop the `resetAllStores` `typeof … === 'function'` tautology + its dead `require`; the `resetSpy` behavioral assertion remains.
- `navigation/hooks.test`: replace the identity pass-through suite (which asserted the mock's own input back to itself) with a delegation-contract check — keeps runtime coverage of the pass-throughs without the theater.
- `SupportCareScreen.test`: remove the unfalsifiable "no chatbot chrome" absence block (the flat scaffold has no code path to render those testIDs); positive card/header/limits assertions retain full coverage.
- `ReauthSheet.test`: feed mixed-case input (`  User@Example.COM  `) so `canonicalizeEmail`'s lowercase path is exercised (kills a bare-`.trim()` mutation) and fix the stale title.

## Test plan

- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, Jest): 397 suites / 4153 tests pass.
- Pre-commit hooks pass (eslint, prettier, typecheck, tests, commitlint, detect-secrets).
- Coverage thresholds unchanged; the pass-through and SupportCare edits preserve the exercised lines.

Closes #1401