### PR TITLE
feat(habits): lock/unlock toggle for any habit in the Edit Habit modal

### DIFF
--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -14,6 +14,8 @@ import { EnergyCostReturnEditor } from './EnergyCostReturnEditor';
 import HabitEmojiPicker from './HabitEmojiPicker';
 import ModalHeader from './ModalHeader';
 
+const LOCK_TOGGLE_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
 const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
   if (current === 'daily') return 'weekly';
   if (current === 'weekly') return 'custom';
@@ -186,6 +188,25 @@ const NotifToggleRow = ({
     <Switch
       value={isEnabled}
       onValueChange={(value) => onChange('notificationFrequency', value ? 'daily' : 'off')}
+    />
+  </View>
+);
+
+const LockToggleRow = ({
+  editedHabit,
+  handleChange,
+}: {
+  editedHabit: Habit;
+  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+}) => (
+  <View style={styles.settingRow}>
+    <Text style={styles.editSettingLabel}>Unlocked:</Text>
+    <Switch
+      testID="habit-settings-lock-toggle"
+      accessibilityLabel="Unlocked"
+      hitSlop={LOCK_TOGGLE_HIT_SLOP}
+      value={editedHabit.revealed === true}
+      onValueChange={(value) => handleChange('revealed', value)}
     />
   </View>
 );
@@ -389,6 +410,7 @@ const SettingsForm = ({
       onRemoveTime={onRemoveTime}
       onToggleDay={onToggleDay}
     />
+    <LockToggleRow editedHabit={editedHabit} handleChange={handleChange} />
     <FormActionButtons onSave={onSave} onDelete={onDelete} />
   </ScrollView>
 );

--- a/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
@@ -325,6 +325,60 @@ describe('HabitSettingsModal missing optional notification arrays', () => {
   });
 });
 
+describe('HabitSettingsModal lock toggle', () => {
+  it('renders ON for an unlocked habit', () => {
+    const { getByTestId } = renderModal({ habit: { ...baseHabit, revealed: true } });
+    const toggle = getByTestId('habit-settings-lock-toggle');
+    expect(toggle.props.value).toBe(true);
+  });
+
+  it('renders OFF for a locked habit', () => {
+    const { getByTestId } = renderModal();
+    const toggle = getByTestId('habit-settings-lock-toggle');
+    expect(toggle.props.value).toBe(false);
+  });
+
+  it('commits locking on save', () => {
+    const { getByTestId, getByText, onUpdate } = renderModal({
+      habit: { ...baseHabit, revealed: true },
+    });
+    const toggle = getByTestId('habit-settings-lock-toggle');
+
+    fireEvent(toggle, 'valueChange', false);
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ revealed: false }));
+  });
+
+  it('commits unlocking on save', () => {
+    const { getByTestId, getByText, onUpdate } = renderModal({
+      habit: { ...baseHabit, revealed: false },
+    });
+    const toggle = getByTestId('habit-settings-lock-toggle');
+
+    fireEvent(toggle, 'valueChange', true);
+    fireEvent.press(getByText('Save Changes'));
+
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ revealed: true }));
+  });
+
+  it('exposes an accessibility label that matches the visible unlocked framing', () => {
+    const { getByTestId } = renderModal();
+    const toggle = getByTestId('habit-settings-lock-toggle');
+    const label = toggle.props.accessibilityLabel as string;
+
+    expect(label).toBe('Unlocked');
+  });
+
+  it('is the third Switch, after notifications and milestone toggles', () => {
+    const { UNSAFE_root } = renderModal();
+    const switches = UNSAFE_root.findAllByType(Switch);
+
+    expect(switches).toHaveLength(3);
+    expect(switches[2]!.props.testID).toBe('habit-settings-lock-toggle');
+  });
+});
+
 describe('HabitSettingsModal actions', () => {
   it('opens the reorder modal with the full habit list', () => {
     const { getByText, onOpenReorderModal } = renderModal();


### PR DESCRIPTION
## Summary

Adds a per-habit lock/unlock control to the Edit Habit modal (`HabitSettingsModal`). A new labeled `Switch` row (`Unlocked:`) mirrors the existing Notifications / Milestone switch rows and reflects the habit's `revealed` lock state. It participates in the modal's existing buffered-edit flow, so flipping it and pressing **Save Changes** commits the new `revealed` value atomically through `onUpdate` — round-tripping to the backend via the existing `toApiPayload` (no new save path, no backend change).

This gives a per-habit re-lock affordance that previously existed only as the bulk drawer action (`lockUntouchedHabits`). Locking preserves all logged completions (it only hides the tile), and `LockedTile` interaction semantics are unchanged. The toggle exposes an accessibility label aligned with its visible `Unlocked:` framing and a 44dp hit target via a named `hitSlop` constant.

Polarity: switch ON = `revealed: true` (unlocked/visible), OFF = locked. `value={editedHabit.revealed === true}` coerces `undefined` to OFF.

## Test plan

New `HabitSettingsModal lock toggle` describe block (6 RTL tests, TDD RED-first):
- renders ON for an unlocked habit (`revealed: true`)
- renders OFF for a locked habit (`revealed` undefined)
- locking commits `revealed: false` through `onUpdate` on save
- unlocking commits `revealed: true` through `onUpdate` on save
- exposes an accessibility label matching the visible `Unlocked` framing
- is the third `Switch`, preserving existing index-based selectors

Gate 2: `./scripts/frontend/check-all.sh` green (ESLint, Prettier, typecheck, full Jest suite 4167/4167). No lint/type suppressions; no coverage threshold changes.

Closes #1613