### PR TITLE
chore(deps): ignore eslint >=10 until plugins support it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,6 +117,12 @@ updates:
       # pinned to Node 20 (.nvmrc). Unpin when CI Node moves to 22+.
       - dependency-name: "@babel/core"
         versions: [">=8.0.0"]
+      # eslint-plugin-import + eslint-plugin-react cap their eslint peer at ^9
+      # and have no eslint-10 release; adopting eslint 10 ERESOLVE-fails. Unpin
+      # when both plugins ship eslint-10 support (or after an import-x /
+      # react-plugin migration).
+      - dependency-name: "eslint"
+        versions: [">=10.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Add one Dependabot ignore entry to the npm section of `.github/dependabot.yml`,
mirroring the established idiom:

- `eslint`, versions `[">=10.0.0"]` — eslint-plugin-import and
  eslint-plugin-react cap their eslint peer at `^9` with no eslint-10 release,
  so a bump to eslint 10 ERESOLVE-fails. Unpin when both plugins ship
  eslint-10 support (or after an import-x / react-plugin migration).

## Test plan

Config-only change; no runtime code touched.

- `pre-commit run --files .github/dependabot.yml` → all applicable hooks pass
  (check yaml, detect secrets, etc.)

Closes #1725