### PR TITLE
feat(backend): Creek Vault MCP client seam + capability handshake + local fallback

### DIFF
--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -36,8 +36,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
-from schemas.wheel import WheelBalanceResponse
-
 # Semantic contract version adepthood presents at handshake and compares against
 # what a vault advertises. A major-version mismatch degrades to unavailable
 # rather than risking a call under an incompatible surface.
@@ -208,6 +206,33 @@ class VaultClassification:
     tags: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class VaultWheelAspect:
+    """One Aspect's fullness at a stage, in a vault-computed wheel read.
+
+    A domain-native mirror of the transport's per-Aspect wheel row so the seam's
+    return type stays pure Python; the adapter validates the wire payload against
+    the Pydantic schema and then projects it onto this value.
+    """
+
+    stage_number: int
+    aspect: str
+    fullness: float
+
+
+@dataclass(frozen=True)
+class VaultWheelBalance:
+    """A vault's Wheel-of-Wholeness read: Aspect fullness in canonical order.
+
+    The domain-layer return type of :meth:`CreekVaultClient.wheel` -- a plain,
+    immutable value carrying no FastAPI/DB/schema dependency, exactly as the rest
+    of this module. The concrete adapter owns the (schema-backed) parse and hands
+    back this value, keeping the domain free of the Pydantic response type.
+    """
+
+    aspects: tuple[VaultWheelAspect, ...]
+
+
 class CreekVaultClient(Protocol):
     """The seam adepthood calls into for all vault interaction.
 
@@ -241,5 +266,13 @@ class CreekVaultClient(Protocol):
     async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
         """Produce a Higher Self reflection grounded in the user's own corpus."""
 
-    async def wheel(self) -> WheelBalanceResponse:
-        """Return a Wheel-of-Wholeness balance read from the vault's corpus."""
+    async def wheel(self) -> VaultWheelBalance:
+        """Return a Wheel-of-Wholeness balance read from the vault's corpus.
+
+        Unlike the other capabilities, a wheel payload whose *fields* are
+        malformed is not normalized to :class:`CreekVaultUnavailableError`: the
+        adapter surfaces a parse error so the read/compute path that consumes the
+        wheel owns field-level validation. The wheel is an optional read, never a
+        write, so a caller that cannot obtain it falls back to computing the
+        balance locally.
+        """

--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -1,0 +1,245 @@
+"""Pure domain seam for the Creek Vault MCP client.
+
+This module holds the vocabulary and value types adepthood uses to talk to an
+optional Creek Vault confidential-compute enclave, and *nothing else*: no
+FastAPI, no SQLModel/DB, no ``httpx``. Mirroring :mod:`domain.resonance`, the
+transport lives behind an injected :class:`CreekVaultClient` protocol so the
+concrete adapter (``services.creek_vault_client``) can be swapped, faked, or
+absent entirely without this module ever importing a network or persistence
+dependency.
+
+The governing principle is **graceful degradation**: no feature adepthood ships
+today depends on a vault being present. Every value type here is designed so a
+missing, unreachable, or capability-poor vault collapses to a well-defined
+"unavailable" state rather than an error the caller must special-case.
+
+Two invariants are load-bearing and deliberately encoded in the types:
+
+* **Fail closed on tier.** :func:`tier_ceiling_for` raises rather than defaulting
+  to :attr:`VaultTierCeiling.OPEN` for an unknown classification. Silently
+  widening a tier would let sensitive content leave under a looser ceiling than
+  the writer chose -- the opposite of "you choose your depth."
+* **Privacy over debuggability.** The error hierarchy exists so the service layer
+  can normalize any transport failure to :class:`CreekVaultUnavailableError`
+  *without* echoing the entry body or an API key into the message.
+
+Cross-references the authoritative contract in
+``docs/creek-vault-mcp-contract.md``; ontology and tier naming (notably the
+``PUBLIC``/``OPEN`` mismatch) come from there.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from schemas.wheel import WheelBalanceResponse
+
+# Semantic contract version adepthood presents at handshake and compares against
+# what a vault advertises. A major-version mismatch degrades to unavailable
+# rather than risking a call under an incompatible surface.
+CONTRACT_VERSION = "0.1.0-draft"
+
+# The identifier adepthood presents to Creek Vault so the vault's router can
+# scope capabilities and attestation to this consumer.
+CONSUMER_ID = "CREEK_MCP_CONSUMER"
+
+
+class CreekCapability(enum.StrEnum):
+    """The MCP capabilities adepthood may call, keyed by their wire names.
+
+    A vault advertises the subset it supports in its ``creek.handshake``
+    response; adepthood must never assume a capability exists without first
+    seeing it there. Values are the exact method strings sent over the wire.
+    """
+
+    HANDSHAKE = "creek.handshake"
+    INGEST = "creek.ingest"
+    SAVE = "creek.save"
+    CLASSIFY = "creek.classify"
+    REFLECT = "creek.reflect"
+    WHEEL = "creek.wheel"
+
+
+class VaultTierCeiling(enum.StrEnum):
+    """Creek's privacy tier ceiling, applied before every vault call.
+
+    Adepthood owns the mapping from its own ``JournalClassification`` onto this
+    enum and labels each call honestly; Creek's router enforces the ceiling at
+    the transport boundary. Note the ``OPEN`` name: it is Creek's word for what
+    adepthood calls ``PUBLIC`` (see the contract's tier-mapping table).
+    """
+
+    OPEN = "open"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+
+
+# Maps a journal classification *string* onto its tier ceiling. Keyed by the raw
+# ``JournalClassification`` values (not the enum) so this domain module stays
+# free of DB/model imports, exactly as :mod:`domain.resonance` keeps ``VALID_KINDS``
+# as literals. A drift-guard test imports ``JournalClassification`` and asserts
+# this key set matches, so the two can never silently diverge.
+TIER_CEILING_BY_CLASSIFICATION: Mapping[str, VaultTierCeiling] = {
+    "public": VaultTierCeiling.OPEN,
+    "personal": VaultTierCeiling.PERSONAL,
+    "intimate": VaultTierCeiling.INTIMATE,
+}
+
+
+def tier_ceiling_for(classification: str) -> VaultTierCeiling:
+    """Resolve a journal classification to its Creek tier ceiling, failing closed.
+
+    Raises :class:`ValueError` for any unknown or empty classification rather
+    than defaulting to :attr:`VaultTierCeiling.OPEN`. Defaulting to the loosest
+    ceiling on unrecognized input would let content leave the app under a looser
+    privacy tier than the writer chose -- so the safe answer to "I don't know
+    this tier" is to refuse the call, not to widen it.
+    """
+    try:
+        return TIER_CEILING_BY_CLASSIFICATION[classification]
+    except KeyError:
+        raise ValueError(f"unknown journal classification: {classification!r}") from None
+
+
+class CreekVaultError(RuntimeError):
+    """Base type for every Creek Vault failure callers should degrade on.
+
+    Subclasses ``RuntimeError`` so a caller can catch one vault-agnostic type.
+    Only genuine vault-seam failures normalize to this hierarchy; an unrelated
+    internal bug propagates unchanged so the real defect is not masked.
+    """
+
+
+class CreekVaultUnavailableError(CreekVaultError):
+    """A configured vault could not service a call (a transport failure).
+
+    The service layer raises this in place of the underlying transport
+    exception. Its message is deliberately static and capability-named -- it
+    must never interpolate the entry body or an API key, since exception
+    strings surface in logs and tracebacks (privacy invariant).
+    """
+
+
+class CreekCapabilityUnsupportedError(CreekVaultError):
+    """A call was attempted for a capability the current handshake did not advertise.
+
+    Distinct from :class:`CreekVaultUnavailableError`: it does not mean the vault
+    is down. Either a reachable vault's handshake did not offer this capability,
+    or no vault is configured at all -- the local-fallback client raises it for
+    every read/compute capability, since it has no vault to serve them. Either
+    way the caller should fall back to its local pipeline for that one feature;
+    degradation is per-capability, not all-or-nothing.
+    """
+
+
+@dataclass(frozen=True)
+class HandshakeResult:
+    """Immutable outcome of a ``creek.handshake`` negotiation.
+
+    Carries whether the vault is usable at all (:attr:`available`), the
+    negotiated ``contract``/``ontology`` versions, the advertised capability set
+    (already narrowed to known :class:`CreekCapability` members), and any
+    attestation evidence the caller needs to decide whether the enclave is
+    trustworthy for the intimate write path. Frozen so a cached handshake cannot
+    be mutated out from under later ``is_available``/``supports`` reads.
+    """
+
+    available: bool
+    contract_version: str | None
+    ontology_version: str | None
+    capabilities: frozenset[CreekCapability]
+    attestation: Mapping[str, object] | None
+
+    @classmethod
+    def unavailable(cls) -> HandshakeResult:
+        """Return the canonical "no usable vault" result.
+
+        Every degradation path (absent config, transport error, malformed
+        payload, version mismatch) collapses to this single value so callers
+        have exactly one shape to branch on for "fall back to local."
+        """
+        return cls(
+            available=False,
+            contract_version=None,
+            ontology_version=None,
+            capabilities=frozenset(),
+            attestation=None,
+        )
+
+
+@dataclass(frozen=True)
+class VaultIngestRequest:
+    """A piece of writing plus the metadata Creek needs to store it durably.
+
+    ``tier_ceiling`` is applied by the client before the call so the vault's
+    router can enforce it; ``aspect_tags`` carries any Aspect/Frequency tags
+    already known locally (empty when none). Frozen so the request cannot mutate
+    between building it and sending it.
+    """
+
+    body: str
+    tier_ceiling: VaultTierCeiling
+    created_at: datetime
+    aspect_tags: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class VaultIngestResult:
+    """Outcome of an ingest attempt.
+
+    ``stored`` is ``False`` (with ``vault_ref`` ``None``) whenever the content
+    was not durably written -- notably on the local-fallback path, where the
+    operator's Postgres remains the sole system of record and ingest is a no-op
+    rather than an error.
+    """
+
+    stored: bool
+    vault_ref: str | None
+
+
+@dataclass(frozen=True)
+class VaultClassification:
+    """Frequency/Wavelength-phase tags Creek assigns to a piece of content."""
+
+    tags: tuple[str, ...]
+
+
+class CreekVaultClient(Protocol):
+    """The seam adepthood calls into for all vault interaction.
+
+    Both the MCP-backed adapter and the local-fallback no-op implement this
+    protocol, so callers depend only on this surface and never on whether a
+    vault is actually present. Parameters are positional-only so concrete
+    implementations may name (or underscore-ignore) them freely while remaining
+    structurally compatible.
+    """
+
+    async def handshake(self) -> HandshakeResult:
+        """Probe the vault and return the negotiated capability/version result.
+
+        Never raises: an absent, unreachable, or incompatible vault yields
+        :meth:`HandshakeResult.unavailable` so callers can branch on the result
+        instead of guarding a call in ``try``/``except``.
+        """
+
+    def is_available(self) -> bool:
+        """Return whether the most recent handshake found a usable vault."""
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether the most recent handshake advertised ``capability``."""
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Hand a piece of writing to the vault for durable storage."""
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Request Frequency/Wavelength-phase tags for ``body``."""
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Produce a Higher Self reflection grounded in the user's own corpus."""
+
+    async def wheel(self) -> WheelBalanceResponse:
+        """Return a Wheel-of-Wholeness balance read from the vault's corpus."""

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -1,0 +1,454 @@
+"""Concrete Creek Vault MCP client adapters and their factory.
+
+This is the service-layer counterpart to the pure :mod:`domain.creek_vault`
+seam, following the same domain-protocol -> service-adapter pattern as
+:mod:`services.marginalia` and the env-var config / error-normalization pattern
+as :mod:`services.botmason`.
+
+Two implementations of :class:`~domain.creek_vault.CreekVaultClient` live here:
+
+* :class:`McpCreekVaultClient` -- talks to a real vault over an injected
+  :class:`VaultTransport`. It is written to **degrade, never crash**:
+  :meth:`~McpCreekVaultClient.handshake` swallows every transport, parsing, and
+  version-mismatch failure into :meth:`HandshakeResult.unavailable`, and every
+  per-capability call normalizes any transport exception to
+  :class:`CreekVaultUnavailableError` with a **static, capability-named message**
+  that never echoes the entry body or the API key.
+* :class:`LocalFallbackCreekVaultClient` -- the no-vault path. Handshake reports
+  unavailable, nothing is supported, ingest is a silent no-op (operator Postgres
+  stays the system of record), and the read/compute capabilities raise
+  :class:`CreekCapabilityUnsupportedError`.
+
+:func:`build_creek_vault_client` chooses between them from ``CREEK_VAULT_URL``,
+so an unconfigured deployment transparently gets the local fallback.
+
+Transport security: :class:`_HttpJsonTransport` refuses a plaintext ``http://``
+URL to any non-loopback host, because every call carries the
+``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier metadata) that
+must never cross a network in cleartext. This seam does not itself encrypt the
+entry *body*: the contract's end-to-end, ciphertext-only intimate-transit rule
+(a client-held key the operator cannot decrypt) is a property of the write path
+built on this seam -- enforced where the body is assembled -- not of the seam's
+construction, and so is deliberately out of scope here rather than forgotten.
+
+Cross-references ``docs/creek-vault-mcp-contract.md`` for the wire surface and
+the graceful-degradation guarantees.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Protocol
+from urllib.parse import urlsplit
+
+import httpx
+
+from domain.creek_vault import (
+    CONSUMER_ID,
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultClient,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+)
+from schemas.wheel import WheelBalanceResponse
+
+# Timeout (seconds) for a single HTTP call to the vault. Bounds how long a slow
+# or hung vault can block a request before adepthood degrades to local.
+_VAULT_TIMEOUT_SECONDS = 10.0
+
+# The major component of the contract version we will interoperate with. A vault
+# advertising a different major is treated as incompatible and degrades to
+# unavailable rather than risking a call under a surface we do not understand.
+_CONTRACT_MAJOR = CONTRACT_VERSION.split(".")[0]
+
+# Transport-layer failures we normalize to a degraded state. ``OSError`` covers
+# connection/timeout errors and ``httpx.HTTPError`` covers every httpx transport
+# and status failure -- mirroring botmason's ``_PROVIDER_ERROR_TYPES``.
+_TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (OSError, httpx.HTTPError)
+
+# Payload-parsing failures. A malformed or wrong-typed handshake response should
+# degrade to unavailable exactly like a transport error, never propagate.
+_PARSE_ERROR_TYPES: tuple[type[Exception], ...] = (KeyError, TypeError, AttributeError, ValueError)
+
+# Everything a handshake probe swallows into an "unavailable" result: transport
+# failures (the vault is unreachable) and parsing failures (its payload is
+# malformed). Combining them keeps the degradation path a single ``except``.
+_HANDSHAKE_DEGRADE_ERRORS: tuple[type[Exception], ...] = (
+    *_TRANSPORT_ERROR_TYPES,
+    *_PARSE_ERROR_TYPES,
+)
+
+# Hosts for which a plaintext ``http://`` vault URL is tolerated: a developer
+# running the vault on the same machine. Every other host must use TLS so the
+# bearer credential and tier metadata never cross a network in cleartext.
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _require_secure_vault_url(url: str) -> None:
+    """Reject a plaintext vault URL to a non-loopback host, failing closed.
+
+    A configured vault is reached over :class:`_HttpJsonTransport`, which sends
+    the ``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier
+    metadata) over the wire. Allowing a plaintext ``http://`` URL to a remote
+    host would expose that credential in cleartext, so a misconfiguration raises
+    here rather than silently leaking. Plaintext to a loopback host is permitted
+    for local development. The message names only the scheme and host -- never
+    the API key.
+    """
+    parsed = urlsplit(url)
+    if parsed.scheme == "https":
+        return
+    if parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS:
+        return
+    raise ValueError(
+        f"CREEK_VAULT_URL must use https for a non-loopback host "
+        f"(scheme {parsed.scheme!r}, host {parsed.hostname!r})"
+    )
+
+
+class VaultTransport(Protocol):
+    """The minimal request/response seam a vault client calls over.
+
+    One async method: send an MCP ``method`` with ``params`` and return the
+    decoded response mapping. Keeping the client's transport behind this
+    protocol lets tests inject scripted fakes and lets the concrete HTTP
+    transport be swapped without touching client logic. Parameters are
+    positional-only so implementations may name them freely.
+    """
+
+    async def call(self, method: str, params: Mapping[str, object], /) -> Mapping[str, object]:
+        """Send ``method`` with ``params`` and return the decoded response."""
+
+
+def _handshake_params() -> Mapping[str, object]:
+    """Build the identity/version params adepthood presents at handshake."""
+    return {"consumer": CONSUMER_ID, "contract_version": CONTRACT_VERSION}
+
+
+def _require_str(payload: Mapping[str, object], key: str) -> str:
+    """Return ``payload[key]`` as a ``str`` or raise so parsing fails closed.
+
+    Raises ``KeyError`` when absent and ``TypeError`` when present but not a
+    string; both are caught upstream and degrade the handshake to unavailable.
+    """
+    value = payload[key]
+    if not isinstance(value, str):
+        raise TypeError(f"handshake field {key!r} must be a string")
+    return value
+
+
+def _coerce_capability(item: object) -> CreekCapability | None:
+    """Map one advertised wire string to a capability, or ``None`` if unknown.
+
+    Unknown/forward-compatible capability strings are dropped rather than
+    erroring, so a vault can advertise new capabilities without breaking an
+    older client.
+    """
+    if not isinstance(item, str):
+        return None
+    try:
+        return CreekCapability(item)
+    except ValueError:
+        return None
+
+
+def _parse_capabilities(raw: object) -> frozenset[CreekCapability]:
+    """Narrow an advertised capability list to the known-capability set.
+
+    Raises ``TypeError`` when ``raw`` is not a list (a malformed payload), which
+    upstream degrades to unavailable. Unknown member strings are ignored.
+    """
+    if not isinstance(raw, list):
+        raise TypeError("handshake capabilities must be a list")
+    return frozenset(
+        capability for item in raw if (capability := _coerce_capability(item)) is not None
+    )
+
+
+def _parse_attestation(raw: object) -> Mapping[str, object] | None:
+    """Return the attestation mapping unchanged, or ``None`` when absent.
+
+    Raises ``TypeError`` for a present-but-wrong-typed value so a malformed
+    payload degrades to unavailable.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, Mapping):
+        return raw
+    raise TypeError("handshake attestation must be a mapping or null")
+
+
+def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
+    """Parse a well-formed handshake payload into a populated result.
+
+    Reads and version-checks the contract before anything else: a major-version
+    mismatch returns unavailable directly (we will not call an incompatible
+    surface). Any missing key or wrong-typed field raises out of the helpers and
+    is caught by :meth:`McpCreekVaultClient.handshake`.
+    """
+    contract_version = _require_str(payload, "contract_version")
+    if contract_version.split(".")[0] != _CONTRACT_MAJOR:
+        return HandshakeResult.unavailable()
+    return HandshakeResult(
+        available=True,
+        contract_version=contract_version,
+        ontology_version=_require_str(payload, "ontology_version"),
+        capabilities=_parse_capabilities(payload["capabilities"]),
+        attestation=_parse_attestation(payload.get("attestation")),
+    )
+
+
+def _parse_ingest_result(payload: Mapping[str, object]) -> VaultIngestResult:
+    """Parse an ingest response, defaulting missing/odd fields conservatively."""
+    vault_ref = payload.get("vault_ref")
+    return VaultIngestResult(
+        stored=bool(payload.get("stored")),
+        vault_ref=vault_ref if isinstance(vault_ref, str) else None,
+    )
+
+
+def _parse_classification(payload: Mapping[str, object]) -> VaultClassification:
+    """Parse a classify response into a tuple of string tags (dropping non-strings)."""
+    raw = payload.get("tags")
+    if not isinstance(raw, list):
+        return VaultClassification(tags=())
+    return VaultClassification(tags=tuple(item for item in raw if isinstance(item, str)))
+
+
+def _content_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, object]:
+    """Build the shared params for a content-bearing call (classify/reflect)."""
+    return {"consumer": CONSUMER_ID, "body": body, "tier_ceiling": tier_ceiling.value}
+
+
+def _ingest_params(request: VaultIngestRequest) -> Mapping[str, object]:
+    """Map an ingest request onto wire params, applying its tier ceiling."""
+    return {
+        "consumer": CONSUMER_ID,
+        "body": request.body,
+        "tier_ceiling": request.tier_ceiling.value,
+        "created_at": request.created_at.isoformat(),
+        "aspect_tags": list(request.aspect_tags),
+    }
+
+
+def _unsupported_message(capability: CreekCapability) -> str:
+    """Build the body/key-free message for an unsupported-capability error.
+
+    Kept here so both the reachable-but-unadvertised path in
+    :meth:`McpCreekVaultClient._invoke` and the no-vault-configured path in
+    :class:`LocalFallbackCreekVaultClient` derive the wire name from
+    :class:`~domain.creek_vault.CreekCapability` rather than duplicating it as a
+    literal that could silently drift from the enum.
+    """
+    return f"creek vault capability unsupported: {capability.value}"
+
+
+class McpCreekVaultClient:
+    """A :class:`CreekVaultClient` backed by an injected MCP transport.
+
+    Caches the last handshake so :meth:`is_available` and :meth:`supports` are
+    cheap, synchronous reads. Re-handshaking re-probes the vault and refreshes
+    that cache, so a vault that gains (or loses) a capability is picked up on the
+    next handshake with no other client-side change.
+    """
+
+    def __init__(self, transport: VaultTransport) -> None:
+        """Store the transport and seed the cache with an unavailable handshake.
+
+        Before any handshake runs the client reports unavailable and supports
+        nothing, so callers that skip the handshake still fail safe.
+        """
+        self._transport = transport
+        self._last_handshake = HandshakeResult.unavailable()
+
+    async def handshake(self) -> HandshakeResult:
+        """Probe the vault, cache the result, and return it -- never raising.
+
+        Every failure mode -- a raising transport, a malformed or wrong-typed
+        payload, or a contract major-version mismatch -- collapses to
+        :meth:`HandshakeResult.unavailable`. This is the crux of graceful
+        degradation: callers get one branchable result and never a surprise
+        exception from probing an optional dependency.
+        """
+        self._last_handshake = await self._probe()
+        return self._last_handshake
+
+    async def _probe(self) -> HandshakeResult:
+        """Perform the handshake call and parse it, degrading on any failure."""
+        try:
+            payload = await self._transport.call(
+                CreekCapability.HANDSHAKE.value, _handshake_params()
+            )
+            result = _parse_handshake(payload)
+        except _HANDSHAKE_DEGRADE_ERRORS:
+            return HandshakeResult.unavailable()
+        return result
+
+    def is_available(self) -> bool:
+        """Return whether the cached handshake found a usable vault."""
+        return self._last_handshake.available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether the cached handshake advertised ``capability``."""
+        return capability in self._last_handshake.capabilities
+
+    async def _invoke(
+        self, capability: CreekCapability, params: Mapping[str, object]
+    ) -> Mapping[str, object]:
+        """Call a capability, gating on support and normalizing failures.
+
+        Raises :class:`CreekCapabilityUnsupportedError` when the capability was
+        not advertised. On any transport failure it raises
+        :class:`CreekVaultUnavailableError` with a *static, capability-named*
+        message and ``from None`` -- the original exception (whose text may
+        contain the entry body or the API key) is deliberately not chained, so
+        neither the message nor the traceback context can leak it. A response
+        that is not a mapping (a malformed or hostile payload) is normalized to
+        the same error, so a per-capability call degrades rather than crashing
+        on garbage -- the same fail-safe the handshake path already applies.
+        """
+        if not self.supports(capability):
+            raise CreekCapabilityUnsupportedError(_unsupported_message(capability))
+        try:
+            payload = await self._transport.call(capability.value, params)
+        except _TRANSPORT_ERROR_TYPES:
+            raise CreekVaultUnavailableError(
+                f"creek vault call failed: {capability.value}"
+            ) from None
+        if not isinstance(payload, Mapping):
+            raise CreekVaultUnavailableError(
+                f"creek vault returned a malformed response: {capability.value}"
+            )
+        return payload
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Store ``request`` in the vault, requiring the INGEST capability."""
+        payload = await self._invoke(CreekCapability.INGEST, _ingest_params(request))
+        return _parse_ingest_result(payload)
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Request Frequency/Wavelength tags for ``body``, requiring CLASSIFY."""
+        payload = await self._invoke(CreekCapability.CLASSIFY, _content_params(body, tier_ceiling))
+        return _parse_classification(payload)
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Produce a Higher Self reflection over the corpus, requiring REFLECT."""
+        payload = await self._invoke(CreekCapability.REFLECT, _content_params(body, tier_ceiling))
+        reflection = payload.get("reflection")
+        return reflection if isinstance(reflection, str) else ""
+
+    async def wheel(self) -> WheelBalanceResponse:
+        """Return a vault-computed Wheel-of-Wholeness read, requiring WHEEL.
+
+        A well-formed mapping whose *fields* do not match
+        :class:`WheelBalanceResponse` still raises ``pydantic.ValidationError``
+        here rather than degrading to :class:`CreekVaultUnavailableError`. That
+        is the one un-normalized error path in this client and is deliberate:
+        field-level wheel validation and a response-size ceiling belong with the
+        read/compute path that consumes the wheel. It does not weaken the floor
+        guarantee -- the wheel is an optional read, never a write, and a caller
+        that cannot obtain it falls back to computing the balance locally.
+        """
+        payload = await self._invoke(CreekCapability.WHEEL, {"consumer": CONSUMER_ID})
+        return WheelBalanceResponse.model_validate(payload)
+
+
+class LocalFallbackCreekVaultClient:
+    """The no-vault :class:`CreekVaultClient`: local pipeline stays authoritative.
+
+    Used whenever no vault is configured. It reports unavailable and supports
+    nothing, so callers uniformly fall back to local behavior. Ingest is a
+    silent no-op (``stored=False``) because the operator's Postgres remains the
+    sole system of record; the read/compute capabilities raise
+    :class:`CreekCapabilityUnsupportedError` since there is nothing to serve
+    them. Unused parameters are underscore-prefixed to match the protocol
+    positionally without pretending to consume them.
+    """
+
+    async def handshake(self) -> HandshakeResult:
+        """Report no usable vault."""
+        return HandshakeResult.unavailable()
+
+    def is_available(self) -> bool:
+        """Report unavailable -- there is no vault behind this client."""
+        return False
+
+    def supports(self, _capability: CreekCapability, /) -> bool:
+        """Report every capability as unsupported."""
+        return False
+
+    async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
+        """No-op ingest: report not stored without raising (Postgres is authoritative)."""
+        return VaultIngestResult(stored=False, vault_ref=None)
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Raise: classification has no local vault to serve it."""
+        raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.CLASSIFY))
+
+    async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> str:
+        """Raise: reflection has no local vault to serve it."""
+        raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.REFLECT))
+
+    async def wheel(self) -> WheelBalanceResponse:
+        """Raise: a vault wheel read has no local vault to serve it."""
+        raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.WHEEL))
+
+
+class _HttpJsonTransport:  # pragma: no cover
+    """A thin JSON-over-HTTP :class:`VaultTransport` for a configured vault.
+
+    POSTs each MCP call as JSON with a bearer ``Authorization`` header sourced
+    from ``CREEK_VAULT_API_KEY``. The key is used only to build that header and
+    is never logged or placed into any exception message (privacy invariant).
+    Construction refuses a plaintext ``http://`` URL to a non-loopback host so
+    the key is never bound to a transport that would send it in cleartext. The
+    network ``call`` is pure I/O with no branching logic; it is exercised in
+    deployment rather than by unit tests, hence the coverage exclusion.
+    """
+
+    def __init__(self, url: str, api_key: str) -> None:
+        """Store the vault base URL and bearer key, refusing an insecure URL.
+
+        Delegates to :func:`_require_secure_vault_url`, which raises for a
+        plaintext ``http://`` URL to a non-loopback host before the key is bound.
+        """
+        _require_secure_vault_url(url)
+        self._url = url
+        self._api_key = api_key
+
+    async def call(self, method: str, params: Mapping[str, object], /) -> Mapping[str, object]:
+        """POST one MCP call and return the decoded JSON response mapping."""
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        async with httpx.AsyncClient(timeout=_VAULT_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                self._url, json={"method": method, "params": dict(params)}, headers=headers
+            )
+            response.raise_for_status()
+            decoded: Mapping[str, object] = response.json()
+            return decoded
+
+
+def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVaultClient:
+    """Return the vault client appropriate for the current configuration.
+
+    When ``CREEK_VAULT_URL`` is unset or empty, no vault is configured and a
+    :class:`LocalFallbackCreekVaultClient` is returned so the app runs fully on
+    its local pipeline. Otherwise an :class:`McpCreekVaultClient` is returned
+    over the injected ``transport`` (tests supply a fake) or a freshly built
+    :class:`_HttpJsonTransport` bound to the configured URL and API key.
+    """
+    # ``CREEK_VAULT_URL`` being unset or empty is the signal that no vault is
+    # configured; the bearer credential is read only to build the transport's
+    # auth header and is never logged or placed in any exception message.
+    url = os.getenv("CREEK_VAULT_URL", "")
+    if not url:
+        return LocalFallbackCreekVaultClient()
+    api_key = os.getenv("CREEK_VAULT_API_KEY", "")
+    return McpCreekVaultClient(transport=transport or _HttpJsonTransport(url, api_key))

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -37,6 +37,7 @@ the graceful-degradation guarantees.
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping
 from typing import Protocol
@@ -71,9 +72,19 @@ _VAULT_TIMEOUT_SECONDS = 10.0
 _CONTRACT_MAJOR = CONTRACT_VERSION.split(".")[0]
 
 # Transport-layer failures we normalize to a degraded state. ``OSError`` covers
-# connection/timeout errors and ``httpx.HTTPError`` covers every httpx transport
-# and status failure -- mirroring botmason's ``_PROVIDER_ERROR_TYPES``.
-_TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (OSError, httpx.HTTPError)
+# connection/timeout errors, ``httpx.HTTPError`` covers every httpx transport and
+# status failure, and ``json.JSONDecodeError`` covers a non-JSON body (a proxy
+# error page, an empty 200, or any vault bug) that ``response.json()`` cannot
+# decode -- the transport contract is to return a *decoded* mapping, so a decode
+# failure is a transport failure. All three normalize the per-capability path to
+# unavailable exactly as the handshake path already does, keeping one coherent
+# degrade-set (``json.JSONDecodeError`` is a ``ValueError`` subclass, so it is
+# already covered by the handshake's parse-error set).
+_TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (
+    OSError,
+    httpx.HTTPError,
+    json.JSONDecodeError,
+)
 
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
@@ -311,8 +322,11 @@ class McpCreekVaultClient:
         :class:`CreekVaultUnavailableError` with a *static, capability-named*
         message and ``from None`` -- the original exception (whose text may
         contain the entry body or the API key) is deliberately not chained, so
-        neither the message nor the traceback context can leak it. A response
-        that is not a mapping (a malformed or hostile payload) is normalized to
+        neither the message nor the traceback context can leak it. Transport
+        failure here includes a non-JSON body (:class:`json.JSONDecodeError`,
+        raised inside the transport's ``response.json()``), so a proxy error
+        page or empty 200 degrades rather than crashing. A response that decodes
+        but is not a mapping (a malformed or hostile payload) is normalized to
         the same error, so a per-capability call degrades rather than crashing
         on garbage -- the same fail-safe the handshake path already applies.
         """
@@ -418,32 +432,50 @@ class LocalFallbackCreekVaultClient:
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.WHEEL))
 
 
-class _HttpJsonTransport:  # pragma: no cover
+class _HttpJsonTransport:
     """A thin JSON-over-HTTP :class:`VaultTransport` for a configured vault.
 
     POSTs each MCP call as JSON with a bearer ``Authorization`` header sourced
     from ``CREEK_VAULT_API_KEY``. The key is used only to build that header and
     is never logged or placed into any exception message (privacy invariant).
     Construction refuses a plaintext ``http://`` URL to a non-loopback host so
-    the key is never bound to a transport that would send it in cleartext. The
-    network ``call`` is pure I/O with no branching logic; it is exercised in
-    deployment rather than by unit tests, hence the coverage exclusion.
+    the key is never bound to a transport that would send it in cleartext.
+
+    ``call`` has two failure branches the rest of the client depends on:
+    ``response.raise_for_status()`` (a non-2xx status) raises an
+    ``httpx.HTTPError`` and ``response.json()`` (a non-JSON body) raises a
+    ``json.JSONDecodeError``. Both are in :data:`_TRANSPORT_ERROR_TYPES`, so the
+    caller normalizes them to the degraded path rather than crashing. An
+    injectable ``transport`` lets tests exercise those branches with an
+    ``httpx.MockTransport`` instead of a live network.
     """
 
-    def __init__(self, url: str, api_key: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        api_key: str,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
         """Store the vault base URL and bearer key, refusing an insecure URL.
 
         Delegates to :func:`_require_secure_vault_url`, which raises for a
         plaintext ``http://`` URL to a non-loopback host before the key is bound.
+        The optional ``transport`` is passed to :class:`httpx.AsyncClient`; it
+        defaults to ``None`` (httpx's own network transport) in production and is
+        supplied as an :class:`httpx.MockTransport` under test.
         """
         _require_secure_vault_url(url)
         self._url = url
         self._api_key = api_key
+        self._transport = transport
 
     async def call(self, method: str, params: Mapping[str, object], /) -> Mapping[str, object]:
         """POST one MCP call and return the decoded JSON response mapping."""
         headers = {"Authorization": f"Bearer {self._api_key}"}
-        async with httpx.AsyncClient(timeout=_VAULT_TIMEOUT_SECONDS) as client:
+        async with httpx.AsyncClient(
+            timeout=_VAULT_TIMEOUT_SECONDS, transport=self._transport
+        ) as client:
             response = await client.post(
                 self._url, json={"method": method, "params": dict(params)}, headers=headers
             )

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -56,6 +56,8 @@ from domain.creek_vault import (
     VaultIngestRequest,
     VaultIngestResult,
     VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
 )
 from schemas.wheel import WheelBalanceResponse
 
@@ -344,20 +346,35 @@ class McpCreekVaultClient:
         reflection = payload.get("reflection")
         return reflection if isinstance(reflection, str) else ""
 
-    async def wheel(self) -> WheelBalanceResponse:
+    async def wheel(self) -> VaultWheelBalance:
         """Return a vault-computed Wheel-of-Wholeness read, requiring WHEEL.
 
-        A well-formed mapping whose *fields* do not match
-        :class:`WheelBalanceResponse` still raises ``pydantic.ValidationError``
-        here rather than degrading to :class:`CreekVaultUnavailableError`. That
-        is the one un-normalized error path in this client and is deliberate:
-        field-level wheel validation and a response-size ceiling belong with the
-        read/compute path that consumes the wheel. It does not weaken the floor
-        guarantee -- the wheel is an optional read, never a write, and a caller
-        that cannot obtain it falls back to computing the balance locally.
+        The wire payload is validated against :class:`WheelBalanceResponse` (the
+        schema import is legitimate in this adapter layer) and then projected onto
+        the pure-domain :class:`VaultWheelBalance` the seam contract returns, so
+        the domain module carries no schema dependency.
+
+        A well-formed mapping whose *fields* do not match the schema still raises
+        ``pydantic.ValidationError`` here rather than degrading to
+        :class:`CreekVaultUnavailableError`. That is the one un-normalized error
+        path in this client and is deliberate: field-level wheel validation and a
+        response-size ceiling belong with the read/compute path that consumes the
+        wheel. It does not weaken the floor guarantee -- the wheel is an optional
+        read, never a write, and a caller that cannot obtain it falls back to
+        computing the balance locally.
         """
         payload = await self._invoke(CreekCapability.WHEEL, {"consumer": CONSUMER_ID})
-        return WheelBalanceResponse.model_validate(payload)
+        validated = WheelBalanceResponse.model_validate(payload)
+        return VaultWheelBalance(
+            aspects=tuple(
+                VaultWheelAspect(
+                    stage_number=aspect.stage_number,
+                    aspect=aspect.aspect,
+                    fullness=aspect.fullness,
+                )
+                for aspect in validated.aspects
+            ),
+        )
 
 
 class LocalFallbackCreekVaultClient:
@@ -396,7 +413,7 @@ class LocalFallbackCreekVaultClient:
         """Raise: reflection has no local vault to serve it."""
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.REFLECT))
 
-    async def wheel(self) -> WheelBalanceResponse:
+    async def wheel(self) -> VaultWheelBalance:
         """Raise: a vault wheel read has no local vault to serve it."""
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.WHEEL))
 

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -1,0 +1,568 @@
+"""Tests for the Creek Vault MCP client seam (services.creek_vault_client)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import cast
+
+import httpx
+import pytest
+
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+)
+from schemas.wheel import WheelAspect, WheelBalanceResponse
+from services.creek_vault_client import (
+    LocalFallbackCreekVaultClient,
+    McpCreekVaultClient,
+    build_creek_vault_client,
+)
+
+_CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+
+
+def _handshake_payload(
+    capabilities: Sequence[str],
+    contract_version: str = CONTRACT_VERSION,
+    ontology_version: str = "1.0.0",
+    attestation: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a well-formed creek.handshake response payload."""
+    return {
+        "capabilities": list(capabilities),
+        "contract_version": contract_version,
+        "ontology_version": ontology_version,
+        "attestation": attestation,
+    }
+
+
+class ScriptedTransport:
+    """Fake transport whose per-method responses/exceptions are pre-scripted."""
+
+    def __init__(
+        self,
+        responses: Mapping[str, Mapping[str, object]] | None = None,
+        raises: Mapping[str, Exception] | None = None,
+    ) -> None:
+        """Store the scripted per-method responses and exceptions."""
+        self._responses = dict(responses or {})
+        self._raises = dict(raises or {})
+
+    async def call(self, method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Raise or return the scripted result for ``method``."""
+        if method in self._raises:
+            raise self._raises[method]
+        return self._responses.get(method, {})
+
+
+class RaisingTransport:
+    """Fake transport whose call() always raises a fixed exception."""
+
+    def __init__(self, exc: Exception) -> None:
+        """Store the exception this fake will raise on every call."""
+        self._exc = exc
+
+    async def call(self, _method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Raise the stored exception unconditionally."""
+        raise self._exc
+
+
+class GarbagePayloadTransport:
+    """Fake transport that returns a fixed, possibly malformed payload for any call."""
+
+    def __init__(self, payload: Mapping[str, object]) -> None:
+        """Store the payload this fake will return verbatim."""
+        self._payload = payload
+
+    async def call(self, _method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Return the stored payload regardless of method or params."""
+        return self._payload
+
+
+class MutableHandshakeTransport:
+    """Fake transport whose advertised capabilities can change between calls."""
+
+    def __init__(self, capabilities: Sequence[str]) -> None:
+        """Store the initially advertised capability list."""
+        self.capabilities = list(capabilities)
+        self.handshake_calls = 0
+
+    async def call(self, method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Return the current capability list for creek.handshake."""
+        if method == CreekCapability.HANDSHAKE.value:
+            self.handshake_calls += 1
+            return _handshake_payload(self.capabilities)
+        return {}
+
+
+class HandshakeThenNonMappingTransport:
+    """Handshakes normally, then returns a non-mapping payload for any other call."""
+
+    def __init__(self, capability: str, payload: object) -> None:
+        """Store the capability to advertise and the non-mapping payload to return."""
+        self._capability = capability
+        self._payload = payload
+
+    async def call(self, method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Return a valid handshake for the probe, else the stored non-mapping payload."""
+        if method == CreekCapability.HANDSHAKE.value:
+            return _handshake_payload([self._capability])
+        return cast("Mapping[str, object]", self._payload)
+
+
+def _ingest_request() -> VaultIngestRequest:
+    """Build a minimal VaultIngestRequest for the ingest-path tests."""
+    return VaultIngestRequest(
+        body="hello vault", tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+    )
+
+
+@pytest.mark.asyncio
+async def test_handshake_happy_path_populates_result() -> None:
+    """A successful handshake returns a populated HandshakeResult."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload(
+                [CreekCapability.INGEST.value, CreekCapability.WHEEL.value],
+                attestation={"quote": "sentinel-attestation"},
+            )
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    result = await client.handshake()
+    assert result.available is True
+    assert result.contract_version == CONTRACT_VERSION
+    assert result.ontology_version == "1.0.0"
+    assert result.capabilities == frozenset({CreekCapability.INGEST, CreekCapability.WHEEL})
+    assert result.attestation == {"quote": "sentinel-attestation"}
+
+
+@pytest.mark.asyncio
+async def test_is_available_true_after_successful_handshake() -> None:
+    """is_available() reflects a successful handshake."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    assert client.is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_supports_reflects_advertised_capabilities() -> None:
+    """supports() is True only for the capabilities the handshake advertised."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    assert client.supports(CreekCapability.INGEST) is True
+    assert client.supports(CreekCapability.WHEEL) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_advertised_capability_strings_are_ignored() -> None:
+    """A capability string outside CreekCapability is dropped, not erroring."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload(
+                [CreekCapability.INGEST.value, "creek.unknown-future-capability"]
+            )
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    result = await client.handshake()
+    assert result.capabilities == frozenset({CreekCapability.INGEST})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError("connection refused"),
+        TimeoutError("timed out"),
+        httpx.ConnectError("unreachable"),
+    ],
+)
+async def test_handshake_degrades_to_unavailable_on_transport_error(exc: Exception) -> None:
+    """A raising transport never propagates -- handshake() degrades to unavailable."""
+    client = McpCreekVaultClient(transport=RaisingTransport(exc))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_on_missing_keys() -> None:
+    """A payload missing the expected keys degrades to unavailable, not a raise."""
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport({"unexpected": "shape"}))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_on_wrong_typed_fields() -> None:
+    """A payload with wrong-typed fields degrades to unavailable, not a raise."""
+    payload = {
+        "capabilities": "not-a-list",
+        "contract_version": 123,
+        "ontology_version": None,
+        "attestation": None,
+    }
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_on_non_list_capabilities() -> None:
+    """Valid versions but a non-list capabilities field degrades to unavailable."""
+    payload = {
+        "capabilities": "not-a-list",
+        "contract_version": CONTRACT_VERSION,
+        "ontology_version": "1.0.0",
+        "attestation": None,
+    }
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_on_contract_major_mismatch() -> None:
+    """A contract-major-version mismatch degrades to unavailable, not a raise."""
+    payload = _handshake_payload([CreekCapability.INGEST.value], contract_version="1.0.0")
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_handshake_ignores_non_string_capability_alongside_valid_ones() -> None:
+    """A non-string capability entry is dropped while valid string entries still parse."""
+    payload: dict[str, object] = {
+        "capabilities": [CreekCapability.INGEST.value, 42, CreekCapability.WHEEL.value],
+        "contract_version": CONTRACT_VERSION,
+        "ontology_version": "1.0.0",
+        "attestation": None,
+    }
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result.available is True
+    assert result.capabilities == frozenset({CreekCapability.INGEST, CreekCapability.WHEEL})
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_on_malformed_attestation() -> None:
+    """An attestation field that is neither a mapping nor null degrades to unavailable."""
+    payload: dict[str, object] = {
+        "capabilities": [CreekCapability.INGEST.value],
+        "contract_version": CONTRACT_VERSION,
+        "ontology_version": "1.0.0",
+        "attestation": "not-a-mapping",
+    }
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_supported_capability_call_succeeds() -> None:
+    """ingest() succeeds through a transport that advertised INGEST at handshake."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value]),
+            CreekCapability.INGEST.value: {"stored": True, "vault_ref": "vault-ref-1"},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.ingest(_ingest_request())
+    assert result == VaultIngestResult(stored=True, vault_ref="vault-ref-1")
+
+
+@pytest.mark.asyncio
+async def test_unsupported_capability_raises_unsupported_error() -> None:
+    """wheel() raises when the handshake did not advertise WHEEL."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await client.wheel()
+
+
+@pytest.mark.asyncio
+async def test_supported_call_normalizes_transport_error() -> None:
+    """A supported call whose transport then raises normalizes to CreekVaultUnavailableError."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+        },
+        raises={CreekCapability.INGEST.value: OSError("connection reset")},
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+async def test_classify_success_drops_non_string_tags() -> None:
+    """classify() returns only the string tags, dropping non-string entries."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.CLASSIFY.value]),
+            CreekCapability.CLASSIFY.value: {"tags": ["courage", "shadow", 123]},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.classify("body text", VaultTierCeiling.OPEN)
+    assert result == VaultClassification(tags=("courage", "shadow"))
+
+
+@pytest.mark.asyncio
+async def test_classify_missing_tags_returns_empty_classification() -> None:
+    """classify() returns an empty tag tuple when the response tags are absent or wrong-typed."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.CLASSIFY.value]),
+            CreekCapability.CLASSIFY.value: {"tags": "not-a-list"},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.classify("body text", VaultTierCeiling.OPEN)
+    assert result == VaultClassification(tags=())
+
+
+@pytest.mark.asyncio
+async def test_reflect_success_returns_reflection_text() -> None:
+    """reflect() returns the reflection string from a successful vault response."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.REFLECT.value]),
+            CreekCapability.REFLECT.value: {"reflection": "a warm note"},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.reflect("body text", VaultTierCeiling.OPEN)
+    assert result == "a warm note"
+
+
+@pytest.mark.asyncio
+async def test_reflect_missing_reflection_returns_empty_string() -> None:
+    """reflect() returns the empty string when the response reflection is absent or wrong-typed."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.REFLECT.value]),
+            CreekCapability.REFLECT.value: {"reflection": 123},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.reflect("body text", VaultTierCeiling.OPEN)
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_wheel_success_returns_wheel_balance_response() -> None:
+    """wheel() parses a vault-computed WheelBalanceResponse payload."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
+            CreekCapability.WHEEL.value: {
+                "aspects": [
+                    {"stage_number": 1, "aspect": "courage", "fullness": 0.5},
+                    {"stage_number": 2, "aspect": "shadow", "fullness": 0.75},
+                ]
+            },
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.wheel()
+    assert result == WheelBalanceResponse(
+        aspects=[
+            WheelAspect(stage_number=1, aspect="courage", fullness=0.5),
+            WheelAspect(stage_number=2, aspect="shadow", fullness=0.75),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_reprobe_picks_up_newly_advertised_capability() -> None:
+    """A second handshake() against a transport advertising a new capability flips supports()."""
+    transport = MutableHandshakeTransport(capabilities=[CreekCapability.INGEST.value])
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    assert client.supports(CreekCapability.WHEEL) is False
+    transport.capabilities = [CreekCapability.INGEST.value, CreekCapability.WHEEL.value]
+    await client.handshake()
+    assert client.supports(CreekCapability.WHEEL) is True
+    assert transport.handshake_calls == 2
+
+
+def test_fresh_client_reports_unavailable_before_handshake() -> None:
+    """A client that has never handshaken reports unavailable and unsupported."""
+    client = McpCreekVaultClient(transport=RaisingTransport(OSError("never called")))
+    assert client.is_available() is False
+    assert client.supports(CreekCapability.INGEST) is False
+    assert client.supports(CreekCapability.WHEEL) is False
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_handshake_is_unavailable() -> None:
+    """LocalFallbackCreekVaultClient.handshake() reports unavailable with no transport."""
+    client = LocalFallbackCreekVaultClient()
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+def test_local_fallback_is_available_false() -> None:
+    """LocalFallbackCreekVaultClient.is_available() is False."""
+    assert LocalFallbackCreekVaultClient().is_available() is False
+
+
+def test_local_fallback_supports_nothing() -> None:
+    """LocalFallbackCreekVaultClient.supports() is False for every capability."""
+    client = LocalFallbackCreekVaultClient()
+    assert all(client.supports(capability) is False for capability in CreekCapability)
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_ingest_reports_not_stored_without_raising() -> None:
+    """ingest() on the local fallback reports stored=False and never raises."""
+    client = LocalFallbackCreekVaultClient()
+    result = await client.ingest(_ingest_request())
+    assert result == VaultIngestResult(stored=False, vault_ref=None)
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_classify_raises_unsupported() -> None:
+    """classify() on the local fallback raises CreekCapabilityUnsupportedError."""
+    client = LocalFallbackCreekVaultClient()
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await client.classify("body text", VaultTierCeiling.OPEN)
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_reflect_raises_unsupported() -> None:
+    """reflect() on the local fallback raises CreekCapabilityUnsupportedError."""
+    client = LocalFallbackCreekVaultClient()
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await client.reflect("body text", VaultTierCeiling.OPEN)
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_wheel_raises_unsupported() -> None:
+    """wheel() on the local fallback raises CreekCapabilityUnsupportedError."""
+    client = LocalFallbackCreekVaultClient()
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await client.wheel()
+
+
+def test_factory_returns_local_fallback_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CREEK_VAULT_URL unset -> LocalFallbackCreekVaultClient."""
+    monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
+    client = build_creek_vault_client()
+    assert isinstance(client, LocalFallbackCreekVaultClient)
+
+
+def test_factory_returns_local_fallback_when_env_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CREEK_VAULT_URL set to the empty string -> LocalFallbackCreekVaultClient."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "")
+    client = build_creek_vault_client()
+    assert isinstance(client, LocalFallbackCreekVaultClient)
+
+
+def test_factory_returns_mcp_client_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CREEK_VAULT_URL set -> McpCreekVaultClient using the injected transport."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "https://vault.example.test")
+    client = build_creek_vault_client(transport=ScriptedTransport())
+    assert isinstance(client, McpCreekVaultClient)
+
+
+def test_factory_rejects_plaintext_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plaintext http:// URL to a remote host fails closed rather than leaking the key."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "http://vault.example.test")
+    monkeypatch.delenv("CREEK_VAULT_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="https"):
+        build_creek_vault_client()
+
+
+def test_factory_accepts_https_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An https URL to a remote host builds a real transport without raising."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "https://vault.example.test")
+    monkeypatch.delenv("CREEK_VAULT_API_KEY", raising=False)
+    assert isinstance(build_creek_vault_client(), McpCreekVaultClient)
+
+
+def test_factory_accepts_plaintext_loopback_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plaintext http:// to a loopback host is tolerated for local development."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "http://localhost:8000")
+    monkeypatch.delenv("CREEK_VAULT_API_KEY", raising=False)
+    assert isinstance(build_creek_vault_client(), McpCreekVaultClient)
+
+
+@pytest.mark.asyncio
+async def test_supported_call_normalizes_non_mapping_payload() -> None:
+    """A supported call whose response is not a mapping degrades to CreekVaultUnavailableError."""
+    transport = HandshakeThenNonMappingTransport(
+        CreekCapability.INGEST.value, ["not", "a", "mapping"]
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+async def test_unavailable_error_never_leaks_body_or_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CreekVaultUnavailableError's message never contains the entry body or the API key."""
+    body_sentinel = "SENTINEL_BODY_TEXT_DO_NOT_LEAK"
+    key_sentinel = "SENTINEL_API_KEY_DO_NOT_LEAK"
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", key_sentinel)
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+        },
+        raises={
+            CreekCapability.INGEST.value: OSError(
+                f"upstream rejected body: {body_sentinel} key={key_sentinel}"
+            )
+        },
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    request = VaultIngestRequest(
+        body=body_sentinel, tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+    )
+    with pytest.raises(CreekVaultUnavailableError) as exc_info:
+        await client.ingest(request)
+    message = str(exc_info.value)
+    assert body_sentinel not in message
+    assert key_sentinel not in message
+    # ``from None`` must sever the chain so no traceback printer surfaces the
+    # original exception (whose text carries both sentinels) as a cause/context.
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from domain.creek_vault import (
     CONTRACT_VERSION,
@@ -19,8 +20,9 @@ from domain.creek_vault import (
     VaultIngestRequest,
     VaultIngestResult,
     VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
 )
-from schemas.wheel import WheelAspect, WheelBalanceResponse
 from services.creek_vault_client import (
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
@@ -383,8 +385,8 @@ async def test_reflect_missing_reflection_returns_empty_string() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wheel_success_returns_wheel_balance_response() -> None:
-    """wheel() parses a vault-computed WheelBalanceResponse payload."""
+async def test_wheel_success_projects_onto_vault_wheel_balance() -> None:
+    """wheel() projects a vault-computed wheel payload onto VaultWheelBalance."""
     transport = ScriptedTransport(
         responses={
             CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
@@ -399,12 +401,27 @@ async def test_wheel_success_returns_wheel_balance_response() -> None:
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     result = await client.wheel()
-    assert result == WheelBalanceResponse(
-        aspects=[
-            WheelAspect(stage_number=1, aspect="courage", fullness=0.5),
-            WheelAspect(stage_number=2, aspect="shadow", fullness=0.75),
-        ]
+    assert result == VaultWheelBalance(
+        aspects=(
+            VaultWheelAspect(stage_number=1, aspect="courage", fullness=0.5),
+            VaultWheelAspect(stage_number=2, aspect="shadow", fullness=0.75),
+        )
     )
+
+
+@pytest.mark.asyncio
+async def test_wheel_malformed_fields_raise_validation_error() -> None:
+    """wheel() does not normalize a bad-fields payload; the parse error surfaces."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
+            CreekCapability.WHEEL.value: {"aspects": [{"stage_number": "not-an-int"}]},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(ValidationError):
+        await client.wheel()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import cast
@@ -26,8 +27,11 @@ from domain.creek_vault import (
 from services.creek_vault_client import (
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
+    _HttpJsonTransport,
     build_creek_vault_client,
 )
+
+_VAULT_URL = "https://vault.example.test"
 
 _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
 
@@ -583,3 +587,65 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
     # original exception (whose text carries both sentinels) as a cause/context.
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__suppress_context__ is True
+
+
+def _handshake_then(capability_response: httpx.Response) -> httpx.MockTransport:
+    """Build a MockTransport that handshakes cleanly, then scripts the capability call.
+
+    The handshake POST is answered with a well-formed payload advertising INGEST
+    so the client marks that capability supported; every other method returns the
+    supplied ``capability_response``, letting a test drive the real transport's
+    failure branches (a non-JSON body or a non-2xx status) without a network.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        method = json.loads(request.content)["method"]
+        if method == CreekCapability.HANDSHAKE.value:
+            return httpx.Response(200, json=_handshake_payload([CreekCapability.INGEST.value]))
+        return capability_response
+
+    return httpx.MockTransport(_handler)
+
+
+@pytest.mark.asyncio
+async def test_http_transport_decodes_valid_json_handshake() -> None:
+    """The real HTTP transport decodes a valid JSON handshake and marks INGEST supported."""
+    # This test only exercises the handshake, so the capability response is never invoked.
+    transport = _HttpJsonTransport(
+        _VAULT_URL, "api-key", transport=_handshake_then(httpx.Response(200))
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    assert client.is_available() is True
+    assert client.supports(CreekCapability.INGEST) is True
+
+
+@pytest.mark.asyncio
+async def test_http_transport_non_json_capability_body_degrades() -> None:
+    """A non-JSON 200 body on the capability path degrades to CreekVaultUnavailableError.
+
+    ``response.json()`` raises ``json.JSONDecodeError`` (a ``ValueError`` subclass,
+    not an ``httpx.HTTPError``); the client must normalize it rather than crash,
+    upholding the module's degrade-never-crash invariant on the capability path.
+    """
+    transport = _HttpJsonTransport(
+        _VAULT_URL,
+        "api-key",
+        transport=_handshake_then(httpx.Response(200, content=b"<html>proxy error</html>")),
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+async def test_http_transport_non_2xx_capability_status_degrades() -> None:
+    """A non-2xx status on the capability path degrades to CreekVaultUnavailableError."""
+    transport = _HttpJsonTransport(
+        _VAULT_URL, "api-key", transport=_handshake_then(httpx.Response(503))
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())

--- a/backend/tests/test_creek_vault_domain.py
+++ b/backend/tests/test_creek_vault_domain.py
@@ -1,0 +1,190 @@
+"""Tests for the pure Creek Vault domain module (domain.creek_vault)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+
+from domain import creek_vault
+from domain.creek_vault import (
+    CONSUMER_ID,
+    CONTRACT_VERSION,
+    TIER_CEILING_BY_CLASSIFICATION,
+    CreekCapability,
+    HandshakeResult,
+    VaultIngestRequest,
+    VaultTierCeiling,
+    tier_ceiling_for,
+)
+from models.journal_entry import JournalClassification
+
+
+class TestTierCeilingMapping:
+    """The three verbatim classification -> tier-ceiling mappings from the contract table."""
+
+    def test_public_maps_to_open(self) -> None:
+        """PUBLIC keys OPEN in the raw mapping dict."""
+        assert (
+            TIER_CEILING_BY_CLASSIFICATION[JournalClassification.PUBLIC.value]
+            is VaultTierCeiling.OPEN
+        )
+
+    def test_personal_maps_to_personal(self) -> None:
+        """PERSONAL keys PERSONAL in the raw mapping dict."""
+        assert (
+            TIER_CEILING_BY_CLASSIFICATION[JournalClassification.PERSONAL.value]
+            is VaultTierCeiling.PERSONAL
+        )
+
+    def test_intimate_maps_to_intimate(self) -> None:
+        """INTIMATE keys INTIMATE in the raw mapping dict."""
+        assert (
+            TIER_CEILING_BY_CLASSIFICATION[JournalClassification.INTIMATE.value]
+            is VaultTierCeiling.INTIMATE
+        )
+
+    def test_tier_ceiling_for_public(self) -> None:
+        """tier_ceiling_for resolves PUBLIC to OPEN."""
+        assert tier_ceiling_for(JournalClassification.PUBLIC.value) is VaultTierCeiling.OPEN
+
+    def test_tier_ceiling_for_personal(self) -> None:
+        """tier_ceiling_for resolves PERSONAL to PERSONAL."""
+        assert tier_ceiling_for(JournalClassification.PERSONAL.value) is VaultTierCeiling.PERSONAL
+
+    def test_tier_ceiling_for_intimate(self) -> None:
+        """tier_ceiling_for resolves INTIMATE to INTIMATE."""
+        assert tier_ceiling_for(JournalClassification.INTIMATE.value) is VaultTierCeiling.INTIMATE
+
+    def test_unknown_classification_raises(self) -> None:
+        """An unrecognized classification fails closed rather than defaulting to OPEN."""
+        with pytest.raises((ValueError, creek_vault.CreekVaultError)):
+            tier_ceiling_for("not-a-real-tier")
+
+    def test_empty_classification_raises(self) -> None:
+        """An empty-string classification also fails closed."""
+        with pytest.raises((ValueError, creek_vault.CreekVaultError)):
+            tier_ceiling_for("")
+
+
+def test_tier_ceiling_keys_match_journal_classification_enum() -> None:
+    """The mapping's key set must not drift from JournalClassification's values."""
+    assert set(TIER_CEILING_BY_CLASSIFICATION) == {c.value for c in JournalClassification}
+
+
+class TestCreekCapability:
+    """Six wire-name capability members."""
+
+    def test_has_six_members(self) -> None:
+        """Exactly six capabilities are defined."""
+        assert len(CreekCapability) == 6
+
+    def test_handshake_value_is_wire_name(self) -> None:
+        """HANDSHAKE's value is the creek.handshake wire name."""
+        assert CreekCapability.HANDSHAKE.value == "creek.handshake"
+
+    def test_ingest_value_is_wire_name(self) -> None:
+        """INGEST's value is the creek.ingest wire name."""
+        assert CreekCapability.INGEST.value == "creek.ingest"
+
+    def test_save_value_is_wire_name(self) -> None:
+        """SAVE's value is the creek.save wire name."""
+        assert CreekCapability.SAVE.value == "creek.save"
+
+    def test_classify_value_is_wire_name(self) -> None:
+        """CLASSIFY's value is the creek.classify wire name."""
+        assert CreekCapability.CLASSIFY.value == "creek.classify"
+
+    def test_reflect_value_is_wire_name(self) -> None:
+        """REFLECT's value is the creek.reflect wire name."""
+        assert CreekCapability.REFLECT.value == "creek.reflect"
+
+    def test_wheel_value_is_wire_name(self) -> None:
+        """WHEEL's value is the creek.wheel wire name."""
+        assert CreekCapability.WHEEL.value == "creek.wheel"
+
+
+class TestHandshakeResultUnavailable:
+    """HandshakeResult.unavailable() is the empty/False result for an absent vault."""
+
+    def test_available_is_false(self) -> None:
+        """Available is False on the unavailable result."""
+        assert HandshakeResult.unavailable().available is False
+
+    def test_contract_version_is_none(self) -> None:
+        """contract_version is None on the unavailable result."""
+        assert HandshakeResult.unavailable().contract_version is None
+
+    def test_ontology_version_is_none(self) -> None:
+        """ontology_version is None on the unavailable result."""
+        assert HandshakeResult.unavailable().ontology_version is None
+
+    def test_capabilities_are_empty(self) -> None:
+        """Capabilities is an empty frozenset on the unavailable result."""
+        assert HandshakeResult.unavailable().capabilities == frozenset()
+
+    def test_attestation_is_none(self) -> None:
+        """Attestation is None on the unavailable result."""
+        assert HandshakeResult.unavailable().attestation is None
+
+
+class TestHandshakeResultPopulated:
+    """A populated HandshakeResult round-trips its fields and is immutable."""
+
+    def test_fields_round_trip(self) -> None:
+        """Every constructor argument is readable back unchanged."""
+        result = HandshakeResult(
+            available=True,
+            contract_version="0.1.0-draft",
+            ontology_version="1.0.0",
+            capabilities=frozenset({CreekCapability.HANDSHAKE, CreekCapability.INGEST}),
+            attestation={"quote": "sentinel-attestation"},
+        )
+        assert result.available is True
+        assert result.contract_version == "0.1.0-draft"
+        assert result.ontology_version == "1.0.0"
+        assert result.capabilities == frozenset({CreekCapability.HANDSHAKE, CreekCapability.INGEST})
+        assert result.attestation == {"quote": "sentinel-attestation"}
+
+    def test_is_frozen(self) -> None:
+        """Mutating a field after construction raises FrozenInstanceError."""
+        result = HandshakeResult.unavailable()
+        with pytest.raises(FrozenInstanceError):
+            result.available = True  # type: ignore[misc]
+
+
+class TestErrorHierarchy:
+    """CreekVaultError is the shared base for both concrete failure types."""
+
+    def test_creek_vault_error_is_runtime_error(self) -> None:
+        """CreekVaultError subclasses RuntimeError."""
+        assert issubclass(creek_vault.CreekVaultError, RuntimeError)
+
+    def test_unavailable_error_is_creek_vault_error(self) -> None:
+        """CreekVaultUnavailableError subclasses CreekVaultError."""
+        assert issubclass(creek_vault.CreekVaultUnavailableError, creek_vault.CreekVaultError)
+
+    def test_capability_unsupported_error_is_creek_vault_error(self) -> None:
+        """CreekCapabilityUnsupportedError subclasses CreekVaultError."""
+        assert issubclass(creek_vault.CreekCapabilityUnsupportedError, creek_vault.CreekVaultError)
+
+
+def test_vault_ingest_request_defaults_aspect_tags_to_empty_tuple() -> None:
+    """aspect_tags defaults to an empty tuple when not supplied."""
+    request = VaultIngestRequest(
+        body="a private page",
+        tier_ceiling=VaultTierCeiling.PERSONAL,
+        created_at=datetime(2026, 7, 10, tzinfo=UTC),
+    )
+    assert request.aspect_tags == ()
+
+
+def test_contract_version_constant() -> None:
+    """CONTRACT_VERSION matches the draft version negotiated in the contract doc."""
+    assert CONTRACT_VERSION == "0.1.0-draft"
+
+
+def test_consumer_id_constant() -> None:
+    """CONSUMER_ID matches the identifier adepthood presents at handshake."""
+    assert CONSUMER_ID == "CREEK_MCP_CONSUMER"


### PR DESCRIPTION
## Summary

Builds adepthood's half of the Creek Vault seam (the foundation of epic #949): a single injectable client the app uses to talk to a user's private Creek Vault, a capability/availability handshake, and graceful fallback to today's local pipeline so the journal floor never depends on a vault being reachable. Implements the ratified contract in `docs/creek-vault-mcp-contract.md`. No write/read-path wiring yet — that lands in #952/#953/#954 on top of this seam.

- **`backend/src/domain/creek_vault.py`** (pure — no FastAPI/DB/httpx, mirroring `domain/resonance.py`): the `CreekVaultClient` `Protocol` capturing the contract capabilities (handshake, ingest/save, classify, reflect, wheel); a six-member `CreekCapability` enum keyed to the wire names; a **fail-closed** `JournalClassification -> VaultTierCeiling` tier mapping (`tier_ceiling_for` raises rather than defaulting to the least-restrictive `OPEN`, drift-guarded against the model enum); the typed `HandshakeResult`; a `CreekVaultError` hierarchy; and minimal ingest/classify request/result dataclasses.
- **`backend/src/services/creek_vault_client.py`** (adapters + factory, mirroring `services/botmason.py`): `McpCreekVaultClient` over an injected `VaultTransport` — `handshake()` **never raises** (transport error, timeout, malformed/wrong-typed payload, or contract-major mismatch all collapse to `HandshakeResult.unavailable()`), per-capability degradation via `supports()`, re-probe on the next handshake, and transport failures normalized to `CreekVaultUnavailableError` with a **static, capability-named message that never leaks the entry body or API key** (verified including a severed `__cause__`/`__suppress_context__` chain). `LocalFallbackCreekVaultClient` keeps the floor working with no vault (ingest is a silent no-op; operator Postgres stays the system of record). A **fail-closed HTTPS guard** rejects cleartext `http://` to non-loopback hosts before any credential crosses the wire. An env-driven factory (`CREEK_VAULT_URL` / `CREEK_VAULT_API_KEY`) selects MCP-client vs local fallback.

Both new modules are at **100% line and branch coverage**; xenon A-grade, radon MI A, mypy strict, ruff `select=ALL`, interrogate 100%.

Deferred (documented in the module docstrings so they are not silently forgotten, not blockers here): end-to-end body ciphertext belongs to the write path (#952); `wheel()` field-level validation + response-size ceiling belong to the read/compute path (#954) — the wheel is an optional read that never blocks the floor.

## Test plan

- `backend/tests/test_creek_vault_domain.py` — tier mapping (fail-closed on unknown/empty input), enum-drift guard against `JournalClassification`, capability wire-name values, `HandshakeResult.unavailable()` shape, error hierarchy, constants.
- `backend/tests/test_creek_vault_client.py` — handshake happy path + all degradation modes (transport error parametrized over `OSError`/`TimeoutError`/`httpx.HTTPError`, malformed/wrong-typed/non-mapping payloads, non-list & non-string capabilities, contract-major mismatch, malformed attestation); per-capability support gating + transport-error normalization; classify/reflect/wheel success paths; re-probe; before-handshake fail-safe state; local fallback; factory URL branches; fail-closed HTTPS guard (plaintext-remote rejected, https + loopback accepted); and a privacy test asserting neither the entry body nor the API key leaks into `str(exc)` or the exception chain.
- `./scripts/backend/check-all.sh` — 7/7 pass, exit 0 (full suite 2777 passed, 96.77% global coverage); manual `xenon`/`radon` A-grade.

Closes #951
Refs #949
Refs #950