### PR TITLE
refactor(frontend): remove dead EditableGoalProps and GoalGroup types

### DIFF
--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -48,17 +48,6 @@ export interface Goal {
   goal_group_id?: number | null;
 }
 
-export interface GoalGroup {
-  id: number;
-  name: string;
-  icon?: string | null;
-  description?: string | null;
-  user_id?: number | null;
-  shared_template: boolean;
-  source?: string | null;
-  goals: Goal[];
-}
-
 export interface Completion {
   id?: string;
   timestamp: Date;
@@ -107,12 +96,6 @@ export interface StatsModalProps {
   habit: Habit | null;
   stats: HabitStatsData | null;
   onClose: () => void;
-}
-
-export interface EditableGoalProps {
-  goal: Goal;
-  onUpdate: (_updatedGoal: Goal) => void;
-  isEditing: boolean;
 }
 
 export interface HabitTileProps {


### PR DESCRIPTION
## Summary

Delete two exported interfaces in `frontend/src/features/Habits/Habits.types.ts` that have zero consumers anywhere in `frontend/src` — dead/orphaned type declarations.

- `EditableGoalProps` — no `EditableGoal` component exists; goal editing lives inside `GoalModal`.
- `GoalGroup` — a redundant duplicate of the live `ApiGoalGroup` type that the goal-group feature actually fetches and renders (`api/index.ts`, consumed by `goalGroups.list`, `useGoalGroup`, etc.). The `Habits.types.ts` copy was never imported.

Verified at HEAD before deleting: exact-word greps `rg '\bEditableGoalProps\b'` and `rg '\bGoalGroup\b'` across `frontend/src` returned only the definition lines — no consumers had appeared since the 2026-07-08 de-slopify scan. After deletion both greps return zero matches. `ApiGoalGroup` and the live `goal_group_id` fields are untouched.

Scope stays clear of #1255 (which deletes `Habit.progress` / `emojiHabitIndex` on different lines).

## Test plan

- `./scripts/frontend/check-all.sh` — green: ESLint, prettier, `tsc --noEmit`, and the full Jest suite (406 suites, 4288 tests) all pass. Pure deletion of zero-consumer types, so the green suite + typecheck are the safety net; no new tests expected.

Closes #1511