### PR TITLE
feat(map): drawer rows show color + category + Aspect; row tap opens the stage modal

### DIFF
--- a/frontend/src/features/Map/MapDrawer.tsx
+++ b/frontend/src/features/Map/MapDrawer.tsx
@@ -1,10 +1,11 @@
 /**
  * The Map header-drawer body: a compact legend of all ten stages rendered as
  * ``ScreenDrawer`` children (the panel supplies the scroll surface, so this maps
- * plain rows). Each row shows the stage's color swatch, persona/descriptor, and
- * its wheel-of-wholeness balance read; the current stage is marked, and a locked
- * stage carries a padlock plus its calendar unlock estimate. Tapping any row —
- * locked or not — glides the magnifier lens to that stage and closes the drawer.
+ * plain rows). Each row shows the stage's color swatch, its category, and — when
+ * present — its Aspect; the current stage is marked, and a locked stage carries a
+ * padlock plus its calendar unlock estimate. Tapping any row — locked or not —
+ * glides the magnifier lens to that stage, opens its detail modal, and closes the
+ * drawer.
  */
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
@@ -14,13 +15,20 @@ import { useDaysUntilStage } from '../../store/useProgramProgression';
 
 import { useJourneySummary } from './hooks/useJourneySummary';
 import { unlockTimeline } from './journeyNarrative';
-import { STAGE_DISPLAY, type StageDisplay } from './mapLayout';
+import { MAP_ROWS, STAGE_DISPLAY, type StageDisplay } from './mapLayout';
 import { isStageUnlocked } from './services/stageService';
 import { STAGE_COUNT, type StageData } from './stageData';
-import { balanceLabelSuffix, stageNodeLabel, THIN_FULLNESS } from './stageLegend';
+import { drawerStageLabel } from './stageLegend';
 
 /** Glyph shown on a locked stage row. */
 const LOCKED_GLYPH = '🔒';
+
+/** Stage number → its category (the containing MAP_ROWS row's rightLabel). */
+const CATEGORY_BY_STAGE: Readonly<Record<number, string>> = Object.fromEntries(
+  MAP_ROWS.flatMap((row) =>
+    row.stageNumbers.map((stageNumber): [number, string] => [stageNumber, row.rightLabel]),
+  ),
+);
 /** Diameter of the current-stage marker dot in dp. */
 const MARKER_SIZE = 10;
 /** Side of the square color swatch in dp. */
@@ -61,28 +69,28 @@ const UnlockRow = ({ stageNumber }: { stageNumber: number }): React.JSX.Element 
 interface LegendRowProps {
   stageNumber: number;
   display: StageDisplay;
-  fullness: number;
   locked: boolean;
   selected: boolean;
   onSelectStage: (_stageNumber: number) => void;
 }
 
-/** One tappable legend row: swatch, persona/descriptor, balance read, and the
+/** One tappable legend row: swatch, category, optional Aspect line, and the
  *  current-stage marker or a locked stage's padlock + unlock estimate. */
 const LegendRow = ({
   stageNumber,
   display,
-  fullness,
   locked,
   selected,
   onSelectStage,
 }: LegendRowProps): React.JSX.Element => {
   const { width } = useWindowDimensions();
+  const category = CATEGORY_BY_STAGE[stageNumber] ?? '';
+  const aspect = display.arrowLabel;
   return (
     <TouchableOpacity
       testID={`map-drawer-stage-${stageNumber}`}
       accessibilityRole="button"
-      accessibilityLabel={stageNodeLabel(display, fullness)}
+      accessibilityLabel={drawerStageLabel(category, aspect, { locked, current: selected })}
       accessibilityState={{ selected }}
       onPress={() => onSelectStage(stageNumber)}
       style={[styles.row, selected ? styles.rowSelected : null, locked ? styles.rowLocked : null]}
@@ -92,15 +100,14 @@ const LegendRow = ({
         style={[styles.swatch, { backgroundColor: display.textColor }]}
       />
       <View style={styles.rowBody}>
-        <Text style={[type(width).label, styles.persona]} numberOfLines={1}>
-          {display.persona}
+        <Text style={[type(width).label, styles.category]} numberOfLines={1}>
+          {category}
         </Text>
-        <Text style={[type(width).caption, styles.descriptor]} numberOfLines={1}>
-          {display.descriptor}
-        </Text>
-        <Text style={[type(width).caption, styles.balanceRead]}>
-          {balanceLabelSuffix(fullness)}
-        </Text>
+        {aspect ? (
+          <Text style={[type(width).caption, styles.aspect]} numberOfLines={1}>
+            {aspect}
+          </Text>
+        ) : null}
         {locked ? <UnlockRow stageNumber={stageNumber} /> : null}
       </View>
       {selected ? (
@@ -116,11 +123,9 @@ export interface MapDrawerProps {
   lookup: Readonly<Record<number, StageData | undefined>>;
   /** The stage the journey currently rests on, marked selected in the list. */
   currentStage: number;
-  /** Wheel-of-wholeness fullness (0..1) by stage; absent reads thin. */
-  fullnessByStage: Readonly<Record<number, number>>;
   /** Which pass through the arc the user is on; past 1 it captions the cycle. */
   cycleNumber: number;
-  /** Glide the magnifier lens to a stage and close the drawer. */
+  /** Glide the lens to a stage, open its detail modal, and close the drawer. */
   onSelectStage: (_stageNumber: number) => void;
 }
 
@@ -128,7 +133,6 @@ export interface MapDrawerProps {
 export default function MapDrawer({
   lookup,
   currentStage,
-  fullnessByStage,
   cycleNumber,
   onSelectStage,
 }: MapDrawerProps): React.JSX.Element {
@@ -145,7 +149,6 @@ export default function MapDrawer({
             key={stageNumber}
             stageNumber={stageNumber}
             display={display}
-            fullness={fullnessByStage[stageNumber] ?? THIN_FULLNESS}
             locked={stage ? !isStageUnlocked(stage, currentStage) : true}
             selected={stageNumber === currentStage}
             onSelectStage={onSelectStage}
@@ -191,14 +194,11 @@ const styles = StyleSheet.create({
   rowBody: {
     flex: 1,
   },
-  persona: {
+  category: {
     color: ink.primary,
   },
-  descriptor: {
+  aspect: {
     color: ink.soft,
-  },
-  balanceRead: {
-    color: ink.muted,
   },
   unlock: {
     color: ink.muted,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -1075,7 +1075,6 @@ interface MapScreenDrawerProps {
   drawer: ScreenDrawerState;
   lookup: StageLookup;
   currentStage: number;
-  fullnessByStage: FullnessLookup;
   cycleNumber: number;
   onSelectStage: (_stageNumber: number) => void;
 }
@@ -1085,7 +1084,6 @@ const MapScreenDrawer = ({
   drawer,
   lookup,
   currentStage,
-  fullnessByStage,
   cycleNumber,
   onSelectStage,
 }: MapScreenDrawerProps): React.JSX.Element => (
@@ -1094,7 +1092,6 @@ const MapScreenDrawer = ({
     <MapDrawer
       lookup={lookup}
       currentStage={currentStage}
-      fullnessByStage={fullnessByStage}
       cycleNumber={cycleNumber}
       onSelectStage={onSelectStage}
     />
@@ -1157,7 +1154,6 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
         drawer={props.drawer}
         lookup={props.lookup}
         currentStage={props.currentStage}
-        fullnessByStage={props.fullnessByStage}
         cycleNumber={props.cycleNumber}
         onSelectStage={props.onDrawerSelectStage}
       />
@@ -1165,17 +1161,19 @@ const MapContent = (props: MapContentProps): React.JSX.Element => (
   </View>
 );
 
-/** Map header drawer: a row tap closes it and glides the lens to that stage. */
+/** Map header drawer: a row tap closes it, glides the lens, and opens the modal. */
 const useMapDrawer = (
   lens: LensFocus,
 ): { drawer: ScreenDrawerState; onDrawerSelectStage: (_stageNumber: number) => void } => {
   const drawer = useScreenDrawer('Map');
-  // A drawer row tap is a pure select-and-highlight: the map is not scrollable,
-  // so close the drawer and glide the magnifier lens to the tapped stage.
+  // A drawer row tap closes the drawer, glides the magnifier lens to the tapped
+  // stage, and opens that stage's detail modal (falling back to glide-only when
+  // the stage isn't loaded yet, since handleOpenStage no-ops on a missing stage).
   const onDrawerSelectStage = useCallback(
     (stageNumber: number) => {
       drawer.close();
       lens.setFocusedStage(stageNumber);
+      lens.handleOpenStage(stageNumber);
     },
     [drawer, lens],
   );

--- a/frontend/src/features/Map/__tests__/MapDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapDrawer.test.tsx
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 // Pure body suite for the Map header drawer's legend: ten stage rows ascending
-// (1 at top), the persona/descriptor/balance-read a11y label, the current-stage
+// (1 at top), each showing a color swatch plus its category and Aspect (no
+// persona/descriptor/balance-read copy in the visible row), the current-stage
 // marker, the locked-row unlock timeline, and the journey summary line.
 import React from 'react';
 import { StyleSheet } from 'react-native';
@@ -10,11 +11,10 @@ import { act, create } from 'react-test-renderer';
 import { cycleLabel } from '../beginAgain';
 import { journeyRead, unlockTimeline } from '../journeyNarrative';
 import MapDrawer from '../MapDrawer';
-import { STAGE_DISPLAY } from '../mapLayout';
+import { MAP_ROWS, STAGE_DISPLAY } from '../mapLayout';
 import { STAGE_COUNT } from '../stageData';
 import type { StageData } from '../stageData';
-import { stageNodeLabel } from '../stageLegend';
-import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
+import { drawerStageLabel } from '../stageLegend';
 
 import { mockMakeStage, mockMapState, resetMapMockState } from './mapTestHarness';
 
@@ -43,6 +43,13 @@ const requireDisplay = (stageNumber: number) => {
   return display;
 };
 
+/** The MAP_ROWS rightLabel (category) that contains the given stage number. */
+const categoryForStage = (stageNumber: number): string => {
+  const row = MAP_ROWS.find((r) => r.stageNumbers.includes(stageNumber));
+  if (!row) throw new Error(`no MAP_ROW for stage ${stageNumber}`);
+  return row.rightLabel;
+};
+
 describe('MapDrawer', () => {
   beforeEach(() => {
     resetMapMockState();
@@ -53,7 +60,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -74,7 +80,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -86,12 +91,50 @@ describe('MapDrawer', () => {
     }
   });
 
-  it('shows persona and descriptor text for every stage', () => {
+  it('shows the category and Aspect text for a stage that has an Aspect', () => {
     const tree = create(
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    for (const n of [1, 5, 6]) {
+      const row = tree.root.findByProps({ testID: `map-drawer-stage-${n}` });
+      expect(
+        row.findAll((node: TestNode) => node.props.children === categoryForStage(n)).length,
+      ).toBeGreaterThan(0);
+      expect(
+        row.findAll((node: TestNode) => node.props.children === requireDisplay(n).arrowLabel)
+          .length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('shows only the category, with no Aspect text, for stages 9 and 10', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    for (const n of [9, 10]) {
+      const row = tree.root.findByProps({ testID: `map-drawer-stage-${n}` });
+      expect(
+        row.findAll((node: TestNode) => node.props.children === categoryForStage(n)).length,
+      ).toBeGreaterThan(0);
+      expect(requireDisplay(n).arrowLabel).toBe('');
+    }
+  });
+
+  it('no longer shows persona, descriptor, or balance-read copy in any row', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -100,26 +143,72 @@ describe('MapDrawer', () => {
       const display = requireDisplay(n);
       expect(
         tree.root.findAll((node: TestNode) => node.props.children === display.persona).length,
-      ).toBeGreaterThan(0);
-      expect(
-        tree.root.findAll((node: TestNode) => node.props.children === display.descriptor).length,
-      ).toBeGreaterThan(0);
+      ).toBe(0);
+      // Stage 8's descriptor string coincides with its Aspect, which the row
+      // legitimately shows; assert descriptor removal only where it cannot alias
+      // the rendered Aspect text.
+      if (display.descriptor !== display.arrowLabel) {
+        expect(
+          tree.root.findAll((node: TestNode) => node.props.children === display.descriptor).length,
+        ).toBe(0);
+      }
     }
+    expect(tree.root.findAll((n: TestNode) => n.props.children === 'reads full').length).toBe(0);
+    expect(tree.root.findAll((n: TestNode) => n.props.children === 'reads thin').length).toBe(0);
   });
 
-  it('gives each row an accessibilityLabel matching stageNodeLabel', () => {
+  it('gives an unlocked, non-current row an accessibilityLabel from drawerStageLabel', () => {
     const tree = create(
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{ 3: FULLNESS_ALIVE_THRESHOLD }}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
     );
-    const row = tree.root.findByProps({ testID: 'map-drawer-stage-3' });
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-2' });
     expect(row.props.accessibilityLabel).toBe(
-      stageNodeLabel(requireDisplay(3), FULLNESS_ALIVE_THRESHOLD),
+      drawerStageLabel(categoryForStage(2), requireDisplay(2).arrowLabel, {
+        locked: false,
+        current: false,
+      }),
+    );
+  });
+
+  it('gives the current row an accessibilityLabel carrying the current marker', () => {
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={5}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-5' });
+    expect(row.props.accessibilityLabel).toBe(
+      drawerStageLabel(categoryForStage(5), requireDisplay(5).arrowLabel, {
+        locked: false,
+        current: true,
+      }),
+    );
+  });
+
+  it('gives a locked row an accessibilityLabel carrying the locked marker', () => {
+    mockMapState.daysUntilStage = 5;
+    const tree = create(
+      <MapDrawer
+        lookup={buildLookup()}
+        currentStage={1}
+        cycleNumber={1}
+        onSelectStage={jest.fn()}
+      />,
+    );
+    const row = tree.root.findByProps({ testID: 'map-drawer-stage-8' });
+    expect(row.props.accessibilityLabel).toBe(
+      drawerStageLabel(categoryForStage(8), requireDisplay(8).arrowLabel, {
+        locked: true,
+        current: false,
+      }),
     );
   });
 
@@ -128,7 +217,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -137,44 +225,11 @@ describe('MapDrawer', () => {
     expect(row.props.accessibilityRole).toBe('button');
   });
 
-  it('shows a reads-full caption when fullness meets the alive threshold', () => {
-    const tree = create(
-      <MapDrawer
-        lookup={buildLookup()}
-        currentStage={1}
-        fullnessByStage={{ 2: FULLNESS_ALIVE_THRESHOLD }}
-        cycleNumber={1}
-        onSelectStage={jest.fn()}
-      />,
-    );
-    const row = tree.root.findByProps({ testID: 'map-drawer-stage-2' });
-    expect(row.findAll((n: TestNode) => n.props.children === 'reads full').length).toBeGreaterThan(
-      0,
-    );
-  });
-
-  it('shows a reads-thin caption when fullness is absent', () => {
-    const tree = create(
-      <MapDrawer
-        lookup={buildLookup()}
-        currentStage={1}
-        fullnessByStage={{}}
-        cycleNumber={1}
-        onSelectStage={jest.fn()}
-      />,
-    );
-    const row = tree.root.findByProps({ testID: 'map-drawer-stage-4' });
-    expect(row.findAll((n: TestNode) => n.props.children === 'reads thin').length).toBeGreaterThan(
-      0,
-    );
-  });
-
   it('marks only the current stage row selected, with its current marker', () => {
     const tree = create(
       <MapDrawer
         lookup={buildLookup()}
         currentStage={5}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -193,7 +248,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -214,7 +268,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={lookup}
         currentStage={STAGE_COUNT}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -230,7 +283,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -246,7 +298,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -262,7 +313,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={onSelectStage}
       />,
@@ -279,7 +329,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={onSelectStage}
       />,
@@ -296,7 +345,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={3}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,
@@ -312,7 +360,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={2}
         onSelectStage={jest.fn()}
       />,
@@ -327,7 +374,6 @@ describe('MapDrawer', () => {
       <MapDrawer
         lookup={buildLookup()}
         currentStage={1}
-        fullnessByStage={{}}
         cycleNumber={1}
         onSelectStage={jest.fn()}
       />,

--- a/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
@@ -2,9 +2,11 @@
 /* global describe, it, expect, beforeEach, jest */
 // Integration suite for the Map header drawer wired into MapScreen: the
 // header-left toggle installs via useScreenDrawer, opening it renders the
-// stage legend, and tapping a row closes the drawer and moves the magnifier
-// lens's focus to the tapped stage. Mirrors MapScreen.test.tsx's mock setup so
-// the same harness-driven stages/wheel/progression state applies.
+// stage legend, and tapping a row closes the drawer, moves the magnifier
+// lens's focus to the tapped stage, AND opens the stage-detail modal for that
+// stage (locked or not, since the harness loads all ten stages). Mirrors
+// MapScreen.test.tsx's mock setup so the same harness-driven
+// stages/wheel/progression state applies.
 import React from 'react';
 import { Image } from 'react-native';
 import { act, create } from 'react-test-renderer';
@@ -141,7 +143,7 @@ describe('MapScreen header drawer', () => {
     expect(headline.props.children).toBe('Nondual');
   });
 
-  it('does not open the stage-detail modal when a drawer row is tapped', () => {
+  it('opens the stage-detail modal for the tapped stage, and closes the drawer', () => {
     const tree = create(<MapScreen />);
     fireGridLayout(tree);
     openDrawer();
@@ -150,7 +152,20 @@ describe('MapScreen header drawer', () => {
       tree.root.findByProps({ testID: 'map-drawer-stage-3' }).props.onPress();
     });
 
-    expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
+    expect(tree.root.findByProps({ testID: 'stage-modal' })).toBeTruthy();
+    expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
+  });
+
+  it('opens the stage-detail modal even for a locked drawer row', () => {
+    const tree = create(<MapScreen />);
+    fireGridLayout(tree);
+    openDrawer();
+
+    act(() => {
+      tree.root.findByProps({ testID: 'map-drawer-stage-8' }).props.onPress();
+    });
+
+    expect(tree.root.findByProps({ testID: 'stage-modal' })).toBeTruthy();
   });
 
   it('reflects the current cycle number in the drawer journey summary', () => {

--- a/frontend/src/features/Map/__tests__/stageLegend.test.ts
+++ b/frontend/src/features/Map/__tests__/stageLegend.test.ts
@@ -1,7 +1,12 @@
 /* eslint-env jest */
 /* global describe, it, expect */
 import { STAGE_DISPLAY } from '../mapLayout';
-import { balanceLabelSuffix, stageNodeLabel, THIN_FULLNESS } from '../stageLegend';
+import {
+  balanceLabelSuffix,
+  drawerStageLabel,
+  stageNodeLabel,
+  THIN_FULLNESS,
+} from '../stageLegend';
 import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
 const requireDisplay = (stageNumber: number) => {
@@ -47,5 +52,45 @@ describe('stageNodeLabel', () => {
 describe('THIN_FULLNESS', () => {
   it('is the absent-fullness fallback of zero', () => {
     expect(THIN_FULLNESS).toBe(0);
+  });
+});
+
+describe('drawerStageLabel', () => {
+  it('joins the category and Aspect with a comma when an aspect is given', () => {
+    expect(drawerStageLabel('Yes-And-Ness', 'Agency', { locked: false, current: false })).toBe(
+      'Yes-And-Ness, Agency',
+    );
+  });
+
+  it('omits the Aspect segment when aspect is empty', () => {
+    expect(drawerStageLabel('Being', '', { locked: false, current: false })).toBe('Being');
+  });
+
+  it('omits the Aspect segment for a title stage with no arrow label, keeping the category', () => {
+    expect(drawerStageLabel('Awareness', '', { locked: false, current: false })).toBe('Awareness');
+  });
+
+  it('appends a locked marker when locked is true', () => {
+    expect(drawerStageLabel('Wisdom', 'Nondual', { locked: true, current: false })).toBe(
+      'Wisdom, Nondual, locked',
+    );
+  });
+
+  it('appends a current marker when current is true', () => {
+    expect(drawerStageLabel('Understanding', 'Embodied', { locked: false, current: true })).toBe(
+      'Understanding, Embodied, current',
+    );
+  });
+
+  it('appends both markers, current before locked, when both are true', () => {
+    expect(drawerStageLabel('Love', 'Self-Love', { locked: true, current: true })).toBe(
+      'Love, Self-Love, current, locked',
+    );
+  });
+
+  it('carries no state markers when neither locked nor current is true', () => {
+    expect(drawerStageLabel('Wisdom', 'Systems', { locked: false, current: false })).toBe(
+      'Wisdom, Systems',
+    );
   });
 });

--- a/frontend/src/features/Map/stageLegend.ts
+++ b/frontend/src/features/Map/stageLegend.ts
@@ -1,9 +1,10 @@
 // frontend/features/Map/stageLegend.ts
 
 /**
- * Accessibility-label helpers shared by the Map grid and its header drawer. A
- * stage node reads as its persona, descriptor, and a wheel-of-wholeness balance
- * suffix, so both surfaces announce the same label. Pure functions — no React.
+ * Accessibility-label helpers for the Map surfaces. A grid node reads as its
+ * persona, descriptor, and a wheel-of-wholeness balance suffix; a header-drawer
+ * row reads as its category and Aspect plus current/locked markers. Pure
+ * functions — no React.
  */
 
 import type { StageDisplay } from './mapLayout';
@@ -19,3 +20,14 @@ export const balanceLabelSuffix = (fullness: number): string =>
 /** Full a11y label for a stage node: persona/descriptor plus the balance read. */
 export const stageNodeLabel = (display: StageDisplay, fullness: number): string =>
   `${display.persona} - ${display.descriptor} - ${balanceLabelSuffix(fullness)}`;
+
+/** Drawer-row a11y label: "Category, Aspect" plus current/locked markers. */
+export const drawerStageLabel = (
+  category: string,
+  aspect: string,
+  opts: { locked: boolean; current: boolean },
+): string => {
+  const base = aspect ? `${category}, ${aspect}` : category;
+  const suffix = (opts.current ? ', current' : '') + (opts.locked ? ', locked' : '');
+  return base + suffix;
+};


### PR DESCRIPTION
## Summary

Simplifies each Map header-drawer legend row to exactly **color swatch + category + Aspect**, and makes a row tap open the stage detail modal in addition to gliding the lens.

- Row content is now the color swatch, the wheel-of-wholeness **category** (`MAP_ROWS` `rightLabel`, e.g. stage 1 → "Yes-And-Ness"), and the stage's **Aspect** (`STAGE_DISPLAY[n].arrowLabel`, e.g. stage 1 → "Agency"). The persona/descriptor lines and the "reads thin / reads full" balance line are removed from the visible row. Stages 9 and 10 carry no Aspect, so they show category only.
- Tapping a row (locked or unlocked) now **closes the drawer, glides the magnifier lens, and opens `StageDetailModal`** for that stage — reusing the lens's existing `handleOpenStage` path, which gracefully falls back to glide-only when the stage's `StageData` isn't loaded.
- Row accessibility labels are built by a new pure helper `drawerStageLabel(category, aspect, { locked, current })` announcing the visible content plus locked/current state. The map grid nodes' `stageNodeLabel` / `balanceLabelSuffix` (with the balance suffix) are untouched.
- The now-dead `fullnessByStage` prop is removed from the drawer path only; the `MapGrid` node path still uses it.
- Preserved: swatch, current-stage marker, 🔒 glyph + "Unlocks in N days" caption, journey summary, drawer nav section.

## Test plan

- `drawerStageLabel` unit tests (aspect present / absent / locked / current) in `stageLegend.test.ts`; existing `stageNodeLabel` / `balanceLabelSuffix` tests unchanged and green.
- `MapDrawer.test.tsx`: rows render category + Aspect; stages 9/10 show category with no Aspect; no persona/descriptor/balance copy anywhere; row a11y labels come from `drawerStageLabel`; lock glyph, unlock timeline, current marker, journey summary, and `onSelectStage` (locked + unlocked) preserved.
- `MapScreenDrawer.test.tsx`: tapping a drawer row (unlocked and locked) closes the drawer, glides the lens, and opens `stage-modal`.
- `MapScreenDrawerNav.test.tsx` (nav section) unchanged and green.
- `./scripts/frontend/check-all.sh` green: ESLint, prettier, tsc, 4241 Jest tests.

Closes #1624