### PR TITLE
fix(course): render locked stage-pill with a tintable Lock icon for real AA contrast

### DIFF
--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -70,9 +70,6 @@ const styles = StyleSheet.create({
   stagePillCheck: {
     fontSize: 16,
   },
-  stagePillLock: {
-    fontSize: 14,
-  },
 
   // Stage cover — the showcase "book cover" for the selected stage.
   stageCover: {

--- a/frontend/src/features/Course/StageSelector.tsx
+++ b/frontend/src/features/Course/StageSelector.tsx
@@ -1,3 +1,4 @@
+import { Lock } from 'lucide-react-native';
 import React from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 
@@ -10,11 +11,14 @@ import {
   isCompleted,
   isUnlocked,
   STAGE_COMPLETED_GLYPH,
-  STAGE_LOCKED_GLYPH,
+  STAGE_STATUS,
   stagePillFill,
-  stageStatusGlyph,
+  stageStatus,
   totalStageCount,
 } from './stageDisplay';
+
+// Matches the removed stagePillLock fontSize so the tintable icon keeps the emoji's footprint.
+const STAGE_PILL_LOCK_ICON_SIZE = 14;
 
 interface StageSelectorProps {
   stages: Stage[];
@@ -45,9 +49,9 @@ const StagePill = ({
   // fill rather than the raw stage color or a fixed canvas tint.
   const effectiveFill = stagePillFill(color, { unlocked, completed, isActive });
   const glyphColor = readableGlyphOn(effectiveFill);
-  // Precedence (completed beats locked) lives once in stageStatusGlyph; each
-  // pill only maps the resolved glyph onto its per-state text style.
-  const glyph = stageStatusGlyph(unlocked, completed);
+  // Precedence (completed beats locked) lives once in stageStatus; each pill
+  // only maps the resolved status onto its per-state marker.
+  const status = stageStatus(unlocked, completed);
   return (
     <TouchableOpacity
       testID={`stage-pill-${stageNumber}`}
@@ -63,10 +67,10 @@ const StagePill = ({
         isActive && styles.stagePillActive,
       ]}
     >
-      {glyph === STAGE_COMPLETED_GLYPH ? (
-        <Text style={[styles.stagePillCheck, { color: glyphColor }]}>{glyph}</Text>
-      ) : glyph === STAGE_LOCKED_GLYPH ? (
-        <Text style={[styles.stagePillLock, { color: glyphColor }]}>{glyph}</Text>
+      {status === STAGE_STATUS.Completed ? (
+        <Text style={[styles.stagePillCheck, { color: glyphColor }]}>{STAGE_COMPLETED_GLYPH}</Text>
+      ) : status === STAGE_STATUS.Locked ? (
+        <Lock size={STAGE_PILL_LOCK_ICON_SIZE} color={glyphColor} />
       ) : (
         <Text style={[styles.stagePillText, { color: glyphColor }]}>{stageNumber}</Text>
       )}

--- a/frontend/src/features/Course/__tests__/StageSelector.test.tsx
+++ b/frontend/src/features/Course/__tests__/StageSelector.test.tsx
@@ -2,11 +2,18 @@
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { render, fireEvent, within } from '@testing-library/react-native';
+import { Lock } from 'lucide-react-native';
 import { StyleSheet } from 'react-native';
 import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 import type { Stage } from '../../../api';
-import { colors, STAGE_COLORS, STAGE_ORDER, surface } from '../../../design/tokens';
+import {
+  colors,
+  readableGlyphOn,
+  STAGE_COLORS,
+  STAGE_ORDER,
+  surface,
+} from '../../../design/tokens';
 import { stagePillFill } from '../stageDisplay';
 import StageSelector from '../StageSelector';
 
@@ -231,18 +238,21 @@ describe('StageSelector', () => {
     );
   });
 
-  it('renders the lock glyph for a locked, non-completed stage', () => {
+  it('renders a Lock icon (not the emoji) for a locked, non-completed stage', () => {
     const stages = [makeStage({ stage_number: 1, is_unlocked: false, progress: 0 })];
     const { getByTestId } = render(
       <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
     );
 
-    expect(within(getByTestId('stage-pill-1')).getByText('🔒')).toBeTruthy();
+    const pill1 = getByTestId('stage-pill-1');
+    expect(pill1.findByType(Lock)).toBeTruthy();
+    expect(within(pill1).queryByText('🔒')).toBeNull();
+    expect(pill1.props.testID).toBe('stage-pill-1');
   });
 
-  it('prioritizes the completed checkmark over the lock glyph when a stage is both', () => {
+  it('prioritizes the completed checkmark over the Lock icon when a stage is both', () => {
     // Unusual API data (progress complete but is_unlocked false) pins the
-    // ternary order: completed wins the glyph even though the pill is locked.
+    // precedence: completed wins the glyph even though the pill is locked.
     const stages = [makeStage({ stage_number: 1, is_unlocked: false, progress: 1.0 })];
     const { getByTestId } = render(
       <StageSelector stages={stages} selectedStage={1} onSelectStage={onSelectStage} />,
@@ -250,6 +260,7 @@ describe('StageSelector', () => {
 
     const pill1 = getByTestId('stage-pill-1');
     expect(within(pill1).getByText('✓')).toBeTruthy();
+    expect(pill1.findAllByType(Lock)).toHaveLength(0);
     expect(within(pill1).queryByText('🔒')).toBeNull();
     expect(pill1.props.accessibilityLabel).toBe('Stage 1, locked, completed');
   });
@@ -315,7 +326,7 @@ describe('StageSelector', () => {
       expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
     });
 
-    it('renders the lock glyph readably on a light stage fill', () => {
+    it('renders the Lock icon readably on a light stage fill', () => {
       const stages = [
         makeStage({
           stage_number: 1,
@@ -330,12 +341,12 @@ describe('StageSelector', () => {
 
       const pill = getByTestId('stage-pill-1');
       const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
-      const glyph = within(pill).getByText('🔒');
-      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
-      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+      const lockColor = pill.findByType(Lock).props.color as string;
+      expect(contrast(lockColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+      expect(lockColor).toBe(readableGlyphOn(fill));
     });
 
-    it('renders the lock glyph readably on the Ultraviolet dark stage fill', () => {
+    it('renders the Lock icon readably on the Ultraviolet dark stage fill', () => {
       const stages = [
         makeStage({
           stage_number: 1,
@@ -350,9 +361,9 @@ describe('StageSelector', () => {
 
       const pill = getByTestId('stage-pill-1');
       const fill = backgroundColorOf(pill.props.style as StyleProp<ViewStyle>);
-      const glyph = within(pill).getByText('🔒');
-      const glyphColor = glyphColorOf(glyph.props.style as StyleProp<TextStyle>);
-      expect(contrast(glyphColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+      const lockColor = pill.findByType(Lock).props.color as string;
+      expect(contrast(lockColor, fill)).toBeGreaterThanOrEqual(AA_NORMAL);
+      expect(lockColor).toBe(readableGlyphOn(fill));
     });
   });
 
@@ -387,6 +398,16 @@ describe('StageSelector', () => {
       return contrast(effGlyph, effFill);
     };
 
+    const effectiveIconContrastOf = (pill: PillInstance): number => {
+      const flat = StyleSheet.flatten(pill.props.style as StyleProp<ViewStyle>) ?? {};
+      const fill = (flat.backgroundColor as string | undefined) ?? '';
+      const opacity = (flat.opacity as number | undefined) ?? FULL_OPACITY;
+      const lockColor = pill.findByType(Lock).props.color as string;
+      const effFill = composite(fill, surface.canvas, opacity);
+      const effIcon = composite(lockColor, surface.canvas, opacity);
+      return contrast(effIcon, effFill);
+    };
+
     it.each(STAGE_ORDER)('locked %s pill clears effective AA contrast on the canvas', (name) => {
       const stages = [
         makeStage({
@@ -405,7 +426,7 @@ describe('StageSelector', () => {
       );
 
       const pill = getByTestId('stage-pill-1');
-      expect(effectiveContrastOf(pill, '🔒')).toBeGreaterThanOrEqual(AA_NORMAL);
+      expect(effectiveIconContrastOf(pill)).toBeGreaterThanOrEqual(AA_NORMAL);
     });
 
     it.each(STAGE_ORDER)(

--- a/frontend/src/features/Course/__tests__/stageDisplay.test.ts
+++ b/frontend/src/features/Course/__tests__/stageDisplay.test.ts
@@ -12,6 +12,8 @@ import {
   isUnlocked,
   STAGE_COMPLETED_GLYPH,
   STAGE_LOCKED_GLYPH,
+  STAGE_STATUS,
+  stageStatus,
   stageStatusGlyph,
   totalStageCount,
 } from '../stageDisplay';
@@ -102,6 +104,24 @@ describe('isCompleted', () => {
   it('returns false at progress 0', () => {
     const stage = makeStage({ stage_number: 1, progress: 0 });
     expect(isCompleted(1, new Map([[1, stage]]))).toBe(false);
+  });
+});
+
+describe('stageStatus', () => {
+  it('returns Completed for a completed, unlocked stage', () => {
+    expect(stageStatus(true, true)).toBe(STAGE_STATUS.Completed);
+  });
+
+  it('prioritizes Completed over Locked when a stage is both', () => {
+    expect(stageStatus(false, true)).toBe(STAGE_STATUS.Completed);
+  });
+
+  it('returns Locked for a locked, incomplete stage', () => {
+    expect(stageStatus(false, false)).toBe(STAGE_STATUS.Locked);
+  });
+
+  it('returns null for an open (unlocked, incomplete) stage', () => {
+    expect(stageStatus(true, false)).toBeNull();
   });
 });
 

--- a/frontend/src/features/Course/stageDisplay.ts
+++ b/frontend/src/features/Course/stageDisplay.ts
@@ -68,13 +68,29 @@ export const STAGE_COMPLETED_GLYPH = '✓';
 /** Glyph marking a locked stage. */
 export const STAGE_LOCKED_GLYPH = '🔒';
 
+/** Discriminated marker states for a stage, absent an open (uncompleted, unlocked) stage. */
+export const STAGE_STATUS = { Completed: 'completed', Locked: 'locked' } as const;
+/** A stage's marker status, or null when the stage is open. */
+export type StageStatus = (typeof STAGE_STATUS)[keyof typeof STAGE_STATUS];
+
 /**
- * Resolve a stage's status glyph by the shared precedence completed → locked →
- * none, so the pill row and the drawer header mark a stage identically. Returns
- * null for an open stage (unlocked and not yet complete).
+ * Resolve a stage's marker status by the shared precedence completed → locked →
+ * none, so the pill row and the drawer header classify a stage identically.
+ * Returns null for an open stage (unlocked and not yet complete).
+ */
+export function stageStatus(unlocked: boolean, completed: boolean): StageStatus | null {
+  if (completed) return STAGE_STATUS.Completed;
+  if (!unlocked) return STAGE_STATUS.Locked;
+  return null;
+}
+
+/**
+ * Thin wrapper mapping the resolved stage status onto its glyph, so glyph
+ * consumers share the precedence in stageStatus. Returns null for an open stage.
  */
 export function stageStatusGlyph(unlocked: boolean, completed: boolean): string | null {
-  if (completed) return STAGE_COMPLETED_GLYPH;
-  if (!unlocked) return STAGE_LOCKED_GLYPH;
+  const status = stageStatus(unlocked, completed);
+  if (status === STAGE_STATUS.Completed) return STAGE_COMPLETED_GLYPH;
+  if (status === STAGE_STATUS.Locked) return STAGE_LOCKED_GLYPH;
   return null;
 }


### PR DESCRIPTION
## Summary

The Course locked stage-pill drew its marker with the lock **emoji**, which renders with OS emoji coloring and largely ignores the `color` style on-device. That meant PR #1756's `readableGlyphOn(stagePillFill(...))` AA-contrast guarantee never reached the actual rendered pixels — the locked-pill contrast was only theoretical.

This swaps the emoji for lucide-react-native's tintable `Lock` vector icon, wired through the **same** `readableGlyphOn(stagePillFill(...))` color path so the computed contrast color now reaches the pixels.

- Added a `stageStatus()` discriminator (`STAGE_STATUS` const object) in `stageDisplay.ts` so `StageSelector` can render either the `✓` text glyph (completed) or the `Lock` icon (locked) or the stage number.
- Refactored `stageStatusGlyph()` into a thin wrapper delegating to `stageStatus()`, so `CourseDrawer` — which still renders the emoji strings on neutral drawer surfaces — is untouched and its tests stay green.
- The completed `✓` is kept as text (text checkmarks honor `color`; only the emoji lock was broken).
- Removed the now-dead `stagePillLock` style; the icon size is a named constant matching the prior footprint.

The pill's `testID` and `accessibilityLabel` (which already announces ", locked") are unchanged, and the `Lock` SVG sits inside the `accessible` TouchableOpacity so it is not double-announced.

## Test plan

- Extended the #1749 contrast tests to assert the locked glyph's **real** rendering path: the `Lock` icon's `color` prop equals `readableGlyphOn(fill)` and clears WCAG AA, including the `it.each(STAGE_ORDER)` effective-composite sweep now reading the icon color.
- Added `stageStatus` discriminator unit tests (precedence completed → locked → open) and kept the existing `stageStatusGlyph` wrapper tests (drawer contract).
- Migrated the locked-pill assertions from the `🔒` emoji Text to `pill.findByType(Lock)`; assert no `🔒` text renders in the pill.
- `./scripts/frontend/check-all.sh` green locally (ESLint, Prettier, TypeScript, 4386 Jest tests). CourseDrawer suite green untouched.

Closes #1757