### PR TITLE
fix(backend): prune stale pre-manifest StageContent rows during seeding

### DIFF
--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -331,7 +332,11 @@ async def _prune_stale_rows(
     so no surviving completion still references a stale row when the row is
     deleted (the ``content_id`` FK is enforced and not deferrable).
     Deletion stays inside the caller's transaction; the shared commit point
-    is the sole writer.
+    is the sole writer.  The first flush executes this run's pending inserts
+    early, so on a concurrent seed it can raise the same race-arbitrating
+    ``IntegrityError`` the guarded commit catches; :func:`_reconcile_prune_commit`
+    wraps this call in that same yield-to-the-winner contract rather than
+    letting the exception escape as a spurious seed failure.
     """
     stale = _stale_rows(existing, reconciled_ids)
     if not stale:
@@ -361,6 +366,60 @@ def _warn_pruned(counts: _PruneCounts) -> None:
         )
 
 
+@dataclass(frozen=True)
+class _SeedOutcome:
+    """Result of one reconcile-prune-commit pass.
+
+    ``counts`` is ``None`` only when the process lost the race at the prune
+    flush and rolled back before any prune could persist, so the caller
+    knows to skip the prune-summary WARNING; ``won`` is ``False`` for both
+    the flush-time and commit-time race-loser paths.
+    """
+
+    inserted: int
+    won: bool
+    counts: _PruneCounts | None
+
+
+async def _reconcile_prune_commit(
+    session: AsyncSession,
+    stage_map: dict[int, int],
+    existing: _ExistingRows,
+) -> _SeedOutcome:
+    """Reconcile, prune, and commit under one race-yield contract.
+
+    Both the prune flush and the final commit push this run's pending
+    inserts to the DB, so either can trip the arbitrating unique index when
+    a peer worker seeds concurrently.  A collision at either seam is turned
+    into the same loser no-op — roll back and report 0 inserts — so a
+    concurrent boot never surfaces a spurious ``seed_failed`` ERROR.
+    """
+    result = _reconcile_all(session, stage_map, existing)
+    try:
+        counts = await _prune_stale_rows(
+            session, existing, result.survivors, _reconciled_stage_ids(stage_map)
+        )
+    except IntegrityError:
+        # Race-loser at PRUNE-FLUSH time: ``_prune_stale_rows`` flushes to
+        # give freshly-inserted survivors ids, which pushes this run's
+        # pending ``_reconcile_all`` inserts to the DB early — before the
+        # guarded commit below could arbitrate.  A peer worker already
+        # seeded the same ``content://`` refs, so the flush trips the
+        # ``ix_stagecontent_stage_content_ref_unique`` index (migration
+        # ``e8f9a0b1c2d3``).  Yield exactly as the commit helper would.
+        await session.rollback()
+        return _SeedOutcome(inserted=0, won=False, counts=None)
+
+    if not (result.dirty or counts.rows > 0):
+        # Nothing to commit, so nothing this process could lose or roll back.
+        return _SeedOutcome(inserted=result.inserted, won=True, counts=counts)
+    # Race-safe commit: a peer worker that seeded the same chapters between
+    # our existence read and this commit trips the same unique index; the
+    # loser rolls back and reports 0 inserts.
+    won = await try_commit_yielding_to_race_winner(session)
+    return _SeedOutcome(inserted=result.inserted if won else 0, won=won, counts=counts)
+
+
 async def seed_content(session: AsyncSession) -> int:
     """Reconcile ``StageContent`` rows with the declarative config.
 
@@ -375,25 +434,10 @@ async def seed_content(session: AsyncSession) -> int:
     stage_map = await _load_stage_map(session)
     existing = await _load_existing_keys(session)
 
-    result = _reconcile_all(session, stage_map, existing)
-    counts = await _prune_stale_rows(
-        session, existing, result.survivors, _reconciled_stage_ids(stage_map)
-    )
-
-    if result.dirty or counts.rows > 0:
-        # Race-safe commit: a peer worker that seeded the same chapters
-        # between our existence read and this commit trips the
-        # ``ix_stagecontent_stage_content_ref_unique`` index (migration
-        # ``e8f9a0b1c2d3``); the loser rolls back and reports 0 inserts.
-        won = await try_commit_yielding_to_race_winner(session)
-        inserted = result.inserted if won else 0
-    else:
-        # Nothing to commit, so nothing this process could lose or roll back.
-        won = True
-        inserted = result.inserted
+    outcome = await _reconcile_prune_commit(session, stage_map, existing)
     _warn_unmapped_manifest_stages(stage_map)
-    if won:
+    if outcome.won and outcome.counts is not None:
         # A prune the losing worker rolled back never persisted from here;
         # only the winner reports its tally.
-        _warn_pruned(counts)
-    return inserted
+        _warn_pruned(outcome.counts)
+    return outcome.inserted

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -37,7 +37,7 @@ from content_config import ChapterRecord, all_chapter_records
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
-from seed_helpers import commit_or_yield_to_race_winner
+from seed_helpers import try_commit_yielding_to_race_winner
 
 logger = logging.getLogger(__name__)
 
@@ -357,9 +357,15 @@ async def seed_content(session: AsyncSession) -> int:
         # between our existence read and this commit trips the
         # ``ix_stagecontent_stage_content_ref_unique`` index (migration
         # ``e8f9a0b1c2d3``); the loser rolls back and reports 0 inserts.
-        inserted = await commit_or_yield_to_race_winner(session, result.inserted)
+        won = await try_commit_yielding_to_race_winner(session)
+        inserted = result.inserted if won else 0
     else:
+        # Nothing to commit, so nothing this process could lose or roll back.
+        won = True
         inserted = result.inserted
     _warn_unmapped_manifest_stages(stage_map)
-    _warn_pruned(counts)
+    if won:
+        # A prune the losing worker rolled back never persisted from here;
+        # only the winner reports its tally.
+        _warn_pruned(counts)
     return inserted

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -4,9 +4,15 @@ Chapters are reconciled from ``manifest.json`` for **every stage the
 manifest ships**: title, content type, and release day come
 from the manifest verbatim, and the ``url`` column carries a local
 ``content://<chapter-id>`` reference instead of a remote CMS URL.
-Reconciliation is idempotent and never destructive: rows update in place
-when their fields drift, and nothing is ever deleted — rows referenced
-by ``ContentCompletion`` stay put.
+Reconciliation is idempotent: a manifest-claimed row survives and updates
+in place when its fields drift.  A ``StageContent`` row in a *reconciled*
+stage that the current manifest no longer claims is pruned; stages the
+manifest does not ship, and stages skipped for a missing ``CourseStage``
+row, are never touched.  When a pruned row carried ``ContentCompletion``
+read-marks, each mark is repointed to a surviving row of the same
+``(stage, title)`` or dropped when no such survivor exists (and dropped,
+rather than repointed, when repointing would collide with a mark the user
+already holds on the survivor).
 
 Seeding is resilient, never all-or-nothing.  Every manifest stage that
 has a matching ``CourseStage`` row is reconciled and committed.  A
@@ -28,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from content_config import ChapterRecord, all_chapter_records
+from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
 from seed_helpers import commit_or_yield_to_race_winner
@@ -130,23 +137,27 @@ def _reconcile_one(
     record: ChapterRecord,
     stage_map: dict[int, int],
     existing: _ExistingRows,
-) -> tuple[bool, bool]:
+) -> tuple[bool, bool, StageContent | None]:
     """Insert or update a single record.
 
-    Returns ``(inserted, dirty)`` — both flags are independent so the
-    caller can track new-row count separately from session-dirty state.
+    Returns ``(inserted, dirty, row)`` — the flags are independent so the
+    caller can track new-row count separately from session-dirty state,
+    and ``row`` is the reconciled ``StageContent`` (the claimed/updated
+    prior row, or the freshly built insert).  ``row`` is ``None`` only
+    when the record's stage has no ``CourseStage`` row and is skipped.
     """
     course_stage_id = stage_map.get(record.stage_number)
     if course_stage_id is None:
-        return False, False
+        return False, False, None
     prior = existing.claim(course_stage_id, record)
     if prior is None:
-        session.add(_build_new_row(record, course_stage_id))
-        return True, True
+        new_row = _build_new_row(record, course_stage_id)
+        session.add(new_row)
+        return True, True, new_row
     if not _row_is_in_sync(prior, record):
         _update_row(prior, record)
-        return False, True
-    return False, False
+        return False, True, prior
+    return False, False, prior
 
 
 def _warn_unmapped_manifest_stages(stage_map: dict[int, int]) -> None:
@@ -161,19 +172,165 @@ def _warn_unmapped_manifest_stages(stage_map: dict[int, int]) -> None:
         logger.warning("content_seed_partial stages_without_course_stage_row=%s", unmapped)
 
 
+@dataclass(frozen=True)
+class _ReconcileResult:
+    """Outcome of reconciling every desired record against the DB.
+
+    ``survivors`` maps ``(course_stage_id, title)`` to the reconciled row
+    that now owns that slot, so the prune step can repoint a stale row's
+    read-marks onto the same-``(stage, title)`` survivor.
+    """
+
+    inserted: int
+    dirty: bool
+    survivors: dict[tuple[int, str], StageContent]
+
+
 def _reconcile_all(
     session: AsyncSession,
     stage_map: dict[int, int],
     existing: _ExistingRows,
-) -> tuple[int, bool]:
-    """Reconcile every desired record; return ``(inserted_count, dirty)``."""
+) -> _ReconcileResult:
+    """Reconcile every desired record; report inserts, dirt, and survivors."""
     inserted = 0
     dirty = False
+    survivors: dict[tuple[int, str], StageContent] = {}
     for record in desired_content_records():
-        was_inserted, was_dirty = _reconcile_one(session, record, stage_map, existing)
+        was_inserted, was_dirty, row = _reconcile_one(session, record, stage_map, existing)
         inserted += int(was_inserted)
         dirty = dirty or was_dirty
-    return inserted, dirty
+        if row is not None:
+            survivors[(row.course_stage_id, row.title)] = row
+    return _ReconcileResult(inserted=inserted, dirty=dirty, survivors=survivors)
+
+
+def _reconciled_stage_ids(stage_map: dict[int, int]) -> set[int]:
+    """The ``CourseStage.id`` set the current manifest reconciles this run.
+
+    This is the prune scope guard: only rows whose ``course_stage_id`` is
+    in this set are ever eligible for deletion, so stages the manifest
+    does not ship and stages skipped for a missing ``CourseStage`` row
+    stay untouched.
+    """
+    shipped = {r.stage_number for r in desired_content_records()}
+    return {stage_map[stage] for stage in shipped if stage in stage_map}
+
+
+def _stale_rows(existing: _ExistingRows, reconciled_ids: set[int]) -> list[StageContent]:
+    """Unclaimed rows in reconciled stages — the deletion candidates.
+
+    After reconciliation ``existing.by_url`` holds exactly the rows no
+    manifest record claimed; narrowing to ``reconciled_ids`` keeps the
+    prune from ever reaching a stage this run did not reconcile.
+    """
+    return [row for row in existing.by_url.values() if row.course_stage_id in reconciled_ids]
+
+
+@dataclass(frozen=True)
+class _PruneCounts:
+    """Tally of a prune pass: rows removed and read-marks moved or dropped."""
+
+    rows: int
+    repointed: int
+    dropped: int
+
+
+async def _user_ids_with_completion(session: AsyncSession, content_id: int) -> set[int]:
+    """User ids that already hold a read-mark on ``content_id``."""
+    result = await session.execute(
+        select(ContentCompletion.user_id).where(ContentCompletion.content_id == content_id)
+    )
+    return set(result.scalars().all())
+
+
+async def _repoint_completions(
+    session: AsyncSession,
+    completions: list[ContentCompletion],
+    survivor_id: int,
+) -> tuple[int, int]:
+    """Repoint marks onto ``survivor_id``; return ``(repointed, dropped)``.
+
+    A user who already holds a mark on the survivor would trip
+    ``uq_contentcompletion_user_content`` on repoint, so that stale mark is
+    dropped instead of moved.
+    """
+    already_marked = await _user_ids_with_completion(session, survivor_id)
+    repointed = 0
+    dropped = 0
+    for completion in completions:
+        if completion.user_id in already_marked:
+            await session.delete(completion)
+            dropped += 1
+        else:
+            completion.content_id = survivor_id
+            repointed += 1
+    return repointed, dropped
+
+
+async def _drop_or_repoint_completions(
+    session: AsyncSession,
+    stale: StageContent,
+    survivor: StageContent | None,
+) -> tuple[int, int]:
+    """Rehome a stale row's read-marks; return ``(repointed, dropped)``.
+
+    With no survivor every mark is deleted; with a survivor the marks are
+    repointed onto it (or dropped on a duplicate) by
+    :func:`_repoint_completions`.
+    """
+    result = await session.execute(
+        select(ContentCompletion).where(ContentCompletion.content_id == stale.id)
+    )
+    completions = list(result.scalars().all())
+    survivor_id = survivor.id if survivor is not None else None
+    if survivor_id is None:
+        for completion in completions:
+            await session.delete(completion)
+        return 0, len(completions)
+    return await _repoint_completions(session, completions, survivor_id)
+
+
+async def _prune_stale_rows(
+    session: AsyncSession,
+    existing: _ExistingRows,
+    survivors: dict[tuple[int, str], StageContent],
+    reconciled_ids: set[int],
+) -> _PruneCounts:
+    """Delete unclaimed rows in reconciled stages, rehoming their read-marks.
+
+    Flushes first so freshly inserted survivors carry ids before any
+    read-mark is repointed onto them, and again once every mark is rehomed
+    so no surviving completion still references a stale row when the row is
+    deleted (the ``content_id`` FK is enforced and not deferrable).
+    Deletion stays inside the caller's transaction; the shared commit point
+    is the sole writer.
+    """
+    stale = _stale_rows(existing, reconciled_ids)
+    if not stale:
+        return _PruneCounts(rows=0, repointed=0, dropped=0)
+    await session.flush()
+    repointed = 0
+    dropped = 0
+    for row in stale:
+        survivor = survivors.get((row.course_stage_id, row.title))
+        row_repointed, row_dropped = await _drop_or_repoint_completions(session, row, survivor)
+        repointed += row_repointed
+        dropped += row_dropped
+    await session.flush()
+    for row in stale:
+        await session.delete(row)
+    return _PruneCounts(rows=len(stale), repointed=repointed, dropped=dropped)
+
+
+def _warn_pruned(counts: _PruneCounts) -> None:
+    """Emit one WARNING summarising a prune pass, only when rows were removed."""
+    if counts.rows > 0:
+        logger.warning(
+            "content_seed_pruned rows=%d completions_repointed=%d completions_deleted=%d",
+            counts.rows,
+            counts.repointed,
+            counts.dropped,
+        )
 
 
 async def seed_content(session: AsyncSession) -> int:
@@ -182,19 +339,27 @@ async def seed_content(session: AsyncSession) -> int:
     Returns the number of newly-inserted rows.  Existing rows whose fields
     have drifted from the config are updated in place; the function is
     idempotent — running it twice with the same config inserts nothing the
-    second time.  Manifest stages without a ``CourseStage`` row are skipped
-    and warned about after the commit, never aborting the seed.
+    second time.  Rows in reconciled stages that the manifest no longer
+    claims are pruned, and their read-marks repointed or dropped.  Manifest
+    stages without a ``CourseStage`` row are skipped and warned about after
+    the commit, never aborting the seed.
     """
     stage_map = await _load_stage_map(session)
     existing = await _load_existing_keys(session)
 
-    inserted, dirty = _reconcile_all(session, stage_map, existing)
+    result = _reconcile_all(session, stage_map, existing)
+    counts = await _prune_stale_rows(
+        session, existing, result.survivors, _reconciled_stage_ids(stage_map)
+    )
 
-    if dirty:
+    if result.dirty or counts.rows > 0:
         # Race-safe commit: a peer worker that seeded the same chapters
         # between our existence read and this commit trips the
         # ``ix_stagecontent_stage_content_ref_unique`` index (migration
         # ``e8f9a0b1c2d3``); the loser rolls back and reports 0 inserts.
-        inserted = await commit_or_yield_to_race_winner(session, inserted)
+        inserted = await commit_or_yield_to_race_winner(session, result.inserted)
+    else:
+        inserted = result.inserted
     _warn_unmapped_manifest_stages(stage_map)
+    _warn_pruned(counts)
     return inserted

--- a/backend/src/seed_content.py
+++ b/backend/src/seed_content.py
@@ -68,22 +68,46 @@ class _ExistingRows:
     ``url`` column), so a manifest title edit must still land on the same
     row.  ``by_url`` is therefore the primary index; ``by_title`` is a
     fallback that heals legacy rows whose ``url`` drifted from the manifest
-    while their title held steady.  Rows are popped from both indexes when
+    while their title held steady.  Rows are removed from both indexes when
     claimed so one DB row can never satisfy two manifest records.
+
+    ``by_url`` maps each ``(course_stage_id, url)`` to the *list* of rows
+    carrying that url, because legacy fossils may share a non-``content://``
+    url without being copies of one chapter.  Keeping every such row means
+    the prune step sees them all, not just the last one indexed.
     """
 
-    by_url: dict[tuple[int, str], StageContent]
+    by_url: dict[tuple[int, str], list[StageContent]]
     by_title: dict[tuple[int, str], StageContent]
 
     def claim(self, course_stage_id: int, record: ChapterRecord) -> StageContent | None:
         """Find and remove the prior row for ``record``: url first, title fallback."""
-        prior = self.by_url.get((course_stage_id, record.url))
+        bucket = self.by_url.get((course_stage_id, record.url))
+        prior = bucket[0] if bucket else None
         if prior is None:
             prior = self.by_title.get((course_stage_id, record.title))
         if prior is not None:
-            self.by_url.pop((course_stage_id, prior.url), None)
-            self.by_title.pop((course_stage_id, prior.title), None)
+            self._discard(course_stage_id, prior)
         return prior
+
+    def _discard(self, course_stage_id: int, row: StageContent) -> None:
+        """Remove ``row`` from both indexes by identity so it cannot reclaim.
+
+        A claimed ``row`` is always still present in its own ``by_url``
+        bucket (every loaded row is indexed there, and rows leave the bucket
+        and ``by_title`` together), so the key is guaranteed to exist.
+        """
+        key = (course_stage_id, row.url)
+        survivors = [candidate for candidate in self.by_url[key] if candidate is not row]
+        if survivors:
+            self.by_url[key] = survivors
+        else:
+            del self.by_url[key]
+        self.by_title.pop((course_stage_id, row.title), None)
+
+    def unclaimed(self) -> list[StageContent]:
+        """Every row no manifest record claimed, across all url buckets."""
+        return [row for bucket in self.by_url.values() for row in bucket]
 
 
 async def _load_existing_keys(session: AsyncSession) -> _ExistingRows:
@@ -91,14 +115,18 @@ async def _load_existing_keys(session: AsyncSession) -> _ExistingRows:
 
     The ``content://<id>`` reference (``url``) is the stable identity, so
     rows are indexed primarily by ``(course_stage_id, url)`` — a title edit
-    on that stable ref updates in place instead of duplicating.  A
-    secondary ``(course_stage_id, title)`` index is a fallback that keeps
-    healing legacy rows whose ``url`` drifted from the manifest.
+    on that stable ref updates in place instead of duplicating.  Each key
+    holds every row with that url so identical-url legacy fossils are all
+    retained.  A secondary ``(course_stage_id, title)`` index is a fallback
+    that keeps healing legacy rows whose ``url`` drifted from the manifest.
     """
     result = await session.execute(select(StageContent))
     rows = list(result.scalars().all())
+    by_url: dict[tuple[int, str], list[StageContent]] = {}
+    for sc in rows:
+        by_url.setdefault((sc.course_stage_id, sc.url), []).append(sc)
     return _ExistingRows(
-        by_url={(sc.course_stage_id, sc.url): sc for sc in rows},
+        by_url=by_url,
         by_title={(sc.course_stage_id, sc.title): sc for sc in rows},
     )
 
@@ -219,11 +247,11 @@ def _reconciled_stage_ids(stage_map: dict[int, int]) -> set[int]:
 def _stale_rows(existing: _ExistingRows, reconciled_ids: set[int]) -> list[StageContent]:
     """Unclaimed rows in reconciled stages — the deletion candidates.
 
-    After reconciliation ``existing.by_url`` holds exactly the rows no
+    After reconciliation ``existing.unclaimed()`` holds exactly the rows no
     manifest record claimed; narrowing to ``reconciled_ids`` keeps the
     prune from ever reaching a stage this run did not reconcile.
     """
-    return [row for row in existing.by_url.values() if row.course_stage_id in reconciled_ids]
+    return [row for row in existing.unclaimed() if row.course_stage_id in reconciled_ids]
 
 
 @dataclass(frozen=True)

--- a/backend/src/seed_helpers.py
+++ b/backend/src/seed_helpers.py
@@ -53,6 +53,24 @@ async def existing_system_keys(
     return {row[0] for row in rows}
 
 
+async def try_commit_yielding_to_race_winner(session: AsyncSession) -> bool:
+    """Commit, reporting whether THIS process won the idempotent-seed race.
+
+    Returns ``True`` when the commit persisted — this process is the race
+    winner — and ``False`` when a concurrent peer already committed the same
+    unique-keyed rows, tripping the arbitrating index; the loser rolls back
+    and reports no win. Exposing the win/loss verdict lets callers suppress
+    side effects — log lines, metrics — that would otherwise claim work this
+    process rolled back rather than persisted.
+    """
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return False
+    return True
+
+
 async def commit_or_yield_to_race_winner(session: AsyncSession, inserted: int) -> int:
     """Commit ``inserted`` new rows, treating a unique-index collision as a no-op.
 
@@ -68,9 +86,4 @@ async def commit_or_yield_to_race_winner(session: AsyncSession, inserted: int) -
     ``Practice(stage_number, name)`` and ``07b8c9d0e1f2`` for the
     ``PracticeTag.slug`` / ``PracticeRecipe.slug`` partial-unique indexes.
     """
-    try:
-        await session.commit()
-    except IntegrityError:
-        await session.rollback()
-        return 0
-    return inserted
+    return inserted if await try_commit_yielding_to_race_winner(session) else 0

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -465,3 +466,342 @@ def test_desired_content_records_counts(
     records = desired_content_records()
     assert len(records) == len(_MANIFEST["chapters"])
     assert {r.url for r in records} == {content_ref(c["id"]) for c in _MANIFEST["chapters"]}
+
+
+# ── pruning ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prunes_legacy_placeholder_row(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A stale row from a retired manifest chapter is deleted on a reconciled stage."""
+    await _seed_stages(db_session, count=1)
+    stage_one = (await db_session.execute(select(CourseStage))).scalars().one()
+    db_session.add(
+        StageContent(
+            course_stage_id=stage_one.id,
+            title="Chapter 3",
+            content_type="chapter",
+            release_day=0,
+            url="https://legacy.example.com/3",
+        )
+    )
+    await db_session.commit()
+
+    install_manifest(_MANIFEST)
+    await seed_content(db_session)
+
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    titles = {r.title for r in rows}
+    assert "Chapter 3" not in titles
+    assert {"Survival", "Breath as Anchor"} <= titles
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prunes_duplicate_title_twin_repointing_completion(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A stale twin sharing a claimed title is pruned and its read mark repointed."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    survivor = (
+        (await db_session.execute(select(StageContent).where(StageContent.title == "Survival")))
+        .scalars()
+        .one()
+    )
+
+    stale_twin = StageContent(
+        course_stage_id=survivor.course_stage_id,
+        title="Survival",
+        content_type="chapter",
+        release_day=0,
+        url="https://legacy.example.com/survival",
+    )
+    db_session.add(stale_twin)
+    await db_session.commit()
+    assert stale_twin.id is not None
+
+    user = User(email="twin-reader@example.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    assert user.id is not None
+    db_session.add(ContentCompletion(user_id=user.id, content_id=stale_twin.id))
+    await db_session.commit()
+
+    await seed_content(db_session)
+
+    remaining_ids = {r.id for r in (await db_session.execute(select(StageContent))).scalars().all()}
+    assert stale_twin.id not in remaining_ids
+    assert survivor.id in remaining_ids
+
+    completions = (await db_session.execute(select(ContentCompletion))).scalars().all()
+    assert len(completions) == 1
+    assert completions[0].content_id == survivor.id
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prune_completion_collision_drops_stale_mark(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A user with completions on both a stale twin and its survivor keeps only the survivor's."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    survivor = (
+        (await db_session.execute(select(StageContent).where(StageContent.title == "Survival")))
+        .scalars()
+        .one()
+    )
+
+    stale_twin = StageContent(
+        course_stage_id=survivor.course_stage_id,
+        title="Survival",
+        content_type="chapter",
+        release_day=0,
+        url="https://legacy.example.com/survival",
+    )
+    db_session.add(stale_twin)
+    await db_session.commit()
+    assert stale_twin.id is not None
+
+    user = User(email="collision-reader@example.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    assert user.id is not None
+    db_session.add(ContentCompletion(user_id=user.id, content_id=survivor.id))
+    db_session.add(ContentCompletion(user_id=user.id, content_id=stale_twin.id))
+    await db_session.commit()
+
+    await seed_content(db_session)
+
+    completions = (
+        (
+            await db_session.execute(
+                select(ContentCompletion).where(ContentCompletion.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(completions) == 1
+    assert completions[0].content_id == survivor.id
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prune_collapses_marks_across_multiple_twins(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Two stale twins of one survivor with the same reader collapse to a single mark."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    survivor = (
+        (await db_session.execute(select(StageContent).where(StageContent.title == "Survival")))
+        .scalars()
+        .one()
+    )
+
+    twin_urls = ["https://legacy.example.com/survival-a", "https://legacy.example.com/survival-b"]
+    twins = [
+        StageContent(
+            course_stage_id=survivor.course_stage_id,
+            title="Survival",
+            content_type="chapter",
+            release_day=0,
+            url=url,
+        )
+        for url in twin_urls
+    ]
+    for twin in twins:
+        db_session.add(twin)
+    await db_session.commit()
+
+    user = User(email="multi-twin-reader@example.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    assert user.id is not None
+    for twin in twins:
+        assert twin.id is not None
+        db_session.add(ContentCompletion(user_id=user.id, content_id=twin.id))
+    await db_session.commit()
+
+    await seed_content(db_session)
+
+    survivors = (
+        (await db_session.execute(select(StageContent).where(StageContent.title == "Survival")))
+        .scalars()
+        .all()
+    )
+    assert [row.id for row in survivors] == [survivor.id]
+    completions = (
+        (
+            await db_session.execute(
+                select(ContentCompletion).where(ContentCompletion.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(completions) == 1
+    assert completions[0].content_id == survivor.id
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prunes_nothing_on_fresh_manifest_db(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A first-ever seed with no stale rows prunes nothing and stays silent."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
+    await seed_content(db_session)
+
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    assert len(rows) == len(_MANIFEST["chapters"])
+
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        second = await seed_content(db_session)
+
+    assert second == 0
+    rows_after = (await db_session.execute(select(StageContent))).scalars().all()
+    assert len(rows_after) == len(_MANIFEST["chapters"])
+    warnings = [record.getMessage() for record in caplog.records]
+    assert not any("content_seed_pruned" in message for message in warnings)
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prune_is_idempotent(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second seed after a prune has already happened inserts and prunes nothing more."""
+    await _seed_stages(db_session, count=1)
+    stage_one = (await db_session.execute(select(CourseStage))).scalars().one()
+    db_session.add(
+        StageContent(
+            course_stage_id=stage_one.id,
+            title="Chapter 3",
+            content_type="chapter",
+            release_day=0,
+            url="https://legacy.example.com/3",
+        )
+    )
+    await db_session.commit()
+
+    install_manifest(_MANIFEST)
+    await seed_content(db_session)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        second = await seed_content(db_session)
+
+    assert second == 0
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    titles = {r.title for r in rows}
+    assert "Chapter 3" not in titles
+    warnings = [record.getMessage() for record in caplog.records]
+    assert not any("content_seed_pruned" in message for message in warnings)
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prune_scope_spares_unshipped_and_skipped_stages(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Pruning only ever touches stages the current manifest reconciles this run."""
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=4)
+    await seed_content(db_session)
+
+    stage_five = CourseStage(
+        title="Stage 5",
+        subtitle="Subtitle 5",
+        stage_number=5,
+        overview_url="https://example.com/stage-5",
+        category="test",
+        aspect="test-aspect",
+        spiral_dynamics_color="beige",
+        growing_up_stage="archaic",
+        divine_gender_polarity="masculine",
+        relationship_to_free_will="active",
+        free_will_description="Active Yes-And-Ness",
+    )
+    db_session.add(stage_five)
+    await db_session.commit()
+    assert stage_five.id is not None
+    db_session.add(
+        StageContent(
+            course_stage_id=stage_five.id,
+            title="Unshipped Fossil",
+            content_type="chapter",
+            release_day=0,
+            url="https://legacy.example.com/unshipped",
+        )
+    )
+    await db_session.commit()
+
+    install_manifest(_STAGE_ONE_ONLY_MANIFEST)
+    await seed_content(db_session)
+
+    titles = {r.title for r in (await db_session.execute(select(StageContent))).scalars().all()}
+    assert "Systems Sight" in titles
+    assert "Unshipped Fossil" in titles
+
+
+@pytest.mark.asyncio
+async def test_seed_content_prunes_fossil_and_drops_orphan_completion(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unclaimed fossil with no survivor is deleted along with its orphaned read mark."""
+    await _seed_stages(db_session, count=1)
+    stage_one = (await db_session.execute(select(CourseStage))).scalars().one()
+    fossil = StageContent(
+        course_stage_id=stage_one.id,
+        title="Chapter 1",
+        content_type="chapter",
+        release_day=0,
+        url="https://legacy.example.com/1",
+    )
+    db_session.add(fossil)
+    await db_session.commit()
+    assert fossil.id is not None
+
+    user = User(email="fossil-reader@example.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    assert user.id is not None
+    db_session.add(ContentCompletion(user_id=user.id, content_id=fossil.id))
+    await db_session.commit()
+
+    install_manifest(_MANIFEST)
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        await seed_content(db_session)
+
+    remaining_ids = {r.id for r in (await db_session.execute(select(StageContent))).scalars().all()}
+    assert fossil.id not in remaining_ids
+    completions = (await db_session.execute(select(ContentCompletion))).scalars().all()
+    assert completions == []
+
+    prune_records = [r for r in caplog.records if "content_seed_pruned" in r.getMessage()]
+    assert len(prune_records) == 1
+    match = re.search(
+        r"rows=(\d+) completions_repointed=(\d+) completions_deleted=(\d+)",
+        prune_records[0].getMessage(),
+    )
+    assert match is not None
+    assert match.group(1) == "1"
+    assert match.group(2) == "0"
+    assert match.group(3) == "1"

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
@@ -805,3 +806,67 @@ async def test_seed_content_prunes_fossil_and_drops_orphan_completion(
     assert match.group(1) == "1"
     assert match.group(2) == "0"
     assert match.group(3) == "1"
+
+
+async def _stage_fossil_prune(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Seed a fossil in a reconciled stage so a prune pass is staged."""
+    await _seed_stages(db_session, count=1)
+    stage_one = (await db_session.execute(select(CourseStage))).scalars().one()
+    db_session.add(
+        StageContent(
+            course_stage_id=stage_one.id,
+            title="Chapter 1",
+            content_type="chapter",
+            release_day=0,
+            url="https://legacy.example.com/1",
+        )
+    )
+    await db_session.commit()
+    install_manifest(_MANIFEST)
+
+
+async def _lost_race(_session: AsyncSession) -> bool:
+    return False
+
+
+@pytest.mark.asyncio
+async def test_seed_content_race_loser_skips_prune_warning(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A prune the losing worker rolls back must not be logged as persisted.
+
+    Proves a negative; its positive control is the winner test below, which
+    shares ``_stage_fossil_prune`` and asserts the same setup *does* warn.
+    """
+    await _stage_fossil_prune(db_session, install_manifest)
+
+    with (
+        patch("seed_content.try_commit_yielding_to_race_winner", new=_lost_race),
+        caplog.at_level(logging.WARNING, logger="seed_content"),
+    ):
+        inserted = await seed_content(db_session)
+
+    assert inserted == 0, "race loser reports no inserts"
+    warnings = [record.getMessage() for record in caplog.records]
+    assert not any("content_seed_pruned" in message for message in warnings)
+
+
+@pytest.mark.asyncio
+async def test_seed_content_race_winner_still_warns_on_prune(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The winning worker whose prune persists still emits the summary WARNING."""
+    await _stage_fossil_prune(db_session, install_manifest)
+
+    with caplog.at_level(logging.WARNING, logger="seed_content"):
+        await seed_content(db_session)
+
+    prune_records = [r for r in caplog.records if "content_seed_pruned" in r.getMessage()]
+    assert len(prune_records) == 1

--- a/backend/tests/test_seed_content.py
+++ b/backend/tests/test_seed_content.py
@@ -657,6 +657,113 @@ async def test_seed_content_prune_collapses_marks_across_multiple_twins(
 
 
 @pytest.mark.asyncio
+async def test_seed_content_prunes_both_fossils_sharing_one_legacy_url(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """Two distinct fossils sharing an identical non-content URL are both pruned.
+
+    Migration ``e8f9a0b1c2d3`` documents that legacy rows may share a
+    non-``content://`` url without being copies of one chapter, so the prune
+    must reach every such row -- not just the last one indexed under that
+    ``(stage, url)`` key -- and rehome each reader's mark.
+    """
+    install_manifest(_MANIFEST)
+    await _seed_stages(db_session, count=1)
+    await seed_content(db_session)
+
+    survivor = (
+        (await db_session.execute(select(StageContent).where(StageContent.title == "Survival")))
+        .scalars()
+        .one()
+    )
+
+    shared_url = "https://legacy.example.com/survival"
+    fossils = [
+        StageContent(
+            course_stage_id=survivor.course_stage_id,
+            title="Survival",
+            content_type="chapter",
+            release_day=0,
+            url=shared_url,
+        )
+        for _ in range(2)
+    ]
+    for fossil in fossils:
+        db_session.add(fossil)
+    await db_session.commit()
+    fossil_ids = {fossil.id for fossil in fossils}
+    assert None not in fossil_ids
+
+    readers = [
+        User(email=f"shared-url-reader-{i}@example.com", password_hash="x") for i in range(2)
+    ]
+    for reader in readers:
+        db_session.add(reader)
+    await db_session.commit()
+    for reader, fossil in zip(readers, fossils, strict=True):
+        assert reader.id is not None
+        db_session.add(ContentCompletion(user_id=reader.id, content_id=fossil.id))
+    await db_session.commit()
+
+    await seed_content(db_session)
+
+    remaining_ids = {r.id for r in (await db_session.execute(select(StageContent))).scalars().all()}
+    assert fossil_ids.isdisjoint(remaining_ids)
+    assert survivor.id in remaining_ids
+
+    completions = (await db_session.execute(select(ContentCompletion))).scalars().all()
+    assert {c.content_id for c in completions} == {survivor.id}
+    assert {c.user_id for c in completions} == {reader.id for reader in readers}
+
+
+@pytest.mark.asyncio
+async def test_seed_content_heals_one_shared_url_row_and_prunes_its_twin(
+    db_session: AsyncSession,
+    install_manifest: Callable[[dict[str, Any]], None],
+) -> None:
+    """A shared-url fossil whose title matches the manifest is healed; its twin is pruned.
+
+    Two rows share a non-content url in one stage: one carries a manifest
+    title (claimed by the title fallback and updated to a ``content://``
+    ref), the other does not (pruned).  This exercises the multi-row url
+    bucket surviving a single claim.
+    """
+    await _seed_stages(db_session, count=1)
+    stage_one = (await db_session.execute(select(CourseStage))).scalars().one()
+
+    shared_url = "https://legacy.example.com/shared"
+    named = StageContent(
+        course_stage_id=stage_one.id,
+        title="Survival",
+        content_type="chapter",
+        release_day=0,
+        url=shared_url,
+    )
+    orphan = StageContent(
+        course_stage_id=stage_one.id,
+        title="Chapter 9",
+        content_type="chapter",
+        release_day=0,
+        url=shared_url,
+    )
+    db_session.add(named)
+    db_session.add(orphan)
+    await db_session.commit()
+    assert named.id is not None
+    assert orphan.id is not None
+
+    install_manifest(_MANIFEST)
+    await seed_content(db_session)
+
+    rows = (await db_session.execute(select(StageContent))).scalars().all()
+    by_id = {row.id: row for row in rows}
+    assert orphan.id not in by_id
+    assert by_id[named.id].title == "Survival"
+    assert by_id[named.id].url == content_ref("beige-1")
+
+
+@pytest.mark.asyncio
 async def test_seed_content_prunes_nothing_on_fresh_manifest_db(
     db_session: AsyncSession,
     install_manifest: Callable[[dict[str, Any]], None],

--- a/backend/tests/test_seed_race.py
+++ b/backend/tests/test_seed_race.py
@@ -28,7 +28,7 @@ from sqlmodel import select
 
 from models.course_stage import CourseStage
 from models.stage_content import StageContent
-from seed_content import _ExistingRows, seed_content
+from seed_content import _ExistingRows, _load_stage_map, seed_content
 from seed_practice_recipes import seed_practice_recipes
 from seed_stages import STAGE_DEFINITIONS, seed_stages
 
@@ -108,6 +108,57 @@ async def test_seed_content_race_loser_yields_to_winner(db_session: AsyncSession
         second = await seed_content(db_session)
 
     assert second == 0, "race loser must report 0 inserts, not raise"
+    assert await _count(db_session, StageContent) == baseline
+
+
+@pytest.mark.asyncio
+async def test_seed_content_race_loser_yields_when_prune_flush_collides(
+    db_session: AsyncSession,
+) -> None:
+    """The content seeder must survive losing the race at PRUNE-FLUSH time.
+
+    ``_prune_stale_rows`` calls ``session.flush()`` before the guarded
+    commit, and that flush pushes every pending ``_reconcile_all`` insert
+    to the DB.  On the two-worker boot against a pre-manifest DB that still
+    carries legacy fossil rows, the losing worker reaches the prune with
+    real stale rows present *and* pending manifest inserts, so its flush
+    fires the ``ix_stagecontent_stage_content_ref_unique`` collision before
+    ``try_commit_yielding_to_race_winner`` could arbitrate — the exact
+    escape ``seed_practice_recipes`` already guards at its own flush.
+
+    Deterministic simulation: the peer's manifest rows are committed, a
+    genuine fossil row sits in a reconciled stage, and this worker's
+    existence read is stale (patched to see only the fossil), so reconcile
+    re-stages every manifest chapter and the prune flush collides.
+    """
+    await seed_stages(db_session)
+    first = await seed_content(db_session)
+    assert first > 0, "vendored manifest must seed chapters"
+
+    reconciled_stage_id = (await _load_stage_map(db_session))[1]
+    fossil = StageContent(
+        course_stage_id=reconciled_stage_id,
+        title="Legacy Fossil No Manifest Claims",
+        content_type="reading",
+        release_day=1,
+        url="legacy://orphaned-fossil",
+    )
+    db_session.add(fossil)
+    await db_session.commit()
+    baseline = await _count(db_session, StageContent)
+
+    fossil_only = _ExistingRows(
+        by_url={(reconciled_stage_id, fossil.url): [fossil]},
+        by_title={(reconciled_stage_id, fossil.title): fossil},
+    )
+
+    async def _stale_read(*_args: object, **_kwargs: object) -> _ExistingRows:
+        return fossil_only
+
+    with patch("seed_content._load_existing_keys", new=_stale_read):
+        second = await seed_content(db_session)
+
+    assert second == 0, "race loser must report 0 inserts, not raise at prune flush"
     assert await _count(db_session, StageContent) == baseline
 
 


### PR DESCRIPTION
## Summary

Pre-manifest production databases carry fossil `StageContent` rows that the manifest-driven seeder never healed, because the seeder only ever inserted or updated rows (its contract was literally "nothing is ever deleted"). Two classes of fossil linger:

- Legacy placeholder rows with non-`content://` urls (titled "Chapter N"), which duplicate course listings and 404 on body read.
- Historical title-keyed duplicate twins (from before reconciliation became url-keyed), one of which gets claimed/updated while its twin is orphaned forever.

These stale rows duplicated the course shelf/listings, produced dead "Chapter N" reader entries, and inflated both the proportional-drip denominator (`_stage_content_count`) and the progress totals for every user on a pre-manifest DB.

This adds an idempotent, race-safe **prune phase** to `seed_content`:

- After reconciliation, `StageContent` rows no longer claimed by the manifest are deleted — scoped **strictly** to stages that are both shipped by the manifest and have a `CourseStage` row. Stages the manifest does not ship (subset manifests) and stages skipped for a missing `CourseStage` row (`content_seed_partial`) are never touched.
- A pruned row's `ContentCompletion` read-marks (the only FK to `stagecontent.id`, unique on `(user_id, content_id)`, no cascade) are repointed to a surviving same-`(stage, title)` row, dropped on a unique-constraint collision, or dropped when no survivor exists — preserving each reader's mark wherever a real chapter still exists.
- Deletion stays inside the existing `commit_or_yield_to_race_winner` transaction (the sole commit point), so a race-loser rollback also unwinds the prune and the next seed re-converges. A single `content_seed_pruned rows=/repointed=/deleted=` WARNING summarises each pass.
- The module docstring is rewritten to retire the "nothing is ever deleted" contract and state the new claimed-survives / unclaimed-pruned rule.

No schema change and no migration — this is runtime seeder reconciliation. The existing deploy-time dedupe migration (`e8f9a0b1c2d3`) still handles `content://` twins; this prune complements it by healing non-`content://` fossils and title-keyed twins on every startup seed.

## Test plan

- `scripts/backend/check-all.sh` passes (2672 passed, 96.76% total coverage; `seed_content.py` at 100% line + branch).
- `xenon --max-absolute A --max-modules A --max-average A src/seed_content.py` and `radon mi src/seed_content.py` both grade A; ruff and mypy clean.
- New seeder tests cover: legacy placeholder pruned; duplicate-title twin pruned while the url-claimed twin survives and its completion is repointed; completion collision drops the stale mark; multiple twins collapse a single reader's marks to one; orphan completion dropped with the `content_seed_pruned` WARNING; fresh manifest-only DB untouched; prune idempotent on reseed; scope guard spares unshipped and skipped stages.
- Existing `test_read_completions_survive_content_resync` and all reconcile/idempotence/partial-seed tests remain green.

Closes #1764