### PR TITLE
feat(backend): locked stages return a titles-only content listing instead of 403

### DIFF
--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -212,6 +212,28 @@ async def _is_stage_unlocked_for_user(
     return is_stage_unlocked(stage_number, progress)
 
 
+async def _listing_unlocked_count(
+    session: AsyncSession, user_id: int, stage: CourseStage, total_items: int
+) -> int:
+    """Chapters to reveal in the stage listing.
+
+    A stage still locked for the user is shown as a titles-only table of
+    contents: every item locked with its ``url`` nulled -- the same shape
+    the drip produces at ``unlocked_count == 0``. This deliberately shows
+    the whole chapter map in the course drawer while keeping bodies and
+    urls out of reach; item detail and mark-read stay gated. An unlocked
+    stage keeps its proportional drip count unchanged.
+    """
+    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
+        return 0
+    day = await _day_in_stage_for_user(session, user_id, stage.stage_number)
+    return unlocked_chapter_count(
+        total=total_items,
+        duration_days=_stage_duration_days(stage.stage_number),
+        day_in_stage=day,
+    )
+
+
 @router.get("/stages/{stage_number}/content", response_model=None)
 async def list_stage_content(
     stage_number: int,
@@ -230,18 +252,16 @@ async def list_stage_content(
     count in the database.  Stage content lists are small (tens of items
     per stage) so paginating in Python after fetching is fine.
 
-    The sibling endpoints (``get_content_item``, ``mark_content_read``)
-    gate on :func:`_check_stage_unlocked`; this listing used to skip it
-    and leak titles + release_days for future stages while only nulling
-    ``url``.  Aligning the unlock gate here closes the last read path
-    for locked-stage metadata.
+    A stage still locked for the user returns a titles-only listing on
+    purpose: the course drawer renders the full chapter map (every item
+    locked with ``url`` nulled) while bodies and urls stay protected.
+    Item detail (``get_content_item``) and ``mark_content_read`` remain
+    gated -- only this table-of-contents view is open on a locked stage.
     """
-    # 404-then-403: missing stages return not_found regardless of caller so a
-    # nonexistent stage_number can't be distinguished from a locked one by
-    # response code (callers for this endpoint don't see a content_id oracle,
-    # so the existence of stages 1..10 is already public knowledge).
+    # A missing stage still 404s here so a nonexistent stage_number can't be
+    # confused with a real one; stages 1..10 are public knowledge, and the
+    # listing itself is open (titles-only when locked) so there's no oracle.
     stage = await _get_stage_by_number(session, stage_number)
-    await _check_stage_unlocked(session, current_user, stage_number)
 
     result = await session.execute(
         select(StageContent)
@@ -250,12 +270,7 @@ async def list_stage_content(
     )
     items = list(result.scalars().all())
 
-    day = await _day_in_stage_for_user(session, current_user, stage_number)
-    unlocked = unlocked_chapter_count(
-        total=len(items),
-        duration_days=_stage_duration_days(stage_number),
-        day_in_stage=day,
-    )
+    unlocked = await _listing_unlocked_count(session, current_user, stage, len(items))
     content_ids = [item.id for item in items if item.id is not None]
     read_ids = await _read_ids_for_user(session, current_user, content_ids)
 

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -157,25 +157,98 @@ async def test_list_content_stage_not_found(
     assert resp.status_code == HTTPStatus.NOT_FOUND
 
 
+_LOCKED_LISTING_KEYS = {
+    "id",
+    "title",
+    "content_type",
+    "release_day",
+    "url",
+    "is_locked",
+    "is_read",
+}
+
+
 @pytest.mark.asyncio
-async def test_list_content_rejects_locked_stage(
+async def test_list_content_locked_stage_returns_titles_only(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """BUG-COURSE-001: listing content for a locked stage must 403.
+    """A locked stage's listing is titles-only, not a 403.
 
-    The sibling single-item endpoints gate on ``_check_stage_unlocked``;
-    until this fix ``list_stage_content`` leaked every item's title and
-    release_day (only the URL was nulled) so a never-enrolled user could
-    enumerate the full 36-stage drip schedule.
+    The course drawer's table of contents needs to show every stage's
+    chapter titles up front so a user can preview what is ahead; only the
+    body and url stay gated behind unlock. This is a deliberate product
+    contract, not a leak: every item comes back locked and url-less.
     """
     headers, _ = await _signup(async_client, "locked")
     # Seed content for stage 2 without giving the user any progress.
+    _, items = await _seed_stage_with_content(db_session, stage_number=2)
+
+    resp = await async_client.get("/course/stages/2/content", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert len(data) == len(items)
+
+    expected_order = sorted(items, key=lambda item: (item.release_day, item.id))
+    assert [d["id"] for d in data] == [item.id for item in expected_order]
+
+    for entry in data:
+        assert set(entry.keys()) == _LOCKED_LISTING_KEYS
+        assert entry["is_locked"] is True
+        assert entry["url"] is None
+        assert entry["is_read"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_content_locked_stage_paginated(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The paginated envelope also returns titles-only rows for a locked stage."""
+    headers, _ = await _signup(async_client, "locked_paginated")
+    content_items = [
+        {
+            "title": f"Chapter {day}",
+            "content_type": "essay",
+            "release_day": day,
+            "url": f"https://cms.example.com/s2-{day}",
+        }
+        for day in range(5)
+    ]
+    expected_count = len(content_items)
+    await _seed_stage_with_content(db_session, stage_number=2, content_items=content_items)
+
+    resp = await async_client.get(
+        "/course/stages/2/content", params={"paginate": "true"}, headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    envelope = resp.json()
+    assert envelope["total"] == expected_count
+    assert len(envelope["items"]) == expected_count
+    for entry in envelope["items"]:
+        assert set(entry.keys()) == _LOCKED_LISTING_KEYS
+        assert entry["is_locked"] is True
+        assert entry["url"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_content_locked_stage_does_not_provision_progress(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Reading a locked stage's titles-only listing never provisions StageProgress."""
+    headers, user_id = await _signup(async_client, "locked_no_provision")
+
+    before = await db_session.execute(select(StageProgress).where(StageProgress.user_id == user_id))
+    assert before.scalars().first() is None
+
     await _seed_stage_with_content(db_session, stage_number=2)
 
     resp = await async_client.get("/course/stages/2/content", headers=headers)
-    assert resp.status_code == HTTPStatus.FORBIDDEN
-    assert resp.json()["detail"] == "stage_locked"
+    assert resp.status_code == HTTPStatus.OK
+
+    after = await db_session.execute(select(StageProgress).where(StageProgress.user_id == user_id))
+    assert after.scalars().first() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`GET /course/stages/{stage_number}/content` now returns a **titles-only listing** (200) for a stage that is still **locked** for the user, instead of the previous `403 stage_locked`. This lets the Course drawer render the full table of contents — every stage's chapter titles as an invitation to look ahead — while keeping locked content unreadable.

For a locked stage the response carries every item in release order with `is_locked: true` and `url: null` — the exact shape `filter_content_for_user` already produces at `unlocked_count == 0`. A small helper `_listing_unlocked_count` returns `0` when the stage is locked, else the unchanged proportional drip count.

This **deliberately reverses** the earlier locked-stage metadata-hardening gate for the listing only, at the product owner's explicit request (the drawer wants the chapter map). It is a scoped product decision, not a leak: the listing response model has no body/summary/markdown field, so titles + `content_type` + `release_day` are the only fields exposed — all already public curriculum shape.

**What stays gated (untouched):**
- `get_content_item`, `mark_content_read`, and the content-body/intro endpoints still 404-mask locked stages (BUG-COURSE-004/005/007) — bodies and urls remain unreachable.
- `get_course_progress` still 403s a locked stage via `_check_stage_unlocked`.

**Notes:**
- The locked-listing path is read-only: `_listing_unlocked_count` short-circuits before `_day_in_stage_for_user` → `ensure_user_progress`, so listing a locked stage does **not** provision a `StageProgress` row (pinned by a test).
- The listing reuses the existing UTC unlock predicate (`_is_stage_unlocked_for_user`) so its locked/unlocked determination stays consistent with the sibling item/mark-read gates. Timezone-aware unlock is intentionally left to the tz-migration surface (Refs #1639) and not expanded here.

## Test plan

- `test_list_content_locked_stage_returns_titles_only` — locked stage → 200, all items present and ordered by `(release_day, id)`, every item `is_locked: true` / `url: null` / `is_read: false`, and the JSON key-set is exactly the `ContentItemResponse` listing fields (no-leak negative).
- `test_list_content_locked_stage_paginated` — `?paginate=true` over a locked stage returns the envelope with `total` = full count and every page item locked/url-less (full key-set pinned).
- `test_list_content_locked_stage_does_not_provision_progress` — no `StageProgress` row exists before or after listing a locked stage.
- Unchanged and still green: drip-feed (day 0 / partway / all-unlocked), past-stage full-unlock, calendar-unlocked-ahead partial drip, read-status, per-user isolation, nonexistent-stage 404, and the sibling locked-stage 404/403 gate tests.
- Full `tests/test_course_api.py`: 36 passed. `scripts/backend/check-all.sh`: 7/7. xenon A / radon MI ≥ B over `src/`.

Closes #1622
Refs #1621