### PR TITLE
feat(graph): always-on graphify steering — CLAUDE.md section + PreToolUse hook-guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,28 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard search || true",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read || true",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,20 @@ When working from the phone interface, these skills are available:
 - `/preflight` — Run pre-commit, fix all failures, iterate until green
 - `/review-diff` — Self-review the current branch diff before PR
 
+## Knowledge Graph (graphify)
+
+This repo ships a queryable code graph (see `scripts/graph/`). When
+`graphify-out/graph.json` exists, prefer it over blind grep/read sweeps:
+
+- For codebase questions, run `graphify query "<question>"` first; use
+  `graphify path "A" "B"` for relationships, `graphify explain "X"` for
+  concepts, and `graphify affected "X"` for change impact.
+- When citing a fact from the graph, quote each node's `source_location`.
+- After modifying code, refresh it with `./scripts/graph/update.sh`
+  (AST-only, no cost).
+- If the graph is absent, build it with `./scripts/graph/build.sh` (~2 min)
+  or proceed without it.
+
 ## Playbook (auto-curated)
 
 Concrete "when X, do Y" rules distilled weekly from real failures — flare-filed

--- a/scripts/graph/test_hook_guards.sh
+++ b/scripts/graph/test_hook_guards.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scripts/graph/test_hook_guards.sh
+#
+# Offline tests for the PreToolUse hook-guard wiring in .claude/settings.json:
+# pins the config shape (Bash + Read|Glob matchers, SessionStart untouched)
+# and the fail-soft invariant (graphify absent or exiting non-zero must never
+# block the tool call) by extracting the real command strings via jq and
+# running them against fake PATH environments.
+#
+# Run:  bash scripts/graph/test_hook_guards.sh
+set -euo pipefail
+
+SETTINGS="$(cd "$(dirname "$0")/../../.claude" && pwd)/settings.json"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+check_contains() { # check_contains <desc> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then ok "$1"; else bad "$1 (expected '$2' to contain '$3')"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/nograph" "$WORK/binfail" "$WORK/binlog"
+
+# nograph holds bash (so `bash -c` can launch) but deliberately no graphify,
+# isolating the "graphify absent from PATH" case from bash's own resolution.
+ln -s "$(command -v bash)" "$WORK/nograph/bash"
+
+# --- group 1: config shape ---------------------------------------------------
+ENTRY_COUNT="$(jq '.hooks.PreToolUse | length' "$SETTINGS")"
+check "PreToolUse has exactly 2 entries" "2" "$ENTRY_COUNT"
+
+BASH_MATCHER_COUNT="$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Bash")] | length' "$SETTINGS")"
+check "one PreToolUse entry matches Bash" "1" "$BASH_MATCHER_COUNT"
+
+READ_MATCHER_COUNT="$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Read|Glob")] | length' "$SETTINGS")"
+check "one PreToolUse entry matches Read|Glob" "1" "$READ_MATCHER_COUNT"
+
+SESSION_START_COUNT="$(jq '.hooks.SessionStart | length' "$SETTINGS")"
+check "SessionStart still has exactly one entry" "1" "$SESSION_START_COUNT"
+
+SESSION_START_CMD="$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$SETTINGS")"
+check_contains "SessionStart hook is untouched" "$SESSION_START_CMD" "session-start.sh"
+
+BASH_TIMEOUT="$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[0].timeout] | first' "$SETTINGS")"
+check "Bash hook has a 10s timeout" "10" "$BASH_TIMEOUT"
+
+READ_TIMEOUT="$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Read|Glob") | .hooks[0].timeout] | first' "$SETTINGS")"
+check "Read|Glob hook has a 10s timeout" "10" "$READ_TIMEOUT"
+
+BASH_CMD="$(jq -r '.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[0].command' "$SETTINGS")"
+READ_CMD="$(jq -r '.hooks.PreToolUse[]? | select(.matcher == "Read|Glob") | .hooks[0].command' "$SETTINGS")"
+
+if [[ -z "$BASH_CMD" || -z "$READ_CMD" ]]; then
+  bad "PreToolUse Bash and Read|Glob commands both extracted (non-empty)"
+  echo "  skip - fail-soft and wiring checks (no command strings to run)"
+else
+  ok "PreToolUse Bash and Read|Glob commands both extracted (non-empty)"
+
+  # --- group 2: binary absent = fail soft ------------------------------------
+  rc=0
+  env PATH="$WORK/nograph" bash -c "$BASH_CMD" </dev/null || rc=$?
+  check "Bash hook exits 0 when graphify is absent from PATH" "0" "$rc"
+
+  rc=0
+  env PATH="$WORK/nograph" bash -c "$READ_CMD" </dev/null || rc=$?
+  check "Read|Glob hook exits 0 when graphify is absent from PATH" "0" "$rc"
+
+  # --- group 3: guard-failure = fail soft -------------------------------------
+  cat > "$WORK/binfail/graphify" <<'STUB'
+#!/usr/bin/env bash
+echo "guard blocked" >&2
+exit 2
+STUB
+  chmod +x "$WORK/binfail/graphify"
+
+  rc=0
+  env PATH="$WORK/binfail:$PATH" bash -c "$BASH_CMD" </dev/null || rc=$?
+  check "Bash hook exits 0 when graphify guard blocks (exit 2)" "0" "$rc"
+
+  rc=0
+  env PATH="$WORK/binfail:$PATH" bash -c "$READ_CMD" </dev/null || rc=$?
+  check "Read|Glob hook exits 0 when graphify guard blocks (exit 2)" "0" "$rc"
+
+  # --- group 4: correct wiring -------------------------------------------------
+  LOG="$WORK/graphify.log"
+  : > "$LOG"
+  cat > "$WORK/binlog/graphify" <<STUB
+#!/usr/bin/env bash
+echo "\$@" >> "$LOG"
+exit 0
+STUB
+  chmod +x "$WORK/binlog/graphify"
+
+  : > "$LOG"
+  env PATH="$WORK/binlog:$PATH" bash -c "$BASH_CMD" </dev/null || true
+  check_contains "Bash hook invokes graphify with hook-guard search" "$(cat "$LOG")" "hook-guard search"
+
+  : > "$LOG"
+  env PATH="$WORK/binlog:$PATH" bash -c "$READ_CMD" </dev/null || true
+  check_contains "Read|Glob hook invokes graphify with hook-guard read" "$(cat "$LOG")" "hook-guard read"
+fi
+
+# --- summary ------------------------------------------------------------------
+echo
+echo "hook-guard tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

G0.2 of the Graphify epic: steer every Claude session in this repo toward the knowledge graph before grep/read sweeps, and keep the graph current.

- **`CLAUDE.md`** — new `## Knowledge Graph (graphify)` section (13 lines, outside the playbook markers). Tells sessions to run `graphify query "<question>"` first when `graphify-out/graph.json` exists (`path`/`explain`/`affected` for relationships/concepts/impact), quote each node's `source_location` when citing graph facts, refresh with `./scripts/graph/update.sh` after code changes, and build with `./scripts/graph/build.sh` (or proceed without) when the graph is absent.
- **`.claude/settings.json`** — two `PreToolUse` hook entries appended (matcher `Bash` → `hook-guard search`, matcher `Read|Glob` → `hook-guard read`), each `timeout: 10`. The existing `SessionStart` hook is preserved byte-for-byte.
- **`scripts/graph/test_hook_guards.sh`** — new shellcheck-clean smoke test that reads the real command strings out of `settings.json` and pins the invariants.

**Fail-soft design.** Each hook is `command -v graphify >/dev/null 2>&1 && graphify hook-guard <sub> || true`. When the `graphify` binary or `graphify-out/graph.json` is absent — or the guard exits non-zero — the command still resolves to exit 0, so a `PreToolUse` hook can never block a tool call. The `command -v` guard also keeps the hook silent (no `command not found` noise) on every Bash/Read/Glob call when graphify is not installed. Authored by hand rather than via `graphify claude install` to merge with, not clobber, the existing `SessionStart` hook and the playbook-managed `CLAUDE.md` section.

## Test plan

`bash scripts/graph/test_hook_guards.sh` → **14 passed, 0 failed**. It asserts, against the real `.claude/settings.json`:

1. **Config shape** — exactly two `PreToolUse` entries with matchers `Bash` and `Read|Glob`, each carrying `timeout: 10`; `SessionStart` still has exactly one entry invoking `session-start.sh` (regression pin).
2. **Fail-soft, binary absent** — each extracted command run with `graphify` absent from `PATH` exits 0.
3. **Fail-soft, guard blocks** — with a fake `graphify` exiting 2, each command still exits 0 (the `|| true` neutralizes a blocking exit-2).
4. **Correct wiring** — the `Bash` command invokes `hook-guard search`; the `Read|Glob` command invokes `hook-guard read`.

Pre-commit (check-json, shellcheck, detect-secrets, commitlint) is green. graphify is not installed in this environment, so the binary-absent path above is the live fail-soft case; the section and hooks are inert until the toolchain and graph land.

Follow-up: the `scripts/graph/` shell test is not yet wired into CI (no job runs it); a follow-up can mirror `.github/workflows/ralph-recap-tests.yml` to run it on config changes.

Closes #1802
Refs #1800