### PR TITLE
refactor(journal): tidy stale RED preambles, dead exports, dup reopen affordance

### DIFF
--- a/frontend/src/features/Journal/CareSupportNote.tsx
+++ b/frontend/src/features/Journal/CareSupportNote.tsx
@@ -13,14 +13,13 @@
  * (mirrors ``ContractionReflectionNote``).
  */
 import React, { useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { reflectionCardStyles } from './noteCards';
 import ReflectionDismiss from './ReflectionDismiss';
 
 import type { CareResource, CareResponse } from '@/api';
 import CareResourceCard from '@/components/care/CareResourceCard';
-import { SPACING, accent, editorialType, touchTarget } from '@/design/tokens';
 
 const DISMISS_LABEL = 'Dismiss';
 const REOPEN_LABEL = 'Show support options';
@@ -35,15 +34,13 @@ export interface CareSupportNoteProps {
 /** The collapsed state: a single affordance that restores the resource list. */
 function ReopenControl({ onPress }: { onPress: () => void }): React.JSX.Element {
   return (
-    <TouchableOpacity
-      style={styles.reopen}
-      onPress={onPress}
-      accessibilityRole="button"
+    <ReflectionDismiss
+      variant="reopen"
+      label={REOPEN_LABEL}
       accessibilityLabel={REOPEN_A11Y}
       testID="care-reopen"
-    >
-      <Text style={styles.reopenText}>{REOPEN_LABEL}</Text>
-    </TouchableOpacity>
+      onPress={onPress}
+    />
   );
 }
 
@@ -88,21 +85,5 @@ function CareSupportNote({ care }: CareSupportNoteProps): React.JSX.Element | nu
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  reopen: {
-    minHeight: touchTarget.minimum,
-    minWidth: touchTarget.minimum,
-    alignSelf: 'flex-start',
-    paddingHorizontal: SPACING.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  reopenText: {
-    ...editorialType.note,
-    fontWeight: '600',
-    color: accent.primary,
-  },
-});
 
 export default CareSupportNote;

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -61,7 +61,7 @@ import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /** Default idle delay before an edit is persisted. */
-export const AUTOSAVE_DELAY_MS = 1500;
+const AUTOSAVE_DELAY_MS = 1500;
 
 /** Below this width the margin column stacks under the writing column. */
 const NARROW_BREAKPOINT = 600;
@@ -109,7 +109,7 @@ function savedHintLabel(state: SaveState): string {
  * journal entry server-side — so we never also ``journal.create``); the practice
  * ids link a session/stage reflection to its source.
  */
-export interface SaveContext {
+interface SaveContext {
   weekNumber?: number;
   practiceSessionId?: number;
   userPracticeId?: number;

--- a/frontend/src/features/Journal/ReflectionDismiss.tsx
+++ b/frontend/src/features/Journal/ReflectionDismiss.tsx
@@ -1,14 +1,24 @@
-/** Shared dismiss affordance for the raised reflection cards — identical chrome. */
+/** Shared dismiss/reopen affordance for the raised reflection cards — shared chrome, per-variant color/margin. */
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 
-import { SPACING, editorialType, ink, touchTarget } from '@/design/tokens';
+import { SPACING, accent, editorialType, ink, touchTarget } from '@/design/tokens';
+
+/**
+ * The two press-target treatments that share this affordance's chrome. ``dismiss``
+ * is the muted collapse control that sits below a card's body; ``reopen`` is the
+ * accent-toned restore control that sits flush (no top margin) where the collapsed
+ * card left off.
+ */
+export type ReflectionDismissVariant = 'dismiss' | 'reopen';
 
 export interface ReflectionDismissProps {
   label: string;
   accessibilityLabel: string;
   testID: string;
   onPress: () => void;
+  /** Chrome treatment; defaults to the muted ``dismiss`` control. */
+  variant?: ReflectionDismissVariant;
 }
 
 function ReflectionDismiss({
@@ -16,22 +26,24 @@ function ReflectionDismiss({
   accessibilityLabel,
   testID,
   onPress,
+  variant = 'dismiss',
 }: ReflectionDismissProps): React.JSX.Element {
+  const isReopen = variant === 'reopen';
   return (
     <TouchableOpacity
-      style={styles.dismiss}
+      style={[styles.control, isReopen && styles.reopenControl]}
       onPress={onPress}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
       testID={testID}
     >
-      <Text style={styles.dismissText}>{label}</Text>
+      <Text style={[styles.text, isReopen ? styles.reopenText : styles.dismissText]}>{label}</Text>
     </TouchableOpacity>
   );
 }
 
 const styles = StyleSheet.create({
-  dismiss: {
+  control: {
     minHeight: touchTarget.minimum,
     minWidth: touchTarget.minimum,
     alignSelf: 'flex-start',
@@ -40,10 +52,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  dismissText: {
+  reopenControl: {
+    marginTop: 0,
+  },
+  text: {
     ...editorialType.note,
     fontWeight: '600',
+  },
+  dismissText: {
     color: ink.soft,
+  },
+  reopenText: {
+    color: accent.primary,
   },
 });
 

--- a/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CareSupportNote.test.tsx
@@ -209,6 +209,14 @@ describe('CareSupportNote — dismiss and re-open', () => {
     expect(getByTestId('care-reopen')).toBeTruthy();
   });
 
+  it('gives the re-open control a descriptive accessibilityLabel', () => {
+    const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
+    fireEvent.press(getByTestId('care-dismiss'));
+    expect(getByTestId('care-reopen').props.accessibilityLabel).toBe(
+      'Show the support options again',
+    );
+  });
+
   it('re-shows resources after pressing care-reopen (not a dead-end)', () => {
     const { getByTestId } = render(<CareSupportNote care={carePayload()} />);
     fireEvent.press(getByTestId('care-dismiss'));

--- a/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ContractionReflectionNote.test.tsx
@@ -4,14 +4,11 @@ import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
 /**
- * RED tests for ``ContractionReflectionNote``.
- *
- * These tests fail until the implementation-specialist creates
- * ``frontend/src/features/Journal/ContractionReflectionNote.tsx``: a warm,
- * declinable "tend your foundation" reflection surface driven by the
- * resonance-pass ``contraction`` field. It is not punitive copy — the note
- * must never read as failure, demotion, or ranking language, and a dismiss
- * always fully hides the surface (no forced re-open, unlike CareSupportNote).
+ * Covers ``ContractionReflectionNote``: a warm, declinable "tend your
+ * foundation" reflection surface driven by the resonance-pass ``contraction``
+ * field. The copy must never read as failure, demotion, or ranking language,
+ * and a dismiss always fully hides the surface (no forced re-open, unlike
+ * CareSupportNote).
  */
 import ContractionReflectionNote from '../ContractionReflectionNote';
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenCare.test.tsx
@@ -4,17 +4,12 @@ import { act, fireEvent, render, waitFor, within } from '@testing-library/react-
 import React from 'react';
 
 /**
- * RED tests for the JournalEntryScreen care-surface placement (issue #891).
- *
- * Requirements:
+ * Covers the JournalEntryScreen care-surface placement:
  * - When a resonance pass yields ``care``, ``CareSupportNote`` (testID
  *   ``"care-support"``) mounts at the SCREEN level — a direct sibling of
  *   ``JournalPage`` inside ``journal-screen``, NOT anywhere inside
  *   ``journal-margin-column`` or ``journal-sheet``.
  * - On an ordinary pass (no care), ``care-support`` is absent entirely.
- *
- * These tests fail until the implementation-specialist wires ``care`` from
- * ``useResonance`` into ``JournalEntryScreen``.
  */
 import type { CareResponse, JournalMessage, ResonanceResponse } from '@/api';
 import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenContraction.test.tsx
@@ -4,16 +4,11 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 /**
- * RED tests for the JournalEntryScreen contraction-reflection surface.
- *
- * Requirements:
+ * Covers the JournalEntryScreen contraction-reflection surface:
  * - A resonance pass returning ``contraction`` mounts
  *   ``ContractionReflectionNote`` (testID ``"contraction-reflection"``).
  * - An ordinary pass (no contraction) renders nothing for it.
  * - The care surface and the contraction surface can coexist on one pass.
- *
- * These tests fail until the implementation-specialist wires ``contraction``
- * from ``useResonance`` into ``JournalEntryScreen``.
  */
 import type { CareResponse, ContractionReflection, JournalMessage, ResonanceResponse } from '@/api';
 import { DEFAULT_IDLE_DELAY_MS } from '@/hooks/useIdle';


### PR DESCRIPTION
## Summary

Low-priority Journal-feature de-slop tidy-up (from the de-slopify scan). No user-visible behavior change. All three findings were re-verified as still live at HEAD before acting; none had been fixed by the quote-promotion churn.

1. **Stale RED-test preambles** — deleted the "RED tests… fail until the implementation-specialist…" doc-comments from `ContractionReflectionNote.test.tsx`, `JournalEntryScreenCare.test.tsx`, and `JournalEntryScreenContraction.test.tsx` (each imports a shipped, green implementation the comment claimed didn't exist yet). Replaced each with a plain description of what the suite covers, and dropped a stray `issue #891` ref per the no-issue-refs-in-code rule.
2. **Dead public exports** — un-exported `AUTOSAVE_DELAY_MS` and `SaveContext` in `JournalEntryScreen.tsx` (grep confirmed zero external importers at HEAD; both are now module-local). Tests override the delay via the `autosaveDelayMs` prop, not the constant.
3. **Duplicated reopen affordance** — folded `CareSupportNote`'s `care-reopen` control onto the shared `ReflectionDismiss` via a new optional `variant?: 'dismiss' | 'reopen'` prop, removing the duplicated `reopen`/`reopenText` styles. The reopen variant reproduces the prior chrome exactly (same 44dp touch target), differing only in the intended `accent.primary` color and flush top margin. The `care-reopen` testID and `'Show the support options again'` a11y label are unchanged.

Scope note: explicitly excludes everything in #1265 and #1266; nothing from either was touched.

## Test plan

- Added one assertion pinning the `care-reopen` a11y label; proved it goes RED under a temporary in-worktree mutation of the label constant, then restored.
- Existing `care-reopen`/`care-dismiss` tests (testID, touch target, re-open flow) stay green unchanged; the two non-care `ReflectionDismiss` consumers default to the `dismiss` variant (byte-for-byte identical to the prior style).
- `./scripts/frontend/check-all.sh` green in the foreground: 4285 tests pass, plus eslint, typecheck, and prettier.

Closes #1442