### PR TITLE
feat(map): show unlock estimate on locked EMPTINESS and UNITY title rows

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -282,6 +282,9 @@ const styles = StyleSheet.create({
   unlockTimelineRight: {
     textAlign: 'right',
   },
+  unlockTimelineCenter: {
+    textAlign: 'center',
+  },
 
   // --- Stage-completion celebration banner ----------------------------------
   celebrationBanner: {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -10,7 +10,9 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  type StyleProp,
   Text,
+  type TextStyle,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -98,13 +100,20 @@ const LockGlyph = (): React.JSX.Element => (
 );
 
 /** Aspect label / unlock estimate corner within a center cell. */
-type LabelCorner = 'left' | 'right';
+type LabelCorner = 'left' | 'right' | 'center';
+
+/** Text-align variant for each corner, keyed to avoid a nested ternary. */
+const UNLOCK_ALIGN_STYLE: Readonly<Record<LabelCorner, StyleProp<TextStyle>>> = {
+  left: styles.unlockTimelineLeft,
+  right: styles.unlockTimelineRight,
+  center: styles.unlockTimelineCenter,
+};
 
 /**
  * "Unlocks in N days" / unlock-condition copy for a locked stage, computed from
  * the existing calendar drip (no new backend). Falls back to the condition when
  * no program anchor is set. Its text aligns to the block's corner so the copy
- * reads away from the wave strand.
+ * reads away from the wave strand (or centers beneath a fitted title).
  */
 const UnlockTimeline = ({
   stageNumber,
@@ -114,7 +123,7 @@ const UnlockTimeline = ({
   corner: LabelCorner;
 }): React.JSX.Element => {
   const daysUntil = useDaysUntilStage(stageNumber);
-  const alignStyle = corner === 'left' ? styles.unlockTimelineLeft : styles.unlockTimelineRight;
+  const alignStyle = UNLOCK_ALIGN_STYLE[corner];
   return (
     <Text style={[styles.unlockTimeline, alignStyle]} testID={`stage-unlock-${stageNumber}`}>
       {unlockTimeline(daysUntil)}
@@ -258,7 +267,12 @@ const CenterContent = ({
 }): React.JSX.Element | null => {
   const title = TITLE_BY_STAGE[display.stageNumber];
   if (title) {
-    return <FittedTitle title={title} />;
+    return (
+      <>
+        <FittedTitle title={title} />
+        {locked ? <UnlockTimeline stageNumber={display.stageNumber} corner="center" /> : null}
+      </>
+    );
   }
   if (!display.arrowLabel) {
     return null;

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -5,6 +5,7 @@ import { Image, StyleSheet } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import { ink, surface } from '../../../design/tokens';
+import { unlockTimeline } from '../journeyNarrative';
 import styles from '../Map.styles';
 import {
   fitRightLabel,
@@ -937,6 +938,59 @@ describe('MapScreen left-column stage text color', () => {
       const node = tree.root.findByProps({ children: title });
       const flat = StyleSheet.flatten(node.props.style) as { color?: string };
       expect(flat.color).toBe(ink.muted);
+    }
+  });
+});
+
+describe('MapScreen locked title-row unlock estimate', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
+    );
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  it('renders the centered unlock estimate on the locked EMPTINESS and UNITY title rows', () => {
+    mockMapState.daysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    for (const stageNumber of [9, 10]) {
+      const estimate = tree.root.findByProps({ testID: `stage-unlock-${stageNumber}` });
+      expect(estimate.props.children).toBe(unlockTimeline(42));
+      const flat = StyleSheet.flatten(estimate.props.style) as {
+        fontSize?: number;
+        color?: string;
+        textAlign?: string;
+      };
+      expect(flat.fontSize).toBe(9);
+      expect(flat.color).toBe(ink.muted);
+      expect(flat.textAlign).toBe('center');
+    }
+  });
+
+  it('omits the unlock estimate on unlocked title rows', () => {
+    mockMapState.derivedStage = 10;
+    const tree = create(<MapScreen />);
+    expect(tree.root.findAll((n: TestNode) => n.props.testID === 'stage-unlock-9')).toHaveLength(0);
+    expect(tree.root.findAll((n: TestNode) => n.props.testID === 'stage-unlock-10')).toHaveLength(
+      0,
+    );
+  });
+
+  it('keeps the fitted-title sizing intact while the locked estimate renders', () => {
+    mockMapState.daysUntilStage = 42;
+    const MEASURED_WIDTH = 140;
+    const tree = create(<MapScreen />);
+    for (const title of ['EMPTINESS', 'UNITY']) {
+      const wrapper = tree.root.findByProps({ testID: `title-fit-${title}` });
+      act(() => {
+        (wrapper.props.onLayout as (e: unknown) => void)({
+          nativeEvent: { layout: { width: MEASURED_WIDTH, height: 40 } },
+        });
+      });
+      const node = tree.root.findByProps({ children: title });
+      const flat = StyleSheet.flatten(node.props.style) as { fontSize?: number };
+      expect(flat.fontSize).toBe(fittedTitleFontSize(title, MEASURED_WIDTH));
     }
   });
 });


### PR DESCRIPTION
## Summary

The Map's EMPTINESS (stage 10) and UNITY (stage 9) title rows previously went
silent about their unlock timing while locked — every other locked stage already
shows an "Unlocks in N days" estimate. This adds that estimate to the two title
rows, centered beneath the fitted title watermark and styled identically to
every other stage's estimate (9px, `ink.muted`).

- Reuses the existing `UnlockTimeline` component, `useDaysUntilStage` hook, and
  `unlockTimeline` copy — no duplicated countdown logic or strings. `N` therefore
  agrees with every other calendar surface.
- Adds a centered `corner` variant (`unlockTimelineCenter`, `textAlign: 'center'`)
  and a `Record<LabelCorner, StyleProp<TextStyle>>` lookup in place of the
  two-way ternary (avoids a nested ternary).
- `CenterContent`'s title branch now renders a fragment: the `FittedTitle` stays
  the direct measurement child (so `fittedTitleFontSize` is untouched — the
  watermark never shrinks, wraps, or hyphenates), with the estimate as a sibling
  below it when locked.
- Unlocked stages 9/10 render exactly as before (no estimate).

## Test plan

- New tests in `MapScreen.test.tsx` (TDD, RED first):
  - locked EMPTINESS/UNITY render the centered estimate (text === `unlockTimeline(42)`,
    `fontSize` 9, `color` `ink.muted`, `textAlign` `center`)
  - unlocked title rows omit the estimate
  - fitted-title sizing stays intact while the locked estimate renders
- `scripts/frontend/check-all.sh` green: prettier, eslint, tsc, and all 4512 Jest
  tests pass.

Closes #1777