### PR TITLE
chore(deps): ignore SDK-coupled npm majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,6 +123,34 @@ updates:
       # react-plugin migration).
       - dependency-name: "eslint"
         versions: [">=10.0.0"]
+      # eslint-plugin-unicorn 65.x requires eslint >=10.4 and Node >=22, neither
+      # of which we run (eslint is pinned <10 above; CI Node is 20). Unpin with
+      # the ESLint-10 / Node-22 migration — see the eslint entry above.
+      - dependency-name: "eslint-plugin-unicorn"
+        versions: [">=65.0.0"]
+      # Jest 30 needs jest-environment-node / babel-jest ^30, but RN 0.76 tooling
+      # pins the jest-29 line. Jest moves with the SDK toolchain, not on its own —
+      # unpin at the Expo SDK 53 upgrade (#885).
+      - dependency-name: "jest"
+        versions: [">=30.0.0"]
+      # @types/jest must match the jest major; it pairs with jest 30 and moves
+      # with it — unpin at the Expo SDK 53 upgrade (#885).
+      - dependency-name: "@types/jest"
+        versions: [">=30.0.0"]
+      # React 19 pairs with the RN 0.78+ / Expo SDK upgrade and ERESOLVE-fails
+      # against the RN 0.76 pins here. React moves with the SDK, not via a bot
+      # bump — unpin at the Expo SDK 53 upgrade (#885).
+      - dependency-name: "react"
+        versions: [">=19.0.0"]
+      # @types/react must match the react major; it pairs with react 19 and moves
+      # with it — unpin at the Expo SDK 53 upgrade (#885).
+      - dependency-name: "@types/react"
+        versions: [">=19.0.0"]
+      # Expo SDK 53+ upgrades deliberately via `expo install` tooling as part of
+      # the SDK epic, never via a Dependabot bump (a bare `expo` bump desyncs the
+      # whole managed toolchain). Unpin at the Expo SDK 53 upgrade (#885).
+      - dependency-name: "expo"
+        versions: [">=53.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Adds six ignore entries to the npm section of `.github/dependabot.yml`,
mirroring the established SDK-managed idiom (see the styleq / react-native /
eslint entries from #1686/#1690/#1714/#1724/#1726). Each blocks a major that
cannot be adopted in isolation because it requires the coordinated Expo SDK /
React 19 / ESLint 10 pairing that lands via the deliberate #885 upgrade, not a
Dependabot bump:

| Dependency | Ignored from | Reason |
|---|---|---|
| `eslint-plugin-unicorn` | `>=65.0.0` | needs eslint >=10.4 + Node >=22 (eslint pinned <10; CI Node 20) |
| `jest` | `>=30.0.0` | RN 0.76 tooling pins jest-29 (jest-environment-node/babel-jest ^29) |
| `@types/jest` | `>=30.0.0` | pairs with jest 30 |
| `react` | `>=19.0.0` | React 19 pairs with the RN/SDK upgrade |
| `@types/react` | `>=19.0.0` | pairs with react 19 |
| `expo` | `>=53.0.0` | SDK upgrades via `expo install` tooling, never a bot bump |

Floors verified against `frontend/package.json` pins (expo ~52.0.43, react
18.3.1, @types/react ~18.3.12, @types/jest 29.5.11, eslint-plugin-unicorn
^55.0.0, jest 29.7.0).

## Test plan

- Config-only change; no code or tests affected.
- `pre-commit run --files .github/dependabot.yml` passes (check yaml + hygiene).

Closes #1735