### PR TITLE
fix(backend): allow customizing your own unapproved draft practice

### DIFF
--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -52,7 +52,11 @@ router = APIRouter(prefix="/user-practices", tags=["user-practices"])
 
 
 async def _resolve_practice(session: AsyncSession, practice_id: int) -> Practice:
-    """Fetch and validate the catalog practice (exists + approved)."""
+    """Fetch and validate the catalog practice (exists + approved).
+
+    Backs the read/GET path only; the write paths use
+    :func:`_resolve_selectable_practice`.
+    """
     result = await session.execute(select(Practice).where(Practice.id == practice_id))
     practice = result.scalars().first()
     if practice is None:
@@ -65,15 +69,16 @@ async def _resolve_practice(session: AsyncSession, practice_id: int) -> Practice
 async def _resolve_selectable_practice(
     session: AsyncSession, practice_id: int, current_user: int
 ) -> Practice:
-    """Fetch a practice the caller is allowed to *select* for a stage.
+    """Fetch a practice the caller is allowed to *select* or customize.
 
-    Unlike :func:`_resolve_practice` (the read/customize path), this write
-    path permits an approved catalog practice **or** the caller's own draft:
-    ``practice.submitted_by_user_id == current_user`` clears an unapproved
-    row so an author can activate the practice they just submitted. A
-    non-owner selecting someone else's still-pending submission continues to
-    receive 400 ``practice_not_approved``; a missing row 404s exactly as the
-    read path does.
+    Both write paths (selection and customize) use this resolver, whereas
+    :func:`_resolve_practice` backs the read/GET path. Unlike that read
+    path, this one permits an approved catalog practice **or** the caller's
+    own draft: ``practice.submitted_by_user_id == current_user`` clears an
+    unapproved row so an author can activate or customize the practice they
+    just submitted. A non-owner selecting someone else's still-pending
+    submission continues to receive 400 ``practice_not_approved``; a missing
+    row 404s exactly as the read path does.
     """
     result = await session.execute(select(Practice).where(Practice.id == practice_id))
     practice = result.scalars().first()
@@ -675,7 +680,9 @@ async def customize_user_practice(
     400 ``mode_mismatch`` because mode changes are conceptually a
     practice replacement, not a tweak.
     """
-    practice = await _resolve_practice(session, user_practice.practice_id)
+    practice = await _resolve_selectable_practice(
+        session, user_practice.practice_id, user_practice.user_id
+    )
     fields_set = payload.model_fields_set
 
     if "mode_config_override" in fields_set:

--- a/backend/tests/test_user_practice_customization.py
+++ b/backend/tests/test_user_practice_customization.py
@@ -407,6 +407,66 @@ async def test_customize_strips_surrounding_whitespace_on_custom_name(
     assert resp.json()["effective_name"] == "My Sit"
 
 
+# -- Owner-drafted (unapproved) practices ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_customize_allows_owner_of_unapproved_draft(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Customizing your own unapproved draft practice must succeed."""
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(db_session, approved=False, submitted_by_user_id=user_id)
+    up_id = await _create_user_practice(async_client, db_session, headers, user_id, practice)
+
+    override = _timer_cfg(25)
+    resp = await async_client.patch(
+        f"/user-practices/{up_id}/customize",
+        json={"custom_name": "My Draft Sit", "mode_config_override": override},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+    assert body["custom_name"] == "My Draft Sit"
+    assert body["effective_name"] == "My Draft Sit"
+    assert body["effective_config"]["duration_minutes"] == 25
+
+    persisted = await db_session.get(UserPractice, up_id)
+    assert persisted is not None
+    await db_session.refresh(persisted)
+    assert persisted.custom_name == "My Draft Sit"
+    assert persisted.mode_config_override is not None
+    assert persisted.mode_config_override["duration_minutes"] == 25
+
+
+@pytest.mark.asyncio
+async def test_customize_rejects_foreign_unapproved_draft(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Regression pin: guards the owner-only carve-out on unapproved drafts."""
+    owner_headers, owner_id = await _signup(async_client, username="owner")
+    _, other_id = await _signup(async_client, username="other")
+    practice = await _seed_practice(db_session, approved=False, submitted_by_user_id=other_id)
+
+    user_practice = UserPractice(
+        user_id=owner_id,
+        practice_id=practice.id,
+        stage_number=practice.stage_number,
+        start_date=datetime.now(UTC).date(),
+    )
+    db_session.add(user_practice)
+    await db_session.commit()
+    await db_session.refresh(user_practice)
+
+    resp = await async_client.patch(
+        f"/user-practices/{user_practice.id}/customize",
+        json={"custom_name": "stolen draft"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "practice_not_approved" in resp.text
+
+
 # -- List endpoint coverage -------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
`PATCH /user-practices/{id}/customize` resolved the catalog practice with the
approved-only `_resolve_practice`, so renaming or changing the duration of a
selection backed by the caller's **own unapproved draft or copied** practice
returned 400 `practice_not_approved` — surfaced to the user as a confusing
"still pending review" message about *selecting*, on a *save*. Because copies
and share-imports are created with `approved=False` and drafts are never
auto-approved, there was no workaround: a user could select their copy but
could never rename it or adjust its duration. This directly degrades the
offer-to-copy flow that just shipped in #1640.

The fix switches the customize path to the approved-OR-owner
`_resolve_selectable_practice` — the same resolver the selection endpoint has
used since #931 — passing `user_practice.user_id`, which is the authenticated
caller by construction of the `require_owned_user_practice` route dependency
(it 403s any non-owner before the resolver runs). The carve-out is strictly
owner-scoped:

- another user's still-pending submission continues to 400 `practice_not_approved`;
- a null-submitter unapproved row still 400s (`None == <user_id>` is `False`);
- `submit_practice`'s `approved=False` posture and the approved-only public
  listing gate are untouched.

The two resolver docstrings were updated so they no longer describe
`_resolve_practice` as the customize path; both write paths (selection and
customize) now share `_resolve_selectable_practice`, while `_resolve_practice`
backs the read/GET path.

Out of scope (follow-up filed as #1642): the GET-one detail path
(`_resolve_effective_fields`) still uses the approved-only resolver and would
400 on an own-draft-backed selection; the new happy-path test deliberately
avoids a GET refetch so it doesn't mask that separate bug.

## Test plan
- `test_customize_allows_owner_of_unapproved_draft` — owner seeds a practice
  with `approved=False, submitted_by_user_id=<self>`, selects it via the real
  selection API, then PATCHes a rename + a `mode_config_override` (duration
  25). Asserts 200 and verifies persistence via both the response body and a
  direct ORM re-read of the `UserPractice` row. (RED before the fix: 400
  `practice_not_approved`.)
- `test_customize_rejects_foreign_unapproved_draft` — ORM-constructs a
  `UserPractice` the caller owns but whose catalog row is
  `approved=False, submitted_by_user_id=<other user>`; PATCH still 400s
  `practice_not_approved`. Regression pin for the owner-only carve-out.
- Full backend suite: 2632 passed, 2 skipped; coverage 96.64%
  (`scripts/backend/check-all.sh`). ruff, mypy, xenon (A), radon MI (A), and
  interrogate (100%) all clean.

Closes #1626
Refs #1642