### PR TITLE
feat(drawer): shared DrawerSearch component + dependency-free fuzzy matcher utility

### DIFF
--- a/frontend/src/components/drawer/DrawerSearch.tsx
+++ b/frontend/src/components/drawer/DrawerSearch.tsx
@@ -1,0 +1,189 @@
+/**
+ * Presentational, uncontrolled search field for a screen drawer: a debounced
+ * text input plus an optional result caption and an optional "search all"
+ * confirm row. It emits the debounced query and leaves matching to the caller.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, TextInput, View } from 'react-native';
+
+import DrawerItem from './DrawerItem';
+
+import {
+  INTERACTIVE_TEXT_MIN,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  radius,
+  surface,
+  touchTarget,
+} from '@/design/tokens';
+
+const DEBOUNCE_DELAY_MS = 300;
+const DEFAULT_PLACEHOLDER = 'Search...';
+const DEFAULT_ACCESSIBILITY_LABEL = 'Search';
+const NO_RESULTS_LABEL = 'No results';
+const INPUT_BORDER_WIDTH = 1;
+
+interface DrawerSearchBaseProps {
+  /** Fired with the debounced query, or '' when the field is cleared. */
+  onQueryChange: (_query: string) => void;
+  /** Number of matches for the active query; omit to hide the caption. */
+  resultCount?: number;
+  /** Placeholder text for the input. */
+  placeholder?: string;
+  /** Accessibility label for the input. */
+  accessibilityLabel?: string;
+  /** Test hook for the wrapper. */
+  testID?: string;
+}
+
+type DrawerSearchDeepProps =
+  | { onConfirmDeepSearch: () => void; deepSearchLabel: string }
+  | { onConfirmDeepSearch?: never; deepSearchLabel?: never };
+
+export type DrawerSearchProps = DrawerSearchBaseProps & DrawerSearchDeepProps;
+
+/** Singular/plural result copy, ASCII-only. */
+function resultCaption(resultCount: number): string {
+  if (resultCount === 0) return NO_RESULTS_LABEL;
+  const noun = resultCount === 1 ? 'result' : 'results';
+  return `${resultCount} ${noun}`;
+}
+
+/** The warm text field; owns its own accent-on-focus border. */
+const DrawerSearchInput = ({
+  text,
+  placeholder,
+  accessibilityLabel,
+  onChangeText,
+}: {
+  text: string;
+  placeholder: string;
+  accessibilityLabel: string;
+  onChangeText: (_value: string) => void;
+}): React.JSX.Element => {
+  const [focused, setFocused] = useState(false);
+  return (
+    <TextInput
+      testID="drawer-search-input"
+      accessibilityLabel={accessibilityLabel}
+      style={[styles.input, focused && styles.inputFocused]}
+      value={text}
+      onChangeText={onChangeText}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      placeholder={placeholder}
+      placeholderTextColor={ink.muted}
+    />
+  );
+};
+
+/** The count / "no results" caption, shown only for an active query. */
+const ResultCaption = ({
+  query,
+  resultCount,
+}: {
+  query: string;
+  resultCount?: number;
+}): React.JSX.Element | null =>
+  query && resultCount != null ? (
+    <Text style={styles.resultCount} testID="drawer-search-result-count">
+      {resultCaption(resultCount)}
+    </Text>
+  ) : null;
+
+/** The "search all" confirm row, shown only when a deep handler and query exist. */
+const DeepSearchRow = ({
+  query,
+  onConfirmDeepSearch,
+  deepSearchLabel,
+}: {
+  query: string;
+  onConfirmDeepSearch?: () => void;
+  deepSearchLabel?: string;
+}): React.JSX.Element | null => {
+  if (!onConfirmDeepSearch || !query || deepSearchLabel == null) return null;
+  return (
+    <DrawerItem
+      label={deepSearchLabel}
+      onPress={onConfirmDeepSearch}
+      testID="drawer-search-deep-search"
+    />
+  );
+};
+
+/** A debounced drawer search field with optional count and deep-search row. */
+export default function DrawerSearch({
+  onQueryChange,
+  resultCount,
+  placeholder = DEFAULT_PLACEHOLDER,
+  accessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
+  testID,
+  onConfirmDeepSearch,
+  deepSearchLabel,
+}: DrawerSearchProps): React.JSX.Element {
+  const [text, setText] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleChangeText = useCallback(
+    (value: string) => {
+      setText(value);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setDebouncedQuery(value);
+        onQueryChange(value);
+      }, DEBOUNCE_DELAY_MS);
+    },
+    [onQueryChange],
+  );
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <DrawerSearchInput
+        text={text}
+        placeholder={placeholder}
+        accessibilityLabel={accessibilityLabel}
+        onChangeText={handleChangeText}
+      />
+      <ResultCaption query={debouncedQuery} resultCount={resultCount} />
+      <DeepSearchRow
+        query={debouncedQuery}
+        onConfirmDeepSearch={onConfirmDeepSearch}
+        deepSearchLabel={deepSearchLabel}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  input: {
+    height: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+    borderRadius: radius.lg,
+    borderWidth: INPUT_BORDER_WIDTH,
+    borderColor: surface.hairline,
+    backgroundColor: surface.raised,
+    fontSize: INTERACTIVE_TEXT_MIN,
+    color: ink.primary,
+  },
+  inputFocused: {
+    borderColor: accent.primary,
+  },
+  resultCount: {
+    ...editorialType.caption,
+    color: ink.muted,
+    marginTop: SPACING.xs,
+  },
+});

--- a/frontend/src/components/drawer/__tests__/DrawerSearch.test.tsx
+++ b/frontend/src/components/drawer/__tests__/DrawerSearch.test.tsx
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import DrawerSearch from '@/components/drawer/DrawerSearch';
+import { INTERACTIVE_TEXT_MIN, accent, ink, radius, surface } from '@/design/tokens';
+
+const DEBOUNCE_MS = 300;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe('DrawerSearch debounce', () => {
+  it('emits nothing before the debounce elapses, then the typed text once after 300ms', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    expect(onQueryChange).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+    expect(onQueryChange).toHaveBeenCalledWith('ritual');
+  });
+
+  it('coalesces rapid successive keystrokes into a single debounced emission', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+    const input = getByTestId('drawer-search-input');
+
+    fireEvent.changeText(input, 'r');
+    fireEvent.changeText(input, 'ri');
+    fireEvent.changeText(input, 'rit');
+    fireEvent.changeText(input, 'ritu');
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+    expect(onQueryChange).toHaveBeenCalledWith('ritu');
+  });
+
+  it('emits an empty string after debounce when the field is cleared', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+    const input = getByTestId('drawer-search-input');
+
+    fireEvent.changeText(input, 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    onQueryChange.mockClear();
+
+    fireEvent.changeText(input, '');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+    expect(onQueryChange).toHaveBeenCalledWith('');
+  });
+
+  it('clears the pending debounce timer on unmount and never calls onQueryChange', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, unmount } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'partial query');
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(onQueryChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DrawerSearch result caption', () => {
+  it('is hidden when no query has been entered, even with a resultCount', () => {
+    const onQueryChange = jest.fn();
+    const { queryByTestId } = render(
+      <DrawerSearch onQueryChange={onQueryChange} resultCount={5} />,
+    );
+
+    expect(queryByTestId('drawer-search-result-count')).toBeNull();
+  });
+
+  it('is hidden when resultCount is undefined even with an active query', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, queryByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(queryByTestId('drawer-search-result-count')).toBeNull();
+  });
+
+  it('shows a "No results" caption for a zero count', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, rerender } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    rerender(<DrawerSearch onQueryChange={onQueryChange} resultCount={0} />);
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('No results');
+  });
+
+  it('uses the singular noun for exactly one result', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, rerender } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    rerender(<DrawerSearch onQueryChange={onQueryChange} resultCount={1} />);
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('1 result');
+  });
+
+  it('uses the plural noun for multiple results', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, rerender } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    rerender(<DrawerSearch onQueryChange={onQueryChange} resultCount={3} />);
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('3 results');
+  });
+
+  it('renders the caption color as the muted ink token', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, rerender } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+    rerender(<DrawerSearch onQueryChange={onQueryChange} resultCount={3} />);
+
+    const caption = getByTestId('drawer-search-result-count');
+    const flatStyle = StyleSheet.flatten(caption.props.style) as { color?: string };
+    expect(flatStyle.color).toBe(ink.muted);
+  });
+});
+
+describe('DrawerSearch deep-search confirm row', () => {
+  it('is absent when onConfirmDeepSearch is not passed', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId, queryByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(queryByTestId('drawer-search-deep-search')).toBeNull();
+  });
+
+  it('is absent when onConfirmDeepSearch is passed but no query has been typed', () => {
+    const onQueryChange = jest.fn();
+    const onConfirmDeepSearch = jest.fn();
+    const { queryByTestId } = render(
+      <DrawerSearch
+        onQueryChange={onQueryChange}
+        onConfirmDeepSearch={onConfirmDeepSearch}
+        deepSearchLabel="Search all entries"
+      />,
+    );
+
+    expect(queryByTestId('drawer-search-deep-search')).toBeNull();
+  });
+
+  it('appears with the exact deepSearchLabel once a non-empty query is active, and fires onConfirmDeepSearch without onQueryChange', () => {
+    const onQueryChange = jest.fn();
+    const onConfirmDeepSearch = jest.fn();
+    const { getByTestId, getByText } = render(
+      <DrawerSearch
+        onQueryChange={onQueryChange}
+        onConfirmDeepSearch={onConfirmDeepSearch}
+        deepSearchLabel="Search all entries"
+      />,
+    );
+
+    fireEvent.changeText(getByTestId('drawer-search-input'), 'ritual');
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(getByText('Search all entries')).toBeTruthy();
+    onQueryChange.mockClear();
+
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(onConfirmDeepSearch).toHaveBeenCalledTimes(1);
+    expect(onQueryChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DrawerSearch placeholder and accessibility label', () => {
+  it('defaults the placeholder to "Search..."', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    expect(getByTestId('drawer-search-input').props.placeholder).toBe('Search...');
+  });
+
+  it('overrides the placeholder when one is given', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(
+      <DrawerSearch onQueryChange={onQueryChange} placeholder="Find a reflection" />,
+    );
+
+    expect(getByTestId('drawer-search-input').props.placeholder).toBe('Find a reflection');
+  });
+
+  it('defaults the accessibility label to "Search"', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    expect(getByTestId('drawer-search-input').props.accessibilityLabel).toBe('Search');
+  });
+
+  it('overrides the accessibility label when one is given', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(
+      <DrawerSearch onQueryChange={onQueryChange} accessibilityLabel="Search this drawer" />,
+    );
+
+    expect(getByTestId('drawer-search-input').props.accessibilityLabel).toBe('Search this drawer');
+  });
+});
+
+describe('DrawerSearch input styling', () => {
+  it('applies the interactive text floor, raised surface, and large radius to the input', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+
+    const flatStyle = StyleSheet.flatten(getByTestId('drawer-search-input').props.style) as {
+      fontSize?: number;
+      backgroundColor?: string;
+      borderRadius?: number;
+    };
+
+    expect(flatStyle.fontSize).toBe(INTERACTIVE_TEXT_MIN);
+    expect(flatStyle.backgroundColor).toBe(surface.raised);
+    expect(flatStyle.borderRadius).toBe(radius.lg);
+  });
+
+  it('turns the border to the accent color on focus and reverts it on blur', () => {
+    const onQueryChange = jest.fn();
+    const { getByTestId } = render(<DrawerSearch onQueryChange={onQueryChange} />);
+    const input = getByTestId('drawer-search-input');
+
+    expect(StyleSheet.flatten(input.props.style).borderColor).not.toBe(accent.primary);
+
+    fireEvent(input, 'focus');
+    expect(StyleSheet.flatten(input.props.style).borderColor).toBe(accent.primary);
+
+    fireEvent(input, 'blur');
+    expect(StyleSheet.flatten(input.props.style).borderColor).not.toBe(accent.primary);
+  });
+});

--- a/frontend/src/components/drawer/__tests__/fuzzyMatch.test.ts
+++ b/frontend/src/components/drawer/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { fuzzyMatch, rankMatches } from '@/components/drawer/fuzzyMatch';
+
+describe('fuzzyMatch', () => {
+  it('matches every query token as an exact token substring of the candidate', () => {
+    expect(fuzzyMatch('mood of blue', 'The Mood of Blue: Love—Community Love')).toBe(true);
+  });
+
+  it('matches a query token that is one edit away from a candidate token', () => {
+    expect(fuzzyMatch('moob of blue', 'The Mood of Blue reflections')).toBe(true);
+  });
+
+  it('folds a diacritic in the candidate to match a plain query token', () => {
+    expect(fuzzyMatch('cafe', 'Café days')).toBe(true);
+  });
+
+  it('folds a diacritic in the query to match a plain candidate token', () => {
+    expect(fuzzyMatch('café', 'cafe day')).toBe(true);
+  });
+
+  it('returns false when no query token relates to any candidate token', () => {
+    expect(fuzzyMatch('green', 'The Mood of Blue')).toBe(false);
+  });
+
+  it('normalizes punctuation and an em-dash to whitespace before tokenizing', () => {
+    expect(fuzzyMatch('love community', 'Love—Community Love')).toBe(true);
+  });
+
+  it('matches a query token that is a character-subsequence of a candidate token', () => {
+    expect(fuzzyMatch('bue of blue', 'The Mood of Blue')).toBe(true);
+  });
+
+  it('treats an empty query as matching any candidate', () => {
+    expect(fuzzyMatch('', 'anything at all')).toBe(true);
+  });
+
+  it('treats a whitespace-only query as matching any candidate', () => {
+    expect(fuzzyMatch('   ', 'anything')).toBe(true);
+  });
+
+  it('returns false for a non-empty query against an empty candidate', () => {
+    expect(fuzzyMatch('blue', '')).toBe(false);
+  });
+
+  it('rejects a token that is two edits away and not a subsequence of any candidate token', () => {
+    expect(fuzzyMatch('xyood', 'The Mood of Blue')).toBe(false);
+  });
+
+  it('does not fuzzy-match a two-character token below the length-3 guard', () => {
+    expect(fuzzyMatch('xz', 'The Mood of Blue')).toBe(false);
+  });
+});
+
+interface Entry {
+  title: string;
+}
+
+const getTitle = (entry: Entry): string => entry.title;
+
+describe('rankMatches', () => {
+  it('filters out items whose text does not match the query', () => {
+    const items: Entry[] = [{ title: 'Blue Skies Ahead' }, { title: 'Green Fields' }];
+
+    const result = rankMatches('blue', items, getTitle);
+
+    expect(result).toEqual([{ title: 'Blue Skies Ahead' }]);
+  });
+
+  it('ranks an exact token match above a weaker fuzzy edit-distance match', () => {
+    const exact: Entry = { title: 'Blue Skies Ahead' };
+    const fuzzy: Entry = { title: 'The Blur of Motion' };
+
+    const result = rankMatches('blue', [fuzzy, exact], getTitle);
+
+    expect(result).toEqual([exact, fuzzy]);
+  });
+
+  it('keeps equally-scoring items in their original input order (stable sort)', () => {
+    const first: Entry = { title: 'Blue Diary' };
+    const second: Entry = { title: 'Blue Notebook' };
+
+    const result = rankMatches('blue', [first, second], getTitle);
+
+    expect(result).toEqual([first, second]);
+  });
+
+  it('returns all items in original order for an empty query', () => {
+    const items: Entry[] = [
+      { title: 'Blue Skies Ahead' },
+      { title: 'Green Fields' },
+      { title: 'The Mood of Blue' },
+    ];
+
+    const result = rankMatches('', items, getTitle);
+
+    expect(result).toEqual(items);
+  });
+
+  it('uses the getText accessor rather than assuming a string item', () => {
+    const items: Entry[] = [{ title: 'Café Reflections' }];
+
+    const result = rankMatches('cafe', items, getTitle);
+
+    expect(result).toEqual(items);
+  });
+});

--- a/frontend/src/components/drawer/fuzzyMatch.ts
+++ b/frontend/src/components/drawer/fuzzyMatch.ts
@@ -1,0 +1,148 @@
+/**
+ * Dependency-free fuzzy matcher for drawer search: a bag-of-tokens model that
+ * folds diacritics, treats punctuation as whitespace, and tolerates a bounded
+ * typo (edit distance one) or dropped characters (subsequence) per token. Pure
+ * functions only — no React, no I/O.
+ */
+
+/** Minimum token length before typo/subsequence tolerance kicks in. */
+const MIN_FUZZY_TOKEN_LENGTH = 3;
+
+// Relative token weights: exact beats prefix beats substring beats fuzzy.
+const EXACT_TOKEN_SCORE = 4;
+const PREFIX_TOKEN_SCORE = 3;
+const SUBSTRING_TOKEN_SCORE = 2;
+const FUZZY_TOKEN_SCORE = 1;
+const NO_MATCH_SCORE = 0;
+
+/** Positive sentinel so an empty query ranks every candidate equally. */
+const EMPTY_QUERY_SCORE = 1;
+
+/** The most edits an approximate token match may span. */
+const MAX_EDIT_DISTANCE = 1;
+
+// Combining marks left behind after NFD folding (the accents on decomposed letters).
+const COMBINING_MARKS = /\p{M}/gu;
+// Any run of non-letter, non-digit characters — punctuation, dashes, spaces.
+const NON_ALPHANUMERIC = /[^\p{L}\p{N}]+/gu;
+const WHITESPACE = /\s+/u;
+
+/** Fold accents, lowercase, and split into alphanumeric tokens. */
+function tokenize(value: string): string[] {
+  const folded = value
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(NON_ALPHANUMERIC, ' ')
+    .trim();
+  return folded.length === 0 ? [] : folded.split(WHITESPACE);
+}
+
+/** True when two equal-length strings differ in at most one position. */
+function withinOneSubstitution(a: string, b: string): boolean {
+  let diffs = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) diffs += 1;
+    if (diffs > MAX_EDIT_DISTANCE) return false;
+  }
+  return true;
+}
+
+/** True when the longer string is the shorter one with a single extra character. */
+function withinOneIndel(shorter: string, longer: string): boolean {
+  let i = 0;
+  let skipped = false;
+  for (let j = 0; j < longer.length; j += 1) {
+    if (shorter[i] === longer[j]) {
+      i += 1;
+    } else if (skipped) {
+      return false;
+    } else {
+      skipped = true;
+    }
+  }
+  return true;
+}
+
+/** True when a and b differ by at most one insert, delete, or substitution. */
+function editDistanceWithinOne(a: string, b: string): boolean {
+  const lengthGap = Math.abs(a.length - b.length);
+  if (lengthGap > MAX_EDIT_DISTANCE) return false;
+  if (lengthGap === 0) return withinOneSubstitution(a, b);
+  return a.length < b.length ? withinOneIndel(a, b) : withinOneIndel(b, a);
+}
+
+/** True when every character of q appears in c in order (gaps allowed). */
+function isSubsequence(q: string, c: string): boolean {
+  let matched = 0;
+  for (let j = 0; j < c.length && matched < q.length; j += 1) {
+    if (q[matched] === c[j]) matched += 1;
+  }
+  return matched === q.length;
+}
+
+/** Approximate match gated by the minimum-length guard. */
+function isFuzzyTokenMatch(queryToken: string, candidateToken: string): boolean {
+  return (
+    queryToken.length >= MIN_FUZZY_TOKEN_LENGTH &&
+    (editDistanceWithinOne(queryToken, candidateToken) || isSubsequence(queryToken, candidateToken))
+  );
+}
+
+/** Weighted score for one query token against one candidate token. */
+function scoreTokenPair(queryToken: string, candidateToken: string): number {
+  if (queryToken === candidateToken) return EXACT_TOKEN_SCORE;
+  if (candidateToken.startsWith(queryToken)) return PREFIX_TOKEN_SCORE;
+  if (candidateToken.includes(queryToken)) return SUBSTRING_TOKEN_SCORE;
+  if (isFuzzyTokenMatch(queryToken, candidateToken)) return FUZZY_TOKEN_SCORE;
+  return NO_MATCH_SCORE;
+}
+
+/** Best score for a query token across all candidate tokens. */
+function bestTokenScore(queryToken: string, candidateTokens: readonly string[]): number {
+  let best = NO_MATCH_SCORE;
+  for (const candidateToken of candidateTokens) {
+    const score = scoreTokenPair(queryToken, candidateToken);
+    if (score > best) best = score;
+  }
+  return best;
+}
+
+/**
+ * Total match strength: 0 when any query token matches nothing, a positive sum
+ * otherwise. An empty query yields the sentinel so all candidates tie.
+ */
+function fuzzyScore(query: string, candidate: string): number {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return EMPTY_QUERY_SCORE;
+  const candidateTokens = tokenize(candidate);
+  let total = NO_MATCH_SCORE;
+  for (const queryToken of queryTokens) {
+    const best = bestTokenScore(queryToken, candidateTokens);
+    if (best === NO_MATCH_SCORE) return NO_MATCH_SCORE;
+    total += best;
+  }
+  return total;
+}
+
+/** True when the candidate satisfies every token of the query. */
+export function fuzzyMatch(query: string, candidate: string): boolean {
+  return fuzzyScore(query, candidate) > NO_MATCH_SCORE;
+}
+
+/**
+ * Keep and order the items whose text matches the query, strongest first. Ties
+ * preserve input order (Array.prototype.sort is stable); an empty query returns
+ * every item untouched.
+ */
+export function rankMatches<T>(
+  query: string,
+  items: readonly T[],
+  getText: (_item: T) => string,
+): T[] {
+  return items
+    .map((item) => ({ item, score: fuzzyScore(query, getText(item)) }))
+    .filter((entry) => entry.score > NO_MATCH_SCORE)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.item);
+}

--- a/frontend/src/components/drawer/index.ts
+++ b/frontend/src/components/drawer/index.ts
@@ -1,6 +1,7 @@
 /**
  * Public surface of the shared screen-drawer module: the panel, its header-left
- * toggle, a row primitive, and the state hook that ties a screen to its drawer.
+ * toggle, a row primitive, the state hook that ties a screen to its drawer, and
+ * the reusable search field plus its dependency-free fuzzy matcher.
  */
 export { default as ScreenDrawer } from './ScreenDrawer';
 export type { ScreenDrawerProps } from './ScreenDrawer';
@@ -12,3 +13,6 @@ export { default as DrawerNavSection } from './DrawerNavSection';
 export type { DrawerNavSectionProps } from './DrawerNavSection';
 export { useScreenDrawer } from './useScreenDrawer';
 export type { ScreenDrawerState } from './useScreenDrawer';
+export { default as DrawerSearch } from './DrawerSearch';
+export type { DrawerSearchProps } from './DrawerSearch';
+export { fuzzyMatch, rankMatches } from './fuzzyMatch';

--- a/frontend/src/design/__tests__/interactiveTextFloor.test.ts
+++ b/frontend/src/design/__tests__/interactiveTextFloor.test.ts
@@ -87,6 +87,7 @@ function collectCaptionUsageIds(): string[] {
 // text). Sorted to match the sorted found-set comparison.
 const AUDITED_NON_INTERACTIVE_CAPTIONS = [
   'components/care/CareResourceCard.tsx::resourceWhat',
+  'components/drawer/DrawerSearch.tsx::resultCount',
   'features/Course/Course.styles.ts::readerEyebrow',
   'features/Course/Course.styles.ts::sectionBandLabel',
   'features/Course/Course.styles.ts::stageCoverEyebrow',


### PR DESCRIPTION
## Summary

Foundation of epic #1771 (`epic:drawer-search`). Adds the two shared pieces the drawer-search epic rests on, with no feature integration (siblings #1773/#1774 consume this API):

- **`fuzzyMatch.ts`** — a pure, dependency-free matcher. `fuzzyMatch(query, candidate): boolean` normalizes both strings (NFD fold + strip combining marks, lowercase, non-alphanumeric → whitespace, tokenize) and applies a bag-of-tokens match: every query token must match a candidate token by substring, or — for tokens of length ≥ 3 — a bounded edit distance ≤ 1 or character-subsequence. No regex/substitution tables; deterministic and synchronous. Also exports `rankMatches<T>(query, items, getText): T[]` (filter + stable descending-score sort; empty query returns all items in input order) so the siblings order their result lists without re-implementing filter/sort.
- **`DrawerSearch.tsx`** — a presentational, uncontrolled, 300ms-debounced input (mirrors the Journal `SearchBar` debounce idiom) that emits the debounced query via `onQueryChange`, renders a non-interactive result-count caption when the host supplies `resultCount`, and — only when the host passes the paired `onConfirmDeepSearch` + `deepSearchLabel` props — a confirm-gated "search bodies" row (composed from `DrawerItem`) that fires only on explicit tap. Styled with Candle & Ink tokens; the input meets `INTERACTIVE_TEXT_MIN` (16).
- Both are exported from the drawer barrel (`index.ts`). The result-count caption is registered in the `interactiveTextFloor` audited-non-interactive allowlist.

Filtering/ranking stays in the hosts (the siblings own their cached lists); `DrawerSearch` is purely presentational. Because `ScreenDrawer` fully unmounts when closed, the field resets on each open with no controlled-value prop needed, and clearing flows to hosts as `onQueryChange('')`.

## Test plan

- New table-driven `fuzzyMatch.test.ts`: case-insensitivity, diacritic folding both directions, punctuation/em-dash + whitespace collapse, one-edit typo, subsequence typo, empty/whitespace query matches all, empty candidate, two-edit and sub-length-3 rejections; `rankMatches` filtering, exact-above-fuzzy ordering, stable ties, empty-query passthrough, `getText` accessor.
- New `DrawerSearch.test.tsx`: debounce (emit-once, coalesce, clear emits '', unmount cancels), caption visibility matrix + singular/plural copy + muted-ink color, deep-search row gating (absent without prop, absent with empty query, present with active query, tap fires only the confirm handler), placeholder/a11y-label defaults + overrides, input styling (`INTERACTIVE_TEXT_MIN`, `surface.raised`, `radius.lg`) and accent-on-focus border.
- `scripts/frontend/check-all.sh` green: ESLint, prettier, `tsc --noEmit`, and the full Jest suite (4453 tests) all pass.

Closes #1772
Refs #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)