### PR TITLE
fix(frontend): clearApiKey signals delete failure so a broken SecureStore shows only the storage warning

### DIFF
--- a/frontend/src/context/ApiKeyContext.tsx
+++ b/frontend/src/context/ApiKeyContext.tsx
@@ -32,6 +32,15 @@ export interface ApiKeySaveResult {
   persisted: boolean;
 }
 
+/** Outcome of a {@link ApiKeyContextValue.clearApiKey} call. */
+export interface ApiKeyClearResult {
+  /**
+   * True when the delete reached SecureStore; false when the key was only
+   * dropped from session state because the SecureStore delete failed.
+   */
+  cleared: boolean;
+}
+
 interface ApiKeyContextValue {
   /** Current user-owned key, or null if none is stored. */
   apiKey: string | null;
@@ -50,8 +59,12 @@ interface ApiKeyContextValue {
    * ``persisted: false`` when it fell back to session-only (the write failed).
    */
   saveApiKey: (_key: string) => Promise<ApiKeySaveResult>;
-  /** Remove the stored key (SecureStore + context state). */
-  clearApiKey: () => Promise<void>;
+  /**
+   * Remove the stored key (SecureStore + context state). Resolves with
+   * ``cleared: true`` when the delete reached SecureStore, or ``cleared: false``
+   * when the key was only dropped from session state (the delete failed).
+   */
+  clearApiKey: () => Promise<ApiKeyClearResult>;
 }
 
 const ApiKeyContext = createContext<ApiKeyContextValue | null>(null);
@@ -81,6 +94,32 @@ function useLlmApiKeyBridge(
   }, [apiKeyRef, setApiKey]);
 }
 
+/**
+ * Load the stored key from SecureStore on mount. On failure, fall back to
+ * in-memory operation (the key stays usable this session via saveApiKey; it
+ * won't persist across launches until the store recovers) and surface the
+ * error so the screen can warn the user.
+ */
+function useLoadStoredApiKey(
+  setApiKey: React.Dispatch<React.SetStateAction<string | null>>,
+  setLoadError: React.Dispatch<React.SetStateAction<Error | null>>,
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
+): void {
+  useEffect(() => {
+    loadLlmApiKey()
+      .then((stored) => {
+        setApiKey(stored);
+        setLoadError(null);
+      })
+      .catch((err: unknown) => {
+        console.warn('[ApiKeyContext] SecureStore load failed', err);
+        setApiKey(null);
+        setLoadError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => setIsLoading(false));
+  }, [setApiKey, setLoadError, setIsLoading]);
+}
+
 export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
   const [apiKey, setApiKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -93,23 +132,7 @@ export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
   apiKeyRef.current = apiKey;
 
   useLlmApiKeyBridge(apiKeyRef, setApiKey);
-
-  useEffect(() => {
-    loadLlmApiKey()
-      .then((stored) => {
-        setApiKey(stored);
-        setLoadError(null);
-      })
-      .catch((err: unknown) => {
-        console.warn('[ApiKeyContext] SecureStore load failed', err);
-        // Fall back to in-memory operation (key still usable for this session
-        // via saveApiKey; won't persist across launches until the store
-        // recovers).
-        setApiKey(null);
-        setLoadError(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => setIsLoading(false));
-  }, []);
+  useLoadStoredApiKey(setApiKey, setLoadError, setIsLoading);
 
   const saveApiKey = useCallback(async (key: string): Promise<ApiKeySaveResult> => {
     let persisted = false;
@@ -126,15 +149,19 @@ export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
     return { persisted };
   }, []);
 
-  const clearApiKey = useCallback(async () => {
+  const clearApiKey = useCallback(async (): Promise<ApiKeyClearResult> => {
+    let cleared = false;
     try {
       await clearLlmApiKey();
       setLoadError(null);
+      cleared = true;
     } catch (err: unknown) {
       console.warn('[ApiKeyContext] SecureStore clear failed', err);
       setLoadError(err instanceof Error ? err : new Error(String(err)));
+      // Drop the key from session state anyway so the user isn't stuck with it.
     }
     setApiKey(null);
+    return { cleared };
   }, []);
 
   const value = useMemo(

--- a/frontend/src/context/__tests__/ApiKeyContext.test.tsx
+++ b/frontend/src/context/__tests__/ApiKeyContext.test.tsx
@@ -179,12 +179,14 @@ describe('ApiKeyProvider', () => {
     );
     await waitFor(() => expect(ctx?.apiKey).toBe('sk-existing'));
 
+    let result: { cleared: boolean } | undefined;
     await act(async () => {
-      await ctx!.clearApiKey();
+      result = await ctx!.clearApiKey();
     });
 
     expect(mockStorage.clearLlmApiKey).toHaveBeenCalled();
     expect(ctx!.apiKey).toBeNull();
+    expect(result).toEqual({ cleared: true });
   });
 
   test('useApiKey throws when used outside a provider', () => {
@@ -283,13 +285,15 @@ describe('ApiKeyProvider', () => {
     );
     await waitFor(() => expect(ctx?.apiKey).toBe('sk-existing'));
 
+    let result: { cleared: boolean } | undefined;
     await act(async () => {
-      await ctx!.clearApiKey();
+      result = await ctx!.clearApiKey();
     });
 
     expect(ctx!.loadError).toBeInstanceOf(Error);
     expect(ctx!.loadError?.message).toBe('locked');
     expect(ctx!.apiKey).toBeNull();
+    expect(result).toEqual({ cleared: false });
     warnSpy.mockRestore();
   });
 });

--- a/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
+++ b/frontend/src/features/Settings/ApiKeySettingsScreen.tsx
@@ -23,7 +23,7 @@ import type { SettingsFormState } from './shared/useSettingsForm';
 import { useSettingsFormState, useSettingsSubmit } from './shared/useSettingsForm';
 
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
-import type { ApiKeySaveResult } from '@/context/ApiKeyContext';
+import type { ApiKeyClearResult, ApiKeySaveResult } from '@/context/ApiKeyContext';
 import { useApiKey } from '@/context/ApiKeyContext';
 import { BORDER_RADIUS, SPACING, colors, ink, surface } from '@/design/tokens';
 import type { RootStackParamList } from '@/navigation/RootStack';
@@ -348,13 +348,15 @@ function useSaveKeyHandler(
 
 function useClearKeyHandler(
   form: SettingsFormState,
-  clearApiKey: () => Promise<void>,
+  clearApiKey: () => Promise<ApiKeyClearResult>,
 ): () => Promise<void> {
   const { setStatus } = form;
   const validate = useCallback(() => null, []);
   const perform = useCallback(async () => {
-    await clearApiKey();
-    setStatus('API key removed from this device.');
+    const result = await clearApiKey();
+    if (result.cleared) {
+      setStatus('API key removed from this device.');
+    }
   }, [clearApiKey, setStatus]);
   const onError = useCallback(
     (err: unknown) =>

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.integration.test.tsx
@@ -2,6 +2,7 @@
 /* global describe, test, expect, jest, beforeEach */
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { Alert } from 'react-native';
 
 import ApiKeySettingsScreen, { SECURE_STORAGE_WARNING } from '../ApiKeySettingsScreen';
 
@@ -86,5 +87,59 @@ describe('ApiKeySettingsScreen integration with a failing SecureStore write', ()
     const status = await findByTestId('api-key-status');
     expect(status).toBeTruthy();
     expect(queryByTestId('api-key-storage-error')).toBeNull();
+  });
+});
+
+describe('ApiKeySettingsScreen integration with a failing SecureStore delete', () => {
+  test('shows only the storage warning, not a false removed status, when the clear delete fails', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce(VALID_KEY);
+    mockStorage.clearLlmApiKey.mockRejectedValueOnce(new Error('keychain locked'));
+    const warnSpy = jest.spyOn(globalThis.console, 'warn').mockImplementation(() => undefined);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId, queryByTestId } = render(
+      <ApiKeyProvider>
+        <ApiKeySettingsScreen />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('api-key-loading')).toBeNull());
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    const warning = await findByTestId('api-key-storage-error');
+    expect(warning.props.children).toBe(SECURE_STORAGE_WARNING);
+    expect(queryByTestId('api-key-status')).toBeNull();
+    expect(queryByTestId('api-key-error')).toBeNull();
+    alertSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  test('shows the removed status and no storage warning when the clear delete succeeds', async () => {
+    mockStorage.loadLlmApiKey.mockResolvedValueOnce(VALID_KEY);
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId, queryByTestId } = render(
+      <ApiKeyProvider>
+        <ApiKeySettingsScreen />
+      </ApiKeyProvider>,
+    );
+
+    await waitFor(() => expect(queryByTestId('api-key-loading')).toBeNull());
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    const status = await findByTestId('api-key-status');
+    expect(status).toBeTruthy();
+    expect(queryByTestId('api-key-storage-error')).toBeNull();
+    alertSpy.mockRestore();
   });
 });

--- a/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
+++ b/frontend/src/features/Settings/__tests__/ApiKeySettingsScreen.test.tsx
@@ -26,7 +26,7 @@ function setApiKeyState(partial: Partial<ReturnType<typeof useApiKey>>) {
     isLoading: false,
     loadError: null,
     saveApiKey: jest.fn(() => Promise.resolve({ persisted: true })),
-    clearApiKey: jest.fn(() => Promise.resolve()),
+    clearApiKey: jest.fn(() => Promise.resolve({ cleared: true })),
   };
   const value = { ...base, ...partial } as ReturnType<typeof useApiKey>;
   mockUseApiKey.mockReturnValue(value);
@@ -284,6 +284,29 @@ describe('ApiKeySettingsScreen', () => {
 
     const status = await findByTestId('api-key-status');
     expect(status.props.children).toContain('removed from this device');
+    alertSpy.mockRestore();
+  });
+
+  test('shows only the storage warning, not the removed status, when the delete does not clear', async () => {
+    const state = setApiKeyState({
+      apiKey: VALID_KEY,
+      loadError: new Error('locked'),
+      clearApiKey: jest.fn(() => Promise.resolve({ cleared: false })),
+    });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+      const destructive = buttons?.find((b) => b.style === 'destructive');
+      destructive?.onPress?.();
+    });
+
+    const { getByTestId, findByTestId, queryByTestId } = render(<ApiKeySettingsScreen />);
+    await act(async () => {
+      fireEvent.press(getByTestId('remove-key-button'));
+    });
+
+    await waitFor(() => expect(state.clearApiKey).toHaveBeenCalled());
+    expect(await findByTestId('api-key-storage-error')).toBeTruthy();
+    expect(queryByTestId('api-key-status')).toBeNull();
+    expect(queryByTestId('api-key-error')).toBeNull();
     alertSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

The REMOVE-path twin of #1474 (fixed on the save path by #1664). Previously `ApiKeyContext.clearApiKey` swallowed a SecureStore delete failure — it caught the error, set `loadError`, nulled the key, and resolved `Promise<void>` without signalling the failure. So when secure storage was broken and the user removed their key, the screen rendered two contradictory banners at once: the success status "API key removed from this device." **and** the "Secure storage is unavailable…" warning.

This mirrors #1664's solution exactly:

- `clearApiKey` now returns `Promise<ApiKeyClearResult>` (`{ cleared: boolean }`), analogous to `saveApiKey`'s `ApiKeySaveResult` (`{ persisted }`). `cleared` is `true` only when the delete reached SecureStore.
- `useClearKeyHandler` gates the "API key removed from this device." status behind `result.cleared`, so a failed delete shows only the storage-unavailable warning.
- The key is still dropped from session state on failure, matching the save path's in-session semantics.
- Extracted the mount load effect into a `useLoadStoredApiKey` hook to keep `ApiKeyProvider` under the 50-line lint limit (behavior-preserving).

## Test plan

- `./scripts/frontend/check-all.sh` green (eslint, prettier, typecheck, 4305 jest tests).
- New/updated tests, mirroring #1664's structure:
  - Context unit test asserts `clearApiKey` resolves `{ cleared: true }` on success and `{ cleared: false }` when the delete rejects (key still nulled, `loadError` set).
  - Screen unit test: when `cleared: false`, only the storage warning renders — no success status, no error banner.
  - Real-provider integration tests for the clear-while-storage-broken path (delete rejects → warning only) and the healthy path (delete succeeds → status only).

Closes #1665