### PR TITLE
docs(ralph): thread graph-first orientation into fleet operating documents

### DIFF
--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -43,6 +43,14 @@ you read, reason, and dispatch.
    `Explore` sub-agent can widen the fan-out — but if it is not, fall back to
    Read/Grep/Glob directly; never stall the plan on a sub-agent. Prefer extending
    what exists over inventing new structure.
+
+   **Graph first, grep second:** when `graphify-out/graph.json` exists, start
+   with `graphify query "<question>"` on the issue's key nouns and
+   `graphify path "A" "B"` to map the blast radius between the modules the
+   plan will touch; quote each cited node's `source_location`. Fail-soft: a
+   fresh worktree has no graph (`graphify-out/` is git-ignored) — restore via
+   the session hook, build with `./scripts/graph/build.sh` (~2 min, $0), or
+   fall back to Read/Grep/Glob exactly as today. Never stall the plan on it.
 3. **Decide the design.** The smallest coherent change that satisfies the issue
    at threshold quality. Name the interfaces/signatures/models that change.
 4. **Flag the risks** — which of these the issue genuinely touches:

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -48,9 +48,12 @@ you read, reason, and dispatch.
    with `graphify query "<question>"` on the issue's key nouns and
    `graphify path "A" "B"` to map the blast radius between the modules the
    plan will touch; quote each cited node's `source_location`. Fail-soft: a
-   fresh worktree has no graph (`graphify-out/` is git-ignored) — restore via
-   the session hook, build with `./scripts/graph/build.sh` (~2 min, $0), or
-   fall back to Read/Grep/Glob exactly as today. Never stall the plan on it.
+   fresh worktree has no graph (`graphify-out/` is git-ignored) — restore by
+   downloading the rolling `knowledge-graph` release (`gh release download
+   knowledge-graph --pattern graph.json --dir graphify-out`, see
+   `scripts/graph/README.md`), build with `./scripts/graph/build.sh` (~2 min,
+   $0), or fall back to Read/Grep/Glob exactly as today. Never stall the plan
+   on it.
 3. **Decide the design.** The smallest coherent change that satisfies the issue
    at threshold quality. Name the interfaces/signatures/models that change.
 4. **Flag the risks** — which of these the issue genuinely touches:

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -49,6 +49,14 @@ Route only the dimensions the diff actually touches — no redundant reviews.
    `comprehensive-pr-review` skill via the Skill tool before reviewing.
 1. Read the diff (`git diff` against the merge base) and the architect's risk
    flags.
+
+   **Blast radius via graph:** for each symbol X the diff touches, run
+   `graphify affected "X"` to surface dependents the diff did *not* change —
+   un-reviewed callers are where regressions hide; quote `source_location`
+   when citing one in a finding. Fail-soft: a fresh worktree has no graph
+   (`graphify-out/` is git-ignored) — restore via the session hook, build
+   with `./scripts/graph/build.sh` (~2 min, $0), or review without it
+   exactly as today. Never stall the review on graph absence.
 2. **Primary path — review the applicable dimensions yourself** against each
    specialist's checklist (above) and the shared constraints. You run on Opus
    precisely so a single agent can carry every dimension. **Enhancement:** where

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -54,7 +54,9 @@ Route only the dimensions the diff actually touches — no redundant reviews.
    `graphify affected "X"` to surface dependents the diff did *not* change —
    un-reviewed callers are where regressions hide; quote `source_location`
    when citing one in a finding. Fail-soft: a fresh worktree has no graph
-   (`graphify-out/` is git-ignored) — restore via the session hook, build
+   (`graphify-out/` is git-ignored) — restore by downloading the rolling
+   `knowledge-graph` release (`gh release download knowledge-graph --pattern
+   graph.json --dir graphify-out`, see `scripts/graph/README.md`), build
    with `./scripts/graph/build.sh` (~2 min, $0), or review without it
    exactly as today. Never stall the review on graph absence.
 2. **Primary path — review the applicable dimensions yourself** against each

--- a/.claude/agents/shared/adepthood-constraints.md
+++ b/.claude/agents/shared/adepthood-constraints.md
@@ -24,6 +24,17 @@ target); the development philosophy in `AGENTS.md`. Build accordingly.
   `backend/conftest.py`). Lives in `backend/`.
 - Layout, commands, and patterns are authoritative in `CLAUDE.md` (repo root).
 
+## Graph first, grep second
+
+When `graphify-out/graph.json` exists, orient with the code graph before
+sweeping files: `graphify query "<question>"` for questions,
+`graphify path "A" "B"` for relationships, `graphify explain "X"` for
+concepts, `graphify affected "X"` for change impact — quoting each cited
+node's `source_location`. Fail-soft: fresh worktrees have no graph
+(`graphify-out/` is git-ignored); restore via the session hook, build with
+`./scripts/graph/build.sh` (~2 min, $0), or proceed with Read/Grep/Glob
+exactly as today. **Never stall on graph absence.**
+
 ## The four gates (the whole game)
 
 | Gate | Check | On pass | On fail |

--- a/.claude/agents/shared/adepthood-constraints.md
+++ b/.claude/agents/shared/adepthood-constraints.md
@@ -31,7 +31,9 @@ sweeping files: `graphify query "<question>"` for questions,
 `graphify path "A" "B"` for relationships, `graphify explain "X"` for
 concepts, `graphify affected "X"` for change impact — quoting each cited
 node's `source_location`. Fail-soft: fresh worktrees have no graph
-(`graphify-out/` is git-ignored); restore via the session hook, build with
+(`graphify-out/` is git-ignored); restore by downloading the rolling
+`knowledge-graph` release (`gh release download knowledge-graph --pattern
+graph.json --dir graphify-out`, see `scripts/graph/README.md`), build with
 `./scripts/graph/build.sh` (~2 min, $0), or proceed with Read/Grep/Glob
 exactly as today. **Never stall on graph absence.**
 

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -41,7 +41,9 @@ its key nouns with `graphify query "<question>"`; before modifying any symbol
 X, run `graphify affected "X"` to see what depends on it; and after the
 implementation lands, run `./scripts/graph/update.sh` (AST-only, no cost) so
 the worktree's graph stays honest. A fresh worktree has no graph
-(`graphify-out/` is git-ignored): restore it via the session hook, build with
+(`graphify-out/` is git-ignored): restore it by downloading the rolling
+`knowledge-graph` release (`gh release download knowledge-graph --pattern
+graph.json --dir graphify-out`, see `scripts/graph/README.md`), build with
 `./scripts/graph/build.sh` (~2 min, $0), or proceed without it exactly as
 today — **never stall on graph absence.**
 

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -35,6 +35,16 @@ drives Gates 3–4. The taxonomy you dispatch is mapped in
 `.claude/agents/README.md`.
 
 ## Steps
+
+**Step 0.5 — Orient via graph (fail-soft).** Once you know your issue, query
+its key nouns with `graphify query "<question>"`; before modifying any symbol
+X, run `graphify affected "X"` to see what depends on it; and after the
+implementation lands, run `./scripts/graph/update.sh` (AST-only, no cost) so
+the worktree's graph stays honest. A fresh worktree has no graph
+(`graphify-out/` is git-ignored): restore it via the session hook, build with
+`./scripts/graph/build.sh` (~2 min, $0), or proceed without it exactly as
+today — **never stall on graph absence.**
+
 1. **Read your assignment.** `gh issue view "$RALPH_ISSUE" --comments`.
 2. **Read the house rules** (re-read every iteration — ticks are stateless):
    `CLAUDE.md` (repo root, project config + guardrails) and `AGENTS.md`


### PR DESCRIPTION
## Summary

- Wire the merged graphify knowledge-graph vocabulary into the fleet's four operating contracts so every role consults the graph at its most valuable moment — architects at planning, workers at orientation, reviewers at impact analysis.
- Four surgical, additions-only insertions (≤10 lines each): `scripts/ralph/PROMPT.md` (Step 0.5 — orient via `graphify query`/`affected`, refresh with `./scripts/graph/update.sh`), `.claude/agents/chief-architect.md` (map blast radius via `graphify query`/`path`), `.claude/agents/shared/adepthood-constraints.md` (one inherited "graph first, grep second" rule), `.claude/agents/code-review-orchestrator.md` (`graphify affected` on touched symbols to surface un-reviewed dependents).
- Every insertion carries the identical fail-soft triad — restore via session hook, build with `./scripts/graph/build.sh` (~2 min, $0), or proceed without the graph exactly as today — so a fresh (graphless) worktree never stalls, since `graphify-out/` is git-ignored.

## Test plan

- Markdown/config-only change (no executable surface). Verification = `pre-commit run --files` on the four touched files: all applicable hooks (hygiene, detect-secrets, commitlint) pass; code/frontend hooks skip (no matching files).
- Self-diff review: additions only (`git diff --stat` = 4 files, +37, -0), no other files touched, ordered-list numbering preserved in the three list-adjacent insertions, command vocabulary matches CLAUDE.md's "Knowledge Graph (graphify)" section verbatim, no playbook HTML-comment markers disturbed.
- Gate 2.5 (code-review-orchestrator, documentation dimension): Verdict CLEAN — no blocking findings.

Closes #1807
Refs #1800
