### PR TITLE
refactor(backend): drop dead X-Admin-API-Key CORS header, fix get_session docstring

### DIFF
--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -37,11 +37,11 @@ async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_o
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     """FastAPI dependency that yields an async database session.
 
-    BUG-INFRA-021: wrap the body in ``try/finally`` so a failed handler
-    rolls back its transaction *and* releases the connection.  The outer
-    ``async with`` already guarantees ``close()``, but adding the explicit
-    rollback prevents an in-flight ``BEGIN`` from being silently committed
-    by the connection pool when reused.
+    BUG-INFRA-021: wrap the yield in ``try/except Exception`` so a failed
+    handler rolls back its transaction and re-raises.  The outer
+    ``async with`` is what releases the connection (it guarantees
+    ``close()``); the explicit rollback prevents an in-flight ``BEGIN``
+    from being silently committed by the connection pool when reused.
     """
     async with async_session_factory() as session:
         try:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -90,7 +90,6 @@ ALLOWED_HEADERS = [
     "Authorization",
     "Content-Type",
     "X-LLM-API-Key",
-    "X-Admin-API-Key",
     "X-Request-ID",
 ]
 # Headers the browser is allowed to read from the response.  Without


### PR DESCRIPTION
## Summary

Two linter-invisible backend-platform de-slop hygiene items (bundled per the de-slop rule):

- **Remove dead `X-Admin-API-Key` CORS allow-header** (`backend/src/main.py`). Nothing reads it — admin routes gate on `User.is_admin` via `require_admin` (the header-secret design was rejected), and a repo-wide case-insensitive grep confirms zero senders in backend, frontend, or docs. Removing it strictly tightens the CORS preflight surface and touches no auth path. The sibling `X-LLM-API-Key` (live BYOK header) and `X-Request-ID` are retained.
- **Fix the stale `get_session` docstring** (`backend/src/database.py`). It claimed a `try/finally` that the code does not contain; it now accurately describes the real `try/except Exception -> rollback -> raise` structure and notes that connection release comes from the outer `async with`. No behavioral change.

## Test plan

- `./scripts/backend/check-all.sh` green: 2619 passed, 2 skipped, 96.64% coverage.
- `xenon` A-grade and `radon mi` A on both touched files.
- `grep -rni "admin.api.key\|Admin-API-Key" backend/` returns no matches (AC1).
- CORS tests (`test_cors.py`, `test_cors_config.py`) unchanged and passing; no test asserted on the removed header.
- Gate 2.5 self-review (incl. security dimension on the CORS change): CLEAN.

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)