### PR TITLE
fix(course): dim stage pills via fill-mix to keep glyph above AA contrast

### DIFF
--- a/frontend/src/design/__tests__/tokens.test.ts
+++ b/frontend/src/design/__tests__/tokens.test.ts
@@ -11,11 +11,13 @@ import {
   colors,
   contentLayout,
   journalLayout,
+  mixColors,
   radius,
   readableGlyphOn,
   resolveStageColor,
   shadows,
   spacing,
+  surface,
   touchTarget,
   type,
   typography,
@@ -352,6 +354,49 @@ describe('design tokens', () => {
 
     it('falls back to the dark-fill glyph color for an unparseable hex', () => {
       expect(readableGlyphOn('not-a-hex')).toBe(GLYPH_ON_DARK_FILL);
+    });
+  });
+
+  describe('mixColors', () => {
+    it('returns the foreground unchanged at full weight', () => {
+      expect(mixColors('#8e44ad', '#faf6ef', 1)).toBe('#8e44ad');
+    });
+
+    it('returns the background unchanged at zero weight', () => {
+      expect(mixColors('#8e44ad', '#faf6ef', 0)).toBe('#faf6ef');
+    });
+
+    it('mixes black and white to the rounded midpoint at half weight', () => {
+      // 0 * 0.5 + 255 * 0.5 = 127.5, which rounds to 128 = 0x80 per channel.
+      expect(mixColors('#000000', '#ffffff', 0.5)).toBe('#808080');
+    });
+
+    it('returns the unparseable foreground unchanged', () => {
+      expect(mixColors('not-a-hex', '#faf6ef', 0.5)).toBe('not-a-hex');
+    });
+
+    it('returns the foreground unchanged when the background is unparseable', () => {
+      expect(mixColors('#8e44ad', 'not-a-hex', 0.5)).toBe('#8e44ad');
+    });
+  });
+
+  describe('readableGlyphOn against a dimmed fill', () => {
+    // Mirrors the stagePillFill locked/completed fill weights (stageDisplay.ts).
+    const LOCKED_WEIGHT = 0.4;
+    const COMPLETED_WEIGHT = 0.8;
+
+    it.each(STAGE_ORDER)('clears AA on the locked-weight dimmed %s fill', (name) => {
+      const fill = STAGE_COLORS[name]!;
+      const dimmedFill = mixColors(fill, surface.canvas, LOCKED_WEIGHT);
+      const glyphColor = readableGlyphOn(dimmedFill);
+      expect(contrast(glyphColor, dimmedFill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it.each(STAGE_ORDER)('clears AA on the completed-weight dimmed %s fill', (name) => {
+      const fill = STAGE_COLORS[name]!;
+      const dimmedFill = mixColors(fill, surface.canvas, COMPLETED_WEIGHT);
+      const glyphColor = readableGlyphOn(dimmedFill);
+      expect(contrast(glyphColor, dimmedFill)).toBeGreaterThanOrEqual(AA_NORMAL);
     });
   });
 });

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -249,6 +249,25 @@ export const brightenColor = (hex: string): string => {
   );
 };
 
+/**
+ * Alpha-composite a foreground hex over a background hex at the given weight:
+ * each channel becomes fg*weight + bg*(1-weight). Used to bake a stage pill's
+ * dimming into its fill color so the glyph can stay full-opacity while the
+ * effective contrast is computed against the flattened result. Weight 1 returns
+ * the foreground and weight 0 the background. Either input failing to parse as
+ * 6-digit hex returns the foreground unchanged (mirrors brightenColor).
+ */
+export const mixColors = (fgHex: string, bgHex: string, weight: number): string => {
+  const fg = parseHexRgb(fgHex);
+  const bg = parseHexRgb(bgHex);
+  if (!fg || !bg) return fgHex;
+  return toHexColor(
+    fg[0] * weight + bg[0] * (1 - weight),
+    fg[1] * weight + bg[1] * (1 - weight),
+    fg[2] * weight + bg[2] * (1 - weight),
+  );
+};
+
 /** Black glyph foreground, chosen when it out-contrasts white on a fill. */
 export const GLYPH_ON_LIGHT_FILL = '#000000';
 

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -54,12 +54,6 @@ const styles = StyleSheet.create({
     borderColor: accent.primary,
     ...shadows.medium,
   },
-  stagePillLocked: {
-    opacity: 0.4,
-  },
-  stagePillCompleted: {
-    opacity: 0.8,
-  },
   stagePillText: {
     fontSize: 14,
     fontWeight: '700',

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -5,7 +5,13 @@ import type { Stage } from '../../api';
 import { readableGlyphOn } from '../../design/tokens';
 
 import styles from './Course.styles';
-import { getStageColor, isCompleted, isUnlocked, totalStageCount } from './stageDisplay';
+import {
+  getStageColor,
+  isCompleted,
+  isUnlocked,
+  stagePillFill,
+  totalStageCount,
+} from './stageDisplay';
 
 interface StageSelectorProps {
   stages: Stage[];
@@ -31,9 +37,11 @@ const StagePill = ({
   color,
   onSelectStage,
 }: StagePillProps): React.JSX.Element => {
-  // The glyph rides directly on the stage fill, so pick a foreground that
-  // clears WCAG AA against this pill's color rather than a fixed canvas tint.
-  const glyphColor = readableGlyphOn(color);
+  // Locked/completed dimming is baked into the fill, so the glyph rides on the
+  // dimmed color; pick a foreground that clears WCAG AA against that effective
+  // fill rather than the raw stage color or a fixed canvas tint.
+  const effectiveFill = stagePillFill(color, { unlocked, completed, isActive });
+  const glyphColor = readableGlyphOn(effectiveFill);
   return (
     <TouchableOpacity
       testID={`stage-pill-${stageNumber}`}
@@ -45,10 +53,8 @@ const StagePill = ({
       onPress={() => onSelectStage(stageNumber)}
       style={[
         styles.stagePill,
-        { backgroundColor: color },
+        { backgroundColor: effectiveFill },
         isActive && styles.stagePillActive,
-        !unlocked && styles.stagePillLocked,
-        completed && !isActive && styles.stagePillCompleted,
       ]}
     >
       {completed ? (

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -6,8 +6,11 @@ import { StyleSheet } from 'react-native';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 import type { Stage } from '../../../api';
-import { colors, STAGE_COLORS, STAGE_ORDER } from '../../../design/tokens';
+import { colors, STAGE_COLORS, STAGE_ORDER, surface } from '../../../design/tokens';
+import { stagePillFill } from '../stageDisplay';
 import StageSelector from '../StageSelector';
+
+type PillInstance = ReturnType<ReturnType<typeof render>['getByTestId']>;
 
 function backgroundColorOf(style: StyleProp<ViewStyle>): string {
   const flat = StyleSheet.flatten(style) ?? {};
@@ -203,7 +206,13 @@ describe('StageSelector', () => {
 
     const pill1 = getByTestId('stage-pill-1');
     const style = pill1.props.style as StyleProp<ViewStyle>;
-    expect(backgroundColorOf(style)).toBe(STAGE_COLORS[STAGE_ORDER[0]!]);
+    expect(backgroundColorOf(style)).toBe(
+      stagePillFill(STAGE_COLORS[STAGE_ORDER[0]!]!, {
+        unlocked: false,
+        completed: false,
+        isActive: true,
+      }),
+    );
     expect(pill1.props.accessibilityState).toMatchObject({ selected: true, disabled: true });
   });
 
@@ -217,7 +226,9 @@ describe('StageSelector', () => {
 
     const pill11 = getByTestId('stage-pill-11');
     const style = pill11.props.style as StyleProp<ViewStyle>;
-    expect(backgroundColorOf(style)).toBe(colors.neutral);
+    expect(backgroundColorOf(style)).toBe(
+      stagePillFill(colors.neutral, { unlocked: false, completed: false, isActive: false }),
+    );
   });
 
   it('renders the lock glyph for a locked, non-completed stage', () => {
@@ -342,6 +353,145 @@ describe('StageSelector', () => {
       const glyph = within(pill).getByText('🔒');
       const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
       expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+  });
+
+  describe('effective (composited) glyph contrast', () => {
+    // Opacity 1 is the default when a pill has neither the locked nor the
+    // completed style applied; named so the fallback isn't a bare literal.
+    const FULL_OPACITY = 1;
+    const NO_ACTIVE_STAGE = 99;
+
+    /** Alpha-composite two #rrggbb colors, mirroring what whole-pill opacity does to rendered pixels. */
+    const composite = (fgHex: string, bgHex: string, weight: number): string => {
+      const fgMatch = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(fgHex);
+      const bgMatch = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i.exec(bgHex);
+      if (!fgMatch || !bgMatch) throw new Error(`not a 6-digit hex: ${fgHex} / ${bgHex}`);
+      const mixedChannel = (index: number): number => {
+        const fgChannel = Number.parseInt(fgMatch[index]!, 16);
+        const bgChannel = Number.parseInt(bgMatch[index]!, 16);
+        return Math.round(fgChannel * weight + bgChannel * (1 - weight));
+      };
+      const channels = [1, 2, 3].map(mixedChannel);
+      return `#${channels.map((c) => c.toString(16).padStart(2, '0')).join('')}`;
+    };
+
+    const effectiveContrastOf = (pill: PillInstance, glyphText: string): number => {
+      const flat = StyleSheet.flatten(pill.props.style as StyleProp<ViewStyle>) ?? {};
+      const fill = (flat.backgroundColor as string | undefined) ?? '';
+      const opacity = (flat.opacity as number | undefined) ?? FULL_OPACITY;
+      const glyph = within(pill).getByText(glyphText);
+      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
+      const effFill = composite(fill, surface.canvas, opacity);
+      const effGlyph = composite(glyphColor, surface.canvas, opacity);
+      return contrast(effGlyph, effFill);
+    };
+
+    it.each(STAGE_ORDER)('locked %s pill clears effective AA contrast on the canvas', (name) => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: name,
+          is_unlocked: false,
+          progress: 0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector
+          stages={stages}
+          selectedStage={NO_ACTIVE_STAGE}
+          onSelectStage={onSelectStage}
+        />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      expect(effectiveContrastOf(pill, '🔒')).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it.each(STAGE_ORDER)(
+      'completed non-active %s pill clears effective AA contrast on the canvas',
+      (name) => {
+        const stages = [
+          makeStage({
+            stage_number: 1,
+            spiral_dynamics_color: name,
+            is_unlocked: true,
+            progress: 1.0,
+          }),
+        ];
+        const { getByTestId } = render(
+          <StageSelector
+            stages={stages}
+            selectedStage={NO_ACTIVE_STAGE}
+            onSelectStage={onSelectStage}
+          />,
+        );
+
+        const pill = getByTestId('stage-pill-1');
+        expect(effectiveContrastOf(pill, '✓')).toBeGreaterThanOrEqual(AA_NORMAL);
+      },
+    );
+
+    it('dims the locked Ultraviolet fill so the rendered color is no longer the raw stage color', () => {
+      const stages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: 'Ultraviolet',
+          is_unlocked: false,
+          progress: 0,
+        }),
+      ];
+      const { getByTestId } = render(
+        <StageSelector
+          stages={stages}
+          selectedStage={NO_ACTIVE_STAGE}
+          onSelectStage={onSelectStage}
+        />,
+      );
+
+      const pill = getByTestId('stage-pill-1');
+      const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
+      expect(fill).not.toBe(STAGE_COLORS['Ultraviolet']);
+    });
+
+    it('dims a locked+completed pill at a different weight when non-active versus active', () => {
+      const stageColor = 'Ultraviolet';
+
+      const nonActiveStages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: stageColor,
+          is_unlocked: false,
+          progress: 1.0,
+        }),
+      ];
+      const nonActiveResult = render(
+        <StageSelector
+          stages={nonActiveStages}
+          selectedStage={NO_ACTIVE_STAGE}
+          onSelectStage={onSelectStage}
+        />,
+      );
+      const nonActiveFill = backgroundColorOf(
+        nonActiveResult.getByTestId('stage-pill-1').props.style as StyleProp<ViewStyle>,
+      );
+
+      const activeStages = [
+        makeStage({
+          stage_number: 1,
+          spiral_dynamics_color: stageColor,
+          is_unlocked: false,
+          progress: 1.0,
+        }),
+      ];
+      const activeResult = render(
+        <StageSelector stages={activeStages} selectedStage={1} onSelectStage={onSelectStage} />,
+      );
+      const activeFill = backgroundColorOf(
+        activeResult.getByTestId('stage-pill-1').props.style as StyleProp<ViewStyle>,
+      );
+
+      expect(nonActiveFill).not.toBe(activeFill);
     });
   });
 });

--- a/frontend/src/features/Course/stageDisplay.ts
+++ b/frontend/src/features/Course/stageDisplay.ts
@@ -5,10 +5,37 @@
  * side redefining them.
  */
 import type { Stage } from '../../api';
-import { STAGE_ORDER, resolveStageColor } from '../../design/tokens';
+import { STAGE_ORDER, mixColors, resolveStageColor, surface } from '../../design/tokens';
 
 /** Progress value at which a stage counts as fully completed. */
 const COMPLETE_PROGRESS = 1;
+
+/** Fill weight for a locked pill — mixes 40% stage color into the canvas. */
+const LOCKED_FILL_WEIGHT = 0.4;
+
+/** Fill weight for a completed, non-active pill — a gentler 80% dim. */
+const COMPLETED_FILL_WEIGHT = 0.8;
+
+/**
+ * Resolve the background fill for a stage pill, baking any locked/completed
+ * dimming into the color itself so the glyph can stay full-opacity. Completed
+ * (non-active) wins over locked, matching the prior style precedence; an
+ * unlocked, uncompleted pill keeps its raw stage color.
+ */
+export function stagePillFill(
+  color: string,
+  state: { unlocked: boolean; completed: boolean; isActive: boolean },
+): string {
+  let weight: number;
+  if (state.completed && !state.isActive) {
+    weight = COMPLETED_FILL_WEIGHT;
+  } else if (!state.unlocked) {
+    weight = LOCKED_FILL_WEIGHT;
+  } else {
+    return color;
+  }
+  return mixColors(color, surface.canvas, weight);
+}
 
 /** Derive the total number of stages from the API response (the max number). */
 export function totalStageCount(stages: Stage[]): number {


### PR DESCRIPTION
## Summary

Locked (`opacity: 0.4`) and completed (`opacity: 0.8`) Course stage pills previously dimmed via whole-pill opacity, which composited **both** the fill and the contrast-aware glyph (#1748's `readableGlyphOn`) toward the canvas — dropping the effective on-screen glyph-on-fill contrast back below WCAG AA (4.5:1) even though the un-dimmed pair passes.

This bakes the dimming into the **fill color** instead:
- New pure `mixColors(fgHex, bgHex, weight)` alpha-composite helper in `design/tokens.ts` (reuses the existing hex parse/emit; unparseable input passes through, mirroring `brightenColor`).
- New `stagePillFill(color, { unlocked, completed, isActive })` in `Course/stageDisplay.ts` mixes the stage color toward `surface.canvas` at named weights (`LOCKED_FILL_WEIGHT` 0.4, `COMPLETED_FILL_WEIGHT` 0.8), preserving the prior flatten precedence (completed-non-active beats locked; active/undimmed keeps the raw color).
- `StageSelector` now sets `backgroundColor` to that effective fill and computes `readableGlyphOn(effectiveFill)`, so the glyph renders at **full opacity** and the AA guarantee holds for the rendered pixels.
- Removed the now-unused `stagePillLocked`/`stagePillCompleted` opacity styles.

The rendered fill is visually identical to before (the pill sits on `surface.canvas`, so the old opacity composited the fill by the same amount now baked in) — only the glyph is repaired.

## Test plan

- RED-first: extended the effective-contrast tests to composite each pill's rendered fill + glyph over the canvas at its actual opacity and assert ≥ 4.5:1 — failed under the old opacity path (e.g. locked Ultraviolet ≈ 1.87:1), passes after the fill-mix.
- `StageSelector.test.tsx`: `it.each` over all 10 stage colors for locked and completed-non-active pills asserting effective AA; plus dim-cue and locked+completed precedence assertions.
- `tokens.test.ts`: `mixColors` unit tests (identity/midpoint/unparseable) and `readableGlyphOn`-against-dimmed-fill AA across all 10 stages × both weights.
- #1748's existing glyph-contrast tests remain green.
- Full frontend `check-all`: eslint, prettier, tsc clean; jest 4378/4378 pass.

Closes #1749