### PR TITLE
refactor(domain): collapse two byte-identical helper pairs (wheel aspect-counts, JSON-envelope loader)

### DIFF
--- a/backend/src/domain/detection.py
+++ b/backend/src/domain/detection.py
@@ -13,12 +13,11 @@ dropped.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 from domain.care import MEDICATION_GUARDRAIL
-from domain.resonance import ResonanceLLM, _overlaps, _quote_span
+from domain.resonance import ResonanceLLM, _load_json_list, _overlaps, _quote_span
 from security import TextTooLongError, sanitize_user_text
 
 # Domain-level literals so this module stays free of DB/model imports (mirrors
@@ -104,19 +103,13 @@ def _hit_from_item(item: object) -> _HitDraft | None:
     return None
 
 
-def _load_hits(raw: str) -> list[object]:
-    """Defensively parse the model payload into a list of items (empty on junk)."""
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, TypeError):
-        return []
-    hits = payload.get("hits") if isinstance(payload, dict) else None
-    return hits if isinstance(hits, list) else []
-
-
 def _parse_hit_drafts(raw: str) -> list[_HitDraft]:
     """Turn the raw payload into well-formed drafts, dropping malformed items."""
-    return [draft for item in _load_hits(raw) if (draft := _hit_from_item(item)) is not None]
+    return [
+        draft
+        for item in _load_json_list(raw, "hits")
+        if (draft := _hit_from_item(item)) is not None
+    ]
 
 
 def _sanitize_label(quote: str) -> str | None:

--- a/backend/src/domain/resonance.py
+++ b/backend/src/domain/resonance.py
@@ -120,19 +120,23 @@ def _draft_from_item(item: object) -> MarginaliaDraft | None:
     return None
 
 
-def _load_notes(raw: str) -> list[object]:
-    """Parse the completion to its ``notes`` list; [] on any malformed input."""
+def _load_json_list(raw: str, key: str) -> list[object]:
+    """Parse ``raw`` JSON and return its ``key`` list; [] on any malformed input."""
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return []
-    notes = payload.get("notes") if isinstance(payload, dict) else None
-    return notes if isinstance(notes, list) else []
+    value = payload.get(key) if isinstance(payload, dict) else None
+    return value if isinstance(value, list) else []
 
 
 def _parse_drafts(raw: str) -> list[MarginaliaDraft]:
     """Defensively parse the model's JSON into drafts; never raise on bad input."""
-    return [draft for item in _load_notes(raw) if (draft := _draft_from_item(item)) is not None]
+    return [
+        draft
+        for item in _load_json_list(raw, "notes")
+        if (draft := _draft_from_item(item)) is not None
+    ]
 
 
 def _sanitize_note(note: str) -> str | None:

--- a/backend/src/domain/wheel.py
+++ b/backend/src/domain/wheel.py
@@ -26,6 +26,7 @@ from typing import TypedDict
 
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped
 from sqlmodel import col, select
 
 from domain.constants import TOTAL_STAGES
@@ -62,36 +63,21 @@ async def _aspect_labels_by_stage(
     return {row.stage_number: row.aspect for row in result.all()}
 
 
-async def _primary_aspect_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
-    """Count non-deleted entries per stage tagged with that stage as primary.
+async def _aspect_counts(
+    session: AsyncSession, user_id: int, aspect_column: Mapped[int | None]
+) -> dict[int, int]:
+    """Count non-deleted entries per stage tagged with that stage on ``aspect_column``.
 
-    One ``GROUP BY`` aggregate over ``primary_aspect`` (no per-stage loop).
+    One ``GROUP BY`` aggregate over the given aspect column (no per-stage loop).
     """
     result = await session.execute(
-        select(JournalEntry.primary_aspect, func.count())
+        select(aspect_column, func.count())
         .where(
             JournalEntry.user_id == user_id,
             col(JournalEntry.deleted_at).is_(None),
-            col(JournalEntry.primary_aspect).is_not(None),
+            aspect_column.is_not(None),
         )
-        .group_by(col(JournalEntry.primary_aspect))
-    )
-    return {row[0]: row[1] for row in result.all()}
-
-
-async def _secondary_aspect_counts(session: AsyncSession, user_id: int) -> dict[int, int]:
-    """Count non-deleted entries per stage tagged with that stage as secondary.
-
-    One ``GROUP BY`` aggregate over ``secondary_aspect`` (no per-stage loop).
-    """
-    result = await session.execute(
-        select(JournalEntry.secondary_aspect, func.count())
-        .where(
-            JournalEntry.user_id == user_id,
-            col(JournalEntry.deleted_at).is_(None),
-            col(JournalEntry.secondary_aspect).is_not(None),
-        )
-        .group_by(col(JournalEntry.secondary_aspect))
+        .group_by(aspect_column)
     )
     return {row[0]: row[1] for row in result.all()}
 
@@ -103,8 +89,8 @@ async def _chord_tag_weighted_counts(session: AsyncSession, user_id: int) -> dic
     * n_secondary`` per stage, over non-deleted entries only, using two constant
     grouped-count queries (no N+1).
     """
-    primary = await _primary_aspect_counts(session, user_id)
-    secondary = await _secondary_aspect_counts(session, user_id)
+    primary = await _aspect_counts(session, user_id, col(JournalEntry.primary_aspect))
+    secondary = await _aspect_counts(session, user_id, col(JournalEntry.secondary_aspect))
     weighted: dict[int, float] = {}
     for stage, count in primary.items():
         weighted[stage] = weighted.get(stage, 0.0) + WHEEL_PRIMARY_TAG_WEIGHT * count


### PR DESCRIPTION
## Summary

Pure de-slop refactor collapsing two byte-identical private-helper pairs in `backend/src/domain/` (taxonomy 3 — duplicated code). No query semantics, JSON-parsing behavior, or public signatures change — internal de-duplication behind unchanged call sites.

- **Wheel aspect-counts** (`wheel.py`): `_primary_aspect_counts` / `_secondary_aspect_counts` differed only in the grouped column and one docstring word. Replaced with one `_aspect_counts(session, user_id, aspect_column)`; the two call sites in `_chord_tag_weighted_counts` now pass `col(JournalEntry.primary_aspect)` / `col(JournalEntry.secondary_aspect)`.
- **JSON-envelope loader** (`resonance.py` + `detection.py`): `_load_notes` / `_load_hits` differed only in the envelope key (`"notes"` vs `"hits"`). Extracted one `_load_json_list(raw, key)` in `resonance.py`; `detection.py` imports it via the existing private-seam import (alongside `_overlaps` / `_quote_span`). The thin `_parse_drafts` / `_parse_hit_drafts` wrappers are kept, now passing their key. Dropped the now-unused `import json` from `detection.py`.

### Divergence check
Both pairs were re-verified byte-identical (modulo the documented single-token diff) at HEAD before consolidation — neither had diverged since the issue was filed, so both were safe to merge.

## Test plan

- Existing `test_wheel_api.py`, `test_resonance_service.py`, and `test_detection_service.py` pass **unmodified** — behavior is pinned by them.
- `./scripts/backend/check-all.sh` green: 2619 passed, coverage 96.64% (≥90), mypy/ruff/bandit/interrogate all pass.
- Manual `xenon --max-absolute A --max-modules A --max-average A src` exit 0; `radon mi` A on all three files.

Closes #1427