### PR TITLE
refactor(course): remove redundant client-side frontmatter strip

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -6,7 +6,7 @@ import { course as courseApi, type ContentBody } from '../../api';
 import { colors, SPACING } from '../../design/tokens';
 
 import styles, { markdownStyles } from './Course.styles';
-import { stripFrontmatter, stripLeadingTitleHeading } from './stripFrontmatter';
+import { stripLeadingTitleHeading } from './stripLeadingTitleHeading';
 
 /**
  * Small-caps eyebrow shown above the sheet title, keyed by content type.
@@ -239,11 +239,10 @@ function useContentBody(source: ChapterReaderSource): {
 }
 
 function renderBody(body: ContentBody): React.ReactElement {
-  const stripped = stripFrontmatter(body.body_markdown);
-  if (stripped.trim() === '') {
+  if (body.body_markdown.trim() === '') {
     return <EmptyView />;
   }
-  const markdown = stripLeadingTitleHeading(stripped, body.title);
+  const markdown = stripLeadingTitleHeading(body.body_markdown, body.title);
   return (
     <ScrollView
       style={styles.readerScroll}

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -245,23 +245,6 @@ describe('ChapterReader', () => {
     expect(queryByText(/line one line two/)).toBeNull();
   });
 
-  // Defensive: raw frontmatter must never reach the Markdown renderer.
-  it('does not render YAML frontmatter fields when body_markdown opens with a fence', async () => {
-    mockContentBody.mockResolvedValueOnce({
-      title: 'Frontmatter Test',
-      content_type: 'chapter',
-      body_markdown: '---\nslug: leak\ntitle: "T"\n---\n\n# Real\n\nProse.\n',
-    });
-    const { findByText, queryByText } = render(
-      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
-    );
-    // Body text must appear once frontmatter is stripped.
-    await findByText(/Real/);
-    // Raw YAML keys must not appear anywhere in the rendered output.
-    expect(queryByText(/slug:/)).toBeNull();
-    expect(queryByText(/title:/)).toBeNull();
-  });
-
   it('renders images from absolute URLs and drops repo-relative image references', async () => {
     mockContentBody.mockResolvedValueOnce({
       title: 'Image Test',

--- a/frontend/src/features/Course/__tests__/stripLeadingTitleHeading.test.ts
+++ b/frontend/src/features/Course/__tests__/stripLeadingTitleHeading.test.ts
@@ -1,52 +1,7 @@
 /* eslint-env jest */
 import { describe, expect, it } from '@jest/globals';
 
-import { stripFrontmatter, stripLeadingTitleHeading } from '../stripFrontmatter';
-
-describe('stripFrontmatter', () => {
-  it('strips a leading YAML frontmatter block', () => {
-    const input = '---\nslug: x\ntitle: "T"\nmedia: []\n---\n\n# Body\n\nProse.\n';
-    const result = stripFrontmatter(input);
-    expect(result).toContain('# Body');
-    expect(result).toContain('Prose.');
-    expect(result).not.toContain('slug:');
-    expect(result).not.toContain('title:');
-    expect(result).not.toContain('media:');
-    expect(result.startsWith('---')).toBe(false);
-  });
-
-  it('returns frontmatter-free input unchanged (exact equality)', () => {
-    const input = '# Heading\n\nProse.\n';
-    expect(stripFrontmatter(input)).toBe(input);
-  });
-
-  it('preserves a mid-body thematic break (--- not on line 1)', () => {
-    const input = '# H\n\nBefore.\n\n---\n\nAfter.\n';
-    const result = stripFrontmatter(input);
-    expect(result).toContain('---');
-    expect(result).toContain('Before.');
-    expect(result).toContain('After.');
-  });
-
-  it('returns an unterminated frontmatter block unchanged (exact equality)', () => {
-    const input = '---\nslug: x\nno close\n';
-    expect(stripFrontmatter(input)).toBe(input);
-  });
-
-  it('does not treat a fence preceded by a blank line as frontmatter', () => {
-    const input = '\n---\nslug: x\n---\n\n# Body\n';
-    const result = stripFrontmatter(input);
-    // The leading blank means the --- is NOT on line 1; input returned unchanged.
-    expect(result).toBe(input);
-  });
-
-  it('tolerates a leading UTF-8 BOM before the opening fence', () => {
-    const input = '﻿---\nslug: x\n---\n\n# Body\n';
-    const result = stripFrontmatter(input);
-    expect(result).not.toContain('slug:');
-    expect(result).toContain('# Body');
-  });
-});
+import { stripLeadingTitleHeading } from '../stripLeadingTitleHeading';
 
 describe('stripLeadingTitleHeading', () => {
   it('strips a leading H1 that exactly matches the title', () => {

--- a/frontend/src/features/Course/stripLeadingTitleHeading.ts
+++ b/frontend/src/features/Course/stripLeadingTitleHeading.ts
@@ -1,32 +1,3 @@
-/** Line that opens and closes a YAML frontmatter block: a lone triple-dash. */
-const FRONTMATTER_FENCE = '---';
-
-/** UTF-8 byte-order mark some editors prepend; tolerated before the fence. */
-const BOM = '﻿';
-
-/**
- * Drop a leading ``---``-delimited YAML frontmatter block from Markdown,
- * mirroring the backend algorithm: only a fence on line 1 (after an optional
- * BOM) counts; a ``---`` after prose is a thematic break and is preserved.
- * When there is no opening fence, or the block is never closed, the input is
- * returned character-for-character so nothing is silently swallowed.
- */
-export function stripFrontmatter(md: string): string {
-  const body = md.startsWith(BOM) ? md.slice(BOM.length) : md;
-  const lines = body.split('\n');
-  const firstLine = lines[0] ?? '';
-  if (firstLine.trimEnd() !== FRONTMATTER_FENCE) {
-    return md;
-  }
-  for (let index = 1; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (line !== undefined && line.trimEnd() === FRONTMATTER_FENCE) {
-      return lines.slice(index + 1).join('\n');
-    }
-  }
-  return md;
-}
-
 /** ATX H1 prefix: exactly one hash followed by a space. */
 const H1_PREFIX = '# ';
 


### PR DESCRIPTION
## Summary

De-slop #1501. Removes the redundant client-side frontmatter strip
(`stripFrontmatter`) from the Course reader.

**Decision: REMOVE** (verified at HEAD, not stale). Rationale: the backend
already strips YAML frontmatter at every body endpoint —
`content_repository._read_markdown` returns `_strip_frontmatter(...)`, and all
three body endpoints funnel through it (`read_body`, `read_resource_body`,
`read_intro_body`). Every `ChapterReader` body source comes only from those API
endpoints (`course.contentBody` / `siteResourceBody` / `stageIntroBody`), so the
client `stripFrontmatter` was a no-op on all real inputs — a line-for-line TS
port of the Python algorithm that had to be kept in sync across the JS/Python
boundary. Per the repo's de-slop philosophy, defensive re-implementation of an
invariant the other side of the API already guarantees is sludge; keeping a
duplicate parser in sync is worse than the residual risk.

Changes:
- Delete `stripFrontmatter` and its constants (`FRONTMATTER_FENCE`, `BOM`).
- `ChapterReader.renderBody` now uses `body.body_markdown` directly and calls
  `stripLeadingTitleHeading` on it — the genuinely-needed H1-dedupe presentation
  logic, kept unchanged.
- Rename `stripFrontmatter.ts` -> `stripLeadingTitleHeading.ts` (and its test) so
  the filename matches its sole surviving export.
- Drop the one synthetic-fence test in `ChapterReader.test.tsx` that hand-injected
  raw frontmatter through a mock — the only test exercising the removed path.

## Test plan

- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, jest:
  405 suites / 4284 tests pass).
- All 9 `stripLeadingTitleHeading` unit tests retained unchanged, plus the two
  reader-integration tests covering H1-dedupe-on-match and preserve-on-differ.
- Existing real-path `ChapterReader` render tests remain green unchanged.

Closes #1501