### PR TITLE
fix(navigation): drawer nav rows silently no-op from JournalEntry

### DIFF
--- a/frontend/src/__tests__/navigation/drawerNavFromJournalEntry.test.tsx
+++ b/frontend/src/__tests__/navigation/drawerNavFromJournalEntry.test.tsx
@@ -1,0 +1,101 @@
+// Real NavigationContainer/stack/tabs harness (no navigation mocks) proving the
+// drawer's nav rows work when hosted from a root-stack screen, not just a tab.
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import type { NavigatorScreenParams } from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import DrawerNavSection from '@/components/drawer/DrawerNavSection';
+import type { RootTabParamList } from '@/navigation/BottomTabs';
+import { useDepthPreferencesStore } from '@/store/useDepthPreferencesStore';
+
+type TestStackParamList = {
+  Tabs: NavigatorScreenParams<RootTabParamList>;
+  JournalEntry: undefined;
+};
+
+const Tab = createBottomTabNavigator<RootTabParamList>();
+const Stack = createNativeStackNavigator<TestStackParamList>();
+
+function JournalScreenStub(): React.JSX.Element {
+  return <Text>Journal screen stub</Text>;
+}
+
+function HabitsScreenStub(): React.JSX.Element {
+  return <Text>Habits screen stub</Text>;
+}
+
+function PracticeScreenStub(): React.JSX.Element {
+  return <Text>Practice screen stub</Text>;
+}
+
+function CourseScreenStub(): React.JSX.Element {
+  return <Text>Course screen stub</Text>;
+}
+
+function MapScreenStub(): React.JSX.Element {
+  return <Text>Map screen stub</Text>;
+}
+
+function TestTabs(): React.JSX.Element {
+  return (
+    <Tab.Navigator screenOptions={{ headerShown: false }}>
+      <Tab.Screen name="Journal" component={JournalScreenStub} />
+      <Tab.Screen name="Habits" component={HabitsScreenStub} />
+      <Tab.Screen name="Practice" component={PracticeScreenStub} />
+      <Tab.Screen name="Course" component={CourseScreenStub} />
+      <Tab.Screen name="Map" component={MapScreenStub} />
+    </Tab.Navigator>
+  );
+}
+
+function JournalEntryHost(): React.JSX.Element {
+  return <DrawerNavSection currentScreen="Journal" onNavigate={() => undefined} />;
+}
+
+function TestRootNavigator(): React.JSX.Element {
+  return (
+    <Stack.Navigator initialRouteName="JournalEntry" screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Tabs" component={TestTabs} />
+      <Stack.Screen name="JournalEntry" component={JournalEntryHost} />
+    </Stack.Navigator>
+  );
+}
+
+function renderFromJournalEntry() {
+  return render(
+    <NavigationContainer>
+      <TestRootNavigator />
+    </NavigationContainer>,
+  );
+}
+
+beforeEach(() => {
+  useDepthPreferencesStore.setState({
+    enable_habits: true,
+    enable_practices: true,
+    enable_course: true,
+  });
+});
+
+describe('drawer nav rows from a root-stack screen (JournalEntry)', () => {
+  it('tapping Map navigates to the Map tab even when the drawer is hosted from JournalEntry', async () => {
+    const { getByTestId, getByText } = renderFromJournalEntry();
+
+    fireEvent.press(getByTestId('drawer-nav-Map'));
+
+    await waitFor(() => expect(getByText('Map screen stub')).toBeTruthy());
+  });
+
+  it('tapping Journal navigates to the Journal tab from JournalEntry', async () => {
+    const { getByTestId, getByText } = renderFromJournalEntry();
+
+    fireEvent.press(getByTestId('drawer-nav-Journal'));
+
+    await waitFor(() => expect(getByText('Journal screen stub')).toBeTruthy());
+  });
+});

--- a/frontend/src/components/drawer/DrawerNavSection.tsx
+++ b/frontend/src/components/drawer/DrawerNavSection.tsx
@@ -5,6 +5,8 @@
  * own drawer contents. Optional depth rings appear only while their toggle is on,
  * subscribed live so a ring flip adds or removes its row without a manual refresh.
  */
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
@@ -13,7 +15,7 @@ import DrawerItem from './DrawerItem';
 import { accent, ink, SPACING, surface } from '@/design/tokens';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
 import { NAV_DESTINATIONS, type NavDestinationRing } from '@/navigation/destinations';
-import { useAppNavigation } from '@/navigation/hooks';
+import type { RootStackParamList } from '@/navigation/RootStack';
 import {
   selectEnableCourse,
   selectEnableHabits,
@@ -26,19 +28,27 @@ const NAV_ICON_SIZE = 24;
 /** Stroke width of the leading lucide icon on each nav row. */
 const NAV_ICON_STROKE = 2;
 
-type TabNavigation = ReturnType<typeof useAppNavigation>;
+type RootStackNavigation = NativeStackNavigationProp<RootStackParamList>;
 
 /**
- * Per-route navigate thunks. Literal ``navigate('Name')`` calls type-check under
- * React Navigation's distributive signature where a union route name does not, so
- * each destination gets its own explicit thunk instead of a single dynamic call.
+ * Per-route navigate thunks. Every drawer nav row dispatches through the root
+ * stack's ``Tabs`` route (``navigate('Tabs', { screen })``) rather than a
+ * tab-scoped ``navigate(name)``: that resolves from any drawer host -- a tab
+ * screen bubbles the action up to the parent stack, and the root-stack
+ * ``JournalEntry`` screen (whose nearest navigator IS the stack) resolves it
+ * directly, so the action is no longer dropped there. Each thunk hard-codes a
+ * literal screen name because a union-typed ``screen`` is not assignable to
+ * ``Tabs``'s distributive ``NavigatorScreenParams`` union; one literal per
+ * destination matches a single member and type-checks.
  */
-const NAVIGATE_BY_NAME: Readonly<Record<keyof RootTabParamList, (nav: TabNavigation) => void>> = {
-  Journal: (nav) => nav.navigate('Journal'),
-  Habits: (nav) => nav.navigate('Habits'),
-  Practice: (nav) => nav.navigate('Practice'),
-  Course: (nav) => nav.navigate('Course'),
-  Map: (nav) => nav.navigate('Map'),
+const NAVIGATE_BY_NAME: Readonly<
+  Record<keyof RootTabParamList, (nav: RootStackNavigation) => void>
+> = {
+  Journal: (nav) => nav.navigate('Tabs', { screen: 'Journal' }),
+  Habits: (nav) => nav.navigate('Tabs', { screen: 'Habits' }),
+  Practice: (nav) => nav.navigate('Tabs', { screen: 'Practice' }),
+  Course: (nav) => nav.navigate('Tabs', { screen: 'Course' }),
+  Map: (nav) => nav.navigate('Tabs', { screen: 'Map' }),
 };
 
 export interface DrawerNavSectionProps {
@@ -57,7 +67,7 @@ export default function DrawerNavSection({
   currentScreen,
   onNavigate,
 }: DrawerNavSectionProps): React.JSX.Element {
-  const navigation = useAppNavigation();
+  const navigation = useNavigation<RootStackNavigation>();
   const enableHabits = useDepthPreferencesStore(selectEnableHabits);
   const enablePractices = useDepthPreferencesStore(selectEnablePractices);
   const enableCourse = useDepthPreferencesStore(selectEnableCourse);

--- a/frontend/src/components/drawer/__tests__/DrawerNavSection.test.tsx
+++ b/frontend/src/components/drawer/__tests__/DrawerNavSection.test.tsx
@@ -3,9 +3,11 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
-const mockNavigate = jest.fn();
-jest.mock('@/navigation/hooks', () => ({
-  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
+const mockRootNavigate = jest.fn();
+// The drawer now dispatches through the root stack, not the tab navigator.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockRootNavigate }),
 }));
 
 import DrawerNavSection from '@/components/drawer/DrawerNavSection';
@@ -100,8 +102,8 @@ describe('DrawerNavSection', () => {
 
     fireEvent.press(getByTestId('drawer-nav-Journal'));
 
-    expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockRootNavigate).toHaveBeenCalledTimes(1);
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Journal' });
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
@@ -113,7 +115,7 @@ describe('DrawerNavSection', () => {
 
     fireEvent.press(getByTestId('drawer-nav-Habits'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Habits');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Habits' });
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenDrawerNav.test.tsx
@@ -174,7 +174,7 @@ describe('Course header drawer nav section', () => {
     fireEvent.press(getByLabelText('Open Course menu'));
     fireEvent.press(getByTestId('drawer-nav-Journal'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Journal' });
     expect(queryByTestId('screen-drawer-panel')).toBeNull();
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsEditModeTile.test.tsx
@@ -47,6 +47,12 @@ const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement })
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 jest.mock('../../../api', () => {
   // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only

--- a/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsLockUnstarted.test.tsx
@@ -41,6 +41,12 @@ const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement })
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 jest.mock('../../../api', () => {
   // The load path maps API rows through the real toLocalHabit; keep it so the

--- a/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsResponsive.test.tsx
@@ -11,6 +11,12 @@ const mockSetOptions = jest.fn();
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 const HabitsScreen = require('../HabitsScreen').default;
 

--- a/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenDrawerNav.test.tsx
@@ -6,6 +6,7 @@ import React, { useSyncExternalStore, type ReactElement } from 'react';
 // drawer. Mirrors PracticeScreenDrawerNav.test.tsx's headerLeftStore harness,
 // adding a stable navigate spy so the shared nav rows have somewhere to route.
 const mockNavigate = jest.fn();
+const mockRootNavigate = jest.fn();
 // HabitsScreen installs its header-left drawer toggle through
 // useAppNavigation (useScreenDrawer), which calls navigation.setOptions in a
 // layout effect on every mount. The store relays the installed headerLeft
@@ -21,6 +22,12 @@ const mockSetOptions = jest.fn((opts: { headerLeft?: () => ReactElement }) => {
 });
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ navigate: mockNavigate, setOptions: mockSetOptions }),
+}));
+
+// The drawer now dispatches through the root stack, not the tab navigator.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockRootNavigate }),
 }));
 
 jest.mock('../../../api', () => ({
@@ -155,7 +162,7 @@ describe('Habits header drawer nav section', () => {
     fireEvent.press(getByLabelText('Open Habits menu'));
     fireEvent.press(getByTestId('drawer-nav-Journal'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Journal' });
     expect(queryByTestId('screen-drawer-panel')).toBeNull();
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsScreenIconChrome.test.tsx
@@ -10,6 +10,12 @@ const mockSetOptions = jest.fn();
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 // Mock the API so HabitsScreen loads instantly with an empty list. Plain
 // promise-returning functions avoid the typed-mock `never` inference of

--- a/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
+++ b/frontend/src/features/Habits/__tests__/StatsModal.fetch-dedup.test.tsx
@@ -44,6 +44,12 @@ const mockSetOptions = jest.fn((opts: { headerLeft?: () => React.ReactElement })
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 jest.mock('../../../api', () => {
   // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenDrawer.test.tsx
@@ -62,6 +62,12 @@ jest.mock('@/navigation/hooks', () => ({
   ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
   useAppNavigation: () => ({ navigate: jest.fn(), setOptions: mockSetOptions }),
 }));
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so the entry screen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 
 const JournalEntryScreen = require('../JournalEntryScreen').default;
 

--- a/frontend/src/features/Journal/__tests__/JournalScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalScreenDrawerNav.test.tsx
@@ -16,6 +16,7 @@ const mockList = jest.fn() as jest.MockedFunction<
   (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
 >;
 const mockNavigate = jest.fn();
+const mockRootNavigate = jest.fn();
 const mockClose = jest.fn();
 
 jest.mock('@/api', () => ({
@@ -26,6 +27,12 @@ jest.mock('@/api', () => ({
 
 jest.mock('@/navigation/hooks', () => ({
   useAppNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
+}));
+
+// The drawer now dispatches through the root stack, not the tab navigator.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockRootNavigate }),
 }));
 
 function fakeDrawer(): ScreenDrawerState {
@@ -92,7 +99,7 @@ describe('Journal header drawer nav section', () => {
 
     fireEvent.press(getByTestId('drawer-nav-Map'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Map');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Map' });
     expect(mockClose).toHaveBeenCalled();
   });
 

--- a/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
@@ -21,6 +21,12 @@ jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
 jest.mock('../../../navigation/hooks', () =>
   jest.requireActual('./mapTestHarness').mockNavigationModule(),
 );
+// The drawer nav section dispatches through the root stack via useNavigation;
+// stub it so MapScreen renders outside a real NavigationContainer.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
 jest.mock('@react-navigation/bottom-tabs', () =>
   jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
 );

--- a/frontend/src/features/Map/__tests__/MapScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawerNav.test.tsx
@@ -8,13 +8,14 @@ import { act, create } from 'react-test-renderer';
 
 import MapScreen from '../MapScreen';
 
-import {
-  mockMakeStage,
-  mockMapState,
-  mockNavigate,
-  mockSetOptions,
-  resetMapMocks,
-} from './mapTestHarness';
+import { mockMakeStage, mockMapState, mockSetOptions, resetMapMocks } from './mapTestHarness';
+
+const mockRootNavigate = jest.fn();
+// The drawer now dispatches through the root stack, not the tab navigator.
+jest.mock('@react-navigation/native', () => ({
+  ...(jest.requireActual('@react-navigation/native') as object),
+  useNavigation: () => ({ navigate: mockRootNavigate }),
+}));
 
 jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
   jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
@@ -69,6 +70,7 @@ const openDrawer = (): void => {
 describe('Map header drawer nav section', () => {
   beforeEach(() => {
     resetMapMocks();
+    mockRootNavigate.mockClear();
     mockMapState.stages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
     jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
     useDepthPreferencesStore.setState({
@@ -115,7 +117,7 @@ describe('Map header drawer nav section', () => {
       tree.root.findByProps({ testID: 'drawer-nav-Journal' }).props.onPress();
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Journal' });
     expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
 
     act(() => tree.unmount());

--- a/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreenDrawerNav.test.tsx
@@ -258,7 +258,7 @@ describe('Practice header drawer nav section', () => {
     fireEvent.press(getByLabelText('Open Practice menu'));
     fireEvent.press(getByTestId('drawer-nav-Journal'));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Journal');
+    expect(mockRootNavigate).toHaveBeenCalledWith('Tabs', { screen: 'Journal' });
     expect(queryByTestId('screen-drawer-panel')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

The in-app drawer is the app's primary navigation (the tab navigator draws no bar). Its primary-nav rows (Journal / Habits / Practice / Course / Map) dispatched tab-scoped `useAppNavigation().navigate('Journal')` through a per-route thunk table. That resolves fine on tab-screen hosts, but when the drawer is hosted from the root-stack `JournalEntry` screen the nearest navigator is the stack — which has no tab routes — so the `NAVIGATE` action bubbled to the container root, found no handler, and was dropped silently in production. From an entry screen the whole nav section was dead weight.

The fix retargets `DrawerNavSection` to the root stack navigation and dispatches through the stack's `Tabs` route: `navigate('Tabs', { screen })`. This resolves from every drawer host — a tab screen bubbles the action up to the parent stack, and the `JournalEntry` screen (whose nearest navigator *is* the stack) resolves it directly. `RootStackParamList` is imported type-only to avoid a runtime require cycle, and the literal-per-destination table stays because a union-typed `screen` is not assignable to `Tabs`'s distributive `NavigatorScreenParams` union.

## Test plan

- New regression test `frontend/src/__tests__/navigation/drawerNavFromJournalEntry.test.tsx` drives a **real** `NavigationContainer` (root stack + nested tabs, `JournalEntry` focused, no navigation mock), taps `drawer-nav-Map`/`drawer-nav-Journal`, and asserts the destination screen renders — it fails against the old code and passes with the fix.
- The five `*ScreenDrawerNav` suites and the `DrawerNavSection` unit suite now assert the new `('Tabs', { screen })` call shape.
- Seven pre-existing drawer-host tests gained a minimal `@react-navigation/native` `useNavigation` stub so they still render outside a container.
- `scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and Jest (410 suites / 4417 tests) all pass. No suppressions.

Closes #1766