### PR TITLE
fix(practice): offer a copy when using a practice in another stage

### DIFF
--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -88,7 +88,7 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   stage_locked:
     "You haven't unlocked this stage yet. Finish the earlier stages first — this practice will be waiting when you get there.",
   stage_number_mismatch:
-    'This practice belongs to a different stage. Open it from that stage to use it.',
+    'This practice belongs to a different stage. Make a copy for your stage to use it there.',
   active_practice_exists_for_stage:
     'Another change to this stage just went through. Pull down to refresh, then try switching again.',
   habits_must_not_be_empty:

--- a/frontend/src/features/Practice/components/CopyToStageDialog.tsx
+++ b/frontend/src/features/Practice/components/CopyToStageDialog.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  ink,
+  surface,
+  surfaceShadow,
+} from '@/design/tokens';
+import { stageLabel } from '@/features/Practice/utils/stageDisplayName';
+
+export interface CopyDialogText {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
+/**
+ * Pure copy for the confirm-and-copy dialog — a warm, declinable offer that
+ * names what will happen (make your own copy), why (the practice lives in
+ * another stage), what you get (your own version here), and the escape (the
+ * original stays put; Cancel backs out).
+ */
+export function copyDialogText(
+  name: string,
+  homeStage: number,
+  targetStage: number,
+): CopyDialogText {
+  return {
+    title: `Make your own copy of ${name}?`,
+    message: `This practice lives in ${stageLabel(homeStage)}. Making a copy gives you your own version in ${stageLabel(targetStage)} — the original stays right where it is.`,
+    confirmLabel: 'Make a copy',
+    cancelLabel: 'Cancel',
+  };
+}
+
+export interface CopyToStageDialogProps {
+  visible: boolean;
+  practiceName: string;
+  homeStage: number;
+  targetStage: number;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Declinable confirm-and-copy dialog shown when a user asks to use a practice
+ * in a stage other than its home stage.
+ *
+ * Mirrors the ``ConfirmDialog`` structure: ``visible`` drives the ``<Modal>``
+ * fade while the body is gated so nothing renders when hidden. Both controls
+ * are inert while ``busy`` so a slow copy can't be double-submitted and the
+ * escape can't fire mid-write.
+ */
+export const CopyToStageDialog = ({
+  visible,
+  practiceName,
+  homeStage,
+  targetStage,
+  busy,
+  onConfirm,
+  onCancel,
+}: CopyToStageDialogProps): React.JSX.Element => {
+  const text = copyDialogText(practiceName, homeStage, targetStage);
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      {visible && (
+        <View style={styles.overlay} testID="practice-copy-dialog">
+          <View style={styles.dialog}>
+            <Text style={styles.title}>{text.title}</Text>
+            <Text style={styles.message}>{text.message}</Text>
+            <View style={styles.actions}>
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel={text.cancelLabel}
+                accessibilityState={{ disabled: busy }}
+                onPress={busy ? undefined : onCancel}
+                style={styles.cancelButton}
+                testID="practice-copy-dialog-cancel"
+              >
+                <Text style={styles.cancelText}>{text.cancelLabel}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel={text.confirmLabel}
+                accessibilityState={{ disabled: busy }}
+                onPress={busy ? undefined : onConfirm}
+                style={[styles.confirmButton, busy && styles.confirmButtonBusy]}
+                testID="practice-copy-dialog-confirm"
+              >
+                <Text style={styles.confirmText}>{text.confirmLabel}</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      )}
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: SPACING.lg,
+    backgroundColor: colors.mystical.overlay,
+  },
+  dialog: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.lg,
+    gap: SPACING.sm,
+    ...surfaceShadow.card,
+  },
+  title: { fontSize: 16, fontWeight: '700', color: ink.primary },
+  message: { fontSize: 14, color: ink.soft, lineHeight: 20 },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: SPACING.sm,
+    marginTop: SPACING.sm,
+  },
+  cancelButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
+  },
+  cancelText: { color: ink.primary, fontWeight: '600', fontSize: 13 },
+  confirmButton: {
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    borderRadius: BORDER_RADIUS.sm,
+    backgroundColor: accent.primary,
+    borderColor: accent.primary,
+    borderWidth: 1,
+  },
+  confirmButtonBusy: { opacity: 0.5 },
+  confirmText: { color: accent.onPrimary, fontWeight: '700', fontSize: 13 },
+});
+
+export default CopyToStageDialog;

--- a/frontend/src/features/Practice/components/__tests__/CopyToStageDialog.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/CopyToStageDialog.test.tsx
@@ -1,0 +1,71 @@
+/* eslint-env jest */
+import { describe, it, expect, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import CopyToStageDialog, { copyDialogText } from '../CopyToStageDialog';
+
+const baseProps = {
+  visible: true,
+  practiceName: 'Forest grounding',
+  homeStage: 2,
+  targetStage: 4,
+  busy: false,
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+describe('copyDialogText', () => {
+  it('names the practice in the title', () => {
+    const text = copyDialogText('Forest grounding', 2, 4);
+    expect(text.title).toContain('Forest grounding');
+  });
+
+  it('names both the home and target stage in the message', () => {
+    const text = copyDialogText('Forest grounding', 2, 4);
+    expect(text.message).toContain('Purple');
+    expect(text.message).toContain('Blue');
+  });
+
+  it('supplies non-empty confirm and cancel labels', () => {
+    const text = copyDialogText('Forest grounding', 2, 4);
+    expect(text.confirmLabel.length).toBeGreaterThan(0);
+    expect(text.cancelLabel.length).toBeGreaterThan(0);
+  });
+});
+
+describe('CopyToStageDialog', () => {
+  it('renders the dialog body with the practice name and both stage names when visible', () => {
+    const { getByTestId, getByText } = render(<CopyToStageDialog {...baseProps} />);
+    expect(getByTestId('practice-copy-dialog')).toBeTruthy();
+    expect(getByText(/Forest grounding/)).toBeTruthy();
+    expect(getByText(/Purple/)).toBeTruthy();
+    expect(getByText(/Blue/)).toBeTruthy();
+  });
+
+  it('renders nothing when not visible', () => {
+    const { queryByTestId } = render(<CopyToStageDialog {...baseProps} visible={false} />);
+    expect(queryByTestId('practice-copy-dialog')).toBeNull();
+  });
+
+  it('fires onConfirm exactly once when the confirm control is pressed', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(<CopyToStageDialog {...baseProps} onConfirm={onConfirm} />);
+    fireEvent.press(getByTestId('practice-copy-dialog-confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onCancel exactly once when the cancel control is pressed', () => {
+    const onCancel = jest.fn();
+    const { getByTestId } = render(<CopyToStageDialog {...baseProps} onCancel={onCancel} />);
+    fireEvent.press(getByTestId('practice-copy-dialog-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onConfirm when busy', () => {
+    const onConfirm = jest.fn();
+    const { getByTestId } = render(<CopyToStageDialog {...baseProps} busy onConfirm={onConfirm} />);
+    fireEvent.press(getByTestId('practice-copy-dialog-confirm'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -46,6 +46,7 @@ import {
   surfaceShadow,
   touchTarget,
 } from '@/design/tokens';
+import CopyToStageDialog from '@/features/Practice/components/CopyToStageDialog';
 import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import {
   MODE_CATEGORIES,
@@ -55,6 +56,7 @@ import {
 import StageSelector from '@/features/Practice/components/StageSelector';
 import { MIN_STAGE } from '@/features/Practice/constants';
 import { useRecentPractices } from '@/features/Practice/hooks/useRecentPractices';
+import { copyPracticeToStage } from '@/features/Practice/utils/copyPracticeToStage';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import type { RecentPractice } from '@/storage/recentPracticesStorage';
@@ -85,9 +87,25 @@ interface CatalogState {
  * before the user picks a chip; pass ``initialStage`` to align with the
  * user's current stage when this screen is the catalog tab.
  */
-export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
-  // Destructure so the useCallback deps below are stable field refs, not the
-  // ``props`` object (a fresh ref each render that would defeat memoization).
+interface CatalogScreenModel {
+  stageNumber: number;
+  setStageNumber: (stage: number) => void;
+  modeCategory: string | null;
+  setModeCategory: (category: string | null) => void;
+  query: string;
+  setQuery: (query: string) => void;
+  state: CatalogState;
+  reload: () => void;
+  onDetail: (id: number) => void;
+  onCreate: () => void;
+  recents: readonly RecentPractice[];
+  catalogUse: CatalogUse;
+  sections: CatalogSection[];
+  renderItem: (info: { item: PracticeItem }) => React.JSX.Element;
+}
+
+/** Wires the catalog screen's filter state, data, navigation, and copy flow. */
+function useCatalogScreen(props: CatalogProps): CatalogScreenModel {
   const { initialStage, loadPractices, navigateToDetail, navigateToCreate, setActive } = props;
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const seededStage = useSeededStage(initialStage);
@@ -103,8 +121,51 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
   );
   const setActivePractice = useCatalogSetActive(stageNumber, navigation, setActive);
   const { recents, record } = useRecentPractices();
-  const onUse = useRecordedUse(setActivePractice, record);
-  const { sections, renderItem } = useCatalogList(state, query, modeCategory, onDetail, onUse);
+  const catalogUse = useCatalogUse(stageNumber, navigation, record, setActivePractice);
+  const { sections, renderItem } = useCatalogList(
+    state,
+    query,
+    modeCategory,
+    onDetail,
+    catalogUse.onUse,
+  );
+
+  return {
+    stageNumber,
+    setStageNumber,
+    modeCategory,
+    setModeCategory,
+    query,
+    setQuery,
+    state,
+    reload,
+    onDetail,
+    onCreate,
+    recents,
+    catalogUse,
+    sections,
+    renderItem,
+  };
+}
+
+/** The cross-stage confirm-and-copy dialog, rendered only while a copy is offered. */
+function CatalogCopyDialog({ use }: { use: CatalogUse }): React.JSX.Element | null {
+  if (use.copyState === null) return null;
+  return (
+    <CopyToStageDialog
+      visible
+      practiceName={use.copyState.practice.name}
+      homeStage={use.copyState.practice.stage_number}
+      targetStage={use.copyState.targetStage}
+      busy={use.busy}
+      onConfirm={use.confirmCopy}
+      onCancel={use.cancelCopy}
+    />
+  );
+}
+
+export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Element {
+  const s = useCatalogScreen(props);
   const insets = useSafeAreaInsets();
   const containerStyle = [styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }];
 
@@ -112,45 +173,102 @@ export function PracticeCatalogScreen(props: CatalogProps = {}): React.JSX.Eleme
     <View style={containerStyle} testID="practice-catalog-safe-area">
       <SectionList<PracticeItem, CatalogSection>
         testID="practice-catalog-screen"
-        sections={state.loading || state.error !== null ? [] : sections}
+        sections={s.state.loading || s.state.error !== null ? [] : s.sections}
         keyExtractor={catalogKeyExtractor}
-        renderItem={renderItem}
+        renderItem={s.renderItem}
         renderSectionHeader={renderSectionHeader}
-        renderSectionFooter={makeSectionFooter(onCreate, sections)}
+        renderSectionFooter={makeSectionFooter(s.onCreate, s.sections)}
         ListHeaderComponent={
           <CatalogHeader
-            query={query}
-            onQueryChange={setQuery}
-            stageNumber={stageNumber}
-            onStage={setStageNumber}
-            modeCategory={modeCategory}
-            onMode={setModeCategory}
-            onCreate={onCreate}
-            recents={recents}
-            onDetail={onDetail}
+            query={s.query}
+            onQueryChange={s.setQuery}
+            stageNumber={s.stageNumber}
+            onStage={s.setStageNumber}
+            modeCategory={s.modeCategory}
+            onMode={s.setModeCategory}
+            onCreate={s.onCreate}
+            recents={s.recents}
+            onDetail={s.onDetail}
           />
         }
-        ListFooterComponent={<CatalogStatus state={state} onRetry={reload} />}
+        ListFooterComponent={<CatalogStatus state={s.state} onRetry={s.reload} />}
         contentContainerStyle={styles.body}
         keyboardShouldPersistTaps="handled"
         stickySectionHeadersEnabled={false}
       />
+      <CatalogCopyDialog use={s.catalogUse} />
     </View>
   );
 }
 
-/** "Use this practice" — snapshot it into the recents list, then set it active. */
-function useRecordedUse(
-  setActivePractice: (id: number) => void,
+interface CopyDialogState {
+  practice: PracticeItem;
+  targetStage: number;
+}
+
+interface CatalogUse {
+  onUse: (practice: PracticeItem) => void;
+  copyState: CopyDialogState | null;
+  busy: boolean;
+  confirmCopy: () => void;
+  cancelCopy: () => void;
+}
+
+/** Create the copy draft, record it, and return to the Practice screen; an
+ * error keeps the user in place behind an alert. */
+async function runCatalogCopy(
+  active: CopyDialogState,
   record: (_entry: RecentPractice) => void,
-): (practice: PracticeItem) => void {
-  return useCallback(
+  navigation: NativeStackNavigationProp<RootStackParamList>,
+): Promise<void> {
+  try {
+    const draft = await copyPracticeToStage(active.practice, active.targetStage);
+    record(toRecentPractice(draft));
+    navigation.goBack();
+  } catch (err) {
+    Alert.alert('Could not set practice', formatApiError(err, { fallback: 'Try again.' }));
+  }
+}
+
+/**
+ * One-tap "Use" for a catalog row. When the row's home stage matches the stage
+ * being browsed, it snapshots into recents and assigns directly (today's
+ * behaviour). When the stages differ, it opens a declinable confirm-and-copy
+ * dialog: confirming creates a user-owned copy at the browsing stage.
+ */
+function useCatalogUse(
+  stageNumber: number,
+  navigation: NativeStackNavigationProp<RootStackParamList>,
+  record: (_entry: RecentPractice) => void,
+  setActivePractice: (id: number) => void,
+): CatalogUse {
+  const [copyState, setCopyState] = useState<CopyDialogState | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const onUse = useCallback(
     (practice: PracticeItem) => {
-      record(toRecentPractice(practice));
-      setActivePractice(practice.id);
+      if (practice.stage_number === stageNumber) {
+        record(toRecentPractice(practice));
+        setActivePractice(practice.id);
+        return;
+      }
+      setCopyState({ practice, targetStage: stageNumber });
     },
-    [record, setActivePractice],
+    [stageNumber, record, setActivePractice],
   );
+
+  const cancelCopy = useCallback(() => setCopyState(null), []);
+
+  const confirmCopy = useCallback(() => {
+    if (copyState === null || busy) return;
+    setBusy(true);
+    void runCatalogCopy(copyState, record, navigation).finally(() => {
+      setBusy(false);
+      setCopyState(null);
+    });
+  }, [copyState, busy, record, navigation]);
+
+  return { onUse, copyState, busy, confirmCopy, cancelCopy };
 }
 
 /** Snapshot a catalog item into the persisted recent-practice shape. */

--- a/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeDetailScreen.tsx
@@ -27,12 +27,15 @@ import {
   surface,
   surfaceShadow,
 } from '@/design/tokens';
+import CopyToStageDialog from '@/features/Practice/components/CopyToStageDialog';
 import { LoadErrorRetry, LoadingBlock } from '@/features/Practice/components/LoadErrorRetry';
 import { resolvePickableMode } from '@/features/Practice/components/ModePicker';
 import ShareSheet from '@/features/Practice/components/ShareSheet';
 import StageSelector from '@/features/Practice/components/StageSelector';
+import { copyPracticeToStage } from '@/features/Practice/utils/copyPracticeToStage';
 import { formatDuration } from '@/features/Practice/utils/formatDuration';
 import type { RootStackParamList } from '@/navigation/RootStack';
+import { programStage, useProgramStore } from '@/store/useProgramStore';
 
 export type PracticeDetailScreenProps = NativeStackScreenProps<
   RootStackParamList,
@@ -46,6 +49,8 @@ interface ScreenState {
   assigning: boolean;
   loading: boolean;
   pickerOpen: boolean;
+  // Target stage while the confirm-and-copy dialog is open; null when closed.
+  copyTarget: number | null;
 }
 
 function initialState(actionError: string | null): ScreenState {
@@ -56,16 +61,73 @@ function initialState(actionError: string | null): ScreenState {
     assigning: false,
     loading: true,
     pickerOpen: false,
+    copyTarget: null,
   };
 }
 
 /**
- * Top-level screen — fetches a single practice and exposes the action row.
- *
- * "Use for stage" opens a 1-10 stage picker that writes via
- * ``userPractices.create``; "Customize a copy" replays the wizard with
- * this practice's mode_config pre-filled.
+ * Which "use this practice" path applies: the picker when the current stage is
+ * unknown, a direct assign when it matches the practice's home stage, or a
+ * confirm-and-copy when it differs.
  */
+export function resolveUseAction(
+  currentStage: number | null,
+  homeStage: number,
+): 'picker' | 'assign' | 'copy' {
+  if (currentStage === null) return 'picker';
+  return currentStage === homeStage ? 'assign' : 'copy';
+}
+
+/** Routes the "use for current stage" and picker taps to assign vs copy. */
+function useDetailUseHandlers(
+  state: PracticeDetailHook,
+  practice: PracticeItem,
+): { onUseForCurrentStage: () => void; onPickStage: (stage: number) => void } {
+  const anchor = useProgramStore((s) => s.programStartDate);
+  const currentStage = programStage(anchor);
+  const onUseForCurrentStage = (): void => {
+    if (currentStage === null) {
+      state.openPicker();
+      return;
+    }
+    if (resolveUseAction(currentStage, practice.stage_number) === 'assign') {
+      void state.assign(currentStage);
+      return;
+    }
+    state.openCopy(currentStage);
+  };
+  const onPickStage = (stage: number): void => {
+    if (stage === practice.stage_number) {
+      void state.assign(stage);
+      return;
+    }
+    // ``openCopy`` also closes the picker, so one dispatch covers both.
+    state.openCopy(stage);
+  };
+  return { onUseForCurrentStage, onPickStage };
+}
+
+/** The cross-stage confirm-and-copy dialog for the detail screen. */
+function DetailCopyDialog({
+  state,
+  practice,
+}: {
+  state: PracticeDetailHook;
+  practice: PracticeItem;
+}): React.JSX.Element {
+  return (
+    <CopyToStageDialog
+      visible={state.copyTarget !== null}
+      practiceName={practice.name}
+      homeStage={practice.stage_number}
+      targetStage={state.copyTarget ?? practice.stage_number}
+      busy={state.assigning}
+      onConfirm={() => void state.confirmCopy()}
+      onCancel={state.cancelCopy}
+    />
+  );
+}
+
 /** The loaded detail view (practice guaranteed non-null); owns the share sheet. */
 function LoadedDetail({
   props,
@@ -77,6 +139,8 @@ function LoadedDetail({
   practice: PracticeItem;
 }): React.JSX.Element {
   const [shareOpen, setShareOpen] = useState(false);
+  const { onUseForCurrentStage, onPickStage } = useDetailUseHandlers(state, practice);
+
   return (
     <ScreenScaffold scroll style={styles.scaffold} testID="practice-detail-screen">
       <DetailHeader practice={practice} />
@@ -88,23 +152,15 @@ function LoadedDetail({
       )}
       <ActionRow
         practice={practice}
-        // A practice is catalogued for exactly one stage and the backend
-        // rejects assigning it anywhere else (BUG-PRACTICE-004), so the
-        // one-tap path targets the practice's own stage rather than the
-        // store's ``currentStage`` (which is derived differently from the
-        // stage the catalog filtered by and could mismatch -> silent 400).
-        onUseForCurrentStage={() => void state.assign(practice.stage_number)}
+        onUseForCurrentStage={onUseForCurrentStage}
         onUseForStage={state.openPicker}
         onCustomizeCopy={() => navigateToCopy(props, practice)}
         onShare={() => setShareOpen(true)}
       />
       {state.pickerOpen && (
-        <StagePicker
-          assigning={state.assigning}
-          onPick={state.assign}
-          onClose={state.closePicker}
-        />
+        <StagePicker assigning={state.assigning} onPick={onPickStage} onClose={state.closePicker} />
       )}
+      <DetailCopyDialog state={state} practice={practice} />
       <ShareSheet
         visible={shareOpen}
         practiceId={practice.id}
@@ -160,10 +216,14 @@ interface PracticeDetailHook {
   assigning: boolean;
   loading: boolean;
   pickerOpen: boolean;
+  copyTarget: number | null;
   reload: () => void;
   openPicker: () => void;
   closePicker: () => void;
   assign: (stageNumber: number) => Promise<void>;
+  openCopy: (targetStage: number) => void;
+  cancelCopy: () => void;
+  confirmCopy: () => Promise<void>;
 }
 
 const withAssignError = (prev: ScreenState, err: unknown): ScreenState => ({
@@ -171,6 +231,47 @@ const withAssignError = (prev: ScreenState, err: unknown): ScreenState => ({
   assigning: false,
   actionError: formatApiError(err, { fallback: 'Could not assign practice.' }),
 });
+
+/** Confirm-and-copy callbacks for the cross-stage dialog. */
+function useCopyFlow(
+  state: ScreenState,
+  setState: React.Dispatch<React.SetStateAction<ScreenState>>,
+  onAssigned?: () => void,
+): {
+  openCopy: (targetStage: number) => void;
+  cancelCopy: () => void;
+  confirmCopy: () => Promise<void>;
+} {
+  const openCopy = useCallback(
+    (targetStage: number) =>
+      setState((prev) => ({
+        ...prev,
+        copyTarget: targetStage,
+        pickerOpen: false,
+        actionError: null,
+      })),
+    [setState],
+  );
+  const cancelCopy = useCallback(
+    () => setState((prev) => ({ ...prev, copyTarget: null })),
+    [setState],
+  );
+  const confirmCopy = useCallback(async () => {
+    const target = state.copyTarget;
+    const source = state.practice;
+    if (target === null || source === null) return;
+    setState((prev) => ({ ...prev, assigning: true, actionError: null }));
+    try {
+      await copyPracticeToStage(source, target);
+      setState((prev) => ({ ...prev, assigning: false, copyTarget: null }));
+      onAssigned?.();
+    } catch (err) {
+      // No rollback: an orphaned draft may remain, so surface the error and stay.
+      setState((prev) => ({ ...withAssignError(prev, err), copyTarget: null }));
+    }
+  }, [state.copyTarget, state.practice, setState, onAssigned]);
+  return { openCopy, cancelCopy, confirmCopy };
+}
 
 function usePracticeDetail(
   practiceId: number,
@@ -222,7 +323,9 @@ function usePracticeDetail(
     [practiceId, onAssigned],
   );
 
-  return { ...state, reload, openPicker, closePicker, assign };
+  const { openCopy, cancelCopy, confirmCopy } = useCopyFlow(state, setState, onAssigned);
+
+  return { ...state, reload, openPicker, closePicker, assign, openCopy, cancelCopy, confirmCopy };
 }
 
 function navigateToCopy(props: PracticeDetailScreenProps, practice: PracticeItem) {

--- a/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeCatalogScreen.test.tsx
@@ -5,7 +5,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Alert, StyleSheet } from 'react-native';
 
-import type { PracticeItem } from '@/api';
+import type { PracticeItem, UserPractice } from '@/api';
 import { surface } from '@/design/tokens';
 
 // Async practice load settling is marginal against Jest's 5s default under CI parallel-worker contention; give this suite headroom.
@@ -89,11 +89,23 @@ const mockRoute: { params?: { stageNumber?: number } } = { params: undefined };
 const mockPracticesList = jest.fn() as jest.MockedFunction<
   (opts: { stageNumber: number; includeMine?: boolean }) => Promise<PracticeItem[]>
 >;
+const mockPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: Record<string, unknown>) => Promise<PracticeItem>
+>;
+const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
+>;
 
 jest.mock('@/api', () => ({
   practices: {
     listAll: (...args: unknown[]) =>
       (mockPracticesList as unknown as (...a: unknown[]) => Promise<PracticeItem[]>)(...args),
+    create: (...args: unknown[]) =>
+      (mockPracticesCreate as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+  },
+  userPractices: {
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
   },
 }));
 
@@ -298,10 +310,10 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
       (id: number, stage: number) => Promise<void>
     >;
     mockPracticesList.mockResolvedValueOnce([presetA]);
-    const view = render(<PracticeCatalogScreen initialStage={2} setActive={setActive} />);
+    const view = render(<PracticeCatalogScreen initialStage={1} setActive={setActive} />);
     await waitForLoad();
     fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
-    expect(setActive).toHaveBeenCalledWith(1, 2);
+    expect(setActive).toHaveBeenCalledWith(1, 1);
     await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1));
   });
 
@@ -311,7 +323,7 @@ describe('PracticeCatalogScreen — defaults wiring', () => {
       throw new Error('boom');
     }) as jest.MockedFunction<(id: number, stage: number) => Promise<void>>;
     mockPracticesList.mockResolvedValueOnce([presetA]);
-    const view = render(<PracticeCatalogScreen initialStage={2} setActive={setActive} />);
+    const view = render(<PracticeCatalogScreen initialStage={1} setActive={setActive} />);
     await waitForLoad();
     fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
     await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(1));
@@ -549,5 +561,82 @@ describe('PracticeCatalogScreen — footer suppression', () => {
     expect(flat.backgroundColor).not.toBe(surface.canvas);
     // Must positively declare itself as non-expanding.
     expect(flat.flex).toBe(0);
+  });
+});
+
+describe('PracticeCatalogScreen — cross-stage copy', () => {
+  beforeEach(() => {
+    mockPracticesList.mockReset();
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+    mockNavigation.navigate.mockReset();
+    mockNavigation.goBack.mockReset();
+    mockRoute.params = undefined;
+  });
+
+  it('shows the copy dialog with no API calls when the row differs from the browsing stage', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={6} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    expect(view.getByTestId('practice-copy-dialog')).toBeTruthy();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('confirming the copy dialog creates a draft at the browsing stage, assigns it, records it, and goes back', async () => {
+    const createdDraft: PracticeItem = { ...presetA, id: 501, stage_number: 6, approved: false };
+    const assignedCopy: UserPractice = {
+      id: 1,
+      user_id: 9,
+      practice_id: 501,
+      stage_number: 6,
+      start_date: '2026-07-15',
+      end_date: null,
+    };
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedCopy);
+    const view = render(<PracticeCatalogScreen initialStage={6} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-copy-dialog-confirm'));
+      await flushPromises();
+    });
+    expect(mockPracticesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ stage_number: 6, name: presetA.name }),
+    );
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 501, stage_number: 6 });
+    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1));
+    const raw = await AsyncStorage.getItem('@adepthood/recent_practices');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)[0].id).toBe(501);
+  });
+
+  it('cancelling the copy dialog makes zero API calls and stays put', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={6} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    fireEvent.press(view.getByTestId('practice-copy-dialog-cancel'));
+    expect(view.queryByTestId('practice-copy-dialog')).toBeNull();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    expect(mockNavigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('keeps the direct same-stage Use behavior when the row matches the browsing stage', async () => {
+    mockPracticesList.mockResolvedValueOnce([presetA]);
+    const view = render(<PracticeCatalogScreen initialStage={1} />);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-catalog-row-1-use'));
+    expect(view.queryByTestId('practice-copy-dialog')).toBeNull();
+    await waitFor(() =>
+      expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 1, stage_number: 1 }),
+    );
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockNavigation.goBack).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
+++ b/frontend/src/features/Practice/screens/__tests__/PracticeDetailScreen.test.tsx
@@ -1,9 +1,10 @@
 /* eslint-env jest */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { act, fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 
 import type { PracticeItem, UserPractice } from '@/api';
+import { useProgramStore } from '@/store/useProgramStore';
 
 const samplePractice: PracticeItem = {
   id: 77,
@@ -33,7 +34,27 @@ const assignedUserPractice: UserPractice = {
   end_date: null,
 };
 
+const copiedDraft: PracticeItem = {
+  ...samplePractice,
+  id: 501,
+  stage_number: 6,
+  approved: false,
+  submitted_by_user_id: 9,
+};
+
+const copiedAssignment: UserPractice = {
+  id: 2,
+  user_id: 9,
+  practice_id: 501,
+  stage_number: 6,
+  start_date: '2026-07-15',
+  end_date: null,
+};
+
 const mockPracticesGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<PracticeItem>>;
+const mockPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: Record<string, unknown>) => Promise<PracticeItem>
+>;
 const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
   (payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
 >;
@@ -42,6 +63,8 @@ jest.mock('@/api', () => ({
   practices: {
     get: (...args: unknown[]) =>
       (mockPracticesGet as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+    create: (...args: unknown[]) =>
+      (mockPracticesCreate as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
   },
   userPractices: {
     create: (...args: unknown[]) =>
@@ -98,6 +121,20 @@ async function waitForLoad() {
   });
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+// STAGE_DURATIONS_DAYS is 21 days per stage through stage 8; these offsets land
+// mid-stage-4 (the practice's home stage) and mid-stage-6 (a different stage).
+const HOME_STAGE_DAYS_AGO = 70;
+const OTHER_STAGE_DAYS_AGO = 110;
+
+function setAnchorDaysAgo(days: number): void {
+  useProgramStore.getState().hydrateProgramStartDate(new Date(Date.now() - days * DAY_MS));
+}
+
+afterEach(() => {
+  useProgramStore.getState().hydrateProgramStartDate(null);
+});
+
 describe('PracticeDetailScreen — read-only summary', () => {
   beforeEach(() => {
     mockPracticesGet.mockReset();
@@ -139,10 +176,13 @@ describe('PracticeDetailScreen — read-only summary', () => {
 describe('PracticeDetailScreen — Use for stage', () => {
   beforeEach(() => {
     mockPracticesGet.mockReset();
+    mockPracticesCreate.mockReset();
     mockUserPracticesCreate.mockReset();
+    useProgramStore.getState().hydrateProgramStartDate(null);
   });
 
-  it("uses the practice's own stage in one tap and returns to the Practice screen", async () => {
+  it("calls userPractices.create directly for the current stage when it matches the practice's home stage", async () => {
+    setAnchorDaysAgo(HOME_STAGE_DAYS_AGO);
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
     const nav = makeNav();
@@ -152,10 +192,9 @@ describe('PracticeDetailScreen — Use for stage', () => {
       fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
       await flushPromises();
     });
-    // The practice is catalogued for stage 4, so the one-tap path targets that
-    // stage (the backend rejects any other) rather than the store's current
-    // stage. No picker is opened, and the screen pops back to Practice.
     expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 77, stage_number: 4 });
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(view.queryByTestId('practice-copy-dialog')).toBeNull();
     expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
     expect(nav.popToTop).toHaveBeenCalledTimes(1);
   });
@@ -180,6 +219,7 @@ describe('PracticeDetailScreen — Use for stage', () => {
   });
 
   it('does not render a write-only success banner on assign success', async () => {
+    setAnchorDaysAgo(HOME_STAGE_DAYS_AGO);
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
     mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
     const nav = makeNav();
@@ -203,19 +243,108 @@ describe('PracticeDetailScreen — Use for stage', () => {
     expect(view.getByTestId('share-sheet')).toBeTruthy();
   });
 
-  it('surfaces an action error and stays put if assignment fails', async () => {
+  it('closes the stage picker without writing when Cancel is tapped', async () => {
     mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
+    fireEvent.press(view.getByTestId('practice-detail-stage-pick-cancel'));
+    expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PracticeDetailScreen — cross-stage copy', () => {
+  beforeEach(() => {
+    mockPracticesGet.mockReset();
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+    useProgramStore.getState().hydrateProgramStartDate(null);
+  });
+
+  it('shows the copy dialog instead of assigning when the current stage differs from the home stage', async () => {
+    setAnchorDaysAgo(OTHER_STAGE_DAYS_AGO);
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+    expect(view.getByTestId('practice-copy-dialog')).toBeTruthy();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    expect(nav.popToTop).not.toHaveBeenCalled();
+  });
+
+  it('confirming the copy dialog creates a draft at the target stage, assigns it, and returns', async () => {
+    setAnchorDaysAgo(OTHER_STAGE_DAYS_AGO);
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockPracticesCreate.mockResolvedValueOnce(copiedDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(copiedAssignment);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+    await act(async () => {
+      fireEvent.press(view.getByTestId('practice-copy-dialog-confirm'));
+      await flushPromises();
+    });
+    expect(mockPracticesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ stage_number: 6, name: 'Forest grounding' }),
+    );
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 501, stage_number: 6 });
+    expect(nav.popToTop).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelling the copy dialog makes zero API calls and leaves the screen in place', async () => {
+    setAnchorDaysAgo(OTHER_STAGE_DAYS_AGO);
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const nav = makeNav();
+    const { view } = renderScreen(77, nav);
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+    fireEvent.press(view.getByTestId('practice-copy-dialog-cancel'));
+    expect(view.queryByTestId('practice-copy-dialog')).toBeNull();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    expect(nav.popToTop).not.toHaveBeenCalled();
+  });
+
+  it('opens the stage picker instead of assigning when there is no program anchor', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
+    expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+  });
+
+  it('shows the copy dialog when a picker selection differs from the home stage', async () => {
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    const { view } = renderScreen();
+    await waitForLoad();
+    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    fireEvent.press(view.getByTestId('practice-detail-stage-pick-6'));
+    expect(view.getByTestId('practice-copy-dialog')).toBeTruthy();
+    expect(mockPracticesCreate).not.toHaveBeenCalled();
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an action error without navigating away when the assign step fails after a successful copy', async () => {
+    setAnchorDaysAgo(OTHER_STAGE_DAYS_AGO);
+    mockPracticesGet.mockResolvedValueOnce(samplePractice);
+    mockPracticesCreate.mockResolvedValueOnce(copiedDraft);
     mockUserPracticesCreate.mockRejectedValueOnce(new Error('nope'));
     const nav = makeNav();
     const { view } = renderScreen(77, nav);
     await waitForLoad();
-    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
+    fireEvent.press(view.getByTestId('practice-detail-use-current-stage'));
     await act(async () => {
-      fireEvent.press(view.getByTestId('practice-detail-stage-pick-2'));
+      fireEvent.press(view.getByTestId('practice-copy-dialog-confirm'));
       await flushPromises();
     });
     expect(view.getByTestId('practice-detail-action-error')).toBeTruthy();
-    // A failed assignment must not navigate away — the user stays to see the error.
     expect(nav.popToTop).not.toHaveBeenCalled();
   });
 });
@@ -255,19 +384,6 @@ describe('PracticeDetailScreen — Duplicate & edit', () => {
     expect(button.props.accessibilityState?.disabled).toBe(true);
     fireEvent.press(button);
     expect(nav.navigate).not.toHaveBeenCalled();
-  });
-});
-
-describe('PracticeDetailScreen — stage picker cancel', () => {
-  it('closes the stage picker without writing when Cancel is tapped', async () => {
-    mockPracticesGet.mockResolvedValueOnce(samplePractice);
-    const { view } = renderScreen();
-    await waitForLoad();
-    fireEvent.press(view.getByTestId('practice-detail-use-for-stage'));
-    expect(view.getByTestId('practice-detail-stage-picker')).toBeTruthy();
-    fireEvent.press(view.getByTestId('practice-detail-stage-pick-cancel'));
-    expect(view.queryByTestId('practice-detail-stage-picker')).toBeNull();
-    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/features/Practice/utils/__tests__/copyPracticeToStage.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/copyPracticeToStage.test.ts
@@ -1,0 +1,133 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import type { PracticeItem, UserPractice } from '@/api';
+
+const practiceWithMode: PracticeItem = {
+  id: 5,
+  stage_number: 2,
+  name: 'Steady breath',
+  description: 'A short reset.',
+  instructions: 'Breathe in for four, out for six.',
+  default_duration_minutes: 5,
+  submitted_by_user_id: null,
+  approved: true,
+  mode: 'meditation_timer',
+  mode_config: { mode: 'meditation_timer', duration_minutes: 5 },
+};
+
+const createdDraft: PracticeItem = {
+  ...practiceWithMode,
+  id: 501,
+  stage_number: 6,
+  approved: false,
+  submitted_by_user_id: 9,
+};
+
+const assignedUserPractice: UserPractice = {
+  id: 1,
+  user_id: 9,
+  practice_id: 501,
+  stage_number: 6,
+  start_date: '2026-07-15',
+  end_date: null,
+};
+
+const mockPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: Record<string, unknown>) => Promise<PracticeItem>
+>;
+const mockUserPracticesCreate = jest.fn() as jest.MockedFunction<
+  (payload: { practice_id: number; stage_number: number }) => Promise<UserPractice>
+>;
+
+jest.mock('@/api', () => ({
+  practices: {
+    create: (...args: unknown[]) =>
+      (mockPracticesCreate as unknown as (...a: unknown[]) => Promise<PracticeItem>)(...args),
+  },
+  userPractices: {
+    create: (...args: unknown[]) =>
+      (mockUserPracticesCreate as unknown as (...a: unknown[]) => Promise<UserPractice>)(...args),
+  },
+}));
+
+const { copyPracticeToStage } = require('../copyPracticeToStage');
+
+describe('copyPracticeToStage', () => {
+  beforeEach(() => {
+    mockPracticesCreate.mockReset();
+    mockUserPracticesCreate.mockReset();
+  });
+
+  it('creates a draft copy at the target stage with the name unchanged', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    await copyPracticeToStage(practiceWithMode, 6);
+    expect(mockPracticesCreate).toHaveBeenCalledWith({
+      stage_number: 6,
+      name: 'Steady breath',
+      description: practiceWithMode.description,
+      instructions: practiceWithMode.instructions,
+      default_duration_minutes: practiceWithMode.default_duration_minutes,
+      mode: practiceWithMode.mode,
+      mode_config: practiceWithMode.mode_config,
+    });
+    const [payload] = mockPracticesCreate.mock.calls[0] as [{ name: string }];
+    expect(payload.name).not.toContain('(copy)');
+  });
+
+  it('assigns the created draft at the target stage after creating it', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    await copyPracticeToStage(practiceWithMode, 6);
+    expect(mockUserPracticesCreate).toHaveBeenCalledWith({ practice_id: 501, stage_number: 6 });
+  });
+
+  it('awaits the create call before issuing the assign call', async () => {
+    const order: string[] = [];
+    mockPracticesCreate.mockImplementationOnce(async () => {
+      order.push('create');
+      return createdDraft;
+    });
+    mockUserPracticesCreate.mockImplementationOnce(async () => {
+      order.push('assign');
+      return assignedUserPractice;
+    });
+    await copyPracticeToStage(practiceWithMode, 6);
+    expect(order).toEqual(['create', 'assign']);
+  });
+
+  it('resolves with the created draft', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    const result = await copyPracticeToStage(practiceWithMode, 6);
+    expect(result).toBe(createdDraft);
+  });
+
+  it('never calls userPractices.create and rejects when practices.create rejects', async () => {
+    mockPracticesCreate.mockRejectedValueOnce(new Error('create failed'));
+    await expect(copyPracticeToStage(practiceWithMode, 6)).rejects.toThrow('create failed');
+    expect(mockUserPracticesCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects after create ran when userPractices.create rejects', async () => {
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockRejectedValueOnce(new Error('assign failed'));
+    await expect(copyPracticeToStage(practiceWithMode, 6)).rejects.toThrow('assign failed');
+    expect(mockPracticesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits mode and mode_config from the create payload when the source practice has neither', async () => {
+    const noModePractice: PracticeItem = {
+      ...practiceWithMode,
+      mode: undefined,
+      mode_config: undefined,
+    };
+    mockPracticesCreate.mockResolvedValueOnce(createdDraft);
+    mockUserPracticesCreate.mockResolvedValueOnce(assignedUserPractice);
+    await copyPracticeToStage(noModePractice, 6);
+    const [payload] = mockPracticesCreate.mock.calls[0] as [Record<string, unknown>];
+    expect('mode' in payload).toBe(false);
+    expect('mode_config' in payload).toBe(false);
+  });
+});

--- a/frontend/src/features/Practice/utils/__tests__/stageDisplayName.test.ts
+++ b/frontend/src/features/Practice/utils/__tests__/stageDisplayName.test.ts
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { stageDisplayName, stageLabel } from '../stageDisplayName';
+
+describe('stageDisplayName', () => {
+  it.each([
+    [1, 'Beige'],
+    [2, 'Purple'],
+    [4, 'Blue'],
+    [10, 'Clear Light'],
+  ])('resolves stage %i to %s', (stage, name) => {
+    expect(stageDisplayName(stage)).toBe(name);
+  });
+
+  it('falls back to "Stage {n}" for a stage below the known range', () => {
+    expect(stageDisplayName(0)).toBe('Stage 0');
+  });
+
+  it('falls back to "Stage {n}" for a stage above the known range', () => {
+    expect(stageDisplayName(99)).toBe('Stage 99');
+  });
+});
+
+describe('stageLabel', () => {
+  it('combines the stage name with its number', () => {
+    expect(stageLabel(2)).toBe('Purple (stage 2)');
+  });
+
+  it('combines a different stage name with its number', () => {
+    expect(stageLabel(4)).toBe('Blue (stage 4)');
+  });
+
+  it('falls back to the numeric name for an out-of-range stage', () => {
+    expect(stageLabel(99)).toBe('Stage 99 (stage 99)');
+  });
+});

--- a/frontend/src/features/Practice/utils/copyPracticeToStage.ts
+++ b/frontend/src/features/Practice/utils/copyPracticeToStage.ts
@@ -1,0 +1,43 @@
+import { type PracticeCreatePayload, type PracticeItem, practices, userPractices } from '@/api';
+
+/**
+ * Build the ``POST /practices/`` payload for a cross-stage copy.
+ *
+ * The name is carried over verbatim (no "(copy)" suffix — that decoration
+ * belongs to the "Duplicate & edit" flow, not this one). ``mode`` and
+ * ``mode_config`` are included only when the source defines them so the
+ * payload never carries ``undefined`` values the server would reject.
+ */
+function buildCopyPayload(practice: PracticeItem, targetStage: number): PracticeCreatePayload {
+  const payload: PracticeCreatePayload = {
+    stage_number: targetStage,
+    name: practice.name,
+    description: practice.description,
+    instructions: practice.instructions,
+    default_duration_minutes: practice.default_duration_minutes,
+  };
+  if (practice.mode !== undefined) payload.mode = practice.mode;
+  if (practice.mode_config !== undefined) payload.mode_config = practice.mode_config;
+  return payload;
+}
+
+/**
+ * Copy a practice into a user-owned draft at ``targetStage`` and assign it.
+ *
+ * Creates the draft (approved=false, owned by the caller), then assigns it as
+ * the active practice for the target stage, and resolves with the created
+ * draft so callers can record it (e.g. in recents).
+ *
+ * Partial-failure semantics: there is no rollback. If the create succeeds but
+ * the assign rejects, an orphaned owner draft is left behind in "My drafts"
+ * (harmless and user-recoverable). This function re-throws the rejection so the
+ * caller can surface the error and decline to navigate.
+ */
+export async function copyPracticeToStage(
+  practice: PracticeItem,
+  targetStage: number,
+): Promise<PracticeItem> {
+  const draft = await practices.create(buildCopyPayload(practice, targetStage));
+  await userPractices.create({ practice_id: draft.id, stage_number: targetStage });
+  return draft;
+}

--- a/frontend/src/features/Practice/utils/stageDisplayName.ts
+++ b/frontend/src/features/Practice/utils/stageDisplayName.ts
@@ -1,0 +1,17 @@
+import { STAGE_ORDER } from '@/design/tokens';
+
+/**
+ * Resolve a 1-based stage number to its Spiral-Dynamics color name (e.g. stage
+ * 2 -> "Purple"), falling back to ``Stage {n}`` when the number falls outside
+ * the ten named stages. The index guard also satisfies
+ * ``noUncheckedIndexedAccess`` (out-of-range reads are ``undefined``).
+ */
+export function stageDisplayName(n: number): string {
+  const name = STAGE_ORDER[n - 1];
+  return name ?? `Stage ${n}`;
+}
+
+/** Combine the stage's name with its number, e.g. ``Purple (stage 2)``. */
+export function stageLabel(n: number): string {
+  return `${stageDisplayName(n)} (stage ${n})`;
+}


### PR DESCRIPTION
## Summary

"Use for current stage" used to send the practice's catalog *home* stage
rather than the user's actual current stage — a deliberate workaround for the
one-stage-per-practice backend rule. The result was a silent write to the
wrong stage (the success banner is unreachable), and the alternative paths
(catalog one-tap "Use", the explicit stage picker) dead-ended on a 400
`stage_number_mismatch`.

This replaces that dead end with a warm, declinable **confirm-and-copy** flow:

- "Use for current stage" now targets the user's real current stage
  (`programStage` from the program store). When it matches the practice's home
  stage, it assigns directly as before.
- Any **cross-stage** assignment (home stage ≠ target) — from the detail
  button, the "Use for stage…" picker, or the catalog one-tap "Use" — opens a
  dialog: "Make your own copy of <name>? This practice lives in <home>. Making
  a copy gives you your own version in <target> — the original stays right
  where it is." Confirming creates a user-owned copy at the target stage and
  assigns it; **Cancel writes nothing**.
- The copy reuses the existing `POST /practices/` + `POST /user-practices/`
  flow (a user-owned draft whose home stage equals the target is immediately
  selectable) — **no backend change, no migration**.
- When there is no program anchor, the detail button falls back to the
  explicit stage picker instead of guessing a current stage.
- `stage_number_mismatch` copy now points at the copy flow instead of the old
  "open it from that stage" dead-end advice.

Both dialog controls are inert while a copy is in flight (no double-submit,
no escape mid-write). Copy uses the original name verbatim — no "(copy)"
suffix (that naming polish is #1620).

## Test plan

- New unit tests: `copyPracticeToStage` (create-then-assign ordering, verbatim
  name, mode/mode_config omission, both partial-failure paths), `stageDisplayName`,
  and `CopyToStageDialog` (copy text, confirm/cancel wiring, busy guard).
- Rewired screen tests: detail same-stage direct assign; cross-stage → dialog →
  confirm creates copy + assigns at the target then `popToTop`; cancel is a
  no-op; null program anchor → picker, no write; picker cross-stage → dialog;
  copy-ok/assign-fails → error banner, no navigation. Catalog: cross-stage →
  dialog → copy+assign, records the new draft in recents, `goBack`; same-stage
  unchanged.
- `./scripts/frontend/check-all.sh` green (4204 Jest tests, tsc, eslint,
  prettier). Frontend-only — backend untouched.

Closes #1619
Refs #1616