### PR TITLE
fix(habits): reclaim the retired 49px tab-bar reserve in tile density

### DIFF
--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -374,9 +374,6 @@ export const touchTarget = {
 /** Habit-tile density in spacing UNITS (fed to `spacing(n, scale)`), not px. */
 export const tileDensity = { paddingV: 0.5, barGap: 0.5 } as const;
 
-/** React Navigation's default bottom tab-bar content height; bump if the tab bar is restyled taller. */
-export const BOTTOM_TAB_BAR_CONTENT_HEIGHT = 49;
-
 /** WCAG-AA on the white modal card: #555 = 7.46:1 on #ffffff (AAA normal). */
 export const CHART_AXIS_LABEL_COLOR = '#555555';
 

--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -3,7 +3,6 @@ import { Animated, Easing, Text, TouchableOpacity, View, type DimensionValue } f
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
-  BOTTOM_TAB_BAR_CONTENT_HEIGHT,
   colors,
   SPACING,
   STAGE_COLORS,
@@ -193,7 +192,7 @@ export const useTileLayout = () => {
   const insets = useSafeAreaInsets();
   const rows = columns === 2 ? MAX_HABITS / columns : MAX_HABITS;
   const chrome = habitGridChrome(scale, gridGutter);
-  const bottomBarReserve = BOTTOM_TAB_BAR_CONTENT_HEIGHT + insets.bottom;
+  const bottomBarReserve = insets.bottom;
   const availableHeight = height - insets.top - bottomBarReserve - chrome;
   const rowPitch = availableHeight / rows;
   // Floor to whole pixels so the reserved stack never rounds above the viewport.

--- a/frontend/src/features/Habits/__tests__/HabitTileFit.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileFit.test.tsx
@@ -5,13 +5,7 @@ import { Text, StyleSheet } from 'react-native';
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 import renderer from 'react-test-renderer';
 
-import {
-  spacing,
-  SPACING,
-  touchTarget,
-  tileDensity,
-  BOTTOM_TAB_BAR_CONTENT_HEIGHT,
-} from '../../../design/tokens';
+import { spacing, SPACING, touchTarget, tileDensity } from '../../../design/tokens';
 import type { Habit } from '../Habits.types';
 import { useTileLayout, HabitTile } from '../HabitTile';
 
@@ -73,11 +67,11 @@ describe('useTileLayout fit invariant', () => {
     expect(tileMinHeight).toBeGreaterThanOrEqual(touchTarget.minimum);
     // Concrete expected density at the target profile: a chrome-model drift or a
     // token change breaks this independently of the reconstructed budget below.
-    const EXPECTED_TILE_MIN_HEIGHT = 57;
+    const EXPECTED_TILE_MIN_HEIGHT = 62;
     expect(tileMinHeight).toBe(EXPECTED_TILE_MIN_HEIGHT);
 
     const chrome = computeChrome(scale, gridGutter);
-    const bottomBarReserve = BOTTOM_TAB_BAR_CONTENT_HEIGHT + insets.bottom;
+    const bottomBarReserve = insets.bottom;
     const stackHeight = TOTAL_HABITS * (tileMinHeight + gridGutter);
     const totalHeight = stackHeight + insets.top + bottomBarReserve + chrome;
 
@@ -90,6 +84,17 @@ describe('useTileLayout fit invariant', () => {
     const { tileMinHeight } = renderTileLayout(insets);
 
     expect(tileMinHeight).toBe(touchTarget.minimum);
+  });
+
+  it('reclaims the retired tab-bar band on a small screen', () => {
+    mockWindowDimensions(360, 640);
+    const insets: Insets = { top: 24, bottom: 0, left: 0, right: 0 };
+    const { tileMinHeight } = renderTileLayout(insets);
+
+    // Computed density for this small profile — coincidentally equal to the
+    // removed tab-bar constant, not a reintroduction of it.
+    const EXPECTED_SMALL_SCREEN_TILE_MIN_HEIGHT = 49;
+    expect(tileMinHeight).toBe(EXPECTED_SMALL_SCREEN_TILE_MIN_HEIGHT);
   });
 });
 

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -90,7 +90,7 @@ const widths = [320, 390, 600, 900, 1200];
 
 const colorValues = Object.values(STAGE_COLORS);
 
-// Proves SOME reserve exists beyond the raw per-row split; the realistic budget lives in HabitTileFit.test.tsx.
+// Per-row footprint is the min-height box plus the two inter-row margins (interior padding excluded); the realistic budget lives in HabitTileFit.test.tsx.
 const CHROME_RESERVE = SPACING.sm;
 
 const assertTileLayout = (tile: any, height: number, expectedColumns: number): void => {
@@ -98,8 +98,7 @@ const assertTileLayout = (tile: any, height: number, expectedColumns: number): v
     ? tile.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
     : tile.props.style;
 
-  const verticalPadding = style.paddingVertical ?? style.padding ?? 0;
-  const tileHeight = (style.minHeight ?? 0) + 2 * verticalPadding + 2 * (style.margin ?? 0);
+  const tileHeight = (style.minHeight ?? 0) + 2 * (style.margin ?? 0);
 
   const rows = expectedColumns === 2 ? 5 : 10;
   const maxTileHeight = (height - CHROME_RESERVE) / rows;


### PR DESCRIPTION
## Summary

The bottom tab bar was retired to a headless, zero-height null bar (epic #1528, PR #1563), but `useTileLayout` in `HabitTile.tsx` still subtracted a 49px `BOTTOM_TAB_BAR_CONTENT_HEIGHT` reserve from the usable viewport. That left a dead ~49px band and under-sized every habit tile.

- Drop the reserve so `bottomBarReserve` is just `insets.bottom`; tile density is now computed against the true viewport.
- Delete the now-unused `BOTTOM_TAB_BAR_CONTENT_HEIGHT` constant from `tokens.ts` (grep confirms zero remaining consumers).
- Correct the `HabitsResponsive` per-row footprint proxy to border-box geometry (`minHeight + 2*margin`); interior padding lives inside the min-height box and was previously double-counted, only passing thanks to the 49px slack. This now matches `useTileLayout`'s own row-pitch model.

Net effect: tiles reclaim the band and grow to fill the real viewport (e.g. 390x844 tileMinHeight 57 -> 62), while still fitting the full 10-tile stack and clamping to the touch-target floor on short viewports.

## Test plan

- Fit-test pins updated to the real new density and strengthened, never loosened:
  - 390x844 (insets 47/34): `tileMinHeight` 57 -> **62**.
  - New small-screen pin 360x640 (insets 24/0): `tileMinHeight` **49** (computed density, not the removed constant).
  - 390x500 short viewport still clamps to `touchTarget.minimum` (44).
- Mutation-verified: temporarily reintroducing the `+ 49` subtraction in-worktree turns both pins RED (62->57, 49->44); restored.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, Jest — 4289 tests).

Closes #1564
Refs #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)