### PR TITLE
feat(full-stack): medicinal vs toxic (integrated/shadow) expression per Stage on the stage-detail surface

### DIFF
--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from curriculum import CurriculumDataError, stage_curriculum
 from database import get_session
 from dependencies.timezone import current_user_timezone
 from domain.constants import TOTAL_STAGES
@@ -36,7 +37,9 @@ from schemas import Page, PaginationParams, build_page
 from schemas.pagination import paginate_query
 from schemas.stage import (
     ProgramCalendarResponse,
+    StageExpression,
     StageHistoryResponse,
+    StageManifestation,
     StageProgressRecord,
     StageProgressResponse,
     StageProgressUpdate,
@@ -47,6 +50,24 @@ from schemas.wheel import WheelAspect, WheelBalanceResponse
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/stages", tags=["stages"])
+
+
+def _stage_manifestations(stage_number: int) -> list[StageManifestation]:
+    """Return a stage's phase manifestations from the cached curriculum loader."""
+    try:
+        stage = stage_curriculum(stage_number)
+    except CurriculumDataError:
+        return []
+    return [
+        StageManifestation(
+            phase=m.phase.value,
+            integrated=StageExpression(
+                name=m.integrated.name, description=m.integrated.description
+            ),
+            shadow=StageExpression(name=m.shadow.name, description=m.shadow.description),
+        )
+        for m in stage.manifestations
+    ]
 
 
 def _build_stage_response(
@@ -75,6 +96,7 @@ def _build_stage_response(
         free_will_description=stage.free_will_description,
         is_unlocked=unlocked,
         progress=float(stage_progress),
+        manifestations=_stage_manifestations(stage.stage_number),
     )
 
 

--- a/backend/src/schemas/stage.py
+++ b/backend/src/schemas/stage.py
@@ -9,6 +9,21 @@ from pydantic import BaseModel, ConfigDict, Field
 from domain.constants import TOTAL_STAGES as MAX_STAGE_NUMBER
 
 
+class StageExpression(BaseModel):
+    """One integrated or shadow expression of a Wavelength phase."""
+
+    name: str
+    description: str
+
+
+class StageManifestation(BaseModel):
+    """How a stage manifests in one phase, as an integrated/shadow pair."""
+
+    phase: str
+    integrated: StageExpression
+    shadow: StageExpression
+
+
 class StageResponse(BaseModel):
     """Public representation of a CourseStage with user progress overlay."""
 
@@ -26,6 +41,7 @@ class StageResponse(BaseModel):
     free_will_description: str
     is_unlocked: bool = False
     progress: float = 0.0
+    manifestations: list[StageManifestation] = Field(default_factory=list)
 
 
 class ProgramCalendarResponse(BaseModel):

--- a/backend/tests/test_stages_api.py
+++ b/backend/tests/test_stages_api.py
@@ -12,6 +12,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import col, select
 
+from curriculum import CANONICAL_PHASE_ORDER, CurriculumDataError, stage_curriculum
 from domain.constants import TOTAL_STAGES
 from models.course_stage import CourseStage
 from models.goal import Goal
@@ -22,6 +23,7 @@ from models.practice import Practice
 from models.practice_session import PracticeSession
 from models.stage_progress import StageProgress
 from models.user_practice import UserPractice
+from routers import stages as stages_router
 
 
 def _stage_data(stage_number: int = 1, **overrides: object) -> dict[str, object]:
@@ -237,6 +239,89 @@ async def test_list_stages_populates_progress_field(
     # Stage 1 is always unlocked, and the user has a practice session,
     # so progress should be > 0.
     assert data[0]["progress"] > 0.0
+
+
+# ── GET /stages manifestations (integrated/shadow phase expressions) ────
+
+_CANONICAL_PHASE_NAMES: tuple[str, ...] = tuple(phase.value for phase in CANONICAL_PHASE_ORDER)
+_MANIFESTATION_COUNT = 6
+
+
+@pytest.mark.asyncio
+async def test_list_stages_includes_six_canonical_manifestations(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Every stage carries its 6 integrated/shadow phase pairs, in canonical order."""
+    headers, _user_id = await _signup(async_client, "manifestations_all")
+    await _seed_stages(db_session, count=TOTAL_STAGES)
+
+    resp = await async_client.get("/stages", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert len(data) == TOTAL_STAGES
+
+    for stage_payload in data:
+        manifestations = stage_payload["manifestations"]
+        assert len(manifestations) == _MANIFESTATION_COUNT
+        assert [m["phase"] for m in manifestations] == list(_CANONICAL_PHASE_NAMES)
+        for m in manifestations:
+            assert m["integrated"]["name"].strip() != ""
+            assert m["integrated"]["description"].strip() != ""
+            assert m["shadow"]["name"].strip() != ""
+            assert m["shadow"]["description"].strip() != ""
+
+
+@pytest.mark.asyncio
+async def test_list_stages_manifestations_match_curriculum_source(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A sampled stage's manifestations mirror the curriculum loader field-for-field."""
+    sample_stage_number = 3
+    headers, _user_id = await _signup(async_client, "manifestations_parity")
+    await _seed_stages(db_session, count=TOTAL_STAGES)
+
+    resp = await async_client.get("/stages", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    stage_payload = next(s for s in data if s["stage_number"] == sample_stage_number)
+
+    expected = stage_curriculum(sample_stage_number)
+    assert len(stage_payload["manifestations"]) == len(expected.manifestations)
+    for actual_m, expected_m in zip(
+        stage_payload["manifestations"],
+        expected.manifestations,
+        strict=True,
+    ):
+        assert actual_m["phase"] == expected_m.phase.value
+        assert actual_m["integrated"]["name"] == expected_m.integrated.name
+        assert actual_m["integrated"]["description"] == expected_m.integrated.description
+        assert actual_m["shadow"]["name"] == expected_m.shadow.name
+        assert actual_m["shadow"]["description"] == expected_m.shadow.description
+
+
+@pytest.mark.asyncio
+async def test_list_stages_manifestations_degrade_to_empty_on_curriculum_error(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A curriculum lookup failure leaves the list intact; that stage's manifestations become []."""
+
+    def _raise_curriculum_error(stage_number: int) -> object:
+        del stage_number
+        raise CurriculumDataError("boom")
+
+    monkeypatch.setattr(stages_router, "stage_curriculum", _raise_curriculum_error)
+
+    headers, _user_id = await _signup(async_client, "manifestations_degrade")
+    await _seed_stages(db_session, count=1)
+
+    resp = await async_client.get("/stages", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    assert data[0]["manifestations"] == []
 
 
 # ── GET /stages/{stage_number}/progress ─────────────────────────────────

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -328,6 +328,26 @@ describe('per-item paginated schemas', () => {
     expect(() => stageSchema.parse({ ...stage, is_unlocked: undefined })).toThrow();
   });
 
+  const stageManifestation = {
+    phase: 'Rising',
+    integrated: { name: 'Commitment', description: 'A grounded promise to begin showing up.' },
+    shadow: { name: 'Over-commitment', description: 'Taking on too much too fast.' },
+  };
+
+  it('stageSchema accepts a payload with manifestations present', () => {
+    const parsed = stageSchema.parse({ ...stage, manifestations: [stageManifestation] });
+    expect(parsed.manifestations).toHaveLength(1);
+  });
+
+  it('stageSchema accepts a payload with manifestations omitted (optional)', () => {
+    expect(stageSchema.parse(stage).manifestations).toBeUndefined();
+  });
+
+  it('stageSchema rejects an unknown phase name in manifestations', () => {
+    const invalidPhase = { ...stageManifestation, phase: 'Not A Real Phase' };
+    expect(() => stageSchema.parse({ ...stage, manifestations: [invalidPhase] })).toThrow();
+  });
+
   const practiceItem = {
     id: 7,
     stage_number: 2,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1630,6 +1630,20 @@ export const prompts = {
 };
 
 // Stage types and client
+
+/** One medicinal (integrated) or toxic (shadow) face of a stage in one Wavelength phase. */
+export interface StageExpression {
+  name: string;
+  description: string;
+}
+
+/** How a stage manifests across one Wavelength phase: its integrated and shadow expressions. */
+export interface StageManifestation {
+  phase: string;
+  integrated: StageExpression;
+  shadow: StageExpression;
+}
+
 export interface Stage {
   id: number;
   title: string;
@@ -1645,6 +1659,9 @@ export interface Stage {
   free_will_description: string;
   is_unlocked: boolean;
   progress: number;
+  // Per-phase integrated/shadow expressions. Optional so responses predating
+  // the field still type-check; the live backend always sends it.
+  manifestations?: StageManifestation[];
 }
 
 export interface PracticeHistoryItem {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -280,6 +280,23 @@ export const journalListResponseSchema = z.object({
 // the whole ModeConfig union on the client.
 // ---------------------------------------------------------------------------
 
+/** One integrated or shadow expression of a stage (mirrors the backend ``StageExpression``). */
+const stageExpressionSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+});
+
+/**
+ * The six canonical Wavelength phases, in order. Pinned as an enum so a drifted
+ * or misspelled phase raises ``ApiValidationError`` at the boundary rather than
+ * rendering an unlabelled block downstream.
+ */
+export const stageManifestationSchema = z.object({
+  phase: z.enum(['Rising', 'Peaking', 'Withdrawal', 'Diminishing', 'Bottoming Out', 'Restoration']),
+  integrated: stageExpressionSchema,
+  shadow: stageExpressionSchema,
+});
+
 /** A course stage row (mirrors the backend ``Stage`` response). */
 export const stageSchema = z.object({
   id: z.number().int(),
@@ -296,6 +313,9 @@ export const stageSchema = z.object({
   free_will_description: z.string(),
   is_unlocked: z.boolean(),
   progress: z.number(),
+  // Per-phase integrated/shadow expressions. Optional so responses predating
+  // the field still validate; the live backend always sends it.
+  manifestations: z.array(stageManifestationSchema).optional(),
 });
 
 /** A user's stage-progress record (mirrors the backend ``StageProgressRecord``). */

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -61,6 +61,7 @@ import {
   highestCompletedStage,
 } from './services/stageService';
 import { type StageData } from './stageData';
+import { StageExpressionsSection } from './StageExpressionsSection';
 import { stageNodeLabel, THIN_FULLNESS } from './stageLegend';
 import { WaveOverlay } from './WaveOverlay';
 
@@ -738,6 +739,7 @@ const ModalBody = ({ stage, onClose, onNavigate }: ModalBodyProps): React.JSX.El
     <Text style={styles.modalSubtitle}>{stage.subtitle}</Text>
     <StageProgressSection stage={stage} />
     <StageMetadataSection stage={stage} />
+    <StageExpressionsSection manifestations={stage.manifestations} />
     {stage.isUnlocked && (
       <StageHistorySection stageNumber={stage.stageNumber} isUnlocked={stage.isUnlocked} />
     )}

--- a/frontend/src/features/Map/StageExpressionsSection.tsx
+++ b/frontend/src/features/Map/StageExpressionsSection.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import type { StageExpression, StageManifestation } from '../../api';
+import { editorialType, onShowcase, radius, showcase, spacing } from '../../design/tokens';
+
+export type { StageExpression, StageManifestation } from '../../api';
+
+// The two faces of a stage in each Wavelength phase read as facets of one wave,
+// never a ranking of the person: an integrated (medicinal) expression beside a
+// shadow (toxic) one. The headings are the only hand-authored copy; every name
+// and description is canon, rendered as received.
+const INTEGRATED_LABEL = 'Integrated';
+const SHADOW_LABEL = 'Shadow';
+
+/** Slug a phase for a testID: lowercased, spaces collapsed to hyphens. */
+const phaseSlug = (phase: string): string => phase.toLowerCase().replace(/\s+/g, '-');
+
+interface ExpressionRowProps {
+  expression: StageExpression;
+  heading: string;
+  testID: string;
+}
+
+/** One face of a phase: its heading, canon name, and canon description. */
+const ExpressionRow = ({ expression, heading, testID }: ExpressionRowProps): React.JSX.Element => (
+  <View style={styles.expression} testID={testID}>
+    <Text style={styles.expressionHeading}>{heading}</Text>
+    <Text style={styles.expressionName}>{expression.name}</Text>
+    <Text style={styles.expressionDescription}>{expression.description}</Text>
+  </View>
+);
+
+/** One Wavelength phase: a caption eyebrow over its integrated + shadow pair. */
+const PhaseBlock = ({
+  manifestation,
+}: {
+  manifestation: StageManifestation;
+}): React.JSX.Element => {
+  const baseTestId = `stage-expression-${phaseSlug(manifestation.phase)}`;
+  return (
+    <View style={styles.phaseBlock} testID={baseTestId}>
+      <Text style={styles.phaseEyebrow} accessibilityRole="header">
+        {manifestation.phase}
+      </Text>
+      <View style={styles.pair}>
+        <ExpressionRow
+          expression={manifestation.integrated}
+          heading={INTEGRATED_LABEL}
+          testID={`${baseTestId}-integrated`}
+        />
+        <ExpressionRow
+          expression={manifestation.shadow}
+          heading={SHADOW_LABEL}
+          testID={`${baseTestId}-shadow`}
+        />
+      </View>
+    </View>
+  );
+};
+
+/**
+ * The stage-detail expressions surface: each of the six canonical Wavelength
+ * phases rendered as an integrated/shadow pair. Renders nothing when the stage
+ * carries no manifestations, so a payload predating the field shows no empty
+ * scaffold.
+ */
+export const StageExpressionsSection = ({
+  manifestations,
+}: {
+  manifestations: StageManifestation[];
+}): React.JSX.Element | null => {
+  if (manifestations.length === 0) {
+    return null;
+  }
+  return (
+    <View style={styles.section} testID="stage-expressions">
+      {manifestations.map((manifestation) => (
+        <PhaseBlock key={manifestation.phase} manifestation={manifestation} />
+      ))}
+    </View>
+  );
+};
+
+const EYEBROW_LETTER_SPACING = 0.6;
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: spacing(1.5),
+    gap: spacing(1.25),
+  },
+  phaseBlock: {
+    gap: spacing(0.5),
+  },
+  // Small, non-interactive caption eyebrow naming the Wavelength phase.
+  phaseEyebrow: {
+    fontFamily: editorialType.serif,
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: EYEBROW_LETTER_SPACING,
+    textTransform: 'uppercase',
+    color: onShowcase.soft,
+  },
+  pair: {
+    flexDirection: 'row',
+    gap: spacing(1),
+  },
+  expression: {
+    flex: 1,
+    backgroundColor: showcase.raised,
+    borderRadius: radius.md,
+    padding: spacing(1),
+    gap: spacing(0.25),
+  },
+  expressionHeading: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: EYEBROW_LETTER_SPACING,
+    color: onShowcase.soft,
+  },
+  expressionName: {
+    fontFamily: editorialType.serif,
+    fontSize: 14,
+    fontWeight: '700',
+    color: onShowcase.primary,
+  },
+  expressionDescription: {
+    fontSize: 12,
+    lineHeight: 18,
+    color: onShowcase.soft,
+  },
+});

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -661,6 +661,38 @@ describe('MapScreen', () => {
   });
 });
 
+describe('MapScreen stage-expressions modal integration', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) => mockMakeStage(10 - i));
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('shows the stage-expressions section in the modal for a stage with manifestations', () => {
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    expect(tree.root.findByProps({ testID: 'stage-expressions' })).toBeTruthy();
+  });
+
+  it('omits the stage-expressions section in the modal for a stage with no manifestations', () => {
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) => {
+      const stageNumber = 10 - i;
+      return stageNumber === 1
+        ? mockMakeStage(1, { manifestations: [] })
+        : mockMakeStage(stageNumber);
+    });
+    const tree = create(<MapScreen />);
+    act(() => {
+      tree.root.findByProps({ testID: 'stage-hotspot-1-0' }).props.onPress();
+    });
+    expect(tree.root.findAll((n: TestNode) => n.props.testID === 'stage-expressions')).toHaveLength(
+      0,
+    );
+  });
+});
+
 describe('MapScreen center-cell overlay layout', () => {
   beforeEach(() => {
     resetMapMocks();

--- a/frontend/src/features/Map/__tests__/StageExpressionsSection.test.tsx
+++ b/frontend/src/features/Map/__tests__/StageExpressionsSection.test.tsx
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+// Gate 1 contract for the stage-detail integrated/shadow expressions surface.
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import { StageExpressionsSection } from '../StageExpressionsSection';
+import type { StageManifestation } from '../StageExpressionsSection';
+
+import { ranksOrShames } from './copyIntentRule';
+
+// react-test-renderer ships no node types, so derive the instance from create.
+type TestInstance = ReturnType<typeof create>['root'];
+type TestNode = { props: Record<string, unknown> };
+
+// Realistic, canon-sourced fixture (Stage 1 / Survival) — the copy an
+// implementer's curriculum-backed component would actually render.
+const REALISTIC_MANIFESTATIONS: StageManifestation[] = [
+  {
+    phase: 'Rising',
+    integrated: { name: 'Commitment', description: 'A grounded promise to begin showing up.' },
+    shadow: { name: 'Over-commitment', description: 'Taking on too much too fast.' },
+  },
+  {
+    phase: 'Peaking',
+    integrated: {
+      name: 'Diligence',
+      description: 'Steady effort anchored in habit and presence.',
+    },
+    shadow: { name: 'Thriving', description: 'Overextending in a rush of manic progress.' },
+  },
+  {
+    phase: 'Withdrawal',
+    integrated: {
+      name: 'Steadiness',
+      description: 'Returning to baseline without abandoning routine.',
+    },
+    shadow: { name: 'Burnout', description: 'Energetic collapse from unsustainable output.' },
+  },
+  {
+    phase: 'Diminishing',
+    integrated: {
+      name: 'Security',
+      description: 'Embracing contraction to restore safety and trust.',
+    },
+    shadow: { name: 'Grasping', description: 'Clinging to momentum as it fades.' },
+  },
+  {
+    phase: 'Bottoming Out',
+    integrated: {
+      name: 'Stability',
+      description: 'Deep stillness that anchors your nervous system.',
+    },
+    shadow: { name: 'Overwhelm', description: 'Flooded by unmet needs or collapsing structure.' },
+  },
+  {
+    phase: 'Restoration',
+    integrated: { name: 'Next Habit', description: 'Humble return with a manageable new step.' },
+    shadow: { name: 'New Plan', description: 'Drastic overhaul to escape discomfort.' },
+  },
+];
+
+const PHASE_SLUGS = [
+  'rising',
+  'peaking',
+  'withdrawal',
+  'diminishing',
+  'bottoming-out',
+  'restoration',
+];
+
+// The static headings the component contract requires — checked for
+// balance-not-altitude compliance alongside the curriculum copy below.
+const HAND_AUTHORED_LABELS = ['Integrated', 'Shadow'];
+
+const textChildren = (node: TestInstance): string[] =>
+  node
+    .findAll((n: TestNode) => typeof n.props.children === 'string')
+    .map((n: TestNode) => n.props.children as string);
+
+describe('StageExpressionsSection', () => {
+  it('renders a container with all 6 phase blocks in canonical order', () => {
+    const tree = create(<StageExpressionsSection manifestations={REALISTIC_MANIFESTATIONS} />);
+    expect(tree.root.findByProps({ testID: 'stage-expressions' })).toBeTruthy();
+    for (const slug of PHASE_SLUGS) {
+      expect(tree.root.findByProps({ testID: `stage-expression-${slug}` })).toBeTruthy();
+    }
+  });
+
+  it('shows each phase integrated name + description under the "Integrated" heading', () => {
+    const tree = create(<StageExpressionsSection manifestations={REALISTIC_MANIFESTATIONS} />);
+    for (const manifestation of REALISTIC_MANIFESTATIONS) {
+      const slug = manifestation.phase.toLowerCase().replace(/\s+/g, '-');
+      const integrated = tree.root.findByProps({
+        testID: `stage-expression-${slug}-integrated`,
+      });
+      const rendered = textChildren(integrated);
+      expect(rendered).toContain('Integrated');
+      expect(rendered).toContain(manifestation.integrated.name);
+      expect(rendered).toContain(manifestation.integrated.description);
+    }
+  });
+
+  it('shows each phase shadow name + description under the "Shadow" heading', () => {
+    const tree = create(<StageExpressionsSection manifestations={REALISTIC_MANIFESTATIONS} />);
+    for (const manifestation of REALISTIC_MANIFESTATIONS) {
+      const slug = manifestation.phase.toLowerCase().replace(/\s+/g, '-');
+      const shadow = tree.root.findByProps({ testID: `stage-expression-${slug}-shadow` });
+      const rendered = textChildren(shadow);
+      expect(rendered).toContain('Shadow');
+      expect(rendered).toContain(manifestation.shadow.name);
+      expect(rendered).toContain(manifestation.shadow.description);
+    }
+  });
+
+  it('renders null for an empty manifestations array', () => {
+    const tree = create(<StageExpressionsSection manifestations={[]} />);
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('trips zero rank/shame patterns for every hand-authored label', () => {
+    for (const label of HAND_AUTHORED_LABELS) {
+      expect(ranksOrShames(label)).toBe(false);
+    }
+  });
+
+  it('trips zero rank/shame patterns across the full rendered text of a realistic fixture stage', () => {
+    const tree = create(<StageExpressionsSection manifestations={REALISTIC_MANIFESTATIONS} />);
+    const allText = textChildren(tree.root).join(' ');
+    expect(ranksOrShames(allText)).toBe(false);
+  });
+});

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -32,6 +32,25 @@ export interface StageHistoryData {
   }>;
 }
 
+/** The six canonical Wavelength phases, in order — mirrors the backend curriculum loader. */
+export const DEFAULT_MANIFESTATION_PHASES: readonly string[] = [
+  'Rising',
+  'Peaking',
+  'Withdrawal',
+  'Diminishing',
+  'Bottoming Out',
+  'Restoration',
+];
+
+/** A realistic 6-phase manifestations default (integrated/shadow pairs), so fixtures keep the StageData type valid. */
+function defaultManifestations(): StageData['manifestations'] {
+  return DEFAULT_MANIFESTATION_PHASES.map((phase) => ({
+    phase,
+    integrated: { name: `${phase} integrated`, description: `${phase} integrated description.` },
+    shadow: { name: `${phase} shadow`, description: `${phase} shadow description.` },
+  }));
+}
+
 /** Build a realistic StageData; ``overrides`` owns the per-test seam. */
 export function mockMakeStage(stageNumber: number, overrides: Partial<StageData> = {}): StageData {
   return {
@@ -50,6 +69,7 @@ export function mockMakeStage(stageNumber: number, overrides: Partial<StageData>
     relationshipToFreeWill: 'Free Will',
     freeWillDescription: 'Description of free will.',
     overviewUrl: '',
+    manifestations: defaultManifestations(),
     ...overrides,
   };
 }

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -383,6 +383,37 @@ describe('stageService', () => {
     });
   });
 
+  describe('toStageData manifestations mapping', () => {
+    const sampleManifestations = [
+      {
+        phase: 'Rising',
+        integrated: {
+          name: 'Commitment',
+          description: 'A grounded promise to begin showing up.',
+        },
+        shadow: { name: 'Over-commitment', description: 'Taking on too much too fast.' },
+      },
+    ];
+
+    it('maps manifestations through unchanged', () => {
+      const { toStageData } = require('../stageService');
+      const apiStage = makeApiStage(1, { manifestations: sampleManifestations });
+
+      const result = toStageData(apiStage);
+
+      expect(result.manifestations).toEqual(sampleManifestations);
+    });
+
+    it('defaults manifestations to [] when the payload omits the field', () => {
+      const { toStageData } = require('../stageService');
+      const apiStage = makeApiStage(1);
+
+      const result = toStageData(apiStage);
+
+      expect(result.manifestations).toEqual([]);
+    });
+  });
+
   describe('beginAgain action', () => {
     function makeProgressRecord(cycleNumber: number): StageProgressRecord {
       return {

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -49,6 +49,7 @@ export const toStageData = (apiStage: Stage): StageData => {
     relationshipToFreeWill: apiStage.relationship_to_free_will,
     freeWillDescription: apiStage.free_will_description,
     overviewUrl: apiStage.overview_url,
+    manifestations: apiStage.manifestations ?? [],
   };
 };
 

--- a/frontend/src/features/Map/stageData.ts
+++ b/frontend/src/features/Map/stageData.ts
@@ -8,7 +8,10 @@
  * here. Stage *content* is fetched from the backend API.
  */
 
+import type { StageManifestation } from '../../api';
+
 export { STAGE_COUNT } from '../../domain/stageProgression';
+export type { StageExpression, StageManifestation } from '../../api';
 
 export interface StageData {
   id: number;
@@ -27,6 +30,9 @@ export interface StageData {
   relationshipToFreeWill: string;
   freeWillDescription: string;
   overviewUrl: string;
+  // How this stage manifests across the six Wavelength phases (integrated +
+  // shadow); an empty array when the backend omits the field.
+  manifestations: StageManifestation[];
 }
 
 /**

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -19,6 +19,7 @@ const makeStage = (stageNumber: number, overrides: Partial<StageData> = {}): Sta
   relationshipToFreeWill: '',
   freeWillDescription: '',
   overviewUrl: '',
+  manifestations: [],
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

Surfaces each Stage's two faces — its **integrated (medicinal)** and **shadow (toxic)** expression — on the stage-detail modal, sourced verbatim from the vendored curriculum dataset (not hand-authored per platform).

Each Stage manifests across the six canonical Wavelength phases (Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration); each phase carries an `integrated` and a `shadow` expression (name + description) in `backend/src/curriculum/archetypal_wavelength.json`, already validated by the `#1021` typed loader. This change surfaces that contrast without ranking or shaming anyone.

**Backend** — Overlays per-phase manifestations onto the `GET /stages` payload via a small query-free `_stage_manifestations()` helper reading the cached curriculum loader, degrading to `[]` on `CurriculumDataError`. New `StageExpression` / `StageManifestation` DTOs. No DB column or migration: the copy is static, loader-cached content, so persisting a duplicate would reintroduce the exact drift the vendored dataset exists to prevent.

**Frontend** — Extends the `Stage` API type and zod schema (phase pinned as a six-value enum for drift detection), maps the field through `toStageData`, and renders a new `StageExpressionsSection` in the modal (between metadata and history) pairing each phase's integrated and shadow expression in Candle & Ink. Reads as two facets of one wavelength — information, never altitude — and is guarded by the existing `ranksOrShames` intent rule. Renders nothing when a Stage carries no manifestations (graceful degradation for pre-field payloads).

Scope is disjoint from #1776 (magnifier lens caption) — only the modal is touched. Copy for stages 7–10 reflects the shipped dataset state pending decision #1637.

## Test plan

- Backend: `test_stages_api.py` — all ten stages carry 6 canonical-order manifestations with populated integrated/shadow copy; content-parity test locks it to `curriculum.stage_curriculum(n)`; degradation test asserts `manifestations == []` on a curriculum error (200, list intact).
- Frontend: new `StageExpressionsSection.test.tsx` (6 phase blocks, per-phase testIDs, null-on-empty, zero `ranksOrShames` hits on labels + a real-fixture stage); `toStageData` mapping + `[]` default; `stageSchema` optional-field + unknown-phase rejection; MapScreen modal integration.
- Gate 2 green locally: `scripts/backend/check-all.sh` (exit 0) + xenon A-grade + radon ≥ B; `scripts/frontend/check-all.sh` (eslint/prettier/tsc + 4466 jest tests). Gate 2.5 self-review: CLEAN.

Closes #1018
Refs #1004