### PR TITLE
fix(course): pick WCAG-AA glyph color per stage-pill fill

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -2,6 +2,8 @@
 /* global describe, it, expect */
 import {
   BORDER_RADIUS,
+  GLYPH_ON_DARK_FILL,
+  GLYPH_ON_LIGHT_FILL,
   SPACING,
   STAGE_COLORS,
   STAGE_ORDER,
@@ -10,6 +12,7 @@ import {
   contentLayout,
   journalLayout,
   radius,
+  readableGlyphOn,
   resolveStageColor,
   shadows,
   spacing,
@@ -17,6 +20,26 @@ import {
   type,
   typography,
 } from '../tokens';
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
 
 describe('design tokens', () => {
   describe('colors', () => {
@@ -294,6 +317,41 @@ describe('design tokens', () => {
         journalLayout.pageMaxWidth + journalLayout.marginColumnWidth,
       );
       expect(contentLayout.maxWidth).toBe(900);
+    });
+  });
+
+  describe('readableGlyphOn', () => {
+    it('exports the black and white glyph fill constants', () => {
+      expect(GLYPH_ON_LIGHT_FILL).toBe('#000000');
+      expect(GLYPH_ON_DARK_FILL).toBe('#ffffff');
+    });
+
+    it('clears WCAG AA contrast against every stage pill fill', () => {
+      STAGE_ORDER.forEach((name) => {
+        const fill = STAGE_COLORS[name]!;
+        const glyphColor = readableGlyphOn(fill);
+        expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+      });
+    });
+
+    it('picks the black glyph fill for light stage colors', () => {
+      expect(readableGlyphOn('#ffffff')).toBe(GLYPH_ON_LIGHT_FILL); // Clear Light
+      expect(readableGlyphOn('#f2e96d')).toBe(GLYPH_ON_LIGHT_FILL); // Yellow
+      expect(readableGlyphOn('#d8cbb8')).toBe(GLYPH_ON_LIGHT_FILL); // Beige
+      expect(readableGlyphOn('#cc5b5b')).toBe(GLYPH_ON_LIGHT_FILL); // Red
+    });
+
+    it('picks the white glyph fill for a dark stage color', () => {
+      expect(readableGlyphOn('#8e44ad')).toBe(GLYPH_ON_DARK_FILL); // Ultraviolet
+    });
+
+    it('clears WCAG AA contrast for the neutral fallback fill', () => {
+      const glyphColor = readableGlyphOn(colors.neutral);
+      expect(contrast(glyphColor, colors.neutral)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it('falls back to the dark-fill glyph color for an unparseable hex', () => {
+      expect(readableGlyphOn('not-a-hex')).toBe(GLYPH_ON_DARK_FILL);
     });
   });
 });

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -249,6 +249,68 @@ export const brightenColor = (hex: string): string => {
   );
 };
 
+/** Black glyph foreground, chosen when it out-contrasts white on a fill. */
+export const GLYPH_ON_LIGHT_FILL = '#000000';
+
+/** White glyph foreground, chosen when it out-contrasts black on a fill. */
+export const GLYPH_ON_DARK_FILL = '#ffffff';
+
+/** Threshold below which an sRGB channel linearizes as a plain scaled value. */
+const SRGB_LINEAR_THRESHOLD = 0.03928;
+/** Divisor applied to channels at or below the linear threshold. */
+const SRGB_LINEAR_DIVISOR = 12.92;
+/** Offset folded into the gamma expansion of above-threshold channels. */
+const SRGB_GAMMA_OFFSET = 0.055;
+/** Scale applied inside the gamma expansion of above-threshold channels. */
+const SRGB_GAMMA_SCALE = 1.055;
+/** Exponent of the sRGB gamma expansion. */
+const SRGB_GAMMA_EXPONENT = 2.4;
+/** Per-channel luminance weights (Rec. 709) for relative luminance. */
+const LUMINANCE_WEIGHTS = { r: 0.2126, g: 0.7152, b: 0.0722 };
+/** Additive term that keeps the WCAG contrast ratio finite near black. */
+const CONTRAST_FLARE = 0.05;
+
+/** Linearize a single 0-255 sRGB channel per the WCAG definition. */
+const linearizeChannel = (channel: number): number => {
+  const x = channel / 255;
+  return x <= SRGB_LINEAR_THRESHOLD
+    ? x / SRGB_LINEAR_DIVISOR
+    : ((x + SRGB_GAMMA_OFFSET) / SRGB_GAMMA_SCALE) ** SRGB_GAMMA_EXPONENT;
+};
+
+/** WCAG relative luminance of an [r, g, b] triple. */
+const relativeLuminance = ([r, g, b]: [number, number, number]): number =>
+  LUMINANCE_WEIGHTS.r * linearizeChannel(r) +
+  LUMINANCE_WEIGHTS.g * linearizeChannel(g) +
+  LUMINANCE_WEIGHTS.b * linearizeChannel(b);
+
+/** WCAG contrast ratio between two relative luminances. */
+const contrastRatio = (a: number, b: number): number => {
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  return (hi + CONTRAST_FLARE) / (lo + CONTRAST_FLARE);
+};
+
+/**
+ * Pick a maximal-contrast dark or light glyph foreground for a given fill so
+ * the glyph clears WCAG AA (>= 4.5:1) on every Spiral-Dynamics stage color --
+ * including near-white fills like "Clear Light" where a canvas-tinted glyph is
+ * effectively invisible. This reproduces the black/white on-fill decision
+ * already made by the Practice frequency palette
+ * (features/Practice/data/colorPalette.ts) rather than adding a second
+ * stage-to-text palette. Unparseable hex falls back to the dark-fill glyph.
+ */
+export const readableGlyphOn = (fillHex: string): string => {
+  const rgb = parseHexRgb(fillHex);
+  if (!rgb) return GLYPH_ON_DARK_FILL;
+  const fillLuminance = relativeLuminance(rgb);
+  const blackLuminance = relativeLuminance([0, 0, 0]);
+  const whiteLuminance = relativeLuminance([255, 255, 255]);
+  const blackContrast = contrastRatio(blackLuminance, fillLuminance);
+  const whiteContrast = contrastRatio(whiteLuminance, fillLuminance);
+  return blackContrast >= whiteContrast ? GLYPH_ON_LIGHT_FILL : GLYPH_ON_DARK_FILL;
+};
+
 // ---------------------------------------------------------------------------
 // Spacing
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -63,15 +63,12 @@ const styles = StyleSheet.create({
   stagePillText: {
     fontSize: 14,
     fontWeight: '700',
-    color: surface.canvas,
   },
   stagePillCheck: {
     fontSize: 16,
-    color: surface.canvas,
   },
   stagePillLock: {
     fontSize: 14,
-    color: surface.canvas,
   },
 
   // Stage cover — the showcase "book cover" for the selected stage.

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
 import type { Stage } from '../../api';
+import { readableGlyphOn } from '../../design/tokens';
 
 import styles from './Course.styles';
 import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
@@ -29,32 +30,37 @@ const StagePill = ({
   isActive,
   color,
   onSelectStage,
-}: StagePillProps): React.JSX.Element => (
-  <TouchableOpacity
-    testID={`stage-pill-${stageNumber}`}
-    accessible
-    accessibilityRole="button"
-    accessibilityLabel={`Stage ${stageNumber}${!unlocked ? ', locked' : ''}${completed ? ', completed' : ''}`}
-    accessibilityState={{ selected: isActive, disabled: !unlocked }}
-    disabled={!unlocked}
-    onPress={() => onSelectStage(stageNumber)}
-    style={[
-      styles.stagePill,
-      { backgroundColor: color },
-      isActive && styles.stagePillActive,
-      !unlocked && styles.stagePillLocked,
-      completed && !isActive && styles.stagePillCompleted,
-    ]}
-  >
-    {completed ? (
-      <Text style={styles.stagePillCheck}>{'✓'}</Text>
-    ) : !unlocked ? (
-      <Text style={styles.stagePillLock}>{'🔒'}</Text>
-    ) : (
-      <Text style={styles.stagePillText}>{stageNumber}</Text>
-    )}
-  </TouchableOpacity>
-);
+}: StagePillProps): React.JSX.Element => {
+  // The glyph rides directly on the stage fill, so pick a foreground that
+  // clears WCAG AA against this pill's color rather than a fixed canvas tint.
+  const glyphColor = readableGlyphOn(color);
+  return (
+    <TouchableOpacity
+      testID={`stage-pill-${stageNumber}`}
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={`Stage ${stageNumber}${!unlocked ? ', locked' : ''}${completed ? ', completed' : ''}`}
+      accessibilityState={{ selected: isActive, disabled: !unlocked }}
+      disabled={!unlocked}
+      onPress={() => onSelectStage(stageNumber)}
+      style={[
+        styles.stagePill,
+        { backgroundColor: color },
+        isActive && styles.stagePillActive,
+        !unlocked && styles.stagePillLocked,
+        completed && !isActive && styles.stagePillCompleted,
+      ]}
+    >
+      {completed ? (
+        <Text style={[styles.stagePillCheck, { color: glyphColor }]}>{'✓'}</Text>
+      ) : !unlocked ? (
+        <Text style={[styles.stagePillLock, { color: glyphColor }]}>{'🔒'}</Text>
+      ) : (
+        <Text style={[styles.stagePillText, { color: glyphColor }]}>{stageNumber}</Text>
+      )}
+    </TouchableOpacity>
+  );
+};
 
 const StageSelector = ({
   stages: stagesList,

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -3,7 +3,7 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, fireEvent, within } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 import type { Stage } from '../../../api';
 import { colors, STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
@@ -13,6 +13,31 @@ function backgroundColorOf(style: StyleProp<ViewStyle>): string {
   const flat = StyleSheet.flatten(style) ?? {};
   return (flat.backgroundColor as string | undefined) ?? '';
 }
+
+function glyphColorOf(style: StyleProp<TextStyle>): string {
+  const flat = StyleSheet.flatten(style) ?? {};
+  return (flat.color as string | undefined) ?? '';
+}
+
+/** WCAG relative luminance of a #rrggbb color. */
+const luminance = (hex: string): number => {
+  const match = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`not a 6-digit hex: ${hex}`);
+  const channels = [match[1], match[2], match[3]].map((pair) => {
+    const c = Number.parseInt(pair!, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+};
+
+const contrast = (a: string, b: string): number => {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
+
+const AA_NORMAL = 4.5;
 
 const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
   id: 1,
@@ -216,5 +241,107 @@ describe('StageSelector', () => {
     expect(within(pill1).getByText('✓')).toBeTruthy();
     expect(within(pill1).queryByText('🔒')).toBeNull();
     expect(pill1.props.accessibilityLabel).toBe('Stage 1, locked, completed');
+  });
+
+  describe('glyph contrast (WCAG AA)', () => {
+    it('renders the number glyph readably on a light stage fill', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Clear Light',
+          is_unlocked: true,
+          progress: 0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      const glyph = within(pill).getByText('1');
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it('renders the completed checkmark readably on a light stage fill', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Clear Light',
+          is_unlocked: true,
+          progress: 1.0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      const glyph = within(pill).getByText('✓');
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it('renders the completed checkmark readably on the Ultraviolet dark stage fill', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Ultraviolet',
+          is_unlocked: true,
+          progress: 1.0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      const glyph = within(pill).getByText('✓');
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it('renders the lock glyph readably on a light stage fill', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Clear Light',
+          is_unlocked: false,
+          progress: 0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      const glyph = within(pill).getByText('🔒');
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it('renders the lock glyph readably on the Ultraviolet dark stage fill', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Ultraviolet',
+          is_unlocked: false,
+          progress: 0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      const glyph = within(pill).getByText('🔒');
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Course stage-selector pills rendered their number / ✓ / 🔒 glyph in a fixed canvas tint (`surface.canvas` #faf6ef) painted directly over each Spiral-Dynamics stage fill. On light fills the glyph fell below WCAG AA — invisible at ~1.08:1 on the near-white **Clear Light** (#ffffff) stage.

This change:
- Adds a design-system helper `readableGlyphOn(fillHex)` in `frontend/src/design/tokens.ts` that picks the maximal-contrast **black or white** foreground for a fill via WCAG relative luminance, with named sRGB/luminance/contrast constants and a white-glyph fallback for unparseable hex.
- Applies the per-fill glyph color inline in `StagePill` (`StageSelector.tsx`).
- Removes the three hardcoded `color: surface.canvas` declarations from `Course.styles.ts`.

Black/white is deliberate and load-bearing: a design-ink foreground (`ink.primary` #2b2620) fails AA on **Red** (3.72:1) and **Ultraviolet** (2.56:1), so black/white is the only pair clearing ≥4.5:1 on all ten stage fills — mirroring the Practice frequency-palette prior art in `features/Practice/data/colorPalette.ts`.

The locked/completed pills' `opacity: 0.4/0.8` compositing is pre-existing and explicitly out of scope (fills unchanged); tracked as a follow-up.

## Test plan

- New unit tests in `frontend/src/design/__tests__/tokens.test.ts`: `readableGlyphOn` picks black on light fills / white on dark fills, handles unparseable hex, and a sweep asserting ≥4.5:1 contrast on every one of the ten stage colors. Test-side luminance/contrast helpers are independently reimplemented so the assertions are non-tautological.
- New rendered-glyph tests in `frontend/src/features/Course/__tests__/StageSelector.test.tsx`: read the actually-composed `backgroundColor` and glyph `color` off the style tree (Clear Light + Ultraviolet × number/check/lock) and assert ≥4.5:1.
- Full frontend jest suite green (4323 tests); eslint / prettier / tsc all pass.

Closes #1742
Refs #6