### PR TITLE
fix(course): strip leading title heading of any ATX level in the reader

### DIFF
--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -201,6 +201,20 @@ describe('ChapterReader', () => {
     expect(queryByTestId('reader-markdown')).toBeNull();
   });
 
+  // An H2 duplicate title heading must also strip down to nothing, not just H1.
+  it('shows the empty state when the body is only its duplicate H2 title heading', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Chapter One',
+      content_type: 'chapter',
+      body_markdown: '## Chapter One\n\n',
+    });
+    const { findByTestId, queryByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    await findByTestId('reader-empty');
+    expect(queryByTestId('reader-markdown')).toBeNull();
+  });
+
   // A single in-paragraph newline (soft break) must reflow to a space.
   it('reflows hard-wrapped lines within a paragraph into a single visual line', async () => {
     mockContentBody.mockResolvedValueOnce({

--- a/frontend/src/features/Course/__tests__/stripLeadingTitleHeading.test.ts
+++ b/frontend/src/features/Course/__tests__/stripLeadingTitleHeading.test.ts
@@ -49,4 +49,35 @@ describe('stripLeadingTitleHeading', () => {
     const input = '# Title \n\nProse.\n';
     expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
   });
+
+  it('strips a leading H2 that exactly matches the title', () => {
+    const input = '## Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('strips a leading H3 that exactly matches the title', () => {
+    const input = '### Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('strips a leading H6 that exactly matches the title', () => {
+    const input = '###### Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe('Prose.\n');
+  });
+
+  it('preserves a 7-hash line unchanged since it is not a valid ATX heading (exact equality)', () => {
+    const input = '####### Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('preserves a hash with no following space unchanged (exact equality)', () => {
+    const input = '#Title\n\nProse.\n';
+    expect(stripLeadingTitleHeading(input, 'Title')).toBe(input);
+  });
+
+  it('consumes the single blank line after a stripped H2 heading', () => {
+    const input = '## Title\n\nProse.\n';
+    const result = stripLeadingTitleHeading(input, 'Title');
+    expect(result.startsWith('\n')).toBe(false);
+  });
 });

--- a/frontend/src/features/Course/stripLeadingTitleHeading.ts
+++ b/frontend/src/features/Course/stripLeadingTitleHeading.ts
@@ -1,11 +1,15 @@
-/** ATX H1 prefix: exactly one hash followed by a space. */
-const H1_PREFIX = '# ';
+/** Deepest ATX heading level Markdown recognises (one to six hashes). */
+const MAX_ATX_DEPTH = 6;
+
+/** Leading ATX heading: one to six hashes followed by a single space. */
+const ATX_HEADING_PREFIX = new RegExp(`^#{1,${MAX_ATX_DEPTH}} `);
 
 /**
- * Drop a leading ``# Heading`` line when its text exactly matches the manifest
- * ``title`` — the reader already renders the title in its sheet header, so a
- * duplicate H1 would read twice.  Only the first non-empty line is considered,
- * it must be a single-hash ATX H1, and a differing heading is left untouched.
+ * Drop a leading ATX heading of any level (1-6 hashes) when its text exactly
+ * matches the manifest ``title`` -- the reader already renders the title in its
+ * sheet header, so a duplicate heading would read twice.  Only the first
+ * non-empty line is considered, it must be a valid ATX heading whose trimmed
+ * text equals the trimmed title, and a differing heading is left untouched.
  * A blank line immediately after the stripped heading is consumed too.
  */
 export function stripLeadingTitleHeading(md: string, title: string): string {
@@ -15,10 +19,11 @@ export function stripLeadingTitleHeading(md: string, title: string): string {
     return md;
   }
   const heading = lines[firstContentIndex] ?? '';
-  if (!heading.startsWith(H1_PREFIX)) {
+  const match = ATX_HEADING_PREFIX.exec(heading);
+  if (match === null) {
     return md;
   }
-  const headingText = heading.slice(H1_PREFIX.length).trim();
+  const headingText = heading.slice(match[0].length).trim();
   if (headingText !== title.trim()) {
     return md;
   }


### PR DESCRIPTION
## Summary

The Course reader stacked the chapter title twice inside the content sheet:
the sheet header (canonical serif title) rendered it, and then the first
markdown heading of the body rendered it again. `stripLeadingTitleHeading`
was meant to de-duplicate this, but it only recognized a leading ATX **H1**
(`# `) — while 209 of 214 real content files open with an **H2** (`## `) that
matches the manifest title, so the strip was a dead path for effectively all
content and the duplicate always rendered.

This generalizes the helper to strip a leading ATX heading of **any level**
(1–6 hashes followed by a single space) whose trimmed text exactly matches the
trimmed manifest title. Every other rule is preserved verbatim: only the first
non-empty line is considered, exact text match, one trailing blank line
consumed, and a differing heading left untouched. `####### Title` (7 hashes)
and `#Title` (no space) correctly fall through unchanged.

Because `renderBody` strips first then tests emptiness, an `## Title`-only body
now also falls through to the empty state — pinned with a test.

No change to `ChapterReader.tsx`; the sheet header remains the canonical title
treatment and the breadcrumb keeps its truncated wayfinding title.

## Test plan

- Added `stripLeadingTitleHeading` tests: H2/H3/H6 matching-title bodies are
  stripped; 7-hash and no-space lines are left unchanged; the trailing blank
  line after a stripped H2 is consumed. Existing H1 and differing-heading tests
  still pass.
- Added a `ChapterReader` test: an `## Title`-only body renders the empty state
  and no markdown sheet.
- Full frontend suite green (408 suites / 4393 tests); ESLint, Prettier, and
  `tsc --noEmit` all clean.

Closes #1760