### PR TITLE
chore(deps): ignore SDK-managed and toolchain-locked npm majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,25 @@ updates:
       # unpin at the SDK 53 upgrade (#885).
       - dependency-name: "react-native-reanimated"
         versions: [">=4.0.0"]
+      # Expo SDK 52 pins expo-image-picker to ~16.0.x; 17.x targets SDK 53+.
+      # Expo packages move together with the SDK via `expo install`, not
+      # piecemeal — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-image-picker"
+        versions: [">=17.0.0"]
+      # Expo SDK 52 pins expo-keep-awake to ~14.0.x; 15.x targets SDK 53+. Same
+      # SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-keep-awake"
+        versions: [">=15.0.0"]
+      # react-test-renderer must match the React major exactly (18.3.1, paired
+      # with RN 0.76); 19.x needs React 19. It moves with the React upgrade, not
+      # on its own — unpin when React itself moves to 19.
+      - dependency-name: "react-test-renderer"
+        versions: [">=19.0.0"]
+      # TypeScript 6/7 is the native-port line, unsupported by the expo / jest /
+      # eslint toolchain we run; adopt it via a deliberate migration, not a
+      # Dependabot bump. Unpin when the toolchain supports the 6+ line.
+      - dependency-name: "typescript"
+        versions: [">=6.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Adds four ignore entries to the npm section of `.github/dependabot.yml`,
mirroring the existing SDK-managed idiom established by #1686/#1690. Floors
verified against `frontend/package.json` pins:

- `expo-image-picker` `>=17.0.0` — SDK-managed (pinned `~16.0.6`), unpin at SDK 53 (#885)
- `expo-keep-awake` `>=15.0.0` — SDK-managed (pinned `~14.0.3`), unpin at SDK 53 (#885)
- `react-test-renderer` `>=19.0.0` — must match the React major (`^18.3.1` with RN 0.76); moves with React
- `typescript` `>=6.0.0` — TS 6/7 native-port line unsupported by the expo/jest/eslint toolchain; adopt via a deliberate migration

## Test plan

Config-only YAML change. Gate: `pre-commit run --files .github/dependabot.yml`
(check yaml Passed; frontend hooks skip on a YAML-only diff for lack of
node_modules, as in the #1689 lane). Commit-time hooks passed on the staged
file.

Closes #1713