### PR TITLE
fix(backend): unlock the calendar stage on its first local day

### DIFF
--- a/backend/src/domain/program_calendar.py
+++ b/backend/src/domain/program_calendar.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from domain.constants import STAGE_DURATIONS_DAYS, TOTAL_STAGES
-from domain.dates import ensure_aware
+from domain.dates import ensure_aware, to_user_date
 from domain.weekly_prompts import TOTAL_WEEKS
 
 if TYPE_CHECKING:
@@ -27,29 +27,46 @@ if TYPE_CHECKING:
 _DAYS_PER_WEEK = 7
 
 
-def elapsed_days(anchor: datetime, now: datetime) -> int:
-    """Whole days since the anchor, floored at zero for clock skew.
+def elapsed_days(anchor: datetime, now: datetime, *, tz: str | None = None) -> int:
+    """Whole CALENDAR days between the anchor's local date and ``now``'s local date.
+
+    Counted in ``tz`` (UTC when ``tz`` is None) and floored at zero for
+    clock skew.  Both operands are converted to their local calendar date
+    via :func:`domain.dates.to_user_date` and subtracted, so the result is
+    the number of midnights crossed in the user's zone — matching the
+    frontend's local-midnight convention — rather than a UTC timedelta
+    anchored to the anchor's wall-clock time-of-day.
 
     Shared by every date-derived program helper (this module's calendar
     math and :mod:`domain.reflection_hierarchy`'s due-date ladder) so the
     naive/aware normalization and the clock-skew floor live in exactly one
-    place.
+    place.  ``to_user_date`` rejects naive inputs, so both operands are
+    wrapped in :func:`domain.dates.ensure_aware` (SQLite reads anchors back
+    naive).
     """
-    delta = ensure_aware(now) - ensure_aware(anchor)
+    delta = to_user_date(tz, ensure_aware(now)) - to_user_date(tz, ensure_aware(anchor))
     return max(0, delta.days)
 
 
-def calendar_week(anchor: datetime, now: datetime | None = None) -> int:
-    """The 1-based program week ``now`` falls in, clamped to the curriculum."""
+def calendar_week(anchor: datetime, now: datetime | None = None, *, tz: str | None = None) -> int:
+    """The 1-based program week ``now`` falls in, clamped to the curriculum.
+
+    Weeks advance on whole CALENDAR days between the anchor's local date
+    and ``now``'s local date in ``tz`` (UTC when ``tz`` is None).
+    """
     moment = now if now is not None else datetime.now(UTC)
-    week = elapsed_days(anchor, moment) // _DAYS_PER_WEEK + 1
+    week = elapsed_days(anchor, moment, tz=tz) // _DAYS_PER_WEEK + 1
     return min(week, TOTAL_WEEKS)
 
 
-def calendar_stage(anchor: datetime, now: datetime | None = None) -> int:
-    """The 1-based stage ``now`` falls in, walking the duration schedule."""
+def calendar_stage(anchor: datetime, now: datetime | None = None, *, tz: str | None = None) -> int:
+    """The 1-based stage ``now`` falls in, walking the duration schedule.
+
+    Stage windows advance on whole CALENDAR days between the anchor's local
+    date and ``now``'s local date in ``tz`` (UTC when ``tz`` is None).
+    """
     moment = now if now is not None else datetime.now(UTC)
-    remaining = elapsed_days(anchor, moment)
+    remaining = elapsed_days(anchor, moment, tz=tz)
     for stage_number, duration in enumerate(STAGE_DURATIONS_DAYS, start=1):
         if remaining < duration:
             return stage_number
@@ -57,7 +74,9 @@ def calendar_stage(anchor: datetime, now: datetime | None = None) -> int:
     return TOTAL_STAGES
 
 
-def calendar_day_in_stage(anchor: datetime, stage_number: int, now: datetime | None = None) -> int:
+def calendar_day_in_stage(
+    anchor: datetime, stage_number: int, now: datetime | None = None, *, tz: str | None = None
+) -> int:
     """The 1-based day ``now`` falls on *within* ``stage_number``'s window.
 
     Feeds the proportional content drip (``domain.course``): a stage's
@@ -65,7 +84,9 @@ def calendar_day_in_stage(anchor: datetime, stage_number: int, now: datetime | N
     "how far into the stage the calendar has carried the user" is what
     decides how many are open.  Day 1 is the first day of the stage;
     values before the window opens are non-positive and values past its
-    close are capped at the stage duration.  Independent of advancement —
+    close are capped at the stage duration.  Progress is measured in whole
+    CALENDAR days between the anchor's local date and ``now``'s local date
+    in ``tz`` (UTC when ``tz`` is None).  Independent of advancement —
     callers combine it with ``current_stage`` so time can only widen
     access.
     """
@@ -73,7 +94,7 @@ def calendar_day_in_stage(anchor: datetime, stage_number: int, now: datetime | N
     stage = min(max(stage_number, 1), TOTAL_STAGES)
     window_start = sum(STAGE_DURATIONS_DAYS[: stage - 1])
     duration = STAGE_DURATIONS_DAYS[stage - 1]
-    day = elapsed_days(anchor, moment) - window_start + 1
+    day = elapsed_days(anchor, moment, tz=tz) - window_start + 1
     return min(day, duration)
 
 

--- a/backend/src/domain/stage_progress.py
+++ b/backend/src/domain/stage_progress.py
@@ -120,18 +120,23 @@ def completed_stage_gap(completed: set[int], current_stage: int) -> tuple[set[in
 
 
 def is_stage_unlocked(
-    stage_number: int, progress: StageProgress | None, now: datetime | None = None
+    stage_number: int,
+    progress: StageProgress | None,
+    now: datetime | None = None,
+    *,
+    tz: str | None = None,
 ) -> bool:
     """Return True iff the stage is open by advancement OR by the calendar.
 
     Advancement: ``N <= current_stage``, which only moves via the
     validated router path (advance must equal ``current + 1``).
-    Calendar (issue #386): ``N <= calendar_stage(anchor)``, the same
-    date-derived schedule the frontend renders, so the server never 403s
-    a stage the user can see is open.  ``max`` of the two means time can
-    OPEN stages but never revoke advancement-granted access — and the
-    calendar itself is server-computed, so a client cannot skip ahead of
-    the schedule.
+    Calendar: ``N <= calendar_stage(anchor)``, the same date-derived
+    schedule the frontend renders, evaluated in the caller's timezone
+    (``tz``; UTC when None) so the server counts the same calendar days
+    the client does and never 403s a stage the user can see is open.
+    ``max`` of the two means time can OPEN stages but never revoke
+    advancement-granted access — and the calendar itself is
+    server-computed, so a client cannot skip ahead of the schedule.
     """
     if stage_number == _STAGE_1:
         return True
@@ -139,7 +144,7 @@ def is_stage_unlocked(
         return False
     unlocked_through = max(
         progress.current_stage,
-        calendar_stage(resolve_program_anchor(progress), now),
+        calendar_stage(resolve_program_anchor(progress), now, tz=tz),
     )
     return stage_number <= unlocked_through
 

--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -89,17 +89,21 @@ async def _check_stage_eligibility(
     current_user: int,
     practice: Practice,
     payload_stage_number: int,
+    user_tz: str,
 ) -> None:
     """Gate on catalog-stage agreement + chain-unlock.
 
     Kept separate from :func:`_resolve_practice` so the 400/403 split stays
     explicit: mismatched stage is a client-side input error, locked stage is
-    an authorization failure against server-owned progression.
+    an authorization failure against server-owned progression.  ``user_tz``
+    threads the caller's timezone into the calendar unlock so the server
+    counts the same calendar days the client does (matching the frontend's
+    local-midnight convention).
     """
     if practice.stage_number != payload_stage_number:
         raise bad_request("stage_number_mismatch")
     progress = await get_user_progress(session, current_user)
-    if not is_stage_unlocked(payload_stage_number, progress):
+    if not is_stage_unlocked(payload_stage_number, progress, tz=user_tz):
         raise forbidden("stage_locked")
 
 
@@ -165,7 +169,7 @@ async def create_user_practice(
     streak math that hangs off it.
     """
     practice = await _resolve_selectable_practice(session, payload.practice_id, current_user)
-    await _check_stage_eligibility(session, current_user, practice, payload.stage_number)
+    await _check_stage_eligibility(session, current_user, practice, payload.stage_number, user_tz)
 
     # ``start_date`` is the user-facing "I started this practice today"
     # label (BUG-HABIT-006), not an internal audit timestamp -- so it

--- a/backend/tests/test_program_calendar.py
+++ b/backend/tests/test_program_calendar.py
@@ -16,6 +16,7 @@ from domain.program_calendar import (
     calendar_day_in_stage,
     calendar_stage,
     calendar_week,
+    elapsed_days,
     resolve_program_anchor,
 )
 from domain.weekly_prompts import TOTAL_WEEKS
@@ -177,6 +178,59 @@ def test_calendar_math_agrees_across_naive_and_aware_utc_representations() -> No
     assert calendar_day_in_stage(naive_anchor, 1, aware_now) == calendar_day_in_stage(
         _ANCHOR, 1, aware_now
     )
+
+
+# ── tz-aware calendar math (local-midnight boundary) ────────────────────
+
+_TZ_LA = "America/Los_Angeles"
+# Deliberately non-midnight UTC so a UTC-date diff and a PT-date diff can
+# disagree: 2026-01-01T20:00Z is still 2026-01-01 in Pacific (noon PST).
+_TZ_ANCHOR = datetime(2026, 1, 1, 20, 0, tzinfo=UTC)
+
+
+def test_elapsed_days_and_stage_flip_at_pacific_local_midnight() -> None:
+    """The stage flips at PT local midnight, not at a UTC-timedelta floor."""
+    now = datetime(2026, 1, 22, 8, 0, tzinfo=UTC)  # 2026-01-22T00:00 PST
+    assert elapsed_days(_TZ_ANCHOR, now, tz=_TZ_LA) == 21
+    assert calendar_stage(_TZ_ANCHOR, now, tz=_TZ_LA) == 2
+
+
+def test_elapsed_days_and_stage_one_local_second_before_the_flip() -> None:
+    now = datetime(2026, 1, 22, 7, 59, 59, tzinfo=UTC)  # 2026-01-21T23:59:59 PST
+    assert elapsed_days(_TZ_ANCHOR, now, tz=_TZ_LA) == 20
+    assert calendar_stage(_TZ_ANCHOR, now, tz=_TZ_LA) == 1
+
+
+def test_calendar_stage_does_not_unlock_early_west_of_utc() -> None:
+    """UTC's date has already rolled to the 22nd, but Pacific has not."""
+    now = datetime(2026, 1, 22, 5, 0, tzinfo=UTC)  # 2026-01-21T21:00 PST
+    assert calendar_stage(_TZ_ANCHOR, now, tz=_TZ_LA) == 1
+
+
+def test_elapsed_days_defaults_to_utc_calendar_dates() -> None:
+    """``tz=None`` still fixes the wall-clock-truncation mismatch, via UTC dates."""
+    now = datetime(2026, 1, 22, 0, 30, tzinfo=UTC)
+    assert elapsed_days(_TZ_ANCHOR, now) == 21
+
+
+def test_elapsed_days_with_tz_floors_a_pre_anchor_now_at_zero() -> None:
+    assert elapsed_days(_TZ_ANCHOR, _TZ_ANCHOR - timedelta(days=3), tz=_TZ_LA) == 0
+
+
+def test_elapsed_days_with_tz_accepts_a_naive_anchor() -> None:
+    naive_anchor = _TZ_ANCHOR.replace(tzinfo=None)
+    now = datetime(2026, 1, 22, 8, 0, tzinfo=UTC)
+    assert elapsed_days(naive_anchor, now, tz=_TZ_LA) == 21
+
+
+def test_calendar_week_forwards_tz_to_the_local_midnight_boundary() -> None:
+    now = datetime(2026, 1, 22, 8, 0, tzinfo=UTC)
+    assert calendar_week(_TZ_ANCHOR, now, tz=_TZ_LA) == 4
+
+
+def test_calendar_day_in_stage_forwards_tz_to_the_local_midnight_boundary() -> None:
+    now = datetime(2026, 1, 22, 8, 0, tzinfo=UTC)
+    assert calendar_day_in_stage(_TZ_ANCHOR, 2, now, tz=_TZ_LA) == 1
 
 
 # ── resolve_program_anchor ──────────────────────────────────────────────

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -184,3 +184,29 @@ def test_is_stage_unlocked_accepts_an_explicit_now() -> None:
     later = datetime.now(UTC) + timedelta(days=22)
     assert is_stage_unlocked(2, progress, now=later) is True
     assert is_stage_unlocked(3, progress, now=later) is False
+
+
+def test_is_stage_unlocked_flips_at_pacific_local_midnight_not_utc() -> None:
+    """The first local calendar day of stage 2 in Pacific time unlocks it."""
+    progress = StageProgress(
+        user_id=1,
+        current_stage=1,
+        completed_stages=[],
+        program_started_at=datetime(2026, 1, 1, 20, 0, tzinfo=UTC),
+    )
+    at_local_midnight = datetime(2026, 1, 22, 8, 0, tzinfo=UTC)
+    one_second_earlier = datetime(2026, 1, 22, 7, 59, 59, tzinfo=UTC)
+    assert is_stage_unlocked(2, progress, now=at_local_midnight, tz="America/Los_Angeles") is True
+    assert is_stage_unlocked(2, progress, now=one_second_earlier, tz="America/Los_Angeles") is False
+
+
+def test_calendar_tz_never_revokes_advancement_ahead_of_it() -> None:
+    """A user already advanced past the tz-derived calendar keeps that access."""
+    progress = StageProgress(
+        user_id=1,
+        current_stage=3,
+        completed_stages=[1, 2],
+        program_started_at=datetime(2026, 1, 1, 20, 0, tzinfo=UTC),
+    )
+    early = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
+    assert is_stage_unlocked(3, progress, now=early, tz="America/Los_Angeles") is True

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
@@ -183,6 +184,50 @@ async def test_select_practice_rejects_locked_stage(
     )
     assert resp.status_code == HTTPStatus.FORBIDDEN
     assert resp.json()["detail"] == "stage_locked"
+
+
+@pytest.mark.asyncio
+async def test_select_practice_first_local_day_of_new_stage_is_unlocked(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The first Pacific calendar day of stage 2 unlocks the pick, not day 22 UTC.
+
+    Anchored to real local dates (DST-proof) rather than a fixed literal so
+    the test is independent of the wall clock it happens to run under.
+    """
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "pacificpicker@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": "America/Los_Angeles",
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = resp.json()["user_id"]
+    practice = await _seed_practice(db_session, name="Stage2Pacific", stage_number=2)
+
+    la = ZoneInfo("America/Los_Angeles")
+    start_date = datetime.now(la).date() - timedelta(days=21)
+    anchor_local = datetime.combine(start_date, time(23, 59), tzinfo=la)
+    anchor = anchor_local.astimezone(UTC).replace(tzinfo=None)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=anchor,
+        )
+    )
+    await db_session.commit()
+
+    create_resp = await async_client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 2},
+        headers=headers,
+    )
+    assert create_resp.status_code == HTTPStatus.CREATED
 
 
 # -- List user-practices ----------------------------------------------------


### PR DESCRIPTION
## Summary

On day one of a new stage the backend's date-derived unlock lagged the app's local-midnight calendar, so `POST /user-practices/` returned `403 stage_locked` for the stage the app already showed as current. The gate counted elapsed program days as a **UTC `timedelta` floor**, so a stage opened only once the program anchor's wall-clock time-of-day passed in UTC — up to ~24h (plus timezone offset) after the frontend flipped at local midnight. It reproduced for any user west of UTC or with any afternoon/evening anchor timestamp, i.e. essentially everyone, at every stage boundary.

The fix counts **whole calendar days in the user's timezone**, matching the frontend's local-midnight convention (`useProgramStore.programDayOffset` normalizes both anchor and today to local midnight and divides):

- `domain/program_calendar.py` — `elapsed_days(anchor, now, *, tz=None)` now diffs the anchor's local date against `now`'s local date via `domain.dates.to_user_date` (both wrapped in `ensure_aware` for SQLite's naive round-trip), instead of a UTC timedelta floor. A keyword-only `tz: str | None = None` threads through `calendar_week` / `calendar_stage` / `calendar_day_in_stage`. `tz=None` resolves to UTC.
- `domain/stage_progress.py` — `is_stage_unlocked(..., *, tz=None)` forwards `tz` into `calendar_stage`. The `max(current_stage, calendar_stage)` posture is preserved exactly: **time can open a stage but never revoke advancement-granted access**, and the calendar stays server-computed so a client cannot skip ahead of the schedule.
- `routers/user_practices.py` — the create-practice path passes its already-resolved `user_tz` (the same dependency used for `start_date`) into the gate.

Worked example (anchor `2026-01-01T20:00:00Z`, stage-1 duration 21 days, `America/Los_Angeles`): the app flips to stage 2 on `2026-01-22` local midnight. Before, `calendar_stage` stayed 1 until `2026-01-22T20:00Z` (noon PT). After, elapsed = `date(2026-01-22) − date(2026-01-01)` in the user's tz = 21 → stage 2 from local midnight, matching the app.

## Behavior change worth noting for review

`elapsed_days` is shared by the reflection due-date ladder (`domain/reflection_hierarchy`) and the reflection week-bucketing (`routers/reflections.py`), which stay on the `tz=None` (UTC) default. The default path changes from a **timedelta floor** to a **UTC calendar-date diff** — these diverge when the anchor's time-of-day differs from `now`'s (the normal production case). This is an intentional unification: `calendar_week`/`calendar_stage` already fed off `elapsed_days` and now all date-derived helpers share one calendar-day basis (consistent with the frontend), rather than the reflection ladder alone being anchored to the anchor's wall-clock time. Effect is a ≤24h shift in which UTC day a reflection comes due; reflections are declinable invitations, so harm is low. The full backend suite (2630 tests) stays green.

## Out of scope (follow-ups)

The sibling `is_stage_unlocked` gates that govern course-content unlock (`routers/course.py`) and stage access (`routers/stages.py`), plus the `/stages/program-calendar` server-view endpoint, remain on the UTC default and share this root cause. Threading `tz` through them for full calendar consistency is a natural follow-up but is out of scope for this P1 point-fix (and coordinates with epic siblings #1618/#1619).

## Test plan

TDD — boundary/timezone fixtures written RED first, then made GREEN:

- `tests/test_program_calendar.py` — frontend-parity flip at the first second of local midnight PT with a **non-midnight** anchor (elapsed 21 → stage 2), one local second earlier (20 → stage 1), no early unlock for a UTC-date-ahead-but-local-behind instant, the `tz=None` UTC-calendar-date default (20→21 vs the old floor), clock-skew floor at 0, naive-anchor handling, and `calendar_week`/`calendar_day_in_stage` tz pass-through.
- `tests/test_program_gating.py` — `is_stage_unlocked` flips at Pacific local midnight (True) but not one second earlier (False); the `max()` never-revoke posture holds when advancement is ahead of the calendar.
- `tests/test_user_practices_api.py` — end-to-end: a Pacific user on the first local day of a new stage now gets `201` selecting a stage-N practice (was `403 stage_locked`); the fresh-user still-locked control is unchanged.

Gate 2 green locally: `./scripts/backend/check-all.sh` 7/7, 2630 passed, coverage 96.62%, ruff + mypy clean, xenon A-grade, radon MI grade A on the changed files.

Closes #1617
Refs #1616