### PR TITLE
ci(graph): rolling knowledge-graph release + main freshness

### DIFF
--- a/.github/workflows/graph-build.yml
+++ b/.github/workflows/graph-build.yml
@@ -51,6 +51,10 @@ jobs:
       OUT_DIR: graphify-out
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        # No step git-pushes (publish rides `gh` + GH_TOKEN, not `git push`), so
+        # the write-scoped token never needs to live in .git/config for the job.
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:

--- a/.github/workflows/graph-build.yml
+++ b/.github/workflows/graph-build.yml
@@ -1,0 +1,187 @@
+name: Graph build
+
+# Keeps `main` carrying a <=24h-fresh, code-only knowledge graph that any
+# environment (CI, Ralph worktree, web session, dev laptop) can fetch in
+# seconds. Distribution rides a single rolling GitHub Release tagged
+# `knowledge-graph`; the graph itself never travels through actions/cache
+# (cache is branch-scoped and evictable — wrong tool for distribution).
+#
+# Two paths converge on one publish step:
+#   * push to main (code paths)  -> incremental `update.sh` off the prior
+#                                   published graph (fast, keeps main fresh).
+#   * nightly schedule / manual  -> full `build.sh`, GRAPHIFY_FORCE=1 so
+#     dispatch                      graphify's shrink guard accepts deletions.
+#
+# $0 job: tree-sitter AST extraction only — no LLM calls, no API keys. The
+# sole secret is the built-in GITHUB_TOKEN, scoped to `contents: write` for the
+# release upsert.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "scripts/**"
+      - ".github/workflows/graph-build.yml"
+  schedule:
+    # Nightly full rebuild (catches deletions the incremental path skips).
+    - cron: "40 4 * * *"
+  workflow_dispatch:
+
+# Only the rolling-release upsert needs write; everything else is read.
+permissions:
+  contents: write
+
+# Serialize runs so overlapping pushes never race the release asset upload.
+# Never cancel in-progress: a cancelled publish would leave the release stale.
+concurrency:
+  group: graph-build
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and publish code graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # GH_TOKEN is scoped per-step (restore + publish only) so the third-party
+    # graphify extractor never runs with a write-scoped token in its env.
+    env:
+      GRAPH_TAG: knowledge-graph
+      OUT_DIR: graphify-out
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Resolve pinned graphifyy version
+        id: tool
+        # Cache key + graph-meta provenance both key off the single pin.
+        run: |
+          version="$(sed -n 's/^graphifyy==//p' scripts/graph/requirements.txt)"
+          if [[ -z "$version" ]]; then
+            echo "::error::could not read graphifyy pin from scripts/graph/requirements.txt"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache graphify toolchain
+        # Tool install only — keyed on the graphifyy pin so a version bump busts
+        # it. The graph output is NOT cached; it travels via the release.
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+        with:
+          path: ~/.cache/pip
+          key: graphifyy-${{ runner.os }}-${{ steps.tool.outputs.version }}
+
+      - name: Install graphify toolchain
+        run: pip install -r scripts/graph/requirements.txt
+
+      - name: Restore prior published graph
+        # Incremental path only. If no release/asset exists yet (first ever
+        # run), leave OUT_DIR empty and let the next step full-build instead.
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "$OUT_DIR"
+          if gh release download "$GRAPH_TAG" --pattern graph.json --dir "$OUT_DIR" --clobber; then
+            echo "restored prior graph.json for incremental refresh"
+          else
+            echo "no prior published graph — falling back to a full build"
+          fi
+
+      - name: Refresh graph (incremental push)
+        if: github.event_name == 'push'
+        run: |
+          if [[ ! -f "$OUT_DIR/graph.json" ]]; then
+            echo "no prior graph restored — running a full build"
+            ./scripts/graph/build.sh
+          elif ! ./scripts/graph/update.sh; then
+            # An incremental update most often fails because deleted files would
+            # shrink the graph past graphify's shrink guard. Keep main green by
+            # forcing a full rebuild; the nightly forced build is the backstop.
+            echo "::warning::incremental update failed — forcing a full rebuild"
+            GRAPHIFY_FORCE=1 ./scripts/graph/build.sh
+          fi
+
+      - name: Build graph (full — schedule / manual dispatch)
+        if: github.event_name != 'push'
+        # GRAPHIFY_FORCE=1 bypasses the shrink guard so a nightly rebuild can
+        # shrink the graph when files were deleted. Logged so a forced smaller
+        # graph is never silent.
+        env:
+          GRAPHIFY_FORCE: "1"
+        run: |
+          echo "full rebuild with GRAPHIFY_FORCE=1 (shrink guard bypassed to catch deletions)"
+          ./scripts/graph/build.sh
+
+      - name: Write graph-meta.json
+        env:
+          GRAPHIFYY_VERSION: ${{ steps.tool.outputs.version }}
+        run: |
+          if [[ ! -f "$OUT_DIR/graph.json" ]]; then
+            echo "::error::$OUT_DIR/graph.json missing after build — nothing to publish"
+            exit 1
+          fi
+          built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          sha="$(git rev-parse --short HEAD)"
+          BUILT_AT="$built_at" SHA="$sha" python3 - "$OUT_DIR/graph.json" "$OUT_DIR/graph-meta.json" <<'PY'
+          import json
+          import os
+          import sys
+
+          graph_path, meta_path = sys.argv[1], sys.argv[2]
+          with open(graph_path, encoding="utf-8") as handle:
+              graph = json.load(handle)
+          meta = {
+              "built_at": os.environ["BUILT_AT"],
+              "sha": os.environ["SHA"],
+              "nodes": len(graph.get("nodes", [])),
+              "edges": len(graph.get("edges", [])),
+              "graphifyy": os.environ["GRAPHIFYY_VERSION"],
+              "kind": "code-only",
+          }
+          with open(meta_path, "w", encoding="utf-8") as handle:
+              json.dump(meta, handle, indent=2, sort_keys=True)
+              handle.write("\n")
+          print(f"graph-meta: {meta['nodes']:,} nodes / {meta['edges']:,} edges @ {meta['sha']}")
+          PY
+
+      - name: Publish rolling knowledge-graph release
+        # Upsert: create the tag/release once, then re-upload assets with
+        # --clobber on every run. Upload is retried once on transient failure,
+        # then fails loudly — publishing is never silently skipped.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          assets=("$OUT_DIR/graph.json" "$OUT_DIR/graph-meta.json")
+          # GRAPH_REPORT.md is a full-build artifact; on incremental push runs it
+          # may be absent, so the release keeps the last full-build report until
+          # the nightly rebuild refreshes it. graph.json/graph-meta.json are
+          # always current.
+          if [[ -f "$OUT_DIR/GRAPH_REPORT.md" ]]; then
+            assets+=("$OUT_DIR/GRAPH_REPORT.md")
+          fi
+
+          if ! gh release view "$GRAPH_TAG" >/dev/null 2>&1; then
+            echo "creating rolling release $GRAPH_TAG"
+            gh release create "$GRAPH_TAG" \
+              --title "Knowledge graph (rolling)" \
+              --notes "Rolling code-only knowledge graph for the default branch. Assets are re-uploaded in place on every graph-build run; do not treat this tag as a version." \
+              --latest=false
+          fi
+
+          upload() {
+            gh release upload "$GRAPH_TAG" "${assets[@]}" --clobber
+          }
+          if ! upload; then
+            echo "release upload failed — retrying once in 10s"
+            sleep 10
+            if ! upload; then
+              echo "::error::release upload failed twice — graph was NOT published"
+              exit 1
+            fi
+          fi
+          echo "published ${#assets[@]} asset(s) to release $GRAPH_TAG"

--- a/scripts/graph/README.md
+++ b/scripts/graph/README.md
@@ -14,8 +14,26 @@ web session) can produce or refresh the graph with one command.
 The build writes ~17 MB of artifacts to `graphify-out/graph.json`. With several
 parallel Ralph worktrees each rebuilding it, committing the output would put
 huge, churning diffs into every PR. So `graphify-out/` is git-ignored in this
-repo; distribution happens later via a rolling GitHub Release. Rebuild it
-locally whenever you need it.
+repo; distribution happens via a rolling GitHub Release. Rebuild it locally
+whenever you need it, or fetch the latest published graph in seconds.
+
+## Fetching the published graph
+
+The `graph-build` workflow (`.github/workflows/graph-build.yml`) keeps `main`
+carrying a graph that is at most 24h fresh, published as a **rolling release**
+tagged `knowledge-graph`. It re-uploads three assets in place on every run —
+`graph.json`, `graph-meta.json` (build provenance: `built_at`, `sha`, node /
+edge counts, pinned `graphifyy` version, `kind`), and `GRAPH_REPORT.md` when
+present. Any environment can pull the current graph without rebuilding:
+
+```bash
+gh release download knowledge-graph --pattern graph.json --dir graphify-out
+```
+
+The `knowledge-graph` git tag stays pinned at the commit where the release was
+first created; it is **not** a version marker. The authoritative build identity
+is `graph-meta.json`'s `sha` field, which tracks the commit each upload was
+built from.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/graph-build.yml`, a $0 code-only workflow that keeps `main` carrying a graph that is at most 24h fresh and published where any environment can fetch it in seconds.

- **`on: push` to `main`** (path-filtered to `backend/**`, `frontend/**`, `scripts/**`, and the workflow itself): restores the prior published `graph.json` from the rolling release, then runs `./scripts/graph/update.sh` for an incremental refresh. Falls back to a full build on first run (no prior release) and to a `GRAPHIFY_FORCE=1` full rebuild if the incremental update trips graphify's shrink guard after deletions, so pushes to `main` stay green.
- **`on: schedule` (nightly 04:40 UTC) + `workflow_dispatch`**: runs a forced full `./scripts/graph/build.sh` (`GRAPHIFY_FORCE=1`, logged) so deletions are caught even when incremental pushes skip them.
- **Publish (shared)**: upserts a single **rolling release** tagged `knowledge-graph` (created once, then assets re-uploaded in place with `--clobber`), carrying `graph.json`, `graph-meta.json`, and `GRAPH_REPORT.md` (when present). Upload is retried once on transient failure, then fails loudly — publishing is never silently skipped.
- `graph-meta.json` provenance (`built_at`, `sha`, `nodes`, `edges`, `graphifyy`, `kind: code-only`) is generated inline; the pinned `graphifyy` version is parsed from `scripts/graph/requirements.txt`, not hardcoded.
- `actions/cache` is keyed on the graphifyy version and scoped to the pip tool install only — the graph itself travels via the release, not the (branch-scoped, evictable) cache.
- `concurrency: group: graph-build, cancel-in-progress: false` serializes push/nightly/dispatch runs so overlapping publishes never race the release upload.

Security posture: `permissions: contents: write` (least privilege for the release upsert); all actions SHA-pinned (checkout v7.0.0, setup-python v6.3.0, cache v4.2.3); `GH_TOKEN` scoped step-level to only the restore + publish steps so the third-party graphify extractor never runs with a write-scoped token in its env; no secret echoing, no `set -x`.

Also documents the now-real release and a `gh release download knowledge-graph` fetch one-liner in `scripts/graph/README.md`.

Out of scope (left for a separate follow-up per the spec): wiring `scripts/graph/test_hook_guards.sh` into CI — #1803 covers graph freshness + distribution, not CI-testing the hook tooling.

## Test plan

A GitHub Actions workflow cannot be executed locally, so verification is static + logic-path:

- `actionlint` (which embeds `shellcheck` over every `run:` block) passes clean.
- Pre-commit `check-yaml` passes; `commitlint` passes.
- The inline `graph-meta.json` generator Python was extracted and run against a fixture `graph.json`, producing the exact spec schema and field values.
- The YAML→shell heredoc dedent, event-name conditional partitioning (push vs schedule/dispatch), first-run fallback, loud retry, and concurrency serialization were reviewed via the Gate 2.5 self-review (verdict: CLEAN).
- Real end-to-end acceptance is a post-merge `workflow_dispatch` run demonstrating the populated `knowledge-graph` release — it needs `contents: write` on the default branch and cannot run from a fork/branch pre-merge.

Closes #1803
Refs #1800