### PR TITLE
refactor(journal): dedup useSettleIn into useEntrance and de-slop stale comments

### DIFF
--- a/frontend/src/features/Journal/CompletionSuggestionNote.tsx
+++ b/frontend/src/features/Journal/CompletionSuggestionNote.tsx
@@ -63,7 +63,7 @@ function AcceptedCard({
   targetType: CompletionSuggestion['target_type'];
   checkIn: CheckInResult | null;
 }): React.JSX.Element {
-  const streak = streakLabel(checkIn);
+  const streak = targetType === 'practice' ? null : streakLabel(checkIn);
   const label = targetType === 'practice' ? LOGGED_LABEL : CHECKED_LABEL;
   return (
     <View style={styles.card} testID={`suggestion-${id}`}>

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -31,7 +31,6 @@ import HighlightedBody from './HighlightedBody';
 import { JournalScreenDrawer } from './JournalDrawer';
 import styles from './JournalEntry.styles';
 import MarginNote from './MarginNote';
-import { useSettleIn } from './motion';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
 import QuoteSelectionSurface, { type CodePointSpan } from './QuoteSelectionSurface';
@@ -56,8 +55,8 @@ import type {
 import { Button } from '@/components/Button';
 import { useScreenDrawer, type ScreenDrawerState } from '@/components/drawer';
 import { colors } from '@/design/tokens';
+import { useEntrance } from '@/hooks/useEntrance';
 import { useIdle } from '@/hooks/useIdle';
-import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { RootStackParamList } from '@/navigation/RootStack';
 
 /** Default idle delay before an edit is persisted. */
@@ -1259,9 +1258,9 @@ function ReadModeControls({ quote, onEdit }: { quote: QuotePromotion; onEdit: ()
 const PROMOTING_COPY = 'Promoting…';
 const PROMOTED_COPY = 'Promoted';
 
-/** Transient success confirmation that settles in (motion-safe via useSettleIn). */
+/** Transient success confirmation that settles in (motion-safe via useEntrance). */
 function PromotedNotice(): React.JSX.Element {
-  const settle = useSettleIn(useReducedMotion());
+  const settle = useEntrance();
   return (
     <Animated.Text
       style={[styles.promotionSuccess, settle]}
@@ -1671,7 +1670,6 @@ function useJournalEntryController(
     resonance,
     quote,
     reflection,
-    isIdle,
     ...gate,
     handleTitle,
     handleBody,
@@ -1729,7 +1727,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
 
 function JournalPage({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholder: string }) {
   const narrow = useWindowDimensions().width < NARROW_BREAKPOINT;
-  const settle = useSettleIn(useReducedMotion());
+  const settle = useEntrance();
   const notes = ctl.resonance.marginalia;
   const suggestions = ctl.resonance.suggestions;
   const hasVisibleSuggestions = suggestions.some((s) => s.status !== 'dismissed');

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -20,7 +20,7 @@ import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
 import { usePressScale } from './motion';
 import { promptTitleForWeek } from './promptTitle';
-import { formatDate, groupByRecency, type ShelfSection } from './recency';
+import { formatDate, groupByRecency, MONTH_DAYS, type ShelfSection } from './recency';
 import ReflectionInvitationBand from './ReflectionInvitationBand';
 import SearchBar from './SearchBar';
 import StatTileRow from './StatTileRow';
@@ -43,7 +43,6 @@ import { MS_PER_DAY } from '@/utils/dateUtils';
 const SEARCH_MIN_LENGTH = 3;
 const SEARCH_MAX_LENGTH = 64; // mirrors the backend JOURNAL_SEARCH_MAX_LENGTH guard
 const EXCERPT_MAX = 140;
-const MONTH_DAYS = 30;
 const WORDS_PER_MINUTE = 200;
 
 // A single curated opening invitation for a brand-new journal (no rotation).

--- a/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
+++ b/frontend/src/features/Journal/ReflectionSourcesPanel.tsx
@@ -63,8 +63,8 @@ export interface ReflectionSourcesPanelProps {
   items: ReflectionSourceItem[];
   /**
    * Fold a pending quote into the reflection body. Resolves ``true`` when it was
-   * marked included (keep the dim), ``false``/reject to revert the dim, or
-   * ``undefined`` on a legacy fire-and-forget caller (keep the dim).
+   * marked included (keep the dim), ``false``/reject to revert the dim. May
+   * return nothing, in which case no confirmation state is shown.
    */
   onInsertQuote: (
     _quote: PromotedQuoteSummary,
@@ -393,7 +393,7 @@ function SourceFeed({
 /**
  * Own the "which pending quotes are folded in" dim and reconcile it with the
  * fold-in outcome: dim on tap, revert on a ``false``/rejected result, keep the
- * dim on ``true`` or a legacy fire-and-forget (``undefined``) caller.
+ * dim on ``true`` or when no outcome is reported (skip the confirmation state).
  */
 function useDimReconciler(onInsertQuote: ReflectionSourcesPanelProps['onInsertQuote']): {
   includedIds: ReadonlySet<number>;
@@ -406,7 +406,7 @@ function useDimReconciler(onInsertQuote: ReflectionSourcesPanelProps['onInsertQu
       const { id } = entry.quote;
       setIncludedIds((prev) => withId(prev, id)); // Dim optimistically.
       const outcome = onInsertQuote(entry.quote, entry.item);
-      if (outcome == null) return; // Legacy fire-and-forget caller: keep the dim.
+      if (outcome == null) return; // No outcome reported — skip the confirmation state.
       let foldedIn = false;
       try {
         foldedIn = await outcome;

--- a/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
+++ b/frontend/src/features/Journal/__tests__/CompletionSuggestionNote.test.tsx
@@ -106,6 +106,20 @@ describe('CompletionSuggestionNote', () => {
     expect(queryByText(/streak/)).toBeNull();
   });
 
+  it('accepted practice: renders no streak line even when the check-in carries a streak', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <CompletionSuggestionNote
+        suggestion={suggestion({ status: 'accepted', target_type: 'practice' })}
+        checkIn={checkIn(4)}
+        onAccept={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(getByTestId('suggestion-7-checked')).toBeTruthy();
+    expect(getByText(/Logged/)).toBeTruthy();
+    expect(queryByText(/-day streak/)).toBeNull();
+  });
+
   it('Not now calls onDismiss(id)', () => {
     const onDismiss = jest.fn(() => Promise.resolve());
     const { getByTestId } = render(

--- a/frontend/src/features/Journal/__tests__/motion.test.ts
+++ b/frontend/src/features/Journal/__tests__/motion.test.ts
@@ -3,7 +3,7 @@ import { jest, describe, it, expect, afterEach } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react-native';
 import { Animated } from 'react-native';
 
-import { PRESS_SCALE, SETTLE_DISTANCE, usePressScale, useSettleIn } from '../motion';
+import { PRESS_SCALE, usePressScale } from '../motion';
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -18,29 +18,6 @@ const stubbedTiming = (): jest.SpiedFunction<typeof Animated.timing> =>
     start: jest.fn(),
     stop: jest.fn(),
   } as unknown as Animated.CompositeAnimation);
-
-describe('useSettleIn', () => {
-  it('animates the surface in from below when motion is allowed', () => {
-    const timing = stubbedTiming();
-
-    const { result } = renderHook(() => useSettleIn(false));
-
-    // Starts below its resting place (translucent, lifted) and schedules a settle.
-    expect(animatedValue(result.current.opacity)).toBe(0);
-    expect(animatedValue(result.current.transform[0]!.translateY)).toBe(SETTLE_DISTANCE);
-    expect(timing).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders at the resting state with no animation under reduced motion', () => {
-    const timing = jest.spyOn(Animated, 'timing');
-
-    const { result } = renderHook(() => useSettleIn(true));
-
-    expect(animatedValue(result.current.opacity)).toBe(1);
-    expect(animatedValue(result.current.transform[0]!.translateY)).toBe(0);
-    expect(timing).not.toHaveBeenCalled();
-  });
-});
 
 describe('usePressScale', () => {
   it('drives the press-in / press-out scale when motion is allowed', () => {

--- a/frontend/src/features/Journal/highlightSegments.ts
+++ b/frontend/src/features/Journal/highlightSegments.ts
@@ -78,10 +78,9 @@ function usableAnchors(length: number, notes: Marginalia[], quotes: PromotedQuot
 }
 
 /**
- * Segment the body against the merged note + quote anchor stream. The same
- * first-wins cursor-skip rule as the notes-only path resolves overlaps: the
- * earliest-starting anchor wins and any anchor overlapping a committed range is
- * skipped.
+ * Segment the body against the merged note + quote anchor stream. Overlaps
+ * resolve first-wins: the earliest-starting anchor wins and any anchor
+ * overlapping a committed range is skipped.
  *
  * All slicing happens in CODE-POINT space (``chars``), matching the anchor
  * contract, so a non-BMP character (emoji / astral) never shifts a boundary or

--- a/frontend/src/features/Journal/motion.ts
+++ b/frontend/src/features/Journal/motion.ts
@@ -1,53 +1,6 @@
 /**
- * Depth-reinforcing motion for the floated journal surfaces — the writing
- * sheet settling in on mount, and cards pressing down when tapped. Every
- * animation here is short, native-driven, and gated on ``useReducedMotion``:
- * when reduce-motion is on the hooks return the resting state and run no
- * animation, so layout is identical and nothing interpolates.
+ * Motion for the Journal surfaces. This module now only re-exports the shared
+ * press-scale hook so cards can press down when tapped; entrance/settle motion
+ * lives in the app-wide ``useEntrance`` hook.
  */
-import { useEffect, useMemo, useRef } from 'react';
-import { Animated } from 'react-native';
-
 export { usePressScale, PRESS_SCALE } from '@/hooks/usePressScale';
-
-/** Sheet settle-in: a brief fade + a few-px lift into place. */
-export const SETTLE_DURATION_MS = 220;
-export const SETTLE_DISTANCE = 6;
-
-export interface SettleStyle {
-  opacity: Animated.AnimatedInterpolation<number> | Animated.Value;
-  transform: { translateY: Animated.AnimatedInterpolation<number> }[];
-}
-
-/**
- * Animated style for a surface that settles in when it mounts. With reduced
- * motion the value starts at its resting position (opacity 1, no offset) and no
- * animation is scheduled.
- */
-export function useSettleIn(reduced: boolean): SettleStyle {
-  const anim = useRef(new Animated.Value(reduced ? 1 : 0)).current;
-
-  useEffect(() => {
-    if (reduced) {
-      anim.setValue(1);
-      return;
-    }
-    const animation = Animated.timing(anim, {
-      toValue: 1,
-      duration: SETTLE_DURATION_MS,
-      useNativeDriver: true,
-    });
-    animation.start();
-    return () => animation.stop();
-  }, [reduced, anim]);
-
-  return useMemo(
-    () => ({
-      opacity: anim,
-      transform: [
-        { translateY: anim.interpolate({ inputRange: [0, 1], outputRange: [SETTLE_DISTANCE, 0] }) },
-      ],
-    }),
-    [anim],
-  );
-}

--- a/frontend/src/features/Journal/recency.ts
+++ b/frontend/src/features/Journal/recency.ts
@@ -8,7 +8,7 @@ import { MS_PER_DAY } from '@/utils/dateUtils';
 /** Days within which an entry counts as "This week". */
 const WEEK_DAYS = 7;
 /** Days within which an entry counts as "This month". */
-const MONTH_DAYS = 30;
+export const MONTH_DAYS = 30;
 
 /** The recency bands, in display order. */
 const RECENCY_ORDER = ['This week', 'This month', 'Earlier'] as const;

--- a/frontend/src/hooks/useEntrance.ts
+++ b/frontend/src/hooks/useEntrance.ts
@@ -1,7 +1,7 @@
 /**
  * App-wide entrance motion: a brief fade + small upward settle when an element
- * mounts, staggerable by index. Mirrors the journal's ``useSettleIn`` but lives
- * in the shared layer so any screen can adopt the same vocabulary.
+ * mounts, staggerable by index. Lives in the shared layer so any screen —
+ * including the journal's floated surfaces — can adopt the same vocabulary.
  *
  * Fully disabled under reduced motion — the value starts at its resting state
  * (opacity 1, no offset) and no animation is scheduled, so layout is identical.


### PR DESCRIPTION
## Summary

Low-severity Journal de-slop tidy-up (bundled hygiene sweep). No user-visible behavior change — each item is a dedup, a dead-field removal, or a comment/type alignment.

- **Dedup the motion hook.** `useSettleIn` in `motion.ts` was a byte-for-byte clone of the shared `useEntrance` hook (`src/hooks/useEntrance.ts`), including shadow copies of the `motion.base`/`motion.settleY` design tokens (`SETTLE_DURATION_MS`/`SETTLE_DISTANCE`). Deleted the clone + its `SettleStyle` interface; both call sites in `JournalEntryScreen.tsx` now call `useEntrance()` (which reads reduced-motion and the tokens itself). Dropped the now-unused `useReducedMotion` import.
- **Drop dead code.** Removed the `isIdle` field from the entry controller's return object — it was already folded into the spread resonance gate (`deriveResonanceGate`), and nothing read `ctl.isIdle`.
- **Unify a duplicated constant.** `MONTH_DAYS = 30` was privately declared in both `recency.ts` and `JournalShelfScreen.tsx` for the same 30-day boundary. Now exported once from `recency.ts` and imported at the shelf.
- **Fix lying/stale comments.** Aligned `CompletionSuggestionNote` to its docstring by guarding the streak line on non-practice targets (practices never render a streak line); removed the phantom "legacy fire-and-forget caller" claim in `ReflectionSourcesPanel` (kept the tolerant branch, re-commented honestly); reworded the stale "notes-only path" cross-reference in `highlightSegments.ts`; refreshed the now-stale `useEntrance` docstring that referenced the deleted `useSettleIn`.

## Test plan

- New RED-then-GREEN unit test: an accepted **practice** suggestion carrying a positive streak renders no streak line (fails without the `targetType` guard, passes with it).
- Removed the obsolete `useSettleIn` describe block from `motion.test.ts`; equivalent reduced-motion/timing/style coverage is preserved by `src/hooks/__tests__/useEntrance.test.tsx`.
- `./scripts/frontend/check-all.sh` green locally: ESLint, Prettier, `tsc --noEmit`, and all 407 suites / 4322 tests pass.

Closes #1738