### PR TITLE
fix(frontend): rename stage-8 color from Turquoise to Teal per APTITUDE canon

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -114,7 +114,7 @@ describe('design tokens', () => {
       expect(STAGE_COLORS['Orange']).toBe('#f29f67');
       expect(STAGE_COLORS['Green']).toBe('#6fcf97');
       expect(STAGE_COLORS['Yellow']).toBe('#f2e96d');
-      expect(STAGE_COLORS['Turquoise']).toBe('#50c9c3');
+      expect(STAGE_COLORS['Teal']).toBe('#50c9c3');
       expect(STAGE_COLORS['Ultraviolet']).toBe('#8e44ad');
       expect(STAGE_COLORS['Clear Light']).toBe('#ffffff');
     });
@@ -130,7 +130,12 @@ describe('design tokens', () => {
     it('lists all ten stages in progression order', () => {
       expect(STAGE_ORDER).toHaveLength(10);
       expect(STAGE_ORDER[0]).toBe('Beige');
+      expect(STAGE_ORDER[7]).toBe('Teal');
       expect(STAGE_ORDER[9]).toBe('Clear Light');
+    });
+
+    it('names stage 8 with the APTITUDE canon "Teal", not the legacy name', () => {
+      expect(STAGE_ORDER).not.toContain('Turquoise');
     });
 
     it('contains exactly the same keys as STAGE_COLORS', () => {
@@ -145,6 +150,12 @@ describe('design tokens', () => {
       expect(resolveStageColor('Beige')).toBe(STAGE_COLORS['Beige']);
       expect(resolveStageColor('Purple')).toBe(STAGE_COLORS['Purple']);
       expect(resolveStageColor('Clear Light')).toBe(STAGE_COLORS['Clear Light']);
+    });
+
+    it('resolves the legacy "Turquoise" name to the stage-8 Teal hex', () => {
+      // A server on the pre-rename dataset can still send "Turquoise"; it
+      // must resolve to the Teal swatch, not the neutral-gray fallback.
+      expect(resolveStageColor('Turquoise')).toBe(STAGE_COLORS['Teal']);
     });
 
     it('falls back to the neutral gray for an unrecognized color name', () => {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -171,7 +171,7 @@ export const STAGE_COLORS: Record<string, string> = {
   Orange: '#f29f67',
   Green: '#6fcf97',
   Yellow: '#f2e96d',
-  Turquoise: '#50c9c3',
+  Teal: '#50c9c3',
   Ultraviolet: '#8e44ad',
   'Clear Light': '#ffffff',
 };
@@ -184,10 +184,17 @@ export const STAGE_ORDER: readonly string[] = [
   'Orange',
   'Green',
   'Yellow',
-  'Turquoise',
+  'Teal',
   'Ultraviolet',
   'Clear Light',
 ];
+
+// Pre-rename Spiral-Dynamics name for stage 8, mapped to its canonical name so
+// a server still on the old dataset resolves to the Teal hex rather than the
+// neutral-gray fallback.
+const LEGACY_STAGE_ALIASES: Record<string, string> = {
+  Turquoise: 'Teal',
+};
 
 /**
  * Resolve a Spiral-Dynamics color name to its hex value, falling back to the
@@ -195,8 +202,13 @@ export const STAGE_ORDER: readonly string[] = [
  * resolution used across the Course stage cover, progress bar, and pill
  * selector — keep it here so the fallback can never silently diverge.
  */
-export const resolveStageColor = (spiralColor: string | undefined): string =>
-  spiralColor ? (STAGE_COLORS[spiralColor] ?? colors.neutral) : colors.neutral;
+export const resolveStageColor = (spiralColor: string | undefined): string => {
+  if (!spiralColor) {
+    return colors.neutral;
+  }
+  const canonical = LEGACY_STAGE_ALIASES[spiralColor] ?? spiralColor;
+  return STAGE_COLORS[canonical] ?? colors.neutral;
+};
 
 /** How far each channel is pushed from the gray point when brightening. */
 const SATURATION_BOOST = 1.7;

--- a/frontend/src/features/Habits/HabitDefaults.tsx
+++ b/frontend/src/features/Habits/HabitDefaults.tsx
@@ -108,7 +108,7 @@ export const HABIT_DEFAULTS: Habit[] = [
   },
   {
     id: 3,
-    stage: 'Turquoise',
+    stage: 'Teal',
     name: 'Limit Caffeine',
     icon: '☕',
     streak: 0,

--- a/frontend/src/features/Practice/data/__tests__/colorPalette.test.ts
+++ b/frontend/src/features/Practice/data/__tests__/colorPalette.test.ts
@@ -26,10 +26,14 @@ describe('COLOR_PALETTE', () => {
       'Orange',
       'Green',
       'Yellow',
-      'Turquoise',
+      'Teal',
       'Ultraviolet',
       'Clear Light',
     ]);
+  });
+
+  it('does not list the legacy Spiral-Dynamics name as canonical', () => {
+    expect(SPIRAL_DYNAMICS_COLORS).not.toContain('Turquoise');
   });
 });
 
@@ -49,6 +53,12 @@ describe('isSpiralDynamicsColor', () => {
 describe('swatchFor', () => {
   it('returns the catalogued swatch for a known colour', () => {
     expect(swatchFor('Orange')).toBe(COLOR_PALETTE.Orange);
+  });
+
+  it('resolves the legacy "Turquoise" label to the Teal swatch', () => {
+    // A server still on the pre-rename dataset can send "Turquoise" for
+    // stage 8; it must render the Teal swatch, not the white fallback.
+    expect(swatchFor('Turquoise')).toBe(COLOR_PALETTE.Teal);
   });
 
   it('falls back to the neutral "Clear Light" swatch for unknown values', () => {

--- a/frontend/src/features/Practice/data/colorPalette.ts
+++ b/frontend/src/features/Practice/data/colorPalette.ts
@@ -16,10 +16,17 @@ export const SPIRAL_DYNAMICS_COLORS = [
   'Orange',
   'Green',
   'Yellow',
-  'Turquoise',
+  'Teal',
   'Ultraviolet',
   'Clear Light',
 ] as const;
+
+// Pre-rename Spiral-Dynamics name for stage 8. A server still on the old
+// dataset can send this label; it maps to the canonical Teal swatch so the
+// banner never falls back to the neutral Clear-Light white.
+const LEGACY_COLOR_ALIASES: Readonly<Record<string, SpiralDynamicsColor>> = Object.freeze({
+  Turquoise: 'Teal',
+});
 
 export type SpiralDynamicsColor = (typeof SPIRAL_DYNAMICS_COLORS)[number];
 
@@ -38,7 +45,7 @@ export const COLOR_PALETTE: Readonly<Record<SpiralDynamicsColor, ColorSwatch>> =
   Orange: { bg: '#f29f67', text: '#000000' },
   Green: { bg: '#6fcf97', text: '#000000' },
   Yellow: { bg: '#f2e96d', text: '#000000' },
-  Turquoise: { bg: '#50c9c3', text: '#000000' },
+  Teal: { bg: '#50c9c3', text: '#000000' },
   Ultraviolet: { bg: '#8e44ad', text: '#ffffff' },
   'Clear Light': { bg: '#ffffff', text: '#000000' },
 });
@@ -48,11 +55,13 @@ export function isSpiralDynamicsColor(value: string): value is SpiralDynamicsCol
 }
 
 /**
- * Look up the swatch for a server-supplied colour string. Falls back to the
- * neutral "Clear Light" swatch if the server sends a label the frontend
+ * Look up the swatch for a server-supplied colour string. Recognises the
+ * legacy "Turquoise" name for stage 8 as an alias of Teal, then falls back to
+ * the neutral "Clear Light" swatch if the server sends a label the frontend
  * palette hasn't catalogued yet — the banner stays legible instead of
  * crashing on a typo from a future content drop.
  */
 export function swatchFor(color: string): ColorSwatch {
-  return isSpiralDynamicsColor(color) ? COLOR_PALETTE[color] : COLOR_PALETTE['Clear Light'];
+  const canonical = LEGACY_COLOR_ALIASES[color] ?? color;
+  return isSpiralDynamicsColor(canonical) ? COLOR_PALETTE[canonical] : COLOR_PALETTE['Clear Light'];
 }


### PR DESCRIPTION
## Summary

The APTITUDE ontology names the stage-8 Spiral-Dynamics color **Teal** everywhere (course map, CLAUDE.md, every `markdown/08-teal/…` chapter), but the frontend color system still used the classic Spiral-Dynamics name **Turquoise** as canonical — mislabeling every stage-8 surface (Practice banner, Habits, Map, Course). The backend dataset already shipped the rename (#1634 / PR #1647), which deferred this frontend half to avoid a lane collision.

This PR sweeps the frontend canon to `Teal`:

- `frontend/src/features/Practice/data/colorPalette.ts` — `SPIRAL_DYNAMICS_COLORS`, `COLOR_PALETTE` key, and `swatchFor`.
- `frontend/src/design/tokens.ts` — `STAGE_COLORS`, `STAGE_ORDER`, and `resolveStageColor`.
- `frontend/src/features/Habits/HabitDefaults.tsx` — the stage-8 default habit.

The hex (`#50c9c3`) and the WCAG contrast invariant are unchanged. A **deliberate, commented legacy alias** in each resolution path maps a server-supplied `"Turquoise"` to the canonical Teal swatch, so a payload from the pre-rename dataset renders Teal instead of silently falling back (to Clear-Light white in the Practice banner, or neutral gray in the token resolver).

Out of scope: `frontend/src/features/Journal/promptTitle.ts` keeps `'Turquoise'` — it is the 12-band Archetypal Wavelength taxonomy (which legitimately has both a Turquoise *and* a Teal band) mirroring `backend/src/domain/weekly_prompts.py`, not the 10-entry Spiral-Dynamics stage system.

## Test plan

- TDD (RED → GREEN): updated the canon-pin assertions in `colorPalette.test.ts` and `tokens.test.ts` to expect `Teal`, added negative assertions that `Turquoise` is no longer canonical, and added legacy-alias tests (`swatchFor('Turquoise')` → Teal swatch; `resolveStageColor('Turquoise')` → stage-8 Teal hex).
- `./scripts/frontend/check-all.sh` — all four gates green (eslint, prettier, typecheck, 4259 jest tests).

Closes #1635
Refs #1633