### PR TITLE
fix(storage): abort recordRecentPractice's write on a transient read

### DIFF
--- a/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
+++ b/frontend/src/storage/__tests__/recentPracticesStorage.test.ts
@@ -109,6 +109,28 @@ describe('recordRecentPractice', () => {
     expect(parsed.map((p) => p.id)).not.toContain(MAX_RECENT_PRACTICES);
   });
 
+  test('a transient read failure preserves the intact on-disk list', async () => {
+    const intact = [makePractice(1), makePractice(2)];
+    const rawOnDisk = JSON.stringify(intact);
+    const store: { raw: string | null } = { raw: rawOnDisk };
+    mockAsyncStorage.getItem
+      .mockRejectedValueOnce(new Error('transient read'))
+      .mockImplementation(() => Promise.resolve(store.raw));
+    mockAsyncStorage.setItem.mockImplementation((_key: string, value: string) => {
+      store.raw = value;
+      return Promise.resolve();
+    });
+
+    await recordRecentPractice(makePractice(3));
+
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+    expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
+    expect(store.raw).toBe(rawOnDisk);
+
+    mockAsyncStorage.getItem.mockImplementation(() => Promise.resolve(null));
+    mockAsyncStorage.setItem.mockImplementation(() => Promise.resolve());
+  });
+
   test('two concurrent recordings both survive instead of clobbering each other', async () => {
     const store: { raw: string | null } = { raw: null };
     mockAsyncStorage.getItem.mockImplementation(() => Promise.resolve(store.raw));

--- a/frontend/src/storage/recentPracticesStorage.ts
+++ b/frontend/src/storage/recentPracticesStorage.ts
@@ -4,7 +4,7 @@
 // stage than the one the catalog is currently paging.
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { resetCorruptKey } from './jsonStore';
+import { getJsonArrayForUpdate, resetCorruptKey } from './jsonStore';
 import { serialize } from './serializedWrite';
 
 const RECENT_PRACTICES_KEY = '@adepthood/recent_practices';
@@ -63,10 +63,28 @@ export async function loadRecentPractices(): Promise<RecentPractice[]> {
  * Move ``entry`` to the front of the recent list (deduped by id), then persist.
  * Runs through the serialized write lane so concurrent appenders can't both
  * read the same list and clobber each other's prepend.
+ *
+ * The read leg uses ``getJsonArrayForUpdate`` rather than the fail-safe
+ * ``loadRecentPractices``: a transient read failure must PROPAGATE so the
+ * write aborts, because falling back to an empty list here would overwrite an
+ * intact on-disk list with a single-item array. Corrupt/non-array JSON still
+ * self-heals to ``null`` and the write proceeds from an empty list.
  */
 export async function recordRecentPractice(entry: RecentPractice): Promise<void> {
   await serialize(RECENT_PRACTICES_KEY, async () => {
-    const existing = await loadRecentPractices();
+    let stored: RecentPractice[] | null;
+    try {
+      stored = await getJsonArrayForUpdate<RecentPractice>(RECENT_PRACTICES_KEY);
+    } catch (err: unknown) {
+      // A transient read must abort the write; falling back to [] here would
+      // overwrite an intact on-disk list with a single-item array.
+      console.warn(
+        '[storage] transient read during recent-practice record, aborting write to preserve list',
+        err,
+      );
+      return;
+    }
+    const existing = sanitize(stored ?? []);
     const deduped = existing.filter((item) => item.id !== entry.id);
     const next = [entry, ...deduped].slice(0, MAX_RECENT_PRACTICES);
     await AsyncStorage.setItem(RECENT_PRACTICES_KEY, JSON.stringify(next));


### PR DESCRIPTION
## Summary

`recordRecentPractice` built its next list from `loadRecentPractices()`, which swallows a transient AsyncStorage read failure by returning `[]`. When the read leg hit a momentary blip while an intact list existed on disk, the read-modify-write proceeded from `[]` and wrote `[entry]` — silently discarding the on-disk recent-practices list. The serialized write lane (added earlier) guards against concurrent clobber across callers, not this within-call clobber.

The RMW read leg now uses the existing `getJsonArrayForUpdate` helper, which **propagates** a transient `getItem` rejection instead of swallowing it. The `catch` warns and returns before `setItem`, so the write aborts and the stored list survives. `sanitize()` still applies element-level filtering and the max-length cap; corrupt/non-array JSON still self-heals to an empty list. The public `loadRecentPractices` reader contract is unchanged. This mirrors the established `savePendingCheckIn` RMW pattern.

## Test plan

- New RED-first test: a transient `getItem` rejection during a recording while the disk holds an intact list asserts `setItem`/`removeItem` are never called and the on-disk snapshot is byte-identical (write aborted, not replaced by `[entry]`). Deterministic, no sleeps.
- Existing `loadRecentPractices` and `recordRecentPractice` tests (including the concurrent-interleaving test) remain green unchanged.
- `./scripts/frontend/check-all.sh` green (lint, format, typecheck, 4306 tests).

Closes #1675