### PR TITLE
fix(frontend): return 404 for scanner probe paths in nginx SPA fallback

### DIFF
--- a/frontend/__tests__/nginx-routing.test.ts
+++ b/frontend/__tests__/nginx-routing.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+
+const NGINX_CONF_PATH = resolve(__dirname, '..', 'nginx.conf');
+const nginxConf = readFileSync(NGINX_CONF_PATH, 'utf-8');
+
+const CATCH_ALL_INDEX = nginxConf.search(/location\s+\/\s*\{/);
+
+/**
+ * Extract the body of the first location block whose selector matches the
+ * given regex source. Returns the raw text between the braces, or null.
+ */
+const locationBody = (selectorSource: string): string | null => {
+  const blockPattern = new RegExp(`location\\s+~\\*\\s+${selectorSource}\\s*\\{([^}]*)\\}`);
+  const match = nginxConf.match(blockPattern);
+  if (!match) {
+    return null;
+  }
+  return match[1] ?? null;
+};
+
+const blockStartIndex = (selectorSource: string): number =>
+  nginxConf.search(new RegExp(`location\\s+~\\*\\s+${selectorSource}\\s*\\{`));
+
+describe('nginx.conf vulnerability-scanner probe paths', () => {
+  it('has a location block matching wp-content/wp-admin/wp-includes', () => {
+    expect(blockStartIndex('\\^/\\(wp-content\\|wp-admin\\|wp-includes\\)')).toBeGreaterThanOrEqual(
+      0,
+    );
+  });
+
+  it('returns 404 for the wp-* probe location block', () => {
+    const body = locationBody('\\^/\\(wp-content\\|wp-admin\\|wp-includes\\)');
+    expect(body).not.toBeNull();
+    expect(body).toMatch(/return\s+404\s*;/);
+  });
+
+  it('has a location block matching any .php request', () => {
+    expect(blockStartIndex('\\\\\\.php\\$')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns 404 for the .php probe location block', () => {
+    const body = locationBody('\\\\\\.php\\$');
+    expect(body).not.toBeNull();
+    expect(body).toMatch(/return\s+404\s*;/);
+  });
+
+  it('finds the SPA catch-all location block', () => {
+    expect(CATCH_ALL_INDEX).toBeGreaterThanOrEqual(0);
+  });
+
+  it('places the wp-* probe block before the SPA catch-all', () => {
+    const index = blockStartIndex('\\^/\\(wp-content\\|wp-admin\\|wp-includes\\)');
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(index).toBeLessThan(CATCH_ALL_INDEX);
+  });
+
+  it('places the .php probe block before the SPA catch-all', () => {
+    const index = blockStartIndex('\\\\\\.php\\$');
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(index).toBeLessThan(CATCH_ALL_INDEX);
+  });
+
+  it('preserves the SPA fallback to index.html for extension-less routes', () => {
+    expect(nginxConf).toMatch(/location\s+\/\s*\{[^}]*try_files\s+\$uri\s+\$uri\/\s+\/index\.html/);
+  });
+});

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -11,6 +11,18 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'; connect-src 'self' https:; frame-ancestors 'none'" always;
 
+    # Return a real 404 for non-SPA vulnerability-scanner probe paths instead
+    # of letting the SPA catch-all serve index.html with 200. Regex locations
+    # take precedence over the prefix "location /" catch-all below; among regex
+    # blocks the first match in file order wins, so keep these ahead of it.
+    location ~* ^/(wp-content|wp-admin|wp-includes) {
+        return 404;
+    }
+
+    location ~* \.php$ {
+        return 404;
+    }
+
     # SPA fallback: serve index.html for all routes that don't match a file
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

Vulnerability scanners constantly probe the public frontend for WordPress
and PHP paths. Because `nginx.conf` had only a `location /` SPA catch-all,
every probe (e.g. `/wp-content/plugins/.../x.php`, `/wp-login.php`,
`/xmlrpc.php`) fell through to `try_files` and served `index.html` with
`200 OK`, polluting Railway logs with entries that read like a compromise.

This adds two regex `location` blocks **above** the SPA catch-all, each
returning a real `404`:

- `location ~* ^/(wp-content|wp-admin|wp-includes)` — WordPress dir probes
- `location ~* \.php$` — any PHP request (covers `wp-login.php` / `xmlrpc.php`)

This is **log-hygiene, not an exploit fix**: nginx has no PHP/FastCGI
handler, so these paths were never executable — they just returned a
misleading `200`. Extension-less SPA routes (`/course`, `/habits`, …) still
fall back to `index.html` with `200`, and the static-asset cache block and
`location = /index.html` block are unchanged. The `return 404;` blocks add
no `add_header`, so they inherit the server-level security headers.

## Test plan

- New `frontend/__tests__/nginx-routing.test.ts` (text-assertion, mirroring
  the existing `nginx-security-headers.test.ts` pattern) asserts the two
  probe blocks exist, `return 404`, and appear **before** the `location /`
  catch-all in the file, and that the SPA `index.html` fallback is preserved.
  Watched RED before the config edit, then GREEN.
- Existing nginx security-header tests pass unchanged.
- `./scripts/frontend/check-all.sh` green (lint, typecheck, prettier, full
  Jest suite — 405 suites / 4288 tests).

Closes #1456