### PR TITLE
docs(practice): correct InsightCaptureModal journal-handoff docstring

### DIFF
--- a/frontend/src/features/Practice/components/InsightCaptureModal.tsx
+++ b/frontend/src/features/Practice/components/InsightCaptureModal.tsx
@@ -7,8 +7,12 @@
  *   - **Save**: POST the session row with the typed insight attached and
  *     dismiss.
  *   - **Save & journal with BotMason** (when ``onJournal`` is wired): POST
- *     then hand off to the Journal tab with ``practiceSessionId`` so
- *     BotMason has context. Hidden when the parent does not wire the handler.
+ *     then hand off via ``onJournal``. The parent (ritual-11's `PracticeScreen`)
+ *     wires this to a ``navigation.navigate('JournalEntry', …)`` into the
+ *     ``RootStack.JournalEntry`` screen, passing ``practiceSessionId``,
+ *     ``userPracticeId``, and a ``prefillTitle`` so the long-form entry opens
+ *     pre-linked to this session. Hidden when the parent does not wire the
+ *     handler.
  *   - **Skip**: POST the session row *without* an insight. Analytics still
  *     need the row; only the free-text field is omitted.
  *


### PR DESCRIPTION
## Summary

The `InsightCaptureModal` docstring's "Save & journal with BotMason" bullet
claimed the flow hands off to the "Journal tab" with `practiceSessionId`. That
is stale: the tab param surface was deleted (PR #1558). The real handoff runs
through the parent's `onJournal` wiring in `PracticeScreen`, which calls
`navigation.navigate('JournalEntry', …)` into the `RootStack.JournalEntry`
screen, passing `practiceSessionId`, `userPracticeId`, and `prefillTitle` so the
long-form entry opens pre-linked to the session.

Rewrote the bullet to describe the actual target and its params, in the file's
existing TSDoc idiom. Docs-only — no behavior, API, or test change.

## Test plan

- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4288
  tests across 406 suites).
- Verified the documented target/params against the live navigate call at
  `PracticeScreen.tsx` and the `RootStack.JournalEntry` param type.

Closes #1559