### PR TITLE
chore(deps): ignore remaining SDK-tied packages until SDK 53

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,30 @@ updates:
       # rule as expo-av — unpin at the SDK 53 upgrade (#885).
       - dependency-name: "expo-notifications"
         versions: [">=0.30.0"]
+      # Expo SDK 52 pins react-native to 0.76.x; 0.77+ needs React 19 / SDK 55+
+      # and ERESOLVE-fails install here. RN's 0.x minors are effective majors,
+      # so they must not ride the patch-minor group — unpin at the SDK 53
+      # upgrade (#885).
+      - dependency-name: "react-native"
+        versions: [">=0.77.0"]
+      # Expo SDK 52 pins expo-status-bar to ~2.0.x; 3.x targets SDK 53+. Expo
+      # packages move together with the SDK via `expo install`, not piecemeal —
+      # unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-status-bar"
+        versions: [">=3.0.0"]
+      # Expo SDK 52 pins @expo/metro-runtime to ~4.0.x; 5.x targets SDK 53+.
+      # Same SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "@expo/metro-runtime"
+        versions: [">=5.0.0"]
+      # Expo SDK 52 pins expo-secure-store to ~55.0.x; 56.x targets SDK 53+.
+      # Same SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-secure-store"
+        versions: [">=56.0.0"]
+      # react-native-reanimated 4.x requires the New Architecture pairing that
+      # ships with newer SDKs; SDK 52 pins ~3.16/3.17. Same SDK-managed rule —
+      # unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "react-native-reanimated"
+        versions: [">=4.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Extends the npm `ignore` list in `.github/dependabot.yml` to cover the five
SDK-tied packages that would jump past the Expo SDK 52 line and ERESOLVE-fail
install, mirroring the existing `styleq`/`expo-av`/`expo-notifications` idiom
exactly (one-line rationale + `unpin at the SDK 53 upgrade (#885)` comment,
quoted `dependency-name`, `versions: [">=X"]`):

| package | current pin (frontend/package.json) | ignore floor |
|---|---|---|
| react-native | 0.76.9 | >=0.77.0 |
| expo-status-bar | ~2.0.1 | >=3.0.0 |
| @expo/metro-runtime | ~4.0.1 | >=5.0.0 |
| expo-secure-store | ^55.0.11 | >=56.0.0 |
| react-native-reanimated | ^3.17.3 | >=4.0.0 |

All five floors were verified against `frontend/package.json` and match the
issue's suggested defaults (each floor is the first version line past the
SDK-52-compatible pin) — no adjustments were required.

This keeps react-native out of the npm patch-minor group and defers the four
other open Dependabot majors until the SDK 53 epic (#885).

## Follow-up (task 2 — delegated to the orchestrator)

Per the issue, the post-merge bot actions are **not** performed in this PR:
comment `@dependabot recreate` on #1683, close/ignore #1327/#1335/#1339/#1341,
and label bridge issues #1328/#1336/#1340/#1342 `blocked` with a pointer to
#885. The orchestrator drives those after merge.

## Test plan

- Config-only change; no runtime code path, so no TDD cycle applies.
- `pre-commit run` on the file is green (check-yaml + hygiene hooks pass).
- Commit passed pre-commit + commitlint on push.

Closes #1685
Refs #885