### PR TITLE
feat(journal): guided quote-selection surface — instructions, live preview, honest confirm

### DIFF
--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -10,6 +10,7 @@ import { StyleSheet } from 'react-native';
 import {
   BORDER_RADIUS,
   SPACING,
+  accent,
   colors,
   editorialType,
   journalLayout,
@@ -18,6 +19,10 @@ import {
   spacing,
   touchTarget,
 } from '@/design/tokens';
+
+/** Warm left rule on the live quote preview, in dp — mirrors the reflection
+ *  panel's pending-quote stripe so both promote surfaces read as one language. */
+const PREVIEW_STRIPE_WIDTH = 3;
 
 /**
  * Bottom inset reserving room for the floating "Get Resonance" button so page
@@ -158,6 +163,32 @@ const styles = StyleSheet.create({
   quoteSelectActions: {
     flexDirection: 'row',
     gap: SPACING.md,
+    paddingTop: spacing(1),
+    alignItems: 'center',
+  },
+  /** Warm guiding line above the field: how to select a passage to promote. */
+  quoteSelectInstruction: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+    paddingBottom: spacing(1),
+  },
+  /** Highlighted card echoing the chosen passage back before it is promoted. */
+  quoteSelectPreview: {
+    backgroundColor: colors.paper.quoteHighlight,
+    borderRadius: BORDER_RADIUS.md,
+    borderLeftWidth: PREVIEW_STRIPE_WIDTH,
+    borderLeftColor: accent.primary,
+    padding: SPACING.md,
+    marginTop: spacing(1),
+  },
+  quoteSelectPreviewText: {
+    ...editorialType.note,
+    color: colors.paper.ink,
+  },
+  /** Warm (not alarming) nudge shown when confirm is tapped with no selection. */
+  quoteSelectHint: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
     paddingTop: spacing(1),
   },
   /** Privacy tier chooser block above the growing body. */

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -1180,14 +1180,11 @@ function useQuoteInteraction(
   const onSelectionChange = useCallback((span: CodePointSpan) => {
     selectionRef.current = span;
   }, []);
-  // A collapsed/empty selection (a caret tap, no highlighted span) can't be
-  // promoted — stay in selection mode rather than post a span the server would
-  // only reject. Otherwise leave selection mode first so a 422 returns the
-  // reader to their place in the read view; ``promote`` never throws (it maps
-  // failures to a hint).
+  // Leave selection mode first so a 422 returns the reader to their place in the
+  // read view; ``promote`` never throws (it maps failures to a hint). The surface
+  // only enables confirm for a non-empty span, so no empty-span guard is needed.
   const confirmSelection = useCallback(async () => {
     const { start, end } = selectionRef.current;
-    if (end <= start) return;
     setSelecting(false);
     await promote(start, end);
   }, [promote]);

--- a/frontend/src/features/Journal/QuoteSelectionSurface.tsx
+++ b/frontend/src/features/Journal/QuoteSelectionSurface.tsx
@@ -2,13 +2,18 @@
  * ``QuoteSelectionSurface`` — a controlled, effectively read-only serif field
  * that mirrors a body so the reader can select a passage to promote without
  * editing it (soft keyboard suppressed, caret hidden; ``editable`` stays true so
- * Android text selection still works). Shared by the read-mode promote flow on
+ * Android text selection still works). It guides the whole gesture in place: a
+ * warm instruction line, a live preview that echoes the raw selection back, and
+ * an honestly disabled "Promote selection" confirm that only lights up once a
+ * non-empty passage is chosen (an empty tap surfaces a gentle hint instead of
+ * silently promoting nothing). Shared by the read-mode promote flow on
  * ``JournalEntryScreen`` and the in-panel re-promotion flow in
  * ``ReflectionSourcesPanel``; ``testID`` prefixes every element so more than one
  * surface can coexist on a page.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
+  Pressable,
   Text,
   TextInput,
   TouchableOpacity,
@@ -19,6 +24,8 @@ import {
 
 import { utf16ToCodePoint } from './codePoints';
 import styles from './JournalEntry.styles';
+
+import { Button } from '@/components/Button';
 
 type SelectionChangeEvent = NativeSyntheticEvent<TextInputSelectionChangeEventData>;
 
@@ -32,8 +39,17 @@ export interface CodePointSpan {
   end: number;
 }
 
+/** The raw UTF-16 selection kept locally so the preview can slice ``body``. */
+interface Utf16Span {
+  start: number;
+  end: number;
+}
+
 /** Prefix for the surface's testIDs; the read-mode flow relies on this default. */
 const DEFAULT_TEST_ID = 'quote-select';
+
+const INSTRUCTION_COPY = 'Touch and hold a passage, then drag to choose it.';
+const EMPTY_HINT_COPY = 'Choose a passage first — touch and hold the text.';
 
 export interface QuoteSelectionSurfaceProps {
   body: string;
@@ -44,23 +60,138 @@ export interface QuoteSelectionSurfaceProps {
   testID?: string;
 }
 
+/** The derived view state the surface chrome renders from. */
+interface SelectionSurfaceState {
+  isEmpty: boolean;
+  previewSlice: string;
+  hintVisible: boolean;
+  handleSelectionChange: (_event: SelectionChangeEvent) => void;
+  showHint: () => void;
+}
+
 /**
- * Adapt the native UTF-16 selection event into a code-point span emitter — the
- * single conversion boundary, lifted out of the component so its body stays lean.
+ * Own the surface's selection and hint state in one place: hold the raw UTF-16
+ * span (so the preview can slice ``body`` verbatim), emit the code-point span at
+ * the single conversion boundary, and clear the empty-tap hint the moment a real
+ * passage is chosen.
  */
-function useCodePointSelection(
+function useSelectionSurfaceState(
   body: string,
   onSelectionChange: (_span: CodePointSpan) => void,
-): (_event: SelectionChangeEvent) => void {
-  return useCallback(
+): SelectionSurfaceState {
+  const [span, setSpan] = useState<Utf16Span>({ start: 0, end: 0 });
+  const [hintVisible, setHintVisible] = useState(false);
+
+  const handleSelectionChange = useCallback(
     (event: SelectionChangeEvent) => {
       const { start, end } = event.nativeEvent.selection;
+      setSpan({ start, end });
       onSelectionChange({
         start: utf16ToCodePoint(body, start),
         end: utf16ToCodePoint(body, end),
       });
+      if (end > start) {
+        setHintVisible(false);
+      }
     },
-    [body, onSelectionChange],
+    [body, onSelectionChange, setSpan, setHintVisible],
+  );
+
+  const showHint = useCallback(() => setHintVisible(true), [setHintVisible]);
+
+  // Gate emptiness on the code-point span the API actually receives (not the raw
+  // UTF-16 span), so the disabled confirm and the posted anchors agree at the
+  // same boundary the rest of this module is careful about. The preview still
+  // slices the raw UTF-16 span to echo exactly what the reader highlighted.
+  const codePointStart = utf16ToCodePoint(body, span.start);
+  const codePointEnd = utf16ToCodePoint(body, span.end);
+  const isEmpty = codePointEnd <= codePointStart;
+  return {
+    isEmpty,
+    previewSlice: isEmpty ? '' : body.slice(span.start, span.end),
+    hintVisible,
+    handleSelectionChange,
+    showHint,
+  };
+}
+
+interface SelectionBodyProps {
+  body: string;
+  onSelectionChange: (_event: SelectionChangeEvent) => void;
+  testID: string;
+}
+
+/**
+ * The read-only body field, isolated in ``React.memo`` behind a stable handler so
+ * preview/hint/confirm state changes re-render only the surrounding chrome, never
+ * the mirrored text.
+ */
+const SelectionBody = React.memo(function SelectionBody({
+  body,
+  onSelectionChange,
+  testID,
+}: SelectionBodyProps): React.JSX.Element {
+  return (
+    <TextInput
+      style={styles.bodyInput}
+      value={body}
+      multiline
+      editable
+      showSoftInputOnFocus={false}
+      caretHidden
+      scrollEnabled={false}
+      onSelectionChange={onSelectionChange}
+      accessibilityLabel="Select a passage to promote"
+      testID={`${testID}-input`}
+    />
+  );
+});
+
+interface SelectionActionsProps {
+  isEmpty: boolean;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+  showHint: () => void;
+  testID: string;
+}
+
+/**
+ * The confirm/cancel row. Exactly one of {guard, Button} is enabled, so an empty
+ * tap lands on the guard (a hint) and ``onConfirm`` never fires on an empty span.
+ */
+function SelectionActions({
+  isEmpty,
+  onConfirm,
+  onCancel,
+  showHint,
+  testID,
+}: SelectionActionsProps): React.JSX.Element {
+  return (
+    <View style={styles.quoteSelectActions}>
+      <Pressable
+        accessible={false}
+        disabled={!isEmpty}
+        onPress={showHint}
+        testID={`${testID}-confirm-guard`}
+      >
+        <Button
+          variant="primary"
+          label="Promote selection"
+          disabled={isEmpty}
+          onPress={() => void onConfirm()}
+          testID={`${testID}-confirm`}
+        />
+      </Pressable>
+      <TouchableOpacity
+        onPress={onCancel}
+        accessibilityRole="button"
+        accessibilityLabel="Cancel promoting"
+        style={styles.quoteActionButton}
+        testID={`${testID}-cancel`}
+      >
+        <Text style={styles.controlLink}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
   );
 }
 
@@ -71,42 +202,34 @@ function QuoteSelectionSurface({
   onCancel,
   testID = DEFAULT_TEST_ID,
 }: QuoteSelectionSurfaceProps): React.JSX.Element {
-  const handleSelectionChange = useCodePointSelection(body, onSelectionChange);
+  const { isEmpty, previewSlice, hintVisible, handleSelectionChange, showHint } =
+    useSelectionSurfaceState(body, onSelectionChange);
 
   return (
     <View>
-      <TextInput
-        style={styles.bodyInput}
-        value={body}
-        multiline
-        editable
-        showSoftInputOnFocus={false}
-        caretHidden
-        scrollEnabled={false}
-        onSelectionChange={handleSelectionChange}
-        accessibilityLabel="Select a passage to promote"
-        testID={`${testID}-input`}
+      <Text style={styles.quoteSelectInstruction} testID={`${testID}-instruction`}>
+        {INSTRUCTION_COPY}
+      </Text>
+      <SelectionBody body={body} onSelectionChange={handleSelectionChange} testID={testID} />
+      {!isEmpty && (
+        <View style={styles.quoteSelectPreview}>
+          <Text style={styles.quoteSelectPreviewText} testID={`${testID}-preview`}>
+            {previewSlice}
+          </Text>
+        </View>
+      )}
+      <SelectionActions
+        isEmpty={isEmpty}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        showHint={showHint}
+        testID={testID}
       />
-      <View style={styles.quoteSelectActions}>
-        <TouchableOpacity
-          onPress={() => void onConfirm()}
-          accessibilityRole="button"
-          accessibilityLabel="Promote the selected passage"
-          style={styles.quoteActionButton}
-          testID={`${testID}-confirm`}
-        >
-          <Text style={styles.controlLink}>Promote selection</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={onCancel}
-          accessibilityRole="button"
-          accessibilityLabel="Cancel promoting"
-          style={styles.quoteActionButton}
-          testID={`${testID}-cancel`}
-        >
-          <Text style={styles.controlLink}>Cancel</Text>
-        </TouchableOpacity>
-      </View>
+      {hintVisible && (
+        <Text style={styles.quoteSelectHint} testID={`${testID}-hint`}>
+          {EMPTY_HINT_COPY}
+        </Text>
+      )}
     </View>
   );
 }

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -327,7 +327,6 @@ function useRowSelection(onPromoteSpan?: PromoteSpanHandler): RowSelection {
   const confirmSelection = useCallback(
     async (item: ReflectionSourceItem, key: string): Promise<void> => {
       const { start, end } = selectionRef.current;
-      if (end <= start) return; // An empty selection promotes nothing; stay put.
       setSelectingKey(null);
       if (onPromoteSpan == null) return;
       const ok = await onPromoteSpan(item, { anchor_start: start, anchor_end: end });

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -151,15 +151,28 @@ describe('JournalEntryScreen -- promote-a-quote affordance', () => {
     expect(mockPromote).not.toHaveBeenCalled();
   });
 
-  it('confirming a collapsed selection promotes nothing and stays in selection mode', async () => {
+  it('entering selection mode renders the instruction line', async () => {
+    const { findByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    expect(await findByTestId('quote-select-instruction')).toBeTruthy();
+  });
+
+  it('a nonempty selection renders the live preview', async () => {
+    const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
+    fireEvent.press(await findByTestId('promote-quote-button'));
+    const input = getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 19 } } });
+    expect(await findByTestId('quote-select-preview')).toBeTruthy();
+  });
+
+  it('pressing the confirm guard on a collapsed selection shows a hint and promotes nothing', async () => {
     const { findByTestId, getByTestId } = renderScreen({ entryId: 7 });
     fireEvent.press(await findByTestId('promote-quote-button'));
     const input = getByTestId('quote-select-input');
     // A caret tap with no highlighted span reports start === end.
     fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 5, end: 5 } } });
-    await act(async () => {
-      fireEvent.press(getByTestId('quote-select-confirm'));
-    });
+    fireEvent.press(getByTestId('quote-select-confirm-guard'));
+    expect(await findByTestId('quote-select-hint')).toBeTruthy();
     expect(mockPromote).not.toHaveBeenCalled();
     expect(getByTestId('quote-select-input')).toBeTruthy(); // still selecting
   });

--- a/frontend/src/features/Journal/__tests__/QuoteSelectionSurface.test.tsx
+++ b/frontend/src/features/Journal/__tests__/QuoteSelectionSurface.test.tsx
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+// RED: `QuoteSelectionSurface` does not yet render an instruction line, a live
+// preview, a guarded "Promote selection" Button, or an empty-tap hint -- every
+// testID below is missing until the implementation-specialist adds them.
+import { jest, describe, it, expect } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import QuoteSelectionSurface from '../QuoteSelectionSurface';
+
+import { editorialType } from '@/design/tokens';
+
+const BODY = 'A steady daily walk to the river.';
+
+const INSTRUCTION_COPY = 'Touch and hold a passage, then drag to choose it.';
+const EMPTY_HINT_COPY = 'Choose a passage first — touch and hold the text.';
+
+type SurfaceProps = React.ComponentProps<typeof QuoteSelectionSurface>;
+
+function renderSurface(overrides: Partial<SurfaceProps> = {}) {
+  const onSelectionChange = jest.fn();
+  const onConfirm = jest.fn(() => Promise.resolve());
+  const onCancel = jest.fn();
+  const utils = render(
+    <QuoteSelectionSurface
+      body={BODY}
+      onSelectionChange={onSelectionChange}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onSelectionChange, onConfirm, onCancel };
+}
+
+describe('QuoteSelectionSurface -- instruction', () => {
+  it('renders the warm instruction line at note size, not caption size', () => {
+    const { getByTestId, getByText } = renderSurface();
+    expect(getByText(INSTRUCTION_COPY)).toBeTruthy();
+    const style = StyleSheet.flatten(getByTestId('quote-select-instruction').props.style);
+    expect(style.fontSize).toBe(editorialType.note.fontSize);
+  });
+});
+
+describe('QuoteSelectionSurface -- empty selection', () => {
+  it('has no preview and a disabled confirm that ignores a press', () => {
+    const { queryByTestId, getByTestId, onConfirm } = renderSurface();
+    expect(queryByTestId('quote-select-preview')).toBeNull();
+    const confirm = getByTestId('quote-select-confirm');
+    expect(confirm.props.accessibilityState.disabled).toBe(true);
+    fireEvent.press(confirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('pressing the confirm guard shows a hint and never confirms', () => {
+    const { getByTestId, onConfirm } = renderSurface();
+    fireEvent.press(getByTestId('quote-select-confirm-guard'));
+    expect(getByTestId('quote-select-hint').props.children).toBe(EMPTY_HINT_COPY);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('QuoteSelectionSurface -- nonempty ASCII selection', () => {
+  it('previews the raw slice, enables confirm, and reports the code-point span', async () => {
+    const { getByTestId, onSelectionChange, onConfirm } = renderSurface();
+    const input = getByTestId('quote-select-input');
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 8 } } });
+
+    expect(getByTestId('quote-select-preview').props.children).toBe(BODY.slice(2, 8));
+    expect(onSelectionChange).toHaveBeenCalledWith({ start: 2, end: 8 });
+    expect(getByTestId('quote-select-confirm').props.accessibilityState.disabled).toBeFalsy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('quote-select-confirm'));
+    });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('QuoteSelectionSurface -- non-BMP selection', () => {
+  const EMOJI_BODY = '\u{1F3B8} solo riff';
+
+  it('converts a leading-astral UTF-16 selection to code points and previews the raw slice', () => {
+    const { getByTestId, onSelectionChange } = renderSurface({ body: EMOJI_BODY });
+    const input = getByTestId('quote-select-input');
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 0, end: 2 } } });
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ start: 0, end: 1 });
+    expect(getByTestId('quote-select-preview').props.children).toBe(EMOJI_BODY.slice(0, 2));
+  });
+
+  it('converts a straddling UTF-16 span to code points and previews the raw slice', () => {
+    const { getByTestId, onSelectionChange } = renderSurface({ body: EMOJI_BODY });
+    const input = getByTestId('quote-select-input');
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 0, end: 7 } } });
+    expect(onSelectionChange).toHaveBeenLastCalledWith({ start: 0, end: 6 });
+    expect(getByTestId('quote-select-preview').props.children).toBe(EMOJI_BODY.slice(0, 7));
+  });
+});
+
+describe('QuoteSelectionSurface -- collapsing a selection', () => {
+  it('removes the preview and disables confirm again', () => {
+    const { getByTestId, queryByTestId } = renderSurface();
+    const input = getByTestId('quote-select-input');
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 8 } } });
+    expect(getByTestId('quote-select-preview')).toBeTruthy();
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 4, end: 4 } } });
+    expect(queryByTestId('quote-select-preview')).toBeNull();
+    expect(getByTestId('quote-select-confirm').props.accessibilityState.disabled).toBe(true);
+  });
+});
+
+describe('QuoteSelectionSurface -- cancel', () => {
+  it('fires onCancel and never mutates the read-only body value', () => {
+    const { getByTestId, onCancel } = renderSurface();
+    const input = getByTestId('quote-select-input');
+    expect(input.props.value).toBe(BODY);
+
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 8 } } });
+    expect(input.props.value).toBe(BODY);
+
+    fireEvent.press(getByTestId('quote-select-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(input.props.value).toBe(BODY);
+  });
+});
+
+describe('QuoteSelectionSurface -- custom testID prefix', () => {
+  it('prefixes every element with the given testID', () => {
+    const { getByTestId } = renderSurface({ testID: 'src-1' });
+    expect(getByTestId('src-1-instruction')).toBeTruthy();
+    expect(getByTestId('src-1-confirm')).toBeTruthy();
+    expect(getByTestId('src-1-confirm-guard')).toBeTruthy();
+    expect(getByTestId('src-1-cancel')).toBeTruthy();
+    expect(getByTestId('src-1-input')).toBeTruthy();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionSourcesPanel.test.tsx
@@ -211,10 +211,10 @@ describe('ReflectionSourcesPanel -- in-panel re-promotion selection surface', ()
     expect(onPromoteSpan).toHaveBeenCalledWith(sourceItem, { anchor_start: 2, anchor_end: 9 });
   });
 
-  it('does not fire onPromoteSpan on a collapsed selection and stays on the selection surface', async () => {
+  it('pressing the confirm guard on a collapsed selection shows a hint and never calls onPromoteSpan', async () => {
     const onPromoteSpan = jest.fn(() => Promise.resolve(true));
     const items = [item({ id: 1 })];
-    const { getByTestId } = render(
+    const { getByTestId, findByTestId } = render(
       <ReflectionSourcesPanel
         items={items}
         onInsertQuote={jest.fn()}
@@ -225,9 +225,8 @@ describe('ReflectionSourcesPanel -- in-panel re-promotion selection surface', ()
     fireEvent.press(getByTestId('source-promote-entry-1'));
     const input = getByTestId('source-select-entry-1-input');
     fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 5, end: 5 } } });
-    await act(async () => {
-      fireEvent.press(getByTestId('source-select-entry-1-confirm'));
-    });
+    fireEvent.press(getByTestId('source-select-entry-1-confirm-guard'));
+    expect(await findByTestId('source-select-entry-1-hint')).toBeTruthy();
     expect(onPromoteSpan).not.toHaveBeenCalled();
     expect(getByTestId('source-select-entry-1-input')).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Makes selecting a passage to promote guided and visible in the shared
`QuoteSelectionSurface`, so both consumers — read-mode promote on
`JournalEntryScreen` and in-panel re-promotion in `ReflectionSourcesPanel` —
inherit the behavior with no consumer API churn:

- A warm one-line instruction ("Touch and hold a passage, then drag to choose it.") on entering selection mode, styled `editorialType.note` (not `caption`).
- A live, quote-styled preview (`quoteHighlight` wash + terracotta stripe, mirroring the pending-quote row) echoing the current selection, updating as it changes.
- "Promote selection" rendered via the shared `Button`, visibly disabled (`disabled` + `accessibilityState`) while the selection is empty.
- An empty tap surfaces a warm inline hint ("Choose a passage first — touch and hold the text.") via an `accessible={false}` guard `Pressable`, instead of a silent no-op.
- Cancel unchanged; 44 dp touch floors and reduced-motion inherited from the shared `Button`.

Emptiness is gated on the converted **code-point** span so the disabled confirm
and the posted anchors agree at the same boundary this module is careful about
(#1548); the raw UTF-16 span is kept only to slice the preview. The code-point
contract emitted to `onSelectionChange` is unchanged. The now-dead empty-span
guards in both consumers' `confirmSelection` are removed since the surface
guards emptiness centrally (the AC6 de-duplication).

Scope is selection-surface UX only — in-flight/success/failure feedback belongs
to the sibling lifecycle issue and is untouched here.

## Test plan

- New unit suite `QuoteSelectionSurface.test.tsx`: instruction copy + `note`-sized style, empty-state disabled confirm, empty-tap hint via the guard, live preview slicing, **non-BMP** fixtures (leading-astral + straddling spans) pinning the code-point boundary and raw-UTF-16 preview, collapse-back, read-only body invariant, custom `testID` prefix propagation.
- Extended `JournalEntryScreenPromotions.test.tsx` and `ReflectionSourcesPanel.test.tsx`: repurposed the old silent-no-op tests into guard-tap-shows-hint (proving AC6 inheritance under a custom prefix) plus instruction/preview smoke assertions; existing offset-passthrough regressions kept.
- `./scripts/frontend/check-all.sh` green (4215 tests, eslint/prettier/tsc clean).

Closes #1628
Refs #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)