### PR TITLE
fix(course): open the shelf drawer from the hamburger while reading a chapter

### DIFF
--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -540,33 +540,28 @@ function useCourseNavigation(
   return { handleStageSelect, handleChapterPress };
 }
 
-const CourseScreen = (): React.JSX.Element => {
-  const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
-  const stageContent = useStageContent(selectedStage, allStages.length > 0);
-  const viewer = useCourseViewer(selectedStage);
-  const drawer = useScreenDrawer('Course');
-  const { handleStageSelect, handleChapterPress } = useCourseNavigation(
-    setSelectedStage,
-    viewer,
-    drawer,
-  );
+interface CourseLandingProps {
+  allStages: Stage[];
+  selectedStage: number;
+  stageContent: ReturnType<typeof useStageContent>;
+  viewer: ReturnType<typeof useCourseViewer>;
+  drawer: ScreenDrawerState;
+  onStageSelect: (_stageNumber: number) => void;
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+}
 
-  const overlay = renderOverlay(viewer, stageContent.handleMarkRead);
-  if (overlay !== null) return overlay;
-
-  if (loading) return <CourseLoadingState />;
-
-  // Stage-list fetch failed: show error+retry, not an empty course.
-  if (error) {
-    return (
-      <SafeAreaView style={styles.container} edges={['bottom']}>
-        <CourseErrorState onRetry={retry} />
-      </SafeAreaView>
-    );
-  }
-
+/** The Course landing view: header, stage selector, the stage-panel scroll
+ *  surface, and the shelf drawer mounted over it. */
+const CourseLanding = ({
+  allStages,
+  selectedStage,
+  stageContent,
+  viewer,
+  drawer,
+  onStageSelect,
+  onChapterPress,
+}: CourseLandingProps): React.JSX.Element => {
   const selectedStageData = allStages.find((s) => s.stage_number === selectedStage);
-
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <ContentContainer fill>
@@ -576,7 +571,7 @@ const CourseScreen = (): React.JSX.Element => {
         <StageSelector
           stages={allStages}
           selectedStage={selectedStage}
-          onSelectStage={handleStageSelect}
+          onSelectStage={onStageSelect}
         />
         <StagePanel
           selectedStage={selectedStage}
@@ -589,10 +584,61 @@ const CourseScreen = (): React.JSX.Element => {
           drawer={drawer}
           stages={allStages}
           selectedStage={selectedStage}
-          onChapterPress={handleChapterPress}
+          onChapterPress={onChapterPress}
         />
       </ContentContainer>
     </SafeAreaView>
+  );
+};
+
+const CourseScreen = (): React.JSX.Element => {
+  const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
+  const stageContent = useStageContent(selectedStage, allStages.length > 0);
+  const viewer = useCourseViewer(selectedStage);
+  const drawer = useScreenDrawer('Course');
+  const { handleStageSelect, handleChapterPress } = useCourseNavigation(
+    setSelectedStage,
+    viewer,
+    drawer,
+  );
+
+  const overlay = renderOverlay(viewer, stageContent.handleMarkRead);
+  if (overlay !== null) {
+    // Drawer must mount alongside the reader so the hamburger works while reading.
+    return (
+      <>
+        {overlay}
+        <CourseScreenDrawer
+          drawer={drawer}
+          stages={allStages}
+          selectedStage={selectedStage}
+          onChapterPress={handleChapterPress}
+        />
+      </>
+    );
+  }
+
+  if (loading) return <CourseLoadingState />;
+
+  // Stage-list fetch failed: show error+retry, not an empty course.
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['bottom']}>
+        <CourseErrorState onRetry={retry} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <CourseLanding
+      allStages={allStages}
+      selectedStage={selectedStage}
+      stageContent={stageContent}
+      viewer={viewer}
+      drawer={drawer}
+      onStageSelect={handleStageSelect}
+      onChapterPress={handleChapterPress}
+    />
   );
 };
 

--- a/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
@@ -3,7 +3,7 @@
 // drawer. Mirrors CourseDrawer.test.tsx's headerLeftStore harness, adding a
 // stable navigate spy so the shared nav rows have somewhere to route.
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native';
 import { useSyncExternalStore, type ReactElement } from 'react';
 
 import type { ContentItem, CourseProgress, Stage } from '../../../api';
@@ -176,5 +176,96 @@ describe('Course header drawer nav section', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('Journal');
     expect(queryByTestId('screen-drawer-panel')).toBeNull();
+  });
+});
+
+// Unlocked chapters for the reading-view drawer tests below. Only stage 1
+// (the default selection with no route param) gets chapters; every other
+// stage resolves empty so the drawer's per-stage fetch loop doesn't collide
+// testIDs across sections.
+const readingChapters: ContentItem[] = [
+  {
+    id: 1,
+    title: 'Chapter One',
+    content_type: 'chapter',
+    release_day: 0,
+    url: null,
+    is_locked: false,
+    is_read: false,
+  },
+  {
+    id: 2,
+    title: 'Chapter Two',
+    content_type: 'chapter',
+    release_day: 0,
+    url: null,
+    is_locked: false,
+    is_read: false,
+  },
+];
+
+describe('Course drawer while reading a chapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    headerLeftStore.current = undefined;
+    headerLeftStore.listeners.clear();
+    mockStagesList.mockResolvedValue(TEN_STAGES);
+    mockStageContent.mockImplementation((stageNumber: number) =>
+      Promise.resolve(stageNumber === 1 ? readingChapters : []),
+    );
+    mockStageProgress.mockResolvedValue(sampleProgress);
+    useDepthPreferencesStore.setState({
+      enable_habits: true,
+      enable_practices: true,
+      enable_course: true,
+    });
+  });
+
+  it('opens the drawer over the reader when the hamburger is tapped while reading', async () => {
+    const { getByTestId, getByLabelText } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-1'));
+    });
+    await waitFor(() => expect(getByTestId('chapter-reader')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    await waitFor(() => expect(getByTestId('screen-drawer-panel')).toBeTruthy());
+  });
+
+  it('switches the reader in place when a chapter is tapped in the drawer while reading', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-1'));
+    });
+    await waitFor(() => expect(getByTestId('chapter-reader')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+    await waitFor(() => expect(getByTestId('course-drawer-chapter-2')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('course-drawer-chapter-2'));
+    });
+
+    await waitFor(() => expect(queryByTestId('screen-drawer-panel')).toBeNull());
+    expect(getByTestId('chapter-reader')).toBeTruthy();
+  });
+
+  it('does not leak the landing stage-selector into the reading view when the drawer is open', async () => {
+    const { getByTestId, getByLabelText, queryByTestId } = render(<CourseScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('stage-selector')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-1'));
+    });
+    await waitFor(() => expect(getByTestId('chapter-reader')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Course menu'));
+
+    expect(queryByTestId('stage-selector')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

The Course header hamburger did nothing while a chapter (or resource / stage
intro) was being read. `CourseScreen` returned the reader overlay as the
entire tree via an early return, so `CourseScreenDrawer` — rendered only in
the landing return — never mounted while reading. `useScreenDrawer('Course')`
kept the toggle installed as the navigator `headerLeft`, so the hamburger
stayed visible and flipped `drawer.isOpen`, but nothing consumed that state:
no drawer appeared, and it could pop open unexpectedly after backing out.

This mounts the drawer alongside the reader overlay (`<>{overlay}<CourseScreenDrawer …/></>`)
so the toggle opens the shelf over the reader, and a drawer chapter tap reuses
the existing `handleChapterPress` (set stage → open reader → close drawer) to
switch the reader in place. The landing view was extracted into a new
`CourseLanding` sub-component to keep `CourseScreen` within the function-length
limit; the extraction is behavior-preserving (identical prop wiring,
`selectedStageData` computed inside where it was before).

Scope is limited to this defect: `renderOverlay` / `useCourseViewer` are
untouched, the landing-view drawer works exactly as before, and no
seed/content code was changed.

## Test plan

- Added three tests to `CourseScreenDrawerNav.test.tsx` (reusing the existing
  in-tree headerLeft harness):
  - the hamburger opens `screen-drawer-panel` over the reader while reading
    (RED at HEAD — the panel never mounted),
  - a drawer chapter tap switches the open reader in place and closes the
    drawer,
  - the landing `stage-selector` does not leak into the reading view.
- `scripts/frontend/check-all.sh` green: ESLint (zero warnings), prettier, tsc
  strict, and the full Jest suite (4415 tests).

Closes #1763