### PR TITLE
feat(journal): stage-visible quote-promotion lifecycle and anchored remove

### DIFF
--- a/frontend/src/features/Journal/HighlightedBody.tsx
+++ b/frontend/src/features/Journal/HighlightedBody.tsx
@@ -5,12 +5,20 @@
  * reader-promoted quote spans share the same body, resolved to one anchor stream.
  */
 import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import { buildAnchoredSegments, type AnchoredSegment } from './highlightSegments';
+import entryStyles from './JournalEntry.styles';
 
 import type { Marginalia, PromotedQuote } from '@/api';
+import { Button } from '@/components/Button';
 import { colors, editorialType } from '@/design/tokens';
+
+/** No-op default so the remove card always has a callable press handler. */
+const NOOP = (): void => {};
+
+/** Cap the echoed quote text so a long passage doesn't blow out the card. */
+const REMOVE_QUOTE_MAX_LINES = 3;
 
 export interface HighlightedBodyProps {
   body: string;
@@ -20,6 +28,12 @@ export interface HighlightedBodyProps {
   quotes?: PromotedQuote[];
   /** Tapping a promoted-quote span hands back its quote. */
   onQuotePress?: (_quote: PromotedQuote) => void;
+  /** The promoted quote whose anchored remove card is revealed, if any. */
+  removeTargetId?: number | null;
+  /** Confirm removing the revealed quote. */
+  onConfirmRemove?: () => void;
+  /** Dismiss the revealed remove card (tapping elsewhere in the body). */
+  onDismissRemove?: () => void;
 }
 
 /** A promoted-quote span: washed while pending, quietly dimmed once folded in. */
@@ -45,40 +59,105 @@ function QuoteSpan({
   );
 }
 
+/**
+ * The anchor text of the promoted quote whose remove card is revealed, or null.
+ * Located through the built segment stream (so an out-of-range quote — one with
+ * no drawn span, hence untappable — never yields a card), and read from the
+ * quote's own ``anchor_text`` rather than a re-slice of the body.
+ */
+function findRemoveQuoteText(
+  segments: AnchoredSegment[],
+  removeTargetId: number | null,
+): string | null {
+  if (removeTargetId == null) return null;
+  const match = segments.find((s) => s.quote != null && s.quote.id === removeTargetId);
+  return match != null && match.quote != null ? match.quote.anchor_text : null;
+}
+
+/** Anchored card echoing a tapped quote's text with a Remove-promotion action. */
+function RemoveQuoteCard({
+  id,
+  text,
+  onConfirm,
+}: {
+  id: number;
+  text: string;
+  onConfirm: () => void;
+}): React.JSX.Element {
+  return (
+    <View style={entryStyles.promotionRemoveCard}>
+      <Text
+        style={entryStyles.promotionRemoveQuote}
+        numberOfLines={REMOVE_QUOTE_MAX_LINES}
+        testID={`promotion-remove-quote-${id}`}
+      >
+        {text}
+      </Text>
+      <Button
+        variant="secondary"
+        label="Remove promotion"
+        accessibilityLabel="Remove promotion"
+        testID={`promotion-remove-${id}`}
+        onPress={onConfirm}
+      />
+    </View>
+  );
+}
+
+/** Render one body segment: a note anchor, a promoted-quote span, or plain text. */
+function renderSegment(
+  segment: AnchoredSegment,
+  onOpen: (_note: Marginalia) => void,
+  onQuotePress?: (_quote: PromotedQuote) => void,
+): React.ReactNode {
+  const { note, quote } = segment;
+  if (note != null) {
+    return (
+      <Text
+        key={segment.start}
+        style={[styles.highlight, { color: colors.marginalia[note.kind] }]}
+        onPress={() => onOpen(note)}
+        accessibilityRole="link"
+        accessibilityLabel={`Highlighted ${note.kind} passage`}
+        testID={`highlight-${note.id}`}
+      >
+        {segment.text}
+      </Text>
+    );
+  }
+  if (quote != null) {
+    return <QuoteSpan key={segment.start} segment={segment} quote={quote} onPress={onQuotePress} />;
+  }
+  return segment.text;
+}
+
 function HighlightedBody({
   body,
   notes,
   onOpen,
   quotes = [],
   onQuotePress,
+  removeTargetId = null,
+  onConfirmRemove = NOOP,
+  onDismissRemove,
 }: HighlightedBodyProps): React.JSX.Element {
   const segments = buildAnchoredSegments(body, notes, quotes);
+  const removeText = findRemoveQuoteText(segments, removeTargetId);
   return (
-    <Text style={styles.body} testID="journal-body-read">
-      {segments.map((segment) => {
-        const { note, quote } = segment;
-        if (note != null) {
-          return (
-            <Text
-              key={segment.start}
-              style={[styles.highlight, { color: colors.marginalia[note.kind] }]}
-              onPress={() => onOpen(note)}
-              accessibilityRole="link"
-              accessibilityLabel={`Highlighted ${note.kind} passage`}
-              testID={`highlight-${note.id}`}
-            >
-              {segment.text}
-            </Text>
-          );
-        }
-        if (quote != null) {
-          return (
-            <QuoteSpan key={segment.start} segment={segment} quote={quote} onPress={onQuotePress} />
-          );
-        }
-        return segment.text;
-      })}
-    </Text>
+    <>
+      <Text
+        style={styles.body}
+        testID="journal-body-read"
+        // A tap on plain body text dismisses a revealed card; inner span onPress
+        // handlers still win in nested RN Text, so quote taps keep revealing.
+        onPress={removeTargetId != null ? onDismissRemove : undefined}
+      >
+        {segments.map((segment) => renderSegment(segment, onOpen, onQuotePress))}
+      </Text>
+      {removeTargetId != null && removeText != null ? (
+        <RemoveQuoteCard id={removeTargetId} text={removeText} onConfirm={onConfirmRemove} />
+      ) : null}
+    </>
   );
 }
 

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -191,6 +191,40 @@ const styles = StyleSheet.create({
     color: colors.paper.inkSoft,
     paddingTop: spacing(1),
   },
+  /** Quiet in-flight line shown under the body while a promote POST is pending. */
+  promotionInflight: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+    paddingTop: spacing(1),
+  },
+  /** Transient success confirmation ("Promoted") after a span is raised. */
+  promotionSuccess: {
+    ...editorialType.note,
+    color: colors.successText,
+    paddingTop: spacing(1),
+  },
+  /** Legible (note-sized) error notice for a failed promote/remove. */
+  promotionErrorText: {
+    ...editorialType.note,
+    color: colors.danger,
+    paddingTop: spacing(1),
+  },
+  /** Anchored card revealed beside a tapped promoted span, offering removal. */
+  promotionRemoveCard: {
+    backgroundColor: colors.paper.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+    borderRadius: BORDER_RADIUS.md,
+    padding: SPACING.md,
+    marginTop: spacing(1),
+  },
+  /** Echo of the tapped quote's text inside the remove card. */
+  promotionRemoveQuote: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
+    fontStyle: 'italic',
+    paddingBottom: spacing(1),
+  },
   /** Privacy tier chooser block above the growing body. */
   privacyTierControl: {
     paddingBottom: spacing(1),

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -1146,6 +1146,12 @@ interface QuotePromotion {
   quotes: PromotedQuote[];
   /** Warm, declinable copy for the latest failed promote/remove; null otherwise. */
   hint: string | null;
+  /** True while a promote POST is in flight; drives the in-flight notice + busy control. */
+  promoting: boolean;
+  /** True briefly after a successful promote; drives the transient success notice. */
+  promoted: boolean;
+  /** Re-post the last failed span with the same anchors; null unless a promote failed. */
+  retryPromote: (() => Promise<void>) | null;
   /** True while the reader is choosing a span in the selection TextInput. */
   selecting: boolean;
   /** The quote whose "Remove promotion" affordance is currently revealed, if any. */
@@ -1156,13 +1162,21 @@ interface QuotePromotion {
   confirmSelection: () => Promise<void>;
   onQuotePress: (_quote: PromotedQuote) => void;
   confirmRemove: () => void;
+  /** Dismiss the revealed remove card without removing (tap elsewhere in the body). */
+  dismissRemove: () => void;
 }
+
+/** The gesture slice of {@link QuotePromotion} owned by {@link useQuoteInteraction}. */
+type QuoteInteraction = Omit<
+  QuotePromotion,
+  'quotes' | 'hint' | 'promoting' | 'promoted' | 'retryPromote'
+>;
 
 /** The read-mode selection/removal gestures over the {@link usePromotions} state. */
 function useQuoteInteraction(
   promote: (_start: number, _end: number) => Promise<void>,
   removePromotion: (_id: number) => Promise<void>,
-): Omit<QuotePromotion, 'quotes' | 'hint'> {
+): QuoteInteraction {
   const [selecting, setSelecting] = useState(false);
   const [removeTargetId, setRemoveTargetId] = useState<number | null>(null);
   // The latest selection, held in a ref so a keystroke-free selection change
@@ -1194,6 +1208,7 @@ function useQuoteInteraction(
     setRemoveTargetId(null);
     if (id != null) void removePromotion(id);
   }, [removeTargetId, removePromotion]);
+  const dismissRemove = useCallback(() => setRemoveTargetId(null), []);
 
   return {
     selecting,
@@ -1204,40 +1219,30 @@ function useQuoteInteraction(
     confirmSelection,
     onQuotePress,
     confirmRemove,
+    dismissRemove,
   };
 }
 
 /** Compose the promoted-quote state with its read-mode selection gestures. */
 function useQuotePromotion(routeEntryId: number | null): QuotePromotion {
-  const { quotes, hint, promote, removePromotion } = usePromotions({ entryId: routeEntryId ?? 0 });
+  const { quotes, hint, promote, removePromotion, promoting, promoted, retryPromote } =
+    usePromotions({ entryId: routeEntryId ?? 0 });
   const interaction = useQuoteInteraction(promote, removePromotion);
-  return { quotes, hint, ...interaction };
+  return { quotes, hint, promoting, promoted, retryPromote, ...interaction };
 }
 
-/** Read-mode affordances: a remove offer (when a span is tapped), Promote, Edit. */
+/** Read-mode affordances: the Promote-a-quote action and the Edit link. */
 function ReadModeControls({ quote, onEdit }: { quote: QuotePromotion; onEdit: () => void }) {
   return (
     <>
-      {quote.removeTargetId != null ? (
-        <TouchableOpacity
-          onPress={quote.confirmRemove}
-          accessibilityRole="button"
-          accessibilityLabel="Remove promotion"
-          style={styles.quoteActionButton}
-          testID={`promotion-remove-${quote.removeTargetId}`}
-        >
-          <Text style={styles.controlLink}>Remove promotion</Text>
-        </TouchableOpacity>
-      ) : null}
-      <TouchableOpacity
+      <Button
+        variant="tertiary"
         onPress={quote.startSelecting}
-        accessibilityRole="button"
         accessibilityLabel="Promote a quote"
-        style={styles.quoteActionButton}
         testID="promote-quote-button"
-      >
-        <Text style={styles.controlLink}>Promote a quote</Text>
-      </TouchableOpacity>
+        label="Promote a quote"
+        busy={quote.promoting}
+      />
       <TouchableOpacity
         onPress={onEdit}
         accessibilityRole="button"
@@ -1248,6 +1253,63 @@ function ReadModeControls({ quote, onEdit }: { quote: QuotePromotion; onEdit: ()
       </TouchableOpacity>
     </>
   );
+}
+
+/** Copy for the promote-lifecycle notices (real ellipsis inside the in-flight line). */
+const PROMOTING_COPY = 'Promoting…';
+const PROMOTED_COPY = 'Promoted';
+
+/** Transient success confirmation that settles in (motion-safe via useSettleIn). */
+function PromotedNotice(): React.JSX.Element {
+  const settle = useSettleIn(useReducedMotion());
+  return (
+    <Animated.Text
+      style={[styles.promotionSuccess, settle]}
+      testID="quote-promotion-success"
+      accessibilityRole="text"
+    >
+      {PROMOTED_COPY}
+    </Animated.Text>
+  );
+}
+
+/** The failed-promote notice: a legible error line plus a same-anchors retry. */
+function PromotionErrorNotice({ quote }: { quote: QuotePromotion }): React.JSX.Element {
+  const retry = quote.retryPromote;
+  return (
+    <>
+      <Text style={styles.promotionErrorText} testID="quote-promotion-error">
+        {quote.hint}
+      </Text>
+      {retry != null ? (
+        <Button
+          variant="tertiary"
+          label="Try again"
+          accessibilityLabel="Try again"
+          testID="quote-promotion-retry"
+          onPress={() => void retry()}
+        />
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * In-flight / error / success feedback for the promote lifecycle, under the body.
+ * An error (``hint``) outranks a lingering success notice so a failed remove that
+ * lands while a prior "Promoted" confirmation is still up reads honestly.
+ */
+function QuotePromotionFeedback({ quote }: { quote: QuotePromotion }): React.JSX.Element | null {
+  if (quote.promoting) {
+    return (
+      <Text style={styles.promotionInflight} testID="quote-promotion-inflight">
+        {PROMOTING_COPY}
+      </Text>
+    );
+  }
+  if (quote.hint != null) return <PromotionErrorNotice quote={quote} />;
+  if (quote.promoted) return <PromotedNotice />;
+  return null;
 }
 
 /** Read-mode body: the title + the highlighted passage tree + an Edit affordance. */
@@ -1282,19 +1344,20 @@ function ReadColumn({
           onCancel={quote.cancelSelecting}
         />
       ) : (
-        <HighlightedBody
-          body={body}
-          notes={notes}
-          onOpen={onOpen}
-          quotes={quote.quotes}
-          onQuotePress={quote.onQuotePress}
-        />
+        <>
+          <HighlightedBody
+            body={body}
+            notes={notes}
+            onOpen={onOpen}
+            quotes={quote.quotes}
+            onQuotePress={quote.onQuotePress}
+            removeTargetId={quote.removeTargetId}
+            onConfirmRemove={quote.confirmRemove}
+            onDismissRemove={quote.dismissRemove}
+          />
+          <QuotePromotionFeedback quote={quote} />
+        </>
       )}
-      {quote.hint != null ? (
-        <Text style={styles.savedHint} testID="quote-promotion-error">
-          {quote.hint}
-        </Text>
-      ) : null}
       {quote.selecting ? null : <ReadModeControls quote={quote} onEdit={onEdit} />}
     </ScrollView>
   );

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPromotions.test.tsx
@@ -9,8 +9,22 @@ import { StyleSheet } from 'react-native';
 // TextInput, or promoted-quote spans -- every testID below is missing until
 // the implementation-specialist wires `usePromotions` + the new affordance
 // into `JournalEntryScreen`/`ReadColumn`.
+import { PROMOTED_NOTICE_MS } from '../usePromotions';
+
 import type { JournalMessage, PromotedQuote } from '@/api';
 import { touchTarget } from '@/design/tokens';
+
+/** A never-settling promise plus its resolve, for pinning in-flight screen state. */
+function deferredPromote(): {
+  promise: Promise<PromotedQuote>;
+  resolve: (_value: PromotedQuote) => void;
+} {
+  let resolve: (_value: PromotedQuote) => void = () => {};
+  const promise = new Promise<PromotedQuote>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
 const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
@@ -296,5 +310,140 @@ describe('JournalEntryScreen -- reopening a finished entry hydrates promoted-quo
     expect(await findByTestId('quote-highlight-12')).toBeTruthy();
     expect(await findByTestId('quote-highlight-34')).toBeTruthy();
     expect(mockPromotionsList).toHaveBeenCalledWith(7);
+  });
+});
+
+describe('JournalEntryScreen -- promote lifecycle feedback (in-flight, success, retry)', () => {
+  async function confirmSelection(screen: ReturnType<typeof renderScreen>): Promise<void> {
+    fireEvent.press(await screen.findByTestId('promote-quote-button'));
+    const input = screen.getByTestId('quote-select-input');
+    fireEvent(input, 'selectionChange', { nativeEvent: { selection: { start: 2, end: 19 } } });
+  }
+
+  async function promoteOne(screen: ReturnType<typeof renderScreen>): Promise<void> {
+    mockPromote.mockResolvedValue(promotedQuote({ id: 90 }));
+    await confirmSelection(screen);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('quote-select-confirm'));
+    });
+    await screen.findByTestId('quote-highlight-90');
+  }
+
+  it('shows an in-flight notice while the promote POST is pending and clears it on resolution', async () => {
+    const { promise, resolve } = deferredPromote();
+    mockPromote.mockReturnValue(promise);
+    const screen = renderScreen({ entryId: 7 });
+    await confirmSelection(screen);
+
+    fireEvent.press(screen.getByTestId('quote-select-confirm'));
+    expect(await screen.findByTestId('quote-promotion-inflight')).toBeTruthy();
+    expect(screen.getByTestId('journal-body-read')).toBeTruthy();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolve(promotedQuote({ id: 90 }));
+      await promise;
+    });
+    await waitFor(() => expect(screen.queryByTestId('quote-promotion-inflight')).toBeNull());
+  });
+
+  it('shows a transient success notice that auto-dismisses after PROMOTED_NOTICE_MS', async () => {
+    mockPromote.mockResolvedValue(promotedQuote({ id: 90 }));
+    const screen = renderScreen({ entryId: 7 });
+    await confirmSelection(screen);
+
+    jest.useFakeTimers();
+    try {
+      await act(async () => {
+        fireEvent.press(screen.getByTestId('quote-select-confirm'));
+      });
+      expect(screen.getByTestId('quote-promotion-success')).toBeTruthy();
+
+      act(() => {
+        jest.advanceTimersByTime(PROMOTED_NOTICE_MS);
+      });
+      expect(screen.queryByTestId('quote-promotion-success')).toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('a failed promote shows the error notice and retry re-posts the same anchors', async () => {
+    mockPromote.mockRejectedValueOnce({ status: 500, detail: 'boom' });
+    mockPromote.mockResolvedValueOnce(promotedQuote({ id: 90 }));
+    const screen = renderScreen({ entryId: 7 });
+    await confirmSelection(screen);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('quote-select-confirm'));
+    });
+
+    expect(await screen.findByTestId('quote-promotion-error')).toBeTruthy();
+    const retryButton = screen.getByTestId('quote-promotion-retry');
+
+    await act(async () => {
+      fireEvent.press(retryButton);
+    });
+    expect(mockPromote).toHaveBeenNthCalledWith(2, 7, { anchor_start: 2, anchor_end: 19 });
+    expect(await screen.findByTestId('quote-highlight-90')).toBeTruthy();
+    expect(screen.queryByTestId('quote-select-input')).toBeNull();
+  });
+
+  it('the anchored remove affordance shows the tapped quote text', async () => {
+    const screen = renderScreen({ entryId: 7 });
+    await promoteOne(screen);
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    expect(await screen.findByTestId('promotion-remove-90')).toBeTruthy();
+    const quoteText = screen.getByTestId('promotion-remove-quote-90');
+    expect(quoteText.props.children).toEqual(
+      expect.stringContaining(promotedQuote({ id: 90 }).anchor_text),
+    );
+  });
+
+  it('pressing elsewhere in the body dismisses the revealed remove affordance', async () => {
+    const screen = renderScreen({ entryId: 7 });
+    await promoteOne(screen);
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    expect(await screen.findByTestId('promotion-remove-90')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('journal-body-read'));
+    expect(screen.queryByTestId('promotion-remove-90')).toBeNull();
+  });
+
+  it('a failed remove restores the quote highlight and shows a legible error notice', async () => {
+    mockRemovePromotion.mockRejectedValue({ status: 500, detail: 'boom' });
+    const screen = renderScreen({ entryId: 7 });
+    await promoteOne(screen);
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    const removeButton = await screen.findByTestId('promotion-remove-90');
+    await act(async () => {
+      fireEvent.press(removeButton);
+    });
+    expect(await screen.findByTestId('quote-highlight-90')).toBeTruthy();
+    expect(await screen.findByTestId('quote-promotion-error')).toBeTruthy();
+  });
+
+  it('a failed remove after a failed promote drops the mis-contexted promote retry', async () => {
+    mockPromotionsList.mockResolvedValue([promotedQuote({ id: 90 })]);
+    mockPromote.mockRejectedValue({ status: 500, detail: 'boom' });
+    mockRemovePromotion.mockRejectedValue({ status: 500, detail: 'boom' });
+    const screen = renderScreen({ entryId: 7 });
+    await screen.findByTestId('quote-highlight-90');
+
+    await confirmSelection(screen);
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('quote-select-confirm'));
+    });
+    expect(await screen.findByTestId('quote-promotion-retry')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('quote-highlight-90'));
+    const removeButton = await screen.findByTestId('promotion-remove-90');
+    await act(async () => {
+      fireEvent.press(removeButton);
+    });
+    expect(await screen.findByTestId('quote-promotion-error')).toBeTruthy();
+    expect(screen.queryByTestId('quote-promotion-retry')).toBeNull();
   });
 });

--- a/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
@@ -5,6 +5,18 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import type { PromotedQuote } from '@/api';
 import { ApiError } from '@/api';
 
+/** A never-settling promise plus its resolve, for pinning in-flight state. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (_value: T) => void;
+} {
+  let resolve: (_value: T) => void = () => {};
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 /** A pending promoted quote anchored near the head of a body. */
 function quote(overrides: Partial<PromotedQuote> = {}): PromotedQuote {
   return {
@@ -37,7 +49,7 @@ jest.mock('@/api', () => {
   };
 });
 
-const { usePromotions } = require('../usePromotions');
+const { usePromotions, PROMOTED_NOTICE_MS } = require('../usePromotions');
 
 beforeEach(() => {
   mockCreate.mockReset();
@@ -99,6 +111,24 @@ describe('usePromotions', () => {
     });
     expect(result.current.quotes).toEqual([]);
     expect(mockRemove).toHaveBeenCalledWith(5);
+  });
+
+  it('a failed removePromotion clears a pending promote retry so the notice is not mis-contexted', async () => {
+    mockCreate.mockRejectedValue(new ApiError(422, 'anchor_out_of_range'));
+    mockRemove.mockRejectedValue(new ApiError(500, 'boom'));
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+
+    await act(async () => {
+      await result.current.promote(0, 9999);
+    });
+    expect(result.current.retryPromote).not.toBeNull();
+
+    await act(async () => {
+      await result.current.removePromotion(5);
+    });
+    expect(result.current.retryPromote).toBeNull();
+    expect(result.current.hint).toBeTruthy();
   });
 
   it('removePromotion reverts the optimistic removal on error and sets a hint', async () => {
@@ -184,5 +214,103 @@ describe('usePromotions', () => {
     await waitFor(() =>
       expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([3, 9]),
     );
+  });
+
+  it('promoting is false initially, true while the create POST is in flight, false after it resolves', async () => {
+    const { promise, resolve } = deferred<PromotedQuote>();
+    mockCreate.mockReturnValue(promise);
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+    expect(result.current.promoting).toBe(false);
+
+    let promotePromise: Promise<void> = Promise.resolve();
+    act(() => {
+      promotePromise = result.current.promote(2, 19);
+    });
+    expect(result.current.promoting).toBe(true);
+
+    await act(async () => {
+      resolve(quote({ id: 9 }));
+      await promotePromise;
+    });
+    expect(result.current.promoting).toBe(false);
+  });
+
+  it('promoting returns to false after a create rejection', async () => {
+    mockCreate.mockRejectedValue(new ApiError(422, 'boom'));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+
+    await act(async () => {
+      await result.current.promote(2, 19);
+    });
+    expect(result.current.promoting).toBe(false);
+  });
+
+  it('promoted is false initially, true after a successful promote, and auto-clears after PROMOTED_NOTICE_MS', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(quote({ id: 9 }));
+      const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+      expect(result.current.promoted).toBe(false);
+
+      await act(async () => {
+        await result.current.promote(2, 19);
+      });
+      expect(result.current.promoted).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(PROMOTED_NOTICE_MS);
+      });
+      expect(result.current.promoted).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('retryPromote is null until a promote fails, then re-posts the same span and clears on success', async () => {
+    mockCreate.mockRejectedValueOnce(new ApiError(500, 'boom'));
+    const { result } = renderHook(() => usePromotions({ entryId: 7 }));
+    expect(result.current.retryPromote).toBeNull();
+
+    await act(async () => {
+      await result.current.promote(2, 19);
+    });
+    expect(result.current.retryPromote).not.toBeNull();
+
+    mockCreate.mockResolvedValueOnce(quote({ id: 9 }));
+    await act(async () => {
+      await result.current.retryPromote!();
+    });
+    expect(mockCreate).toHaveBeenNthCalledWith(2, 7, { anchor_start: 2, anchor_end: 19 });
+    expect(result.current.retryPromote).toBeNull();
+    expect(result.current.quotes.map((q: PromotedQuote) => q.id)).toEqual([9]);
+  });
+
+  it('a failed removePromotion sets a hint and leaves retryPromote null', async () => {
+    mockRemove.mockRejectedValue(new ApiError(500, 'boom'));
+    const seeded = quote({ id: 5 });
+    const { result } = renderHook(() => usePromotions({ entryId: 7, initialQuotes: [seeded] }));
+
+    await act(async () => {
+      await result.current.removePromotion(5);
+    });
+    expect(result.current.hint).toBeTruthy();
+    expect(result.current.retryPromote).toBeNull();
+  });
+
+  it('unmounting while the promoted notice timer is pending does not throw', async () => {
+    jest.useFakeTimers();
+    try {
+      mockCreate.mockResolvedValue(quote({ id: 9 }));
+      const { result, unmount } = renderHook(() => usePromotions({ entryId: 7 }));
+
+      await act(async () => {
+        await result.current.promote(2, 19);
+      });
+      expect(result.current.promoted).toBe(true);
+
+      expect(() => unmount()).not.toThrow();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/frontend/src/features/Journal/usePromotions.ts
+++ b/frontend/src/features/Journal/usePromotions.ts
@@ -24,6 +24,12 @@ export interface UsePromotionsArgs {
   initialQuotes?: PromotedQuote[];
 }
 
+/**
+ * How long the transient "Promoted" confirmation stays up before it auto-clears.
+ * Exported so the screen and its tests share one source of truth for the notice.
+ */
+export const PROMOTED_NOTICE_MS = 2500;
+
 export interface UsePromotionsResult {
   quotes: PromotedQuote[];
   /** Warm, declinable copy for the latest failed action; null when all is well. */
@@ -32,6 +38,15 @@ export interface UsePromotionsResult {
   promote: (_start: number, _end: number) => Promise<void>;
   /** Un-promote a quote by id; optimistic, reverting on error. */
   removePromotion: (_id: number) => Promise<void>;
+  /** True while a promote POST is in flight (render mirror of the single-flight guard). */
+  promoting: boolean;
+  /** True briefly after a successful promote; auto-clears after {@link PROMOTED_NOTICE_MS}. */
+  promoted: boolean;
+  /**
+   * Re-post the last attempted span with the same anchors; null unless the most
+   * recent promote failed. Cleared once a subsequent promote succeeds.
+   */
+  retryPromote: (() => Promise<void>) | null;
 }
 
 /** The list's canonical order: by anchor offset, then id as a stable tiebreak. */
@@ -96,14 +111,103 @@ function useHydrateOnOpen(
   }, [entryId, setQuotes, setHint]);
 }
 
+/** The span most recently handed to ``promote`` — held so a retry re-posts it. */
+interface Span {
+  start: number;
+  end: number;
+}
+
+/**
+ * Auto-clear the transient "Promoted" notice after {@link PROMOTED_NOTICE_MS}.
+ * Flat and unmount-safe: the timer is cleared on cleanup so an unmount mid-notice
+ * never sets state, and it re-arms only while ``promoted`` is true.
+ */
+function usePromotedNotice(promoted: boolean, clear: () => void): void {
+  useEffect(() => {
+    if (!promoted) return undefined;
+    const timer = setTimeout(clear, PROMOTED_NOTICE_MS);
+    return () => clearTimeout(timer);
+  }, [promoted, clear]);
+}
+
+/** The promote-lifecycle slice: pending/success signals plus a retryable post. */
+interface PromoteAction {
+  promote: (_start: number, _end: number) => Promise<void>;
+  retryPromote: (() => Promise<void>) | null;
+  promoting: boolean;
+  promoted: boolean;
+  /** Drop a pending promote retry so an unrelated failure can't re-offer it. */
+  clearRetry: () => void;
+}
+
+/**
+ * Own the promote lifecycle for one entry: the single-flight ``create`` (never
+ * throws — failures map to ``setHint``), the ``promoting``/``promoted`` render
+ * signals, and a ``retryPromote`` that re-posts the last attempted span verbatim
+ * so a failure never loses the reader's selection.
+ */
+function usePromoteAction(
+  entryId: number,
+  setQuotes: Dispatch<SetStateAction<PromotedQuote[]>>,
+  setHint: (_hint: string | null) => void,
+): PromoteAction {
+  const [promoting, setPromoting] = useState(false);
+  const [promoted, setPromoted] = useState(false);
+  const [promoteFailed, setPromoteFailed] = useState(false);
+  // One promote at a time — the ref is the synchronous guard, the state is its
+  // render mirror. The last span is held so ``retryPromote`` re-posts the same
+  // anchors rather than re-deriving them from a now-stale selection.
+  const promotingRef = useRef(false);
+  const lastSpanRef = useRef<Span>({ start: 0, end: 0 });
+
+  const clearPromoted = useCallback(() => setPromoted(false), []);
+  usePromotedNotice(promoted, clearPromoted);
+
+  const promote = useCallback(
+    async (start: number, end: number): Promise<void> => {
+      if (promotingRef.current) return;
+      lastSpanRef.current = { start, end };
+      promotingRef.current = true;
+      setPromoting(true);
+      setHint(null);
+      try {
+        const created = await promotions.create(entryId, { anchor_start: start, anchor_end: end });
+        setQuotes((prev) => insertSorted(prev, created));
+        setPromoted(true);
+        setPromoteFailed(false);
+      } catch (err) {
+        setHint(formatApiError(err));
+        setPromoteFailed(true);
+      } finally {
+        promotingRef.current = false;
+        setPromoting(false);
+      }
+    },
+    [entryId, setQuotes, setHint],
+  );
+
+  const retryCallback = useCallback((): Promise<void> => {
+    const { start, end } = lastSpanRef.current;
+    return promote(start, end);
+  }, [promote]);
+  const clearRetry = useCallback(() => setPromoteFailed(false), []);
+
+  return {
+    promote,
+    retryPromote: promoteFailed ? retryCallback : null,
+    promoting,
+    promoted,
+    clearRetry,
+  };
+}
+
 export function usePromotions({
   entryId,
   initialQuotes = [],
 }: UsePromotionsArgs): UsePromotionsResult {
   const [quotes, setQuotes] = useState<PromotedQuote[]>(initialQuotes);
   const [hint, setHint] = useState<string | null>(null);
-  // One promote at a time; per-id guard for removals — no double-post/-delete.
-  const promotingRef = useRef(false);
+  // Per-id guard for removals — no double-delete.
   const removingIdsRef = useRef<Set<number>>(new Set());
   // Mirror the latest quotes so ``removePromotion`` can look up the row it drops
   // (for revert-on-error) without depending on ``quotes`` — that keeps its
@@ -112,22 +216,10 @@ export function usePromotions({
   quotesRef.current = quotes;
 
   useHydrateOnOpen(entryId, setQuotes, setHint);
-
-  const promote = useCallback(
-    async (start: number, end: number): Promise<void> => {
-      if (promotingRef.current) return;
-      promotingRef.current = true;
-      setHint(null);
-      try {
-        const created = await promotions.create(entryId, { anchor_start: start, anchor_end: end });
-        setQuotes((prev) => insertSorted(prev, created));
-      } catch (err) {
-        setHint(formatApiError(err));
-      } finally {
-        promotingRef.current = false;
-      }
-    },
-    [entryId],
+  const { promote, retryPromote, promoting, promoted, clearRetry } = usePromoteAction(
+    entryId,
+    setQuotes,
+    setHint,
   );
 
   const removePromotion = useCallback(
@@ -139,10 +231,15 @@ export function usePromotions({
         removeRemote: promotions.remove,
         reinsert: insertSorted,
         onError: setHint,
-        beforeStart: () => setHint(null),
+        // Drop any pending promote retry: a remove failure surfaces its own
+        // notice, and a promote "Try again" beside it would be mis-contexted.
+        beforeStart: () => {
+          setHint(null);
+          clearRetry();
+        },
       }),
-    [],
+    [clearRetry],
   );
 
-  return { quotes, hint, promote, removePromotion };
+  return { quotes, hint, promote, removePromotion, promoting, promoted, retryPromote };
 }


### PR DESCRIPTION
## Summary

Makes every post-confirm stage of quote promotion visible in the journal read view, and anchors the remove flow to the tapped quote (scope: post-confirm lifecycle + remove only; the guided selection surface shipped in #1644).

- **In-flight**: a quiet "Promoting…" line appears in the read view while the POST runs (`confirmSelection` already returns the reader to their place, so the indicator lands where the highlight will settle).
- **Success**: a transient "Promoted" notice settles in via `useSettleIn` and auto-dismisses after `PROMOTED_NOTICE_MS` (2.5s); reduced-motion safe via `useReducedMotion`.
- **Failure**: the hint moves out of the 13px caption into a legible note-sized notice (`colors.danger`) with a one-tap **Try again** that re-posts the *same* span — the selection is never lost. `promote` keeps its never-throws contract and one-at-a-time guard.
- **Anchored remove**: tapping a promoted quote reveals a small card showing that quote's text plus a **Remove promotion** Button adjacent to it (replacing the disconnected bottom-of-column link); tapping elsewhere in the body dismisses it. Optimistic revert-on-error is preserved and a failed remove surfaces its own legible notice.
- Promotion actions now use the shared `Button` component (≥16px, 44dp floor) instead of caption `controlLink`s.
- Honest reconciliation: a failed remove clears any pending promote retry so a "Try again" is never mis-contexted next to a removal error (Gate 2.5 review finding).

The hook grows `promoting` / `promoted` / `retryPromote`; the promote lifecycle is extracted into `usePromoteAction`. No API payload or code-point anchor changes; `ReflectionSourcesPanel`'s separate flow is untouched.

## Test plan

- `usePromotions.test.tsx`: `promoting` transitions (both paths), `promoted` set + auto-clear at `PROMOTED_NOTICE_MS` (fake timers), unmount-safe timer, `retryPromote` null→failed→retry-same-anchors→null, failed-remove leaves `retryPromote` null and clears a pending promote retry.
- `JournalEntryScreenPromotions.test.tsx`: in-flight notice appears/clears (deferred promise, `mockGet` called once), transient success auto-dismiss, failure notice + retry re-posts same anchors without re-entering selection, anchored remove card shows the quote text, tap-elsewhere dismiss, failed remove restores the span + legible notice, and no mis-contexted retry after a failed remove.
- `./scripts/frontend/check-all.sh`: green (lint, prettier, typecheck, 4229 jest tests). Reduced-motion, tokens-only, no suppressions.

Closes #1629
Refs #1627