### PR TITLE
refactor(course): dedupe retry button and reconcile "Try again" label

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -6,6 +6,7 @@ import { course as courseApi, type ContentBody } from '../../api';
 import { colors, SPACING } from '../../design/tokens';
 
 import styles, { markdownStyles } from './Course.styles';
+import RetryButton from './RetryButton';
 import { stripLeadingTitleHeading } from './stripLeadingTitleHeading';
 
 /**
@@ -131,15 +132,7 @@ const ErrorView = ({ message, onRetry }: ErrorViewProps): React.JSX.Element => (
   <View style={styles.readerError} testID="reader-error">
     <Text style={styles.readerErrorTitle}>This page couldn’t load right now</Text>
     <Text style={styles.readerErrorSubtitle}>{message}</Text>
-    <TouchableOpacity
-      onPress={onRetry}
-      style={styles.retryButton}
-      testID="reader-retry-button"
-      accessibilityRole="button"
-      accessibilityLabel="Try again"
-    >
-      <Text style={styles.retryText}>Try Again</Text>
-    </TouchableOpacity>
+    <RetryButton onRetry={onRetry} testID="reader-retry-button" />
   </View>
 );
 

--- a/frontend/src/features/Course/ContentViewer.tsx
+++ b/frontend/src/features/Course/ContentViewer.tsx
@@ -32,7 +32,7 @@ const ViewerFooter = ({
       {marking ? (
         <ActivityIndicator testID="mark-read-loading" size="small" color={colors.text.light} />
       ) : (
-        <Text style={[styles.markReadText, isRead && styles.markReadTextDone]}>
+        <Text style={[styles.buttonLabelOnAccent, isRead && styles.markReadTextDone]}>
           {isRead ? '✓ Read' : 'Mark as Read'}
         </Text>
       )}
@@ -45,7 +45,7 @@ const ViewerFooter = ({
         accessibilityRole="button"
         accessibilityLabel="Reflect in Journal"
       >
-        <Text style={styles.reflectText}>Reflect in Journal</Text>
+        <Text style={styles.buttonLabelOnAccent}>Reflect in Journal</Text>
       </TouchableOpacity>
     )}
   </View>

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -297,7 +297,8 @@ const styles = StyleSheet.create({
   markReadButtonDone: {
     backgroundColor: surface.sunken,
   },
-  markReadText: {
+  // Shared label for buttons painted on an accent surface (mark-read, reflect, retry).
+  buttonLabelOnAccent: {
     fontSize: 15,
     fontWeight: '600',
     color: surface.canvas,
@@ -312,11 +313,6 @@ const styles = StyleSheet.create({
     backgroundColor: accent.strong,
     alignItems: 'center',
     marginTop: SPACING.sm,
-  },
-  reflectText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: surface.canvas,
   },
 
   // Loading and empty/error states
@@ -413,11 +409,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.lg,
     borderRadius: radius.md,
     backgroundColor: accent.primary,
-  },
-  retryText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: surface.canvas,
+    alignItems: 'center',
   },
 
   // Site resources panel

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, FlatList, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
@@ -35,6 +35,7 @@ import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
 import CourseDrawer, { useCourseDrawerContent } from './CourseDrawer';
+import RetryButton from './RetryButton';
 import SiteResourcesPanel from './SiteResourcesPanel';
 import StageIntroCard from './StageIntroCard';
 import StageSelector from './StageSelector';
@@ -250,15 +251,7 @@ const CourseErrorState = ({ onRetry }: { onRetry: () => void }): React.JSX.Eleme
     <Text style={styles.emptySubtitle}>
       Something went wrong loading this stage. Check your connection and try again.
     </Text>
-    <TouchableOpacity
-      onPress={onRetry}
-      accessibilityRole="button"
-      accessibilityLabel="Try again"
-      style={styles.retryButton}
-      testID="course-retry"
-    >
-      <Text style={styles.retryText}>Try again</Text>
-    </TouchableOpacity>
+    <RetryButton onRetry={onRetry} testID="course-retry" />
   </View>
 );
 

--- a/frontend/src/features/Course/RetryButton.tsx
+++ b/frontend/src/features/Course/RetryButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+
+import styles from './Course.styles';
+
+export const RETRY_LABEL = 'Try again';
+
+interface RetryButtonProps {
+  onRetry: () => void;
+  testID?: string;
+}
+
+const RetryButton = ({ onRetry, testID }: RetryButtonProps): React.JSX.Element => (
+  <TouchableOpacity
+    onPress={onRetry}
+    accessibilityRole="button"
+    accessibilityLabel={RETRY_LABEL}
+    style={styles.retryButton}
+    testID={testID}
+  >
+    <Text style={styles.buttonLabelOnAccent}>{RETRY_LABEL}</Text>
+  </TouchableOpacity>
+);
+
+export default RetryButton;

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -153,10 +153,12 @@ describe('ChapterReader', () => {
       content_type: 'chapter',
       body_markdown: 'retried body\n',
     });
-    const { findByTestId, findByText } = render(
+    const { findByTestId, findByText, getByText, queryByText } = render(
       <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
     );
     await findByText(/please try again/i);
+    expect(getByText('Try again')).toBeTruthy();
+    expect(queryByText('Try Again')).toBeNull();
     fireEvent.press(await findByTestId('reader-retry-button'));
     await findByText(/retried body/);
   });

--- a/frontend/src/features/Course/__tests__/RetryButton.test.tsx
+++ b/frontend/src/features/Course/__tests__/RetryButton.test.tsx
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import RetryButton, { RETRY_LABEL } from '../RetryButton';
+
+describe('RetryButton', () => {
+  it('renders the visible label "Try again"', () => {
+    const { getByText } = render(<RetryButton onRetry={jest.fn()} testID="x" />);
+    expect(getByText('Try again')).toBeTruthy();
+  });
+
+  it('keeps the accessibility label in sync with the visible text', () => {
+    const { getByTestId, getByText } = render(<RetryButton onRetry={jest.fn()} testID="x" />);
+    const button = getByTestId('x');
+    const visibleText = getByText('Try again').props.children;
+    expect(button.props.accessibilityLabel).toBe('Try again');
+    expect(visibleText).toBe('Try again');
+    expect(button.props.accessibilityLabel).toBe(visibleText);
+  });
+
+  it('calls onRetry once when pressed', () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(<RetryButton onRetry={onRetry} testID="x" />);
+    fireEvent.press(getByTestId('x'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('exports RETRY_LABEL as "Try again"', () => {
+    expect(RETRY_LABEL).toBe('Try again');
+  });
+});


### PR DESCRIPTION
## Summary
De-slop of the Course tab's two hand-rolled error-retry buttons (issue filed 2026-07-08; all findings re-verified at HEAD before changing anything).

- Extract a shared `RetryButton` component in `features/Course/` with a single `RETRY_LABEL = 'Try again'` constant driving both the visible text and the `accessibilityLabel`, so the two can never disagree.
- Use it from both `CourseErrorState` (`CourseScreen.tsx`, testID `course-retry`) and the `ChapterReader` `ErrorView` (testID `reader-retry-button`), replacing two divergent copy-pasted `TouchableOpacity` blocks. The ChapterReader surface previously showed "Try Again" (capital A) while its own `accessibilityLabel` said "Try again" — now reconciled to "Try again".
- Collapse the three byte-identical on-accent label styles (`markReadText` / `reflectText` / `retryText`) in `Course.styles.ts` into one shared `buttonLabelOnAccent` key (updating the `ContentViewer` consumers), and restore the dropped `alignItems: 'center'` on `retryButton` so its label centers like `markReadButton` / `reflectButton`.

No behavior change beyond consistent label casing and centering.

## Test plan
- New `RetryButton.test.tsx` asserts the visible label, that the visible text equals the `accessibilityLabel` (both exactly "Try again"), a single `onRetry` on press, and the exported constant — an anti-drift guard so the casing can't silently regress.
- Extended `ChapterReader.test.tsx` to positively assert "Try again" and negatively assert the old "Try Again" on the reader error surface.
- Full `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and Jest (4288 tests) all pass.

Closes #1502