### PR TITLE
chore(deps): ignore react-native-screens >=4.5 and react-native-web >=0.20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,11 @@ updates:
       # when react-native-web is upgraded (Expo SDK 53 epic, #885).
       - dependency-name: "styleq"
         versions: [">=0.2.0"]
+      # Expo SDK 52 pins react-native-web to ~0.19.13; 0.20+ desyncs styleq (it
+      # targets the styleq 0.2.x line we pin below <0.2 — see the styleq entry
+      # above). Same SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "react-native-web"
+        versions: [">=0.20.0"]
       # Expo SDK 52 pins expo-av to ~15.0.2 (verified by `expo install --check`);
       # expo-av 16.x targets SDK 53. Expo packages are managed by `expo install`
       # and must move together with the SDK, not piecemeal. Unpin at the SDK 53
@@ -55,6 +60,11 @@ updates:
       # upgrade (#885).
       - dependency-name: "react-native"
         versions: [">=0.77.0"]
+      # Expo SDK 52 pins react-native-screens to ~4.4.0; 4.5+ targets newer RN
+      # lines and its 4.26 fabric ScreenNativeComponent breaks the Jest suites.
+      # Same SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "react-native-screens"
+        versions: [">=4.5.0"]
       # Expo SDK 52 pins expo-status-bar to ~2.0.x; 3.x targets SDK 53+. Expo
       # packages move together with the SDK via `expo install`, not piecemeal —
       # unpin at the SDK 53 upgrade (#885).


### PR DESCRIPTION
## Summary

Adds two npm-ecosystem ignore entries to `.github/dependabot.yml`, mirroring the established `expo install --check` SDK-pin idiom. These are Expo-SDK-52-managed pins that the SDK-pin ignore sweep (#1685 / PR #1686) missed, so the recreated npm patch-minor group (PR #1687) still fails frontend-quality:

- **react-native-screens** — pinned `~4.4.0` (verified in `frontend/package.json`); `>=4.5.0` targets newer RN lines and its 4.26 fabric `ScreenNativeComponent` breaks the Jest suites.
- **react-native-web** — pinned `~0.19.13` (verified in `frontend/package.json`); `>=0.20.0` desyncs styleq — 0.20 targets the styleq 0.2.x line we already pin `<0.2` for RNW 0.19.13 (see the adjacent styleq ignore comment).

Both carry the one-line rationale + "unpin at the SDK 53 upgrade (#885)" per the existing entries. Issue refs in `dependabot.yml` comments are the sanctioned idiom here.

Config-only change; no code or lockfile touched.

Note: task 2 of the issue (`@dependabot recreate` on PR #1687) is intentionally NOT performed here — the orchestrator runs it post-merge.

## Test plan

- `pre-commit run --files .github/dependabot.yml` — all applicable hooks pass (`check yaml` Passed).
- Floors verified against current `frontend/package.json` pins (`react-native-screens ~4.4.0`, `react-native-web ~0.19.13`, `styleq 0.1.3`).
- Frontend Jest/lint/typecheck hooks are unaffected (this diff touches no frontend files).

Closes #1689