### PR TITLE
feat(habits): regroup the Edit Habit modal into titled sections

### DIFF
--- a/frontend/src/features/Habits/Habits.styles.ts
+++ b/frontend/src/features/Habits/Habits.styles.ts
@@ -15,6 +15,10 @@ import {
 
 const JUSTIFY_SPACE_BETWEEN = 'space-between' as const;
 
+const SECTION_TITLE_FONT_SIZE = 13;
+const SECTION_TITLE_LETTER_SPACING = 0.5;
+const FREQ_CHIP_FONT_SIZE = 14;
+
 // Device dimensions (for responsive layouts)
 
 //------------------
@@ -130,11 +134,26 @@ export const styles = StyleSheet.create({
   settingsContainer: {
     marginTop: SPACING.md,
   },
-  settingGroup: {
+  settingsSection: {
     marginVertical: SPACING.md,
     borderBottomWidth: 1,
     borderColor: surface.hairline,
     paddingBottom: SPACING.md,
+  },
+  sectionTitle: {
+    fontSize: SECTION_TITLE_FONT_SIZE,
+    fontWeight: '600',
+    color: ink.soft,
+    textTransform: 'uppercase',
+    letterSpacing: SECTION_TITLE_LETTER_SPACING,
+    marginBottom: SPACING.sm,
+    fontFamily: fonts.sans,
+  },
+  utilityRow: {
+    marginVertical: SPACING.md,
+  },
+  saveRow: {
+    marginBottom: SPACING.md,
   },
   settingRow: {
     flexDirection: 'row',
@@ -339,23 +358,35 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 
-  // ===== Frequency Button =====
-  frequencyButton: {
-    backgroundColor: surface.sunken,
+  // ===== Frequency Chips =====
+  freqChipRow: {
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    marginVertical: SPACING.sm,
+  },
+  freqChip: {
+    flex: 1,
+    minHeight: touchTarget.minimum,
+    borderRadius: BORDER_RADIUS.circle,
     borderWidth: 1,
     borderColor: surface.hairline,
-    minHeight: touchTarget.minimum,
-    paddingVertical: SPACING.sm,
-    paddingHorizontal: SPACING.md,
-    borderRadius: BORDER_RADIUS.xs,
-    flex: 1,
-    marginLeft: SPACING.md,
+    backgroundColor: 'transparent',
+    alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: SPACING.md,
   },
-  frequencyButtonText: {
-    color: ink.primary,
+  freqChipSelected: {
+    backgroundColor: accent.primary,
+    borderColor: accent.primary,
+  },
+  freqChipText: {
+    color: ink.soft,
     fontFamily: fonts.sans,
-    fontSize: 16,
+    fontSize: FREQ_CHIP_FONT_SIZE,
+    textTransform: 'capitalize',
+  },
+  freqChipTextSelected: {
+    color: accent.onPrimary,
   },
 
   // ===== Stats Modal =====

--- a/frontend/src/features/Habits/components/HabitSettingsModal.tsx
+++ b/frontend/src/features/Habits/components/HabitSettingsModal.tsx
@@ -4,7 +4,7 @@ import { View, Text, TouchableOpacity, Modal, Platform, ScrollView, Switch } fro
 
 import { Button } from '../../../components/Button';
 import { TextField } from '../../../components/TextField';
-import { STAGE_COLORS, SPACING } from '../../../design/tokens';
+import { STAGE_COLORS } from '../../../design/tokens';
 import { DAYS_OF_WEEK } from '../constants';
 import styles from '../Habits.styles';
 import type { Habit, HabitSettingsModalProps } from '../Habits.types';
@@ -15,34 +15,18 @@ import HabitEmojiPicker from './HabitEmojiPicker';
 import ModalHeader from './ModalHeader';
 
 const LOCK_TOGGLE_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+// Enlarges the 24dp remove-time pill to a 44dp accessible touch target.
+const REMOVE_TIME_HIT_SLOP = { top: 10, bottom: 10, left: 10, right: 10 };
+const FREQUENCY_OPTIONS = ['daily', 'weekly', 'custom'] as const;
 
-const cycleFrequency = (current: string | undefined): 'daily' | 'weekly' | 'custom' => {
-  if (current === 'daily') return 'weekly';
-  if (current === 'weekly') return 'custom';
-  return 'daily';
-};
+type ChangeHandler = <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
 
-interface NotificationSettingsProps {
-  habit: Habit;
-  notificationTime: string;
-  showTimePicker: boolean;
-  showDaysPicker: boolean;
-  setShowTimePicker: (_v: boolean) => void;
-  setShowDaysPicker: (_v: boolean) => void;
-  onChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
-  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
-  onAddTime: () => void;
-  onRemoveTime: (_time: string) => void;
-  onToggleDay: (_day: string) => void;
-}
-
-interface NotifFrequencyProps {
-  habit: Habit;
-  showDaysPicker: boolean;
-  setShowDaysPicker: (_v: boolean) => void;
-  onChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
-  onToggleDay: (_day: string) => void;
-}
+const SettingsSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <View style={styles.settingsSection}>
+    <Text style={styles.sectionTitle}>{title}</Text>
+    {children}
+  </View>
+);
 
 const DayPickerGrid = ({
   days,
@@ -69,52 +53,73 @@ const DayPickerGrid = ({
 const formatDaysLabel = (days: string[] | undefined): string =>
   days && days.length > 0 ? days.map((d) => d.substring(0, 3)).join(', ') : 'Select days';
 
-const NotifFrequencySection = ({
+const FrequencyChip = ({
+  value,
+  selected,
+  onSelect,
+}: {
+  value: (typeof FREQUENCY_OPTIONS)[number];
+  selected: boolean;
+  onSelect: (_value: (typeof FREQUENCY_OPTIONS)[number]) => void;
+}) => (
+  <TouchableOpacity
+    testID={`habit-settings-frequency-${value}`}
+    accessibilityRole="radio"
+    accessibilityState={{ checked: selected }}
+    accessibilityLabel={value}
+    style={[styles.freqChip, selected && styles.freqChipSelected]}
+    onPress={() => onSelect(value)}
+  >
+    <Text style={[styles.freqChipText, selected && styles.freqChipTextSelected]}>{value}</Text>
+  </TouchableOpacity>
+);
+
+const FrequencyChipRow = ({ habit, onChange }: { habit: Habit; onChange: ChangeHandler }) => {
+  const current = habit.notificationFrequency ?? 'daily';
+  return (
+    <View
+      testID="habit-settings-frequency"
+      accessibilityRole="radiogroup"
+      style={styles.freqChipRow}
+    >
+      {FREQUENCY_OPTIONS.map((value) => (
+        <FrequencyChip
+          key={value}
+          value={value}
+          selected={current === value}
+          onSelect={(next) => onChange('notificationFrequency', next)}
+        />
+      ))}
+    </View>
+  );
+};
+
+const CustomDaysPicker = ({
   habit,
   showDaysPicker,
   setShowDaysPicker,
-  onChange,
   onToggleDay,
-}: NotifFrequencyProps) => (
+}: {
+  habit: Habit;
+  showDaysPicker: boolean;
+  setShowDaysPicker: (_v: boolean) => void;
+  onToggleDay: (_day: string) => void;
+}) => (
   <>
     <View style={styles.settingRow}>
-      <Text style={styles.editSettingLabel}>Frequency:</Text>
+      <Text style={styles.editSettingLabel}>Days:</Text>
       <TouchableOpacity
-        testID="habit-settings-frequency"
-        style={styles.frequencyButton}
-        onPress={() =>
-          onChange('notificationFrequency', cycleFrequency(habit.notificationFrequency))
-        }
+        style={styles.daysButton}
+        onPress={() => setShowDaysPicker(!showDaysPicker)}
       >
-        <Text style={styles.frequencyButtonText}>{habit.notificationFrequency || 'daily'}</Text>
+        <Text style={styles.daysButtonText}>{formatDaysLabel(habit.notificationDays)}</Text>
       </TouchableOpacity>
     </View>
-    {habit.notificationFrequency === 'custom' && (
-      <View style={styles.settingRow}>
-        <Text style={styles.editSettingLabel}>Days:</Text>
-        <TouchableOpacity
-          style={styles.daysButton}
-          onPress={() => setShowDaysPicker(!showDaysPicker)}
-        >
-          <Text style={styles.daysButtonText}>{formatDaysLabel(habit.notificationDays)}</Text>
-        </TouchableOpacity>
-      </View>
-    )}
     {showDaysPicker && (
       <DayPickerGrid days={habit.notificationDays || []} onToggleDay={onToggleDay} />
     )}
   </>
 );
-
-interface NotifTimeProps {
-  notificationTime: string;
-  showTimePicker: boolean;
-  notifTimes: string[];
-  setShowTimePicker: (_v: boolean) => void;
-  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
-  onAddTime: () => void;
-  onRemoveTime: (_time: string) => void;
-}
 
 const TimesList = ({
   times,
@@ -124,10 +129,16 @@ const TimesList = ({
   onRemoveTime: (_time: string) => void;
 }) => (
   <View style={styles.timesList}>
-    {times.map((time, index) => (
-      <View key={index} style={styles.timeItem}>
+    {times.map((time) => (
+      <View key={time} style={styles.timeItem}>
         <Text style={styles.timeText}>{time}</Text>
-        <TouchableOpacity style={styles.removeTimeButton} onPress={() => onRemoveTime(time)}>
+        <TouchableOpacity
+          testID={`habit-settings-remove-time-${time}`}
+          accessibilityLabel={`Remove ${time}`}
+          hitSlop={REMOVE_TIME_HIT_SLOP}
+          style={styles.removeTimeButton}
+          onPress={() => onRemoveTime(time)}
+        >
           <Text style={styles.removeTimeButtonText}>×</Text>
         </TouchableOpacity>
       </View>
@@ -141,6 +152,16 @@ const parseTimeValue = (timeStr: string): Date => {
   defaultTime.setHours(hours, minutes);
   return defaultTime;
 };
+
+interface NotifTimeProps {
+  notificationTime: string;
+  showTimePicker: boolean;
+  notifTimes: string[];
+  setShowTimePicker: (_v: boolean) => void;
+  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
+  onAddTime: () => void;
+  onRemoveTime: (_time: string) => void;
+}
 
 const NotifTimeSection = ({
   notificationTime,
@@ -158,7 +179,12 @@ const NotifTimeSection = ({
         <TouchableOpacity style={styles.timeButton} onPress={() => setShowTimePicker(true)}>
           <Text style={styles.timeButtonText}>{notificationTime}</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.addTimeButton} onPress={onAddTime}>
+        <TouchableOpacity
+          testID="habit-settings-add-time"
+          accessibilityLabel="Add reminder time"
+          style={styles.addTimeButton}
+          onPress={onAddTime}
+        >
           <Text style={styles.addTimeButtonText}>+</Text>
         </TouchableOpacity>
       </View>
@@ -176,18 +202,30 @@ const NotifTimeSection = ({
   </>
 );
 
-const NotifToggleRow = ({
+const NotificationsToggleRow = ({
   isEnabled,
   onChange,
 }: {
   isEnabled: boolean;
-  onChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+  onChange: ChangeHandler;
 }) => (
   <View style={styles.settingRow}>
     <Text style={styles.editSettingLabel}>Notifications:</Text>
     <Switch
+      testID="habit-settings-notifications-toggle"
       value={isEnabled}
       onValueChange={(value) => onChange('notificationFrequency', value ? 'daily' : 'off')}
+    />
+  </View>
+);
+
+const MilestoneToggleRow = ({ habit, onChange }: { habit: Habit; onChange: ChangeHandler }) => (
+  <View style={styles.settingRow}>
+    <Text style={styles.editSettingLabel}>Milestone Notifications:</Text>
+    <Switch
+      testID="habit-settings-milestone-toggle"
+      value={habit.milestoneNotifications || false}
+      onValueChange={(value) => onChange('milestoneNotifications', value)}
     />
   </View>
 );
@@ -197,7 +235,7 @@ const LockToggleRow = ({
   handleChange,
 }: {
   editedHabit: Habit;
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+  handleChange: ChangeHandler;
 }) => (
   <View style={styles.settingRow}>
     <Text style={styles.editSettingLabel}>Unlocked:</Text>
@@ -211,89 +249,20 @@ const LockToggleRow = ({
   </View>
 );
 
-const NotificationSettings = ({
-  habit,
-  notificationTime,
-  showTimePicker,
-  showDaysPicker,
-  setShowTimePicker,
-  setShowDaysPicker,
-  onChange,
-  onTimeChange,
-  onAddTime,
-  onRemoveTime,
-  onToggleDay,
-}: NotificationSettingsProps) => (
-  <View style={styles.settingGroup}>
-    <NotifToggleRow isEnabled={habit.notificationFrequency !== 'off'} onChange={onChange} />
-    {habit.notificationFrequency !== 'off' && (
-      <>
-        <NotifFrequencySection
-          habit={habit}
-          showDaysPicker={showDaysPicker}
-          setShowDaysPicker={setShowDaysPicker}
-          onChange={onChange}
-          onToggleDay={onToggleDay}
-        />
-        <NotifTimeSection
-          notificationTime={notificationTime}
-          showTimePicker={showTimePicker}
-          notifTimes={habit.notificationTimes || []}
-          setShowTimePicker={setShowTimePicker}
-          onTimeChange={onTimeChange}
-          onAddTime={onAddTime}
-          onRemoveTime={onRemoveTime}
-        />
-      </>
-    )}
-    <View style={styles.settingRow}>
-      <Text style={styles.editSettingLabel}>Milestone Notifications:</Text>
-      <Switch
-        value={habit.milestoneNotifications || false}
-        onValueChange={(value) => onChange('milestoneNotifications', value)}
-      />
-    </View>
-  </View>
-);
-
-interface SettingsFormProps {
+interface HabitSectionProps {
   editedHabit: Habit;
   showEmojiSelector: boolean;
   setShowEmojiSelector: (_v: boolean) => void;
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
-  allHabits: Habit[];
-  onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
-  notificationTime: string;
-  showTimePicker: boolean;
-  showDaysPicker: boolean;
-  setShowTimePicker: (_v: boolean) => void;
-  setShowDaysPicker: (_v: boolean) => void;
-  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
-  onAddTime: () => void;
-  onRemoveTime: (_time: string) => void;
-  onToggleDay: (_day: string) => void;
-  onSave: () => void;
-  onDelete: () => void;
+  handleChange: ChangeHandler;
 }
 
-interface BasicFieldsProps {
-  editedHabit: Habit;
-  showEmojiSelector: boolean;
-  setShowEmojiSelector: (_v: boolean) => void;
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
-  allHabits: Habit[];
-  onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
-}
-
-const BasicFields = ({
+const HabitSection = ({
   editedHabit,
   showEmojiSelector,
   setShowEmojiSelector,
   handleChange,
-  allHabits,
-  onOpenReorderModal,
-}: BasicFieldsProps) => (
-  <>
+}: HabitSectionProps) => (
+  <SettingsSection title="Habit">
     <View style={styles.settingRow}>
       <Text style={styles.editSettingLabel}>Name:</Text>
       <TextField
@@ -320,51 +289,153 @@ const BasicFields = ({
       <Text style={styles.editSettingLabel}>Stage:</Text>
       <Text style={styles.settingValue}>{editedHabit.stage}</Text>
     </View>
-    <Button
-      label="Reorder Habits"
-      variant="secondary"
-      onPress={() => onOpenReorderModal(allHabits)}
-      testID="habit-settings-reorder"
-      style={{ marginVertical: SPACING.md }}
-    />
-  </>
+    <LockToggleRow editedHabit={editedHabit} handleChange={handleChange} />
+  </SettingsSection>
 );
 
-const EnergyAndDateSection = ({
+const EnergySection = ({
   editedHabit,
   handleChange,
 }: {
   editedHabit: Habit;
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+  handleChange: ChangeHandler;
 }) => (
-  <>
-    <View style={styles.settingRow}>
-      <Text style={styles.editSettingLabel}>Energy Rating:</Text>
-    </View>
+  <SettingsSection title="Energy">
     <EnergyCostReturnEditor
       cost={editedHabit.energy_cost}
       energyReturn={editedHabit.energy_return}
       onCommitCost={(value) => handleChange('energy_cost', value)}
       onCommitReturn={(value) => handleChange('energy_return', value)}
     />
+  </SettingsSection>
+);
+
+const ScheduleSection = ({
+  editedHabit,
+  handleChange,
+}: {
+  editedHabit: Habit;
+  handleChange: ChangeHandler;
+}) => (
+  <SettingsSection title="Schedule">
     <View style={styles.settingRow}>
       <Text style={styles.editSettingLabel}>Start Date:</Text>
       <DateTimePicker
         value={new Date(editedHabit.start_date)}
         mode="date"
         display="default"
-        onChange={(event, date) => date && handleChange('start_date', date)}
+        onChange={(_event, date) => date && handleChange('start_date', date)}
       />
     </View>
-  </>
+  </SettingsSection>
 );
 
-const FormActionButtons = ({ onSave, onDelete }: { onSave: () => void; onDelete: () => void }) => (
-  <View style={styles.buttonGroup}>
-    <Button label="Save Changes" variant="primary" onPress={onSave} testID="habit-settings-save" />
+interface RemindersSectionProps {
+  habit: Habit;
+  notificationTime: string;
+  showTimePicker: boolean;
+  showDaysPicker: boolean;
+  setShowTimePicker: (_v: boolean) => void;
+  setShowDaysPicker: (_v: boolean) => void;
+  onChange: ChangeHandler;
+  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
+  onAddTime: () => void;
+  onRemoveTime: (_time: string) => void;
+  onToggleDay: (_day: string) => void;
+}
+
+const RemindersSection = ({
+  habit,
+  notificationTime,
+  showTimePicker,
+  showDaysPicker,
+  setShowTimePicker,
+  setShowDaysPicker,
+  onChange,
+  onTimeChange,
+  onAddTime,
+  onRemoveTime,
+  onToggleDay,
+}: RemindersSectionProps) => {
+  const notificationsOn = habit.notificationFrequency !== 'off';
+  return (
+    <SettingsSection title="Reminders">
+      <NotificationsToggleRow isEnabled={notificationsOn} onChange={onChange} />
+      {notificationsOn && (
+        <>
+          <FrequencyChipRow habit={habit} onChange={onChange} />
+          {habit.notificationFrequency === 'custom' && (
+            <CustomDaysPicker
+              habit={habit}
+              showDaysPicker={showDaysPicker}
+              setShowDaysPicker={setShowDaysPicker}
+              onToggleDay={onToggleDay}
+            />
+          )}
+          <NotifTimeSection
+            notificationTime={notificationTime}
+            showTimePicker={showTimePicker}
+            notifTimes={habit.notificationTimes || []}
+            setShowTimePicker={setShowTimePicker}
+            onTimeChange={onTimeChange}
+            onAddTime={onAddTime}
+            onRemoveTime={onRemoveTime}
+          />
+        </>
+      )}
+      <MilestoneToggleRow habit={habit} onChange={onChange} />
+    </SettingsSection>
+  );
+};
+
+const UtilityRow = ({
+  allHabits,
+  onOpenReorderModal,
+}: {
+  allHabits: Habit[];
+  onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
+}) => (
+  <View style={styles.utilityRow}>
+    <Button
+      label="Reorder Habits"
+      variant="secondary"
+      onPress={() => onOpenReorderModal(allHabits)}
+      testID="habit-settings-reorder"
+    />
+  </View>
+);
+
+const DangerZoneSection = ({ onDelete }: { onDelete: () => void }) => (
+  <SettingsSection title="Danger Zone">
     <TouchableOpacity testID="habit-settings-delete" style={styles.deleteButton} onPress={onDelete}>
       <Text style={styles.deleteButtonText}>Delete Habit</Text>
     </TouchableOpacity>
+  </SettingsSection>
+);
+
+interface SettingsFormProps {
+  editedHabit: Habit;
+  showEmojiSelector: boolean;
+  setShowEmojiSelector: (_v: boolean) => void;
+  handleChange: ChangeHandler;
+  allHabits: Habit[];
+  onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
+  notificationTime: string;
+  showTimePicker: boolean;
+  showDaysPicker: boolean;
+  setShowTimePicker: (_v: boolean) => void;
+  setShowDaysPicker: (_v: boolean) => void;
+  onTimeChange: (_event: DateTimePickerEvent, _date?: Date) => void;
+  onAddTime: () => void;
+  onRemoveTime: (_time: string) => void;
+  onToggleDay: (_day: string) => void;
+  onSave: () => void;
+  onDelete: () => void;
+}
+
+const SaveRow = ({ onSave }: { onSave: () => void }) => (
+  <View style={styles.saveRow}>
+    <Button label="Save Changes" variant="primary" onPress={onSave} testID="habit-settings-save" />
   </View>
 );
 
@@ -388,16 +459,15 @@ const SettingsForm = ({
   onDelete,
 }: SettingsFormProps) => (
   <ScrollView style={styles.settingsContainer}>
-    <BasicFields
+    <HabitSection
       editedHabit={editedHabit}
       showEmojiSelector={showEmojiSelector}
       setShowEmojiSelector={setShowEmojiSelector}
       handleChange={handleChange}
-      allHabits={allHabits}
-      onOpenReorderModal={onOpenReorderModal}
     />
-    <EnergyAndDateSection editedHabit={editedHabit} handleChange={handleChange} />
-    <NotificationSettings
+    <EnergySection editedHabit={editedHabit} handleChange={handleChange} />
+    <ScheduleSection editedHabit={editedHabit} handleChange={handleChange} />
+    <RemindersSection
       habit={editedHabit}
       notificationTime={notificationTime}
       showTimePicker={showTimePicker}
@@ -410,18 +480,16 @@ const SettingsForm = ({
       onRemoveTime={onRemoveTime}
       onToggleDay={onToggleDay}
     />
-    <LockToggleRow editedHabit={editedHabit} handleChange={handleChange} />
-    <FormActionButtons onSave={onSave} onDelete={onDelete} />
+    <UtilityRow allHabits={allHabits} onOpenReorderModal={onOpenReorderModal} />
+    <SaveRow onSave={onSave} />
+    <DangerZoneSection onDelete={onDelete} />
   </ScrollView>
 );
 
 const formatTime = (date: Date): string =>
   `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
 
-const useNotificationHandlers = (
-  editedHabit: Habit | null,
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void,
-) => {
+const useNotificationHandlers = (editedHabit: Habit | null, handleChange: ChangeHandler) => {
   const [showTimePicker, setShowTimePicker] = useState(false);
   const [notificationTime, setNotificationTime] = useState('08:00');
   const [showDaysPicker, setShowDaysPicker] = useState(false);
@@ -471,7 +539,7 @@ const useSettingsHandlers = (
   onUpdate: HabitSettingsModalProps['onUpdate'],
   onDeleteProp: HabitSettingsModalProps['onDelete'],
   onClose: () => void,
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void,
+  handleChange: ChangeHandler,
 ) => {
   const notif = useNotificationHandlers(editedHabit, handleChange);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -509,7 +577,7 @@ interface SettingsBodyProps {
   editedHabit: Habit;
   showEmojiSelector: boolean;
   setShowEmojiSelector: (_v: boolean) => void;
-  handleChange: <K extends keyof Habit>(_field: K, _value: Habit[K]) => void;
+  handleChange: ChangeHandler;
   allHabits: Habit[];
   onClose: () => void;
   onOpenReorderModal: HabitSettingsModalProps['onOpenReorderModal'];
@@ -531,7 +599,7 @@ const SettingsModalBody = ({
       testID="habit-settings-card"
       style={[styles.editModalCard, { borderTopColor: STAGE_COLORS[editedHabit.stage] }]}
     >
-      <ModalHeader title="Edit Habit" onClose={onClose} />
+      <ModalHeader title="Edit Habit" onClose={onClose} closeTestID="habit-settings-close" />
       <SettingsForm
         editedHabit={editedHabit}
         showEmojiSelector={showEmojiSelector}

--- a/frontend/src/features/Habits/components/__tests__/HabitEditModalsTokens.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitEditModalsTokens.test.tsx
@@ -10,7 +10,7 @@ import type { Habit, HabitSettingsModalProps } from '../../Habits.types';
 import { HabitSettingsModal } from '../HabitSettingsModal';
 import ReorderHabitsModal from '../ReorderHabitsModal';
 
-import { accent, colors, fonts, ink, shadows, surface, surfaceShadow } from '@/design/tokens';
+import { accent, colors, fonts, ink, shadows, surfaceShadow } from '@/design/tokens';
 
 jest.mock('react-native-draggable-flatlist', () => 'DraggableFlatList');
 jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
@@ -180,18 +180,30 @@ describe('Candle & Ink token guard — delete-habit action (habit-settings-delet
   });
 });
 
-// Guard 7: frequency pill background resolves to surface.sunken, not legacy colors.secondary.
-describe('Candle & Ink token guard — frequency pill (habit-settings-frequency)', () => {
-  it('frequency pill background resolves to surface.sunken', () => {
-    const { getByTestId } = renderSettingsModal();
-    const pill = getByTestId('habit-settings-frequency');
-    expect(flatten(pill.props.style).backgroundColor).toBe(surface.sunken);
+// Guard 7: selected frequency chip background resolves to accent.primary, not legacy colors.secondary.
+describe('Candle & Ink token guard — frequency chips (habit-settings-frequency)', () => {
+  it('selected chip background resolves to accent.primary', () => {
+    const { getByTestId } = renderSettingsModal({
+      habit: { ...baseHabit, notificationFrequency: 'daily' },
+    });
+    const selectedChip = getByTestId('habit-settings-frequency-daily');
+    expect(flatten(selectedChip.props.style).backgroundColor).toBe(accent.primary);
   });
 
-  it('frequency pill does NOT use the legacy colors.secondary', () => {
-    const { getByTestId } = renderSettingsModal();
-    const pill = getByTestId('habit-settings-frequency');
-    expect(flatten(pill.props.style).backgroundColor).not.toBe(colors.secondary);
+  it('selected chip does NOT use the legacy colors.secondary', () => {
+    const { getByTestId } = renderSettingsModal({
+      habit: { ...baseHabit, notificationFrequency: 'daily' },
+    });
+    const selectedChip = getByTestId('habit-settings-frequency-daily');
+    expect(flatten(selectedChip.props.style).backgroundColor).not.toBe(colors.secondary);
+  });
+
+  it('unselected chip background does NOT resolve to accent.primary', () => {
+    const { getByTestId } = renderSettingsModal({
+      habit: { ...baseHabit, notificationFrequency: 'daily' },
+    });
+    const unselectedChip = getByTestId('habit-settings-frequency-weekly');
+    expect(flatten(unselectedChip.props.style).backgroundColor).not.toBe(accent.primary);
   });
 });
 

--- a/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitSettingsModal.test.tsx
@@ -123,23 +123,48 @@ describe('HabitSettingsModal energy inputs', () => {
 });
 
 describe('HabitSettingsModal notification frequency', () => {
-  it('cycles daily to weekly to custom and back to daily', () => {
-    const { getByText } = renderModal({
+  it('defaults to the daily chip selected and exposes all three chips as radios', () => {
+    const { getByTestId } = renderModal({
       habit: { ...baseHabit, notificationFrequency: undefined },
     });
-    const frequencyButton = getByText('daily');
+    const daily = getByTestId('habit-settings-frequency-daily');
+    const weekly = getByTestId('habit-settings-frequency-weekly');
+    const custom = getByTestId('habit-settings-frequency-custom');
 
-    fireEvent.press(frequencyButton);
-    getByText('daily');
+    expect(daily.props.accessibilityRole).toBe('radio');
+    expect(weekly.props.accessibilityRole).toBe('radio');
+    expect(custom.props.accessibilityRole).toBe('radio');
+    expect(daily.props.accessibilityState.checked).toBe(true);
+    expect(weekly.props.accessibilityState.checked).toBe(false);
+    expect(custom.props.accessibilityState.checked).toBe(false);
+  });
 
-    fireEvent.press(getByText('daily'));
-    getByText('weekly');
+  it('selects the weekly chip on press and clears the daily selection', () => {
+    const { getByTestId } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: undefined },
+    });
 
-    fireEvent.press(getByText('weekly'));
-    getByText('custom');
+    fireEvent.press(getByTestId('habit-settings-frequency-weekly'));
 
-    fireEvent.press(getByText('custom'));
-    getByText('daily');
+    expect(getByTestId('habit-settings-frequency-weekly').props.accessibilityState.checked).toBe(
+      true,
+    );
+    expect(getByTestId('habit-settings-frequency-daily').props.accessibilityState.checked).toBe(
+      false,
+    );
+  });
+
+  it('selects the custom chip on press and reveals the day picker button', () => {
+    const { getByTestId, getByText } = renderModal({
+      habit: { ...baseHabit, notificationFrequency: undefined },
+    });
+
+    fireEvent.press(getByTestId('habit-settings-frequency-custom'));
+
+    expect(getByTestId('habit-settings-frequency-custom').props.accessibilityState.checked).toBe(
+      true,
+    );
+    getByText('Select days');
   });
 
   it('reveals the day-picker grid and updates the days summary when a day is toggled', () => {
@@ -172,22 +197,20 @@ describe('HabitSettingsModal notification frequency', () => {
 });
 
 describe('HabitSettingsModal notification and milestone toggles', () => {
-  it('turns notifications off and hides frequency controls, then back on', () => {
-    const { getByText, queryByText, UNSAFE_root } = renderModal();
-    const notifSwitch = UNSAFE_root.findAllByType(Switch)[0]!;
+  it('turns notifications off and hides the frequency chip row, then back on', () => {
+    const { getByTestId, queryByTestId } = renderModal();
 
-    fireEvent(notifSwitch, 'valueChange', false);
-    expect(queryByText('Frequency:')).toBeNull();
+    fireEvent(getByTestId('habit-settings-notifications-toggle'), 'valueChange', false);
+    expect(queryByTestId('habit-settings-frequency')).toBeNull();
 
-    fireEvent(notifSwitch, 'valueChange', true);
-    getByText('Frequency:');
+    fireEvent(getByTestId('habit-settings-notifications-toggle'), 'valueChange', true);
+    getByTestId('habit-settings-frequency');
   });
 
   it('toggles milestone notifications independently', () => {
-    const { onUpdate, UNSAFE_root, getByText } = renderModal();
-    const milestoneSwitch = UNSAFE_root.findAllByType(Switch)[1]!;
+    const { onUpdate, getByTestId, getByText } = renderModal();
 
-    fireEvent(milestoneSwitch, 'valueChange', true);
+    fireEvent(getByTestId('habit-settings-milestone-toggle'), 'valueChange', true);
     fireEvent.press(getByText('Save Changes'));
 
     expect(onUpdate).toHaveBeenCalledWith(
@@ -198,7 +221,7 @@ describe('HabitSettingsModal notification and milestone toggles', () => {
 
 describe('HabitSettingsModal notification times', () => {
   it('adds a picked time and ignores a duplicate add', () => {
-    const { getByText, onUpdate, UNSAFE_root } = renderModal();
+    const { getByText, getByTestId, onUpdate, UNSAFE_root } = renderModal();
 
     fireEvent.press(getByText('08:00'));
     const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
@@ -206,8 +229,11 @@ describe('HabitSettingsModal notification times', () => {
     )!;
     fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
 
-    fireEvent.press(getByText('+'));
-    fireEvent.press(getByText('+'));
+    expect(getByTestId('habit-settings-add-time').props.accessibilityLabel).toBe(
+      'Add reminder time',
+    );
+    fireEvent.press(getByTestId('habit-settings-add-time'));
+    fireEvent.press(getByTestId('habit-settings-add-time'));
 
     fireEvent.press(getByText('Save Changes'));
     expect(onUpdate).toHaveBeenCalledWith(
@@ -216,17 +242,18 @@ describe('HabitSettingsModal notification times', () => {
   });
 
   it('removes an added notification time before saving', () => {
-    const { getByText, getAllByText, onUpdate, UNSAFE_root } = renderModal();
+    const { getByText, getByTestId, onUpdate, UNSAFE_root } = renderModal();
 
     fireEvent.press(getByText('08:00'));
     const timePicker = UNSAFE_root.findAllByType('DateTimePicker').find(
       (node: { props: { mode?: string } }) => node.props.mode === 'time',
     )!;
     fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
-    fireEvent.press(getByText('+'));
+    fireEvent.press(getByTestId('habit-settings-add-time'));
 
-    const removeButtons = getAllByText('×');
-    fireEvent.press(removeButtons[removeButtons.length - 1]!);
+    const removeButton = getByTestId('habit-settings-remove-time-09:05');
+    expect(removeButton.props.accessibilityLabel).toBe('Remove 09:05');
+    fireEvent.press(removeButton);
 
     fireEvent.press(getByText('Save Changes'));
     expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ notificationTimes: [] }));
@@ -293,7 +320,7 @@ describe('HabitSettingsModal time picker platform behavior', () => {
 
 describe('HabitSettingsModal missing optional notification arrays', () => {
   it('adds a time when the habit has no existing notificationTimes array', () => {
-    const { getByText, onUpdate, UNSAFE_root } = renderModal({
+    const { getByText, getByTestId, onUpdate, UNSAFE_root } = renderModal({
       habit: { ...baseHabit, notificationTimes: undefined },
     });
 
@@ -302,7 +329,7 @@ describe('HabitSettingsModal missing optional notification arrays', () => {
       (node: { props: { mode?: string } }) => node.props.mode === 'time',
     )!;
     fireEvent(timePicker, 'onChange', {}, new Date(2024, 0, 1, 9, 5));
-    fireEvent.press(getByText('+'));
+    fireEvent.press(getByTestId('habit-settings-add-time'));
 
     fireEvent.press(getByText('Save Changes'));
     expect(onUpdate).toHaveBeenCalledWith(
@@ -370,12 +397,25 @@ describe('HabitSettingsModal lock toggle', () => {
     expect(label).toBe('Unlocked');
   });
 
-  it('is the third Switch, after notifications and milestone toggles', () => {
+  it('is the first Switch, before notifications and milestone toggles', () => {
     const { UNSAFE_root } = renderModal();
     const switches = UNSAFE_root.findAllByType(Switch);
 
     expect(switches).toHaveLength(3);
-    expect(switches[2]!.props.testID).toBe('habit-settings-lock-toggle');
+    expect(switches[0]!.props.testID).toBe('habit-settings-lock-toggle');
+    expect(switches[1]!.props.testID).toBe('habit-settings-notifications-toggle');
+    expect(switches[2]!.props.testID).toBe('habit-settings-milestone-toggle');
+  });
+});
+
+describe('HabitSettingsModal section composition', () => {
+  it('renders each section title as visible text', () => {
+    const { getByText } = renderModal();
+    getByText('Habit');
+    getByText('Energy');
+    getByText('Schedule');
+    getByText('Reminders');
+    getByText('Danger Zone');
   });
 });
 
@@ -398,8 +438,8 @@ describe('HabitSettingsModal actions', () => {
   });
 
   it('closes via the header close button without saving', () => {
-    const { getAllByText, onClose, onUpdate } = renderModal();
-    fireEvent.press(getAllByText('×')[0]!);
+    const { getByTestId, onClose, onUpdate } = renderModal();
+    fireEvent.press(getByTestId('habit-settings-close'));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onUpdate).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Recompose the Edit Habit modal (`HabitSettingsModal`) from a flat, mixed-idiom `ScrollView` into five titled Candle & Ink sections — **Habit** (name / icon / stage / unlocked toggle), **Energy**, **Schedule**, **Reminders**, **Danger Zone** — using a shared `SettingsSection` wrapper and a `sectionTitle` style mirroring the sibling `GoalModal` idiom.
- Replace the undiscoverable cycle-on-tap frequency button with an explicit three-chip radio selector (daily / weekly / custom all visible at once, `accessibilityRole="radio"` inside a `radiogroup`); move the list-level "Reorder Habits" action out of the form body into a subdued utility row; isolate Delete in the Danger Zone below the single Save CTA; and give the notification time add/remove controls real testIDs, accessibility labels, and 44dp touch targets.
- Preserve all behavior, save/delete flows, and Candle & Ink token guards; remove the now-dead `frequencyButton*` and `settingGroup` styles.

## Test plan
- Rewrote `HabitSettingsModal.test.tsx` and `HabitEditModalsTokens.test.tsx` to pin the new section composition, chip-radio frequency semantics, switch order (`[lock, notifications, milestone]`), and testID-based time add/remove — TDD RED first (14 failing), then GREEN (55/55).
- `./scripts/frontend/check-all.sh` exits 0: ESLint zero-warning, prettier, `tsc --noEmit` strict, and the full Jest suite (4171 tests, 398 suites) all pass.

Closes #1614
