### PR TITLE
test(course): deflake 'renders stage selector after loading' with a deterministic handshake

### DIFF
--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -168,6 +168,17 @@ jest.mock('react-native-safe-area-context', () => {
 const { render, waitFor, fireEvent, act, within } = require('@testing-library/react-native');
 const CourseScreen = require('../CourseScreen').default;
 
+// Drain the microtask queue across several ticks so a resolved fetch fully
+// propagates through the loading -> loaded state chain before we assert,
+// regardless of chain depth -- no wall-clock polling.
+const flushMicrotasks = async (): Promise<void> => {
+  for (let i = 0; i < 4; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
+
 describe('CourseScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -186,11 +197,26 @@ describe('CourseScreen', () => {
   });
 
   it('renders stage selector after loading', async () => {
-    const { getByTestId } = render(<CourseScreen />);
+    // Control when the stage list settles so the loading -> loaded transition is
+    // driven by an explicit resolution, not a wall-clock waitFor that flakes on
+    // slow runners.
+    let resolveStages: (_stages: Stage[]) => void = () => undefined;
+    mockStagesList.mockReturnValue(
+      new Promise<Stage[]>((resolve) => {
+        resolveStages = resolve;
+      }),
+    );
 
-    await waitFor(() => {
-      expect(getByTestId('stage-selector')).toBeTruthy();
-    });
+    const { getByTestId, queryByTestId } = render(<CourseScreen />);
+
+    // Until the stage list resolves the screen holds the loading spinner.
+    expect(getByTestId('course-loading')).toBeTruthy();
+    expect(queryByTestId('stage-selector')).toBeNull();
+
+    resolveStages(sampleStages);
+    await flushMicrotasks();
+
+    expect(getByTestId('stage-selector')).toBeTruthy();
   });
 
   it('renders the stage selector and content list inside the shared content-capped container', async () => {
@@ -348,15 +374,6 @@ describe('CourseScreen', () => {
       const call = deferredCalls[index];
       if (!call) throw new Error(`No deferred stageContentAll call at index ${index}`);
       call.resolve(content);
-    };
-
-    // Several ticks so a resolved Promise.all fully propagates through state, regardless of chain depth.
-    const flushMicrotasks = async (): Promise<void> => {
-      for (let i = 0; i < 4; i += 1) {
-        await act(async () => {
-          await Promise.resolve();
-        });
-      }
     };
 
     const { getByTestId, getByText, queryByText } = render(<CourseScreen />);


### PR DESCRIPTION
## Summary

`CourseScreen.test.tsx`'s `renders stage selector after loading` case timed out
on slow CI runners (Jest's 5s default `waitFor` window) and failed CI on PR
#1640 — a runner-speed flake, since the parallel/duplicate run on the same
commit passed. This deflakes it per the repo's established pattern (awaiting the
actual settled state, not the wall clock).

- Replaced the wall-clock `waitFor` with a deterministic handshake: a deferred
  promise for the `stages.listAll` fetch mock, resolved explicitly, then a
  shared `flushMicrotasks` helper drains the loading → loaded state chain via
  `act` before a synchronous assertion.
- The test now also asserts the loading spinner is present and the selector
  absent *before* resolution, proving the transition is resolution-driven, not
  timing-driven.
- Hoisted the previously-duplicated `flushMicrotasks` helper to module scope and
  removed the local copy in the stale-fetch test.

Test-only change; no production code touched.

## Test plan

- Ran the target case 10× in isolation — 10/10 green (previously flaked ~1-in-2
  in isolation on this machine).
- Ran the full `CourseScreen.test.tsx` suite 3× — 28/28 each time.
- Verified it still goes RED with a temporary in-worktree break (removed the
  `<StageSelector>` render): the final `getByTestId('stage-selector')` throws.
  Break reverted; not committed.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, Jest — 404
  suites / 4262 tests).

Closes #1641