### PR TITLE
fix(frontend): enforce a minimum interactive text size across the app

### DIFF
--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -51,6 +51,13 @@ base as `typography()`:
 - **Ramp** — `type(width)` → `{ display, title, heading, body, label, caption }`,
   each `{ fontFamily, fontSize, lineHeight, fontWeight }`; sizes descend and
   scale up from phone → tablet.
+- **Interactive-text floor** — `INTERACTIVE_TEXT_MIN` (16) is the legibility
+  floor for any tappable label; `editorialType.action` (serif, 16/24/600) and
+  `uiType.button` both source it. `editorialType.caption` (13px) is reserved for
+  **non-interactive** metadata — timestamps, eyebrows, hints, explainers — and
+  must never style a control's label. The `interactiveTextFloor` guard test
+  fails if a new `editorialType.caption` usage appears without being audited as
+  non-interactive, so caption sizing cannot silently reach tappable text again.
 
 ## Constraints (carried from the epic)
 

--- a/frontend/src/design/__tests__/editorialTokens.test.ts
+++ b/frontend/src/design/__tests__/editorialTokens.test.ts
@@ -1,6 +1,14 @@
 /* eslint-env jest */
 /* global describe, it, expect */
-import { colors, editorialType, journalLayout, journalSheet, paperShadow } from '../tokens';
+import {
+  INTERACTIVE_TEXT_MIN,
+  colors,
+  editorialType,
+  journalLayout,
+  journalSheet,
+  paperShadow,
+  uiType,
+} from '../tokens';
 
 /** WCAG relative luminance of a #rrggbb color. */
 const luminance = (hex: string): number => {
@@ -118,7 +126,15 @@ describe('editorial tokens', () => {
     });
 
     it('exports the long-form scale + a margin-note style', () => {
-      for (const key of ['display', 'title', 'body', 'note', 'caption', 'marginNote'] as const) {
+      for (const key of [
+        'display',
+        'title',
+        'body',
+        'note',
+        'caption',
+        'marginNote',
+        'action',
+      ] as const) {
         const style = editorialType[key];
         expect(style.fontFamily).toBe(editorialType.serif);
         expect(style.fontSize).toBeGreaterThan(0);
@@ -129,6 +145,21 @@ describe('editorial tokens', () => {
     it('uses a body size in the editorial 17-18px range', () => {
       expect(editorialType.body.fontSize).toBeGreaterThanOrEqual(17);
       expect(editorialType.body.fontSize).toBeLessThanOrEqual(18);
+    });
+
+    it('defines an accessibility floor for tappable text, exactly 16px', () => {
+      // caption is 13px, below the tappable-text floor -- interactive labels
+      // must use editorialType.action (16px) instead. This constant is an
+      // exact accessibility floor, never a >= comparison.
+      expect(INTERACTIVE_TEXT_MIN).toBe(16);
+    });
+
+    it('sizes action to the interactive floor, matching the ui button face', () => {
+      expect(editorialType.action.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+      expect(editorialType.action.fontSize).toBe(uiType.button.fontSize);
+      expect(editorialType.action.lineHeight).toBe(24);
+      expect(editorialType.action.fontWeight).toBe('600');
+      expect(editorialType.action.fontFamily).toBe(editorialType.serif);
     });
   });
 });

--- a/frontend/src/design/__tests__/interactiveTextFloor.test.ts
+++ b/frontend/src/design/__tests__/interactiveTextFloor.test.ts
@@ -1,0 +1,177 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { StyleSheet } from 'react-native';
+
+import { INTERACTIVE_TEXT_MIN } from '../tokens';
+
+import journalEntryStyles from '@/features/Journal/JournalEntry.styles';
+import { journalHeroStyles } from '@/features/Journal/JournalHero.styles';
+import statTileStyles from '@/features/Journal/StatTile.styles';
+import { welcomeStyles } from '@/features/Welcome/Welcome.styles';
+
+/**
+ * Guard for the minimum interactive text size.
+ *
+ * editorialType.caption is 13px, which sits below the tappable-text floor:
+ * text a reader is meant to tap or press needs to read as legible chrome, not
+ * a fine-print footnote. Interactive labels (links, buttons, chips, dismiss
+ * and accept affordances, and similar tappable text) must use
+ * editorialType.action (16px, the same size as the ui button face) instead.
+ * Genuine non-interactive captions -- timestamps, eyebrows, section labels,
+ * hints, and explainer copy that is not itself tappable -- may keep the 13px
+ * caption face.
+ *
+ * Part A walks every source file for editorialType.caption usages and diffs
+ * the found set against a hardcoded, manually audited allowlist. An entry in
+ * the allowlist below asserts that a human looked at that usage and confirmed
+ * it is not interactive. Any new caption usage -- whether interactive or
+ * not -- will change the found set and fail this test, forcing a conscious
+ * re-audit rather than a silent regression.
+ */
+
+// __dirname -> frontend/src/design/__tests__; climb to frontend/src.
+const SRC_ROOT = path.join(__dirname, '..', '..');
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue;
+      files.push(...collectSourceFiles(fullPath));
+    } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      if (entry.name.includes('.test.')) continue;
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const CAPTION_USAGE = /\.\.\.editorialType\.caption\b/;
+const SAME_LINE_KEY = /([A-Za-z_$][\w$]*)\s*:\s*\{/;
+const PRECEDING_KEY = /^\s*([A-Za-z_$][\w$]*)\s*:\s*\{/;
+
+/** The enclosing style-object key for a caption-usage line, or null if none is found. */
+function resolveKey(lines: string[], lineIndex: number): string | null {
+  const sameLineMatch = SAME_LINE_KEY.exec(lines[lineIndex] ?? '');
+  if (sameLineMatch) return sameLineMatch[1] ?? null;
+  for (let i = lineIndex - 1; i >= 0; i -= 1) {
+    const precedingMatch = PRECEDING_KEY.exec(lines[i] ?? '');
+    if (precedingMatch) return precedingMatch[1] ?? null;
+  }
+  return null;
+}
+
+function collectCaptionUsageIds(): string[] {
+  const ids: string[] = [];
+  for (const file of collectSourceFiles(SRC_ROOT)) {
+    if (file === __filename) continue;
+    const relPath = path.relative(SRC_ROOT, file).split(path.sep).join('/');
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      if (!CAPTION_USAGE.test(line)) return;
+      const key = resolveKey(lines, index);
+      ids.push(`${relPath}::${key ?? '(unknown)'}`);
+    });
+  }
+  return ids;
+}
+
+// Manually audited: every caption usage below was confirmed NON-interactive
+// (a timestamp, eyebrow, section label, hint, or explainer -- never tappable
+// text). Sorted to match the sorted found-set comparison.
+const AUDITED_NON_INTERACTIVE_CAPTIONS = [
+  'components/care/CareResourceCard.tsx::resourceWhat',
+  'features/Course/Course.styles.ts::readerEyebrow',
+  'features/Course/Course.styles.ts::sectionBandLabel',
+  'features/Course/Course.styles.ts::stageCoverEyebrow',
+  'features/Course/Course.styles.ts::stageCoverProgressLabel',
+  'features/Journal/CompletionSuggestionNote.tsx::streak',
+  'features/Journal/JournalEntry.styles.ts::aspectChordSectionLabel',
+  'features/Journal/JournalEntry.styles.ts::loadErrorText',
+  'features/Journal/JournalEntry.styles.ts::marginError',
+  'features/Journal/JournalEntry.styles.ts::privacyResonanceReason',
+  'features/Journal/JournalEntry.styles.ts::privacyTierExplainer',
+  'features/Journal/JournalEntry.styles.ts::savedHint',
+  'features/Journal/JournalHero.styles.ts::eyebrow',
+  'features/Journal/JournalShelf.styles.ts::cardCaption',
+  'features/Journal/JournalShelf.styles.ts::cardDate',
+  'features/Journal/JournalShelf.styles.ts::promptLabel',
+  'features/Journal/JournalShelf.styles.ts::sectionHeading',
+  'features/Journal/MarginNote.tsx::kind',
+  'features/Journal/MarginNote.tsx::staleCaption',
+  'features/Journal/ReflectionInvitationBand.tsx::label',
+  'features/Journal/ReflectionSourcesPanel.tsx::groupHeading',
+  'features/Journal/ReflectionSourcesPanel.tsx::levelLabel',
+  'features/Journal/ReflectionSourcesPanel.tsx::promoteHint',
+  'features/Journal/ReflectionSourcesPanel.tsx::rowExcerpt',
+  'features/Journal/ResonanceEssayModal.tsx::kind',
+  'features/Journal/SearchBar.tsx::searchResultCount',
+  'features/Journal/StatTile.styles.ts::title',
+  'features/Practice/PracticeScreen.tsx::heroEyebrow',
+  'features/Practice/components/ModePicker.tsx::categoryBlurb',
+  'features/Practice/components/ModePicker.tsx::rowDescription',
+  'features/Practice/configurator/RitualConfiguratorSheet.tsx::aspectText',
+  'features/Practice/configurator/RitualConfiguratorSheet.tsx::headerSubtitle',
+  'features/Practice/configurator/forms/CardMeditationForm.tsx::photoError',
+  'features/Practice/configurator/forms/CardMeditationForm.tsx::photoNote',
+  'features/Practice/configurator/forms/CardMeditationForm.tsx::sectionTitle',
+  'features/Practice/configurator/forms/CardMeditationForm.tsx::summaryCount',
+  'features/Practice/configurator/forms/CardMeditationForm.tsx::summaryDescription',
+  'features/Practice/configurator/forms/IntervalBellForm.tsx::subLabel',
+  'features/Practice/screens/CreatePracticeWizard.tsx::entryCardSubtitle',
+  'features/Practice/screens/CreatePracticeWizard.tsx::fieldHelp',
+  'features/Practice/screens/CreatePracticeWizard.tsx::indicatorStep',
+  'features/Practice/screens/CreatePracticeWizard.tsx::noticeText',
+  'features/Practice/screens/PracticeDetailScreen.tsx::eyebrow',
+  'features/Return/MettaSessionModal.tsx::weekTitle',
+  'features/Settings/SupportCareScreen.tsx::limits',
+  'features/Welcome/Welcome.styles.ts::eyebrow',
+  'features/Welcome/Welcome.styles.ts::note',
+].sort();
+
+describe('interactive text floor', () => {
+  describe('caption usage allowlist', () => {
+    it('matches the audited non-interactive set exactly (a superset means an unaudited or unmigrated interactive usage)', () => {
+      const found = collectCaptionUsageIds().sort();
+      expect(found).toEqual(AUDITED_NON_INTERACTIVE_CAPTIONS);
+    });
+  });
+
+  describe('migrated interactive style pins', () => {
+    it('sizes the JournalEntry interactive labels to the floor', () => {
+      const controlLink = StyleSheet.flatten(journalEntryStyles.controlLink);
+      const privacyTierLabel = StyleSheet.flatten(journalEntryStyles.privacyTierLabel);
+      const aspectChordTriggerLabel = StyleSheet.flatten(
+        journalEntryStyles.aspectChordTriggerLabel,
+      );
+      const aspectChordChipLabel = StyleSheet.flatten(journalEntryStyles.aspectChordChipLabel);
+      const aspectChordClearLabel = StyleSheet.flatten(journalEntryStyles.aspectChordClearLabel);
+      expect(controlLink.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+      expect(privacyTierLabel.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+      expect(aspectChordTriggerLabel.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+      expect(aspectChordChipLabel.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+      expect(aspectChordClearLabel.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+    });
+
+    it('sizes the StatTile cue to the floor', () => {
+      const cue = StyleSheet.flatten(statTileStyles.cue);
+      expect(cue.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+    });
+
+    it('sizes the JournalHero positionCue to the floor', () => {
+      const positionCue = StyleSheet.flatten(journalHeroStyles.positionCue);
+      expect(positionCue.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+    });
+
+    it('sizes the Welcome skipLabel to the floor', () => {
+      const skipLabel = StyleSheet.flatten(welcomeStyles.skipLabel);
+      expect(skipLabel.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+    });
+  });
+});

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -463,6 +463,17 @@ export const fonts = {
   sans: sansStack,
 } as const;
 
+/**
+ * WCAG-legibility floor (in dp) for tappable/interactive text. Companion to
+ * ``touchTarget``: where ``touchTarget`` is the tap-AREA floor, this is the
+ * floor for the text a reader is meant to tap or press, so an interactive label
+ * reads as legible chrome rather than a fine-print footnote. The 13px caption
+ * face sits below this floor and is metadata-only; interactive labels use
+ * ``editorialType.action`` (and the ui button face) at this size instead.
+ * Declared above ``editorialType`` and ``uiType`` so both can source it.
+ */
+export const INTERACTIVE_TEXT_MIN = 16;
+
 export const editorialType = {
   serif: serifStack,
   display: { fontFamily: serifStack, fontSize: 34, lineHeight: 42, fontWeight: '700' as const },
@@ -470,6 +481,14 @@ export const editorialType = {
   body: { fontFamily: serifStack, fontSize: 18, lineHeight: 29, fontWeight: '400' as const },
   note: { fontFamily: serifStack, fontSize: 15, lineHeight: 24, fontWeight: '400' as const },
   caption: { fontFamily: serifStack, fontSize: 13, lineHeight: 20, fontWeight: '400' as const },
+  // Interactive/tappable label face — serif to stay editorial, sized to the
+  // interactive floor. caption is metadata-only and below the tappable floor.
+  action: {
+    fontFamily: serifStack,
+    fontSize: INTERACTIVE_TEXT_MIN,
+    lineHeight: 24,
+    fontWeight: '600' as const,
+  },
   marginNote: {
     fontFamily: serifStack,
     fontSize: 14,
@@ -529,7 +548,7 @@ export const type = (width: number) => {
 
 /** Typography for interactive chrome, so button/label sizing lives in tokens. */
 export const uiType = {
-  button: { fontSize: 16, fontWeight: '600' as const },
+  button: { fontSize: INTERACTIVE_TEXT_MIN, fontWeight: '600' as const },
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Invitations/InvitationNote.tsx
+++ b/frontend/src/features/Invitations/InvitationNote.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   declineText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Journal/CompletionSuggestionNote.tsx
+++ b/frontend/src/features/Journal/CompletionSuggestionNote.tsx
@@ -200,12 +200,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.tier.clear,
   },
   acceptText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.background,
-    fontWeight: '600',
   },
   dismissText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
   disabled: {

--- a/frontend/src/features/Journal/JournalEntry.styles.ts
+++ b/frontend/src/features/Journal/JournalEntry.styles.ts
@@ -150,8 +150,8 @@ const styles = StyleSheet.create({
     marginBottom: journalLayout.marginNoteGap,
   },
   controlLink: {
-    ...editorialType.caption,
-    color: colors.paper.inkSoft,
+    ...editorialType.action,
+    color: accent.primary,
     paddingTop: spacing(2),
   },
   /** Read-mode quote affordances (Promote / Remove promotion): 44dp touch floor. */
@@ -250,7 +250,7 @@ const styles = StyleSheet.create({
     borderColor: colors.paper.inkSoft,
   },
   privacyTierLabel: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
   privacyTierLabelSelected: {
@@ -280,7 +280,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.sm,
   },
   aspectChordTriggerLabel: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
   /** Section label above a row of Aspect chips (primary / secondary). */
@@ -310,7 +310,7 @@ const styles = StyleSheet.create({
     borderColor: colors.paper.inkSoft,
   },
   aspectChordChipLabel: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
   aspectChordChipLabelSelected: {
@@ -323,7 +323,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.sm,
   },
   aspectChordClearLabel: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Journal/JournalHero.styles.ts
+++ b/frontend/src/features/Journal/JournalHero.styles.ts
@@ -27,7 +27,7 @@ export const journalHeroStyles = StyleSheet.create({
     color: onShowcase.soft,
   },
   positionCue: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: onShowcase.muted,
     marginTop: SPACING.xs,
   },

--- a/frontend/src/features/Journal/MarginNote.tsx
+++ b/frontend/src/features/Journal/MarginNote.tsx
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
     paddingTop: spacing(0.5),
   },
   open: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
     paddingTop: spacing(1),
   },

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -586,9 +586,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   actionLink: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: accent.primary,
-    fontWeight: '600',
   },
   promoteOpener: {
     minHeight: touchTarget.minimum,
@@ -596,9 +595,8 @@ const styles = StyleSheet.create({
     paddingTop: spacing(1),
   },
   promoteOpenerLink: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: accent.primary,
-    fontWeight: '600',
   },
   promoteHint: {
     ...editorialType.caption,

--- a/frontend/src/features/Journal/ResonanceEssayModal.tsx
+++ b/frontend/src/features/Journal/ResonanceEssayModal.tsx
@@ -184,7 +184,7 @@ const styles = StyleSheet.create({
     color: colors.danger,
   },
   retry: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
     paddingTop: spacing(1),
   },

--- a/frontend/src/features/Journal/StatTile.styles.ts
+++ b/frontend/src/features/Journal/StatTile.styles.ts
@@ -43,9 +43,8 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
   },
   cue: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: accent.primary,
-    fontWeight: '600',
     marginTop: SPACING.xs,
   },
 });

--- a/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/CardMeditationForm.tsx
@@ -366,7 +366,7 @@ const styles = StyleSheet.create({
     borderRadius: BORDER_RADIUS.md,
     backgroundColor: surface.sunken,
   },
-  photoButtonText: { ...editorialType.caption, fontWeight: '500', color: ink.primary },
+  photoButtonText: { ...editorialType.action, color: ink.primary },
   photoError: { ...editorialType.caption, color: colors.danger },
   photoThumb: { width: THUMB_SIZE, height: THUMB_SIZE, borderRadius: BORDER_RADIUS.sm },
 });

--- a/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/IntervalBellForm.tsx
@@ -156,7 +156,7 @@ const localStyles = StyleSheet.create({
     borderRadius: BORDER_RADIUS.lg,
     backgroundColor: surface.sunken,
   },
-  offsetChipText: { ...editorialType.caption, color: ink.primary },
+  offsetChipText: { ...editorialType.action, color: ink.primary },
   addRow: { flexDirection: 'row', alignItems: 'center', gap: SPACING.sm },
   addButton: {
     paddingVertical: SPACING.xs,

--- a/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
+++ b/frontend/src/features/Practice/configurator/forms/SenseGroundingForm.tsx
@@ -167,7 +167,7 @@ const localStyles = StyleSheet.create({
     backgroundColor: surface.sunken,
     minHeight: 32,
   },
-  smallButtonText: { ...editorialType.caption, color: ink.primary },
+  smallButtonText: { ...editorialType.action, color: ink.primary },
   disabled: { opacity: 0.4 },
   addButton: { marginTop: SPACING.sm },
 });

--- a/frontend/src/features/Practice/configurator/forms/shared.tsx
+++ b/frontend/src/features/Practice/configurator/forms/shared.tsx
@@ -455,7 +455,7 @@ const formStyles = StyleSheet.create({
     borderColor: accent.primary,
   },
   chipText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: ink.soft,
   },
   chipTextActive: {

--- a/frontend/src/features/Return/MettaSessionModal.tsx
+++ b/frontend/src/features/Return/MettaSessionModal.tsx
@@ -245,7 +245,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   closeText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Return/ReturnArcCard.tsx
+++ b/frontend/src/features/Return/ReturnArcCard.tsx
@@ -216,7 +216,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   actionText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.background,
   },
   leave: {
@@ -229,7 +229,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   leaveText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Return/ReturnCompletionCard.tsx
+++ b/frontend/src/features/Return/ReturnCompletionCard.tsx
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   leaveText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Return/ReturnOfferCard.tsx
+++ b/frontend/src/features/Return/ReturnOfferCard.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   acceptText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.background,
   },
   dismiss: {
@@ -115,7 +115,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   dismissText: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: colors.paper.inkSoft,
   },
 });

--- a/frontend/src/features/Welcome/Welcome.styles.ts
+++ b/frontend/src/features/Welcome/Welcome.styles.ts
@@ -32,7 +32,7 @@ export const welcomeStyles = StyleSheet.create({
     justifyContent: 'center',
   },
   skipLabel: {
-    ...editorialType.caption,
+    ...editorialType.action,
     color: accent.primary,
   },
   panel: {


### PR DESCRIPTION
## Summary

Interactive/tappable labels across the app were styled with `editorialType.caption` (13px serif) — visually the same weight as timestamps and hints, and below a comfortable tap-label legibility floor. This establishes and enforces a minimum interactive text size in the Candle & Ink design system.

- Adds `INTERACTIVE_TEXT_MIN` (16) as the WCAG-legibility floor for tappable text, a companion to `touchTarget` (the tap-*area* floor), and a serif `editorialType.action` face (16/24/600) sourced from it. `uiType.button` now sources its size from the same constant so the floor has a single home (value unchanged).
- Migrates the **interactive subset** of caption usages — 25 style keys across 17 files in Journal, Return, Practice, Welcome and Invitations — from `editorialType.caption` to `editorialType.action`, and raises `controlLink`'s colour from `inkSoft` to the link accent (`accent.primary`, WCAG AA on the paper ground). Genuine non-interactive captions (timestamps, eyebrows, hints, explainers) stay at 13px.
- **Enforcement:** `interactiveTextFloor.test.ts` walks `src` for every `...editorialType.caption` spread and fails unless each appears in an audited non-interactive allowlist — so a new caption usage forces a conscious audit (use `action` if tappable, add to the list if not) and 13px sizing can no longer silently reach interactive labels. Plus style pins assert migrated keys resolve to the floor exactly (`=== INTERACTIVE_TEXT_MIN`, not `>=` — it's an accessibility floor). `DESIGN.md` documents the floor and the caption-is-metadata-only convention.

Convention ratified during review: eyebrows/kickers inside a composite tap target keep caption size; only the primary CTA/affordance label of a control migrates (e.g. `StatTile.title` stays caption while its `cue` migrates).

**Design-review note:** chip/radio labels (`privacyTierLabel`, `aspectChordChipLabel`, `chipText`, `offsetChipText`) read denser at 16/600 — intended, but worth an eyeball. `ReflectionSourcesPanel.tsx` was touched minimally (two style objects) since a sibling promote-flow epic is churning it.

## Test plan

- `npx jest src/design/__tests__/editorialTokens.test.ts src/design/__tests__/interactiveTextFloor.test.ts` — token shape + enforcement (RED before, GREEN after).
- `./scripts/frontend/check-all.sh` — lint, types, full jest suite (404 suites / 4254 tests), format: all green.

Closes #1631