### PR TITLE
feat(backend): backdated journal entry creation (entry_date on create) + timestamp-ordered listing

### DIFF
--- a/backend/migrations/versions/f8a9b0c1d2e3_add_journalentry_user_timestamp_id_index.py
+++ b/backend/migrations/versions/f8a9b0c1d2e3_add_journalentry_user_timestamp_id_index.py
@@ -1,0 +1,38 @@
+"""add journalentry composite (user_id, timestamp, id) ordering index
+
+Revision ID: f8a9b0c1d2e3
+Revises: e8f9a0b1c2d3
+Create Date: 2026-07-10 00:00:00.000000
+
+Issue #1788: backdated journal entries carry a ``timestamp`` earlier than their
+insertion id, so the list endpoint now orders by ``(timestamp DESC, id DESC)``
+(id breaks ties for entries sharing a noon-UTC timestamp) instead of ``id DESC``.
+The prior indexes did not cover that ordering, so a paged list scanned + sorted
+the user's full journal history.  This adds a composite b-tree index over
+``(user_id, timestamp, id)`` covering the new ``(timestamp DESC, id DESC)`` list
+read.  Non-destructive and fully reversible.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f8a9b0c1d2e3"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e8f9a0b1c2d3"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = "ix_journalentry_user_timestamp_id"
+_TABLE_NAME = "journalentry"
+_INDEX_COLUMNS = ["user_id", "timestamp", "id"]
+
+
+def upgrade() -> None:
+    """Create the composite index covering the timestamp-ordered list read."""
+    op.create_index(_INDEX_NAME, _TABLE_NAME, _INDEX_COLUMNS, unique=False)
+
+
+def downgrade() -> None:
+    """Drop the composite index (reverts to scanning + sorting the list read)."""
+    op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -150,12 +150,17 @@ class JournalEntry(SQLModel, table=True):
     # (BUG-JOURNAL-007).  ``ix_journalentry_user_sender_deleted`` is created by
     # migration ``e3f4a5b6c7d8`` (issue #469): ``load_recent_conversation``
     # filters on ``(user_id, sender, deleted_at)`` and orders by ``id DESC``, so
-    # this composite index covers that hot chat read.  Both are declared here so
-    # the model and migrations agree — ``alembic check`` otherwise reports the
-    # indexes as drift and fails CI.
+    # this composite index covers that hot chat read.
+    # ``ix_journalentry_user_timestamp_id`` is created by migration
+    # ``f8a9b0c1d2e3``: the list endpoint orders by ``(timestamp DESC, id DESC)``
+    # (so backdated entries sort by date, not insertion id), and this composite
+    # index over ``(user_id, timestamp, id)`` covers that read.  All are declared
+    # here so the model and migrations agree — ``alembic check`` otherwise reports
+    # the indexes as drift and fails CI.
     __table_args__ = (
         Index("ix_journalentry_deleted_at", "deleted_at"),
         Index("ix_journalentry_user_sender_deleted", "user_id", "sender", "deleted_at"),
+        Index("ix_journalentry_user_timestamp_id", "user_id", "timestamp", "id"),
         _classification_check(),
         _aspect_range_check("primary_aspect", "ck_journalentry_primary_aspect_range"),
         _aspect_range_check("secondary_aspect", "ck_journalentry_secondary_aspect_range"),

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
@@ -143,6 +143,36 @@ class _ListFilters:
     offset: int = Query(default=0, ge=0)
 
 
+# Noon is the midpoint of the UTC day, so a backdated entry stays on its intended
+# calendar date across every real-world display timezone (~UTC-12..UTC+14): a
+# morning-UTC stamp would render on the prior day for far-west zones and an
+# evening-UTC stamp on the next day for far-east zones. Noon minimizes that
+# off-by-one-day rendering.
+BACKDATED_ENTRY_NOON_UTC_HOUR = 12
+
+
+def _resolve_backdated_timestamp(entry_date: date | None) -> datetime | None:
+    """Map an optional backdate ``entry_date`` to its stored noon-UTC ``timestamp``.
+
+    Returns ``None`` when no date is supplied (the caller then leaves the column's
+    ``default_factory`` to stamp the current instant). A supplied date must not be
+    in the future (relative to today in UTC), else a 422 ``entry_date_in_future``
+    is raised; otherwise it is anchored at noon UTC (see
+    :data:`BACKDATED_ENTRY_NOON_UTC_HOUR`).
+    """
+    if entry_date is None:
+        return None
+    if entry_date > datetime.now(UTC).date():
+        raise unprocessable("entry_date_in_future")
+    return datetime(
+        entry_date.year,
+        entry_date.month,
+        entry_date.day,
+        BACKDATED_ENTRY_NOON_UTC_HOUR,
+        tzinfo=UTC,
+    )
+
+
 @router.post("/", response_model=JournalMessageResponse, status_code=status.HTTP_201_CREATED)
 async def create_journal_entry(
     payload: JournalMessageCreate,
@@ -158,6 +188,11 @@ async def create_journal_entry(
     smuggling in log viewers.
     """
     data = payload.model_dump()
+    # ``entry_date`` is not a column: resolve it to a stored ``timestamp`` (or,
+    # when absent, leave it out so the model's default_factory stamps "now").
+    backdated = _resolve_backdated_timestamp(data.pop("entry_date"))
+    if backdated is not None:
+        data["timestamp"] = backdated
     data["message"] = _sanitize_message(data["message"])
     _coerce_reflection_level(data)
     entry = JournalEntry(sender="user", user_id=current_user, **data)
@@ -220,7 +255,7 @@ async def _encrypted_search_page(
             col(JournalEntry.deleted_at).is_(None),
             *_non_search_conditions(filters),
         )
-        .order_by(col(JournalEntry.id).desc())
+        .order_by(col(JournalEntry.timestamp).desc(), col(JournalEntry.id).desc())
     )
     rows = list((await session.execute(query)).scalars().all())
     if len(rows) > _ENCRYPTED_SCAN_WARN_THRESHOLD:
@@ -265,8 +300,14 @@ async def list_journal_entries(
     # Count total before pagination
     total = await count_query_total(session, query)
 
-    # Fetch paginated results, newest first
-    query = query.order_by(col(JournalEntry.id).desc()).offset(filters.offset).limit(filters.limit)
+    # Fetch paginated results, newest first. Order by timestamp DESC so a
+    # backdated entry (higher id, earlier timestamp) lands by its date; id DESC
+    # breaks ties so identical timestamps page stably.
+    query = (
+        query.order_by(col(JournalEntry.timestamp).desc(), col(JournalEntry.id).desc())
+        .offset(filters.offset)
+        .limit(filters.limit)
+    )
     result = await session.execute(query)
     items = list(result.scalars().all())
 

--- a/backend/src/schemas/journal.py
+++ b/backend/src/schemas/journal.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Self
 
 from pydantic import BaseModel, Field, model_validator
@@ -73,6 +73,10 @@ class JournalMessageCreate(BaseModel):
     secondary_aspect: int | None = Field(default=None, ge=ASPECT_MIN, le=ASPECT_MAX)
     reflection_level: ReflectionLevel | None = None
     reflection_scope_key: str | None = None
+    # A calendar date to backdate the entry to; ``None`` stamps the current
+    # instant. Like ``user_id`` and ``sender``, the stored ``timestamp`` is
+    # derived server-side (noon UTC of this date) — clients never set it directly.
+    entry_date: date | None = None
 
     @model_validator(mode="after")
     def _validate_chord(self) -> Self:

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
@@ -17,6 +18,19 @@ def _message_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {"message": "Today I meditated for 20 minutes."}
     payload.update(overrides)
     return payload
+
+
+def _parse_utc(value: str) -> datetime:
+    """Parse a response timestamp as UTC, treating the naive SQLite form as UTC.
+
+    Postgres returns tz-aware values; the SQLite test backend drops the tzinfo
+    and hands back the bare UTC wall-clock, so a naive value is reattached to UTC
+    rather than shifted by the local offset.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
@@ -162,6 +176,132 @@ async def test_list_journal_pagination(async_client: AsyncClient) -> None:
     data2 = resp2.json()
     assert len(data2["items"]) == 1
     assert data2["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_pagination_stable_with_identical_timestamps(async_client: AsyncClient) -> None:
+    """Entries sharing one noon-UTC timestamp still page without dupes or gaps."""
+    headers = await _signup(async_client, "pagination_stab")
+    expected_ts = "2023-03-03T12:00:00+00:00"
+    created_ids: list[int] = []
+    for i in range(5):
+        resp = await async_client.post(
+            "/journal/",
+            json=_message_payload(message=f"Same day entry {i}", entry_date="2023-03-03"),
+            headers=headers,
+        )
+        assert resp.status_code == HTTPStatus.CREATED
+        ts = _parse_utc(resp.json()["timestamp"])
+        assert ts.isoformat() == expected_ts
+        created_ids.append(resp.json()["id"])
+
+    seen: list[int] = []
+    offset = 0
+    limit = 2
+    while True:
+        page = await async_client.get(f"/journal/?limit={limit}&offset={offset}", headers=headers)
+        items = page.json()["items"]
+        if not items:
+            break
+        seen.extend(item["id"] for item in items)
+        offset += limit
+
+    assert sorted(seen) == sorted(created_ids)
+    assert len(seen) == len(set(seen))
+
+
+# ── Backdated entry creation (entry_date) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_without_entry_date_stamps_now(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "backdate_omit")
+    before = datetime.now(UTC)
+    resp = await async_client.post("/journal/", json=_message_payload(), headers=headers)
+    after = datetime.now(UTC)
+    assert resp.status_code == HTTPStatus.CREATED
+    ts = _parse_utc(resp.json()["timestamp"])
+    assert before - timedelta(seconds=5) <= ts <= after + timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_create_with_entry_date_null_stamps_now(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "backdate_null")
+    before = datetime.now(UTC)
+    resp = await async_client.post(
+        "/journal/", json=_message_payload(entry_date=None), headers=headers
+    )
+    after = datetime.now(UTC)
+    assert resp.status_code == HTTPStatus.CREATED
+    ts = _parse_utc(resp.json()["timestamp"])
+    assert before - timedelta(seconds=5) <= ts <= after + timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_create_with_past_entry_date_stamps_noon_utc(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "backdate_past")
+    resp = await async_client.post(
+        "/journal/", json=_message_payload(entry_date="2024-01-15"), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    ts = _parse_utc(resp.json()["timestamp"])
+    assert ts.date().isoformat() == "2024-01-15"
+    assert ts.hour == 12
+    assert ts.minute == 0
+    assert ts.second == 0
+
+
+@pytest.mark.asyncio
+async def test_create_with_entry_date_today_stamps_noon_utc(async_client: AsyncClient) -> None:
+    """The non-UTC boundary case: today-in-UTC must be accepted, stamped noon UTC."""
+    headers = await _signup(async_client, "backdate_today")
+    today = datetime.now(UTC).date()
+    resp = await async_client.post(
+        "/journal/", json=_message_payload(entry_date=today.isoformat()), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    ts = _parse_utc(resp.json()["timestamp"])
+    assert ts.date() == today
+    assert ts.hour == 12
+    assert ts.minute == 0
+    assert ts.second == 0
+
+
+@pytest.mark.asyncio
+async def test_create_with_future_entry_date_returns_422(async_client: AsyncClient) -> None:
+    headers = await _signup(async_client, "backdate_future")
+    tomorrow = (datetime.now(UTC).date() + timedelta(days=1)).isoformat()
+    resp = await async_client.post(
+        "/journal/", json=_message_payload(entry_date=tomorrow), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "entry_date_in_future"
+
+
+@pytest.mark.asyncio
+async def test_list_orders_by_timestamp_desc_not_id(async_client: AsyncClient) -> None:
+    """A backdated entry has the highest id but must sort by timestamp, not id."""
+    headers = await _signup(async_client, "order_check")
+    await async_client.post(
+        "/journal/", json=_message_payload(message="Fresh one"), headers=headers
+    )
+    await async_client.post(
+        "/journal/", json=_message_payload(message="Fresh two"), headers=headers
+    )
+    backdated = await async_client.post(
+        "/journal/",
+        json=_message_payload(message="Backdated", entry_date="2020-06-01"),
+        headers=headers,
+    )
+    backdated_id = backdated.json()["id"]
+
+    resp = await async_client.get("/journal/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert len(items) == 3
+    assert items[-1]["id"] == backdated_id
+    timestamps = [_parse_utc(item["timestamp"]) for item in items]
+    assert timestamps == sorted(timestamps, reverse=True)
 
 
 # ── Get single entry ────────────────────────────────────────────────────
@@ -569,6 +709,33 @@ async def test_encrypted_search_is_scoped_to_the_requesting_user(
     body = resp.json()
     assert body["total"] == 1
     assert body["items"][0]["message"] == "bob secret kayak"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_encryption_key")
+async def test_encrypted_search_orders_by_timestamp_desc(async_client: AsyncClient) -> None:
+    """The encrypted-search path also sorts by timestamp DESC, not id DESC."""
+    headers = await _signup(async_client, "enc_order_check")
+    await async_client.post(
+        "/journal/", json=_message_payload(message="kombucha fresh one"), headers=headers
+    )
+    await async_client.post(
+        "/journal/", json=_message_payload(message="kombucha fresh two"), headers=headers
+    )
+    backdated = await async_client.post(
+        "/journal/",
+        json=_message_payload(message="kombucha backdated", entry_date="2020-06-01"),
+        headers=headers,
+    )
+    backdated_id = backdated.json()["id"]
+
+    resp = await async_client.get("/journal/?search=kombucha", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()["items"]
+    assert len(items) == 3
+    assert items[-1]["id"] == backdated_id
+    timestamps = [_parse_utc(item["timestamp"]) for item in items]
+    assert timestamps == sorted(timestamps, reverse=True)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2647,3 +2647,98 @@ def test_course_dedupe_migration_round_trip_on_sqlite(
     # Phase 3: re-upgrade on the clean DB succeeds (dedupe CTEs match nothing).
     command.upgrade(cfg, _COURSE_DEDUPE_REVISION)
     assert "ix_coursestage_stage_number_unique" in _index_names(db_url, "coursestage")
+
+
+# -- backdated journal entry ordering migration round-trip ------------------
+
+# down_revision is e8f9a0b1c2d3 (the course-dedupe migration, current head).
+_BACKDATED_ENTRY_BASE_REVISION = "e8f9a0b1c2d3"  # pragma: allowlist secret
+_BACKDATED_ENTRY_REVISION = "f8a9b0c1d2e3"  # pragma: allowlist secret
+
+
+def _bootstrap_backdated_entry_baseline(sync_url: str) -> None:
+    """Pre-create minimal ``user`` and ``journalentry`` tables for the round-trip fixture.
+
+    Mirrors the shape just before the backdated-entry-ordering migration.
+    Only the columns the new composite index touches (user_id, timestamp, id)
+    are required, so the bootstrap stays narrow rather than replaying the
+    whole preceding chain.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'backdate@example.com')"))
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry (id, user_id, sender, message)"
+                " VALUES (1, 1, 'user', 'Pre-migration entry.')"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_backdated_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before ``f8a9b0c1d2e3``.
+
+    Bootstraps minimal ``user`` and ``journalentry`` tables and stamps the DB
+    at ``e8f9a0b1c2d3`` (the chain head before this migration) so the
+    round-trip exercises only the new migration.
+    """
+    db_path = tmp_path / "backdated_entry_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_backdated_entry_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _BACKDATED_ENTRY_BASE_REVISION)
+    return cfg
+
+
+def test_backdated_entry_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_backdated_entry: Config,
+) -> None:
+    """Round-trip ``f8a9b0c1d2e3``: upgrade installs the composite ordering index.
+
+    Phase 1: upgrade adds ``ix_journalentry_user_timestamp_id`` on
+    ``(user_id, timestamp, id)`` -- the index the timestamp-DESC/id-DESC list
+    ordering relies on.
+    Phase 2: downgrade drops it.
+    Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_backdated_entry
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade installs the composite index.
+    command.upgrade(cfg, _BACKDATED_ENTRY_REVISION)
+    assert "ix_journalentry_user_timestamp_id" in _index_names(db_url, "journalentry")
+
+    # Phase 2: downgrade removes it.
+    command.downgrade(cfg, _BACKDATED_ENTRY_BASE_REVISION)
+    assert "ix_journalentry_user_timestamp_id" not in _index_names(db_url, "journalentry")
+
+    # Phase 3: re-upgrade is idempotent.
+    command.upgrade(cfg, _BACKDATED_ENTRY_REVISION)
+    assert "ix_journalentry_user_timestamp_id" in _index_names(db_url, "journalentry")


### PR DESCRIPTION
## Summary

Lets a journal entry be created with a caller-chosen calendar date (handwritten pages are often days old — Journal Photographer epic) and fixes the listing-order hazard that backdating exposes.

- `JournalMessageCreate` gains an optional `entry_date: date | None`. When absent or `null`, the server-set timestamp is unchanged, so typed entries are byte-for-byte unaffected.
- `create_journal_entry` maps a supplied `entry_date` to `12:00 UTC` on that date (named constant `BACKDATED_ENTRY_NOON_UTC_HOUR` — noon anchors the entry inside its intended calendar day across all inhabited display timezones). Strictly-future dates are rejected with `422 entry_date_in_future`.
- Both list paths (plain and encrypted-search) now order by `timestamp DESC, id DESC`, so a backdated entry files by its date rather than at the top; `id DESC` breaks ties for stable pagination.
- New Alembic migration `f8a9b0c1d2e3` adds a composite index on `(user_id, timestamp, id)` (reversible up/down); the model `__table_args__` declares the same index to keep `alembic check` drift-free.
- `JournalMessageResponse` is unchanged (still returns `timestamp`).

## Test plan

- `pytest tests/test_journal_api.py tests/test_migrations.py` — create with/without `entry_date` (incl. explicit `null`); past date stamped noon UTC; today-in-UTC accepted (non-UTC boundary); future date → 422; listing interleaves backdated + fresh in strict timestamp order on both the plain and encrypted-search paths; pagination stability across equal timestamps (id tiebreak); migration up/down round-trip.
- Full `./scripts/backend/check-all.sh` passes (96.82% coverage, all quality checks); xenon A-grade; radon MI ≥ B; single Alembic head.

Closes #1788
Refs #1799