### PR TITLE
feat(backend): creek vault write path — store and classify entries behind the privacy gate

### DIFF
--- a/backend/migrations/versions/c7d8e9f0a1b3_journalentry_vault_ref_tags.py
+++ b/backend/migrations/versions/c7d8e9f0a1b3_journalentry_vault_ref_tags.py
@@ -1,0 +1,43 @@
+"""add journalentry.vault_ref / vault_tags for the Creek Vault write path.
+
+Revision ID: c7d8e9f0a1b3
+Revises: f8a9b0c1d2e3
+Create Date: 2026-07-10 00:00:00.000000
+
+Adds two nullable columns to ``journalentry`` that link an entry to the Creek
+Vault: ``vault_ref`` (the opaque handle a successful vault ingest returns) and
+``vault_tags`` (the JSON array of Frequency / Wavelength-phase tags the vault
+classified). Both are NULL for entries never sent to a vault -- intimate entries
+and every entry written while no vault is configured -- so this is a purely
+additive, non-destructive change. A plain nullable ``ADD COLUMN`` is SQLite-safe
+without a batch rebuild; the downgrade drops both columns inside a
+``batch_alter_table`` so ``DROP COLUMN`` also works on SQLite.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d8e9f0a1b3"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "f8a9b0c1d2e3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "journalentry"
+_VAULT_REF_COLUMN = "vault_ref"
+_VAULT_TAGS_COLUMN = "vault_tags"
+
+
+def upgrade() -> None:
+    """Add the nullable ``vault_ref`` (String) and ``vault_tags`` (JSON) columns."""
+    op.add_column(_TABLE_NAME, sa.Column(_VAULT_REF_COLUMN, sa.String(), nullable=True))
+    op.add_column(_TABLE_NAME, sa.Column(_VAULT_TAGS_COLUMN, sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop both vault columns (batch mode keeps ``DROP COLUMN`` SQLite-compatible)."""
+    with op.batch_alter_table(_TABLE_NAME) as batch_op:
+        batch_op.drop_column(_VAULT_TAGS_COLUMN)
+        batch_op.drop_column(_VAULT_REF_COLUMN)

--- a/backend/src/models/journal_entry.py
+++ b/backend/src/models/journal_entry.py
@@ -2,7 +2,7 @@ import enum
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Index, String, and_
+from sqlalchemy import JSON, CheckConstraint, Column, DateTime, Index, String, and_
 from sqlmodel import Field, Relationship, SQLModel
 
 from domain.constants import TOTAL_STAGES
@@ -220,6 +220,15 @@ class JournalEntry(SQLModel, table=True):
     reflection_scope_key: str | None = Field(default=None, max_length=30)
     practice_session_id: int | None = Field(default=None, foreign_key="practicesession.id")
     user_practice_id: int | None = Field(default=None, foreign_key="userpractice.id")
+    # Creek Vault write-path linkage. ``vault_ref`` is the opaque handle a
+    # successful vault ingest returns; ``vault_tags`` holds the Frequency /
+    # Wavelength-phase tags the vault classified. Both stay NULL for entries never
+    # sent to a vault -- intimate entries (withheld until the encrypted transit
+    # path lands) and every entry written while no vault is configured. Declared
+    # with no length / as JSON to match the migration exactly (drift-free), and
+    # both nullable so the write path is purely additive over existing rows.
+    vault_ref: str | None = Field(default=None, sa_column=Column(String, nullable=True))
+    vault_tags: list[str] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     # BUG-JOURNAL-007: soft-delete column.  ``None`` = live row; non-None = deleted.
     deleted_at: datetime | None = Field(
         default=None,

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -18,6 +18,7 @@ from dependencies.ownership import require_owned_journal_entry
 from dependencies.timezone import current_user_timezone
 from domain.care import CarePayload, build_care_payload
 from domain.contraction import build_contraction_invitation, detect_contraction
+from domain.creek_vault import CreekVaultClient
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
 from domain.reflection_hierarchy import ReflectionLevel
@@ -67,6 +68,11 @@ from services.botmason import LLMProviderError, resolve_chat_api_key
 from services.checkin import CheckInContext, current_check_in, record_goal_completion
 from services.completion_candidates import gather_candidates
 from services.contraction import gather_contraction_aggregates
+from services.creek_vault_write import (
+    VaultWriteStatus,
+    get_creek_vault_client,
+    store_and_classify,
+)
 from services.llm_usage import record_llm_usage
 from services.marginalia import (
     BotmasonResonanceLLM,
@@ -173,11 +179,70 @@ def _resolve_backdated_timestamp(entry_date: date | None) -> datetime | None:
     )
 
 
+# PATCH fields whose change re-sends the entry to the Creek Vault. A body edit
+# ('message') or a privacy-tier change ('classification') alters what the vault
+# should hold; a title/status/chord-only PATCH must issue zero vault calls.
+_VAULT_REINGEST_FIELDS = frozenset({"message", "classification"})
+
+
+def _entry_aspect_tags(entry: JournalEntry) -> tuple[int, ...]:
+    """Collect an entry's chord Aspects (primary then secondary) as ingest tags.
+
+    Only the set notes of the chord are forwarded, so a scopeless (freeform)
+    entry sends an empty tuple rather than ``None`` placeholders.
+    """
+    return tuple(a for a in (entry.primary_aspect, entry.secondary_aspect) if a is not None)
+
+
+async def _record_vault_outcome(
+    session: AsyncSession, entry: JournalEntry, vault_client: CreekVaultClient
+) -> None:
+    """Store + classify a committed entry via the Creek Vault, reconciling its ref columns.
+
+    Best-effort: :func:`store_and_classify` never raises a vault error, so a
+    missing, unreachable, or intimate-skipped write leaves the entry saved. The
+    persisted ``vault_ref`` / ``vault_tags`` are reconciled to the outcome:
+
+    - ``INGESTED`` writes the new ref + tags (a re-ingest overwrites any prior ref).
+    - ``SKIPPED_INTIMATE`` clears a prior non-intimate ref/tags, since an entry
+      re-classified intimate must not retain a handle to plaintext it no longer
+      consents to expose (the model documents these columns stay NULL for
+      intimate entries). The vault still holds that plaintext until a retract
+      capability exists -- see :mod:`services.creek_vault_write`.
+    - ``DEGRADED`` / ``UNAVAILABLE`` are transient, so any existing ref is kept
+      untouched rather than dropped on a passing network blip.
+
+    Only a real column change re-commits, so the common no-op paths stay free of
+    a redundant write.
+    """
+    outcome = await store_and_classify(
+        vault_client,
+        body=entry.message,
+        classification=entry.classification,
+        created_at=entry.timestamp,
+        aspect_tags=_entry_aspect_tags(entry),
+    )
+    if outcome.status is VaultWriteStatus.INGESTED:
+        entry.vault_ref = outcome.vault_ref
+        entry.vault_tags = list(outcome.tags)
+    elif outcome.status is VaultWriteStatus.SKIPPED_INTIMATE and (
+        entry.vault_ref is not None or entry.vault_tags is not None
+    ):
+        entry.vault_ref = None
+        entry.vault_tags = None
+    else:
+        return
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+
+
 @router.post("/", response_model=JournalMessageResponse, status_code=status.HTTP_201_CREATED)
 async def create_journal_entry(
     payload: JournalMessageCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],
 ) -> JournalEntry:
     """Create a journal message for the authenticated user.
 
@@ -207,6 +272,7 @@ async def create_journal_entry(
             raise conflict("reflection_scope_taken") from exc
         raise
     await session.refresh(entry)
+    await _record_vault_outcome(session, entry, vault_client)
     logger.info("journal_entry_created", extra={"user_id": current_user, "entry_id": entry.id})
     return entry
 
@@ -396,6 +462,7 @@ async def update_journal_entry(
     payload: JournalEntryUpdate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],
 ) -> JournalEntry:
     """Patch ``message`` / ``title`` / ``status`` on the caller's own entry.
 
@@ -427,6 +494,10 @@ async def update_journal_entry(
             raise conflict("reflection_scope_taken") from exc
         raise
     await session.refresh(entry)
+    # Re-ingest only when the body or privacy tier changed; a title/status/chord
+    # PATCH leaves the vault's copy untouched (and issues zero vault calls).
+    if payload.model_fields_set & _VAULT_REINGEST_FIELDS:
+        await _record_vault_outcome(session, entry, vault_client)
     logger.info("journal_entry_updated", extra={"user_id": current_user, "entry_id": entry_id})
     return entry
 

--- a/backend/src/services/creek_vault_write.py
+++ b/backend/src/services/creek_vault_write.py
@@ -1,0 +1,181 @@
+"""Creek Vault write path: store a journal entry, then classify it, degrading safely.
+
+This is the thin orchestration layer the journal router calls after an entry is
+committed. It sits atop the pure :mod:`domain.creek_vault` seam and the concrete
+adapters in :mod:`services.creek_vault_client`, and its whole job is to turn the
+seam's fine-grained handshake/ingest/classify surface into one best-effort call
+that *never raises a vault error* -- so the user's entry is saved regardless of
+whether a vault is present, reachable, or capable.
+
+The governing rule is **graceful degradation**: a missing, unreachable, or
+capability-poor vault collapses to a well-defined :class:`VaultWriteStatus`
+rather than an exception the router must special-case. A classify failure never
+undoes a successful ingest -- classification is optional enrichment layered on
+top of durable storage, not a precondition for it.
+
+**Intimate content is deliberately not sent here.** An entry classified
+``intimate`` short-circuits to :attr:`VaultWriteStatus.SKIPPED_INTIMATE` before
+any vault call -- not even a handshake. This is a considered deferral, not a
+permanent prohibition: the Creek Vault contract's intimate transit path
+(``docs/creek-vault-mcp-contract.md`` decisions (a) ciphertext-only, client-held
+key the operator cannot decrypt, and (b) attestation-gated transit) is not yet
+built. Until that path exists, routing intimate bodies through this plaintext
+ingest surface would violate the writer's chosen depth, so the safe answer is to
+withhold them here and revisit once the encrypted, attested channel lands.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.creek_vault import (
+    CreekCapability,
+    CreekVaultClient,
+    CreekVaultError,
+    VaultIngestRequest,
+    VaultTierCeiling,
+    tier_ceiling_for,
+)
+from models.journal_entry import JournalClassification
+from services.creek_vault_client import build_creek_vault_client
+
+
+class VaultWriteStatus(enum.StrEnum):
+    """The terminal outcome of a :func:`store_and_classify` attempt.
+
+    Exactly one of these is always returned; the router branches on it to decide
+    whether to persist a vault ref. ``INGESTED`` is the only status that carries a
+    ``vault_ref``; every other status is a no-op for the entry's stored columns.
+    """
+
+    INGESTED = "ingested"
+    SKIPPED_INTIMATE = "skipped_intimate"
+    UNAVAILABLE = "unavailable"
+    DEGRADED = "degraded"
+
+
+@dataclass(frozen=True)
+class VaultWriteOutcome:
+    """Immutable result of a vault write attempt: a status plus any earned metadata.
+
+    ``vault_ref`` is populated only on :attr:`VaultWriteStatus.INGESTED`; ``tags``
+    carries the vault's classification (empty when the vault does not support, or
+    fails, classification). Frozen so a recorded outcome cannot mutate between the
+    write path and the caller that persists it.
+    """
+
+    status: VaultWriteStatus
+    vault_ref: str | None
+    tags: tuple[str, ...]
+
+
+# The three non-ingested outcomes are value-identical every time, so they are
+# interned as module constants rather than rebuilt on each degrade path.
+_SKIPPED_INTIMATE_OUTCOME = VaultWriteOutcome(
+    status=VaultWriteStatus.SKIPPED_INTIMATE, vault_ref=None, tags=()
+)
+_UNAVAILABLE_OUTCOME = VaultWriteOutcome(
+    status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()
+)
+_DEGRADED_OUTCOME = VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
+
+
+def _ingest_ready(client: CreekVaultClient) -> bool:
+    """Return whether the last handshake found a vault that can ingest.
+
+    Both conditions must hold: the vault is available at all, and it advertised
+    the INGEST capability. Either being false degrades the write to UNAVAILABLE.
+    """
+    return client.is_available() and client.supports(CreekCapability.INGEST)
+
+
+async def _try_ingest(client: CreekVaultClient, request: VaultIngestRequest) -> str | None:
+    """Attempt an ingest, returning the vault ref on durable storage or ``None``.
+
+    A :class:`CreekVaultError` (the seam's normalized transport failure) and a
+    ``stored=False`` result both collapse to ``None`` -- the caller treats either
+    as a degraded write rather than propagating the error or fabricating a ref.
+    """
+    try:
+        result = await client.ingest(request)
+    except CreekVaultError:
+        return None
+    return result.vault_ref if result.stored else None
+
+
+async def _try_classify(
+    client: CreekVaultClient, body: str, tier_ceiling: VaultTierCeiling
+) -> tuple[str, ...]:
+    """Classify ``body`` when supported, swallowing failure to an empty tag tuple.
+
+    Classification is optional enrichment: a vault that does not advertise
+    CLASSIFY, or one whose classify call raises, yields no tags rather than
+    demoting the already-successful ingest. ``tier_ceiling`` is the resolved
+    :class:`~domain.creek_vault.VaultTierCeiling` passed straight through.
+    """
+    if not client.supports(CreekCapability.CLASSIFY):
+        return ()
+    try:
+        classification = await client.classify(body, tier_ceiling)
+    except CreekVaultError:
+        return ()
+    return classification.tags
+
+
+async def store_and_classify(
+    client: CreekVaultClient,
+    *,
+    body: str,
+    classification: str,
+    created_at: datetime,
+    aspect_tags: tuple[int, ...] = (),
+) -> VaultWriteOutcome:
+    """Store ``body`` in the vault and classify it, degrading rather than raising.
+
+    The order of checks is load-bearing:
+
+    1. An ``intimate`` classification short-circuits to
+       :attr:`VaultWriteStatus.SKIPPED_INTIMATE` *before touching the client* --
+       see the module docstring for why intimate bodies are withheld.
+    2. :func:`~domain.creek_vault.tier_ceiling_for` resolves the tier, raising
+       ``ValueError`` (fail closed) for an unknown classification -- this error
+       propagates, since an unrecognized tier must never widen to OPEN.
+    3. A handshake probes the vault; an unavailable or non-ingesting vault
+       degrades to :attr:`VaultWriteStatus.UNAVAILABLE`.
+    4. Ingest runs; a transport failure or a ``stored=False`` result degrades to
+       :attr:`VaultWriteStatus.DEGRADED`.
+    5. On a durable ingest, classification runs as optional enrichment and the
+       call returns :attr:`VaultWriteStatus.INGESTED` with the ref and any tags.
+
+    Never raises :class:`~domain.creek_vault.CreekVaultError`: the caller can
+    persist the entry unconditionally and only records vault metadata on INGESTED.
+    """
+    if classification == JournalClassification.INTIMATE:
+        return _SKIPPED_INTIMATE_OUTCOME
+    tier_ceiling = tier_ceiling_for(classification)
+    await client.handshake()
+    if not _ingest_ready(client):
+        return _UNAVAILABLE_OUTCOME
+    request = VaultIngestRequest(
+        body=body,
+        tier_ceiling=tier_ceiling,
+        created_at=created_at,
+        aspect_tags=aspect_tags,
+    )
+    vault_ref = await _try_ingest(client, request)
+    if vault_ref is None:
+        return _DEGRADED_OUTCOME
+    tags = await _try_classify(client, body, tier_ceiling)
+    return VaultWriteOutcome(status=VaultWriteStatus.INGESTED, vault_ref=vault_ref, tags=tags)
+
+
+def get_creek_vault_client() -> CreekVaultClient:
+    """Return a per-request Creek Vault client for FastAPI dependency injection.
+
+    A thin wrapper over :func:`~services.creek_vault_client.build_creek_vault_client`
+    with no module-level cache, so a test can override this provider and a
+    reconfigured deployment picks up the change on the next request.
+    """
+    return build_creek_vault_client()

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -1,0 +1,294 @@
+"""Tests for the Creek Vault write path (services.creek_vault_write).
+
+This is the TDD RED suite: services.creek_vault_write does not exist yet, so
+every test here fails on import until the implementation specialist writes
+the module against the signatures documented in the module docstring these
+tests assume.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelBalance,
+)
+from services.creek_vault_client import LocalFallbackCreekVaultClient
+from services.creek_vault_write import (
+    VaultWriteOutcome,
+    VaultWriteStatus,
+    get_creek_vault_client,
+    store_and_classify,
+)
+
+_CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+_BODY = "A quiet entry about the week's practice."
+
+
+class RecordingVaultClient:
+    """Fake CreekVaultClient that records every call and returns scripted results."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.INGEST}),
+        ingest: VaultIngestResult | Exception | None = None,
+        classify: VaultClassification | Exception | None = None,
+    ) -> None:
+        """Store the scripted handshake/ingest/classify behavior for this fake.
+
+        ``ingest`` and ``classify`` each take either the scripted success result
+        or an ``Exception`` to raise when that method is called.
+        """
+        self.calls: list[tuple[str, object]] = []
+        self._available = available
+        self._capabilities = capabilities
+        self._ingest = ingest or VaultIngestResult(stored=True, vault_ref="ref-default")
+        self._classify = classify or VaultClassification(tags=())
+
+    async def handshake(self) -> HandshakeResult:
+        """Record the call and return the scripted availability/capabilities."""
+        self.calls.append(("handshake", None))
+        return HandshakeResult(
+            available=self._available,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Return the scripted availability without recording a call."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the scripted capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Record the ingest request, then raise or return the scripted result."""
+        self.calls.append(("ingest", request))
+        if isinstance(self._ingest, Exception):
+            raise self._ingest
+        return self._ingest
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Record the classify call, then raise or return the scripted result."""
+        self.calls.append(("classify", (body, tier_ceiling)))
+        if isinstance(self._classify, Exception):
+            raise self._classify
+        return self._classify
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Record the reflect call and return an empty string (unused here)."""
+        self.calls.append(("reflect", (body, tier_ceiling)))
+        return ""
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Record the wheel call and return an empty balance (unused here)."""
+        self.calls.append(("wheel", None))
+        return VaultWheelBalance(aspects=())
+
+
+def _call_names(client: RecordingVaultClient) -> list[str]:
+    """Return the ordered list of method names the fake recorded."""
+    return [name for name, _args in client.calls]
+
+
+def _ingest_request(client: RecordingVaultClient) -> VaultIngestRequest:
+    """Return the single VaultIngestRequest the fake recorded on ingest."""
+    args = next(a for name, a in client.calls if name == "ingest")
+    assert isinstance(args, VaultIngestRequest)
+    return args
+
+
+@pytest.mark.asyncio
+async def test_intimate_entry_skips_and_never_touches_client() -> None:
+    """An intimate entry never calls the vault -- not even handshake()."""
+    client = RecordingVaultClient()
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="intimate", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.SKIPPED_INTIMATE, vault_ref=None, tags=()
+    )
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unavailable_vault_returns_unavailable_status() -> None:
+    """A handshake reporting unavailable degrades to UNAVAILABLE, never calling ingest."""
+    client = RecordingVaultClient(available=False, capabilities=frozenset())
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()
+    )
+    assert _call_names(client) == ["handshake"]
+
+
+@pytest.mark.asyncio
+async def test_available_but_ingest_unsupported_returns_unavailable_status() -> None:
+    """An available vault that does not advertise INGEST also degrades to UNAVAILABLE."""
+    client = RecordingVaultClient(available=True, capabilities=frozenset({CreekCapability.REFLECT}))
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome.status == VaultWriteStatus.UNAVAILABLE
+    assert outcome.vault_ref is None
+    assert outcome.tags == ()
+    assert _call_names(client) == ["handshake"]
+
+
+@pytest.mark.asyncio
+async def test_public_classification_maps_to_open_tier_ceiling() -> None:
+    """A public entry's ingest request carries the OPEN tier ceiling."""
+    client = RecordingVaultClient(ingest=VaultIngestResult(stored=True, vault_ref="ref-open"))
+    await store_and_classify(client, body=_BODY, classification="public", created_at=_CREATED_AT)
+    ingest_call = _ingest_request(client)
+    assert ingest_call.tier_ceiling == VaultTierCeiling.OPEN
+
+
+@pytest.mark.asyncio
+async def test_personal_classification_maps_to_personal_tier_ceiling() -> None:
+    """A personal entry's ingest request carries the PERSONAL tier ceiling."""
+    client = RecordingVaultClient(ingest=VaultIngestResult(stored=True, vault_ref="ref-personal"))
+    await store_and_classify(client, body=_BODY, classification="personal", created_at=_CREATED_AT)
+    ingest_call = _ingest_request(client)
+    assert ingest_call.tier_ceiling == VaultTierCeiling.PERSONAL
+
+
+@pytest.mark.asyncio
+async def test_ingest_request_carries_body_created_at_and_aspect_tags() -> None:
+    """The mapped VaultIngestRequest carries the caller's body, timestamp, and aspect tags."""
+    client = RecordingVaultClient()
+    await store_and_classify(
+        client,
+        body=_BODY,
+        classification="personal",
+        created_at=_CREATED_AT,
+        aspect_tags=(3, 7),
+    )
+    ingest_call = _ingest_request(client)
+    assert ingest_call.body == _BODY
+    assert ingest_call.created_at == _CREATED_AT
+    assert ingest_call.aspect_tags == (3, 7)
+
+
+@pytest.mark.asyncio
+async def test_ingest_success_without_classify_support_returns_ingested_empty_tags() -> None:
+    """A vault supporting only INGEST returns INGESTED with the vault_ref and empty tags."""
+    client = RecordingVaultClient(
+        capabilities=frozenset({CreekCapability.INGEST}),
+        ingest=VaultIngestResult(stored=True, vault_ref="ref-x"),
+    )
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.INGESTED, vault_ref="ref-x", tags=()
+    )
+    assert _call_names(client) == ["handshake", "ingest"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_classify_success_populates_tags() -> None:
+    """A vault supporting INGEST and CLASSIFY returns INGESTED with the classified tags."""
+    client = RecordingVaultClient(
+        capabilities=frozenset({CreekCapability.INGEST, CreekCapability.CLASSIFY}),
+        ingest=VaultIngestResult(stored=True, vault_ref="ref-y"),
+        classify=VaultClassification(tags=("courage", "shadow")),
+    )
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.INGESTED, vault_ref="ref-y", tags=("courage", "shadow")
+    )
+    assert _call_names(client) == ["handshake", "ingest", "classify"]
+    classify_call = next(args for name, args in client.calls if name == "classify")
+    assert classify_call == (_BODY, VaultTierCeiling.PERSONAL)
+
+
+@pytest.mark.asyncio
+async def test_ingest_raising_creek_vault_error_returns_degraded_without_raising() -> None:
+    """A CreekVaultError from ingest() degrades to DEGRADED rather than propagating."""
+    client = RecordingVaultClient(
+        capabilities=frozenset({CreekCapability.INGEST}),
+        ingest=CreekVaultUnavailableError("creek vault call failed: creek.ingest"),
+    )
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
+
+
+@pytest.mark.asyncio
+async def test_ingest_reporting_not_stored_from_available_vault_returns_degraded() -> None:
+    """stored=False from an available, supporting vault is a degraded write, not an ingest."""
+    client = RecordingVaultClient(
+        capabilities=frozenset({CreekCapability.INGEST}),
+        ingest=VaultIngestResult(stored=False, vault_ref=None),
+    )
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
+
+
+@pytest.mark.asyncio
+async def test_classify_error_after_successful_ingest_still_returns_ingested() -> None:
+    """Classification is optional enrichment: its failure never demotes a successful ingest."""
+    client = RecordingVaultClient(
+        capabilities=frozenset({CreekCapability.INGEST, CreekCapability.CLASSIFY}),
+        ingest=VaultIngestResult(stored=True, vault_ref="ref-z"),
+        classify=CreekVaultUnavailableError("creek vault call failed: creek.classify"),
+    )
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.INGESTED, vault_ref="ref-z", tags=()
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_classification_raises_value_error_without_touching_client() -> None:
+    """An unrecognized classification fails closed via tier_ceiling_for, before any vault call."""
+    client = RecordingVaultClient()
+    with pytest.raises(ValueError, match="bogus"):
+        await store_and_classify(client, body=_BODY, classification="bogus", created_at=_CREATED_AT)
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_client_returns_unavailable_for_non_intimate_entry() -> None:
+    """The real no-vault LocalFallbackCreekVaultClient degrades a non-intimate write."""
+    client = LocalFallbackCreekVaultClient()
+    outcome = await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()
+    )
+
+
+def test_get_creek_vault_client_returns_local_fallback_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no CREEK_VAULT_URL configured, the FastAPI provider yields the local fallback."""
+    monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
+    client = get_creek_vault_client()
+    assert isinstance(client, LocalFallbackCreekVaultClient)

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -1,0 +1,299 @@
+"""Integration tests wiring the journal router to the Creek Vault write path.
+
+RED: the create/update journal endpoints do not yet call
+``services.creek_vault_write.store_and_classify`` and ``JournalEntry`` does not
+yet carry ``vault_ref`` / ``vault_tags`` columns, so every test here fails
+until both are implemented.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelBalance,
+)
+from main import app
+from models.journal_entry import JournalEntry
+from services.creek_vault_write import get_creek_vault_client
+
+_SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Sign up a fresh user and return an Authorization header for it."""
+    resp = await client.post(
+        "/auth/signup",
+        json={"email": f"{username}@example.com", "password": _SIGNUP_PASSWORD},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+async def _entry_row(db_session: AsyncSession, entry_id: int) -> JournalEntry:
+    """Fetch the persisted JournalEntry row by id."""
+    result = await db_session.execute(select(JournalEntry).where(col(JournalEntry.id) == entry_id))
+    return result.scalar_one()
+
+
+class SequencedVaultClient:
+    """Fake CreekVaultClient: available, ingests successfully, refs increment per call."""
+
+    def __init__(
+        self,
+        *,
+        capabilities: frozenset[CreekCapability] = frozenset(
+            {CreekCapability.INGEST, CreekCapability.CLASSIFY}
+        ),
+        ingest_error: Exception | None = None,
+    ) -> None:
+        """Store the advertised capabilities and any scripted ingest failure."""
+        self.ingest_calls: list[VaultIngestRequest] = []
+        self._capabilities = capabilities
+        self._ingest_error = ingest_error
+
+    async def handshake(self) -> HandshakeResult:
+        """Report available with the configured capability set."""
+        return HandshakeResult(
+            available=True,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Always report available -- this fake never degrades on handshake."""
+        return True
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the configured capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Record the request, then raise or return an incrementing vault ref."""
+        self.ingest_calls.append(request)
+        if self._ingest_error is not None:
+            raise self._ingest_error
+        return VaultIngestResult(stored=True, vault_ref=f"vault-ref-{len(self.ingest_calls)}")
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Return a fixed classification tag set."""
+        return VaultClassification(tags=("courage",))
+
+    async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> str:
+        """Return an empty reflection (unused by the write path)."""
+        return ""
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Return an empty wheel balance (unused by the write path)."""
+        return VaultWheelBalance(aspects=())
+
+
+@pytest.mark.asyncio
+async def test_create_non_intimate_entry_persists_vault_ref_and_tags(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-intimate create with an available, classifying vault persists ref + tags."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_create")
+
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "A public reflection.", "classification": "public"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await _entry_row(db_session, int(resp.json()["id"]))
+    assert row.vault_ref == "vault-ref-1"
+    assert row.vault_tags == ["courage"]
+
+
+@pytest.mark.asyncio
+async def test_create_intimate_entry_never_touches_vault(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An intimate create leaves vault_ref/vault_tags unset and never calls the vault."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_intimate")
+
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "A private confession.", "classification": "intimate"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await _entry_row(db_session, int(resp.json()["id"]))
+    assert row.vault_ref is None
+    assert row.vault_tags is None
+    assert fake.ingest_calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_degrades_gracefully_when_ingest_raises(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A vault ingest failure never blocks the write -- the entry still saves, unrefed."""
+    fake = SequencedVaultClient(
+        ingest_error=CreekVaultUnavailableError("creek vault call failed: creek.ingest")
+    )
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_degrade")
+
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Written while the vault is down.", "classification": "personal"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await _entry_row(db_session, int(resp.json()["id"]))
+    assert row.vault_ref is None
+
+
+@pytest.mark.asyncio
+async def test_create_with_default_provider_and_no_vault_configured_behaves_as_today(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no dependency override and no CREEK_VAULT_URL, the write path is a no-op."""
+    monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
+    headers = await _signup(async_client, "vault_unconfigured")
+
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Ordinary entry, no vault configured.", "classification": "personal"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await _entry_row(db_session, int(resp.json()["id"]))
+    assert row.vault_ref is None
+
+
+@pytest.mark.asyncio
+async def test_patch_message_edit_reingests_and_updates_vault_ref(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Editing the body re-ingests and the persisted vault_ref advances to the new ref."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_patch_body")
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": "Original body.", "classification": "public"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+    first_row = await _entry_row(db_session, entry_id)
+    assert first_row.vault_ref == "vault-ref-1"
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": "Revised body."}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    second_row = await _entry_row(db_session, entry_id)
+    assert len(fake.ingest_calls) == 2
+    assert second_row.vault_ref == "vault-ref-2"
+
+
+@pytest.mark.asyncio
+async def test_patch_title_only_does_not_reingest(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A title-only PATCH sends no body to the vault -- no second ingest call."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_patch_title")
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": "Untouched body.", "classification": "public"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+    assert len(fake.ingest_calls) == 1
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"title": "A new title"}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+    assert len(fake.ingest_calls) == 1
+
+    row = await _entry_row(db_session, entry_id)
+    assert row.vault_ref == "vault-ref-1"
+
+
+@pytest.mark.asyncio
+async def test_patch_to_intimate_clears_prior_vault_ref_and_tags(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-classifying an ingested entry as intimate clears its ref/tags and re-sends nothing."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_to_intimate")
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": "A shareable reflection.", "classification": "public"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+    first_row = await _entry_row(db_session, entry_id)
+    assert first_row.vault_ref == "vault-ref-1"
+    assert first_row.vault_tags == ["courage"]
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"classification": "intimate"}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    await db_session.refresh(first_row)
+    assert len(fake.ingest_calls) == 1
+    assert first_row.vault_ref is None
+    assert first_row.vault_tags is None
+
+
+@pytest.mark.asyncio
+async def test_patch_from_intimate_to_personal_ingests(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-classifying an intimate entry as personal ingests it for the first time."""
+    fake = SequencedVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_from_intimate")
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": "A private note, later shared.", "classification": "intimate"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+    assert fake.ingest_calls == []
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"classification": "personal"}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    row = await _entry_row(db_session, entry_id)
+    assert len(fake.ingest_calls) == 1
+    assert row.vault_ref == "vault-ref-1"

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2742,3 +2742,115 @@ def test_backdated_entry_migration_round_trip_on_sqlite(
     # Phase 3: re-upgrade is idempotent.
     command.upgrade(cfg, _BACKDATED_ENTRY_REVISION)
     assert "ix_journalentry_user_timestamp_id" in _index_names(db_url, "journalentry")
+
+
+# -- Creek Vault write-path vault_ref / vault_tags migration round-trip -----
+#
+# ``alembic check`` itself only runs against a live Postgres database in the
+# ``backend-ci.yml`` migration-drift job (see DEPLOYMENT.md); there is no local
+# SQLite-backed unit test for it anywhere in this file. The column-presence
+# round-trip below is this suite's equivalent drift guard for the new columns,
+# matching every other migration section here.
+
+# down_revision is f8a9b0c1d2e3 (the backdated-entry-ordering migration, current head).
+_CREEK_VAULT_WRITE_BASE_REVISION = "f8a9b0c1d2e3"  # pragma: allowlist secret
+# The implementer must set this to the real revision ID of the migration they
+# author for the Creek Vault write path.
+_CREEK_VAULT_WRITE_REVISION = "c7d8e9f0a1b3"  # pragma: allowlist secret
+
+
+def _bootstrap_creek_vault_write_baseline(sync_url: str) -> None:
+    """Pre-create minimal ``user`` and ``journalentry`` tables for the round-trip fixture.
+
+    Mirrors the shape just before the vault-write columns migration. Only the
+    columns unrelated to the new ``vault_ref`` / ``vault_tags`` pair are needed,
+    so the bootstrap stays narrow rather than replaying the whole preceding chain.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE user ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(text("INSERT INTO user (id, email) VALUES (1, 'vault@example.com')"))
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry (id, user_id, sender, message)"
+                " VALUES (1, 1, 'user', 'Pre-migration entry.')"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_creek_vault_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before the vault-write columns migration."""
+    db_path = tmp_path / "creek_vault_write_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_creek_vault_write_baseline(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _CREEK_VAULT_WRITE_BASE_REVISION)
+    return cfg
+
+
+def _journalentry_ids(db_url: str) -> list[int]:
+    """Return every ``journalentry.id`` present, to prove a migration preserves rows."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text("SELECT id FROM journalentry")).fetchall()
+            return [row[0] for row in rows]
+    finally:
+        engine.dispose()
+
+
+def test_creek_vault_write_migration_adds_and_drops_columns(
+    alembic_sqlite_config_creek_vault_write: Config,
+) -> None:
+    """The vault-write migration adds nullable vault_ref/vault_tags; downgrade drops them.
+
+    This test fails with an Alembic ``CommandError`` (unknown revision) until the
+    implementer authors the migration and sets ``_CREEK_VAULT_WRITE_REVISION`` to
+    its real revision ID -- the correct RED failure mode for a not-yet-written
+    migration, matching the placeholder-revision pattern used elsewhere in this
+    file for other not-yet-authored migrations.
+    """
+    cfg = alembic_sqlite_config_creek_vault_write
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds both nullable columns; the pre-existing row survives.
+    command.upgrade(cfg, _CREEK_VAULT_WRITE_REVISION)
+    cols = _columns_of(db_url, "journalentry")
+    assert {"vault_ref", "vault_tags"}.issubset(cols)
+    assert _journalentry_ids(db_url) == [1]
+
+    # Phase 2: downgrade removes both columns.
+    command.downgrade(cfg, _CREEK_VAULT_WRITE_BASE_REVISION)
+    cols_after = _columns_of(db_url, "journalentry")
+    assert {"vault_ref", "vault_tags"}.isdisjoint(cols_after)
+
+    # Phase 3: re-upgrade is idempotent.
+    command.upgrade(cfg, _CREEK_VAULT_WRITE_REVISION)
+    cols_again = _columns_of(db_url, "journalentry")
+    assert {"vault_ref", "vault_tags"}.issubset(cols_again)


### PR DESCRIPTION
## Summary

Wires the journal create/update endpoints to a best-effort **Creek Vault write path** (`services.creek_vault_write.store_and_classify`) that stores an entry's body in the vault and records the vault's classification, while guaranteeing the entry is always saved locally regardless of vault state.

- **Privacy gate.** An entry classified `intimate` short-circuits to `SKIPPED_INTIMATE` **before any vault call** — not even a handshake — because the contract's encrypted, attestation-gated intimate transit path is not yet built. A PATCH that re-classifies an already-ingested entry as `intimate` also **clears** its persisted `vault_ref` / `vault_tags`, so the row never retains a handle to plaintext the writer has withdrawn consent to expose.
- **Graceful degradation.** `store_and_classify` never raises a vault error. Outcomes:
  - `SKIPPED_INTIMATE` — intimate content, withheld.
  - `UNAVAILABLE` — no vault configured, unreachable, or no INGEST capability.
  - `DEGRADED` — transport failure or `stored=False`; a transient state that **keeps** any existing ref rather than dropping it on a passing blip.
  - `INGESTED` — durable store; the only status that writes `vault_ref` + `vault_tags`. Classification is optional enrichment layered on top and never demotes a successful ingest.
- **Re-ingest** fires on a PATCH only when `message` or `classification` changed; a title/status/chord-only PATCH issues zero vault calls.
- **Migration `c7d8e9f0a1b3`** adds two nullable columns to `journalentry` (`vault_ref` String, `vault_tags` JSON), parented off `f8a9b0c1d2e3`. Purely additive and SQLite-safe; single alembic head.

### Follow-ups (non-blocking, noted from self-review)
- The re-ingest trigger keys on `payload.model_fields_set` rather than an actual value change, so a PATCH echoing an unchanged `message`/`classification` issues a redundant ingest. Minor; can be gated on a real change later.
- The vault round-trip is awaited before the HTTP response. No prod impact today (unconfigured → instant local fallback), but a configured vault would add latency — a candidate for `BackgroundTasks` before a real vault lands.

## Test plan

- `backend/tests/test_creek_vault_write.py` — unit coverage of `store_and_classify` degrade matrix (intimate skip, unavailable, ingest-unsupported, tier-ceiling mapping, ingest-request contents, classify-optional, transport-failure → DEGRADED).
- `backend/tests/test_journal_vault_write.py` — integration coverage of create + PATCH wiring, including the `personal`→`intimate` transition (clears ref/tags, sends nothing) and `intimate`→`personal` transition (first ingest).
- `backend/tests/test_migrations.py` — migration round-trip.
- Full `./scripts/backend/check-all.sh` green (2844 passed, 96.9% coverage; `creek_vault_write.py` 100%), plus manual xenon (A) / radon (MI A); single alembic head verified.

Closes #952
Refs #949
Refs #951