### PR TITLE
fix(storage): serialize recordRecentPractice's read-modify-write

### DIFF
--- a/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
+++ b/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_RECENT_PRACTICES,
   type RecentPractice,
 } from '../recentPracticesStorage';
+import { _resetSerializedWriteForTests } from '../serializedWrite';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   setItem: jest.fn(() => Promise.resolve()),
@@ -25,6 +26,7 @@ function makePractice(id: number): RecentPractice {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  _resetSerializedWriteForTests();
 });
 
 describe('loadRecentPractices', () => {
@@ -105,5 +107,25 @@ describe('recordRecentPractice', () => {
     expect(parsed).toHaveLength(MAX_RECENT_PRACTICES);
     expect(parsed[0]!.id).toBe(999);
     expect(parsed.map((p) => p.id)).not.toContain(MAX_RECENT_PRACTICES);
+  });
+
+  test('two concurrent recordings both survive instead of clobbering each other', async () => {
+    const store: { raw: string | null } = { raw: null };
+    mockAsyncStorage.getItem.mockImplementation(() => Promise.resolve(store.raw));
+    mockAsyncStorage.setItem.mockImplementation((_key: string, value: string) => {
+      store.raw = value;
+      return Promise.resolve();
+    });
+
+    await Promise.all([
+      recordRecentPractice(makePractice(1)),
+      recordRecentPractice(makePractice(2)),
+    ]);
+
+    const parsed = JSON.parse(store.raw as string) as RecentPractice[];
+    expect(parsed.map((p) => p.id)).toEqual([2, 1]);
+
+    mockAsyncStorage.getItem.mockImplementation(() => Promise.resolve(null));
+    mockAsyncStorage.setItem.mockImplementation(() => Promise.resolve());
   });
 });

--- a/frontend/src/storage/recentPracticesStorage.ts
+++ b/frontend/src/storage/recentPracticesStorage.ts
@@ -5,6 +5,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { resetCorruptKey } from './jsonStore';
+import { serialize } from './serializedWrite';
 
 const RECENT_PRACTICES_KEY = '@adepthood/recent_practices';
 
@@ -58,10 +59,16 @@ export async function loadRecentPractices(): Promise<RecentPractice[]> {
   }
 }
 
-/** Move ``entry`` to the front of the recent list (deduped by id), then persist. */
+/**
+ * Move ``entry`` to the front of the recent list (deduped by id), then persist.
+ * Runs through the serialized write lane so concurrent appenders can't both
+ * read the same list and clobber each other's prepend.
+ */
 export async function recordRecentPractice(entry: RecentPractice): Promise<void> {
-  const existing = await loadRecentPractices();
-  const deduped = existing.filter((item) => item.id !== entry.id);
-  const next = [entry, ...deduped].slice(0, MAX_RECENT_PRACTICES);
-  await AsyncStorage.setItem(RECENT_PRACTICES_KEY, JSON.stringify(next));
+  await serialize(RECENT_PRACTICES_KEY, async () => {
+    const existing = await loadRecentPractices();
+    const deduped = existing.filter((item) => item.id !== entry.id);
+    const next = [entry, ...deduped].slice(0, MAX_RECENT_PRACTICES);
+    await AsyncStorage.setItem(RECENT_PRACTICES_KEY, JSON.stringify(next));
+  });
 }


### PR DESCRIPTION
## Summary

`recordRecentPractice` performed an unserialized read-modify-write against
AsyncStorage: two concurrent calls could both read the same stale list before
either wrote, so the slower `setItem` clobbered the faster one — the same
concurrent-appender clobber class that `serialize()` already closes for the
pending check-in queue.

This routes the load-modify-write through the existing per-key `serialize()`
lane (`frontend/src/storage/serializedWrite.ts`), reusing the primitive exactly
as `savePendingCheckIn` does — no new mechanism. The load/dedupe/prepend/slice
logic and `loadRecentPractices`' transient/corrupt semantics are unchanged.

## Test plan

- Added a deterministic, timer-free interleaving test: two concurrent
  `recordRecentPractice` calls interleave their reads before writes; asserts
  both entries survive (`[2, 1]`). It fails against the unserialized
  implementation (only one entry survives) and passes once serialized.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, full Jest
  suite — 4301 tests).

Closes #1594