### PR TITLE
feat(backend): vision content blocks + per-model vision capability metadata in the LLM provider layer

### DIFF
--- a/backend/src/services/botmason.py
+++ b/backend/src/services/botmason.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 import secrets
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
@@ -37,6 +37,18 @@ logger = logging.getLogger(__name__)
 # Awaited result type threaded through the retry helper so concrete provider
 # response types survive the retry wrapper instead of being erased to ``object``.
 _ResultT = TypeVar("_ResultT")
+
+# Message-content shapes for the provider APIs. A turn's content is either a
+# plain ``str`` (text-only) or a list of typed content parts (text + image
+# blocks) -- both OpenAI and Anthropic accept the list form for multimodal
+# turns. ``object`` values keep the heterogeneous part shapes (nested dicts,
+# strings) expressible without an ``Any`` escape hatch. These are implicit
+# type aliases (bare assignments) rather than ``TypeAlias``-annotated so the
+# module keeps parsing on the 3.11 cross-version job -- the newer ``type``
+# keyword form is a syntax error there.
+ContentPart = dict[str, object]
+MessageContent = str | list[ContentPart]
+ChatMessage = dict[str, MessageContent]
 
 # Default system prompt used when no external prompt file is configured.
 _DEFAULT_SYSTEM_PROMPT = (
@@ -81,6 +93,11 @@ class ProviderSpec:
     tests can keep monkeypatching ``_call_openai`` etc. on the module —
     storing the function object here would freeze the original and silently
     bypass those patches.
+
+    ``vision_models`` is the subset of models that accept image content
+    blocks. It is audited independently of ``allowed_models`` — a model may
+    be allowed for text yet not (yet) certified for vision — so the two sets
+    are written out separately rather than aliased.
     """
 
     #: Required key prefix; more-specific prefixes other providers own.
@@ -91,6 +108,8 @@ class ProviderSpec:
     #: Closed allowlist (BUG-BM-001) — every addition is an audit decision.
     allowed_models: frozenset[str]
     call_name: str
+    #: Vision-capable subset — audited independently of ``allowed_models``.
+    vision_models: frozenset[str]
 
 
 # Anthropic model IDs intentionally mix two formats per Anthropic's naming:
@@ -116,6 +135,9 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
         default_model="gpt-4o-mini",
         allowed_models=frozenset({"gpt-4o-mini", "gpt-4o", "gpt-4-turbo"}),
         call_name="_call_openai",
+        # Explicit, independently-audited vision set (not aliased to
+        # ``allowed_models``): each of these OpenAI models accepts images.
+        vision_models=frozenset({"gpt-4o-mini", "gpt-4o", "gpt-4-turbo"}),
     ),
     "anthropic": ProviderSpec(
         key_prefix="sk-ant-",
@@ -132,6 +154,16 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
             }
         ),
         call_name="_call_anthropic",
+        # Explicit, independently-audited vision set (not aliased to
+        # ``allowed_models``): each of these Anthropic models accepts images.
+        vision_models=frozenset(
+            {
+                "claude-sonnet-4-20250514",
+                "claude-haiku-4-5-20251001",
+                "claude-opus-4-7",
+                "claude-sonnet-4-6",
+            }
+        ),
     ),
 }
 
@@ -168,6 +200,21 @@ class LLMProviderError(RuntimeError):
     """
 
 
+class LLMVisionUnsupportedError(LLMProviderError):
+    """The selected provider/model cannot accept image inputs.
+
+    Callers map this to HTTP 422 (unprocessable content): the request is
+    well-formed but asks a text-only model to look at an image. It is
+    deliberately *never* retried and *never* triggers a silent model
+    substitution — swapping in a different model behind the user's back would
+    change cost and behavior without consent. Because it subclasses
+    :class:`LLMProviderError` (which is not in :data:`_PROVIDER_ERROR_TYPES`),
+    it propagates out of :func:`generate_response` unwrapped, preserving the
+    subclass identity that lets callers distinguish "no vision support" from
+    every other provider failure.
+    """
+
+
 # Genuine provider/transport failures normalized to LLMProviderError; OSError
 # covers ConnectionError/TimeoutError and mirrors what ``_is_retryable`` treats
 # as transient, while the two SDK base classes give an SDK-agnostic catch.
@@ -199,6 +246,84 @@ class LLMResponse:
     def total_tokens(self) -> int:
         """Sum of prompt and completion tokens — always derived, never stored."""
         return self.prompt_tokens + self.completion_tokens
+
+
+# Media types the vision path accepts. Restricting to the three formats every
+# supported provider decodes keeps us from forwarding an exotic type the model
+# would reject after we already burned the request.
+_ALLOWED_IMAGE_MEDIA_TYPES: frozenset[str] = frozenset({"image/jpeg", "image/png", "image/webp"})
+
+# Upper bound on a base64-encoded image, in characters. Base64 expands raw
+# bytes by 4/3, so this caps the *decoded* payload at ~5 MB. The ceiling is a
+# DoS / provider-limit guardrail: it stops an oversized attachment from
+# inflating a request body (and provider bill) before the SDK ever sees it.
+_MAX_IMAGE_BASE64_CHARS: int = (5 * 1024 * 1024 * 4) // 3
+
+
+@dataclass(frozen=True, slots=True)
+class ImagePayload:
+    """An immutable, validated base64 image attachment for a vision request.
+
+    ``data`` is the base64-encoded image bytes and ``media_type`` its MIME
+    type. Validation happens at construction so a malformed attachment fails
+    before it reaches any provider. The instance is frozen: once built it
+    cannot be mutated into an invalid state.
+    """
+
+    data: str
+    media_type: str
+
+    def __post_init__(self) -> None:
+        """Reject unsupported media types and oversized payloads.
+
+        The ``ValueError`` names the offending media type and/or the length,
+        but never interpolates ``data`` — image bytes must never appear in an
+        exception message, log line, or traceback (privacy invariant).
+        """
+        if self.media_type not in _ALLOWED_IMAGE_MEDIA_TYPES:
+            msg = f"unsupported image media_type: {self.media_type!r}"
+            raise ValueError(msg)
+        if len(self.data) > _MAX_IMAGE_BASE64_CHARS:
+            msg = f"image base64 length {len(self.data)} exceeds maximum {_MAX_IMAGE_BASE64_CHARS}"
+            raise ValueError(msg)
+
+
+def supports_vision(provider: str, model: str) -> bool:
+    """Return True when ``provider``/``model`` can accept image content blocks.
+
+    The stub provider/model reports ``True`` so local development can exercise
+    the vision path without a real key. Unknown providers report ``False``.
+    Otherwise the answer is whether ``model`` appears in the provider's
+    independently-audited :attr:`ProviderSpec.vision_models` set.
+    """
+    if provider == STUB_PROVIDER_NAME and model == STUB_MODEL_NAME:
+        return True
+    spec = PROVIDER_REGISTRY.get(provider)
+    if spec is None:
+        return False
+    return model in spec.vision_models
+
+
+def _ensure_vision_capable(
+    provider: str,
+    model: str,
+    images: Sequence[ImagePayload] | None,
+) -> None:
+    """Raise when images are supplied to a provider/model that lacks vision.
+
+    A no-op when ``images`` is falsy. Otherwise, if the resolved provider and
+    model cannot accept image inputs, raises :class:`LLMVisionUnsupportedError`
+    (which callers map to HTTP 422). The message names the provider, model, and
+    image *count* only — never any base64 payload (privacy invariant).
+    """
+    if not images:
+        return
+    if not supports_vision(provider, model):
+        msg = (
+            f"provider {provider!r} model {model!r} does not accept image "
+            f"inputs ({len(images)} image(s) supplied)"
+        )
+        raise LLMVisionUnsupportedError(msg)
 
 
 def get_provider() -> str:
@@ -454,11 +579,62 @@ def _entry_message(entry: dict[str, str]) -> str:
     return entry.get("message", "")
 
 
+def _openai_image_part(image: ImagePayload) -> ContentPart:
+    """Return an OpenAI-shaped image content part for one attachment.
+
+    OpenAI takes images as a ``data:`` URL inside an ``image_url`` block. The
+    base64 ``data`` is embedded verbatim — never sanitized or nonce-wrapped —
+    because it is opaque bytes, not user prose.
+    """
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:{image.media_type};base64,{image.data}"},
+    }
+
+
+def _anthropic_image_part(image: ImagePayload) -> ContentPart:
+    """Return an Anthropic-shaped image content part for one attachment.
+
+    Anthropic takes images as a ``base64`` source block carrying the media
+    type and raw base64 ``data`` — embedded verbatim, never sanitized or
+    nonce-wrapped, for the same reason as the OpenAI variant.
+    """
+    return {
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": image.media_type,
+            "data": image.data,
+        },
+    }
+
+
+def _final_user_turn(
+    user_message: str,
+    nonce: str,
+    image_parts: list[ContentPart] | None,
+) -> ChatMessage:
+    """Build the trailing new-user turn, attaching image parts when present.
+
+    When ``image_parts`` is falsy the content is a plain ``str`` — byte-
+    identical to the pre-vision behavior, so text-only callers are untouched.
+    When images are present the content becomes ``[*image_parts, text_part]``:
+    the image parts pass through verbatim while the sibling text part keeps the
+    full sanitize + nonce wrapper.
+    """
+    wrapped_text = _wrap_user_input(user_message, nonce)
+    if not image_parts:
+        return {"role": "user", "content": wrapped_text}
+    text_part: ContentPart = {"type": "text", "text": wrapped_text}
+    return {"role": "user", "content": [*image_parts, text_part]}
+
+
 def _wrap_history(
     conversation_history: list[dict[str, str]],
     user_message: str,
     nonce: str,
-) -> list[dict[str, str]]:
+    image_parts: list[ContentPart] | None = None,
+) -> list[ChatMessage]:
     """Build the nonce-wrapped turn list: history followed by the new user turn.
 
     Shared by the OpenAI and Anthropic message builders (BUG-BM-004): every
@@ -466,14 +642,17 @@ def _wrap_history(
     the delimiter tags cannot be forged from a prior conversation, while
     assistant turns pass through verbatim.  The system prompt is *not* part
     of this list -- each caller places it where its provider expects.
+
+    ``image_parts`` (already provider-formatted) attach only to the final new
+    user turn; history turns never receive image parts.
     """
-    messages: list[dict[str, str]] = []
+    messages: list[ChatMessage] = []
     for entry in conversation_history:
         role = "assistant" if entry.get("sender") == "bot" else "user"
         message = _entry_message(entry)
         content = _wrap_user_input(message, nonce) if role == "user" else message
         messages.append({"role": role, "content": content})
-    messages.append({"role": "user", "content": _wrap_user_input(user_message, nonce)})
+    messages.append(_final_user_turn(user_message, nonce, image_parts))
     return messages
 
 
@@ -481,7 +660,8 @@ def _build_messages(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
-) -> list[dict[str, str]]:
+    images: Sequence[ImagePayload] | None = None,
+) -> list[ChatMessage]:
     """Build the message list for the LLM API call.
 
     Returns a list of dicts with ``role`` and ``content`` keys suitable for
@@ -490,11 +670,19 @@ def _build_messages(
     (BUG-BM-004).  The system prompt is augmented with a delimiter
     explanation; every user-role content (including history) is sanitized
     and nonce-wrapped.
+
+    When ``images`` are supplied they are formatted as OpenAI image parts and
+    attached to the final user turn only; without them the final turn's content
+    stays a plain ``str``, byte-identical to the text-only path.
     """
     _check_prompt_injection(user_message)
     nonce = _make_nonce()
-    system_turn = {"role": "system", "content": _augment_system_prompt(system_prompt, nonce)}
-    return [system_turn, *_wrap_history(conversation_history, user_message, nonce)]
+    system_turn: ChatMessage = {
+        "role": "system",
+        "content": _augment_system_prompt(system_prompt, nonce),
+    }
+    image_parts = [_openai_image_part(image) for image in images or ()]
+    return [system_turn, *_wrap_history(conversation_history, user_message, nonce, image_parts)]
 
 
 def _provider_default_model(provider: str) -> str:
@@ -531,7 +719,8 @@ def _build_anthropic_messages(
     user_message: str,
     conversation_history: list[dict[str, str]],
     system_prompt: str,
-) -> tuple[list[dict[str, str]], str]:
+    images: Sequence[ImagePayload] | None = None,
+) -> tuple[list[ChatMessage], str]:
     """Build Anthropic messages + augmented system prompt (BUG-BM-004).
 
     Anthropic takes the system prompt as a separate parameter rather than
@@ -539,10 +728,15 @@ def _build_anthropic_messages(
     tuple — callers pass ``augmented_system`` to ``messages.create(system=...)``.
     The nonce is generated once per call and threaded through both the
     augmented prompt and every user-role wrap.
+
+    When ``images`` are supplied they are formatted as Anthropic image parts
+    and attached to the final user turn only; without them the final turn's
+    content stays a plain ``str``, byte-identical to the text-only path.
     """
     _check_prompt_injection(user_message)
     nonce = _make_nonce()
-    messages = _wrap_history(conversation_history, user_message, nonce)
+    image_parts = [_anthropic_image_part(image) for image in images or ()]
+    messages = _wrap_history(conversation_history, user_message, nonce, image_parts)
     return messages, _augment_system_prompt(system_prompt, nonce)
 
 
@@ -607,6 +801,7 @@ async def generate_response(
     conversation_history: list[dict[str, str]],
     system_prompt: str | None = None,
     api_key: str | None = None,
+    images: Sequence[ImagePayload] | None = None,
 ) -> LLMResponse:
     """Generate a BotMason response using the configured LLM provider.
 
@@ -625,6 +820,13 @@ async def generate_response(
     whether the call routes to OpenAI or Anthropic, so a BYOK key activates
     a real model even when ``BOTMASON_PROVIDER`` is the default ``stub``.
 
+    ``images`` optionally attaches base64 image content blocks to the final
+    user turn. When the resolved provider/model cannot accept images this
+    raises :class:`LLMVisionUnsupportedError` (a 422-mappable subclass of
+    :class:`LLMProviderError`) *before* any network call — it is never retried
+    and never triggers a silent model substitution. The stub provider serves a
+    deterministic canned transcription for image requests instead.
+
     Returns an :class:`LLMResponse` carrying both the generated text and the
     token counts needed to log usage downstream.
     """
@@ -640,13 +842,18 @@ async def generate_response(
         spec = PROVIDER_REGISTRY.get(provider)
         if spec is None:
             # Default: stub provider for development and testing.
+            if images:
+                return _stub_vision_response(user_message, len(images))
             return _stub_response(user_message)
+        # Capability check before dispatch: LLMVisionUnsupportedError is not in
+        # _PROVIDER_ERROR_TYPES, so it escapes this try unwrapped.
+        _ensure_vision_capable(provider, _get_model(provider), images)
         # Resolve by name at call time so test monkeypatches on the module
         # attribute (e.g. ``patch.object(botmason, "_call_openai", ...)``)
         # keep working — the registry never freezes the function objects.
         caller = globals()[spec.call_name]
         result: LLMResponse = await caller(
-            user_message, conversation_history, resolved_prompt, api_key
+            user_message, conversation_history, resolved_prompt, api_key, images
         )
     except _PROVIDER_ERROR_TYPES as exc:
         raise LLMProviderError(str(exc)) from exc
@@ -662,6 +869,30 @@ def _stub_response(user_message: str) -> LLMResponse:
     """
     text = (
         f'BotMason hears you. You said: "{user_message}" — '
+        "Let the Archetypal Wavelength guide your reflection."
+    )
+    return LLMResponse(
+        text=text,
+        provider=STUB_PROVIDER_NAME,
+        model=STUB_MODEL_NAME,
+        prompt_tokens=0,
+        completion_tokens=0,
+    )
+
+
+def _stub_vision_response(user_message: str, image_count: int) -> LLMResponse:
+    """Return a deterministic canned vision transcription for dev/testing.
+
+    Mirrors :func:`_stub_response` but acknowledges ``image_count`` attached
+    images so the stub vision path is visibly distinct from the text-only stub.
+    The text references only the count — never any base64 payload — so the
+    privacy invariant (image bytes never appear in a response or log) holds for
+    stub traffic too. Token counts are zero because no real model runs, and two
+    calls with the same arguments produce identical text.
+    """
+    text = (
+        f"BotMason gazes at your {image_count} attached image(s) and reflects "
+        f'on your words: "{user_message}" — '
         "Let the Archetypal Wavelength guide your reflection."
     )
     return LLMResponse(
@@ -722,6 +953,7 @@ async def _call_openai(
     conversation_history: list[dict[str, str]],
     system_prompt: str,
     api_key: str | None = None,
+    images: Sequence[ImagePayload] | None = None,
 ) -> LLMResponse:
     """Call the OpenAI chat completions API with timeout and retry."""
     # Model validation precedes key resolution and client construction so a
@@ -729,7 +961,7 @@ async def _call_openai(
     model = _get_model("openai")
     key = _resolve_api_key(api_key)
     client = openai.AsyncOpenAI(api_key=key, timeout=_LLM_TIMEOUT_SECONDS)
-    messages = _build_messages(user_message, conversation_history, system_prompt)
+    messages = _build_messages(user_message, conversation_history, system_prompt, images)
     max_tokens = _dynamic_max_tokens(conversation_history)
 
     async def _do_call() -> ChatCompletion:
@@ -755,6 +987,7 @@ async def _call_anthropic(
     conversation_history: list[dict[str, str]],
     system_prompt: str,
     api_key: str | None = None,
+    images: Sequence[ImagePayload] | None = None,
 ) -> LLMResponse:
     """Call the Anthropic messages API with timeout and retry."""
     # Model validation first — same zero-side-effect guarantee as OpenAI.
@@ -768,6 +1001,7 @@ async def _call_anthropic(
         user_message,
         conversation_history,
         system_prompt,
+        images,
     )
     max_tokens = _dynamic_max_tokens(conversation_history)
 

--- a/backend/tests/services/test_botmason_retry.py
+++ b/backend/tests/services/test_botmason_retry.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
+import openai
 import pytest
 
 from services import botmason
 from services.botmason import (
+    _LLM_TIMEOUT_SECONDS,
     _MAX_RETRIES,
     _RETRY_BASE_DELAY,
+    ImagePayload,
+    _call_openai,
     _is_retryable,
     _retry_on_transient,
 )
@@ -161,3 +165,74 @@ class TestRetryOnTransient:
         expected_delays = [_RETRY_BASE_DELAY * 2**0, _RETRY_BASE_DELAY * 2**1]
         actual_delays = [call.args[0] for call in sleep_mock.call_args_list]
         assert actual_delays == expected_delays
+
+
+def _fake_openai_completion(text: str) -> object:
+    """Build a bare object shaped like an OpenAI ``ChatCompletion`` for a fake client."""
+    message = type("Msg", (), {"content": text})()
+    choice = type("Choice", (), {"message": message})()
+    usage = type("Usage", (), {"prompt_tokens": 5, "completion_tokens": 3})()
+    return type("Completion", (), {"choices": [choice], "usage": usage})()
+
+
+class TestCallOpenAIRetryWithImages:
+    """A vision request retries transient failures exactly like a text-only one."""
+
+    @pytest.mark.asyncio
+    async def test_transient_error_then_success_retries_once_with_images(
+        self, sleep_mock: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        success = _fake_openai_completion("described the image")
+        create_mock = AsyncMock(side_effect=[_FakeStatusCodeError(503), success])
+        constructed_kwargs: dict[str, object] = {}
+
+        class _FakeOpenAIClient:
+            def __init__(self, **kwargs: object) -> None:
+                constructed_kwargs.update(kwargs)
+                completions = type("Completions", (), {"create": staticmethod(create_mock)})()
+                self.chat = type("Chat", (), {"completions": completions})()
+
+        monkeypatch.setattr(openai, "AsyncOpenAI", _FakeOpenAIClient)
+        image = ImagePayload(data="ZmFrZQ==", media_type="image/png")
+
+        result = await _call_openai(
+            "describe this",
+            [],
+            "SYSTEM PROMPT",
+            api_key="sk-test-key",  # pragma: allowlist secret
+            images=[image],
+        )
+
+        assert result.text == "described the image"
+        assert create_mock.await_count == 2
+        assert sleep_mock.await_count == 1
+        assert constructed_kwargs["timeout"] == _LLM_TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_persistent_transient_error_exhausts_retries_with_images(
+        self, sleep_mock: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        create_mock = AsyncMock(side_effect=_FakeStatusCodeError(503))
+        constructed_kwargs: dict[str, object] = {}
+
+        class _FakeOpenAIClient:
+            def __init__(self, **kwargs: object) -> None:
+                constructed_kwargs.update(kwargs)
+                completions = type("Completions", (), {"create": staticmethod(create_mock)})()
+                self.chat = type("Chat", (), {"completions": completions})()
+
+        monkeypatch.setattr(openai, "AsyncOpenAI", _FakeOpenAIClient)
+        image = ImagePayload(data="ZmFrZQ==", media_type="image/png")
+
+        with pytest.raises(_FakeStatusCodeError):
+            await _call_openai(
+                "describe this",
+                [],
+                "SYSTEM PROMPT",
+                api_key="sk-test-key",  # pragma: allowlist secret
+                images=[image],
+            )
+
+        assert create_mock.await_count == _MAX_RETRIES + 1
+        assert sleep_mock.await_count == _MAX_RETRIES
+        assert constructed_kwargs["timeout"] == _LLM_TIMEOUT_SECONDS

--- a/backend/tests/services/test_botmason_wrapping.py
+++ b/backend/tests/services/test_botmason_wrapping.py
@@ -19,6 +19,7 @@ system prompt and an operator-supplied ``BOTMASON_SYSTEM_PROMPT``.
 from __future__ import annotations
 
 import re
+from dataclasses import FrozenInstanceError
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -30,7 +31,11 @@ import services.botmason as botmason_mod
 from domain.care import MEDICATION_GUARDRAIL
 from services.botmason import (
     _DEFAULT_SYSTEM_PROMPT,
+    _MAX_IMAGE_BASE64_CHARS,
+    ImagePayload,
     LLMProviderError,
+    LLMVisionUnsupportedError,
+    ProviderSpec,
     _augment_system_prompt,
     _build_anthropic_messages,
     _build_messages,
@@ -38,10 +43,25 @@ from services.botmason import (
     _make_nonce,
     _wrap_user_input,
     generate_response,
+    supports_vision,
 )
 
 # Regex for a 16-hex-char nonce as produced by ``_make_nonce``.
 _NONCE_RE = re.compile(r"[0-9a-f]{16}")
+
+
+def _str_leaf(part: object, *keys: str) -> str:
+    """Walk ``keys`` through nested content-part dicts and return the leaf string.
+
+    Keeps the multimodal-assertion sites readable while satisfying mypy strict:
+    every hop is narrowed with ``isinstance`` rather than cast.
+    """
+    value: object = part
+    for key in keys:
+        assert isinstance(value, dict)
+        value = value[key]
+    assert isinstance(value, str)
+    return value
 
 
 class TestMakeNonce:
@@ -113,18 +133,24 @@ class TestBuildMessages:
     def test_system_prompt_first_and_augmented(self) -> None:
         messages = _build_messages("hello", [], "ROOT PROMPT")
         assert messages[0]["role"] == "system"
-        assert messages[0]["content"].startswith("ROOT PROMPT")
-        assert _NONCE_RE.search(messages[0]["content"])
+        system_content = messages[0]["content"]
+        assert isinstance(system_content, str)
+        assert system_content.startswith("ROOT PROMPT")
+        assert _NONCE_RE.search(system_content)
 
     def test_user_message_wrapped_with_same_nonce_as_system(self) -> None:
         """The augmented system prompt and user wrapper must share a nonce."""
         messages = _build_messages("hello", [], "PROMPT")
-        sys_nonces = _NONCE_RE.findall(messages[0]["content"])
-        usr_nonces = _NONCE_RE.findall(messages[-1]["content"])
+        system_content = messages[0]["content"]
+        final_content = messages[-1]["content"]
+        assert isinstance(system_content, str)
+        assert isinstance(final_content, str)
+        sys_nonces = _NONCE_RE.findall(system_content)
+        usr_nonces = _NONCE_RE.findall(final_content)
         # All nonce occurrences in this request resolve to one value.
         all_nonces = set(sys_nonces) | set(usr_nonces)
         assert len(all_nonces) == 1
-        assert messages[-1]["content"].startswith(f"<user_input_{sys_nonces[0]}>")
+        assert final_content.startswith(f"<user_input_{sys_nonces[0]}>")
 
     def test_history_user_messages_wrapped_bot_messages_passthrough(self) -> None:
         history = [
@@ -141,7 +167,11 @@ class TestBuildMessages:
         # the expected wrapping shape from the nonce we extract from the new
         # turn — a regression that drops history wrapping (or uses a
         # different nonce for history vs. new turn) fails this assertion.
-        nonce = _NONCE_RE.search(messages[3]["content"]).group(0)  # type: ignore[union-attr]
+        final_content = messages[3]["content"]
+        assert isinstance(final_content, str)
+        nonce_match = _NONCE_RE.search(final_content)
+        assert nonce_match is not None
+        nonce = nonce_match.group(0)
         assert messages[1]["content"] == f"<user_input_{nonce}>first user turn</user_input_{nonce}>"
         assert messages[3]["content"] == f"<user_input_{nonce}>now</user_input_{nonce}>"
 
@@ -150,7 +180,9 @@ class TestBuildMessages:
         history = [{"sender": "user", "message": "evil\x00\u202epayload"}]
         messages = _build_messages("now", history, "PROMPT")
         # Stripped chars must not appear anywhere in the prompt:
-        prompt_text = "".join(m["content"] for m in messages)
+        contents = [m["content"] for m in messages]
+        assert all(isinstance(content, str) for content in contents)
+        prompt_text = "".join(content for content in contents if isinstance(content, str))
         assert "\x00" not in prompt_text
         assert "\u202e" not in prompt_text
         assert "evilpayload" in messages[1]["content"]
@@ -162,9 +194,15 @@ class TestBuildMessages:
         """
         a = _build_messages("hi", [], "P")
         b = _build_messages("hi", [], "P")
-        nonce_a = _NONCE_RE.search(a[-1]["content"]).group(0)  # type: ignore[union-attr]
-        nonce_b = _NONCE_RE.search(b[-1]["content"]).group(0)  # type: ignore[union-attr]
-        assert nonce_a != nonce_b
+        a_content = a[-1]["content"]
+        b_content = b[-1]["content"]
+        assert isinstance(a_content, str)
+        assert isinstance(b_content, str)
+        a_match = _NONCE_RE.search(a_content)
+        b_match = _NONCE_RE.search(b_content)
+        assert a_match is not None
+        assert b_match is not None
+        assert a_match.group(0) != b_match.group(0)
 
 
 class TestBuildAnthropicMessages:
@@ -263,8 +301,10 @@ class TestBuildMessagesKeyErrorSafety:
         assert len(messages) == expected_turn_count
         # The malformed row produces an empty wrapped user turn rather than a crash.
         assert messages[1]["role"] == "user"
-        assert messages[1]["content"].startswith("<user_input_")
-        assert messages[1]["content"].endswith(">")
+        malformed_content = messages[1]["content"]
+        assert isinstance(malformed_content, str)
+        assert malformed_content.startswith("<user_input_")
+        assert malformed_content.endswith(">")
 
     def test_anthropic_history_entry_missing_message_does_not_raise(self) -> None:
         """Same KeyError safety on the Anthropic builder path.
@@ -284,8 +324,10 @@ class TestBuildMessagesKeyErrorSafety:
         assert len(messages) == expected_turn_count
         assert all(m["role"] in {"user", "assistant"} for m in messages)
         assert messages[0]["role"] == "user"
-        assert messages[0]["content"].startswith("<user_input_")
-        assert messages[0]["content"].endswith(">")
+        malformed_content = messages[0]["content"]
+        assert isinstance(malformed_content, str)
+        assert malformed_content.startswith("<user_input_")
+        assert malformed_content.endswith(">")
         # The augmented system prompt is unaffected by malformed history rows.
         assert _NONCE_RE.search(augmented) is not None
 
@@ -353,7 +395,9 @@ class TestMedicationGuardrailInSystemPrompt:
             "guardrail must be present in the system role message"
         )
         # ...and must NOT live in a user turn (where crafted input could displace it).
-        user_turns_content = " ".join(m["content"] for m in messages if m["role"] == "user")
+        user_contents = [m["content"] for m in messages if m["role"] == "user"]
+        assert all(isinstance(content, str) for content in user_contents)
+        user_turns_content = " ".join(c for c in user_contents if isinstance(c, str))
         assert MEDICATION_GUARDRAIL not in user_turns_content
 
     # --- Anthropic path (_build_anthropic_messages) ---
@@ -525,3 +569,349 @@ class TestGenerateResponseExceptionContract:
         monkeypatch.setenv("LLM_MODEL", "gpt-99-turbo-megamax")
         with pytest.raises(LLMProviderError):
             _get_model("openai")
+
+
+# ── Vision content blocks (image payloads in the LLM provider layer) ──────
+
+_FIXED_NONCE = "deadbeefcafef00d"
+_FAKE_JPEG_B64 = "ZmFrZWJhc2U2NA=="
+
+
+class TestImagePayload:
+    """``ImagePayload`` validates media type and size, and is immutable."""
+
+    def test_valid_media_types_are_accepted(self) -> None:
+        for media_type in ("image/jpeg", "image/png", "image/webp"):
+            image = ImagePayload(data=_FAKE_JPEG_B64, media_type=media_type)
+            assert image.media_type == media_type
+            assert image.data == _FAKE_JPEG_B64
+
+    def test_invalid_media_type_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="media_type"):
+            ImagePayload(data=_FAKE_JPEG_B64, media_type="image/gif")
+
+    def test_invalid_media_type_error_does_not_leak_data(self) -> None:
+        sensitive_data = "NOTLEAKEDBASE64DATA" * 10
+        with pytest.raises(ValueError, match="unsupported image media_type") as excinfo:
+            ImagePayload(data=sensitive_data, media_type="application/pdf")
+        assert sensitive_data not in str(excinfo.value)
+
+    def test_max_image_base64_chars_matches_five_mb_decoded(self) -> None:
+        expected = (5 * 1024 * 1024 * 4) // 3
+        assert expected == _MAX_IMAGE_BASE64_CHARS
+
+    def test_data_at_max_length_is_accepted(self) -> None:
+        at_limit = "a" * _MAX_IMAGE_BASE64_CHARS
+        image = ImagePayload(data=at_limit, media_type="image/png")
+        assert len(image.data) == _MAX_IMAGE_BASE64_CHARS
+
+    def test_oversized_data_raises_value_error(self) -> None:
+        oversized = "a" * (_MAX_IMAGE_BASE64_CHARS + 1)
+        with pytest.raises(ValueError, match="exceeds"):
+            ImagePayload(data=oversized, media_type="image/png")
+
+    def test_oversized_data_error_does_not_leak_data(self) -> None:
+        oversized = "a" * (_MAX_IMAGE_BASE64_CHARS + 1)
+        with pytest.raises(ValueError, match="exceeds maximum") as excinfo:
+            ImagePayload(data=oversized, media_type="image/png")
+        assert oversized not in str(excinfo.value)
+
+    def test_frozen_field_assignment_raises(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/png")
+        with pytest.raises(FrozenInstanceError):
+            image.media_type = "image/jpeg"  # type: ignore[misc]
+
+
+class TestBuildMessagesImagesAnchor:
+    """Byte-identical anchor: text-only calls are unchanged by the ``images`` param.
+
+    With ``_make_nonce`` patched to a fixed value, calling either builder
+    with ``images=None`` or ``images=[]`` must reproduce exactly the output
+    the pre-images builder produced -- proving the text-only path is
+    untouched by the new code path.
+    """
+
+    def test_build_messages_images_none_matches_pre_images_output(self) -> None:
+        history = [
+            {"sender": "user", "message": "first user turn"},
+            {"sender": "bot", "message": "first bot turn"},
+        ]
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            actual = _build_messages("hello", history, "PROMPT", images=None)
+            expected = [
+                {"role": "system", "content": _augment_system_prompt("PROMPT", _FIXED_NONCE)},
+                {
+                    "role": "user",
+                    "content": _wrap_user_input("first user turn", _FIXED_NONCE),
+                },
+                {"role": "assistant", "content": "first bot turn"},
+                {"role": "user", "content": _wrap_user_input("hello", _FIXED_NONCE)},
+            ]
+        assert actual == expected
+        for message in actual:
+            assert isinstance(message["content"], str)
+
+    def test_build_messages_images_empty_list_matches_pre_images_output(self) -> None:
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            actual = _build_messages("hello", [], "PROMPT", images=[])
+            expected = [
+                {"role": "system", "content": _augment_system_prompt("PROMPT", _FIXED_NONCE)},
+                {"role": "user", "content": _wrap_user_input("hello", _FIXED_NONCE)},
+            ]
+        assert actual == expected
+        for message in actual:
+            assert isinstance(message["content"], str)
+
+    def test_build_anthropic_messages_images_none_matches_pre_images_output(self) -> None:
+        history = [
+            {"sender": "user", "message": "old"},
+            {"sender": "bot", "message": "reply"},
+        ]
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            actual_messages, actual_system = _build_anthropic_messages(
+                "new", history, "PROMPT", images=None
+            )
+            expected_messages = [
+                {"role": "user", "content": _wrap_user_input("old", _FIXED_NONCE)},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": _wrap_user_input("new", _FIXED_NONCE)},
+            ]
+            expected_system = _augment_system_prompt("PROMPT", _FIXED_NONCE)
+        assert actual_messages == expected_messages
+        assert actual_system == expected_system
+        for message in actual_messages:
+            assert isinstance(message["content"], str)
+
+    def test_build_anthropic_messages_images_empty_list_matches_pre_images_output(
+        self,
+    ) -> None:
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            actual_messages, actual_system = _build_anthropic_messages(
+                "hi", [], "PROMPT", images=[]
+            )
+            expected_messages = [{"role": "user", "content": _wrap_user_input("hi", _FIXED_NONCE)}]
+            expected_system = _augment_system_prompt("PROMPT", _FIXED_NONCE)
+        assert actual_messages == expected_messages
+        assert actual_system == expected_system
+
+
+class TestBuildMessagesWithImages:
+    """The final new user turn becomes a list of parts when images are present."""
+
+    def test_openai_final_turn_content_is_image_part_plus_text_part(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/jpeg")
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages = _build_messages("describe this", [], "PROMPT", images=[image])
+        expected_text_part = {
+            "type": "text",
+            "text": _wrap_user_input("describe this", _FIXED_NONCE),
+        }
+        expected_image_part = {
+            "type": "image_url",
+            "image_url": {"url": f"data:{image.media_type};base64,{image.data}"},
+        }
+        assert messages[-1]["content"] == [expected_image_part, expected_text_part]
+
+    def test_openai_multiple_images_preserve_order(self) -> None:
+        image_a = ImagePayload(data="aaaa", media_type="image/png")
+        image_b = ImagePayload(data="bbbb", media_type="image/webp")
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages = _build_messages("two images", [], "PROMPT", images=[image_a, image_b])
+        final_content = messages[-1]["content"]
+        assert isinstance(final_content, list)
+        expected_url_count = 2
+        assert _str_leaf(final_content[0], "image_url", "url") == "data:image/png;base64,aaaa"
+        assert _str_leaf(final_content[1], "image_url", "url") == "data:image/webp;base64,bbbb"
+        assert _str_leaf(final_content[expected_url_count], "type") == "text"
+
+    def test_openai_history_turns_never_receive_image_parts(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/jpeg")
+        history = [{"sender": "user", "message": "earlier turn"}]
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages = _build_messages("now with image", history, "PROMPT", images=[image])
+        history_content = messages[1]["content"]
+        assert isinstance(history_content, str)
+        assert history_content == _wrap_user_input("earlier turn", _FIXED_NONCE)
+
+    def test_anthropic_final_turn_content_is_image_part_plus_text_part(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/jpeg")
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages, _augmented = _build_anthropic_messages(
+                "describe this", [], "PROMPT", images=[image]
+            )
+        expected_text_part = {
+            "type": "text",
+            "text": _wrap_user_input("describe this", _FIXED_NONCE),
+        }
+        expected_image_part = {
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": image.media_type,
+                "data": image.data,
+            },
+        }
+        assert messages[-1]["content"] == [expected_image_part, expected_text_part]
+
+    def test_anthropic_history_turns_never_receive_image_parts(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/jpeg")
+        history = [{"sender": "user", "message": "earlier turn"}]
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages, _augmented = _build_anthropic_messages(
+                "now", history, "PROMPT", images=[image]
+            )
+        history_content = messages[0]["content"]
+        assert isinstance(history_content, str)
+        assert history_content == _wrap_user_input("earlier turn", _FIXED_NONCE)
+
+
+class TestImagePartsBypassSanitization:
+    """Image data is emitted verbatim -- never sanitized, never nonce-wrapped."""
+
+    def test_openai_image_data_is_byte_identical_to_input(self) -> None:
+        raw_data = "notsanitizedZmFrZQ=="
+        image = ImagePayload(data=raw_data, media_type="image/png")
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages = _build_messages("hi", [], "PROMPT", images=[image])
+        content = messages[-1]["content"]
+        assert isinstance(content, list)
+        url = _str_leaf(content[0], "image_url", "url")
+        assert url == f"data:image/png;base64,{raw_data}"
+        assert "<user_input_" not in url
+
+    def test_anthropic_image_data_is_byte_identical_to_input(self) -> None:
+        raw_data = "notsanitizedZmFrZQ=="
+        image = ImagePayload(data=raw_data, media_type="image/png")
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages, _augmented = _build_anthropic_messages("hi", [], "PROMPT", images=[image])
+        content = messages[-1]["content"]
+        assert isinstance(content, list)
+        data = _str_leaf(content[0], "source", "data")
+        assert data == raw_data
+        assert "<user_input_" not in data
+
+    def test_sibling_text_part_is_still_nonce_wrapped_and_sanitized(self) -> None:
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/jpeg")
+        attack = "evil\x00text"
+        with patch.object(botmason_mod, "_make_nonce", return_value=_FIXED_NONCE):
+            messages = _build_messages(attack, [], "PROMPT", images=[image])
+        content = messages[-1]["content"]
+        assert isinstance(content, list)
+        text = _str_leaf(content[1], "text")
+        assert text == _wrap_user_input(attack, _FIXED_NONCE)
+        assert "\x00" not in text
+
+
+class TestSupportsVision:
+    """``supports_vision`` truth table across all registered models."""
+
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [
+            ("openai", "gpt-4o-mini"),
+            ("openai", "gpt-4o"),
+            ("openai", "gpt-4-turbo"),
+            ("anthropic", "claude-sonnet-4-20250514"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
+            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-sonnet-4-6"),
+        ],
+    )
+    def test_real_models_support_vision_under_own_provider(self, provider: str, model: str) -> None:
+        assert supports_vision(provider, model) is True
+
+    def test_model_under_wrong_provider_returns_false(self) -> None:
+        assert supports_vision("openai", "claude-sonnet-4-20250514") is False
+        assert supports_vision("anthropic", "gpt-4o") is False
+
+    def test_unknown_provider_returns_false(self) -> None:
+        assert supports_vision("carrier-pigeon", "gpt-4o") is False
+
+    def test_unknown_model_returns_false(self) -> None:
+        assert supports_vision("openai", "gpt-99-turbo-megamax") is False
+
+    def test_stub_provider_and_model_returns_true(self) -> None:
+        assert supports_vision("stub", "stub") is True
+
+
+def _incapable_openai_spec() -> ProviderSpec:
+    """Return an OpenAI ``ProviderSpec`` whose ``vision_models`` is empty.
+
+    Used to force :func:`generate_response` down the vision-capability-check
+    failure path without needing a real vision-incapable model on the
+    allowlist.
+    """
+    return ProviderSpec(
+        key_prefix="sk-",
+        disallowed_prefixes=("sk-ant-",),
+        default_model="gpt-4o-mini",
+        allowed_models=frozenset({"gpt-4o-mini"}),
+        vision_models=frozenset(),
+        call_name="_call_openai",
+    )
+
+
+class TestGenerateResponseVisionCapabilityError:
+    """Passing images to a vision-incapable provider/model raises the dedicated error."""
+
+    @pytest.mark.asyncio
+    async def test_raises_llm_vision_unsupported_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_openai_env(monkeypatch)
+        monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+        monkeypatch.setitem(botmason_mod.PROVIDER_REGISTRY, "openai", _incapable_openai_spec())
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/png")
+
+        with pytest.raises(LLMVisionUnsupportedError):
+            await generate_response("describe", [], images=[image])
+
+    @pytest.mark.asyncio
+    async def test_vision_unsupported_error_is_an_llm_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Existing ``LLMProviderError`` catchers keep working unmodified."""
+        _configure_openai_env(monkeypatch)
+        monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+        monkeypatch.setitem(botmason_mod.PROVIDER_REGISTRY, "openai", _incapable_openai_spec())
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/png")
+
+        with pytest.raises(LLMProviderError) as excinfo:
+            await generate_response("describe", [], images=[image])
+        assert isinstance(excinfo.value, LLMVisionUnsupportedError)
+
+    @pytest.mark.asyncio
+    async def test_error_is_not_double_wrapped_into_plain_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The capability error escapes as its own subclass, never re-wrapped.
+
+        Mirrors ``test_existing_provider_error_is_not_double_wrapped``: the
+        generic ``except _PROVIDER_ERROR_TYPES`` clause in
+        ``generate_response`` must not catch and re-raise this error as a
+        bare ``LLMProviderError``, which would lose the subclass identity
+        callers rely on to distinguish "no vision support" from every other
+        provider failure.
+        """
+        _configure_openai_env(monkeypatch)
+        monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+        monkeypatch.setitem(botmason_mod.PROVIDER_REGISTRY, "openai", _incapable_openai_spec())
+        image = ImagePayload(data=_FAKE_JPEG_B64, media_type="image/png")
+
+        with pytest.raises(LLMVisionUnsupportedError) as excinfo:
+            await generate_response("describe", [], images=[image])
+        assert type(excinfo.value) is LLMVisionUnsupportedError
+
+    @pytest.mark.asyncio
+    async def test_error_message_contains_no_base64_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_openai_env(monkeypatch)
+        monkeypatch.setenv("LLM_MODEL", "gpt-4o-mini")
+        monkeypatch.setitem(botmason_mod.PROVIDER_REGISTRY, "openai", _incapable_openai_spec())
+        sensitive_data = "NOTLEAKEDIMAGEBASE64DATA" * 5
+        image = ImagePayload(data=sensitive_data, media_type="image/png")
+
+        with pytest.raises(LLMVisionUnsupportedError) as excinfo:
+            await generate_response("describe", [], images=[image])
+        assert sensitive_data not in str(excinfo.value)

--- a/backend/tests/test_botmason_api.py
+++ b/backend/tests/test_botmason_api.py
@@ -28,7 +28,12 @@ import services.botmason as botmason_mod
 from models.user import User
 from services.botmason import (
     LLM_API_KEY_MAX_LENGTH,
+    STUB_MODEL_NAME,
+    STUB_PROVIDER_NAME,
+    ImagePayload,
     LLMResponse,
+    _stub_response,
+    _stub_vision_response,
     generate_response,
     get_system_prompt,
     provider_for_api_key,
@@ -778,3 +783,116 @@ async def test_allowed_model_passes_the_gate(monkeypatch: pytest.MonkeyPatch) ->
 
     result = await generate_response("Hello", [])
     assert result.provider == "openai"
+
+
+# ── Vision content blocks: generate_response seam + stub vision path ────
+
+
+_TEST_IMAGE = ImagePayload(data="ZmFrZWJhc2U2NA==", media_type="image/jpeg")
+
+
+def _forwarded_images(mock_call: AsyncMock) -> object:
+    """Return the ``images`` argument forwarded to a provider call mock.
+
+    Mirrors ``_forwarded_key``: the implementation may forward ``images`` as
+    the 5th positional argument or as the ``images`` keyword.
+    """
+    call = mock_call.await_args
+    assert call is not None, "expected provider mock to have been awaited"
+    args, kwargs = call
+    if "images" in kwargs:
+        return kwargs["images"]
+    if len(args) >= 5:
+        return args[4]
+    return None
+
+
+@pytest.mark.asyncio
+async def test_generate_response_accepts_images_kwarg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``generate_response`` accepts an optional ``images`` sequence."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    result = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+    assert isinstance(result, LLMResponse)
+
+
+@pytest.mark.asyncio
+async def test_generate_response_images_default_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``images`` entirely keeps the stub text-only response."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    result = await generate_response("Hello", [])
+    assert "Hello" in result.text
+
+
+@pytest.mark.asyncio
+async def test_generate_response_forwards_images_to_openai_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured provider receives the ``images`` argument on the call path."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "sk-server-key")  # pragma: allowlist secret
+
+    mock_call = AsyncMock(return_value=_mock_openai_response("saw the image"))
+    with patch.object(botmason_mod, "_call_openai", mock_call):
+        result = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+
+    assert result.text == "saw the image"
+    assert _forwarded_images(mock_call) == [_TEST_IMAGE]
+
+
+# ── Stub vision path ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stub_provider_with_images_returns_deterministic_vision_transcription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stub + images returns a canned transcription, distinct from the text-only stub."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    result = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+    assert result.provider == STUB_PROVIDER_NAME
+    assert result.model == STUB_MODEL_NAME
+    assert result.prompt_tokens == 0
+    assert result.completion_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_stub_vision_response_is_identical_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two stub-vision calls with the same image count produce identical text."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    first = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+    second = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+    assert first.text == second.text
+
+
+@pytest.mark.asyncio
+async def test_stub_vision_response_contains_no_image_base64_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canned vision transcription never echoes the raw image payload."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    secret_image = ImagePayload(data="SECRETIMAGEBASE64DATA" * 5, media_type="image/png")
+    result = await generate_response("What do you see?", [], images=[secret_image])
+    assert secret_image.data not in result.text
+
+
+@pytest.mark.asyncio
+async def test_stub_vision_response_differs_from_text_only_stub_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stub vision text is produced by a distinct helper from the text-only stub."""
+    monkeypatch.setenv("BOTMASON_PROVIDER", "stub")
+    text_only = await generate_response("What do you see?", [])
+    with_image = await generate_response("What do you see?", [], images=[_TEST_IMAGE])
+    assert text_only.text != with_image.text
+
+
+def test_stub_vision_response_helper_is_distinct_from_stub_response() -> None:
+    """The module exposes ``_stub_vision_response`` as a helper separate from ``_stub_response``."""
+    assert hasattr(botmason_mod, "_stub_vision_response")
+    assert id(_stub_vision_response) != id(_stub_response)


### PR DESCRIPTION
## Summary

Foundation issue of the Journal Photographer epic. Extends the LLM provider
layer (`backend/src/services/botmason.py`) so a call can carry base64 **images**
alongside text — through the existing provider/timeout/retry/BYOK machinery,
with no parallel LLM stack. No endpoint or UI in this issue.

## What changed

- **`ImagePayload`** — frozen, `slots` dataclass. `media_type` strictly
  allowlisted to `image/jpeg` / `image/png` / `image/webp`; `data` (base64)
  bounded by `_MAX_IMAGE_BASE64_CHARS` (~5 MB decoded). Validation in
  `__post_init__` so an invalid attachment can never exist; the `ValueError`
  never interpolates image bytes.
- **`generate_response(..., images=None)`** — one new optional public seam
  (`Sequence[ImagePayload] | None`). Text-only callers (marginalia) are
  untouched.
- **Message builders** — `_build_messages` emits OpenAI `image_url` data-URL
  parts; `_build_anthropic_messages` emits Anthropic
  `{"type":"image","source":{"type":"base64",...}}` blocks. Images attach only
  to the final user turn; multiple images preserve order. **Text-only calls are
  byte-identical to before**, anchored by a fixed-nonce regression test.
- **Sanitization boundary** — image parts bypass `_wrap_user_input`
  (sanitize + nonce wrap); the sibling text part keeps the full pipeline.
- **`PROVIDER_REGISTRY` vision metadata** — new `ProviderSpec.vision_models`
  (explicit per-provider sets, independently audited from `allowed_models`) plus
  a public `supports_vision(provider, model)` helper. All seven allowlisted real
  models are vision-capable; `stub`/`stub` → True. Truth table tested.
- **Capability error** — `LLMVisionUnsupportedError(LLMProviderError)`: passing
  images to a vision-incapable provider/model raises before any provider call,
  carrying a distinguishable marker the endpoint maps to 422 (never a silent
  model substitution). Propagates unwrapped through `generate_response`.
- **Stub vision path** — `_stub_vision_response` returns deterministic canned
  transcription text (references image count only), zero tokens.
- **Retry/timeout unchanged** — `_retry_on_transient` + `_LLM_TIMEOUT_SECONDS`
  wrap image calls identically (tested with a fake transient 503).

## Privacy

No log line, exception message, or stub output interpolates image bytes/base64
or transcribed text (epic invariant: log-the-fact-not-the-content).

## Design decisions worth noting

- **Size cap added (spec left it open):** the issue forbids size-unbounded
  payloads without a documented cap decision. Adopted a ~5 MB-decoded per-image
  cap — a defensive bound against memory blowup / pointless provider round-trips
  on the BYOK path. One named constant, one branch, one test.
- **Type aliases** (`ContentPart`/`MessageContent`/`ChatMessage`) are bare
  implicit aliases rather than `TypeAlias`-annotated, so the module keeps parsing
  on the 3.11 cross-version CI job (the newer `type` keyword form is a syntax
  error there).

## Verification

- `scripts/backend/check-all.sh`: 7/7 pass — full backend suite 2710 passed,
  96.78% coverage.
- ruff (lint + format), mypy strict (332 files), xenon A-grade + radon MI A on
  `botmason.py`, interrogate 100% docstrings — all clean. No suppressions beyond
  the one `# type: ignore[misc]` on the frozen-assignment test (matches the
  existing house pattern in `test_practice_insights.py` / `test_contraction.py`).

## Follow-ups (out of scope — provider layer only)

- Aggregate multi-image request cap belongs at the future transcription
  router/schema boundary, not this layer.

Closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)