### PR TITLE
fix(journal): grapheme-safe excerpt truncation

### DIFF
--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Animated, SectionList, Text, TouchableOpacity, View } from 'react-native';
 import type { SectionListData, SectionListRenderItemInfo } from 'react-native';
 
+import { excerpt } from './excerpt';
 import { JournalScreenDrawer } from './JournalDrawer';
 import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
@@ -49,11 +50,6 @@ const WORDS_PER_MINUTE = 200;
 const FIRST_PROMPT = 'What brought you here?';
 
 type ShelfNavigation = NativeStackNavigationProp<RootStackParamList>;
-
-function excerpt(body: string): string {
-  const flat = body.replace(/\s+/g, ' ').trim();
-  return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
-}
 
 /** Estimated reading time in whole minutes (≥1). */
 function readingMinutes(body: string): number {
@@ -157,7 +153,7 @@ function PageCard({
           <Text style={styles.cardDate}>{formatDate(entry.timestamp)}</Text>
         </View>
         <Text style={styles.cardExcerpt} numberOfLines={2}>
-          {excerpt(entry.message)}
+          {excerpt(entry.message, EXCERPT_MAX)}
         </Text>
         <Text style={styles.cardCaption}>{pageCaption(entry, now)}</Text>
       </TouchableOpacity>

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -24,6 +24,7 @@ import {
   useWindowDimensions,
 } from 'react-native';
 
+import { excerpt } from './excerpt';
 import QuoteSelectionSurface, { type CodePointSpan } from './QuoteSelectionSurface';
 import { sourceAttribution } from './reflectionCopy';
 
@@ -78,12 +79,6 @@ export interface ReflectionSourcesPanelProps {
 interface PendingEntry {
   quote: PromotedQuoteSummary;
   item: ReflectionSourceItem;
-}
-
-/** A single-line excerpt of a body for a collapsed row. */
-function excerpt(body: string): string {
-  const flat = body.replace(/\s+/g, ' ').trim();
-  return flat.length > EXCERPT_MAX ? `${flat.slice(0, EXCERPT_MAX).trimEnd()}…` : flat;
 }
 
 /** Warm, sentence-case label for a reflection row's level (e.g. "Week reflection"). */
@@ -267,7 +262,7 @@ function SourceRow({
         <Text style={styles.rowTitle}>{sourceAttribution(item)}</Text>
         {expanded ? null : (
           <Text style={styles.rowExcerpt} numberOfLines={2}>
-            {excerpt(item.body)}
+            {excerpt(item.body, EXCERPT_MAX)}
           </Text>
         )}
       </TouchableOpacity>

--- a/frontend/src/features/Journal/__tests__/excerpt.test.ts
+++ b/frontend/src/features/Journal/__tests__/excerpt.test.ts
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+// RED: `excerpt.ts` doesn't exist yet -- pins excerpt(body, maxLength) as a code-point-safe truncator.
+import { excerpt } from '../excerpt';
+
+describe('excerpt', () => {
+  it('flattens all whitespace to single spaces and trims both edges', () => {
+    expect(excerpt('  a\n\tb   c  ', 100)).toBe('a b c');
+  });
+
+  it('returns a flattened, trimmed body with no ellipsis when under maxLength', () => {
+    expect(excerpt('  short body  ', 100)).toBe('short body');
+  });
+
+  it('returns an ASCII body of exactly maxLength unchanged, with no ellipsis', () => {
+    const body = 'abcde';
+    expect(excerpt(body, 5)).toBe('abcde');
+  });
+
+  it('truncates a long ASCII body to maxLength code points then appends an ellipsis', () => {
+    expect(excerpt('abcdefghij', 5)).toBe('abcde…');
+  });
+
+  it('trims a trailing space at the cut before appending the ellipsis', () => {
+    expect(excerpt('abcd efghij', 5)).toBe('abcd…');
+  });
+
+  it('returns an empty string for an empty body, with no ellipsis', () => {
+    expect(excerpt('', 5)).toBe('');
+  });
+
+  it('returns an empty string for an all-whitespace body, with no ellipsis', () => {
+    expect(excerpt('   \n\t  ', 5)).toBe('');
+  });
+
+  it('does not split a surrogate pair at the truncation boundary', () => {
+    const body = 'a'.repeat(4) + '\u{1F600}' + 'bbbb';
+    const result = excerpt(body, 5);
+    expect(result).toBe('aaaa\u{1F600}…');
+    expect(result).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(result).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    expect(result).not.toContain('�');
+  });
+
+  it('counts code points, not UTF-16 units, for emoji-dense truncation', () => {
+    const body = '\u{1F600}\u{1F601}\u{1F602}\u{1F603}\u{1F604}';
+    expect(excerpt(body, 3)).toBe('\u{1F600}\u{1F601}\u{1F602}…');
+  });
+
+  it('appends no ellipsis when the code-point count fits despite a longer UTF-16 length', () => {
+    // Five code points (one astral) fit maxLength 5, though the UTF-16 length is 6.
+    expect(excerpt('abcd\u{1F600}', 5)).toBe('abcd\u{1F600}');
+  });
+});

--- a/frontend/src/features/Journal/excerpt.ts
+++ b/frontend/src/features/Journal/excerpt.ts
@@ -1,0 +1,34 @@
+/**
+ * Single source of truth for the collapsed-row / entry-tile excerpt: a pure,
+ * whitespace-flattening truncator shared by the journal shelf and the reflection
+ * sources feed so both surfaces cut a body identically.
+ *
+ * Truncation counts Unicode CODE POINTS rather than UTF-16 units so an emoji or
+ * other astral character straddling the cut is kept whole or dropped whole,
+ * never sheared into a lone surrogate.
+ */
+
+/**
+ * Flatten a body's whitespace, then truncate to ``maxLength`` code points with a
+ * trailing ellipsis when it overflows.
+ *
+ * The fast path returns the flattened body untouched when its UTF-16 length is
+ * within ``maxLength`` (a code-unit count that small guarantees an equal-or-lower
+ * code-point count, so no astral char can push it over) — sparing the common
+ * short body the ``Array.from`` allocation. Otherwise the body is materialised
+ * into code points and a second guard returns it untouched when the CODE-POINT
+ * count fits, so an astral-dense body that overflows in UTF-16 units yet fits in
+ * code points is never given a misleading ellipsis. Only a genuine code-point
+ * overflow is sliced — by CODE POINT: a fixed UTF-16 slice can split a surrogate
+ * pair at the boundary and render the broken half as U+FFFD, whereas iterating
+ * whole code points keeps the boundary character intact or excludes it entirely.
+ * No ``Intl.Segmenter`` — its Hermes/React Native availability is unreliable,
+ * which would make its branch an untestable dead path.
+ */
+export function excerpt(body: string, maxLength: number): string {
+  const flat = body.replace(/\s+/g, ' ').trim();
+  if (flat.length <= maxLength) return flat;
+  const points = Array.from(flat);
+  if (points.length <= maxLength) return flat;
+  return `${points.slice(0, maxLength).join('').trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary

Excerpt-preview truncation sliced journal text at a fixed UTF-16 code-unit
length, so a preview ending on a surrogate pair (emoji or other non-BMP
character) could split the pair and render a U+FFFD replacement character
before the ellipsis.

- Adds a shared, code-point-safe truncation helper
  `frontend/src/features/Journal/excerpt.ts` (`excerpt(body, maxLength)`) that
  flattens whitespace, then — only on a genuine code-point overflow — slices by
  whole code points via `Array.from`, so an astral character at the boundary is
  kept intact or dropped whole and is never sheared into a lone surrogate.
  Follows the `codePoints.ts` `utf16ToCodePoint` conventions (pure module,
  clamping/never-throws JSDoc). Deliberately no `Intl.Segmenter` — its
  Hermes/React Native availability is unreliable, so it would be an untestable
  dead branch; code-point-safe truncation fully eliminates the reported defect.
- Rewires both known preview sites to the shared helper, deleting their
  duplicated inline `excerpt`: `JournalShelfScreen.tsx` (max 140) and
  `ReflectionSourcesPanel.tsx` (max 120). Each keeps its own length constant.
  Swept the Journal feature — these are the only raw preview-slice sites; other
  `slice` uses are quote-selection/insertion spans, already code-point-aware.
- Frontend-only; no API changes.

## Test plan

- New `frontend/src/features/Journal/__tests__/excerpt.test.ts` (10 cases,
  explicit `\u{...}` escapes): whitespace flatten/trim, under/exact/over the
  boundary, the mid-surrogate cut (asserts no lone surrogate via regex and no
  U+FFFD), code-point (not UTF-16) counting, and the astral-dense body that
  fits in code points yet exceeds the UTF-16 length (no misleading ellipsis).
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and the full
  Jest suite (4298 tests, incl. both rewired screen suites unchanged).

Closes #1549