### PR TITLE
refactor(course): dedupe stage glyphs and labels, drop dead memo and guard

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -20,6 +20,15 @@ const STAGE_PILL_SIZE = 40;
 const PROGRESS_BAR_HEIGHT = 6;
 const STAGE_COVER_ARC = 4;
 
+// Shared uppercase small-caps label face (muted); consumers add per-use margins.
+const upperLabel = {
+  fontSize: 12,
+  fontWeight: '600',
+  color: ink.muted,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+} as const;
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -139,11 +148,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   stageDetailLabel: {
-    fontSize: 12,
-    color: ink.muted,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    ...upperLabel,
   },
   stageDetailValue: {
     fontSize: 12,
@@ -162,11 +167,7 @@ const styles = StyleSheet.create({
     ...surfaceShadow.card,
   },
   introCardLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: ink.muted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    ...upperLabel,
     marginBottom: 2,
   },
   introCardTitle: {
@@ -417,11 +418,7 @@ const styles = StyleSheet.create({
     backgroundColor: surface.canvas,
   },
   resourcesHeading: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: ink.muted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    ...upperLabel,
     marginBottom: SPACING.sm,
   },
   resourcesRow: {

--- a/frontend/src/features/Course/CourseDrawer.tsx
+++ b/frontend/src/features/Course/CourseDrawer.tsx
@@ -23,12 +23,14 @@ import {
 import { course as courseApi, type ContentItem, type Stage } from '../../api';
 import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
 
-import { getStageColor, isCompleted, isUnlocked } from './stageDisplay';
+import {
+  getStageColor,
+  isCompleted,
+  isUnlocked,
+  STAGE_LOCKED_GLYPH,
+  stageStatusGlyph,
+} from './stageDisplay';
 
-/** Glyph shown on a completed stage header. */
-const COMPLETED_GLYPH = '✓';
-/** Glyph shown on a locked stage header or chapter row. */
-const LOCKED_GLYPH = '🔒';
 /** Copy for the inline per-section retry row after a failed fetch. */
 const RETRY_LABEL = 'Content failed to load. Tap to retry.';
 /** Dim factor applied to a locked chapter row. */
@@ -112,13 +114,6 @@ export function useCourseDrawerContent(
   return { sections, retry: loadStage };
 }
 
-/** Resolve the status glyph for a stage header, or null for an open stage. */
-function headerGlyph(unlocked: boolean, completed: boolean): string | null {
-  if (completed) return COMPLETED_GLYPH;
-  if (!unlocked) return LOCKED_GLYPH;
-  return null;
-}
-
 interface StageHeaderProps {
   stageNumber: number;
   title: string;
@@ -138,7 +133,7 @@ const StageHeader = ({
   isSelected,
 }: StageHeaderProps): React.JSX.Element => {
   const { width } = useWindowDimensions();
-  const glyph = headerGlyph(unlocked, completed);
+  const glyph = stageStatusGlyph(unlocked, completed);
   return (
     <View
       testID={`course-drawer-stage-${stageNumber}`}
@@ -176,16 +171,13 @@ const ChapterRow = ({ stageNumber, item, onChapterPress }: ChapterRowProps): Rea
       accessibilityLabel={locked ? `${item.title}, locked` : item.title}
       accessibilityState={{ disabled: locked }}
       disabled={locked}
-      onPress={() => {
-        if (locked) return;
-        onChapterPress(stageNumber, item);
-      }}
+      onPress={() => onChapterPress(stageNumber, item)}
       style={[styles.chapterRow, locked && styles.chapterRowLocked]}
     >
       <Text style={[type(width).body, styles.chapterRowLabel]} numberOfLines={1}>
         {item.title}
       </Text>
-      {locked ? <Text style={styles.chapterRowGlyph}>{LOCKED_GLYPH}</Text> : null}
+      {locked ? <Text style={styles.chapterRowGlyph}>{STAGE_LOCKED_GLYPH}</Text> : null}
     </TouchableOpacity>
   );
 };

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -457,29 +457,27 @@ const StagePanel = ({
   stageContent,
   viewer,
 }: StagePanelProps): React.JSX.Element => {
-  const header = useMemo(
-    () => (
-      <StageHeader
-        selectedStage={selectedStage}
-        selectedStageData={selectedStageData}
-        stageContent={stageContent}
-        viewer={viewer}
-      />
-    ),
-    [selectedStage, selectedStageData, stageContent, viewer],
-  );
-
   // While loading or after a failed fetch the list is empty so the header stays
   // pinned and the loading/error state renders in ListEmptyComponent.
   const items =
     stageContent.loadingContent || stageContent.error ? EMPTY_CONTENT : stageContent.content;
 
+  // The header is inlined rather than memoized: stageContent and viewer are
+  // fresh object literals every render, so a useMemo keyed on them never hit
+  // its cache and only added indirection.
   return (
     <ContentArea
       content={items}
       loadingContent={stageContent.loadingContent}
       error={stageContent.error}
-      header={header}
+      header={
+        <StageHeader
+          selectedStage={selectedStage}
+          selectedStageData={selectedStageData}
+          stageContent={stageContent}
+          viewer={viewer}
+        />
+      }
       onContentPress={viewer.handleContentPress}
       onRetry={stageContent.retry}
     />

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -5,7 +5,15 @@ import type { Stage } from '../../api';
 import { readableGlyphOn } from '../../design/tokens';
 
 import styles from './Course.styles';
-import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
+import {
+  getStageColor,
+  isCompleted,
+  isUnlocked,
+  STAGE_COMPLETED_GLYPH,
+  STAGE_LOCKED_GLYPH,
+  stageStatusGlyph,
+  totalStageCount,
+} from './stageDisplay';
 
 interface StageSelectorProps {
   stages: Stage[];
@@ -34,6 +42,9 @@ const StagePill = ({
   // The glyph rides directly on the stage fill, so pick a foreground that
   // clears WCAG AA against this pill's color rather than a fixed canvas tint.
   const glyphColor = readableGlyphOn(color);
+  // Precedence (completed beats locked) lives once in stageStatusGlyph; each
+  // pill only maps the resolved glyph onto its per-state text style.
+  const glyph = stageStatusGlyph(unlocked, completed);
   return (
     <TouchableOpacity
       testID={`stage-pill-${stageNumber}`}
@@ -51,10 +62,10 @@ const StagePill = ({
         completed && !isActive && styles.stagePillCompleted,
       ]}
     >
-      {completed ? (
-        <Text style={[styles.stagePillCheck, { color: glyphColor }]}>{'✓'}</Text>
-      ) : !unlocked ? (
-        <Text style={[styles.stagePillLock, { color: glyphColor }]}>{'🔒'}</Text>
+      {glyph === STAGE_COMPLETED_GLYPH ? (
+        <Text style={[styles.stagePillCheck, { color: glyphColor }]}>{glyph}</Text>
+      ) : glyph === STAGE_LOCKED_GLYPH ? (
+        <Text style={[styles.stagePillLock, { color: glyphColor }]}>{glyph}</Text>
       ) : (
         <Text style={[styles.stagePillText, { color: glyphColor }]}>{stageNumber}</Text>
       )}

--- a/frontend/src/features/Course/__tests__/stageDisplay.test.ts
+++ b/frontend/src/features/Course/__tests__/stageDisplay.test.ts
@@ -6,7 +6,15 @@ import { describe, it, expect } from '@jest/globals';
 
 import type { Stage } from '../../../api';
 import { colors, resolveStageColor, STAGE_ORDER } from '../../../design/tokens';
-import { getStageColor, isCompleted, isUnlocked, totalStageCount } from '../stageDisplay';
+import {
+  getStageColor,
+  isCompleted,
+  isUnlocked,
+  STAGE_COMPLETED_GLYPH,
+  STAGE_LOCKED_GLYPH,
+  stageStatusGlyph,
+  totalStageCount,
+} from '../stageDisplay';
 
 const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
   id: 1,
@@ -94,5 +102,23 @@ describe('isCompleted', () => {
   it('returns false at progress 0', () => {
     const stage = makeStage({ stage_number: 1, progress: 0 });
     expect(isCompleted(1, new Map([[1, stage]]))).toBe(false);
+  });
+});
+
+describe('stageStatusGlyph', () => {
+  it('returns the completed glyph for a completed stage', () => {
+    expect(stageStatusGlyph(true, true)).toBe(STAGE_COMPLETED_GLYPH);
+  });
+
+  it('returns the lock glyph for a locked, incomplete stage', () => {
+    expect(stageStatusGlyph(false, false)).toBe(STAGE_LOCKED_GLYPH);
+  });
+
+  it('returns null for an open (unlocked, incomplete) stage', () => {
+    expect(stageStatusGlyph(true, false)).toBeNull();
+  });
+
+  it('prioritizes completed over locked when a stage is both', () => {
+    expect(stageStatusGlyph(false, true)).toBe(STAGE_COMPLETED_GLYPH);
   });
 });

--- a/frontend/src/features/Course/stageDisplay.ts
+++ b/frontend/src/features/Course/stageDisplay.ts
@@ -35,3 +35,19 @@ export function isCompleted(stageNumber: number, stageById: Map<number, Stage>):
   const stage = stageById.get(stageNumber);
   return stage != null && stage.progress >= COMPLETE_PROGRESS;
 }
+
+/** Glyph marking a completed stage. */
+export const STAGE_COMPLETED_GLYPH = '✓';
+/** Glyph marking a locked stage. */
+export const STAGE_LOCKED_GLYPH = '🔒';
+
+/**
+ * Resolve a stage's status glyph by the shared precedence completed → locked →
+ * none, so the pill row and the drawer header mark a stage identically. Returns
+ * null for an open stage (unlocked and not yet complete).
+ */
+export function stageStatusGlyph(unlocked: boolean, completed: boolean): string | null {
+  if (completed) return STAGE_COMPLETED_GLYPH;
+  if (!unlocked) return STAGE_LOCKED_GLYPH;
+  return null;
+}


### PR DESCRIPTION
## Summary

De-slop bundle for #1744 — four independent Low-severity Course-feature tidy-ups, all behavior-preserving. Reconciled against today's churn (#1745 deep-link, #1747 drawer gap, #1748 `readableGlyphOn`, #1754 empty-state ordering).

1. **Triplicated uppercase-label style** — extracted a shared `upperLabel` base const in `Course.styles.ts`; `stageDetailLabel`, `introCardLabel`, and `resourcesHeading` now spread it and keep their own per-use margins.
2. **Duplicated stage-glyph precedence** — moved the glyph literals and the `completed → locked → none` precedence into `stageDisplay.ts` as `STAGE_COMPLETED_GLYPH` / `STAGE_LOCKED_GLYPH` + a `stageStatusGlyph(unlocked, completed)` helper. Both `CourseDrawer` (StageHeader) and `StageSelector` (StagePill) now consume it; the drawer's local `COMPLETED_GLYPH`/`LOCKED_GLYPH`/`headerGlyph` and StageSelector's inline `'✓'`/`'🔒'` are gone. **Reconciliation note:** #1748's `readableGlyphOn` refactor changed only the glyph *color* in StageSelector, not the literals or precedence — so this finding was still fully valid at HEAD; the glyph-color logic is untouched.
3. **Unreachable `onPress` guard** — removed the dead `if (locked) return;` in `ChapterRow`; `disabled={locked}` is the real (and only) guard.
4. **Ineffective `useMemo`** — inlined `<StageHeader/>` in `StagePanel`, dropping a memo whose deps (`stageContent`, `viewer`) are fresh object literals every render, so it never cached.

Named helper is `stageStatusGlyph` (not the issue's suggested `stageHeaderGlyph`) to avoid colliding with the existing `styles.stageHeaderGlyph` style key.

## Test plan

- New unit tests in `stageDisplay.test.ts` pin the full `stageStatusGlyph` 2×2 matrix including the `locked && completed` precedence edge.
- Existing tests stay green unchanged (the locked-row test still passes without the removed guard, confirming it was unexercised).
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and all 408 suites / 4334 tests pass.
- Gate 2.5 code-review: CLEAN, no blockers.

Closes #1744