### PR TITLE
feat(journal): drawer search over entry titles with confirm-gated body search

### DIFF
--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -8,7 +8,7 @@
  * ``useJournalDrawerEntries`` hook, which lives above the ``ScreenDrawer`` panel
  * so its cache survives close/reopen (mirrors ``useCourseDrawerContent``).
  */
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   StyleSheet,
@@ -25,6 +25,8 @@ import type { JournalMessage } from '@/api';
 import {
   DrawerItem,
   DrawerNavSection,
+  DrawerSearch,
+  rankMatches,
   ScreenDrawer,
   type ScreenDrawerState,
 } from '@/components/drawer';
@@ -36,6 +38,12 @@ const NEW_ENTRY_LABEL = 'New entry';
 const LOAD_MORE_LABEL = 'Load older entries';
 /** Fallback label for an entry saved without a title. */
 const UNTITLED_LABEL = 'Untitled';
+/** Placeholder for the drawer's fuzzy entry-search field. */
+const SEARCH_PLACEHOLDER = 'Search entries...';
+/** Accessibility label for the drawer's fuzzy entry-search field. */
+const SEARCH_ACCESSIBILITY_LABEL = 'Search entries';
+/** Confirm-row copy that invites widening the search into entry bodies. */
+const DEEP_SEARCH_LABEL = 'Search inside entries? This loads your older entries.';
 /** Copy shown when the entry fetch failed, above the retry row. */
 const ERROR_LABEL = 'We could not load your entries.';
 /** Retry affordance shown alongside the error copy. */
@@ -58,8 +66,9 @@ export function useJournalDrawerEntries(isOpen: boolean): {
   hasMore: boolean;
   loadMore: () => void;
   retry: () => void;
+  confirmBodySearch: () => void;
 } {
-  const { items, hasMore, loading, error, load } = usePagedJournal();
+  const { items, hasMore, loading, error, load, loadAll } = usePagedJournal();
   const hasOpened = useRef(false);
 
   useEffect(() => {
@@ -77,7 +86,20 @@ export function useJournalDrawerEntries(isOpen: boolean): {
     void load(undefined, 0);
   }, [load]);
 
-  return { items, loading, error: error !== null, hasMore, loadMore, retry };
+  const confirmBodySearch = useCallback(() => {
+    // Pull in every remaining older page so body matching sees the full corpus;
+    // guarded like loadMore so a fetch in flight or an exhausted list is a no-op.
+    if (hasMore && !loading) void loadAll(items.length);
+  }, [hasMore, loading, loadAll, items.length]);
+
+  return { items, loading, error: error !== null, hasMore, loadMore, retry, confirmBodySearch };
+}
+
+/** The entry's trimmed title, or the untitled fallback when it has none. */
+function entryLabel(entry: JournalMessage): string {
+  const title = entry.title;
+  if (typeof title === 'string' && title.trim().length > 0) return title;
+  return UNTITLED_LABEL;
 }
 
 /** Full-panel spinner shown before the first page of entries resolves. */
@@ -112,7 +134,7 @@ interface EntryRowProps {
 /** One entry row: title (or "Untitled") + its saved date, selectable + tappable. */
 const EntryRow = ({ entry, selected, onPress }: EntryRowProps): React.JSX.Element => {
   const { width } = useWindowDimensions();
-  const label = entry.title?.trim() ? entry.title : UNTITLED_LABEL;
+  const label = entryLabel(entry);
   const dateText = formatDate(entry.timestamp);
   // Drop the separator when the date is unparseable so the label never trails a
   // bare comma.
@@ -210,6 +232,71 @@ function DrawerBody({
   );
 }
 
+interface SearchResultsProps {
+  matches: JournalMessage[];
+  currentEntryId?: number | null;
+  onRowPress: (_id: number) => void;
+}
+
+/** Flat, ranked matches for an active query: no recency headings, no load-more. */
+function SearchResults({
+  matches,
+  currentEntryId,
+  onRowPress,
+}: SearchResultsProps): React.JSX.Element {
+  return (
+    <View>
+      {matches.map((entry) => (
+        <EntryRow
+          key={entry.id}
+          entry={entry}
+          selected={entry.id === currentEntryId}
+          onPress={onRowPress}
+        />
+      ))}
+    </View>
+  );
+}
+
+interface DrawerSearchFieldProps {
+  /** Match count for the active query, or undefined to hide the caption. */
+  resultCount?: number;
+  /** True once the deep body search is confirmed; hides the confirm row. */
+  bodySearchActive: boolean;
+  /** Receives the debounced query (or '' on clear). */
+  onQueryChange: (_query: string) => void;
+  /** Confirm widening the search into entry bodies. */
+  onConfirmDeepSearch: () => void;
+}
+
+/**
+ * The drawer's search field. The deep-search confirm row is offered only until
+ * body search is active; because ``DrawerSearchProps`` is an exclusive union, we
+ * branch the element rather than widen the props to keep the deep pair paired.
+ */
+function DrawerSearchField({
+  resultCount,
+  bodySearchActive,
+  onQueryChange,
+  onConfirmDeepSearch,
+}: DrawerSearchFieldProps): React.JSX.Element {
+  const shared = {
+    testID: 'journal-drawer-search',
+    placeholder: SEARCH_PLACEHOLDER,
+    accessibilityLabel: SEARCH_ACCESSIBILITY_LABEL,
+    resultCount,
+    onQueryChange,
+  };
+  if (bodySearchActive) return <DrawerSearch {...shared} />;
+  return (
+    <DrawerSearch
+      {...shared}
+      onConfirmDeepSearch={onConfirmDeepSearch}
+      deepSearchLabel={DEEP_SEARCH_LABEL}
+    />
+  );
+}
+
 export interface JournalDrawerProps {
   /** The entries to group and render (newest-first, per the API order). */
   items: JournalMessage[];
@@ -231,9 +318,52 @@ export interface JournalDrawerProps {
   onLoadMore: () => void;
   /** Refetch the first page after a failure. */
   onRetry: () => void;
+  /**
+   * Confirm the deep body search: the host pulls in every remaining older page
+   * so the subsequent match runs against titles and message bodies alike.
+   */
+  onConfirmBodySearch: () => void;
 }
 
-/** The Journal header drawer's contents: New entry, then the grouped entry list. */
+interface DrawerSearchState {
+  bodySearchActive: boolean;
+  isSearching: boolean;
+  matches: JournalMessage[];
+  handleQueryChange: (_next: string) => void;
+  handleConfirmDeepSearch: () => void;
+}
+
+/**
+ * Own the drawer's search query and body-search gate, and derive the ranked
+ * matches. A cleared query drops back to title-only until body search is
+ * re-confirmed; body search additionally ranks against each entry's message.
+ */
+function useDrawerSearch(
+  items: JournalMessage[],
+  onConfirmBodySearch: () => void,
+): DrawerSearchState {
+  const [query, setQuery] = useState('');
+  const [bodySearchActive, setBodySearchActive] = useState(false);
+
+  const handleQueryChange = useCallback((next: string) => {
+    setQuery(next);
+    if (next.length === 0) setBodySearchActive(false);
+  }, []);
+
+  const handleConfirmDeepSearch = useCallback(() => {
+    setBodySearchActive(true);
+    onConfirmBodySearch();
+  }, [onConfirmBodySearch]);
+
+  const isSearching = query.length > 0;
+  const getText = (entry: JournalMessage): string =>
+    bodySearchActive ? `${entryLabel(entry)} ${entry.message}` : entryLabel(entry);
+  const matches = isSearching ? rankMatches(query, items, getText) : items;
+
+  return { bodySearchActive, isSearching, matches, handleQueryChange, handleConfirmDeepSearch };
+}
+
+/** The Journal header drawer's contents: New entry, a search field, then the list. */
 export default function JournalDrawer({
   items,
   now,
@@ -245,21 +375,34 @@ export default function JournalDrawer({
   onNewEntry,
   onLoadMore,
   onRetry,
+  onConfirmBodySearch,
 }: JournalDrawerProps): React.JSX.Element {
-  const sections = groupByRecency(items, now);
+  const { bodySearchActive, isSearching, matches, handleQueryChange, handleConfirmDeepSearch } =
+    useDrawerSearch(items, onConfirmBodySearch);
+
   return (
     <View testID="journal-drawer">
       <DrawerItem testID="journal-drawer-new-entry" label={NEW_ENTRY_LABEL} onPress={onNewEntry} />
-      <DrawerBody
-        sections={sections}
-        loading={loading}
-        error={error}
-        hasMore={hasMore}
-        currentEntryId={currentEntryId}
-        onRowPress={onRowPress}
-        onLoadMore={onLoadMore}
-        onRetry={onRetry}
+      <DrawerSearchField
+        resultCount={isSearching ? matches.length : undefined}
+        bodySearchActive={bodySearchActive}
+        onQueryChange={handleQueryChange}
+        onConfirmDeepSearch={handleConfirmDeepSearch}
       />
+      {isSearching ? (
+        <SearchResults matches={matches} currentEntryId={currentEntryId} onRowPress={onRowPress} />
+      ) : (
+        <DrawerBody
+          sections={groupByRecency(items, now)}
+          loading={loading}
+          error={error}
+          hasMore={hasMore}
+          currentEntryId={currentEntryId}
+          onRowPress={onRowPress}
+          onLoadMore={onLoadMore}
+          onRetry={onRetry}
+        />
+      )}
     </View>
   );
 }
@@ -282,9 +425,8 @@ export function JournalScreenDrawer({
   onSelectEntry,
   onNewEntry,
 }: JournalScreenDrawerProps): React.JSX.Element {
-  const { items, loading, error, hasMore, loadMore, retry } = useJournalDrawerEntries(
-    drawer.isOpen,
-  );
+  const { items, loading, error, hasMore, loadMore, retry, confirmBodySearch } =
+    useJournalDrawerEntries(drawer.isOpen);
   return (
     <ScreenDrawer
       visible={drawer.isOpen}
@@ -304,6 +446,7 @@ export function JournalScreenDrawer({
         onNewEntry={onNewEntry}
         onLoadMore={loadMore}
         onRetry={retry}
+        onConfirmBodySearch={confirmBodySearch}
       />
     </ScreenDrawer>
   );

--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -48,6 +48,10 @@ const DEEP_SEARCH_LABEL = 'Search inside entries? This loads your older entries.
 const ERROR_LABEL = 'We could not load your entries.';
 /** Retry affordance shown alongside the error copy. */
 const RETRY_LABEL = 'Tap to retry';
+/** Quiet caption shown while the confirm-triggered deep-search sweep is running. */
+const SEARCH_LOADING_LABEL = 'Searching all your entries...';
+/** Quiet caption shown when the deep-search sweep failed, above its retry row. */
+const SEARCH_ERROR_LABEL = 'We could not finish searching your entries.';
 
 /**
  * Fetch the drawer's entries lazily on its first open and cache them across
@@ -258,6 +262,84 @@ function SearchResults({
   );
 }
 
+interface SearchSweepStatusProps {
+  /** True once the deep body search is confirmed; gates the sweep's status. */
+  active: boolean;
+  /** True while the confirm-triggered page sweep is in flight. */
+  loading: boolean;
+  /** True when that sweep failed. */
+  error: boolean;
+  /** Re-run the sweep after a failure. */
+  onRetry: () => void;
+}
+
+/**
+ * A quiet inline status row shown beneath the search field while the deep body
+ * search is active: a "searching..." caption during the confirm-triggered page
+ * sweep, or a failure caption plus a retry row if that sweep rejected. It keeps
+ * the sweep's in-flight and error states visible without leaving the results
+ * view (which would otherwise swallow both until the query is cleared).
+ */
+function SearchSweepStatus({
+  active,
+  loading,
+  error,
+  onRetry,
+}: SearchSweepStatusProps): React.JSX.Element | null {
+  const { width } = useWindowDimensions();
+  if (!active) return null;
+  if (loading) {
+    return (
+      <View testID="journal-drawer-search-loading" style={styles.searchStatusRow}>
+        <ActivityIndicator size="small" color={accent.primary} />
+        <Text style={[type(width).caption, styles.searchStatusText]}>{SEARCH_LOADING_LABEL}</Text>
+      </View>
+    );
+  }
+  if (error) {
+    return (
+      <View testID="journal-drawer-search-error" style={styles.searchStatusBlock}>
+        <Text style={[type(width).caption, styles.searchStatusText]}>{SEARCH_ERROR_LABEL}</Text>
+        <DrawerItem testID="journal-drawer-search-retry" label={RETRY_LABEL} onPress={onRetry} />
+      </View>
+    );
+  }
+  return null;
+}
+
+interface SearchViewProps {
+  matches: JournalMessage[];
+  bodySearchActive: boolean;
+  loading: boolean;
+  error: boolean;
+  currentEntryId?: number | null;
+  onRowPress: (_id: number) => void;
+  onConfirmBodySearch: () => void;
+}
+
+/** The active-query view: the sweep status row above the flat, ranked matches. */
+function SearchView({
+  matches,
+  bodySearchActive,
+  loading,
+  error,
+  currentEntryId,
+  onRowPress,
+  onConfirmBodySearch,
+}: SearchViewProps): React.JSX.Element {
+  return (
+    <View>
+      <SearchSweepStatus
+        active={bodySearchActive}
+        loading={loading}
+        error={error}
+        onRetry={onConfirmBodySearch}
+      />
+      <SearchResults matches={matches} currentEntryId={currentEntryId} onRowPress={onRowPress} />
+    </View>
+  );
+}
+
 interface DrawerSearchFieldProps {
   /** Match count for the active query, or undefined to hide the caption. */
   resultCount?: number;
@@ -390,7 +472,15 @@ export default function JournalDrawer({
         onConfirmDeepSearch={handleConfirmDeepSearch}
       />
       {isSearching ? (
-        <SearchResults matches={matches} currentEntryId={currentEntryId} onRowPress={onRowPress} />
+        <SearchView
+          matches={matches}
+          bodySearchActive={bodySearchActive}
+          loading={loading}
+          error={error}
+          currentEntryId={currentEntryId}
+          onRowPress={onRowPress}
+          onConfirmBodySearch={onConfirmBodySearch}
+        />
       ) : (
         <DrawerBody
           sections={groupByRecency(items, now)}
@@ -462,6 +552,21 @@ const styles = StyleSheet.create({
     gap: SPACING.xs,
   },
   errorText: {
+    color: ink.muted,
+  },
+  searchStatusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  searchStatusBlock: {
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  searchStatusText: {
     color: ink.muted,
   },
   section: {

--- a/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
@@ -69,6 +69,7 @@ function renderDrawer(props: Partial<DrawerHarness> = {}) {
   const onNewEntry = props.onNewEntry ?? jest.fn();
   const onLoadMore = jest.fn();
   const onRetry = jest.fn();
+  const onConfirmBodySearch = jest.fn();
   const result = render(
     <JournalDrawer
       items={props.items ?? []}
@@ -81,9 +82,10 @@ function renderDrawer(props: Partial<DrawerHarness> = {}) {
       onNewEntry={onNewEntry}
       onLoadMore={onLoadMore}
       onRetry={onRetry}
+      onConfirmBodySearch={onConfirmBodySearch}
     />,
   );
-  return { ...result, onRowPress, onNewEntry, onLoadMore, onRetry };
+  return { ...result, onRowPress, onNewEntry, onLoadMore, onRetry, onConfirmBodySearch };
 }
 
 describe('JournalDrawer (presentational)', () => {
@@ -240,6 +242,7 @@ function Harness(): React.JSX.Element {
           onNewEntry={() => undefined}
           onLoadMore={loadMore}
           onRetry={retry}
+          onConfirmBodySearch={() => undefined}
         />
       ) : null}
     </View>

--- a/frontend/src/features/Journal/__tests__/JournalDrawerSearch.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawerSearch.test.tsx
@@ -1,0 +1,375 @@
+/* eslint-env jest */
+// Fuzzy title search inside the Journal drawer, plus its confirm-gated body
+// (message) search: a debounced DrawerSearch field renders a flat, ranked
+// list of matches while a query is active, offers a deep-search confirm row
+// whenever a query is active, and pressing that row pulls in every remaining
+// older page before re-matching against each entry's message too.
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import type { JournalListResponse, JournalMessage } from '@/api';
+
+const DEEP_SEARCH_LABEL = 'Search inside entries? This loads your older entries.';
+const DEBOUNCE_MS = 300;
+const PAGE_SIZE = 20;
+
+const mockList = jest.fn() as jest.MockedFunction<
+  (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+const { default: JournalDrawer, useJournalDrawerEntries } = require('../JournalDrawer');
+
+const DAY_MS = 86_400_000;
+const ago = (days: number): string => new Date(Date.now() - days * DAY_MS).toISOString();
+
+function entry(id: number, overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id,
+    message: `Body of entry ${id}.`,
+    sender: 'user',
+    timestamp: ago(1),
+    tag: 'reflection' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: `Entry ${id}`,
+    status: 'finished',
+    updated_at: ago(1),
+    ...overrides,
+  };
+}
+
+function page(items: JournalMessage[], hasMore = false): JournalListResponse {
+  return { items, total: items.length, has_more: hasMore };
+}
+
+type GetByTestId = ReturnType<typeof render>['getByTestId'];
+
+/** Type a query into the drawer search field and flush its 300ms debounce. */
+async function typeQuery(getByTestId: GetByTestId, query: string): Promise<void> {
+  await act(async () => {
+    fireEvent.changeText(getByTestId('drawer-search-input'), query);
+    await jest.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+interface DrawerHarnessProps {
+  items: JournalMessage[];
+  hasMore: boolean;
+  onConfirmBodySearch?: () => void;
+}
+
+function renderDrawer(props: Partial<DrawerHarnessProps> = {}) {
+  const onConfirmBodySearch = props.onConfirmBodySearch ?? jest.fn();
+  const result = render(
+    <JournalDrawer
+      items={props.items ?? []}
+      now={Date.now()}
+      loading={false}
+      error={false}
+      hasMore={props.hasMore ?? false}
+      onRowPress={jest.fn()}
+      onNewEntry={jest.fn()}
+      onLoadMore={jest.fn()}
+      onRetry={jest.fn()}
+      onConfirmBodySearch={onConfirmBodySearch}
+    />,
+  );
+  return { ...result, onConfirmBodySearch };
+}
+
+describe('JournalDrawer search field placement and identity', () => {
+  it('renders the search field below New entry and above the entry rows', () => {
+    const items = [entry(1)];
+    const { getAllByTestId } = renderDrawer({ items });
+    const ids = getAllByTestId(
+      /^(journal-drawer-new-entry|journal-drawer-search|journal-drawer-entry-\d+)$/,
+    ).map((n) => n.props.testID as string);
+    expect(ids[0]).toBe('journal-drawer-new-entry');
+    expect(ids[1]).toBe('journal-drawer-search');
+  });
+
+  it('uses the journal-specific placeholder and accessibility label', () => {
+    const { getByTestId } = renderDrawer({ items: [] });
+    const input = getByTestId('drawer-search-input');
+    expect(input.props.placeholder).toBe('Search entries...');
+    expect(input.props.accessibilityLabel).toBe('Search entries');
+  });
+});
+
+describe('JournalDrawer fuzzy title search', () => {
+  it('matches a title with a typo and hides the recency headings while the query is active', async () => {
+    const items = [entry(1, { title: 'Gratitude' }), entry(2, { title: 'Morning pages' })];
+    const { getByTestId, queryByTestId, queryByText } = renderDrawer({ items });
+
+    await typeQuery(getByTestId, 'gratitde');
+
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+    expect(queryByTestId('journal-drawer-entry-2')).toBeNull();
+    expect(queryByText('This week')).toBeNull();
+  });
+
+  it('shows the singular result caption for exactly one title match', async () => {
+    const items = [entry(1, { title: 'Gratitude' }), entry(2, { title: 'Morning pages' })];
+    const { getByTestId } = renderDrawer({ items });
+
+    await typeQuery(getByTestId, 'gratitde');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('1 result');
+  });
+
+  it('shows the plural result caption for multiple title matches', async () => {
+    const items = [entry(1, { title: 'Morning ritual' }), entry(2, { title: 'Morning pages' })];
+    const { getByTestId } = renderDrawer({ items });
+
+    await typeQuery(getByTestId, 'morning');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('2 results');
+  });
+
+  it('shows "No results" when nothing matches by title or body', async () => {
+    const items = [entry(1, { title: 'Gratitude', message: 'A quiet morning.' })];
+    const { getByTestId } = renderDrawer({ items });
+
+    await typeQuery(getByTestId, 'xylophone');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('No results');
+  });
+
+  it('matches a null-titled entry by the word "untitled"', async () => {
+    const items = [entry(1, { title: null })];
+    const { getByTestId } = renderDrawer({ items });
+
+    await typeQuery(getByTestId, 'untitled');
+
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+  });
+
+  it('hides the load-more row while a query is active even when hasMore is true', async () => {
+    const items = [entry(1, { title: 'Gratitude' })];
+    const { getByTestId, queryByTestId } = renderDrawer({ items, hasMore: true });
+    expect(getByTestId('journal-drawer-load-more')).toBeTruthy();
+
+    await typeQuery(getByTestId, 'gratitude');
+
+    expect(queryByTestId('journal-drawer-load-more')).toBeNull();
+  });
+
+  it('restores grouped recency sections, the load-more row, and hides the caption once the query is cleared', async () => {
+    const items = [entry(1, { title: 'Gratitude', timestamp: ago(1) })];
+    const { getByTestId, queryByTestId, getByText } = renderDrawer({ items, hasMore: true });
+
+    await typeQuery(getByTestId, 'gratitude');
+    expect(queryByTestId('journal-drawer-load-more')).toBeNull();
+
+    await typeQuery(getByTestId, '');
+
+    expect(getByText('This week')).toBeTruthy();
+    expect(getByTestId('journal-drawer-load-more')).toBeTruthy();
+    expect(queryByTestId('drawer-search-result-count')).toBeNull();
+  });
+});
+
+describe('JournalDrawer confirm-gated body search', () => {
+  function bodyOnlyItems(): JournalMessage[] {
+    return [
+      entry(1, { title: 'Gratitude', message: 'Nothing about the secret word here.' }),
+      entry(2, { title: 'Morning pages', message: 'The lighthouse kept the ships safe.' }),
+    ];
+  }
+
+  it('leaves a body-only match absent from title-only results', async () => {
+    const { getByTestId, queryByTestId } = renderDrawer({ items: bodyOnlyItems() });
+
+    await typeQuery(getByTestId, 'lighthouse');
+
+    expect(queryByTestId('journal-drawer-entry-2')).toBeNull();
+  });
+
+  it('offers the deep-search confirm row with the exact copy once a query is active', async () => {
+    const { getByTestId, getByText } = renderDrawer({ items: bodyOnlyItems() });
+
+    await typeQuery(getByTestId, 'lighthouse');
+
+    expect(getByTestId('drawer-search-deep-search')).toBeTruthy();
+    expect(getByText(DEEP_SEARCH_LABEL)).toBeTruthy();
+  });
+
+  it('fires onConfirmBodySearch exactly once, reveals the body match, and removes the confirm row', async () => {
+    const { getByTestId, queryByTestId, onConfirmBodySearch } = renderDrawer({
+      items: bodyOnlyItems(),
+    });
+
+    await typeQuery(getByTestId, 'lighthouse');
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(onConfirmBodySearch).toHaveBeenCalledTimes(1);
+    expect(getByTestId('journal-drawer-entry-2')).toBeTruthy();
+    expect(queryByTestId('drawer-search-deep-search')).toBeNull();
+  });
+
+  it('resets body search on a cleared query, so a new query is title-only until re-confirmed', async () => {
+    const { getByTestId, queryByTestId } = renderDrawer({ items: bodyOnlyItems() });
+
+    await typeQuery(getByTestId, 'lighthouse');
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+    expect(getByTestId('journal-drawer-entry-2')).toBeTruthy();
+
+    await typeQuery(getByTestId, '');
+    await typeQuery(getByTestId, 'lighthouse');
+
+    expect(queryByTestId('journal-drawer-entry-2')).toBeNull();
+    expect(getByTestId('drawer-search-deep-search')).toBeTruthy();
+  });
+});
+
+// Wiring: the hook drives the confirm-gated fetch of every remaining older
+// page, mounted the same way the presentational-harness tests above mount it
+// (isOpen gates the panel), so the cache/offset semantics are exercised
+// end-to-end without navigation.
+function Harness(): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const { items, loading, error, hasMore, loadMore, retry, confirmBodySearch } =
+    useJournalDrawerEntries(isOpen);
+  return (
+    <View>
+      <TouchableOpacity testID="harness-open" onPress={() => setIsOpen(true)} />
+      {isOpen ? (
+        <JournalDrawer
+          items={items}
+          now={Date.now()}
+          loading={loading}
+          error={error}
+          hasMore={hasMore}
+          onRowPress={() => undefined}
+          onNewEntry={() => undefined}
+          onLoadMore={loadMore}
+          onRetry={retry}
+          onConfirmBodySearch={confirmBodySearch}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+async function openHarness(getByTestId: GetByTestId): Promise<void> {
+  await act(async () => {
+    fireEvent.press(getByTestId('harness-open'));
+    await jest.advanceTimersByTimeAsync(0);
+  });
+}
+
+describe('useJournalDrawerEntries confirm-gated body search (wiring)', () => {
+  beforeEach(() => {
+    mockList.mockReset();
+  });
+
+  it('fetches no page while the user is only typing a title query', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValue(page(firstPage, true));
+    const { getByTestId } = render(<Harness />);
+
+    await openHarness(getByTestId);
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    await typeQuery(getByTestId, 'entry');
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches every remaining page from offset 20 onward when confirmed, then reveals the body match', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    const secondPage = [entry(21, { title: 'Second page' })];
+    const thirdPage = [
+      entry(22, { title: 'Third page', message: 'A hidden lighthouse keeps watch.' }),
+    ];
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockResolvedValueOnce(page(secondPage, true));
+    mockList.mockResolvedValueOnce(page(thirdPage, false));
+
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    const offsets = mockList.mock.calls.map((call) => (call[0] as { offset: number }).offset);
+    expect(offsets).toEqual([0, PAGE_SIZE, PAGE_SIZE + 1]);
+    expect(getByTestId('journal-drawer-entry-22')).toBeTruthy();
+  });
+
+  it('makes no further network call when confirmed with no remaining pages, but still enables body matching', async () => {
+    const items = [entry(1, { title: 'Gratitude', message: 'A hidden lighthouse keeps watch.' })];
+    mockList.mockResolvedValueOnce(page(items, false));
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    expect(mockList).toHaveBeenCalledTimes(1);
+
+    await typeQuery(getByTestId, 'lighthouse');
+    expect(queryByTestId('journal-drawer-entry-1')).toBeNull();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockList).toHaveBeenCalledTimes(1);
+    expect(getByTestId('journal-drawer-entry-1')).toBeTruthy();
+  });
+
+  it('surfaces the error state when a confirmed page sweep fails mid-way', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockRejectedValueOnce(new Error('network down'));
+
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    await typeQuery(getByTestId, '');
+    expect(getByTestId('journal-drawer-error')).toBeTruthy();
+  });
+
+  it('stops the sweep when a page comes back empty despite reporting more', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockResolvedValueOnce(page([], true));
+
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    // The empty page halts the loop rather than looping forever on has_more.
+    expect(mockList).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalDrawerSearch.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawerSearch.test.tsx
@@ -355,6 +355,85 @@ describe('useJournalDrawerEntries confirm-gated body search (wiring)', () => {
     expect(getByTestId('journal-drawer-error')).toBeTruthy();
   });
 
+  it('shows the inline searching indicator while a confirmed sweep is still in flight', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    let resolveSecond: (_value: JournalListResponse) => void = () => undefined;
+    const secondPending = new Promise<JournalListResponse>((resolve) => {
+      resolveSecond = resolve;
+    });
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockReturnValueOnce(secondPending);
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    // The second page has not settled: the deep-search sweep is still running,
+    // so its in-flight caption is visible without leaving the results view.
+    expect(getByTestId('journal-drawer-search-loading')).toBeTruthy();
+
+    // Let the sweep settle so no promise is left dangling; the caption clears.
+    await act(async () => {
+      resolveSecond(page([entry(21)], false));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(queryByTestId('journal-drawer-search-loading')).toBeNull();
+  });
+
+  it('surfaces the sweep failure inline while the query is still active', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockRejectedValueOnce(new Error('network down'));
+
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    // No need to clear the query: the failure is surfaced inline beneath the
+    // field, with a retry affordance, while the query is still active.
+    expect(getByTestId('journal-drawer-search-error')).toBeTruthy();
+    expect(getByTestId('journal-drawer-search-retry')).toBeTruthy();
+  });
+
+  it('resumes the sweep from the inline retry row after a failure', async () => {
+    const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
+    const recovered = entry(21, {
+      title: 'Recovered',
+      message: 'A hidden lighthouse keeps watch.',
+    });
+    mockList.mockResolvedValueOnce(page(firstPage, true));
+    mockList.mockRejectedValueOnce(new Error('network down'));
+    mockList.mockResolvedValueOnce(page([recovered], false));
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(getByTestId('journal-drawer-search-error')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-drawer-search-retry'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(queryByTestId('journal-drawer-search-error')).toBeNull();
+    expect(getByTestId('journal-drawer-entry-21')).toBeTruthy();
+  });
+
   it('stops the sweep when a page comes back empty despite reporting more', async () => {
     const firstPage = Array.from({ length: PAGE_SIZE }, (_, i) => entry(i + 1));
     mockList.mockResolvedValueOnce(page(firstPage, true));

--- a/frontend/src/features/Journal/usePagedJournal.ts
+++ b/frontend/src/features/Journal/usePagedJournal.ts
@@ -23,6 +23,17 @@ export interface PagedJournal {
   error: string | null;
   /** Fetch ``offset``'s page: offset 0 replaces the list, otherwise appends. */
   load: (_search: string | undefined, _offset: number) => Promise<void>;
+  /**
+   * Fetch and append every remaining page in sequence, starting at
+   * ``startOffset``. Each page's items extend the list; ``offset`` advances by
+   * the number of items that page returned (tracked in a local, since React
+   * state is stale within the loop) and the loop stops the moment a page reports
+   * ``has_more: false`` or returns zero items (an infinite-loop guard).
+   *
+   * Shares ``load``'s stale-response guard: one request id covers the whole
+   * sweep, so a newer ``load`` or ``loadAll`` cancels every unsettled page here.
+   */
+  loadAll: (_startOffset: number) => Promise<void>;
 }
 
 /** Offset-paged fetch with a stale-response guard; the caller layers intent on top. */
@@ -55,5 +66,33 @@ export function usePagedJournal(): PagedJournal {
     }
   }, []);
 
-  return { items, total, hasMore, loading, error, load };
+  const loadAll = useCallback(async (startOffset: number) => {
+    // One request id for the whole sweep; drop it wholesale once superseded.
+    const requestId = (requestSeq.current += 1);
+    const isLatest = () => requestId === requestSeq.current;
+    setLoading(true);
+    setError(null);
+    try {
+      // Track offset/more locally: the setState calls below won't be visible to
+      // this closure until the next render, so reading them here would loop stale.
+      let offset = startOffset;
+      let more = true;
+      while (more) {
+        const page = await journal.list({ limit: PAGE_SIZE, offset });
+        if (!isLatest()) return;
+        setItems((prev) => [...prev, ...page.items]);
+        setTotal(page.total);
+        setHasMore(page.has_more);
+        offset += page.items.length;
+        // Stop on the last page or a zero-length page so we never spin forever.
+        more = page.has_more && page.items.length > 0;
+      }
+    } catch (err) {
+      if (isLatest()) setError(formatApiError(err));
+    } finally {
+      if (isLatest()) setLoading(false);
+    }
+  }, []);
+
+  return { items, total, hasMore, loading, error, load, loadAll };
 }


### PR DESCRIPTION
## Summary

Mounts the shared `DrawerSearch` (from the `epic:drawer-search` foundation) into the Journal header drawer, between the New-entry row and the recency list.

- **Live fuzzy title search.** Typing filters the drawer's cached entries by title via `rankMatches`, rendering a flat ranked list (no recency headings) while a query is active. `Untitled` entries match the literal "untitled". The result-count caption reflects matches.
- **Confirm-gated body search.** A "Search inside entries? This loads your older entries." row appears while a query is active; tapping it widens matching to entry bodies (`message`) and, because that can need the full corpus, triggers a new `usePagedJournal.loadAll` sweep of every remaining older page. No network fan-out fires from typing alone — only the confirm tap.
- **Clearing restores state.** An empty query drops back to the grouped recency view and the load-more row unchanged, and resets body-search so a fresh query is title-only until re-confirmed.
- **Both hosts.** The shelf and `JournalEntry` screens share `JournalScreenDrawer`, so both get the feature.

`loadAll` tracks offset/`has_more` in loop-locals (avoiding stale React state), reuses the existing `requestSeq` stale-response guard for the whole sweep, and halts on an empty page.

## Test plan

- New suite `JournalDrawerSearch.test.tsx` (18 tests): field placement/identity; fuzzy title match incl. typo tolerance; singular/plural/"No results" captions; null-title "untitled" match; load-more hidden while searching; clear restores sections + load-more; body-only match absent pre-confirm; deep-search row copy; confirm fires once + reveals body match + hides the row; body-search reset on clear; wiring — no fetch on typing, offset-20-onward sweep on confirm, no fetch when `hasMore` is false, error state on a failed sweep, and the empty-page halt guard.
- `scripts/frontend/check-all.sh`: ESLint, Prettier, and `tsc --noEmit` clean; scoped Journal suites (drawer + both hosts) pass. The full local jest run hit ENOSPC transform-cache errors from a disk-constrained machine (0 real assertion failures — 3384 passed); CI is authoritative for the full suite + coverage.

Closes #1773
Refs #1771