### PR TITLE
refactor(habits): extract shared buildTileStyle base builder in HabitTile

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -512,11 +512,12 @@ interface LockedTileProps {
   onUnlockHabit?: (_habitId: number) => void;
 }
 
-const getLockedTileStyle = (
+const buildTileStyle = (
   stageColor: string,
   scale: number,
   gridGutter: number,
   tileMinHeight: number,
+  overlay: { backgroundColor: string; opacity?: number },
 ) => ({
   flex: 1 as const,
   borderWidth: TILE_BORDER_WIDTH,
@@ -526,10 +527,20 @@ const getLockedTileStyle = (
   margin: gridGutter / 2,
   minHeight: tileMinHeight,
   borderRadius: spacing(1, scale),
-  backgroundColor: LOCKED_BACKGROUND,
-  opacity: LOCKED_OPACITY,
+  ...overlay,
   ...longPressGestureStyle,
 });
+
+const getLockedTileStyle = (
+  stageColor: string,
+  scale: number,
+  gridGutter: number,
+  tileMinHeight: number,
+) =>
+  buildTileStyle(stageColor, scale, gridGutter, tileMinHeight, {
+    backgroundColor: LOCKED_BACKGROUND,
+    opacity: LOCKED_OPACITY,
+  });
 
 const LOCKED_NAME_STYLE = {
   flex: 1 as const,
@@ -612,18 +623,10 @@ const buildUnlockedTileStyle = (
   scale: number,
   gridGutter: number,
   tileMinHeight: number,
-) => ({
-  flex: 1 as const,
-  borderWidth: TILE_BORDER_WIDTH,
-  borderColor: stageColor,
-  paddingVertical: spacing(tileDensity.paddingV, scale),
-  paddingHorizontal: spacing(1, scale),
-  margin: gridGutter / 2,
-  minHeight: tileMinHeight,
-  borderRadius: spacing(1, scale),
-  backgroundColor: surface.canvas,
-  ...longPressGestureStyle,
-});
+) =>
+  buildTileStyle(stageColor, scale, gridGutter, tileMinHeight, {
+    backgroundColor: surface.canvas,
+  });
 
 interface TileProgressSectionProps {
   habit: Habit;


### PR DESCRIPTION
## Summary
Deduplicates `getLockedTileStyle`/`buildUnlockedTileStyle` in `HabitTile.tsx` into a shared `buildTileStyle(stageColor, scale, gridGutter, tileMinHeight, { backgroundColor, opacity? })` base builder. The two variants were byte-identical except for background color and the locked opacity; each now derives from the base via an overlay applied before `...longPressGestureStyle`, producing key-for-key identical style objects.

Pure refactor — zero behavior change. Render logic and `React.memo` boundaries untouched. Existing `HabitTile*` tests (including `HabitTileFit`/`HabitTileLocked`) pass unchanged as the behavior pin; full `./scripts/frontend/check-all.sh` green (4288 tests).

De-slop finding verified live at HEAD before the change (frontend-habits scan, 2026-07-08).

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)