### PR TITLE
feat(course): drawer search over chapter titles with confirm-gated body search

### DIFF
--- a/frontend/src/features/Course/CourseDrawer.tsx
+++ b/frontend/src/features/Course/CourseDrawer.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react-native';
 
 import { course as courseApi, type ContentItem, type Stage } from '../../api';
+import { DrawerItem, DrawerSearch, fuzzyMatch } from '../../components/drawer';
 import { SPACING, accent, ink, radius, surface, touchTarget, type } from '../../design/tokens';
 
 import {
@@ -37,6 +38,20 @@ const RETRY_LABEL = 'Content failed to load. Tap to retry.';
 const LOCKED_ROW_OPACITY = 0.5;
 /** Side of the square stage-color swatch in dp. */
 const SWATCH_SIZE = 14;
+/** Placeholder for the drawer's fuzzy chapter-title search field. */
+const SEARCH_PLACEHOLDER = 'Search chapters...';
+/** Accessibility label for that search field. */
+const SEARCH_ACCESSIBILITY_LABEL = 'Search chapters';
+/** Test hook for the drawer's search-field wrapper. */
+const SEARCH_TESTID = 'course-drawer-search';
+/** Confirm-row copy that invites widening the search into chapter bodies. */
+const DEEP_SEARCH_LABEL = 'Search inside chapters? This downloads chapter text.';
+/** Quiet caption shown while the confirm-triggered body sweep is running. */
+const SEARCH_LOADING_LABEL = 'Searching inside chapters...';
+/** Quiet caption shown when the body sweep failed, above its retry row. */
+const SEARCH_ERROR_LABEL = 'We could not finish searching the chapters.';
+/** Retry affordance shown alongside the sweep-error caption. */
+const SEARCH_RETRY_LABEL = 'Tap to retry';
 
 /** Load state for one stage's chapter list within the drawer. */
 type DrawerSection =
@@ -46,6 +61,9 @@ type DrawerSection =
 
 /** Per-stage-number load state, keyed by stage number. */
 export type DrawerSections = Readonly<Record<number, DrawerSection | undefined>>;
+
+/** Progress of the confirm-gated chapter-body sweep for deep search. */
+export type BodySweepStatus = 'idle' | 'loading' | 'error';
 
 /**
  * Lazily load every stage's chapters while the drawer is open, caching the
@@ -112,6 +130,104 @@ export function useCourseDrawerContent(
   }, [isOpen, stages, sections, loadStage]);
 
   return { sections, retry: loadStage };
+}
+
+/** Stage numbers present in the section map, ascending. */
+function sortedSectionStageNumbers(sections: DrawerSections): number[] {
+  return Object.keys(sections)
+    .map(Number)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * The unlocked, loaded, not-yet-cached chapter ids to fetch, in stage-then-list
+ * order. Locked chapters never expose a body and already-cached ones are
+ * skipped, so a repeat confirm retries only the ids still missing.
+ */
+function collectBodyTargets(
+  sections: DrawerSections,
+  bodies: Readonly<Record<number, string>>,
+): number[] {
+  const targets: number[] = [];
+  for (const stageNumber of sortedSectionStageNumbers(sections)) {
+    const section = sections[stageNumber];
+    if (section?.status !== 'loaded') continue;
+    for (const item of section.items) {
+      if (!item.is_locked && bodies[item.id] === undefined) targets.push(item.id);
+    }
+  }
+  return targets;
+}
+
+/**
+ * Fetch each target body in sequence, caching successes as they arrive and
+ * counting them. One fetch's rejection degrades that row silently; the caller
+ * decides whether an all-failed sweep is a systemic error. The mount guard drops
+ * a late resolution after the drawer host unmounts.
+ */
+async function sweepChapterBodies(
+  targets: readonly number[],
+  setBodies: React.Dispatch<React.SetStateAction<Record<number, string>>>,
+  isMounted: () => boolean,
+): Promise<number> {
+  let succeeded = 0;
+  for (const contentId of targets) {
+    try {
+      const body = await courseApi.contentBody(contentId);
+      if (isMounted()) setBodies((prev) => ({ ...prev, [contentId]: body.body_markdown }));
+      succeeded += 1;
+    } catch {
+      // A single chapter's failure (drip-locked or 404-masked body) is dropped
+      // silently; only an all-failed sweep surfaces below as an error status.
+    }
+  }
+  return succeeded;
+}
+
+/**
+ * Confirm-gated chapter-body cache backing the drawer's deep search. Titles
+ * search with no fetch; only an explicit confirm sweeps every unlocked, loaded,
+ * uncached chapter's body into ``bodies`` so it becomes matchable.
+ *
+ * Mounted above the drawer panel (which unmounts on close) so the cache survives
+ * close/reopen. ``confirmBodySearch`` recomputes its targets at call time and is
+ * a no-op while a sweep is already in flight or when nothing remains to fetch;
+ * re-invoking it after a failure naturally retries only the still-missing ids.
+ */
+export function useCourseDrawerBodies(sections: DrawerSections): {
+  bodies: Record<number, string>;
+  status: BodySweepStatus;
+  confirmBodySearch: () => void;
+} {
+  const [bodies, setBodies] = useState<Record<number, string>>({});
+  const [status, setStatus] = useState<BodySweepStatus>('idle');
+  const mountedRef = useRef(true);
+  const sweepingRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const confirmBodySearch = useCallback(() => {
+    if (sweepingRef.current) return;
+    const targets = collectBodyTargets(sections, bodies);
+    if (targets.length === 0) {
+      setStatus('idle');
+      return;
+    }
+    sweepingRef.current = true;
+    setStatus('loading');
+    const isMounted = (): boolean => mountedRef.current;
+    void sweepChapterBodies(targets, setBodies, isMounted).then((succeeded) => {
+      sweepingRef.current = false;
+      if (isMounted()) setStatus(succeeded === 0 ? 'error' : 'idle');
+    });
+  }, [sections, bodies]);
+
+  return { bodies, status, confirmBodySearch };
 }
 
 interface StageHeaderProps {
@@ -292,31 +408,187 @@ const StageSection = ({
   );
 };
 
-export interface CourseDrawerProps {
-  /** Every stage in the course; only present stages render (gap numbers are skipped). */
-  stages: Stage[];
-  /** The stage currently shown on the screen, marked selected in the list. */
+/** The text a chapter is matched against: its title, plus its body only once a
+ *  body search is active for an unlocked chapter whose body is cached. */
+function chapterSearchText(
+  item: ContentItem,
+  bodies: Readonly<Record<number, string>>,
+  bodySearchActive: boolean,
+): string {
+  const body = bodies[item.id];
+  if (bodySearchActive && !item.is_locked && body) return `${item.title} ${body}`;
+  return item.title;
+}
+
+/** A loaded stage narrowed to the chapters that match the active query. */
+interface MatchedStage {
+  stageNumber: number;
+  items: ContentItem[];
+}
+
+/** Loaded stages (ascending) filtered to their query-matching chapters; stages
+ *  with no match are dropped so only relevant sections render. */
+function matchStages(
+  query: string,
+  sections: DrawerSections,
+  bodies: Readonly<Record<number, string>>,
+  bodySearchActive: boolean,
+): MatchedStage[] {
+  const matched: MatchedStage[] = [];
+  for (const stageNumber of sortedSectionStageNumbers(sections)) {
+    const section = sections[stageNumber];
+    if (section?.status !== 'loaded') continue;
+    const items = section.items.filter((item) =>
+      fuzzyMatch(query, chapterSearchText(item, bodies, bodySearchActive)),
+    );
+    if (items.length > 0) matched.push({ stageNumber, items });
+  }
+  return matched;
+}
+
+/** Total chapters matched across every kept stage — feeds the result caption. */
+function countMatches(matched: readonly MatchedStage[]): number {
+  return matched.reduce((sum, stage) => sum + stage.items.length, 0);
+}
+
+interface SearchSweepStatusProps {
+  /** True once the deep body search is confirmed; gates the sweep's status. */
+  active: boolean;
+  /** Current progress of the confirm-triggered body sweep. */
+  status: BodySweepStatus;
+  /** Re-run the sweep after a failure. */
+  onRetry: () => void;
+}
+
+/**
+ * A quiet inline status row shown beneath the search field while deep body
+ * search is active: a "searching..." caption during the sweep, or a failure
+ * caption plus a retry row if it rejected. It keeps the sweep's in-flight and
+ * error states visible without leaving the results view.
+ */
+function SearchSweepStatus({
+  active,
+  status,
+  onRetry,
+}: SearchSweepStatusProps): React.JSX.Element | null {
+  const { width } = useWindowDimensions();
+  if (!active) return null;
+  if (status === 'loading') {
+    return (
+      <View testID="course-drawer-search-loading" style={styles.searchStatusRow}>
+        <ActivityIndicator size="small" color={accent.primary} />
+        <Text style={[type(width).caption, styles.searchStatusText]}>{SEARCH_LOADING_LABEL}</Text>
+      </View>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <View testID="course-drawer-search-error" style={styles.searchStatusBlock}>
+        <Text style={[type(width).caption, styles.searchStatusText]}>{SEARCH_ERROR_LABEL}</Text>
+        <DrawerItem
+          testID="course-drawer-search-retry"
+          label={SEARCH_RETRY_LABEL}
+          onPress={onRetry}
+        />
+      </View>
+    );
+  }
+  return null;
+}
+
+interface DrawerSearchFieldProps {
+  /** Match count for the active query, or undefined to hide the caption. */
+  resultCount?: number;
+  /** True once the deep body search is confirmed; hides the confirm row. */
+  bodySearchActive: boolean;
+  /** Receives the debounced query (or '' on clear). */
+  onQueryChange: (_query: string) => void;
+  /** Confirm widening the search into chapter bodies. */
+  onConfirmDeepSearch: () => void;
+}
+
+/**
+ * The drawer's search field. The deep-search confirm row is offered only until
+ * body search is active; because ``DrawerSearchProps`` is an exclusive union, we
+ * branch the element rather than widen the props to keep the deep pair paired.
+ */
+function DrawerSearchField({
+  resultCount,
+  bodySearchActive,
+  onQueryChange,
+  onConfirmDeepSearch,
+}: DrawerSearchFieldProps): React.JSX.Element {
+  const shared = {
+    testID: SEARCH_TESTID,
+    placeholder: SEARCH_PLACEHOLDER,
+    accessibilityLabel: SEARCH_ACCESSIBILITY_LABEL,
+    resultCount,
+    onQueryChange,
+  };
+  if (bodySearchActive) return <DrawerSearch {...shared} />;
+  return (
+    <DrawerSearch
+      {...shared}
+      onConfirmDeepSearch={onConfirmDeepSearch}
+      deepSearchLabel={DEEP_SEARCH_LABEL}
+    />
+  );
+}
+
+interface CourseDrawerSearchState {
+  query: string;
+  bodySearchActive: boolean;
+  isSearching: boolean;
+  handleQueryChange: (_next: string) => void;
+  handleConfirmDeepSearch: () => void;
+}
+
+/**
+ * Own the drawer's search query and body-search gate. Clearing the query drops
+ * back to title-only matching until body search is re-confirmed; confirming
+ * flips the gate and asks the host to sweep the chapter bodies.
+ */
+function useCourseDrawerSearch(onConfirmBodySearch: () => void): CourseDrawerSearchState {
+  const [query, setQuery] = useState('');
+  const [bodySearchActive, setBodySearchActive] = useState(false);
+
+  const handleQueryChange = useCallback((next: string) => {
+    setQuery(next);
+    if (next.length === 0) setBodySearchActive(false);
+  }, []);
+
+  const handleConfirmDeepSearch = useCallback(() => {
+    setBodySearchActive(true);
+    onConfirmBodySearch();
+  }, [onConfirmBodySearch]);
+
+  const isSearching = query.length > 0;
+  return { query, bodySearchActive, isSearching, handleQueryChange, handleConfirmDeepSearch };
+}
+
+interface StageListProps {
+  stageById: Map<number, Stage>;
   selectedStage: number;
-  /** Per-stage chapter load state, owned by :func:`useCourseDrawerContent`. */
-  sections: DrawerSections;
-  /** Select a stage, open the chapter, and close the drawer. */
   onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
-  /** Refetch a single failed stage's chapters. */
   onRetry: (_stageNumber: number) => void;
 }
 
-/** The stage-grouped table of contents for the Course header drawer. */
-export default function CourseDrawer({
-  stages,
-  selectedStage,
+interface FullStageListProps extends StageListProps {
+  stageNumbers: number[];
+  sections: DrawerSections;
+}
+
+/** The unfiltered stage-grouped list shown when no query is active. */
+function FullStageList({
+  stageNumbers,
   sections,
+  stageById,
+  selectedStage,
   onChapterPress,
   onRetry,
-}: CourseDrawerProps): React.JSX.Element {
-  const stageById = useMemo(() => new Map(stages.map((s) => [s.stage_number, s])), [stages]);
-  const stageNumbers = useMemo(() => [...stageById.keys()].sort((a, b) => a - b), [stageById]);
+}: FullStageListProps): React.JSX.Element {
   return (
-    <View testID="course-drawer">
+    <View>
       {stageNumbers.map((stageNumber) => (
         <StageSection
           key={stageNumber}
@@ -332,7 +604,136 @@ export default function CourseDrawer({
   );
 }
 
+interface CourseSearchViewProps extends StageListProps {
+  matched: MatchedStage[];
+  bodySearchActive: boolean;
+  sweepStatus: BodySweepStatus;
+  onConfirmBodySearch: () => void;
+}
+
+/** The active-query view: the sweep-status row above the matched stage sections
+ *  (each reuses ``StageSection`` for free header/selected/locked styling). */
+function CourseSearchView({
+  matched,
+  stageById,
+  selectedStage,
+  bodySearchActive,
+  sweepStatus,
+  onChapterPress,
+  onRetry,
+  onConfirmBodySearch,
+}: CourseSearchViewProps): React.JSX.Element {
+  return (
+    <View>
+      <SearchSweepStatus
+        active={bodySearchActive}
+        status={sweepStatus}
+        onRetry={onConfirmBodySearch}
+      />
+      {matched.map(({ stageNumber, items }) => (
+        <StageSection
+          key={stageNumber}
+          stageNumber={stageNumber}
+          stageById={stageById}
+          section={{ status: 'loaded', items }}
+          isSelected={stageNumber === selectedStage}
+          onChapterPress={onChapterPress}
+          onRetry={onRetry}
+        />
+      ))}
+    </View>
+  );
+}
+
+export interface CourseDrawerProps {
+  /** Every stage in the course; only present stages render (gap numbers are skipped). */
+  stages: Stage[];
+  /** The stage currently shown on the screen, marked selected in the list. */
+  selectedStage: number;
+  /** Per-stage chapter load state, owned by :func:`useCourseDrawerContent`. */
+  sections: DrawerSections;
+  /** Cached chapter bodies (contentId to markdown), owned by :func:`useCourseDrawerBodies`. */
+  bodies: Readonly<Record<number, string>>;
+  /** Progress of the confirm-gated body sweep, owned by :func:`useCourseDrawerBodies`. */
+  sweepStatus: BodySweepStatus;
+  /** Select a stage, open the chapter, and close the drawer. */
+  onChapterPress: (_stageNumber: number, _item: ContentItem) => void;
+  /** Refetch a single failed stage's chapters. */
+  onRetry: (_stageNumber: number) => void;
+  /** Confirm the deep body search: the host sweeps every unlocked chapter body. */
+  onConfirmBodySearch: () => void;
+}
+
+/** The stage-grouped table of contents for the Course header drawer, with a
+ *  fuzzy chapter-title search and a confirm-gated body search on top. */
+export default function CourseDrawer({
+  stages,
+  selectedStage,
+  sections,
+  bodies,
+  sweepStatus,
+  onChapterPress,
+  onRetry,
+  onConfirmBodySearch,
+}: CourseDrawerProps): React.JSX.Element {
+  const stageById = useMemo(() => new Map(stages.map((s) => [s.stage_number, s])), [stages]);
+  const stageNumbers = useMemo(() => [...stageById.keys()].sort((a, b) => a - b), [stageById]);
+  const { query, bodySearchActive, isSearching, handleQueryChange, handleConfirmDeepSearch } =
+    useCourseDrawerSearch(onConfirmBodySearch);
+  const matched = useMemo(
+    () => matchStages(query, sections, bodies, bodySearchActive),
+    [query, sections, bodies, bodySearchActive],
+  );
+
+  return (
+    <View testID="course-drawer">
+      <DrawerSearchField
+        resultCount={isSearching ? countMatches(matched) : undefined}
+        bodySearchActive={bodySearchActive}
+        onQueryChange={handleQueryChange}
+        onConfirmDeepSearch={handleConfirmDeepSearch}
+      />
+      {isSearching ? (
+        <CourseSearchView
+          matched={matched}
+          stageById={stageById}
+          selectedStage={selectedStage}
+          bodySearchActive={bodySearchActive}
+          sweepStatus={sweepStatus}
+          onChapterPress={onChapterPress}
+          onRetry={onRetry}
+          onConfirmBodySearch={onConfirmBodySearch}
+        />
+      ) : (
+        <FullStageList
+          stageNumbers={stageNumbers}
+          sections={sections}
+          stageById={stageById}
+          selectedStage={selectedStage}
+          onChapterPress={onChapterPress}
+          onRetry={onRetry}
+        />
+      )}
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
+  searchStatusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  searchStatusBlock: {
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+    gap: SPACING.xs,
+  },
+  searchStatusText: {
+    color: ink.muted,
+  },
   section: {
     marginBottom: SPACING.sm,
   },

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -35,7 +35,7 @@ import ChapterReader from './ChapterReader';
 import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
-import CourseDrawer, { useCourseDrawerContent } from './CourseDrawer';
+import CourseDrawer, { useCourseDrawerBodies, useCourseDrawerContent } from './CourseDrawer';
 import RetryButton from './RetryButton';
 import SiteResourcesPanel from './SiteResourcesPanel';
 import StageIntroCard from './StageIntroCard';
@@ -501,6 +501,7 @@ const CourseScreenDrawer = ({
   onChapterPress,
 }: CourseScreenDrawerProps): React.JSX.Element => {
   const { sections, retry } = useCourseDrawerContent(stages, drawer.isOpen);
+  const { bodies, status, confirmBodySearch } = useCourseDrawerBodies(sections);
   return (
     <ScreenDrawer visible={drawer.isOpen} onClose={drawer.close} screenName="Course" title="Course">
       <DrawerNavSection currentScreen="Course" onNavigate={drawer.close} />
@@ -508,8 +509,11 @@ const CourseScreenDrawer = ({
         stages={stages}
         selectedStage={selectedStage}
         sections={sections}
+        bodies={bodies}
+        sweepStatus={status}
         onChapterPress={onChapterPress}
         onRetry={retry}
+        onConfirmBodySearch={confirmBodySearch}
       />
     </ScreenDrawer>
   );

--- a/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseDrawer.test.tsx
@@ -464,8 +464,11 @@ describe('Course header drawer', () => {
         stages={gappyStages}
         selectedStage={3}
         sections={{}}
+        bodies={{}}
+        sweepStatus="idle"
         onChapterPress={jest.fn()}
         onRetry={jest.fn()}
+        onConfirmBodySearch={jest.fn()}
       />,
     );
 

--- a/frontend/src/features/Course/__tests__/CourseDrawerSearch.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseDrawerSearch.test.tsx
@@ -1,0 +1,492 @@
+/* eslint-env jest */
+// Fuzzy chapter-title search inside the Course drawer, plus its confirm-gated
+// body (chapter text) search: a debounced DrawerSearch field filters each
+// loaded stage's chapters while a query is active, offers a deep-search
+// confirm row whenever a query is active, and pressing that row sweeps every
+// unlocked, loaded, uncached chapter's body text into the match.
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React, { useState } from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+import type { ContentBody, ContentItem, Stage } from '../../../api';
+
+const DEEP_SEARCH_LABEL = 'Search inside chapters? This downloads chapter text.';
+const DEBOUNCE_MS = 300;
+
+const mockStageContent = jest.fn<(stageNumber: number, token?: string) => Promise<ContentItem[]>>();
+const mockContentBody = jest.fn<(contentId: number, token?: string) => Promise<ContentBody>>();
+
+jest.mock('../../../api', () => ({
+  course: {
+    stageContentAll: (stageNumber: number) => mockStageContent(stageNumber),
+    contentBody: (contentId: number) => mockContentBody(contentId),
+  },
+}));
+
+// These modules are required after the jest.mock call above so the mock is in
+// place before the module-under-test loads.
+const {
+  default: CourseDrawer,
+  useCourseDrawerContent,
+  useCourseDrawerBodies,
+} = require('../CourseDrawer');
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage',
+  subtitle: 'Subtitle',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const chapterItem = (
+  id: number,
+  title: string,
+  overrides: Partial<ContentItem> = {},
+): ContentItem => ({
+  id,
+  title,
+  content_type: 'chapter',
+  release_day: 0,
+  url: null,
+  is_locked: false,
+  is_read: false,
+  ...overrides,
+});
+
+type GetByTestId = ReturnType<typeof render>['getByTestId'];
+
+/** Type a query into the drawer search field and flush its 300ms debounce. */
+async function typeQuery(getByTestId: GetByTestId, query: string): Promise<void> {
+  await act(async () => {
+    fireEvent.changeText(getByTestId('drawer-search-input'), query);
+    await jest.advanceTimersByTimeAsync(DEBOUNCE_MS);
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+// Three loaded, unlocked stages with distinct titles. Stage 1 also carries a
+// locked chapter (title-matchable but never a body-search target) and an
+// unlocked chapter with no title match, used by the body-only-match tests.
+const STAGES: Stage[] = [
+  makeStage({ id: 1, stage_number: 1, title: 'Stage One' }),
+  makeStage({ id: 2, stage_number: 2, title: 'Stage Two' }),
+  makeStage({ id: 3, stage_number: 3, title: 'Stage Three' }),
+];
+
+const SECTIONS = {
+  1: {
+    status: 'loaded' as const,
+    items: [
+      chapterItem(101, 'Gratitude Practice'),
+      chapterItem(102, 'Deep Focus', { is_locked: true }),
+      chapterItem(103, 'Unrelated Notes'),
+    ],
+  },
+  2: {
+    status: 'loaded' as const,
+    items: [chapterItem(201, 'Morning Pages')],
+  },
+  3: {
+    status: 'loaded' as const,
+    items: [chapterItem(301, 'Gratitude Journal')],
+  },
+};
+
+interface DrawerHarnessProps {
+  sections: typeof SECTIONS;
+  bodies: Readonly<Record<number, string>>;
+  sweepStatus: 'idle' | 'loading' | 'error';
+  onConfirmBodySearch?: () => void;
+}
+
+function renderDrawer(props: Partial<DrawerHarnessProps> = {}) {
+  const onConfirmBodySearch = props.onConfirmBodySearch ?? jest.fn();
+  const result = render(
+    <CourseDrawer
+      stages={STAGES}
+      selectedStage={1}
+      sections={props.sections ?? SECTIONS}
+      bodies={props.bodies ?? {}}
+      sweepStatus={props.sweepStatus ?? 'idle'}
+      onChapterPress={jest.fn()}
+      onRetry={jest.fn()}
+      onConfirmBodySearch={onConfirmBodySearch}
+    />,
+  );
+  return { ...result, onConfirmBodySearch };
+}
+
+describe('CourseDrawer search field placement and identity', () => {
+  it('renders the search field at the top of the drawer, above the first stage header', () => {
+    const { getAllByTestId } = renderDrawer();
+    const ids = getAllByTestId(/^(course-drawer-search|course-drawer-stage-\d+)$/).map(
+      (n) => n.props.testID as string,
+    );
+    expect(ids[0]).toBe('course-drawer-search');
+    expect(ids[1]).toBe('course-drawer-stage-1');
+  });
+
+  it('uses the course-specific placeholder and accessibility label', () => {
+    const { getByTestId } = renderDrawer();
+    const input = getByTestId('drawer-search-input');
+    expect(input.props.placeholder).toBe('Search chapters...');
+    expect(input.props.accessibilityLabel).toBe('Search chapters');
+  });
+});
+
+describe('CourseDrawer fuzzy title search', () => {
+  it('keeps matching stage headers and chapters, and collapses a stage with no title match', async () => {
+    const { getByTestId, queryByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'gratitude');
+
+    expect(getByTestId('course-drawer-stage-1')).toBeTruthy();
+    expect(getByTestId('course-drawer-chapter-101')).toBeTruthy();
+    expect(getByTestId('course-drawer-stage-3')).toBeTruthy();
+    expect(getByTestId('course-drawer-chapter-301')).toBeTruthy();
+
+    expect(queryByTestId('course-drawer-stage-2')).toBeNull();
+    expect(queryByTestId('course-drawer-chapter-201')).toBeNull();
+  });
+
+  it('matches a title with a one-character typo', async () => {
+    const { getByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'gratitde');
+
+    expect(getByTestId('course-drawer-chapter-101')).toBeTruthy();
+  });
+
+  it('shows the singular result caption for exactly one title match', async () => {
+    const { getByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'journal');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('1 result');
+  });
+
+  it('shows the plural result caption for multiple title matches', async () => {
+    const { getByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'gratitude');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('2 results');
+  });
+
+  it('shows "No results" when nothing matches by title', async () => {
+    const { getByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'xylophone');
+
+    expect(getByTestId('drawer-search-result-count')).toHaveTextContent('No results');
+  });
+
+  it('restores every stage section and hides the caption once the query is cleared', async () => {
+    const { getByTestId, queryByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'gratitude');
+    expect(queryByTestId('course-drawer-stage-2')).toBeNull();
+
+    await typeQuery(getByTestId, '');
+
+    expect(getByTestId('course-drawer-stage-1')).toBeTruthy();
+    expect(getByTestId('course-drawer-stage-2')).toBeTruthy();
+    expect(getByTestId('course-drawer-stage-3')).toBeTruthy();
+    expect(queryByTestId('drawer-search-result-count')).toBeNull();
+  });
+
+  it('renders a locked chapter whose title matches, still disabled and never a body-search target', async () => {
+    const { getByTestId } = renderDrawer();
+
+    await typeQuery(getByTestId, 'focus');
+
+    const row = getByTestId('course-drawer-chapter-102');
+    expect(row).toBeTruthy();
+    expect(row.props.accessibilityState.disabled).toBe(true);
+  });
+});
+
+describe('CourseDrawer confirm-gated body search', () => {
+  it('offers the deep-search confirm row with the exact copy while a query is active, and removes it once confirmed', async () => {
+    const { getByTestId, queryByTestId, getByText, onConfirmBodySearch } = renderDrawer();
+
+    await typeQuery(getByTestId, 'gratitude');
+
+    expect(getByTestId('drawer-search-deep-search')).toBeTruthy();
+    expect(getByText(DEEP_SEARCH_LABEL)).toBeTruthy();
+
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(onConfirmBodySearch).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('drawer-search-deep-search')).toBeNull();
+  });
+
+  it('reveals a body-only match after the deep-search row is confirmed', async () => {
+    const { getByTestId, queryByTestId } = renderDrawer({
+      bodies: { 103: 'a hidden lighthouse keeps watch' },
+    });
+
+    await typeQuery(getByTestId, 'lighthouse');
+    expect(queryByTestId('course-drawer-chapter-103')).toBeNull();
+
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(getByTestId('course-drawer-chapter-103')).toBeTruthy();
+  });
+
+  it('shows the loading indicator once body search is active and the sweep is loading', async () => {
+    const { getByTestId } = renderDrawer({ sweepStatus: 'loading' });
+
+    await typeQuery(getByTestId, 'gratitude');
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(getByTestId('course-drawer-search-loading')).toBeTruthy();
+  });
+
+  it('shows the error row with a retry once body search is active and the sweep failed, and retry re-invokes the confirm handler', async () => {
+    const { getByTestId, onConfirmBodySearch } = renderDrawer({ sweepStatus: 'error' });
+
+    await typeQuery(getByTestId, 'gratitude');
+    fireEvent.press(getByTestId('drawer-search-deep-search'));
+
+    expect(getByTestId('course-drawer-search-error')).toBeTruthy();
+    expect(getByTestId('course-drawer-search-retry')).toBeTruthy();
+
+    fireEvent.press(getByTestId('course-drawer-search-retry'));
+
+    expect(onConfirmBodySearch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Wiring: the hook drives the confirm-gated sequential sweep of every
+// unlocked, loaded, uncached chapter's body, mounted the same way the
+// presentational-harness tests above mount it (isOpen gates the panel), so
+// the cache/sweep semantics are exercised end-to-end without navigation.
+const WIRING_STAGES: Stage[] = [
+  makeStage({ id: 1, stage_number: 1, title: 'Stage One' }),
+  makeStage({ id: 2, stage_number: 2, title: 'Stage Two' }),
+];
+
+function Harness(): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const { sections } = useCourseDrawerContent(WIRING_STAGES, isOpen);
+  const { bodies, status, confirmBodySearch } = useCourseDrawerBodies(sections);
+  return (
+    <View>
+      <TouchableOpacity testID="harness-open" onPress={() => setIsOpen(true)} />
+      {isOpen ? (
+        <CourseDrawer
+          stages={WIRING_STAGES}
+          selectedStage={1}
+          sections={sections}
+          bodies={bodies}
+          sweepStatus={status}
+          onChapterPress={() => undefined}
+          onRetry={() => undefined}
+          onConfirmBodySearch={confirmBodySearch}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+async function openHarness(getByTestId: GetByTestId): Promise<void> {
+  await act(async () => {
+    fireEvent.press(getByTestId('harness-open'));
+    await jest.advanceTimersByTimeAsync(0);
+  });
+}
+
+/** A resolved body payload with the given markdown text. */
+function bodyOf(markdown: string): ContentBody {
+  return { title: 'Chapter', content_type: 'chapter', body_markdown: markdown };
+}
+
+describe('useCourseDrawerBodies confirm-gated body search (wiring)', () => {
+  beforeEach(() => {
+    mockStageContent.mockReset();
+    mockContentBody.mockReset();
+    mockStageContent.mockImplementation((stageNumber: number) => {
+      if (stageNumber === 1) {
+        return Promise.resolve([
+          chapterItem(11, 'Alpha Notes'),
+          chapterItem(12, 'Locked Notes', { is_locked: true }),
+        ]);
+      }
+      return Promise.resolve([chapterItem(21, 'Gamma Notes')]);
+    });
+  });
+
+  it('fetches no chapter body while the user is only typing a title query', async () => {
+    mockContentBody.mockResolvedValue(bodyOf('irrelevant'));
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+
+    await typeQuery(getByTestId, 'alpha');
+
+    expect(mockContentBody).not.toHaveBeenCalled();
+  });
+
+  it('fetches only unlocked, loaded chapters on confirm, sequentially and never the locked one', async () => {
+    mockContentBody.mockResolvedValue(bodyOf('irrelevant'));
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    const ids = mockContentBody.mock.calls.map((call) => call[0]);
+    expect(ids).toEqual([11, 21]);
+  });
+
+  it('reveals a body-only match once the sweep resolves', async () => {
+    mockContentBody.mockImplementation((contentId: number) =>
+      Promise.resolve(
+        bodyOf(contentId === 21 ? 'a hidden lighthouse keeps watch' : 'nothing special here'),
+      ),
+    );
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+    expect(queryByTestId('course-drawer-chapter-21')).toBeNull();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(getByTestId('course-drawer-chapter-21')).toBeTruthy();
+    expect(queryByTestId('course-drawer-chapter-11')).toBeNull();
+  });
+
+  it('does not refetch already-cached ids on a second confirm', async () => {
+    mockContentBody.mockImplementation((contentId: number) =>
+      Promise.resolve(
+        bodyOf(contentId === 21 ? 'a hidden lighthouse keeps watch' : 'nothing special here'),
+      ),
+    );
+    const { getByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(mockContentBody).toHaveBeenCalledTimes(2);
+
+    await typeQuery(getByTestId, '');
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockContentBody).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows the inline searching indicator while the sweep is still in flight, then clears once it settles', async () => {
+    let resolveFirst: (_value: ContentBody) => void = () => undefined;
+    const firstPending = new Promise<ContentBody>((resolve) => {
+      resolveFirst = resolve;
+    });
+    mockContentBody.mockReturnValueOnce(firstPending);
+    mockContentBody.mockResolvedValueOnce(bodyOf('irrelevant'));
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    // The first id's body has not settled: the sweep is sequential, so the
+    // second id is not yet requested and the loading caption is visible.
+    expect(mockContentBody).toHaveBeenCalledTimes(1);
+    expect(getByTestId('course-drawer-search-loading')).toBeTruthy();
+
+    await act(async () => {
+      resolveFirst(bodyOf('irrelevant'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(queryByTestId('course-drawer-search-loading')).toBeNull();
+  });
+
+  it('surfaces a systemic failure when every attempted body fetch rejects, and retry recovers', async () => {
+    mockContentBody.mockRejectedValueOnce(new Error('network down'));
+    mockContentBody.mockRejectedValueOnce(new Error('network down'));
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(getByTestId('course-drawer-search-error')).toBeTruthy();
+    expect(getByTestId('course-drawer-search-retry')).toBeTruthy();
+
+    mockContentBody.mockReset();
+    mockContentBody.mockImplementation((contentId: number) =>
+      Promise.resolve(
+        bodyOf(contentId === 21 ? 'a hidden lighthouse keeps watch' : 'nothing special here'),
+      ),
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId('course-drawer-search-retry'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(queryByTestId('course-drawer-search-error')).toBeNull();
+    expect(getByTestId('course-drawer-chapter-21')).toBeTruthy();
+  });
+
+  it('shows no error UI on a partial failure (one chapter rejects, one resolves)', async () => {
+    mockContentBody.mockImplementation((contentId: number) => {
+      if (contentId === 11) return Promise.reject(new Error('one chapter failed'));
+      return Promise.resolve(bodyOf('a hidden lighthouse keeps watch'));
+    });
+
+    const { getByTestId, queryByTestId } = render(<Harness />);
+    await openHarness(getByTestId);
+    await typeQuery(getByTestId, 'lighthouse');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('drawer-search-deep-search'));
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(queryByTestId('course-drawer-search-error')).toBeNull();
+    expect(getByTestId('course-drawer-chapter-21')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
Mounts the shared `DrawerSearch` (from #1785) in the Course drawer, mirroring the merged Journal sibling (#1832): live fuzzy title filtering with stage collapse, and a confirm-gated body search that sequentially sweeps unlocked, loaded, uncached chapter bodies through the existing content endpoints — no network fan-out from typing. The `SearchSweepStatus` row (the reviewer-required idiom from #1832) surfaces the sweep's in-flight, error, and retry states inline beneath the field. Cache sits above the panel so repeat sweeps are free.

## Tests (RED-first)
20 new tests in `CourseDrawerSearch.test.tsx` (RED confirmed against missing `useCourseDrawerBodies` + behaviors, then GREEN): title filtering, stage collapse, confirm gate, sequential sweep, cache reuse, locked-stage exclusion, in-flight/error/retry status, empty-query restore. Scoped suites 30/30; tsc + eslint clean. The full local jest run was cut short by the disk incident with zero real assertion failures — CI is authoritative for the full suite.

Completes epic #1771 (epic:drawer-search) — the last sub-issue.

Closes #1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)