### PR TITLE
fix(backend): view your own unapproved draft on the user-practice detail path

### DIFF
--- a/backend/src/routers/user_practices.py
+++ b/backend/src/routers/user_practices.py
@@ -51,34 +51,18 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/user-practices", tags=["user-practices"])
 
 
-async def _resolve_practice(session: AsyncSession, practice_id: int) -> Practice:
-    """Fetch and validate the catalog practice (exists + approved).
-
-    Backs the read/GET path only; the write paths use
-    :func:`_resolve_selectable_practice`.
-    """
-    result = await session.execute(select(Practice).where(Practice.id == practice_id))
-    practice = result.scalars().first()
-    if practice is None:
-        raise not_found("practice")
-    if not practice.approved:
-        raise bad_request("practice_not_approved")
-    return practice
-
-
 async def _resolve_selectable_practice(
     session: AsyncSession, practice_id: int, current_user: int
 ) -> Practice:
-    """Fetch a practice the caller is allowed to *select* or customize.
+    """Fetch a practice the caller is allowed to *select*, customize, or view.
 
-    Both write paths (selection and customize) use this resolver, whereas
-    :func:`_resolve_practice` backs the read/GET path. Unlike that read
-    path, this one permits an approved catalog practice **or** the caller's
-    own draft: ``practice.submitted_by_user_id == current_user`` clears an
-    unapproved row so an author can activate or customize the practice they
-    just submitted. A non-owner selecting someone else's still-pending
-    submission continues to receive 400 ``practice_not_approved``; a missing
-    row 404s exactly as the read path does.
+    The write paths (selection and customize) and the GET-one read path all
+    share this resolver. It permits an approved catalog practice **or** the
+    caller's own draft: ``practice.submitted_by_user_id == current_user``
+    clears an unapproved row so an author can activate, customize, or view the
+    practice they just submitted. A non-owner reaching someone else's
+    still-pending submission continues to receive 400 ``practice_not_approved``;
+    a missing row 404s.
     """
     result = await session.execute(select(Practice).where(Practice.id == practice_id))
     practice = result.scalars().first()
@@ -98,9 +82,9 @@ async def _check_stage_eligibility(
 ) -> None:
     """Gate on catalog-stage agreement + chain-unlock.
 
-    Kept separate from :func:`_resolve_practice` so the 400/403 split stays
-    explicit: mismatched stage is a client-side input error, locked stage is
-    an authorization failure against server-owned progression.  ``user_tz``
+    Kept separate from :func:`_resolve_selectable_practice` so the 400/403
+    split stays explicit: mismatched stage is a client-side input error,
+    locked stage is an authorization failure against server-owned progression.  ``user_tz``
     threads the caller's timezone into the calendar unlock so the server
     counts the same calendar days the client does (matching the frontend's
     local-midnight convention).
@@ -320,8 +304,16 @@ async def _resolve_effective_fields(
     batches catalog lookups via :func:`_load_catalog_map`. The config
     is resolved via :func:`_safe_resolve_config` so a corrupt stored
     override falls through to ``None`` rather than crashing the GET.
+
+    Resolution uses the approved-OR-owner
+    :func:`_resolve_selectable_practice` scoped to ``user_practice.user_id``
+    so the row's owner can view a selection backed by their own unapproved
+    draft, mirroring the write paths. Ownership is already enforced upstream
+    by ``require_owned_user_practice``, so a foreign draft stays unreachable.
     """
-    practice = await _resolve_practice(session, user_practice.practice_id)
+    practice = await _resolve_selectable_practice(
+        session, user_practice.practice_id, user_practice.user_id
+    )
     name = effective_name(practice, user_practice)
     return name, _safe_resolve_config(user_practice, practice)
 
@@ -472,9 +464,10 @@ async def _frequency_from_active(
 ) -> FrequencyResponse:
     """Build the banner from an active ``UserPractice`` selection.
 
-    ``_resolve_practice`` 400s on unapproved rows; for the banner path
-    we only need the catalog row to exist (the user already selected
-    it, so its approval state shouldn't break their read view).
+    ``_resolve_selectable_practice`` still 400s on a *foreign* unapproved
+    row; for the banner path we only need the catalog row to exist (the
+    user already selected it, so its approval state shouldn't break their
+    read view).
     """
     practice_row = (
         (await session.execute(select(Practice).where(Practice.id == active.practice_id)))

--- a/backend/tests/test_owner_practice_selection.py
+++ b/backend/tests/test_owner_practice_selection.py
@@ -135,7 +135,7 @@ async def test_owner_can_select_own_unapproved_practice(
 ) -> None:
     """Author selecting their own unapproved draft must return 201.
 
-    Today this returns 400 practice_not_approved because _resolve_practice
+    Today this returns 400 practice_not_approved because the selection path
     rejects any unapproved row without an ownership check.  After the fix a
     new resolver (_resolve_selectable_practice) allows the row when
     practice.submitted_by_user_id == current_user.

--- a/backend/tests/test_user_practices_api.py
+++ b/backend/tests/test_user_practices_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
+from typing import cast
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -422,6 +423,73 @@ async def test_get_other_users_practice_forbidden(
 
     resp = await async_client.get(f"/user-practices/{up_id}", headers=bob_headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
+
+
+# -- Owner-drafted (unapproved) practices on the GET-one detail path ----------
+
+
+async def _insert_user_practice(db_session: AsyncSession, user_id: int, practice: Practice) -> int:
+    """Insert a UserPractice row directly and return its id.
+
+    Bypasses the POST selection gate so a row backed by an unapproved draft can
+    be set up regardless of ownership — the GET-one path is what these tests
+    exercise, not selection.
+    """
+    user_practice = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=practice.stage_number,
+        start_date=datetime.now(UTC).date(),
+    )
+    db_session.add(user_practice)
+    await db_session.commit()
+    await db_session.refresh(user_practice)
+    # ``UserPractice.id`` is ``int | None`` to model the pre-insert state; a
+    # freshly committed + refreshed row always has its primary key set.
+    return cast("int", user_practice.id)
+
+
+@pytest.mark.asyncio
+async def test_get_user_practice_backed_by_own_unapproved_draft(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Viewing a selection backed by your own unapproved draft must return 200."""
+    headers, user_id = await _signup(async_client)
+    practice = await _seed_practice(
+        db_session, approved=False, submitted_by_user_id=user_id, name="My Draft Sit"
+    )
+    up_id = await _insert_user_practice(db_session, user_id, practice)
+
+    resp = await async_client.get(f"/user-practices/{up_id}", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    data = resp.json()
+    assert data["id"] == up_id
+    assert data["effective_name"] == "My Draft Sit"
+    assert data["effective_config"]["duration_minutes"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_user_practice_backed_by_foreign_unapproved_draft_rejected(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Regression pin: the owner-scoped carve-out must not clear a foreign draft.
+
+    The caller owns the ``UserPractice`` row (so ``require_owned_user_practice``
+    passes), but the catalog practice is another user's unapproved submission —
+    the resolver must still 400 ``practice_not_approved``.
+    """
+    owner_headers, owner_id = await _signup(async_client, "detail_owner")
+    _, other_id = await _signup(async_client, "detail_other")
+    practice = await _seed_practice(
+        db_session, approved=False, submitted_by_user_id=other_id, name="Foreign Draft"
+    )
+    up_id = await _insert_user_practice(db_session, owner_id, practice)
+
+    resp = await async_client.get(f"/user-practices/{up_id}", headers=owner_headers)
+
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["detail"] == "practice_not_approved"
 
 
 # -- BUG-PRACTICE-005: single-active-practice TOCTOU --------------------------


### PR DESCRIPTION
## Summary

`GET /user-practices/{id}` resolved its catalog practice with the approved-only `_resolve_practice`, so viewing the detail of a selection backed by the caller's **own** unapproved draft or copied practice returned 400 `practice_not_approved` — even though the user can already *select* (#931) and *customize* (#1626/#1643) that same draft. This is the read-path sibling of #1626; the customize write-path twin was fixed in #1643.

The fix switches the GET-one path's `_resolve_effective_fields` to the approved-OR-owner `_resolve_selectable_practice`, threading `user_practice.user_id` — which `require_owned_user_practice` guarantees is the authenticated caller — exactly mirroring the write path. The carve-out is owner-scoped: a row the caller owns whose catalog practice is *another* user's still-pending submission continues to 400. `submit_practice`'s `approved=False` posture and the approved-only public listing gate are untouched.

`_resolve_practice` is now unused and was removed; its three docstring cross-references were reworded.

## Test plan

Added to `backend/tests/test_user_practices_api.py`:
- `test_get_user_practice_backed_by_own_unapproved_draft` — owner viewing their own unapproved-draft-backed selection → 200 with resolved `effective_name`/`effective_config` (RED before the fix).
- `test_get_user_practice_backed_by_foreign_unapproved_draft_rejected` — caller owns the `UserPractice` row but the catalog practice is another user's unapproved submission → 400 `practice_not_approved` (regression pin for the owner-scoped boundary).

Gate 2: `./scripts/backend/check-all.sh` green (coverage 96.66%); xenon A / radon MI A on the changed module; all pre-commit hooks pass.

Closes #1642
Refs #1626