### PR TITLE
fix(frontend): retire stale Settings banner on edit and collapse Welcome dismissal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -145,7 +145,7 @@ function WelcomeGate(): React.JSX.Element {
   const { token } = useAuth();
   const { isFirstRun, markSeen } = useFirstRun(token);
   if (isFirstRun) {
-    return <WelcomeScreen onComplete={markSeen} onBegin={markSeen} />;
+    return <WelcomeScreen onComplete={markSeen} />;
   }
   return <RootStack key="auth" />;
 }

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -6,11 +6,11 @@
 
 // ─── Screen stubs (keep the navigation plumbing real) ───────────────────────
 
-// WelcomeScreen stub: Begin fires onBegin+onComplete, Skip fires onComplete only.
+// WelcomeScreen stub: Begin and Skip both fire onComplete (the single dismissal).
 jest.mock('@/features/Welcome/WelcomeScreen', () => {
   const React = require('react');
   const { Pressable, Text, View } = require('react-native');
-  const WelcomeStub = ({ onComplete, onBegin }: { onComplete: () => void; onBegin: () => void }) =>
+  const WelcomeStub = ({ onComplete }: { onComplete: () => void }) =>
     React.createElement(
       View,
       { testID: 'welcome-screen' },
@@ -18,10 +18,7 @@ jest.mock('@/features/Welcome/WelcomeScreen', () => {
         Pressable,
         {
           testID: 'welcome-begin',
-          onPress: () => {
-            onBegin();
-            onComplete();
-          },
+          onPress: onComplete,
         },
         React.createElement(Text, null, 'Begin'),
       ),
@@ -250,7 +247,7 @@ beforeEach(() => {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('Welcome → Journal landing', () => {
-  // Begin (onBegin+onComplete → markSeen) lands on Journal; fails if the initial route reverts.
+  // Begin (onComplete → markSeen) lands on Journal; fails if the initial route reverts.
   it('Begin path: focused route is Journal after Welcome is dismissed', async () => {
     const navRef = React.createRef<NavigationContainerRef<RootTabParamList>>();
     act(() => useWelcomeStore.setState({ hasSeenWelcome: false }));
@@ -260,7 +257,7 @@ describe('Welcome → Journal landing', () => {
     // Welcome is showing before Begin is pressed.
     expect(getByTestId('welcome-screen')).toBeTruthy();
 
-    // Dismiss via the Begin path (mirrors production: onBegin + onComplete).
+    // Dismiss via the Begin path (mirrors production: onComplete).
     act(() => {
       fireEvent.press(getByTestId('welcome-begin'));
     });

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -385,13 +385,14 @@ export default function ApiKeySettingsScreen({ navigation }: Props = {}): React.
   const performClear = useClearKeyHandler(form, clearApiKey);
   const handleRequestRemove = useRemoveConfirmation(performClear);
 
-  const { setDraft, setError } = form;
+  const { setDraft, setError, setStatus } = form;
   const onChangeDraft = useCallback(
     (value: string) => {
       setDraft(value);
       setError(null);
+      setStatus(null);
     },
-    [setDraft, setError],
+    [setDraft, setError, setStatus],
   );
   const toggleReveal = useCallback(() => setReveal((prev) => !prev), [setReveal]);
   const { onBack, onOpenTimezone } = useScreenNavHandlers(navigation);

--- a/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
+++ b/frontend/src/features/Settings/TimezoneSettingsScreen.tsx
@@ -186,19 +186,21 @@ export default function TimezoneSettingsScreen({ navigation }: Props = {}): Reac
   // Depend on the stable useState setters, not ``state`` itself — the hook
   // returns a fresh object every render, so a ``[state]`` dependency would
   // silently defeat the memoization.
-  const { setDraft, setError } = state;
+  const { setDraft, setError, setStatus } = state;
   const onChangeDraft = useCallback(
     (value: string) => {
       setDraft(value);
       setError(null);
+      setStatus(null);
     },
-    [setDraft, setError],
+    [setDraft, setError, setStatus],
   );
 
   const onUseDeviceZone = useCallback(() => {
     setDraft(detectDeviceTimezone());
     setError(null);
-  }, [setDraft, setError]);
+    setStatus(null);
+  }, [setDraft, setError, setStatus]);
 
   const onBack = useMemo(
     () => (navigation?.goBack ? () => navigation.goBack?.() : undefined),

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -175,6 +175,22 @@ describe('ApiKeySettingsScreen', () => {
     expect(getByTestId('api-key-input').props.value).toBe('');
   });
 
+  test('clears the success banner once the draft changes after a save', async () => {
+    setApiKeyState({});
+    const { getByTestId, findByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+    await findByTestId('api-key-status');
+
+    // Typing a replacement key must retire the stale "saved" confirmation.
+    fireEvent.changeText(getByTestId('api-key-input'), 'typing a new value');
+
+    expect(queryByTestId('api-key-status')).toBeNull();
+  });
+
   test('the reveal toggle flips secureTextEntry', () => {
     setApiKeyState({});
     const { getByTestId } = render(<ApiKeySettingsScreen />);

--- a/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/TimezoneSettingsScreen.test.tsx
@@ -91,6 +91,34 @@ describe('TimezoneSettingsScreen', () => {
     expect(setUserTimezone).not.toHaveBeenCalled();
   });
 
+  test('clears the success banner once the draft changes after a save', async () => {
+    setAuthState('Europe/Paris');
+    mockUpdateMyTimezone.mockResolvedValueOnce({ timezone: 'America/Los_Angeles' });
+    const { getByTestId, queryByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.changeText(getByTestId('timezone-input'), 'America/Los_Angeles');
+    fireEvent.press(getByTestId('save-timezone-button'));
+    await waitFor(() => expect(getByTestId('timezone-status')).toBeTruthy());
+
+    fireEvent.changeText(getByTestId('timezone-input'), 'America/New_York');
+
+    expect(queryByTestId('timezone-status')).toBeNull();
+  });
+
+  test('clears the success banner when the device zone is applied after a save', async () => {
+    setAuthState('Europe/Paris');
+    mockUpdateMyTimezone.mockResolvedValueOnce({ timezone: 'America/Los_Angeles' });
+    const { getByTestId, queryByTestId } = render(<TimezoneSettingsScreen />);
+
+    fireEvent.changeText(getByTestId('timezone-input'), 'America/Los_Angeles');
+    fireEvent.press(getByTestId('save-timezone-button'));
+    await waitFor(() => expect(getByTestId('timezone-status')).toBeTruthy());
+
+    fireEvent.press(getByTestId('use-device-timezone-button'));
+
+    expect(queryByTestId('timezone-status')).toBeNull();
+  });
+
   test('"Use device time zone" fills the input with the detected zone', () => {
     setAuthState('UTC');
     const { getByTestId } = render(<TimezoneSettingsScreen />);

--- a/frontend/src/features/Welcome/WelcomeScreen.tsx
+++ b/frontend/src/features/Welcome/WelcomeScreen.tsx
@@ -111,7 +111,7 @@ interface Pager {
   page: number;
   width: number;
   scrollRef: React.RefObject<ScrollView>;
-  onScroll: (_e: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onScroll: (e: NativeSyntheticEvent<NativeScrollEvent>) => void;
   goNext: () => void;
 }
 
@@ -140,28 +140,29 @@ const useWelcomePager = (): Pager => {
 };
 
 export interface WelcomeScreenProps {
-  /** Persist the flag and dismiss the welcome (called on Begin and Skip). */
+  /** Persist the flag and dismiss the welcome; fired once by Begin or Skip. */
   onComplete: () => void;
-  /** Land on the Journal home, optionally opening the first-habits step. */
-  onBegin: () => void;
 }
 
 /**
  * The program welcome (#836): a swipeable editorial intro to the 36-week
  * journey. Paging works with or without animation (reduced-motion-safe), a
  * persistent Skip sits on every panel, and the final panel's Begin CTA lands
- * the user on the Journal home (the app shell's initial route).
+ * the user on the Journal home (the app shell's initial route). Begin and Skip
+ * share one dismissal path, latched so a rapid double-tap persists only once.
  */
-export const WelcomeScreen = ({ onComplete, onBegin }: WelcomeScreenProps): React.JSX.Element => {
+export const WelcomeScreen = ({ onComplete }: WelcomeScreenProps): React.JSX.Element => {
   const { page, width, scrollRef, onScroll, goNext } = useWelcomePager();
-  const begin = useCallback(() => {
+  const dismissed = useRef(false);
+  const dismiss = useCallback(() => {
+    if (dismissed.current) return;
+    dismissed.current = true;
     onComplete();
-    onBegin();
-  }, [onComplete, onBegin]);
+  }, [onComplete]);
 
   return (
     <SafeAreaView style={s.ground} testID="welcome-screen">
-      <SkipButton onSkip={onComplete} />
+      <SkipButton onSkip={dismiss} />
       <ScrollView
         ref={scrollRef}
         horizontal
@@ -178,7 +179,7 @@ export const WelcomeScreen = ({ onComplete, onBegin }: WelcomeScreenProps): Reac
         page={page}
         isLast={page === WELCOME_PANELS.length - 1}
         onNext={goNext}
-        onBegin={begin}
+        onBegin={dismiss}
       />
     </SafeAreaView>
   );

--- a/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
+++ b/frontend/src/features/Welcome/__tests__/WelcomeScreen.test.tsx
@@ -23,9 +23,8 @@ beforeEach(() => {
 
 const setup = () => {
   const onComplete = jest.fn();
-  const onBegin = jest.fn();
-  const utils = render(<WelcomeScreen onComplete={onComplete} onBegin={onBegin} />);
-  return { onComplete, onBegin, ...utils };
+  const utils = render(<WelcomeScreen onComplete={onComplete} />);
+  return { onComplete, ...utils };
 };
 
 describe('WelcomeScreen', () => {
@@ -53,7 +52,7 @@ describe('WelcomeScreen', () => {
   });
 
   it("Begin completes (sets flag) and lands on Journal (the app shell's initial route)", () => {
-    const { getByTestId, onComplete, onBegin } = setup();
+    const { getByTestId, onComplete } = setup();
     // Page to the last panel via the pager scroll handler.
     const lastIndex = WELCOME_PANELS.length - 1;
     fireEvent(getByTestId('welcome-pager'), 'momentumScrollEnd', {
@@ -61,14 +60,32 @@ describe('WelcomeScreen', () => {
     });
     fireEvent.press(getByTestId('welcome-begin'));
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onBegin).toHaveBeenCalledTimes(1);
   });
 
-  it('Skip completes (sets flag) without beginning', () => {
-    const { getByTestId, onComplete, onBegin } = setup();
+  it('Skip completes (sets flag)', () => {
+    const { getByTestId, onComplete } = setup();
     fireEvent.press(getByTestId('welcome-skip'));
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onBegin).not.toHaveBeenCalled();
+  });
+
+  it('persists once when Begin is double-tapped rapidly', () => {
+    const { getByTestId, onComplete } = setup();
+    const lastIndex = WELCOME_PANELS.length - 1;
+    fireEvent(getByTestId('welcome-pager'), 'momentumScrollEnd', {
+      nativeEvent: { contentOffset: { x: lastIndex * 400 }, layoutMeasurement: { width: 400 } },
+    });
+    const begin = getByTestId('welcome-begin');
+    fireEvent.press(begin);
+    fireEvent.press(begin);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists once when Skip is double-tapped rapidly', () => {
+    const { getByTestId, onComplete } = setup();
+    const skip = getByTestId('welcome-skip');
+    fireEvent.press(skip);
+    fireEvent.press(skip);
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   it('advances pages under reduced motion (paging works without animation)', () => {
@@ -144,22 +161,20 @@ describe('WelcomeScreen — onboarding privacy note (issue #897)', () => {
     expect(within(panel).getByText(PRIVACY_NOTE)).toBeTruthy();
   });
 
-  it('Skip still fires onComplete without onBegin after privacy note added', () => {
-    const { getByTestId, onComplete, onBegin } = setup();
+  it('Skip still fires onComplete after privacy note added', () => {
+    const { getByTestId, onComplete } = setup();
     fireEvent.press(getByTestId('welcome-skip'));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onBegin).not.toHaveBeenCalled();
   });
 
-  it('Begin on the last panel still fires both onComplete and onBegin after privacy note added', () => {
-    const { getByTestId, onComplete, onBegin } = setup();
+  it('Begin on the last panel still fires onComplete after privacy note added', () => {
+    const { getByTestId, onComplete } = setup();
     const lastIndex = WELCOME_PANELS.length - 1;
     scrollToPanelIndex(getByTestId, lastIndex);
     fireEvent.press(getByTestId('welcome-begin'));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onBegin).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Two frontend-entry honesty fixes (de-slop), both TDD'd:

- **Stale Settings success banner.** `ApiKeySettingsScreen.onChangeDraft` and `TimezoneSettingsScreen.onChangeDraft`/`onUseDeviceZone` cleared `error` but never `status`, so the "saved" confirmation persisted under an unsaved draft (the banner renders error-else-status). Now they clear `status` too, retiring the confirmation the moment the draft diverges.
- **WelcomeScreen double-fire + lying docstring.** `onComplete` and `onBegin` were both wired to `markSeen`, so pressing Begin persisted the seen flag twice, and `onBegin`'s docstring promised unbuilt first-habits navigation. Collapsed to a single `onComplete`, latched behind a ref so Begin or Skip persists exactly once even on a rapid double-tap. Dropped the misleading docstring and renamed the `Pager.onScroll` type's `_e` param to match its used `e` implementation.

No changes to validation, save logic, or navigation targets — only persisted banner state and the Welcome callback shape.

## Test plan

- New RED→GREEN test: after a successful save, changing the ApiKey/Timezone draft removes the `-status` banner (plus a Timezone "use device zone" variant).
- New WelcomeScreen tests: rapid double-tap of Begin and of Skip each persists once; Begin/Skip each fire `onComplete` once.
- Updated the `welcomeLandsOnJournal` navigation stub to the single-`onComplete` shape.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, 4158 Jest tests).

Closes #1402