### PR TITLE
fix(course): derive CourseDrawer sections from present stages, ending the gap-stage infinite spinner

### DIFF
--- a/frontend/src/features/Course/CourseDrawer.tsx
+++ b/frontend/src/features/Course/CourseDrawer.tsx
@@ -23,7 +23,7 @@ import {
 import { course as courseApi, type ContentItem, type Stage } from '../../api';
 import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
 
-import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
+import { getStageColor, isCompleted, isUnlocked } from './stageDisplay';
 
 /** Glyph shown on a completed stage header. */
 const COMPLETED_GLYPH = '✓';
@@ -301,7 +301,7 @@ const StageSection = ({
 };
 
 export interface CourseDrawerProps {
-  /** Every stage in the course; the drawer renders one section per stage. */
+  /** Every stage in the course; only present stages render (gap numbers are skipped). */
   stages: Stage[];
   /** The stage currently shown on the screen, marked selected in the list. */
   selectedStage: number;
@@ -322,7 +322,7 @@ export default function CourseDrawer({
   onRetry,
 }: CourseDrawerProps): React.JSX.Element {
   const stageById = useMemo(() => new Map(stages.map((s) => [s.stage_number, s])), [stages]);
-  const stageNumbers = Array.from({ length: totalStageCount(stages) }, (_, i) => i + 1);
+  const stageNumbers = useMemo(() => [...stageById.keys()].sort((a, b) => a - b), [stageById]);
   return (
     <View testID="course-drawer">
       {stageNumbers.map((stageNumber) => (

--- a/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
@@ -147,7 +147,7 @@ const {
   renderHook,
 } = require('@testing-library/react-native');
 const CourseScreen = require('../CourseScreen').default;
-const { useCourseDrawerContent } = require('../CourseDrawer');
+const { default: CourseDrawer, useCourseDrawerContent } = require('../CourseDrawer');
 /* eslint-enable import/order */
 
 const subscribeHeaderLeft = (onChange: () => void): (() => void) => {
@@ -455,5 +455,26 @@ describe('Course header drawer', () => {
     expect(mockStageContent.mock.calls.filter((c) => c[0] === 3).length).toBe(
       stage3CallsBefore + 1,
     );
+  });
+
+  it('a gap stage number absent from stages renders no header and no never-resolving spinner', () => {
+    const gappyStages = [makeStage({ stage_number: 3, id: 3 })];
+    const { queryByTestId } = render(
+      <CourseDrawer
+        stages={gappyStages}
+        selectedStage={3}
+        sections={{}}
+        onChapterPress={jest.fn()}
+        onRetry={jest.fn()}
+      />,
+    );
+
+    expect(queryByTestId('course-drawer-stage-1')).toBeNull();
+    expect(queryByTestId('course-drawer-stage-2')).toBeNull();
+    expect(queryByTestId('course-drawer-loading-1')).toBeNull();
+    expect(queryByTestId('course-drawer-loading-2')).toBeNull();
+
+    expect(queryByTestId('course-drawer-stage-3')).toBeTruthy();
+    expect(queryByTestId('course-drawer-loading-3')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
`CourseDrawer` rendered one section per number in `1..max(stage_number)` while its loader only fetched content for stage records that actually exist — so any gap number's section stayed `undefined` forever and fell through to a never-resolving `ActivityIndicator`.

The drawer now derives its rendered stage numbers from the present stage records (ascending) instead of the dense `1..max` range, mirroring the sparse-array tolerance the sibling surfaces already have (`StageSelector`'s graceful gap pill, `MapDrawer`'s `if (!display) return null`). Present-stage load/retry/cache behavior untouched.

## Tests (RED-first)
Sparse `stages = [{ stage_number: 3 }]` with the drawer open: no perpetual `course-drawer-loading-2` spinner; only the present stage renders and resolves. RED against the old code; full `CourseDrawer` suite 10/10 green, deterministic deferred-promise idiom.

Local gates: pre-commit fully green; full jest run 3912 passed with zero assertion failures (some unrelated suites cut short only by local ENOSPC on the transform cache — CI is the authoritative full run).

De-slop finding (frontend-course scan, 2026-07-16), priority-medium.

Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)