### PR TITLE
feat(map): enrich the magnifier lens caption with stage ontology

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -431,11 +431,17 @@ const LensCaptionBlock = ({
           <Text style={styles.youAreHereText}>YOU ARE HERE</Text>
         </View>
       ) : null}
+      <Text style={styles.magnifierEyebrow} testID="magnifier-eyebrow" numberOfLines={1}>
+        {caption.eyebrow}
+      </Text>
       <Text style={styles.magnifierHeadline} testID="magnifier-headline" numberOfLines={1}>
         {caption.headline}
       </Text>
       <Text style={styles.magnifierDetail} testID="magnifier-detail" numberOfLines={1}>
         {caption.detail}
+      </Text>
+      <Text style={styles.magnifierPractice} testID="magnifier-practice" numberOfLines={1}>
+        {caption.practice}
       </Text>
     </View>
   );
@@ -446,7 +452,7 @@ const lensAccessibilityLabel = (stageNumber: number, isCurrent: boolean): string
   const caption = lensCaption(stageNumber);
   const prefix = isCurrent ? 'You are here. ' : '';
   return (
-    `${prefix}Magnifier over ${caption.headline} — ${caption.detail}. ` +
+    `${prefix}Magnifier over ${caption.headline}, stage ${caption.eyebrow} — ${caption.detail}. Practice: ${caption.practice}. ` +
     'Tap to read about this stage; drag to explore others.'
   );
 };

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -184,6 +184,14 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: ink.soft,
   },
+  magnifierEyebrow: {
+    fontSize: 9,
+    lineHeight: 11,
+    fontWeight: '600',
+    letterSpacing: 1,
+    color: ink.soft,
+  },
+  magnifierPractice: { fontSize: 9, lineHeight: 11, color: ink.soft },
   // "You are here" chip riding the lens when it rests on the current stage.
   youAreHere: {
     marginBottom: spacing(0.25),

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -52,6 +52,9 @@ const lensNode = (tree: ReturnType<typeof create>) =>
 const headlineText = (tree: ReturnType<typeof create>): string =>
   tree.root.findByProps({ testID: 'magnifier-headline' }).props.children as string;
 
+const textByTestId = (tree: ReturnType<typeof create>, testID: string) =>
+  tree.root.findByProps({ testID });
+
 /** Synthetic responder touch event at a page position. */
 const touch = (pageX: number, pageY: number, timestamp = 0) => ({
   nativeEvent: { pageX, pageY, timestamp },
@@ -129,6 +132,12 @@ describe('MagnifierLens', () => {
     expect(headlineText(tree)).toBe('Self-Love');
     const detail = tree.root.findByProps({ testID: 'magnifier-detail' });
     expect(detail.props.children).toBe('Dominator · Power');
+    const eyebrow = textByTestId(tree, 'magnifier-eyebrow');
+    expect(eyebrow.props.children).toBe('3 · RED');
+    expect(eyebrow.props.numberOfLines).toBe(1);
+    const practice = textByTestId(tree, 'magnifier-practice');
+    expect(practice.props.children).toBe('Belly breathing');
+    expect(practice.props.numberOfLines).toBe(1);
   });
 
   it('re-captions when the focused stage prop changes (stage tap glide)', () => {
@@ -147,6 +156,7 @@ describe('MagnifierLens', () => {
       );
     });
     expect(headlineText(tree)).toBe('Intellectual');
+    expect(textByTestId(tree, 'magnifier-eyebrow').props.children).toBe('5 · ORANGE');
   });
 
   it('renders a magnified copy of the wave under the glass', () => {
@@ -253,6 +263,9 @@ describe('MagnifierLens', () => {
     expect(lens.props.accessibilityRole).toBe('button');
     expect(lens.props.accessibilityLabel).toContain('You are here');
     expect(lens.props.accessibilityLabel).toContain('Agency');
+    expect(lens.props.accessibilityLabel).toContain('1 · BEIGE');
+    expect(lens.props.accessibilityLabel).toContain('5-4-3-2-1 grounding');
+    expect(lens.props.accessibilityLabel).toContain('drag to explore');
   });
 
   it('glides with animation when reduced motion is off', () => {

--- a/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* global describe, it, expect */
 
+import { STAGE_ORDER } from '../../../design/tokens';
 import {
   clampLensCenter,
   DRAG_TAP_SLOP,
@@ -190,21 +191,35 @@ describe('lensCaption', () => {
     expect(caption.detail).toBe('Dominator · Power');
   });
 
+  it('prefixes the stage number and spiral color as the eyebrow', () => {
+    const caption = lensCaption(4);
+    expect(caption.eyebrow).toBe('4 · BLUE');
+    expect(caption.practice).toBe('Metta');
+  });
+
+  it('uppercases a two-word spiral color name in the eyebrow', () => {
+    expect(lensCaption(10).eyebrow).toBe('10 · CLEAR LIGHT');
+    expect(lensCaption(10).headline).toBe(TITLE_BY_STAGE[10]);
+  });
+
   it('falls back to the UNITY / EMPTINESS titles for the top stages', () => {
     expect(lensCaption(9).headline).toBe(TITLE_BY_STAGE[9]);
     expect(lensCaption(10).headline).toBe(TITLE_BY_STAGE[10]);
   });
 
-  it('covers every stage with a non-empty headline and detail', () => {
+  it('covers every stage with a non-empty headline, detail, eyebrow, and practice', () => {
     for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
       const caption = lensCaption(stage);
       expect(caption.headline.length).toBeGreaterThan(0);
       expect(caption.detail).toContain(STAGE_DISPLAY[stage]?.persona ?? '');
+      expect(caption.eyebrow).toBe(`${stage} · ${(STAGE_ORDER[stage - 1] ?? '').toUpperCase()}`);
+      expect(caption.practice).toBe(STAGE_DISPLAY[stage]?.practice);
+      expect(caption.practice.length).toBeGreaterThan(0);
     }
   });
 
   it('resolves unknown stages to empty strings instead of throwing', () => {
-    expect(lensCaption(99)).toEqual({ headline: '', detail: '' });
+    expect(lensCaption(99)).toEqual({ eyebrow: '', headline: '', detail: '', practice: '' });
   });
 });
 

--- a/frontend/src/features/Map/magnifierGeometry.ts
+++ b/frontend/src/features/Map/magnifierGeometry.ts
@@ -11,6 +11,8 @@
  * through, so its per-stage resting points sit exactly on the strand.
  */
 
+import { STAGE_ORDER } from '../../design/tokens';
+
 import { STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import { STAGE_COUNT } from './stageData';
 import { centerColumnBounds, stageWavePoint } from './waveGeometry';
@@ -181,23 +183,34 @@ export const magnifierTransform = (
 export const glideDurationMs = (distancePx: number): number =>
   clamp(distancePx * GLIDE_MS_PER_PX, GLIDE_MIN_MS, GLIDE_MAX_MS);
 
-/** The two caption lines the lens shows for the stage under the glass. */
+/** The enriched caption the lens shows for the stage under the glass. */
 export interface LensCaption {
+  /** Stage number + Spiral color name, e.g. "4 · BLUE". */
+  eyebrow: string;
   /** The Aspect word for the stage (or its UNITY / EMPTINESS title). */
   headline: string;
   /** The stage's persona and mode of knowing, dot-separated. */
   detail: string;
+  /** The practice cultivated at this stage. */
+  practice: string;
 }
 
 /**
- * Resolve the caption for a stage under the glass: its Aspect arrow word (or
- * the UNITY / EMPTINESS title carried by stages 9–10) over its persona and
- * descriptor. Unknown stages resolve to empty strings rather than throwing so
- * a transient out-of-range hover can never take the Map down.
+ * Resolve the caption for a stage under the glass: an eyebrow pairing the stage
+ * number with its Spiral color, the Aspect arrow word (or the UNITY / EMPTINESS
+ * title carried by stages 9–10) over its persona and descriptor, and the
+ * stage's cultivated practice. Unknown stages resolve to empty strings rather
+ * than throwing so a transient out-of-range hover can never take the Map down.
  */
 export const lensCaption = (stageNumber: number): LensCaption => {
   const display = STAGE_DISPLAY[stageNumber];
-  if (!display) return { headline: '', detail: '' };
+  if (!display) return { eyebrow: '', headline: '', detail: '', practice: '' };
   const headline = display.arrowLabel || TITLE_BY_STAGE[display.stageNumber] || '';
-  return { headline, detail: `${display.persona} · ${display.descriptor}` };
+  const colorName = (STAGE_ORDER[display.stageNumber - 1] ?? '').toUpperCase();
+  return {
+    eyebrow: `${display.stageNumber} · ${colorName}`,
+    headline,
+    detail: `${display.persona} · ${display.descriptor}`,
+    practice: display.practice,
+  };
 };


### PR DESCRIPTION
## Summary

Enriches the Map magnifier lens caption so a drag along the strand reads as a tour, not just a label — while keeping the Aspect word the largest element exactly as before.

- Extends the pure `lensCaption(stageNumber)` resolver from `{ headline, detail }` to `{ eyebrow, headline, detail, practice }`.
- New **eyebrow** above the headline: stage number + Spiral color name, small-caps (e.g. `4 · BLUE`).
- New **practice** line under the persona·descriptor detail (e.g. `Metta`).
- Every added line is sourced from in-repo ontology (`STAGE_DISPLAY`, `TITLE_BY_STAGE`, `STAGE_ORDER`) — no hardcoded ontology strings — so it inherits the stage-ontology corrections automatically.
- The Aspect headline (16px serif) stays the dominant element; the two new lines are 9px accessories with tight `lineHeight` and `numberOfLines={1}`.
- Unknown stages keep the all-empty fallback (never throws); UNITY/EMPTINESS titles for stages 9–10 keep working.
- The accessibility label reads the same enriched content; the YOU ARE HERE chip behavior is unchanged.
- Scope is the magnifier lens caption only — disjoint from the stage-detail modal expressions.

## Test plan

- Extended `magnifierGeometry.test.ts`: eyebrow/practice content, two-word color-name uppercasing (`10 · CLEAR LIGHT`), full 1–10 data-sourced coverage loop, and the unknown-stage empty-shape fallback.
- Extended `MagnifierLens.test.tsx`: rendered `magnifier-eyebrow`/`magnifier-practice` lines with `numberOfLines={1}`, live re-caption on prop change, and the enriched accessibility label.
- `scripts/frontend/check-all.sh` green locally: ESLint, Prettier, tsc, and the full Jest suite (4509 tests).

Closes #1776