### PR TITLE
refactor(frontend): drop dead layout default exports + tautological DEAD_FILES test

### DIFF
--- a/frontend/src/__tests__/noDeadFiles.test.ts
+++ b/frontend/src/__tests__/noDeadFiles.test.ts
@@ -3,22 +3,9 @@ import * as path from 'path';
 
 import { describe, expect, it } from '@jest/globals';
 
-const DEAD_FILES = [
-  'src/features/Habits/HabitCard.tsx',
-  'src/features/Habits/HabitCard.styles.ts',
-  'src/styles/colors.ts',
-  'src/components/Button/Button.tsx',
-  'src/components/Button/Button.styles.ts',
-];
-
 const ROOT = path.resolve(__dirname, '..', '..');
 
 describe('phase-2-04: no dead/empty files', () => {
-  it.each(DEAD_FILES)('%s should not exist', (relPath) => {
-    const fullPath = path.join(ROOT, relPath);
-    expect(fs.existsSync(fullPath)).toBe(false);
-  });
-
   it('should have no empty .ts/.tsx files in src/', () => {
     const findEmpty = (dir: string): string[] => {
       const results: string[] = [];

--- a/frontend/src/components/layout/ContentContainer.tsx
+++ b/frontend/src/components/layout/ContentContainer.tsx
@@ -59,5 +59,3 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
-
-export default ContentContainer;

--- a/frontend/src/components/layout/EditorialSection.tsx
+++ b/frontend/src/components/layout/EditorialSection.tsx
@@ -43,5 +43,3 @@ const styles = StyleSheet.create({
     marginBottom: rhythm.blockGap,
   },
 });
-
-export default EditorialSection;

--- a/frontend/src/components/layout/ScreenHeader.tsx
+++ b/frontend/src/components/layout/ScreenHeader.tsx
@@ -71,5 +71,3 @@ const styles = StyleSheet.create({
     marginLeft: rhythm.blockGap,
   },
 });
-
-export default ScreenHeader;

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -60,5 +60,3 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
 });
-
-export default ScreenScaffold;


### PR DESCRIPTION
## Summary

De-slop tidy-up (issue filed 2026-07-07; every finding re-verified live at HEAD before deleting). Two surgical dead-surface removals in shared frontend infrastructure:

1. **Dead layout default exports.** Deleted the unused `export default` line from `ContentContainer.tsx`, `EditorialSection.tsx`, `ScreenHeader.tsx`, and `ScreenScaffold.tsx` in `frontend/src/components/layout/`. A HEAD grep confirmed **zero** default-imports of any of the four across `frontend/src` — every call site uses the named export, which is preserved. This makes the directory named-export-only, consistent with its sibling primitives (`ShowcaseCard`, `CalloutBand`). `CareResourceCard`'s live default export was left untouched.
2. **Tautological DEAD_FILES test.** Deleted the `DEAD_FILES` constant and its `it.each(...)` block in `frontend/src/__tests__/noDeadFiles.test.ts` — it asserted the continued absence of files that were already gone and unreferenced (a tautology). The genuine, live empty-file scan test (`'should have no empty .ts/.tsx files in src/'`) is retained.

Nothing already-fixed was skipped: all four default exports and the DEAD_FILES block were still present at HEAD (line numbers had shifted from the original scan due to recent layout churn, but the code was intact).

Pure deletion — no new tests; the existing suite staying green is the safety net.

## Test plan

- `grep -rn "export default" frontend/src/components/layout` returns nothing (acceptance: layout dir is named-export-only).
- `./scripts/frontend/check-all.sh` fully green: ESLint, Prettier, TypeScript typecheck, and Jest (404 suites, 4280 tests passing).
- Gate 2.5 self-review (code-review-orchestrator): CLEAN, zero blockers — no orphaned default-import consumers, no dangling `DEAD_FILES` reference, no unused imports left behind.
- All pre-commit hooks pass.

Closes #1446