### PR TITLE
feat(frontend): desk-ground BottomFade variant for the Course chapter reader

### DIFF
--- a/frontend/src/components/layout/BottomFade.tsx
+++ b/frontend/src/components/layout/BottomFade.tsx
@@ -25,20 +25,34 @@ import { rhythm, surface } from '@/design/tokens';
  * content by `rhythm.bottomFadeHeight` (see `ScreenScaffold`'s `scrollContent`
  * style) so the veil only ever covers already-read trailing whitespace, never
  * the last line of real content.
+ *
+ * `color` overrides the ground the veil fades into (defaults to
+ * `surface.canvas`); both gradient stops share it so only the opacity ramps.
  */
-export const BottomFade = ({ testID = 'bottom-fade' }: { testID?: string }): React.JSX.Element => (
-  <View pointerEvents="none" style={styles.overlay} testID={testID}>
-    <Svg width="100%" height="100%">
-      <Defs>
-        <LinearGradient id="bottom-fade-grad" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0" stopColor={surface.canvas} stopOpacity="0" />
-          <Stop offset="1" stopColor={surface.canvas} stopOpacity="1" />
-        </LinearGradient>
-      </Defs>
-      <Rect width="100%" height="100%" fill="url(#bottom-fade-grad)" />
-    </Svg>
-  </View>
-);
+export const BottomFade = ({
+  testID = 'bottom-fade',
+  color = surface.canvas,
+}: {
+  testID?: string;
+  color?: string;
+}): React.JSX.Element => {
+  // Derive a per-instance id so distinct fades never collide on web, where all
+  // gradient ids share one DOM (native scopes Defs per-Svg).
+  const gradientId = `${testID}-grad`;
+  return (
+    <View pointerEvents="none" style={styles.overlay} testID={testID}>
+      <Svg width="100%" height="100%">
+        <Defs>
+          <LinearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0" stopColor={color} stopOpacity="0" />
+            <Stop offset="1" stopColor={color} stopOpacity="1" />
+          </LinearGradient>
+        </Defs>
+        <Rect width="100%" height="100%" fill={`url(#${gradientId})`} />
+      </Svg>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   overlay: {

--- a/frontend/src/components/layout/__tests__/BottomFade.test.tsx
+++ b/frontend/src/components/layout/__tests__/BottomFade.test.tsx
@@ -26,6 +26,14 @@ const findStopAtOffset = (component: Rendered, offset: string): TestNode =>
 const findGradient = (component: Rendered): TestNode =>
   component.root.find((node: TestNode) => node.props.id === 'bottom-fade-grad');
 
+const findAnyGradient = (component: Rendered): TestNode =>
+  component.root.find(
+    (node: TestNode) => typeof node.props.id === 'string' && node.props.x1 !== undefined,
+  );
+
+const findRect = (component: Rendered): TestNode =>
+  component.root.find((node: TestNode) => typeof node.props.fill === 'string');
+
 describe('BottomFade', () => {
   it('fades from transparent to the canvas surface color, top to bottom', () => {
     const component = renderer.create(<BottomFade />);
@@ -89,5 +97,25 @@ describe('BottomFade', () => {
     expect(getByTestId('bottom-fade').props.pointerEvents).toBe('none');
     fireEvent.press(getByText('Underneath'));
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('fades to the desk surface color when given a color prop, opacity ramp unchanged', () => {
+    const component = renderer.create(<BottomFade color={surface.desk} />);
+    const top = findStopAtOffset(component, '0').props;
+    expect(top.stopColor).toBe(surface.desk);
+    expect(top.stopOpacity).toBe('0');
+    const bottom = findStopAtOffset(component, '1').props;
+    expect(bottom.stopColor).toBe(surface.desk);
+    expect(bottom.stopOpacity).toBe('1');
+  });
+
+  it('gives each instance a distinct gradient id and points its own Rect at it', () => {
+    const first = renderer.create(<BottomFade testID="fade-one" />);
+    const second = renderer.create(<BottomFade testID="fade-two" />);
+    const firstGradientId = findAnyGradient(first).props.id;
+    const secondGradientId = findAnyGradient(second).props.id;
+    expect(firstGradientId).not.toBe(secondGradientId);
+    expect(findRect(first).props.fill).toBe(`url(#${String(firstGradientId)})`);
+    expect(findRect(second).props.fill).toBe(`url(#${String(secondGradientId)})`);
   });
 });

--- a/frontend/src/design/DESIGN.md
+++ b/frontend/src/design/DESIGN.md
@@ -36,8 +36,10 @@ instead. Enforced by `__tests__/semanticTokens.test.ts`.
 is the paper ground rising to absorb the last inch of scrolling content — quiet
 and structural, not decorative. It gradients from transparent to `surface.canvas`
 exactly, never black, so the veil reads as more of the same ground rather than a
-grey shadow at the screen's end. `ScreenScaffold` renders it automatically in
-`scroll` mode.
+grey shadow at the screen's end. An optional `color` prop overrides that ground
+for scrollers floated on a different surface — the Course chapter reader passes
+`surface.desk` so its fade dissolves into the desk rather than banding canvas.
+`ScreenScaffold` renders it automatically in `scroll` mode.
 
 ## Palette provenance
 

--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -3,7 +3,8 @@ import { ActivityIndicator, Image, ScrollView, Text, TouchableOpacity, View } fr
 import Markdown from 'react-native-markdown-display';
 
 import { course as courseApi, type ContentBody } from '../../api';
-import { colors, SPACING } from '../../design/tokens';
+import { BottomFade } from '../../components/layout/BottomFade';
+import { colors, rhythm, surface } from '../../design/tokens';
 
 import styles, { markdownStyles } from './Course.styles';
 import RetryButton from './RetryButton';
@@ -237,18 +238,21 @@ function renderBody(body: ContentBody): React.ReactElement {
     return <EmptyView />;
   }
   return (
-    <ScrollView
-      style={styles.readerScroll}
-      contentContainerStyle={{ paddingBottom: SPACING.xxl }}
-      testID="reader-markdown"
-    >
-      <View style={styles.readerSheet}>
-        <ReaderSheetHeader eyebrow={READER_EYEBROWS[body.content_type]} title={body.title} />
-        <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={isExternalWebUrl}>
-          {markdown}
-        </Markdown>
-      </View>
-    </ScrollView>
+    <View style={styles.readerScrollRegion}>
+      <ScrollView
+        style={styles.readerScroll}
+        contentContainerStyle={{ paddingBottom: rhythm.bottomFadeHeight }}
+        testID="reader-markdown"
+      >
+        <View style={styles.readerSheet}>
+          <ReaderSheetHeader eyebrow={READER_EYEBROWS[body.content_type]} title={body.title} />
+          <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={isExternalWebUrl}>
+            {markdown}
+          </Markdown>
+        </View>
+      </ScrollView>
+      <BottomFade color={surface.desk} testID="reader-bottom-fade" />
+    </View>
   );
 }
 

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -345,6 +345,10 @@ const styles = StyleSheet.create({
   },
 
   // Native Markdown reader body — floated on a warm paper sheet.
+  // Relative region the bottom fade pins to (its absolute bottom:0 anchors here).
+  readerScrollRegion: {
+    flex: 1,
+  },
   readerScroll: {
     flex: 1,
     backgroundColor: surface.desk,

--- a/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReader.test.tsx
@@ -2,10 +2,15 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 
 import type * as Api from '../../../api';
+import { rhythm, surface } from '../../../design/tokens';
 import ChapterReader from '../ChapterReader';
+
+interface TestNode {
+  props: Record<string, unknown>;
+}
 
 jest.mock('../../../api', () => ({
   course: {
@@ -351,5 +356,54 @@ describe('ChapterReader', () => {
     const title = await findByTestId('reader-sheet-title');
     expect(title.props.children).toBe('Manifest Title');
     await findByText('Different Heading');
+  });
+
+  it('renders a desk-colored bottom fade beneath the loaded body', async () => {
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const fade = await findByTestId('reader-bottom-fade');
+    const stops = fade.findAll(
+      (node: TestNode) => typeof node.props.offset === 'string' && 'stopColor' in node.props,
+    );
+    expect(stops.length).toBeGreaterThan(0);
+    for (const stop of stops) {
+      expect(stop.props.stopColor).toBe(surface.desk);
+    }
+  });
+
+  it('renders the bottom fade as a sibling overlay, never nested inside the markdown ScrollView', async () => {
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const fade = await findByTestId('reader-bottom-fade');
+    const scrollView = await findByTestId('reader-markdown');
+    const nestedFade = scrollView.findAll(
+      (node: TestNode) => node.props.testID === 'reader-bottom-fade',
+    );
+    expect(nestedFade).toHaveLength(0);
+    expect(fade).toBeTruthy();
+  });
+
+  it('pads the markdown ScrollView content by the bottom-fade height', async () => {
+    const { findByTestId } = render(
+      <ChapterReader source={{ kind: 'content', id: 1 }} fallbackTitle="x" onBack={jest.fn()} />,
+    );
+    const scrollView = await findByTestId('reader-markdown');
+    const flat = StyleSheet.flatten(scrollView.props.contentContainerStyle);
+    expect(flat.paddingBottom).toBe(rhythm.bottomFadeHeight);
+  });
+
+  it('still renders a footer alongside the bottom fade once content has loaded', async () => {
+    const { findByTestId, findByText } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 1 }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+        footer={<Text>FOOTER_HERE</Text>}
+      />,
+    );
+    await findByTestId('reader-bottom-fade');
+    await findByText('FOOTER_HERE');
   });
 });


### PR DESCRIPTION
## Summary
The shared `BottomFade` layout primitive (added in #1762) fades a scroller's bottom edge into `surface.canvas`. The Course chapter reader floats its paper sheet on the deeper `surface.desk` ground, so a canvas fade would band the wrong color at the bottom — it was deliberately left unwired pending a ground-aware variant.

This change:
- Adds an optional `color?: string` prop to `BottomFade` (defaults to `surface.canvas`, so every existing caller is untouched), applied to both gradient stops per the primitive's same-color contract.
- Derives the `LinearGradient` id from `testID` so a canvas fade and a desk fade can coexist without colliding on react-native-web (native scopes `Defs` per-`Svg`; web shares one DOM id space).
- Wires `BottomFade color={surface.desk}` into the reader's scroll region as an absolutely-positioned, `pointerEvents="none"` sibling of the `ScrollView` (never a scroll child), preserving the ScrollView's own height contract. The scroller pads its content by `rhythm.bottomFadeHeight` so the veil only covers trailing whitespace.

Token-only styling throughout (`surface.desk`, `rhythm.bottomFadeHeight`); no hardcoded hex, no new dependencies, no backend or migration changes. `DESIGN.md`'s bottom-fade note documents the new `color` override.

## Test plan
- `BottomFade.test.tsx`: the `color` prop drives both stops to `surface.desk` with the opacity ramp unchanged; the default remains `surface.canvas`; two instances get distinct gradient ids and each `Rect` points at its own id.
- `ChapterReader.test.tsx`: after content loads, `reader-bottom-fade` is present with desk-colored stops, is a sibling of (not nested in) the `reader-markdown` ScrollView, the scroller's `contentContainerStyle.paddingBottom` equals `rhythm.bottomFadeHeight`, and a passed `footer` still renders.
- Gate 2 local: `./scripts/frontend/check-all.sh` green — ESLint (zero-warning), Prettier, `tsc --strict`, and the full Jest suite (4405 tests) all pass.

Closes #1761
Refs #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)