### PR TITLE
fix(frontend): show one coherent banner when API-key SecureStore write fails

### DIFF
--- a/frontend/src/context/ApiKeyContext.tsx
+++ b/frontend/src/context/ApiKeyContext.tsx
@@ -23,6 +23,15 @@ import { clearLlmApiKey, loadLlmApiKey, saveLlmApiKey } from '@/storage/llmKeySt
  * in any API response — it lives only on the device.
  */
 
+/** Outcome of a {@link ApiKeyContextValue.saveApiKey} call. */
+export interface ApiKeySaveResult {
+  /**
+   * True when the write reached SecureStore; false when it fell back to
+   * session-only because the SecureStore write failed.
+   */
+  persisted: boolean;
+}
+
 interface ApiKeyContextValue {
   /** Current user-owned key, or null if none is stored. */
   apiKey: string | null;
@@ -35,8 +44,12 @@ interface ApiKeyContextValue {
    * visible instead of the app silently running with a blank, non-persisted key.
    */
   loadError: Error | null;
-  /** Persist a new key to SecureStore and update context state. */
-  saveApiKey: (_key: string) => Promise<void>;
+  /**
+   * Persist a new key and update context state. Resolves with
+   * ``persisted: true`` when the write reached SecureStore, or
+   * ``persisted: false`` when it fell back to session-only (the write failed).
+   */
+  saveApiKey: (_key: string) => Promise<ApiKeySaveResult>;
   /** Remove the stored key (SecureStore + context state). */
   clearApiKey: () => Promise<void>;
 }
@@ -98,16 +111,19 @@ export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
       .finally(() => setIsLoading(false));
   }, []);
 
-  const saveApiKey = useCallback(async (key: string) => {
+  const saveApiKey = useCallback(async (key: string): Promise<ApiKeySaveResult> => {
+    let persisted = false;
     try {
       await saveLlmApiKey(key);
       setLoadError(null);
+      persisted = true;
     } catch (err: unknown) {
       console.warn('[ApiKeyContext] SecureStore save failed', err);
       setLoadError(err instanceof Error ? err : new Error(String(err)));
       // Set state anyway so the key is at least usable this session.
     }
     setApiKey(key);
+    return { persisted };
   }, []);
 
   const clearApiKey = useCallback(async () => {

--- a/frontend/src/context/__tests__/ApiKeyContext.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyContext.test.tsx
@@ -155,12 +155,14 @@ describe('ApiKeyProvider', () => {
     );
     await waitFor(() => expect(ctx?.isLoading).toBe(false));
 
+    let result: { persisted: boolean } | undefined;
     await act(async () => {
-      await ctx!.saveApiKey('sk-new');
+      result = await ctx!.saveApiKey('sk-new');
     });
 
     expect(mockStorage.saveLlmApiKey).toHaveBeenCalledWith('sk-new');
     expect(ctx!.apiKey).toBe('sk-new');
+    expect(result).toEqual({ persisted: true });
   });
 
   test('clearApiKey deletes the stored key and resets state', async () => {
@@ -253,13 +255,15 @@ describe('ApiKeyProvider', () => {
     );
     await waitFor(() => expect(ctx?.isLoading).toBe(false));
 
+    let result: { persisted: boolean } | undefined;
     await act(async () => {
-      await ctx!.saveApiKey('sk-fallback');
+      result = await ctx!.saveApiKey('sk-fallback');
     });
 
     expect(ctx!.loadError).toBeInstanceOf(Error);
     expect(ctx!.loadError?.message).toBe('disk full');
     expect(ctx!.apiKey).toBe('sk-fallback');
+    expect(result).toEqual({ persisted: false });
     warnSpy.mockRestore();
   });
 

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -23,6 +23,7 @@ import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import type { ApiKeySaveResult } from '@/context/ApiKeyContext';
 import { useApiKey } from '@/context/ApiKeyContext';
 import { BORDER_RADIUS, SPACING, colors, ink, surface } from '@/design/tokens';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -325,15 +326,17 @@ const ScreenBody = ({
 function useSaveKeyHandler(
   form: SettingsFormState,
   setReveal: Dispatch<SetStateAction<boolean>>,
-  saveApiKey: (_k: string) => Promise<void>,
+  saveApiKey: (_k: string) => Promise<ApiKeySaveResult>,
 ): () => Promise<void> {
   const { draft, setDraft, setStatus } = form;
   const validate = useCallback(() => validateUserApiKey(draft)?.message ?? null, [draft]);
   const perform = useCallback(async () => {
-    await saveApiKey(draft.trim());
+    const result = await saveApiKey(draft.trim());
     setDraft('');
     setReveal(false);
-    setStatus('API key saved on this device.');
+    if (result.persisted) {
+      setStatus('API key saved on this device.');
+    }
   }, [draft, saveApiKey, setDraft, setReveal, setStatus]);
   const onError = useCallback(
     (err: unknown) =>

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
@@ -1,12 +1,14 @@
 /* eslint-env jest */
 /* global describe, test, expect, jest, beforeEach */
-import { render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
 import ApiKeySettingsScreen, { SECURE_STORAGE_WARNING } from '../ApiKeySettingsScreen';
 
 import { ApiKeyProvider } from '@/context/ApiKeyContext';
 import * as llmKeyStorage from '@/storage/llmKeyStorage';
+
+const VALID_KEY = 'sk-user-owned-example-key-0123456789';
 
 jest.mock('@/api', () => ({
   setLlmApiKeyGetter: jest.fn(),
@@ -41,5 +43,48 @@ describe('ApiKeySettingsScreen integration with a failing SecureStore read', () 
 
     expect(getByTestId('api-key-storage-error').props.children).toBe(SECURE_STORAGE_WARNING);
     warnSpy.mockRestore();
+  });
+});
+
+describe('ApiKeySettingsScreen integration with a failing SecureStore write', () => {
+  test('shows only the storage warning, not a false success status, when the save write fails', async () => {
+    mockStorage.saveLlmApiKey.mockRejectedValueOnce(new Error('keychain locked'));
+    const warnSpy = jest.spyOn(globalThis.console, 'warn').mockImplementation(() => undefined);
+
+    const { getByTestId, findByTestId, queryByTestId } = render(
+      <ApiKeyProvider>
+        <ApiKeySettingsScreen />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('api-key-loading')).toBeNull());
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    const warning = await findByTestId('api-key-storage-error');
+    expect(warning.props.children).toBe(SECURE_STORAGE_WARNING);
+    expect(queryByTestId('api-key-status')).toBeNull();
+    expect(queryByTestId('api-key-error')).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test('shows the success status and no storage warning when the save write succeeds', async () => {
+    const { getByTestId, findByTestId, queryByTestId } = render(
+      <ApiKeyProvider>
+        <ApiKeySettingsScreen />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('api-key-loading')).toBeNull());
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    const status = await findByTestId('api-key-status');
+    expect(status).toBeTruthy();
+    expect(queryByTestId('api-key-storage-error')).toBeNull();
   });
 });

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -25,7 +25,7 @@ function setApiKeyState(partial: Partial<ReturnType<typeof useApiKey>>) {
     apiKey: null,
     isLoading: false,
     loadError: null,
-    saveApiKey: jest.fn(() => Promise.resolve()),
+    saveApiKey: jest.fn(() => Promise.resolve({ persisted: true })),
     clearApiKey: jest.fn(() => Promise.resolve()),
   };
   const value = { ...base, ...partial } as ReturnType<typeof useApiKey>;
@@ -370,5 +370,24 @@ describe('ApiKeySettingsScreen', () => {
     const formError = await findByTestId('api-key-error');
     expect(formError).toBeTruthy();
     expect(getByTestId('api-key-storage-error').props.children).toBe(SECURE_STORAGE_WARNING);
+  });
+
+  test('shows only the storage warning, not the success status, when the write does not persist', async () => {
+    const state = setApiKeyState({
+      loadError: new Error('disk full'),
+      saveApiKey: jest.fn(() => Promise.resolve({ persisted: false })),
+    });
+    const { getByTestId, findByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);
+
+    fireEvent.changeText(getByTestId('api-key-input'), VALID_KEY);
+    await act(async () => {
+      fireEvent.press(getByTestId('save-key-button'));
+    });
+
+    await waitFor(() => expect(state.saveApiKey).toHaveBeenCalledWith(VALID_KEY));
+    expect(await findByTestId('api-key-storage-error')).toBeTruthy();
+    expect(queryByTestId('api-key-status')).toBeNull();
+    expect(queryByTestId('api-key-error')).toBeNull();
+    expect(getByTestId('api-key-input').props.value).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

`ApiKeyContext.saveApiKey` swallowed SecureStore write failures — it caught the error, set `loadError`, still called `setApiKey`, and resolved `Promise<void>`. The settings screen then rendered the green **"API key saved on this device."** success status while `loadError` simultaneously drove the **"Secure storage is unavailable…"** warning: two contradictory banners on one screen.

The fix makes the write outcome a first-class signal. `saveApiKey` now returns `Promise<ApiKeySaveResult>` (`{ persisted: boolean }`) — `true` when the write reached SecureStore, `false` when it fell back to session-only. `ApiKeySettingsScreen` only sets the success status when `result.persisted` is true, so a failed persist shows **only** the storage-unavailable warning (which already explains the key still works this session but won't survive a restart). The key remains usable in-session in both cases.

`clearApiKey` keeps its `Promise<void>` contract — it has the same latent contradiction on the remove path, but that is out of scope here and tracked separately.

## Test plan

- Context unit tests assert `saveApiKey` resolves `{ persisted: true }` on success and `{ persisted: false }` when the write rejects (while still setting `loadError` and the in-session key).
- Screen unit test asserts that a non-persisted save with `loadError` set renders no success status and no form error (single coherent message), draft cleared.
- Real-provider integration test drives the full `ApiKeyProvider` with `saveLlmApiKey` rejecting: pressing save shows the storage-unavailable warning with `api-key-status` and `api-key-error` both absent; the healthy-store counterpart shows the success status and no storage banner.
- `./scripts/frontend/check-all.sh` green (4291 tests, lint, typecheck, format); `tsc --noEmit` clean.

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)