### PR TITLE
fix(backend): thread user timezone into the prompts week gate

### DIFF
--- a/backend/src/routers/prompts.py
+++ b/backend/src/routers/prompts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
@@ -13,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from dependencies.timezone import current_user_timezone
 from domain.program_calendar import calendar_week, resolve_program_anchor
 from domain.stage_progress import get_user_progress
 from domain.weekly_prompts import (
@@ -38,7 +40,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/prompts", tags=["prompts"])
 
 
-async def _get_user_week(session: AsyncSession, user_id: int) -> int:
+async def _get_user_week(
+    session: AsyncSession, user_id: int, tz: str, *, now: datetime | None = None
+) -> int:
     """The user's current week: completion-derived OR calendar, whichever leads.
 
     Completion model: ``count(responses) + 1`` — the count only ever
@@ -46,9 +50,12 @@ async def _get_user_week(session: AsyncSession, user_id: int) -> int:
     endpoint rejects ``week_number > user_week``), so ``count + 1`` is
     the first unfinished week and a single POST cannot skip ahead.
 
-    Calendar model (issue #386): ``calendar_week(program anchor)`` — the
-    same date-derived schedule the frontend renders, so a user eight days
-    into the program can read week 2 without having answered week 1.
+    Calendar model: ``calendar_week(program anchor)`` — the same
+    date-derived schedule the frontend renders, so a user eight days into
+    the program can read week 2 without having answered week 1.  The week
+    is computed in the caller's timezone ``tz`` (the anchor's local
+    calendar), so week boundaries flip at the user's local midnight rather
+    than UTC.  ``now`` is an injectable clock seam for deterministic tests.
 
     ``max`` of the two: time opens weeks, completions can run ahead of a
     backdated anchor, and both are server-computed so neither adds a
@@ -60,11 +67,13 @@ async def _get_user_week(session: AsyncSession, user_id: int) -> int:
     completed = int(result.scalar() or 0)
     completion_week = completed + 1
     progress = await get_user_progress(session, user_id)
-    time_week = calendar_week(resolve_program_anchor(progress)) if progress else 1
+    time_week = calendar_week(resolve_program_anchor(progress), now, tz=tz) if progress else 1
     return int(max(1, min(max(completion_week, time_week), TOTAL_WEEKS)))
 
 
-async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number: int) -> None:
+async def _check_week_unlocked(
+    session: AsyncSession, user_id: int, week_number: int, tz: str
+) -> None:
     """Raise 403 when ``week_number`` is past the user's current week.
 
     Both :func:`get_prompt_by_week` and :func:`submit_prompt_response`
@@ -73,7 +82,7 @@ async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number:
     Factored into a shared helper so the two endpoints cannot drift out
     of sync.
     """
-    user_week = await _get_user_week(session, user_id)
+    user_week = await _get_user_week(session, user_id, tz)
     if week_number > user_week:
         raise forbidden("week_locked")
 
@@ -82,9 +91,10 @@ async def _check_week_unlocked(session: AsyncSession, user_id: int, week_number:
 async def get_current_prompt(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> PromptDetail:
     """Return the prompt for the user's current week in the program."""
-    week = await _get_user_week(session, current_user)
+    week = await _get_user_week(session, current_user, user_tz)
     question = get_prompt_for_week(week)
     if question is None:
         raise not_found("prompt")
@@ -183,6 +193,7 @@ async def get_prompt_by_week(
     week_number: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> PromptDetail:
     """Get a specific week's prompt and the user's response (if any).
 
@@ -194,7 +205,7 @@ async def get_prompt_by_week(
     question = get_prompt_for_week(week_number)
     if question is None:
         raise not_found("prompt")
-    await _check_week_unlocked(session, current_user, week_number)
+    await _check_week_unlocked(session, current_user, week_number, user_tz)
 
     result = await session.execute(
         select(PromptResponse).where(
@@ -242,6 +253,7 @@ async def submit_prompt_response(
     payload: PromptSubmit,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    user_tz: Annotated[str, Depends(current_user_timezone)],
 ) -> PromptDetail:
     """Submit a response to a weekly prompt. Prevents duplicate responses.
 
@@ -262,7 +274,7 @@ async def submit_prompt_response(
     question = get_prompt_for_week(week_number)
     if question is None:
         raise not_found("prompt")
-    await _check_week_unlocked(session, current_user, week_number)
+    await _check_week_unlocked(session, current_user, week_number, user_tz)
 
     # Sanitize once at the boundary (BUG-PROMPT-003); both PromptResponse and
     # JournalEntry receive the cleaned text so the two rows agree byte-for-byte

--- a/backend/tests/test_program_gating.py
+++ b/backend/tests/test_program_gating.py
@@ -16,9 +16,13 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from dependencies.timezone import current_user_timezone
+from domain.program_calendar import calendar_week, resolve_program_anchor
 from domain.stage_progress import is_stage_unlocked
+from main import app
 from models.stage_progress import StageProgress
 from models.user import User
+from routers.prompts import _get_user_week
 
 
 async def _signup(client: AsyncClient, username: str = "anchored") -> dict[str, str]:
@@ -259,3 +263,121 @@ async def test_program_calendar_reflects_pacific_first_local_day_of_stage_two(
     assert body["calendar_stage"] == 2
     expected_calendar_week = 4
     assert body["calendar_week"] == expected_calendar_week
+
+
+# ── Weekly prompt gate reads the caller's timezone ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_user_week_computes_calendar_week_in_caller_timezone(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A near-midnight anchor reads program week 4 in Pacific but week 3 in UTC at one instant."""
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "tzweekhelper@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    user_id = resp.json()["user_id"]
+
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            program_started_at=datetime(2026, 1, 1, 3, 0, tzinfo=UTC).replace(tzinfo=None),
+        )
+    )
+    await db_session.commit()
+
+    pinned = datetime(2026, 1, 21, 12, 0, tzinfo=UTC)
+    la_week = await _get_user_week(db_session, user_id, tz="America/Los_Angeles", now=pinned)
+    utc_week = await _get_user_week(db_session, user_id, tz="UTC", now=pinned)
+
+    assert la_week == 4
+    assert utc_week == 3
+
+
+@pytest.mark.asyncio
+async def test_prompts_current_endpoint_uses_resolved_caller_timezone(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """GET /prompts/current computes week_number from the resolved caller timezone, not UTC."""
+    la = ZoneInfo("America/Los_Angeles")
+    now_utc = datetime.now(UTC)
+    now_la = now_utc.astimezone(la)
+    utc_ahead = now_utc.date() != now_la.date()
+    days_back = 27 if utc_ahead else 28
+    anchor_hour = 10 if utc_ahead else 23
+    start_date = now_la.date() - timedelta(days=days_back)
+    anchor_local = datetime.combine(start_date, time(anchor_hour, 0), tzinfo=la)
+    anchor = anchor_local.astimezone(UTC).replace(tzinfo=None)
+
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "wiredweektz@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    user_id = resp.json()["user_id"]
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=1,
+        completed_stages=[],
+        program_started_at=anchor,
+    )
+    db_session.add(progress)
+    await db_session.commit()
+    await db_session.refresh(progress)
+
+    app.dependency_overrides[current_user_timezone] = lambda: "America/Los_Angeles"
+    try:
+        current_resp = await async_client.get("/prompts/current", headers=headers)
+    finally:
+        app.dependency_overrides.pop(current_user_timezone, None)
+
+    assert current_resp.status_code == HTTPStatus.OK
+    expected_week = calendar_week(resolve_program_anchor(progress), tz="America/Los_Angeles")
+    assert current_resp.json()["week_number"] == expected_week
+
+
+@pytest.mark.asyncio
+async def test_prompts_current_endpoint_falls_back_to_utc_without_override(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A caller with no non-UTC timezone still gets the UTC-derived week (regression guard)."""
+    anchor = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=25)
+
+    resp = await async_client.post(
+        "/auth/signup",
+        json={
+            "email": "utcfallbackweek@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    user_id = resp.json()["user_id"]
+    headers = {"Authorization": f"Bearer {resp.json()['token']}"}
+
+    progress = StageProgress(
+        user_id=user_id,
+        current_stage=1,
+        completed_stages=[],
+        program_started_at=anchor,
+    )
+    db_session.add(progress)
+    await db_session.commit()
+    await db_session.refresh(progress)
+
+    current_resp = await async_client.get("/prompts/current", headers=headers)
+
+    assert current_resp.status_code == HTTPStatus.OK
+    expected_week = calendar_week(resolve_program_anchor(progress), tz="UTC")
+    assert current_resp.json()["week_number"] == expected_week


### PR DESCRIPTION
## Summary
The prompts router's week gate was the last user-facing unlock surface still computing `calendar_week` on the UTC default after the tz-alignment thread (epic #1616: PR #1638 practice gates, PR #1662 course/stages gates + program-calendar). A user near local midnight could see the prompt week advance or lag relative to every other surface.

`_get_user_week` now takes the server-resolved user timezone (plus an injectable pinned `now` for deterministic tests) and passes it to `calendar_week(resolve_program_anchor(progress), now, tz=tz)`; `_check_week_unlocked` threads it through; the three gated endpoints (`get_current_prompt`, `get_prompt_by_week`, `submit_prompt_response`) inject `user_tz` via the existing `current_user_timezone` dependency. UTC remains the fallback for users without a stored timezone. `list_prompt_history` is untouched (it does not gate).

## Tests (RED-first)
- Year-round deterministic boundary guard: pinned near-midnight anchor where America/Los_Angeles resolves week 4 vs UTC's week 3 — RED before the fix (TypeError on `tz` / `assert 4 == 5`), GREEN after. Domain-level with pinned `now` because integration tests only discriminate inside a daily UTC-overlap window.
- Endpoint wiring test via `app.dependency_overrides[current_user_timezone]`.
- UTC-fallback regression for users with no stored timezone.

Gate 2 verified: full backend suite 2651 passed / 96.72% coverage, ruff clean, xenon A-grade (exit 0), radon MI A (60.37) on the touched module.

Closes #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)