### PR TITLE
test(journal): pin cleanup + attribution behaviours in 3 weak tests

### DIFF
--- a/frontend/src/features/Journal/__tests__/ReflectionInvitationBand.test.tsx
+++ b/frontend/src/features/Journal/__tests__/ReflectionInvitationBand.test.tsx
@@ -84,10 +84,10 @@ beforeEach(() => {
 
 describe('ReflectionInvitationBand', () => {
   it('renders the band with level-appropriate copy when a reflection is due', async () => {
-    const { findByTestId, getByTestId } = render(<ReflectionInvitationBand />);
-    const band = await findByTestId('journal-reflection-band');
-    expect(band).toBeTruthy();
-    expect(getByTestId('journal-reflection-band')).toBeTruthy();
+    const { findByText } = render(<ReflectionInvitationBand />);
+    // The default due window is a week reflection at scope c1:w14, so the band's
+    // title must read the week-level copy rather than a generic fallback.
+    expect(await findByText('Week 14 Reflection')).toBeTruthy();
   });
 
   it('shows the stage title alongside stage-level copy', async () => {

--- a/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
+++ b/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
@@ -1,8 +1,21 @@
-// RED: `reflectionCopy` does not exist yet -- these imports fail until the
-// implementation-specialist adds `reflectionTitle` and `formatBlockquote`.
 import { describe, it, expect } from '@jest/globals';
 
-import { reflectionTitle, formatBlockquote } from '../reflectionCopy';
+import { reflectionTitle, formatBlockquote, sourceAttribution } from '../reflectionCopy';
+
+import type { ReflectionSourceItem } from '@/api';
+
+function sourceItem(overrides: Partial<ReflectionSourceItem> = {}): ReflectionSourceItem {
+  return {
+    kind: 'entry',
+    id: 1,
+    title: null,
+    timestamp: '2026-06-15T12:00:00Z',
+    body: 'went for a daily walk',
+    reflection_level: null,
+    promoted_quotes: [],
+    ...overrides,
+  };
+}
 
 describe('reflectionTitle', () => {
   it('titles a week reflection from its week-number scope key', () => {
@@ -49,9 +62,22 @@ describe('formatBlockquote', () => {
     const block = formatBlockquote('went for a daily walk', 'Runs');
     expect(block.endsWith('\n\n')).toBe(true);
   });
+});
+
+describe('sourceAttribution', () => {
+  it('uses the source title when one is present', () => {
+    expect(sourceAttribution(sourceItem({ title: 'Morning Pages' }))).toBe('Morning Pages');
+  });
 
   it('falls back to a formatted date attribution when no title is given', () => {
-    const block = formatBlockquote('went for a daily walk', 'Jun 1, 2026');
-    expect(block).toContain('Jun 1, 2026');
+    const attribution = sourceAttribution(sourceItem({ title: null }));
+    expect(attribution).toContain('Jun');
+    expect(attribution).toContain('2026');
+  });
+
+  it('treats a whitespace-only title as no title and falls back to the date', () => {
+    const attribution = sourceAttribution(sourceItem({ title: '   ' }));
+    expect(attribution).toContain('Jun');
+    expect(attribution).toContain('2026');
   });
 });

--- a/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
+++ b/frontend/src/features/Journal/__tests__/usePromotions.test.tsx
@@ -325,7 +325,7 @@ describe('usePromotions', () => {
     expect(result.current.retryPromote).toBeNull();
   });
 
-  it('unmounting while the promoted notice timer is pending does not throw', async () => {
+  it('clears the pending promoted-notice timer on unmount so no callback leaks', async () => {
     jest.useFakeTimers();
     try {
       mockCreate.mockResolvedValue(quote({ id: 9 }));
@@ -335,8 +335,14 @@ describe('usePromotions', () => {
         await result.current.promote(2, 19);
       });
       expect(result.current.promoted).toBe(true);
+      // The auto-clear timer is armed while the notice is showing.
+      expect(jest.getTimerCount()).toBe(1);
 
-      expect(() => unmount()).not.toThrow();
+      unmount();
+
+      // Unmount must clear that timer. A leaked timer would still be pending
+      // here and later fire its state update on the torn-down hook.
+      expect(jest.getTimerCount()).toBe(0);
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## Summary

Test-only de-slop (Family 9 / Testing Slop) tightening exactly the three weak
Journal tests called out in the issue so each asserts a real, mutation-killing
outcome. No production code changed.

- **`usePromotions.test.tsx`** — the tautological `unmounting ... does not throw`
  test (fake timers were never advanced past unmount, and a leaked RN timer
  warns rather than throws, so deleting the hook's `clearTimeout` still passed)
  now pins the real cleanup: it asserts `jest.getTimerCount()` is `1` while the
  promoted-notice timer is armed, then `0` after `unmount()`.
- **`ReflectionInvitationBand.test.tsx`** — the `renders ... level-appropriate
  copy` test only asserted `toBeTruthy()` twice after a throwing `findByTestId`
  (both no-ops) and never checked any copy. It now asserts the actual week-level
  copy `Week 14 Reflection`; the redundant `toBeTruthy()` lines are removed.
- **`reflectionCopy.test.ts`** — the mis-named `falls back to a formatted date
  attribution when no title is given` test passed the date straight in as the
  attribution arg to `formatBlockquote` (duplicating the neighboring
  `includes the attribution` case; the real fallback lives in
  `sourceAttribution`). Replaced with a genuine `sourceAttribution` suite that
  exercises the real no-title -> formatted-date fallback, plus title-present and
  whitespace-title branches. Also dropped a now-inaccurate stale TDD-RED header
  comment on the edited import block.

All three findings still lived at HEAD (line numbers had shifted after the
Journal churn from #1746/#1751); none were already fixed. No overlap with the
`QuoteSelectionSurface`/`webSelectionListener` files being edited by #1750.

## Mutation RED proofs

Each strengthened assertion was proven RED under the exact mutation it pins
(temporary in-worktree break -> RED -> restore -> GREEN); the committed diff
touches tests only.

| Test | Temporary production mutation | Result |
|------|-------------------------------|--------|
| usePromotions cleanup | drop `return () => clearTimeout(timer)` in `usePromotedNotice` | `getTimerCount()` after unmount `1`, expected `0` -> **FAIL** |
| ReflectionInvitationBand copy | neuter `weekTitle` to return `'Week Reflection'` (drop the number) | `Week 14 Reflection` not found -> **FAIL** |
| sourceAttribution fallback | replace fallback with `return title ?? ''` | both no-title tests `''`, expected `Jun`/`2026` -> **FAIL** (title-present test still passes) |

After restoring production in every case: all 42 tests across the three files GREEN.

## Test plan

- `npx jest` scoped to the three files from the worktree: **42 passed**.
- `./scripts/frontend/check-all.sh`: ESLint, Prettier, and TypeScript clean.
  The full Jest run hit ENOSPC transform-cache write failures on the constrained
  fleet worktree disk (31 suites "failed to run" with zero real assertion
  failures; **4133 tests passed, 0 failed**). Pre-commit's `frontend tests` hook
  subsequently passed after a cache clear. CI is authoritative for the full
  suite + coverage.
- Date assertions are timezone-hardened: the fixture stamps noon UTC
  (`2026-06-15T12:00:00Z`) and asserts only `Jun` + `2026`, so no UTC offset can
  shift the month.

Closes #1739
