### PR TITLE
fix(course): show empty state for a title-only chapter body

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -232,10 +232,10 @@ function useContentBody(source: ChapterReaderSource): {
 }
 
 function renderBody(body: ContentBody): React.ReactElement {
-  if (body.body_markdown.trim() === '') {
+  const markdown = stripLeadingTitleHeading(body.body_markdown, body.title);
+  if (markdown.trim() === '') {
     return <EmptyView />;
   }
-  const markdown = stripLeadingTitleHeading(body.body_markdown, body.title);
   return (
     <ScrollView
       style={styles.readerScroll}

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -186,6 +186,21 @@ describe('ChapterReader', () => {
     await findByText(/hasn['’]t been written yet/i);
   });
 
+  // A body that is only its duplicate title heading strips down to nothing, so
+  // it must fall through to the empty state — not a headed, bodyless sheet.
+  it('shows the empty state when the body is only its duplicate title heading', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Chapter One',
+      content_type: 'chapter',
+      body_markdown: '# Chapter One\n\n',
+    });
+    const { findByTestId, queryByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByTestId('reader-empty');
+    expect(queryByTestId('reader-markdown')).toBeNull();
+  });
+
   // A single in-paragraph newline (soft break) must reflow to a space.
   it('reflows hard-wrapped lines within a paragraph into a single visual line', async () => {
     mockContentBody.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
`renderBody` in `ChapterReader` chose the empty state by trimming the raw
`body_markdown`, but then stripped the leading duplicate title heading before
rendering. A chapter whose entire body is its title heading (e.g.
`"# Chapter One\n\n"`) has a non-empty raw body — so `EmptyView` was skipped —
yet `stripLeadingTitleHeading` reduced it to `""`, rendering a headed but
bodyless markdown sheet instead of the "Nothing here yet" empty state.

The fix reorders the check: compute the stripped markdown first, then test
**that** for emptiness before choosing `EmptyView` vs. the markdown sheet.
`stripLeadingTitleHeading` is unchanged. The blank-body path is preserved
because that function returns its input unchanged when the first non-empty line
isn't a matching H1.

## Test plan
- Added a regression test asserting a title-only body (`"# Chapter One\n\n"`)
  renders `reader-empty` and not `reader-markdown` — RED before the fix, GREEN
  after.
- Existing guards stay green: blank body → empty state, matching-H1 dedup with
  real body, differing-H1 preserved.
- `scripts/frontend/check-all.sh` (ESLint, Prettier, tsc, Jest) passes; full
  suite 4325 tests green.

Closes #1743