### PR TITLE
refactor(practice): tidy dead code, dedup style/slug helpers, surface photo-picker errors

### DIFF
--- a/frontend/src/features/Practice/components/ConfiguratorBody.tsx
+++ b/frontend/src/features/Practice/components/ConfiguratorBody.tsx
@@ -31,7 +31,7 @@ type FormComponent<M extends ModeConfig['mode']> = React.ComponentType<{
   onChange: (next: Extract<ModeConfig, { mode: M }>) => void;
 }>;
 
-type FormTable = { [K in ModeConfig['mode']]: FormComponent<K> | null };
+type FormTable = { [K in ModeConfig['mode']]: FormComponent<K> };
 
 /** The single source of truth mapping a mode to its configurator form. */
 export const MODE_FORMS: FormTable = {
@@ -69,8 +69,8 @@ const ConfiguratorBody = ({
   onChange,
   renderFallback,
 }: ConfiguratorBodyProps): React.JSX.Element => {
-  const Form = MODE_FORMS[config.mode] as AnyForm | undefined | null;
-  if (Form === null || Form === undefined) {
+  const Form = MODE_FORMS[config.mode] as AnyForm | undefined;
+  if (Form === undefined) {
     return renderFallback(config.mode);
   }
   return <Form value={config} onChange={onChange} />;

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -225,14 +225,16 @@ interface CardPhotoFieldProps {
 }
 
 const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.JSX.Element => {
+  const [pickError, setPickError] = React.useState<string | null>(null);
   const choosePhoto = async () => {
+    setPickError(null);
     try {
       const photo = await pickCardPhoto();
       if (photo) onUpdate(index, { image_uri: photo.uri, image_asset_key: null });
     } catch (error) {
-      // A broken native build can reject the permission/picker call; keep the
-      // form usable and leave a dev-only breadcrumb rather than crashing.
+      // Surface a recoverable notice instead of swallowing picker failures.
       if (__DEV__) console.warn('Card photo picker failed:', error);
+      setPickError('Could not open your photos. Please try again.');
     }
   };
   return (
@@ -256,6 +258,11 @@ const CardPhotoField = ({ index, card, onUpdate }: CardPhotoFieldProps): React.J
           style={styles.photoThumb}
           testID={`card-meditation-photo-thumb-${index}`}
         />
+      )}
+      {pickError !== null && (
+        <Text style={styles.photoError} testID={`card-meditation-photo-error-${index}`}>
+          {pickError}
+        </Text>
       )}
     </View>
   );
@@ -360,6 +367,7 @@ const styles = StyleSheet.create({
     backgroundColor: surface.sunken,
   },
   photoButtonText: { ...editorialType.caption, fontWeight: '500', color: ink.primary },
+  photoError: { ...editorialType.caption, color: colors.danger },
   photoThumb: { width: THUMB_SIZE, height: THUMB_SIZE, borderRadius: BORDER_RADIUS.sm },
 });
 

--- a/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
+++ b/frontend/src/features/Practice/configurator/forms/__tests__/CardMeditationForm.test.tsx
@@ -183,6 +183,44 @@ describe('CardMeditationForm — custom card editor', () => {
     fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
     await waitFor(() => expect(warn).toHaveBeenCalled());
     expect(onChange).not.toHaveBeenCalled();
+    expect(getByTestId('card-meditation-photo-error-0')).toBeTruthy();
+    warn.mockRestore();
+  });
+
+  it('shows no photo-error notice on initial render', () => {
+    const { queryByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={jest.fn()} />,
+    );
+    expect(queryByTestId('card-meditation-photo-error-0')).toBeNull();
+  });
+
+  it('shows a visible notice after the photo picker rejects', async () => {
+    mockPickCardPhoto.mockRejectedValueOnce(new Error('native module unavailable'));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    await waitFor(() => expect(getByTestId('card-meditation-photo-error-0')).toBeTruthy());
+    expect(onChange).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('clears a shown photo-error notice on the next successful pick', async () => {
+    mockPickCardPhoto
+      .mockRejectedValueOnce(new Error('native module unavailable'))
+      .mockResolvedValueOnce({ uri: 'file:///ok.jpg' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onChange = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <CardMeditationForm value={custom([EMPTY_CARD])} onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    await waitFor(() => expect(getByTestId('card-meditation-photo-error-0')).toBeTruthy());
+    fireEvent.press(getByTestId('card-meditation-choose-photo-0'));
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(queryByTestId('card-meditation-photo-error-0')).toBeNull();
     warn.mockRestore();
   });
 

--- a/frontend/src/features/Practice/data/decks/rws.ts
+++ b/frontend/src/features/Practice/data/decks/rws.ts
@@ -1,5 +1,6 @@
 // Rider-Waite-Smith deck content (78 cards) for the card_meditation practice mode.
 
+import { slugifyCore } from '../../utils/slugify';
 import { MAJOR_ARCANA } from '../tarot';
 
 import type { CardMeta } from './index';
@@ -13,10 +14,7 @@ type CardRow = readonly [slug: string, name: string, keyword: string, symbolism:
 
 /** Derive a card slug from its display name; shared with the major_arcana_text deck. */
 export function deriveSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, '_')
-    .replaceAll(/^_+|_+$/g, '');
+  return slugifyCore(name);
 }
 
 // Major arcana derive from the canonical MAJOR_ARCANA (tarot.ts) so the two decks cannot drift.

--- a/frontend/src/features/Practice/recipes/types.ts
+++ b/frontend/src/features/Practice/recipes/types.ts
@@ -7,6 +7,8 @@
  * uses for `PracticeRecipeStepInput`).
  */
 
+import { slugifyCore } from '../utils/slugify';
+
 import type { RecipeMode } from '@/api';
 
 export type { RecipeMode };
@@ -38,10 +40,7 @@ export interface RecipeDraft {
  * `untitled`.
  */
 export function nameToSlug(name: string): string {
-  const cleaned = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
+  const cleaned = slugifyCore(name);
   if (cleaned.length === 0) return 'untitled';
   if (!/^[a-z]/.test(cleaned)) return `r_${cleaned}`;
   return cleaned;

--- a/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
+++ b/frontend/src/features/Practice/screens/CreatePracticeWizard.tsx
@@ -68,6 +68,7 @@ export const PRACTICE_NAME_MAX = 120;
 export const PRACTICE_DESCRIPTION_MAX = 1_000;
 export const PRACTICE_INSTRUCTIONS_MAX = 2_000;
 const PRACTICE_NAME_MIN = 1;
+const DEFAULT_SUGGESTED_MINUTES = 10;
 
 type WizardStep = 'entry' | 'mode' | 'configure' | 'metadata';
 
@@ -448,7 +449,7 @@ const InstructionsField = ({ state, setState }: MetadataFieldProps): React.JSX.E
 );
 
 const DurationField = ({ state, setState }: MetadataFieldProps): React.JSX.Element => {
-  const suggested = state.config ? suggestedDurationFor(state.config) : 10;
+  const suggested = state.config ? suggestedDurationFor(state.config) : DEFAULT_SUGGESTED_MINUTES;
   return (
     <FieldLabel label="Default duration (minutes)">
       <TextInput

--- a/frontend/src/features/Practice/utils/__tests__/slugify.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/slugify.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { slugifyCore } from '../slugify';
+
+describe('slugifyCore', () => {
+  it('lowercases and underscores a simple name', () => {
+    expect(slugifyCore('Find the Rainbow')).toBe('find_the_rainbow');
+  });
+
+  it('collapses runs of non-alphanumeric characters to a single underscore', () => {
+    expect(slugifyCore('5-4-3-2-1 grounding')).toBe('5_4_3_2_1_grounding');
+  });
+
+  it('trims leading and trailing underscores', () => {
+    expect(slugifyCore('---hello---')).toBe('hello');
+  });
+
+  it('returns an empty string for all-punctuation input', () => {
+    expect(slugifyCore('!!!')).toBe('');
+  });
+
+  it('keeps existing digits and letters unchanged', () => {
+    expect(slugifyCore('The Sun')).toBe('the_sun');
+  });
+});

--- a/frontend/src/features/Practice/utils/slugify.ts
+++ b/frontend/src/features/Practice/utils/slugify.ts
@@ -1,0 +1,7 @@
+/** Lower-cap snake-case core: collapse non-alnum runs to `_`, trim edge `_`. */
+export function slugifyCore(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}

--- a/frontend/src/features/Practice/views/CountUpTimerView.tsx
+++ b/frontend/src/features/Practice/views/CountUpTimerView.tsx
@@ -6,7 +6,7 @@ import type { RitualControls, RitualState } from '../engine/types';
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
-import { SUCCESS_FILL, SessionContainer } from './shared';
+import { SESSION_CAPTION_LABEL, SUCCESS_FILL, SessionContainer } from './shared';
 
 import { BORDER_RADIUS, SPACING, colors } from '@/design/tokens';
 
@@ -48,11 +48,9 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xxl,
   },
   label: {
-    fontSize: 14,
+    ...SESSION_CAPTION_LABEL,
     marginTop: SPACING.xs,
     marginBottom: SPACING.xl,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
   },
   endButton: {
     paddingVertical: SPACING.md,

--- a/frontend/src/features/Practice/views/IntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/IntervalBellView.tsx
@@ -8,7 +8,7 @@ import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import type { SessionSurface } from './sessionSurface';
 import { useSessionSurface } from './sessionSurface';
-import { SessionContainer } from './shared';
+import { SESSION_BIG_TIME, SESSION_CAPTION_LABEL, SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -104,15 +104,11 @@ const OffsetRow = ({
 const styles = StyleSheet.create({
   container: { flex: 1 },
   label: {
-    fontSize: 14,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
+    ...SESSION_CAPTION_LABEL,
     marginTop: SPACING.xl,
   },
   time: {
-    fontSize: 48,
-    fontWeight: '300',
-    fontVariant: ['tabular-nums'],
+    ...SESSION_BIG_TIME,
     marginVertical: SPACING.md,
   },
   list: { width: '100%', maxHeight: 220, marginVertical: SPACING.md },

--- a/frontend/src/features/Practice/views/MetronomeView.tsx
+++ b/frontend/src/features/Practice/views/MetronomeView.tsx
@@ -6,7 +6,7 @@ import type { MetronomeConfig, RitualControls, RitualState } from '../engine/typ
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
-import { SessionContainer } from './shared';
+import { SESSION_CAPTION_LABEL, SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -69,9 +69,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xl,
   },
   label: {
-    fontSize: 14,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
+    ...SESSION_CAPTION_LABEL,
     marginBottom: SPACING.xl,
   },
   dot: {

--- a/frontend/src/features/Practice/views/MindfulAnchorView.tsx
+++ b/frontend/src/features/Practice/views/MindfulAnchorView.tsx
@@ -32,6 +32,7 @@ import {
   PRIMARY_FILL,
   SESSION_BUTTON_BASE,
   SESSION_BUTTON_TEXT,
+  SESSION_CAPTION_LABEL,
   SessionContainer,
   SessionCtaButton,
 } from './shared';
@@ -374,10 +375,8 @@ const styles = StyleSheet.create({
     fontVariant: ['tabular-nums'],
   },
   elapsedLabel: {
-    fontSize: 14,
+    ...SESSION_CAPTION_LABEL,
     marginTop: SPACING.xs,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
   },
   begin: { ...SESSION_BUTTON_BASE, ...PRIMARY_FILL, marginBottom: SPACING.xl },
   beginText: { ...SESSION_BUTTON_TEXT },

--- a/frontend/src/features/Practice/views/RandomIntervalBellView.tsx
+++ b/frontend/src/features/Practice/views/RandomIntervalBellView.tsx
@@ -16,7 +16,7 @@ import { MS_PER_SECOND, RANDOM_BELL_MAX_BELLS_CEILING, SECONDS_PER_MINUTE } from
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
-import { SessionContainer } from './shared';
+import { SESSION_BIG_TIME, SESSION_CAPTION_LABEL, SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -196,15 +196,11 @@ function nextBellHint(
 const styles = StyleSheet.create({
   fill: { flex: 1 },
   label: {
-    fontSize: 14,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
+    ...SESSION_CAPTION_LABEL,
     marginTop: SPACING.xl,
   },
   time: {
-    fontSize: 48,
-    fontWeight: '300',
-    fontVariant: ['tabular-nums'],
+    ...SESSION_BIG_TIME,
     marginVertical: SPACING.md,
   },
   count: {

--- a/frontend/src/features/Practice/views/RepCounterView.tsx
+++ b/frontend/src/features/Practice/views/RepCounterView.tsx
@@ -7,7 +7,7 @@ import { MS_PER_MINUTE } from '../engine/types';
 import { formatTime } from './formatTime';
 import RitualControlsBar from './RitualControlsBar';
 import { useSessionSurface } from './sessionSurface';
-import { SessionContainer } from './shared';
+import { SESSION_CAPTION_LABEL, SessionContainer } from './shared';
 
 import { SPACING } from '@/design/tokens';
 
@@ -71,9 +71,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
   },
   unit: {
-    fontSize: 14,
-    textTransform: 'uppercase',
-    letterSpacing: 2,
+    ...SESSION_CAPTION_LABEL,
     marginTop: SPACING.xs,
   },
   timeCap: {

--- a/frontend/src/features/Practice/views/RitualControlsBar.tsx
+++ b/frontend/src/features/Practice/views/RitualControlsBar.tsx
@@ -97,7 +97,6 @@ const styles = StyleSheet.create({
   lightText: { color: colors.text.light, fontSize: 16, fontWeight: '600' },
   dangerText: { color: colors.danger, fontSize: 16, fontWeight: '600' },
   completeText: {
-    color: colors.success,
     fontSize: 16,
     fontWeight: '600',
     paddingVertical: SPACING.md,

--- a/frontend/src/features/Practice/views/shared/index.ts
+++ b/frontend/src/features/Practice/views/shared/index.ts
@@ -6,9 +6,11 @@ export { SessionTimerLabel } from './SessionTimerLabel';
 export {
   MEDITATION_TIMER_LABEL,
   PRIMARY_FILL,
+  SESSION_BIG_TIME,
   SESSION_BUTTON_BASE,
   SESSION_BUTTON_DISABLED,
   SESSION_BUTTON_TEXT,
+  SESSION_CAPTION_LABEL,
   SESSION_CONTAINER,
   SUCCESS_FILL,
 } from './sessionStyles';

--- a/frontend/src/features/Practice/views/shared/sessionStyles.ts
+++ b/frontend/src/features/Practice/views/shared/sessionStyles.ts
@@ -44,3 +44,17 @@ export const MEDITATION_TIMER_LABEL: TextStyle = {
   fontVariant: ['tabular-nums'],
   marginBottom: SPACING.lg,
 };
+
+/** Uppercase small-caps caption label under a session readout. */
+export const SESSION_CAPTION_LABEL: TextStyle = {
+  fontSize: 14,
+  textTransform: 'uppercase',
+  letterSpacing: 2,
+};
+
+/** Large tabular time readout used by the interval-bell session views. */
+export const SESSION_BIG_TIME: TextStyle = {
+  fontSize: 48,
+  fontWeight: '300',
+  fontVariant: ['tabular-nums'],
+};


### PR DESCRIPTION
## Summary

Second bundled cluster of low-priority Practice de-slop cleanups (issue #1436). Each item is a self-contained edit:

- **Dead code** — removed the dead `color: colors.success` in `RitualControlsBar.completeText` (the sole consumer always overrides it with an inline `surface.accent` color), and dropped the unreachable `| null` member from `ConfiguratorBody`'s `FormTable` type plus the `=== null` half of its guard (every `MODE_FORMS` entry is a real component; only the `=== undefined` unknown-mode path is live).
- **Style dedup** — extracted `SESSION_CAPTION_LABEL` and `SESSION_BIG_TIME` into `views/shared/sessionStyles.ts` (re-exported from the barrel) and consumed them from the six session views; each site keeps its own margins, so resolved styles are byte-identical.
- **Prod-silent swallow** — the card-meditation photo picker previously only logged under `__DEV__`, so a failed "Choose photo" was silent in production. `CardPhotoField` now shows a user-visible inline notice (cleared on the next attempt), while keeping the dev-only warn.
- **Slug dedup** — extracted `slugifyCore()` (new `utils/slugify.ts`) shared by `recipes/types.ts` `nameToSlug` (which keeps its `untitled` / `r_` guards) and `data/decks/rws.ts` `deriveSlug`; behavior unchanged.
- **Magic number** — named the bare `10` suggested-duration fallback in `CreatePracticeWizard` as `DEFAULT_SUGGESTED_MINUTES`.

## Test plan

- New `utils/__tests__/slugify.test.ts` specifies `slugifyCore` (lowercasing, non-alnum collapse, edge-underscore trim, empty-on-punctuation, no caller guards).
- Extended `CardMeditationForm.test.tsx`: the photo-picker failure now asserts the visible `card-meditation-photo-error-0` notice appears on rejection, is absent on initial render, and clears on the next successful pick.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, Jest — 4161 tests pass).

Closes #1436