### PR TITLE
feat(backend): handwriting transcription prompt builder in domain/transcription.py

### DIFF
--- a/backend/src/domain/transcription.py
+++ b/backend/src/domain/transcription.py
@@ -1,0 +1,64 @@
+"""Handwriting-transcription prompt for the Journal Photographer.
+
+Build the plain-text instruction sent to the LLM when a user photographs a page
+of their handwritten journal and wants it turned into faithful body text for a
+digital entry. Like its sibling resonance/detection prompt builders, this leads
+with the shared medication-safety guardrail from :mod:`domain.care`, but unlike
+them it deliberately returns *body text only* — it carries no STRICT-JSON
+response contract, because the model's job here is transcription, not structured
+extraction.
+
+The conventions are fixed: transcribe every word verbatim (no summarizing,
+correcting, or rewording); mark an unreadable word ``[illegible]``; mark an
+uncertain reading as a best guess with a trailing question mark in brackets,
+e.g. ``[word?]``; drop struck-through text entirely; and integrate caret or
+margin insertions inline where the writer intended them.
+
+The prompt is a zero-argument, deterministic constant derived from nothing
+user-specific. Holding the whole instruction as a fixed string means every call
+sends byte-identical text, which lets the provider serve prompt-cache hits
+across requests instead of re-billing the shared preamble each time.
+"""
+
+from __future__ import annotations
+
+from domain.care import MEDICATION_GUARDRAIL
+
+# The prompt body after the guardrail: the fixed transcription conventions,
+# the two few-shot examples, and the body-only output rule. One module
+# constant so the wording is reviewed in a single place.
+_TRANSCRIPTION_INSTRUCTIONS = (
+    "You are transcribing a photographed page of someone's handwritten "
+    "journal into faithful body text for their digital journal entry.\n\n"
+    "Transcribe every word exactly as written. Do not summarize, paraphrase, "
+    "correct grammar or spelling, reword sentences, or add anything the "
+    "writer did not write.\n\n"
+    "Conventions:\n"
+    "- If a word or short phrase is illegible, write [illegible] in its "
+    "place and keep transcribing the rest of the sentence.\n"
+    "- If you can make out a word but are not certain, write your best "
+    "guess followed by a question mark inside brackets, e.g. [word?].\n"
+    "- If a word or phrase is crossed out or struck through, omit it "
+    "entirely from the transcription — do not include struck-through text, "
+    "even in brackets.\n"
+    "- If the writer added a word or phrase via a caret insertion or a "
+    "margin note pointing back into the text, integrate it inline at the "
+    "point the writer intended it to be inserted.\n\n"
+    "Examples:\n"
+    "- Handwriting shows: I felt <s>angry</s> frustrated about the "
+    "meeting. Transcribe as: I felt frustrated about the meeting.\n"
+    "- Handwriting shows a word you cannot make out in the middle of a "
+    "sentence. Transcribe as: I went to the [illegible] with my sister.\n\n"
+    "Return only the journal entry body text. No preamble, no commentary, "
+    "no markdown formatting, no headers — just the transcribed body text."
+)
+
+
+def build_transcription_prompt() -> str:
+    """Return the handwriting-transcription prompt (guardrail + conventions).
+
+    Pure, zero-argument, and deterministic: the medication-safety guardrail
+    followed by the fixed transcription instructions, identical on every call.
+    Returns body-text instructions only — no STRICT-JSON response contract.
+    """
+    return f"{MEDICATION_GUARDRAIL}\n\n{_TRANSCRIPTION_INSTRUCTIONS}"

--- a/backend/tests/domain/test_transcription.py
+++ b/backend/tests/domain/test_transcription.py
@@ -1,0 +1,143 @@
+"""RED-state tests for the handwriting-transcription prompt builder.
+
+``domain.transcription`` does not exist yet, so importing
+:func:`~domain.transcription.build_transcription_prompt` below fails with
+``ModuleNotFoundError: No module named 'domain.transcription'``. That failure,
+not a passing test, is the correct RED state for this module.
+
+The rest of these tests pin the contract the implementation must satisfy once
+it exists: the prompt is a constant, zero-argument, plain-text string that
+leads with the shared medication-safety guardrail from :mod:`domain.care`,
+carries fixed conventions for illegible and uncertain handwriting, preserves
+cross-outs and margin insertions faithfully, returns body text only (no
+preamble or markdown), and never inherits the STRICT-JSON response contract
+used by the sibling resonance/detection prompt builders.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from domain.care import MEDICATION_GUARDRAIL
+from domain.transcription import build_transcription_prompt
+
+# Independent copy of the prompt body after the guardrail. Any drift between
+# this literal and the source constant fails the golden test below.
+_PROMPT_BODY = (
+    "You are transcribing a photographed page of someone's handwritten "
+    "journal into faithful body text for their digital journal entry.\n\n"
+    "Transcribe every word exactly as written. Do not summarize, paraphrase, "
+    "correct grammar or spelling, reword sentences, or add anything the "
+    "writer did not write.\n\n"
+    "Conventions:\n"
+    "- If a word or short phrase is illegible, write [illegible] in its "
+    "place and keep transcribing the rest of the sentence.\n"
+    "- If you can make out a word but are not certain, write your best "
+    "guess followed by a question mark inside brackets, e.g. [word?].\n"
+    "- If a word or phrase is crossed out or struck through, omit it "
+    "entirely from the transcription — do not include struck-through text, "
+    "even in brackets.\n"
+    "- If the writer added a word or phrase via a caret insertion or a "
+    "margin note pointing back into the text, integrate it inline at the "
+    "point the writer intended it to be inserted.\n\n"
+    "Examples:\n"
+    "- Handwriting shows: I felt <s>angry</s> frustrated about the "
+    "meeting. Transcribe as: I felt frustrated about the meeting.\n"
+    "- Handwriting shows a word you cannot make out in the middle of a "
+    "sentence. Transcribe as: I went to the [illegible] with my sister.\n\n"
+    "Return only the journal entry body text. No preamble, no commentary, "
+    "no markdown formatting, no headers — just the transcribed body text."
+)
+
+# Golden snapshot: guardrail plus the exact remainder above, byte for byte.
+_EXPECTED_PROMPT = f"{MEDICATION_GUARDRAIL}\n\n{_PROMPT_BODY}"
+
+
+# ---------------------------------------------------------------------------
+# Medication-safety guardrail
+# ---------------------------------------------------------------------------
+
+
+def test_build_transcription_prompt_starts_with_medication_guardrail() -> None:
+    """The prompt begins with MEDICATION_GUARDRAIL, not merely contains it."""
+    prompt = build_transcription_prompt()
+    assert prompt.startswith(MEDICATION_GUARDRAIL)
+
+
+# ---------------------------------------------------------------------------
+# Transcription conventions
+# ---------------------------------------------------------------------------
+
+_CONVENTION_TOKENS = (
+    ("illegible-word marker", "[illegible]"),
+    ("uncertain-word marker", "[word?]"),
+    ("cross-out omission rule", "crossed out or struck through"),
+    ("caret / margin-note integration rule", "caret insertion or a margin note"),
+    ("body-only, no-preamble, no-markdown rule", "no markdown formatting"),
+    ("faithful, non-summarizing rule", "Do not summarize, paraphrase"),
+)
+
+
+_CONVENTION_IDS = [label for label, _ in _CONVENTION_TOKENS]
+
+
+@pytest.mark.parametrize(("label", "token"), _CONVENTION_TOKENS, ids=_CONVENTION_IDS)
+def test_build_transcription_prompt_contains_convention(label: str, token: str) -> None:
+    """Each transcription convention/rule the AC requires is present verbatim."""
+    prompt = build_transcription_prompt()
+    assert token in prompt, f"missing {label!r}: expected {token!r} in prompt"
+
+
+# ---------------------------------------------------------------------------
+# Few-shot examples
+# ---------------------------------------------------------------------------
+
+
+def test_build_transcription_prompt_includes_cross_out_example() -> None:
+    """The cross-out few-shot example's resolved output is present."""
+    prompt = build_transcription_prompt()
+    assert "felt frustrated about" in prompt
+
+
+def test_build_transcription_prompt_includes_illegible_mid_sentence_example() -> None:
+    """The illegible-mid-sentence few-shot example is present."""
+    prompt = build_transcription_prompt()
+    assert "I went to the [illegible] with my sister" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Not the sibling STRICT-JSON contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_transcription_prompt_has_no_json_response_contract() -> None:
+    """This prompt returns body text, not the resonance/detection JSON tail."""
+    prompt = build_transcription_prompt()
+    assert "JSON" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Determinism and purity
+# ---------------------------------------------------------------------------
+
+
+def test_build_transcription_prompt_is_deterministic() -> None:
+    """Two calls return the identical string — no hidden randomness or state."""
+    assert build_transcription_prompt() == build_transcription_prompt()
+
+
+def test_build_transcription_prompt_takes_no_arguments() -> None:
+    """Zero-arg signature pins the cache-hit contract: nothing request-varying."""
+    assert inspect.signature(build_transcription_prompt).parameters == {}
+
+
+# ---------------------------------------------------------------------------
+# Golden snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_build_transcription_prompt_matches_golden_snapshot() -> None:
+    """Exact text match against _EXPECTED_PROMPT, guardrail plus literal body."""
+    assert build_transcription_prompt() == _EXPECTED_PROMPT


### PR DESCRIPTION
## Summary

Adds `backend/src/domain/transcription.py` with `build_transcription_prompt() -> str`, the pure, zero-argument prompt builder for the Journal Photographer transcription flow. It turns a photographed handwritten page into faithful journal body text.

- Leads with the shared `MEDICATION_GUARDRAIL` (imported from `domain.care`, defense-in-depth) exactly like the sibling `resonance`/`detection` builders.
- Encodes the settled transcription conventions: faithful verbatim transcription (no summarizing or rewording); `[illegible]` for unreadable words; `[word?]` for uncertain best guesses; omission of struck-through text; inline integration of caret and margin insertions; body-text-only output with no preamble or markdown.
- Deliberately carries **no** STRICT-JSON response tail — the reply is journal body text, not structured extraction.
- Constant, deterministic text so every call is byte-identical, maximizing provider prompt-cache hits. The image travels separately as a content block (built on #1786's vision blocks), so the prompt takes no request-varying arguments.

## Test plan

- New `backend/tests/domain/test_transcription.py` (RED-first): asserts the prompt starts with `MEDICATION_GUARDRAIL` (imported, not copied), every convention token/rule is present, both few-shot examples are present, the STRICT-JSON tail is absent, the builder is deterministic and zero-argument, and a golden snapshot pins the full text byte-for-byte via an independently re-typed body literal (real drift protection).
- `./scripts/backend/check-all.sh` green (coverage 96.82%, ≥90% gate); manual `xenon` exit 0 and `radon mi` grade A; all pre-commit hooks pass.

Closes #1787
Refs #1799