### PR TITLE
fix(backend): compute course/stages unlock gates in the user's timezone

### DIFF
--- a/backend/src/routers/course.py
+++ b/backend/src/routers/course.py
@@ -14,6 +14,7 @@ from sqlmodel import col, select
 
 from content_config import CONTENT_REF_SCHEME, content_ref
 from database import get_session
+from dependencies.timezone import current_user_timezone
 from domain.constants import STAGE_DURATIONS_DAYS
 from domain.course import (
     compute_days_elapsed,
@@ -80,7 +81,9 @@ async def _get_stage_by_number(session: AsyncSession, stage_number: int) -> Cour
     return stage
 
 
-async def _day_in_stage_for_user(session: AsyncSession, user_id: int, stage_number: int) -> int:
+async def _day_in_stage_for_user(
+    session: AsyncSession, user_id: int, stage_number: int, tz: str
+) -> int:
     """The 1-based day the user is on within ``stage_number`` for the drip.
 
     First course access provisions a ``current_stage=1`` StageProgress row
@@ -102,7 +105,7 @@ async def _day_in_stage_for_user(session: AsyncSession, user_id: int, stage_numb
     duration = _stage_duration_days(stage_number)
     if progress.current_stage > stage_number:
         return duration
-    calendar_day = calendar_day_in_stage(resolve_program_anchor(progress), stage_number)
+    calendar_day = calendar_day_in_stage(resolve_program_anchor(progress), stage_number, tz=tz)
     if progress.current_stage == stage_number:
         started_day = compute_days_elapsed(progress.stage_started_at) + 1
         return max(calendar_day, started_day)
@@ -142,10 +145,10 @@ async def _ordinal_position(session: AsyncSession, item: StageContent) -> int:
 
 
 async def _content_item_is_locked(
-    session: AsyncSession, user_id: int, stage: CourseStage, item: StageContent
+    session: AsyncSession, user_id: int, stage: CourseStage, item: StageContent, tz: str
 ) -> bool:
     """Whether ``item`` is drip-locked for the user under the proportional model."""
-    day = await _day_in_stage_for_user(session, user_id, stage.stage_number)
+    day = await _day_in_stage_for_user(session, user_id, stage.stage_number, tz)
     if stage.id is None:
         raise RuntimeError("CourseStage from database must have an id")
     total = await _stage_content_count(session, stage.id)
@@ -188,19 +191,21 @@ def _items_to_raw_dicts(items: list[StageContent]) -> list[dict[str, object]]:
     ]
 
 
-async def _check_stage_unlocked(session: AsyncSession, user_id: int, stage_number: int) -> None:
+async def _check_stage_unlocked(
+    session: AsyncSession, user_id: int, stage_number: int, tz: str
+) -> None:
     """Raise 403 if the given stage is locked for the user.
 
     Used by endpoints that take ``stage_number`` directly (1..10 are
     public knowledge), so the 403 carries no enumeration risk.
     """
     progress = await get_user_progress(session, user_id)
-    if not is_stage_unlocked(stage_number, progress):
+    if not is_stage_unlocked(stage_number, progress, tz=tz):
         raise forbidden("stage_locked")
 
 
 async def _is_stage_unlocked_for_user(
-    session: AsyncSession, user_id: int, stage_number: int
+    session: AsyncSession, user_id: int, stage_number: int, tz: str
 ) -> bool:
     """Predicate form of :func:`_check_stage_unlocked`.
 
@@ -209,11 +214,11 @@ async def _is_stage_unlocked_for_user(
     raising a 403 the attacker could observe directly.
     """
     progress = await get_user_progress(session, user_id)
-    return is_stage_unlocked(stage_number, progress)
+    return is_stage_unlocked(stage_number, progress, tz=tz)
 
 
 async def _listing_unlocked_count(
-    session: AsyncSession, user_id: int, stage: CourseStage, total_items: int
+    session: AsyncSession, user_id: int, stage: CourseStage, total_items: int, tz: str
 ) -> int:
     """Chapters to reveal in the stage listing.
 
@@ -224,9 +229,9 @@ async def _listing_unlocked_count(
     urls out of reach; item detail and mark-read stay gated. An unlocked
     stage keeps its proportional drip count unchanged.
     """
-    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
+    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number, tz):
         return 0
-    day = await _day_in_stage_for_user(session, user_id, stage.stage_number)
+    day = await _day_in_stage_for_user(session, user_id, stage.stage_number, tz)
     return unlocked_chapter_count(
         total=total_items,
         duration_days=_stage_duration_days(stage.stage_number),
@@ -239,6 +244,7 @@ async def list_stage_content(
     stage_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
     pagination: Annotated[PaginationParams, Depends()],
 ) -> Page[ContentItemResponse] | list[ContentItemResponse]:
     """List content for a stage with drip-feed gating applied.
@@ -270,7 +276,7 @@ async def list_stage_content(
     )
     items = list(result.scalars().all())
 
-    unlocked = await _listing_unlocked_count(session, current_user, stage, len(items))
+    unlocked = await _listing_unlocked_count(session, current_user, stage, len(items), user_tz)
     content_ids = [item.id for item in items if item.id is not None]
     read_ids = await _read_ids_for_user(session, current_user, content_ids)
 
@@ -289,6 +295,7 @@ async def get_content_item(
     content_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> ContentItemResponse:
     """Get a single content item with lock/read status.
 
@@ -302,7 +309,7 @@ async def get_content_item(
     item, stage = await _load_content_with_stage(session, content_id)
     # BUG-COURSE-004: mask locked-stage access as 404 so locked content
     # is indistinguishable from nonexistent content over the wire.
-    if not await _is_stage_unlocked_for_user(session, current_user, stage.stage_number):
+    if not await _is_stage_unlocked_for_user(session, current_user, stage.stage_number, user_tz):
         raise not_found("content")
 
     item_id = item.id
@@ -311,7 +318,7 @@ async def get_content_item(
         raise RuntimeError(msg)
     read_ids = await _read_ids_for_user(session, current_user, [item_id])
 
-    is_locked = await _content_item_is_locked(session, current_user, stage, item)
+    is_locked = await _content_item_is_locked(session, current_user, stage, item, user_tz)
     enriched = enrich_content_item(
         _items_to_raw_dicts([item])[0], is_locked=is_locked, read_content_ids=read_ids
     )
@@ -343,6 +350,7 @@ async def _resolve_unlocked_content(
     session: AsyncSession,
     user_id: int,
     content_id: int,
+    tz: str,
 ) -> StageContent:
     """Fetch ``content_id`` and gate on the parent stage being unlocked.
 
@@ -354,7 +362,7 @@ async def _resolve_unlocked_content(
     testable.
     """
     item, stage = await _load_content_with_stage(session, content_id)
-    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
+    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number, tz):
         raise not_found("content")
     return item
 
@@ -396,6 +404,7 @@ async def mark_content_read(
     content_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> ContentCompletionResponse:
     """Mark a content item as read. Idempotent — repeated calls return existing record.
 
@@ -405,7 +414,7 @@ async def mark_content_read(
     loser via ``IntegrityError`` and the existing row is returned —
     closes the BUG-COURSE-002 TOCTOU.
     """
-    await _resolve_unlocked_content(session, current_user, content_id)
+    await _resolve_unlocked_content(session, current_user, content_id, user_tz)
 
     existing = await _existing_content_completion(session, current_user, content_id)
     if existing is not None:
@@ -433,10 +442,11 @@ async def get_course_progress(
     stage_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> CourseProgressResponse:
     """Get read-progress for a stage's content; 403 when the caller has not unlocked it."""
     stage = await _get_stage_by_number(session, stage_number)
-    await _check_stage_unlocked(session, current_user, stage_number)
+    await _check_stage_unlocked(session, current_user, stage_number, user_tz)
     result = await session.execute(
         select(StageContent).where(StageContent.course_stage_id == stage.id)
     )
@@ -447,7 +457,7 @@ async def get_course_progress(
 
     read_ids = await _read_ids_for_user(session, current_user, _content_ids_from_items(items))
     progress_pct = round((len(read_ids) / len(items)) * 100, 2)
-    day = await _day_in_stage_for_user(session, current_user, stage_number)
+    day = await _day_in_stage_for_user(session, current_user, stage_number, user_tz)
 
     # ``total_items`` stays the whole-stage count (not the unlocked count)
     # so "stage complete" only fires when everything is read; the drip only
@@ -520,7 +530,7 @@ async def _load_content_with_stage(
 
 
 async def _resolve_released_content_ref(
-    session: AsyncSession, user_id: int, content_id: int
+    session: AsyncSession, user_id: int, content_id: int, tz: str
 ) -> str:
     """Gate on stage-unlock + proportional drip, return the local chapter id.
 
@@ -534,9 +544,9 @@ async def _resolve_released_content_ref(
     mask.
     """
     item, stage = await _load_content_with_stage(session, content_id)
-    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number):
+    if not await _is_stage_unlocked_for_user(session, user_id, stage.stage_number, tz):
         raise not_found("content")
-    if await _content_item_is_locked(session, user_id, stage, item):
+    if await _content_item_is_locked(session, user_id, stage, item, tz):
         raise not_found("content")
     reference = item.url or ""
     if not reference.startswith(_CONTENT_REF_PREFIX):
@@ -551,6 +561,7 @@ async def get_content_body(
     content_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> ContentBodyResponse:
     """Return raw Markdown for a content item from the vendored content.
 
@@ -559,7 +570,7 @@ async def get_content_body(
     URL cannot be used as an enumeration oracle.  The drip-feed unlock
     check is applied here too: locked-day content never escapes.
     """
-    chapter_id = await _resolve_released_content_ref(session, current_user, content_id)
+    chapter_id = await _resolve_released_content_ref(session, current_user, content_id, user_tz)
     return _read_local_body(lambda: get_content_repository().read_body(chapter_id), chapter_id)
 
 
@@ -612,6 +623,7 @@ async def _require_unlocked_stage(
     session: AsyncSession,
     user_id: int,
     stage_number: int,
+    tz: str,
 ) -> None:
     """Require the stage to exist and be unlocked for ``user_id``.
 
@@ -620,7 +632,7 @@ async def _require_unlocked_stage(
     from a nonexistent one over the wire.
     """
     await _get_stage_by_number(session, stage_number)
-    if not await _is_stage_unlocked_for_user(session, user_id, stage_number):
+    if not await _is_stage_unlocked_for_user(session, user_id, stage_number, tz):
         raise not_found("content")
 
 
@@ -629,6 +641,7 @@ async def get_stage_introduction(
     stage_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> StageIntroResponse:
     """Return a stage's course-introduction metadata.
 
@@ -636,7 +649,7 @@ async def get_stage_introduction(
     stage with no intro both return ``content_not_found`` (BUG-COURSE-004) so
     neither acts as an enumeration oracle.
     """
-    await _require_unlocked_stage(session, current_user, stage_number)
+    await _require_unlocked_stage(session, current_user, stage_number, user_tz)
     intro = get_content_repository().get_stage_intro(stage_number)
     if intro is None:
         raise not_found("content")
@@ -656,6 +669,7 @@ async def get_stage_intro_body(
     stage_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> ContentBodyResponse:
     """Return raw Markdown for a stage's course introduction.
 
@@ -663,7 +677,7 @@ async def get_stage_intro_body(
     :func:`_read_local_body`, so an unknown stage keeps the 404 mask and a
     broken repository surfaces as ``502 content_unavailable``.
     """
-    await _require_unlocked_stage(session, current_user, stage_number)
+    await _require_unlocked_stage(session, current_user, stage_number, user_tz)
     return _read_local_body(
         lambda: get_content_repository().read_intro_body(stage_number),
         f"stage-{stage_number}-intro",

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from dependencies.timezone import current_user_timezone
 from domain.constants import TOTAL_STAGES
 from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
 from domain.stage_progress import (
@@ -92,6 +93,7 @@ async def _stage_responses_with_progress(
     session: AsyncSession,
     user_id: int,
     stages: list[CourseStage],
+    tz: str,
 ) -> list[StageResponse]:
     """Overlay batched progress onto a page of stages (issue #473).
 
@@ -100,7 +102,7 @@ async def _stage_responses_with_progress(
     report ``0.0`` without entering the batch.
     """
     progress = await get_user_progress(session, user_id)
-    unlocked = {s.stage_number: is_stage_unlocked(s.stage_number, progress) for s in stages}
+    unlocked = {s.stage_number: is_stage_unlocked(s.stage_number, progress, tz=tz) for s in stages}
     unlocked_numbers = [n for n, ok in unlocked.items() if ok]
     batch = await compute_stage_progress_batch(session, user_id, unlocked_numbers)
     return [_overlay_stage(s, unlocked, batch) for s in stages]
@@ -110,6 +112,7 @@ async def _stage_responses_with_progress(
 async def list_stages(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
     pagination: Annotated[PaginationParams, Depends()],
 ) -> Page[StageResponse] | list[StageResponse]:
     """List all stages with per-user progress overlay.
@@ -127,7 +130,7 @@ async def list_stages(
     """
     query = select(CourseStage).order_by(col(CourseStage.stage_number).asc())
     stages, total = await paginate_query(session, query, pagination)
-    responses = await _stage_responses_with_progress(session, current_user, stages)
+    responses = await _stage_responses_with_progress(session, current_user, stages, user_tz)
 
     if pagination.paginate:
         return build_page(responses, total, pagination)
@@ -138,6 +141,7 @@ async def list_stages(
 async def get_program_calendar(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> ProgramCalendarResponse:
     """The server's view of the date-derived program calendar (issue #386).
 
@@ -156,8 +160,8 @@ async def get_program_calendar(
     anchor = resolve_program_anchor(progress)
     return ProgramCalendarResponse(
         program_started_at=anchor,
-        calendar_stage=calendar_stage(anchor),
-        calendar_week=calendar_week(anchor),
+        calendar_stage=calendar_stage(anchor, tz=user_tz),
+        calendar_week=calendar_week(anchor, tz=user_tz),
         current_stage=progress.current_stage,
         cycle_number=progress.cycle_number,
     )
@@ -197,13 +201,14 @@ async def get_stage_history(
     stage_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> StageHistoryResponse:
     """Aggregated practice and habit history for a stage."""
     if not await stage_exists(session, stage_number):
         raise not_found("stage")
 
     progress = await get_user_progress(session, current_user)
-    if not is_stage_unlocked(stage_number, progress):
+    if not is_stage_unlocked(stage_number, progress, tz=user_tz):
         raise forbidden("stage_locked")
 
     practices = await get_stage_practice_history(session, current_user, stage_number)

--- a/backend/tests/test_course_api.py
+++ b/backend/tests/test_course_api.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
@@ -54,6 +55,45 @@ async def _signup(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _signup_with_timezone(
+    client: AsyncClient,
+    username: str,
+    timezone: str,
+) -> tuple[dict[str, str], int]:
+    """Create a user with an explicit IANA timezone; returns (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": timezone,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+_STAGE_ONE_DURATION_DAYS = 21
+_DRIP_ISOLATION_DAY_IN_STAGE = 8
+_EXPECTED_NEXT_UNLOCK_DAY_LOCAL = 15
+
+
+def _pacific_anchor_for_stage_two_day(day_in_stage: int) -> datetime:
+    """UTC-naive anchor placing "now" on local day ``day_in_stage`` of stage 2 in LA time.
+
+    Stage 1 runs ``_STAGE_ONE_DURATION_DAYS`` days; anchoring at 23:59 local
+    time makes the UTC-default calendar read one calendar day behind Pacific
+    time regardless of when the test runs.
+    """
+    la = ZoneInfo("America/Los_Angeles")
+    start_date = datetime.now(la).date() - timedelta(
+        days=_STAGE_ONE_DURATION_DAYS + day_in_stage - 1
+    )
+    anchor_local = datetime.combine(start_date, time(23, 59), tzinfo=la)
+    return anchor_local.astimezone(UTC).replace(tzinfo=None)
 
 
 async def _seed_stage_with_content(
@@ -982,6 +1022,92 @@ async def test_progress_endpoint_rejects_locked_stage(
     resp = await async_client.get("/course/stages/2/progress", headers=headers)
     assert resp.status_code == HTTPStatus.FORBIDDEN
     assert resp.json()["detail"] == "stage_locked"
+
+
+# ── Timezone-aware stage-unlock gating ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_course_progress_unlocked_on_pacific_first_local_day_of_stage_two(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The stage-unlock gate reads the caller's timezone, not UTC.
+
+    A Pacific user on the first local calendar day of stage 2 can read the
+    stage-2 progress surface; the UTC default still reads day 20 of stage 1
+    and 403s.
+    """
+    headers, user_id = await _signup_with_timezone(
+        async_client, "pacificcourse", "America/Los_Angeles"
+    )
+    await _seed_stage_with_content(db_session, stage_number=2)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=_pacific_anchor_for_stage_two_day(1),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/course/stages/2/progress", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_content_item_not_masked_on_pacific_first_local_day_of_stage_two(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The BUG-COURSE-004 404 mask must not hide a stage the caller's local calendar opened."""
+    headers, user_id = await _signup_with_timezone(
+        async_client, "pacificcontent", "America/Los_Angeles"
+    )
+    _, items = await _seed_stage_with_content(db_session, stage_number=2)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=_pacific_anchor_for_stage_two_day(1),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/course/content/{items[0].id}", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_next_unlock_day_reflects_pacific_local_day_not_utc_lag(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``_day_in_stage_for_user`` must thread the caller's timezone into the drip day count.
+
+    The user has already advanced into stage 2, so the stage-unlock gate
+    passes regardless of timezone threading -- isolating the drip day count
+    itself: at Pacific local day 8 of stage 2, two chapters are unlocked and
+    the next opens on day 15; the UTC default reads local day 7 (one
+    chapter fewer unlocked) and reports the next opening on day 8.
+    """
+    headers, user_id = await _signup_with_timezone(
+        async_client, "pacificdrip", "America/Los_Angeles"
+    )
+    await _seed_stage_with_content(db_session, stage_number=2)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=2,
+            completed_stages=[1],
+            stage_started_at=datetime.now(UTC) - timedelta(days=1),
+            program_started_at=_pacific_anchor_for_stage_two_day(_DRIP_ISOLATION_DAY_IN_STAGE),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/course/stages/2/progress", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["next_unlock_day"] == _EXPECTED_NEXT_UNLOCK_DAY_LOCAL
 
 
 def test_compute_days_elapsed_logs_on_future_timestamp(

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -7,8 +7,9 @@ never revoked.  ``max(advancement, calendar)`` on both gates.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
@@ -210,3 +211,51 @@ def test_calendar_tz_never_revokes_advancement_ahead_of_it() -> None:
     )
     early = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
     assert is_stage_unlocked(3, progress, now=early, tz="America/Los_Angeles") is True
+
+
+# ── /stages/program-calendar reads the caller's timezone ───────────────
+
+
+@pytest.mark.asyncio
+async def test_program_calendar_reflects_pacific_first_local_day_of_stage_two(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The calendar-stage view is computed in the caller's timezone, not UTC.
+
+    A Pacific user on the first local calendar day of stage 2 sees
+    ``calendar_stage == 2``; the UTC default still reads day 20 of stage 1
+    and reports ``calendar_stage == 1``.
+    """
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "pacificcalendar@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": "America/Los_Angeles",
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+    user_id = resp.json()["user_id"]
+
+    la = ZoneInfo("America/Los_Angeles")
+    stage_one_duration = 21
+    start_date = datetime.now(la).date() - timedelta(days=stage_one_duration)
+    anchor_local = datetime.combine(start_date, time(23, 59), tzinfo=la)
+    anchor = anchor_local.astimezone(UTC).replace(tzinfo=None)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=anchor,
+        )
+    )
+    await db_session.commit()
+
+    calendar_resp = await async_client.get("/stages/program-calendar", headers=headers)
+    assert calendar_resp.status_code == HTTPStatus.OK
+    body = calendar_resp.json()
+    assert body["calendar_stage"] == 2
+    expected_calendar_week = 4
+    assert body["calendar_week"] == expected_calendar_week

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
+from zoneinfo import ZoneInfo
 
 import pytest
 from httpx import AsyncClient
@@ -57,6 +58,43 @@ async def _signup(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+async def _signup_with_timezone(
+    client: AsyncClient,
+    username: str,
+    timezone: str,
+) -> tuple[dict[str, str], int]:
+    """Create a user with an explicit IANA timezone; returns (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "timezone": timezone,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, data["user_id"]
+
+
+_STAGE_ONE_DURATION_DAYS = 21
+
+
+def _pacific_anchor_for_stage_two_day(day_in_stage: int) -> datetime:
+    """UTC-naive anchor placing "now" on local day ``day_in_stage`` of stage 2 in LA time.
+
+    Stage 1 runs ``_STAGE_ONE_DURATION_DAYS`` days; anchoring at 23:59 local
+    time makes the UTC-default calendar read one calendar day behind Pacific
+    time regardless of when the test runs.
+    """
+    la = ZoneInfo("America/Los_Angeles")
+    start_date = datetime.now(la).date() - timedelta(
+        days=_STAGE_ONE_DURATION_DAYS + day_in_stage - 1
+    )
+    anchor_local = datetime.combine(start_date, time(23, 59), tzinfo=la)
+    return anchor_local.astimezone(UTC).replace(tzinfo=None)
 
 
 async def _seed_stages(db_session: AsyncSession, count: int = 3) -> list[CourseStage]:
@@ -629,6 +667,64 @@ async def test_stage_unlocked_uses_current_stage_only(
     assert data[0]["is_unlocked"] is True
     assert data[1]["is_unlocked"] is True  # current_stage=3 unlocks 1..3
     assert data[2]["is_unlocked"] is True
+
+
+# ── Timezone-aware stage-unlock gating ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_stages_shows_stage_two_unlocked_on_pacific_first_local_day(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """``GET /stages`` reads the calendar unlock in the caller's timezone, not UTC.
+
+    A Pacific user on the first local calendar day of stage 2 sees it
+    unlocked; the UTC default still reads day 20 of stage 1 and reports it
+    locked.
+    """
+    headers, user_id = await _signup_with_timezone(
+        async_client, "pacificstages", "America/Los_Angeles"
+    )
+    await _seed_stages(db_session, count=3)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=_pacific_anchor_for_stage_two_day(1),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/stages", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data[1]["is_unlocked"] is True
+
+
+@pytest.mark.asyncio
+async def test_stage_history_open_on_pacific_first_local_day_of_stage_two(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """``GET /stages/{n}/history`` must honor the same timezone-aware calendar unlock."""
+    headers, user_id = await _signup_with_timezone(
+        async_client, "pacifichistory", "America/Los_Angeles"
+    )
+    await _seed_stages(db_session, count=3)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=_pacific_anchor_for_stage_two_day(1),
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get("/stages/2/history", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
 
 
 # ── User isolation ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The course-content and stages unlock gates and the `/stages/program-calendar` view still floored elapsed program days as a UTC diff, so users ahead of UTC saw those surfaces unlock up to a calendar day later than the practice-assignment gate — which PR #1638 already made timezone-aware. This aligns the remaining sibling call sites to the same local-midnight convention the frontend uses, closing the last cross-surface inconsistency on stage-boundary days.

This is a mechanical replication of the shipped #1638 pattern — no domain-layer changes. The shared functions `is_stage_unlocked`, `calendar_stage`, `calendar_week`, and `calendar_day_in_stage` already accept a keyword-only `tz`; the routers now thread the caller's server-resolved timezone (the existing `current_user_timezone` dependency) into every gate:

- `routers/course.py` — the `user_tz` dependency is added to the 7 gated endpoints (`list_stage_content`, `get_content_item`, `mark_content_read`, `get_course_progress`, `get_content_body`, `get_stage_introduction`, `get_stage_intro_body`) and forwarded through the 8 private helpers down to `is_stage_unlocked` (the stage gate) and the adjacent `calendar_day_in_stage` (the proportional drip on the same paths). The advancement-based `compute_days_elapsed(stage_started_at)` sibling is left on its own basis, and the non-gated `list_site_resources`/site-resource-body endpoints are untouched.
- `routers/stages.py` — `list_stages`, `get_stage_history`, and `get_program_calendar` gain the dependency; it threads through `_stage_responses_with_progress` into `is_stage_unlocked`, and into `calendar_stage`/`calendar_week` for the program-calendar view.

The `max(current_stage, calendar_stage)` never-revoke posture and the BUG-COURSE-004 404/403 enumeration masks are preserved exactly — the timezone can only OPEN a stage a calendar day earlier for ahead-of-UTC users, never revoke advancement-granted access, and `tz` is server-resolved from the stored profile so a client cannot skip ahead.

### Out of scope

The `prompts.py` week-gate `calendar_week` remains on the UTC default; the issue enumerates only the course/stages gates and `/stages/program-calendar` as its surfaces, and the reflection due-date ladder was deliberately kept on UTC in #1638.

## Test plan

TDD — boundary fixtures written RED first, then GREEN, using the DST-proof #1638 recipe (Pacific user anchored to the first *local* calendar day of stage 2, where the UTC-date diff still reads stage 1):

- `tests/test_program_gating.py` — `/stages/program-calendar` returns `calendar_stage == 2` for the Pacific first-local-day user (was 1); a domain-level never-revoke assertion holds when advancement is ahead of the calendar.
- `tests/test_course_api.py` — the gated stage-2 course surfaces (`/course/stages/2/progress`, content detail) open on the first local day; `next_unlock_day` reflects the local day, not the UTC lag.
- `tests/test_stages_api.py` — `GET /stages` shows stage 2 `is_unlocked: true` and `/stages/2/history` returns 200 on the first local day.

Gate 2 green locally: `./scripts/backend/check-all.sh` 7/7, 2648 passed, coverage 96.70%, ruff + mypy clean; xenon A-grade and radon MI grade A on both changed routers.

Closes #1639
Refs #1616