### PR TITLE
feat(frontend): fade scrollable screens' bottom edge into the canvas ground

### DIFF
--- a/frontend/src/components/layout/BottomFade.tsx
+++ b/frontend/src/components/layout/BottomFade.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg';
+
+import { rhythm, surface } from '@/design/tokens';
+
+/**
+ * A sibling overlay that dissolves the bottom edge of a scroll surface into the
+ * canvas ground, so long content appears to fade out rather than clip at a hard
+ * line. The transparent stop is `surface.canvas` at zero opacity, not black --
+ * a black-to-opaque ramp prints a visible grey mid-fringe on the warm ground,
+ * while fading between two stops of the same color is invisible until the
+ * opacity itself takes over. It renders as an absolutely-positioned sibling of
+ * the ScrollView, never as a scroll child, so the ScrollView's own
+ * `contentContainerStyle` keeps sole ownership of the height/grow contract
+ * that makes native scrolling work. It is `pointerEvents="none"` so it never
+ * intercepts taps on the controls it overlaps.
+ *
+ * The veil is a fixed `rhythm.bottomFadeHeight` tall, pinned to its container's
+ * bottom edge; its opaque `surface.canvas` base blends seamlessly into whatever
+ * ground sits below -- the physical screen bottom (where it covers the home
+ * indicator zone) or a bottom safe-area region (where a `SafeAreaView` has
+ * already inset the content). A fixed height keeps the fade consistent across
+ * both layouts instead of double-counting the inset. Callers pad the scroller's
+ * content by `rhythm.bottomFadeHeight` (see `ScreenScaffold`'s `scrollContent`
+ * style) so the veil only ever covers already-read trailing whitespace, never
+ * the last line of real content.
+ */
+export const BottomFade = ({ testID = 'bottom-fade' }: { testID?: string }): React.JSX.Element => (
+  <View pointerEvents="none" style={styles.overlay} testID={testID}>
+    <Svg width="100%" height="100%">
+      <Defs>
+        <LinearGradient id="bottom-fade-grad" x1="0" y1="0" x2="0" y2="1">
+          <Stop offset="0" stopColor={surface.canvas} stopOpacity="0" />
+          <Stop offset="1" stopColor={surface.canvas} stopOpacity="1" />
+        </LinearGradient>
+      </Defs>
+      <Rect width="100%" height="100%" fill="url(#bottom-fade-grad)" />
+    </Svg>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: rhythm.bottomFadeHeight,
+  },
+});
+
+export default BottomFade;

--- a/frontend/src/components/layout/ScreenScaffold.tsx
+++ b/frontend/src/components/layout/ScreenScaffold.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
+import { BottomFade } from './BottomFade';
 import { ContentContainer } from './ContentContainer';
 
 import { rhythm, surface } from '@/design/tokens';
@@ -28,16 +29,21 @@ export const ScreenScaffold = ({
 }: ScreenScaffoldProps): React.JSX.Element => {
   if (scroll) {
     return (
-      <ScrollView
-        style={styles.ground}
-        // Invariant: only the ScrollView content container grows. The inner
-        // wrapper stays content-sized so the native contentSize tracks the real
-        // content height (fills when short, scrolls when tall — journal idiom).
-        contentContainerStyle={[styles.content, styles.scrollContent, style]}
-        testID={testID}
-      >
-        <ContentContainer>{children}</ContentContainer>
-      </ScrollView>
+      <View style={styles.ground}>
+        <ScrollView
+          style={styles.fill}
+          // Invariant: only the ScrollView content container grows. The inner
+          // wrapper stays content-sized so the native contentSize tracks the real
+          // content height (fills when short, scrolls when tall — journal idiom).
+          // The BottomFade is an absolutely-positioned sibling (not a scroll
+          // child) so it stays pinned while content scrolls beneath it.
+          contentContainerStyle={[styles.content, styles.scrollContent, style]}
+          testID={testID}
+        >
+          <ContentContainer>{children}</ContentContainer>
+        </ScrollView>
+        <BottomFade />
+      </View>
     );
   }
   return (
@@ -52,11 +58,16 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: surface.canvas,
   },
+  fill: {
+    flex: 1,
+  },
   content: {
     paddingHorizontal: rhythm.screenPaddingH,
     paddingTop: rhythm.screenPaddingTop,
   },
   scrollContent: {
     flexGrow: 1,
+    // Clear the BottomFade veil so the final line of content is never masked.
+    paddingBottom: rhythm.bottomFadeHeight,
   },
 });

--- a/frontend/src/components/layout/__tests__/BottomFade.test.tsx
+++ b/frontend/src/components/layout/__tests__/BottomFade.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+import renderer from 'react-test-renderer';
+
+import { BottomFade } from '../BottomFade';
+
+import { rhythm, surface } from '@/design/tokens';
+
+// react-test-renderer ships no type definitions in this project, so test
+// instances are annotated structurally (matching the TierStar renderer tests)
+// to satisfy noImplicitAny.
+interface TestNode {
+  props: Record<string, unknown>;
+}
+
+type Rendered = ReturnType<typeof renderer.create>;
+
+const findStopAtOffset = (component: Rendered, offset: string): TestNode =>
+  component.root.find(
+    (node: TestNode) => node.props.offset === offset && 'stopColor' in node.props,
+  );
+
+const findGradient = (component: Rendered): TestNode =>
+  component.root.find((node: TestNode) => node.props.id === 'bottom-fade-grad');
+
+describe('BottomFade', () => {
+  it('fades from transparent to the canvas surface color, top to bottom', () => {
+    const component = renderer.create(<BottomFade />);
+    const top = findStopAtOffset(component, '0').props;
+    expect(top.stopColor).toBe(surface.canvas);
+    expect(top.stopOpacity).toBe('0');
+    const bottom = findStopAtOffset(component, '1').props;
+    expect(bottom.stopColor).toBe(surface.canvas);
+    expect(bottom.stopOpacity).toBe('1');
+  });
+
+  it('orients the gradient vertically', () => {
+    const component = renderer.create(<BottomFade />);
+    const gradient = findGradient(component).props;
+    expect(gradient.x1).toBe('0');
+    expect(gradient.y1).toBe('0');
+    expect(gradient.x2).toBe('0');
+    expect(gradient.y2).toBe('1');
+  });
+
+  it('is non-interactive and pinned to the bottom edge', () => {
+    const { getByTestId } = render(<BottomFade />);
+    const wrapper = getByTestId('bottom-fade');
+    expect(wrapper.props.pointerEvents).toBe('none');
+    const flat = StyleSheet.flatten(wrapper.props.style);
+    expect(flat.position).toBe('absolute');
+    expect(flat.bottom).toBe(0);
+  });
+
+  it('sizes its height from the rhythm token', () => {
+    const { getByTestId } = render(<BottomFade />);
+    const flat = StyleSheet.flatten(getByTestId('bottom-fade').props.style);
+    expect(flat.height).toBe(rhythm.bottomFadeHeight);
+  });
+
+  it('keeps a fixed veil height regardless of the bottom safe-area inset', () => {
+    const { getByTestId } = render(
+      <SafeAreaInsetsContext.Provider value={{ top: 0, bottom: 34, left: 0, right: 0 }}>
+        <BottomFade />
+      </SafeAreaInsetsContext.Provider>,
+    );
+    const flat = StyleSheet.flatten(getByTestId('bottom-fade').props.style);
+    expect(flat.height).toBe(rhythm.bottomFadeHeight);
+  });
+
+  it('forwards a custom testID', () => {
+    const { getByTestId } = render(<BottomFade testID="fade-x" />);
+    expect(getByTestId('fade-x')).toBeTruthy();
+  });
+
+  it('does not intercept touches on controls it overlaps', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByText } = render(
+      <View>
+        <Pressable onPress={onPress}>
+          <Text>Underneath</Text>
+        </Pressable>
+        <BottomFade />
+      </View>,
+    );
+    expect(getByTestId('bottom-fade').props.pointerEvents).toBe('none');
+    fireEvent.press(getByText('Underneath'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
+++ b/frontend/src/components/layout/__tests__/ScreenScaffold.test.tsx
@@ -114,4 +114,22 @@ describe('ScreenScaffold', () => {
     expect(flat.paddingHorizontal).toBe(rhythm.screenPaddingH);
     expect(flat.paddingTop).toBe(rhythm.screenPaddingTop);
   });
+
+  it('fades the bottom edge into the canvas ground in scroll mode', () => {
+    const { getByTestId } = render(
+      <ScreenScaffold scroll>
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    expect(getByTestId('bottom-fade')).toBeTruthy();
+  });
+
+  it('does not render the bottom fade in the plain (non-scroll) mode', () => {
+    const { queryByTestId } = render(
+      <ScreenScaffold>
+        <Text>x</Text>
+      </ScreenScaffold>,
+    );
+    expect(queryByTestId('bottom-fade')).toBeNull();
+  });
 });

--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -32,6 +32,13 @@ The language began on the journal-resonance surface (`colors.paper`,
 `accent.onPrimary` is a foreground that clears AA on the `accent.primary` fill
 instead. Enforced by `__tests__/semanticTokens.test.ts`.
 
+**Bottom fade** (`components/layout/BottomFade.tsx`, `rhythm.bottomFadeHeight`)
+is the paper ground rising to absorb the last inch of scrolling content — quiet
+and structural, not decorative. It gradients from transparent to `surface.canvas`
+exactly, never black, so the veil reads as more of the same ground rather than a
+grey shadow at the screen's end. `ScreenScaffold` renders it automatically in
+`scroll` mode.
+
 ## Palette provenance
 
 The accent is an **original** terracotta/sienna derived from the app's own

--- a/frontend/src/design/__tests__/rhythmTokens.test.ts
+++ b/frontend/src/design/__tests__/rhythmTokens.test.ts
@@ -15,6 +15,7 @@ describe('rhythm tokens (#825)', () => {
       'sectionGap',
       'blockGap',
       'heroPaddingV',
+      'bottomFadeHeight',
     ]);
   });
 

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -366,6 +366,7 @@ export const rhythm = {
   sectionGap: spacing(3), // 24 — between editorial sections
   blockGap: spacing(1.5), // 12 — between blocks within a section
   heroPaddingV: spacing(3), // 24 — vertical breathing room around a screen header
+  bottomFadeHeight: spacing(8), // 64 — height of the BottomFade veil that dissolves a scroller's bottom edge into the canvas ground
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
   contentListContent: {
     flexGrow: 1,
     paddingTop: SPACING.sm,
-    paddingBottom: SPACING.xl,
+    paddingBottom: rhythm.bottomFadeHeight,
   },
 
   // Native Markdown reader body — floated on a warm paper sheet.

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../components/drawer';
 import { Celebration } from '../../components/feedback/Celebration';
 import { EmptyState } from '../../components/feedback/EmptyState';
+import { BottomFade } from '../../components/layout/BottomFade';
 import { ContentContainer } from '../../components/layout/ContentContainer';
 import { EditorialSection } from '../../components/layout/EditorialSection';
 import { ScreenHeader } from '../../components/layout/ScreenHeader';
@@ -583,6 +584,7 @@ const CourseScreen = (): React.JSX.Element => {
           stageContent={stageContent}
           viewer={viewer}
         />
+        <BottomFade />
         <CourseScreenDrawer
           drawer={drawer}
           stages={allStages}

--- a/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreen.test.tsx
@@ -307,6 +307,30 @@ describe('CourseScreen', () => {
     });
   });
 
+  it('fades the bottom edge of the landing page into the canvas ground', async () => {
+    const { getByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('content-list')).toBeTruthy());
+    expect(getByTestId('bottom-fade')).toBeTruthy();
+  });
+
+  it('does not fade the bottom edge of the chapter reader (desk ground)', async () => {
+    const { getByText, getByTestId, queryByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => {
+      expect(getByText('Welcome Essay')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-1'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('chapter-reader')).toBeTruthy();
+    });
+    expect(queryByTestId('bottom-fade')).toBeNull();
+  });
+
   it('loads new content when a different stage is selected', async () => {
     const { getByTestId } = render(<CourseScreen />);
 

--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -8,6 +8,7 @@ import {
   colors,
   editorialType,
   ink,
+  rhythm,
   spacing,
   surface,
   surfaceShadow,
@@ -22,7 +23,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   listContent: {
-    paddingBottom: SPACING.xxl,
+    paddingBottom: rhythm.bottomFadeHeight,
     flexGrow: 1,
   },
   sectionHeading: {

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -31,6 +31,7 @@ import type { JournalMessage, PromptDetail } from '@/api';
 import { Button } from '@/components/Button';
 import { useScreenDrawer } from '@/components/drawer';
 import { EmptyState } from '@/components/feedback/EmptyState';
+import { BottomFade } from '@/components/layout/BottomFade';
 import { ScreenHeader } from '@/components/layout/ScreenHeader';
 import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
 import InvitationStack from '@/features/Invitations/InvitationStack';
@@ -450,6 +451,7 @@ function JournalShelfScreen(): React.JSX.Element {
   return (
     <ScreenScaffold testID="journal-shelf">
       <ShelfBody shelf={shelf} nav={nav} prompt={prompt} week={week} now={now} />
+      <BottomFade />
       <JournalScreenDrawer
         drawer={shelfDrawer.drawer}
         onSelectEntry={shelfDrawer.onSelectEntry}

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -522,6 +522,11 @@ describe('JournalShelfScreen', () => {
     expect(await findByTestId('journal-hero')).toBeTruthy();
   });
 
+  it('fades the bottom edge of the shelf into the canvas ground', async () => {
+    const { findByTestId } = render(<JournalShelfScreen />);
+    expect(await findByTestId('bottom-fade')).toBeTruthy();
+  });
+
   it('shows "Journal" as the header title and drops "Your shelf"', async () => {
     const { findByTestId, getByText, queryByText } = render(<JournalShelfScreen />);
     await findByTestId('journal-hero');

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -43,6 +43,7 @@ import {
   type ScreenDrawerState,
 } from '@/components/drawer';
 import { EmptyState } from '@/components/feedback/EmptyState';
+import { BottomFade } from '@/components/layout/BottomFade';
 import { ContentContainer } from '@/components/layout/ContentContainer';
 import { ShowcaseCard } from '@/components/layout/ShowcaseCard';
 import { useAuth } from '@/context/AuthContext';
@@ -53,6 +54,7 @@ import {
   colors,
   editorialType,
   onShowcase,
+  rhythm,
   surface,
   touchTarget,
 } from '@/design/tokens';
@@ -299,7 +301,7 @@ interface ActiveSessionViewProps {
   sessionRef?: React.Ref<ActiveRitualSessionHandle>;
 }
 
-const ActiveSessionView = ({
+const SessionScrollBody = ({
   userPractice,
   practiceName,
   effectiveName,
@@ -311,43 +313,51 @@ const ActiveSessionView = ({
   banner,
   stageNumber,
   sessionRef,
-}: ActiveSessionViewProps): React.JSX.Element => {
+}: ActiveSessionViewProps): React.JSX.Element => (
+  <>
+    {banner}
+    <BeginHero practiceName={effectiveName ?? practiceName} />
+    {/* The primary switch affordance, in the scroll header (not over the
+        timer, so it doesn't intercept mid-session taps). */}
+    <CatalogButton
+      stageNumber={stageNumber}
+      label="Change practice"
+      testID="change-practice-button"
+      icon={<RefreshCw size={16} color={accent.primary} style={styles.browseCatalogIcon} />}
+    />
+    <ActiveRitualSession
+      key={`practice-${userPractice.id}`}
+      ref={sessionRef}
+      userPractice={userPractice}
+      effectiveName={effectiveName ?? practiceName}
+      effectiveConfig={effectiveConfig}
+      userTimezone={userTimezone}
+      onSessionApply={weekly.increment}
+      onSessionRollback={weekly.decrement}
+      onSessionCommitted={() => void weekly.refresh()}
+      onUserPracticeUpdated={onUserPracticeUpdated}
+      onWriteReflection={onWriteReflection}
+    />
+    <WeeklyProgress count={weekly.count} />
+  </>
+);
+
+const ActiveSessionView = (props: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
   return (
     // paddingTop lives on the wrapper so the ScrollView's *viewport* starts
-    // below the notch (content can't scroll up behind it); paddingBottom
-    // rides contentContainerStyle so the scroll content clears the home indicator.
+    // below the notch (content can't scroll up behind it); the content pads its
+    // bottom by the fade-veil height so the last line settles above the fade,
+    // whose opaque base in turn covers the home-indicator zone.
     <View style={[styles.screen, { paddingTop: insets.top }]} testID="practice-screen-safe-area">
       <ScrollView
         style={styles.fill}
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: rhythm.bottomFadeHeight }]}
         testID="practice-screen"
       >
-        {banner}
-        <BeginHero practiceName={effectiveName ?? practiceName} />
-        {/* The primary switch affordance, in the scroll header (not over the
-            timer, so it doesn't intercept mid-session taps). */}
-        <CatalogButton
-          stageNumber={stageNumber}
-          label="Change practice"
-          testID="change-practice-button"
-          icon={<RefreshCw size={16} color={accent.primary} style={styles.browseCatalogIcon} />}
-        />
-        <ActiveRitualSession
-          key={`practice-${userPractice.id}`}
-          ref={sessionRef}
-          userPractice={userPractice}
-          effectiveName={effectiveName ?? practiceName}
-          effectiveConfig={effectiveConfig}
-          userTimezone={userTimezone}
-          onSessionApply={weekly.increment}
-          onSessionRollback={weekly.decrement}
-          onSessionCommitted={() => void weekly.refresh()}
-          onUserPracticeUpdated={onUserPracticeUpdated}
-          onWriteReflection={onWriteReflection}
-        />
-        <WeeklyProgress count={weekly.count} />
+        <SessionScrollBody {...props} />
       </ScrollView>
+      <BottomFade />
     </View>
   );
 };
@@ -458,7 +468,7 @@ const ErrorView = ({
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: surface.canvas },
   fill: { flex: 1 },
-  scrollContent: { padding: SPACING.md, paddingBottom: SPACING.xxl },
+  scrollContent: { padding: SPACING.md },
   centered: {
     flex: 1,
     justifyContent: 'center',

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -372,6 +372,13 @@ describe('PracticeScreen', () => {
     );
   });
 
+  it('fades the bottom edge of the active session into the canvas ground', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
+    expect(getByTestId('bottom-fade')).toBeTruthy();
+  });
+
   it('renders an active custom (draft) practice by including own drafts in the catalogue fetch', async () => {
     // A user-created practice is an unapproved draft: the backend lets its
     // author select it (POST /user-practices/ succeeds), but the approved-only
@@ -470,11 +477,14 @@ describe('PracticeScreen', () => {
       expect(getByTestId('active-practice-card')).toBeTruthy();
     });
     // Top inset constrains the wrapper viewport (so content can't scroll behind
-    // the notch); bottom inset rides the ScrollView's contentContainerStyle.
+    // the notch); the scroll content pads its bottom by the fade-veil height so
+    // the last line settles above the fade (whose opaque base covers the
+    // home-indicator zone).
+    const { rhythm } = require('../../../design/tokens');
     expect(getByTestId('practice-screen-safe-area')).toHaveStyle({ paddingTop: 47 });
     const scroll = getByTestId('practice-screen');
     expect(scroll.props.contentContainerStyle).toEqual(
-      expect.arrayContaining([expect.objectContaining({ paddingBottom: 34 })]),
+      expect.arrayContaining([expect.objectContaining({ paddingBottom: rhythm.bottomFadeHeight })]),
     );
   });
 


### PR DESCRIPTION
## Summary
Scrollable screens now dissolve their bottom edge into the warm paper ground instead of clipping at a hard line — a quiet Candle & Ink affordance that the page continues below, fitting now that the bottom tab bar is retired and content runs to the physical screen bottom.

- New shared `BottomFade` layout primitive (`frontend/src/components/layout/BottomFade.tsx`): an absolutely-positioned, `pointerEvents="none"` SVG `LinearGradient` (transparent to `surface.canvas`) sibling overlay. No new dependency — uses the already-shipped `react-native-svg` (the `TierStar` idiom). Token-driven height via the new `rhythm.bottomFadeHeight` (64dp). The veil is a **fixed** height pinned to its container bottom; its opaque `surface.canvas` base blends into whatever ground sits below (physical screen bottom, where it covers the home-indicator zone, or a `SafeAreaView` inset region), so it stays consistent without double-counting the safe-area inset.
- `ScreenScaffold` renders it automatically in `scroll` mode as a **sibling** overlay wrapped alongside the `ScrollView` — the documented `ContentContainer` height contract (only `contentContainerStyle` owns the single `flexGrow: 1`) is preserved.
- Wired into each tab's primary scroller that bypasses `ScreenScaffold`'s scroll mode: **Journal** shelf `SectionList`, **Practice** active-session `ScrollView`, and the **Course** landing `FlatList`. Each scroller pads its content by `rhythm.bottomFadeHeight` so the last line of real content always settles above the veil.
- Token-only styling (derives from `surface.canvas` + `rhythm`), no suppressions, no `any`.

### Deliberately out of scope
- **Habits** — its grid is paginated to fit the viewport (not a scroll surface); the bottom edge is the pagination control, which a fade would wash.
- **Map** — its only scroller lives inside a modal (modals are out of scope); the map proper is a non-scroll canvas.
- **Course chapter reader** — floats a paper sheet on the deeper `surface.desk` ground, so a `surface.canvas` fade would band the wrong color. Tracked as a follow-up for a ground-color-aware variant.
- **Scroll-position-aware hide-at-bottom** — the static veil is the required default; a hide-at-bottom refinement was not trivially clean (per-scroller `onScroll` + animated opacity) and is not pursued here.

## Test plan
- `BottomFade` unit tests: gradient stops transparent to `surface.canvas` top-to-bottom, vertical orientation, `pointerEvents="none"` + absolute bottom pin, fixed token height (locked to `rhythm.bottomFadeHeight` even when a bottom safe-area inset is injected), custom `testID`, and touch passthrough to a control it overlaps.
- `ScreenScaffold` integration: the fade is present in `scroll` mode and absent in non-scroll mode; existing height-contract assertions unchanged.
- Feature-presence tests: fade present on the Journal shelf, Practice active session, and Course landing; absent on the Course reader path.
- Token contract: `rhythm.bottomFadeHeight` added to the `rhythm` key contract test.
- Full `scripts/frontend/check-all.sh` green locally (ESLint, Prettier, TypeScript, Jest — 4399 tests). Coverage is CI-enforced.

Closes #1759
Refs #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)