### PR TITLE
refactor(map): tidy backdrop touch symmetry, dead momentum passthrough, misplaced completion math

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -254,13 +254,6 @@ const rememberVerticalVelocity = (
   origin.current.lastY = nextY;
 };
 
-const settleStageWithMomentum = (
-  centerY: number,
-  velocityY: number,
-  gridHeight: number,
-  anchors: StageAnchors,
-): number => inertialStageTarget(centerY, velocityY, gridHeight, anchors);
-
 const dragCenterOnRail = (
   event: GestureResponderEvent,
   origin: DragOrigin,
@@ -278,7 +271,7 @@ const dragCenterOnRail = (
 const settleDraggedLens = (params: LensDragParams, dragOrigin: DragOrigin): void => {
   const { motion, gridHeight, anchors } = params;
   motion.dragging.current = false;
-  const settled = settleStageWithMomentum(
+  const settled = inertialStageTarget(
     motion.lastCenter.current.y,
     dragOrigin.velocityY,
     gridHeight,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -9,6 +9,7 @@ import {
   Modal,
   Pressable,
   ScrollView,
+  StyleSheet,
   Text,
   TouchableOpacity,
   View,
@@ -53,7 +54,12 @@ import {
   TITLE_BY_STAGE,
 } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
-import { stageService, isStageUnlocked, isEndOfCycle } from './services/stageService';
+import {
+  stageService,
+  isStageUnlocked,
+  isEndOfCycle,
+  highestCompletedStage,
+} from './services/stageService';
 import { type StageData } from './stageData';
 import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
@@ -811,18 +817,19 @@ interface MapGridProps {
 }
 
 // Optional decorative backdrop. The grid is fully legible without it (#766), so
-// a missing PNG is a faint no-op rather than a third-party placeholder.
-const MapBackdrop = (): React.JSX.Element =>
-  MAP_BACKGROUND_URI ? (
-    <Image
-      source={{ uri: MAP_BACKGROUND_URI }}
-      resizeMode="contain"
-      style={styles.backdrop}
-      testID="map-background"
-    />
-  ) : (
-    <View style={styles.backdrop} testID="map-background" pointerEvents="none" />
-  );
+// a missing PNG is a faint no-op rather than a third-party placeholder. The
+// absolute-fill layer is always non-interactive so it never intercepts touches
+// meant for the grid or its surrounding padding; the art (when configured) sits
+// inside the same non-interactive wrapper.
+export const MapBackdrop = ({
+  uri = MAP_BACKGROUND_URI,
+}: {
+  uri?: string | null;
+}): React.JSX.Element => (
+  <View style={styles.backdrop} testID="map-background" pointerEvents="none">
+    {uri ? <Image source={{ uri }} resizeMode="contain" style={StyleSheet.absoluteFill} /> : null}
+  </View>
+);
 
 interface JourneyHeaderProps {
   currentStage: number;
@@ -1013,10 +1020,6 @@ const useLensFocus = (
 
   return { focusedStage, setFocusedStage, handleSelectStage, handleOpenStage };
 };
-
-/** Highest stage number whose progress has reached 100%, or 0 when none. */
-const highestCompletedStage = (stages: readonly StageData[]): number =>
-  stages.reduce((max, s) => (s.progress >= FULL_PROGRESS ? Math.max(max, s.stageNumber) : max), 0);
 
 interface CompletionCelebration {
   active: boolean;

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -15,7 +15,7 @@ import {
   RIGHT_LABEL_MIN_FONT_SIZE,
   STAGE_DISPLAY,
 } from '../mapLayout';
-import MapScreen from '../MapScreen';
+import MapScreen, { MapBackdrop } from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
 import { FULLNESS_ALIVE_THRESHOLD } from '../wheelBalance';
 
@@ -565,6 +565,23 @@ describe('MapScreen', () => {
     // and the wave overlay renders alongside it with no dependency between them.
     expect(tree.root.findByProps({ testID: 'map-background' })).toBeTruthy();
     expect(tree.root.findByProps({ testID: 'map-wave' })).toBeTruthy();
+  });
+
+  it('wraps the configured background PNG in a non-interactive no-op layer', () => {
+    const tree = create(<MapBackdrop uri="file:///bg.png" />);
+    const backdrop = tree.root.findByProps({ testID: 'map-background' });
+    expect(backdrop.props.pointerEvents).toBe('none');
+    // The art renders inside the non-interactive wrapper, not as a bare Image
+    // that could intercept touches in the grid's padding regions.
+    const image = backdrop.findByType(Image);
+    expect(image.props.source).toEqual({ uri: 'file:///bg.png' });
+  });
+
+  it('renders the empty backdrop as a non-interactive no-op when no PNG is configured', () => {
+    const tree = create(<MapBackdrop uri={null} />);
+    const backdrop = tree.root.findByProps({ testID: 'map-background' });
+    expect(backdrop.props.pointerEvents).toBe('none');
+    expect(backdrop.findAllByType(Image)).toHaveLength(0);
   });
 
   // --- wave overlay follows measured row/cell centers, not nominal bands ---

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 /* global jest */
+import { FULLY_COMPLETE } from '../../../domain/stageProgression';
 import type { StageData } from '../stageData';
 
 /**
@@ -210,6 +211,11 @@ export function mockStageServiceModule() {
     isStageUnlocked: mockIsStageUnlocked,
     isEndOfCycle: (stagesByNumber: Record<number, { progress: number }>, currentStage: number) =>
       mockMapState.isEndOfCycle(stagesByNumber, currentStage),
+    highestCompletedStage: (stages: ReadonlyArray<{ progress: number; stageNumber: number }>) =>
+      stages.reduce(
+        (max, s) => (s.progress >= FULLY_COMPLETE ? Math.max(max, s.stageNumber) : max),
+        0,
+      ),
   };
 }
 

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -340,6 +340,49 @@ describe('stageService', () => {
     });
   });
 
+  describe('highestCompletedStage', () => {
+    it('returns 0 when no stage has reached full progress', () => {
+      const { highestCompletedStage } = require('../stageService');
+      expect(
+        highestCompletedStage([
+          { stageNumber: 1, progress: 0.9 },
+          { stageNumber: 2, progress: 0 },
+        ]),
+      ).toBe(0);
+    });
+
+    it('returns 0 for an empty list', () => {
+      const { highestCompletedStage } = require('../stageService');
+      expect(highestCompletedStage([])).toBe(0);
+    });
+
+    it('returns the highest stage number whose progress is exactly complete', () => {
+      const { highestCompletedStage } = require('../stageService');
+      expect(
+        highestCompletedStage([
+          { stageNumber: 1, progress: 1 },
+          { stageNumber: 3, progress: 1 },
+          { stageNumber: 2, progress: 0.5 },
+        ]),
+      ).toBe(3);
+    });
+
+    it('counts progress past the completion threshold as complete', () => {
+      const { highestCompletedStage } = require('../stageService');
+      expect(highestCompletedStage([{ stageNumber: 4, progress: 1.2 }])).toBe(4);
+    });
+
+    it('ignores completed stages with a lower number than an earlier complete stage', () => {
+      const { highestCompletedStage } = require('../stageService');
+      expect(
+        highestCompletedStage([
+          { stageNumber: 5, progress: 1 },
+          { stageNumber: 2, progress: 1 },
+        ]),
+      ).toBe(5);
+    });
+  });
+
   describe('beginAgain action', () => {
     function makeProgressRecord(cycleNumber: number): StageProgressRecord {
       return {

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -58,6 +58,12 @@ export const isStageUnlocked = (
   currentStage: number | null,
 ): boolean => stage.isUnlocked || (currentStage !== null && stage.stageNumber <= currentStage);
 
+/** Highest stage number whose progress has reached 100%, or 0 when none is complete — the baseline the completion celebration watches for a rise. */
+export const highestCompletedStage = (
+  stages: readonly Pick<StageData, 'progress' | 'stageNumber'>[],
+): number =>
+  stages.reduce((max, s) => (s.progress >= FULLY_COMPLETE ? Math.max(max, s.stageNumber) : max), 0);
+
 /** True only on the final stage with its progress complete — the gate for the declinable "begin again" affordance. */
 export const isEndOfCycle = (
   stagesByNumber: Record<number, { progress: number } | undefined>,


### PR DESCRIPTION
## Summary

Bundled de-slop of three corroborated Low nits in the Map feature (all verified still present at HEAD despite heavy Map churn):

1. **Backdrop touch asymmetry (behavior-adjacent).** `MapBackdrop`'s `Image` branch omitted the `pointerEvents="none"` its fallback `View` already carried. A configured absolute-fill background PNG (prod-only; `null` in dev/test) could intercept touches in the grid's padding regions. Both branches now render inside a single non-interactive `View` wrapper bearing `testID="map-background"`; the art sits inside it. `MapBackdrop` gained an injectable `uri` prop (default = `MAP_BACKGROUND_URI`) so both branches are unit-covered without fragile module mocking. RN 0.76 doesn't type `pointerEvents` on `Image`/`ImageStyle`, so the wrapper is also the type-safe idiom.
2. **Dead passthrough.** `settleStageWithMomentum` forwarded four args to `inertialStageTarget` verbatim with zero added logic. Deleted; `settleDraggedLens` now calls `inertialStageTarget` directly. Behavior unchanged.
3. **Misplaced domain math.** `highestCompletedStage` moved from `MapScreen` into `services/stageService` beside its sibling `isEndOfCycle`, exported, and imported back. Stage-completion math now lives in one layer (uses the canonical `FULLY_COMPLETE` threshold).

## Test plan

- New focused unit tests for `highestCompletedStage` in `stageService.test.ts` (empty list, none complete, exact/over threshold, highest-wins).
- New `MapBackdrop` tests covering both branches: configured PNG wrapped in a non-interactive layer, and the empty non-interactive fallback.
- Existing `MagnifierLens` drag/settle tests continue to cover the inlined call site; celebration tests (`MapJourney`) unchanged and green (harness mock exports `highestCompletedStage`).
- `./scripts/frontend/check-all.sh` green: eslint, prettier, typecheck, and full Jest (404 suites / 4269 tests) all pass.

Closes #1440