### PR TITLE
feat(journal): prefillQuote param on JournalEntry with return-to-source affordance

### DIFF
--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -34,6 +34,7 @@ import MarginNote from './MarginNote';
 import PrivacyTierControl, { DEFAULT_TIER } from './PrivacyTierControl';
 import { promptTitleForWeek } from './promptTitle';
 import QuoteSelectionSurface, { type CodePointSpan } from './QuoteSelectionSurface';
+import { formatQuotePrefill } from './reflectionCopy';
 import ReflectionSourcesPanel from './ReflectionSourcesPanel';
 import ResonanceEssayModal from './ResonanceEssayModal';
 import { usePromotions } from './usePromotions';
@@ -779,6 +780,12 @@ function useFieldHandlers(
   return { onChangeTitle, onChangeBody };
 }
 
+/** The pre-fill an entry opens with: a title and a body, either possibly ''. */
+interface InitialText {
+  title: string;
+  body: string;
+}
+
 interface EntryState {
   title: string;
   body: string;
@@ -799,17 +806,17 @@ interface EntryState {
 }
 
 /** The entry's editable state (title/body/status/tier) + one-time load-on-open. */
-function useEntryState(routeEntryId: number | null, initialTitle: string): EntryState {
-  const [title, setTitle] = useState(initialTitle);
-  const [body, setBody] = useState('');
+function useEntryState(routeEntryId: number | null, initialText: InitialText): EntryState {
+  const [title, setTitle] = useState(initialText.title);
+  const [body, setBody] = useState(initialText.body);
   const [status, setStatus] = useState<EntryStatus>('draft');
   const [classification, setClassification] = useState<JournalClassification>(DEFAULT_TIER);
   const [chord, setChord] = useState<AspectChordValue>(EMPTY_CHORD);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   // Refs mirror the latest text so the change handlers stay referentially stable.
-  const titleRef = useRef(initialTitle);
-  const bodyRef = useRef('');
+  const titleRef = useRef(initialText.title);
+  const bodyRef = useRef(initialText.body);
 
   useEntryLoadEffect(
     routeEntryId,
@@ -909,11 +916,11 @@ function useJournalAutosave(
   routeEntryId: number | null,
   delayMs: number,
   ctx: SaveContext,
-  initialTitle: string,
+  initialText: InitialText,
   onSaved?: () => void,
   onConflict?: () => void,
 ): AutosaveApi {
-  const entry = useEntryState(routeEntryId, initialTitle);
+  const entry = useEntryState(routeEntryId, initialText);
   const { titleRef, bodyRef } = entry;
   // An existing entry is "unsettled" until its load settles: entry.loaded flips
   // true only in the success apply, so it stays false through both the in-flight
@@ -1636,7 +1643,7 @@ function useJournalEntryController(
   autosaveDelayMs: number,
   navigation: ScreenNavigation,
   ctx: SaveContext,
-  initialTitle: string,
+  initialText: InitialText,
 ) {
   const { refreshRef, handleSaved, onConfirmEdit } = useRefreshAfterEdit();
   const onCreateConflict = useCreateConflictHandler(ctx, navigation);
@@ -1644,7 +1651,7 @@ function useJournalEntryController(
     routeEntryId,
     autosaveDelayMs,
     ctx,
-    initialTitle,
+    initialText,
     handleSaved,
     onCreateConflict,
   );
@@ -1768,15 +1775,19 @@ function JournalPage({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceholde
 
 interface EntryEntrypoint {
   ctx: SaveContext;
-  initialTitle: string;
+  initialText: InitialText;
   bodyPlaceholder: string;
 }
 
-/** Translate the route params into the save context + pre-filled title/placeholder. */
+/** Translate the route params into the save context + pre-filled title/body/placeholder. */
 function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntrypoint {
   const p = params ?? {};
-  const initialTitle =
-    p.prefillTitle ?? (p.weekNumber != null ? promptTitleForWeek(p.weekNumber) : '');
+  const title = p.prefillTitle ?? (p.weekNumber != null ? promptTitleForWeek(p.weekNumber) : '');
+  // A folded-in quote seeds the body as a blockquote; otherwise the body opens blank.
+  const body =
+    p.prefillQuote != null
+      ? formatQuotePrefill(p.prefillQuote.text, p.prefillQuote.sourceTitle)
+      : '';
   return {
     ctx: {
       weekNumber: p.weekNumber,
@@ -1785,7 +1796,7 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
       reflectionLevel: p.reflectionLevel,
       reflectionScopeKey: p.reflectionScopeKey,
     },
-    initialTitle,
+    initialText: { title, body },
     bodyPlaceholder: p.promptQuestion ?? DEFAULT_BODY_PLACEHOLDER,
   };
 }
@@ -1822,6 +1833,45 @@ function LoadErrorBanner({ message }: { message: string | null }): React.JSX.Ele
         {message}
       </Text>
     </View>
+  );
+}
+
+/** The reader location "Back to reading" returns to, carrying the scroll offset. */
+type CourseReturnTo = NonNullable<RootStackParamList['JournalEntry']>['returnTo'];
+
+/**
+ * "Back to reading" affordance shown only when the writer arrived from the course
+ * reader (``returnTo`` present). Pressing it flushes any typed draft — kicking the
+ * save in flight and cancelling the debounce timer so nothing is lost as this
+ * stack screen unmounts — then returns to the exact Course content they left. The
+ * flush is fired, not awaited, so the return navigation happens immediately while
+ * the persist completes independently of this screen's lifecycle.
+ */
+function ReturnToReadingLink({
+  returnTo,
+  navigation,
+  flush,
+}: {
+  returnTo: CourseReturnTo;
+  navigation: ScreenNavigation;
+  flush: () => Promise<number | null>;
+}): React.JSX.Element | null {
+  const onPress = useCallback(() => {
+    if (returnTo == null) return;
+    void flush();
+    navigation.navigate('Tabs', { screen: returnTo.screen, params: returnTo.params });
+  }, [returnTo, navigation, flush]);
+  if (returnTo == null) return null;
+  return (
+    <TouchableOpacity
+      style={styles.quoteActionButton}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Back to reading — return to where you were reading"
+      testID="journal-return-to-reading"
+    >
+      <Text style={styles.controlLink}>Back to reading</Text>
+    </TouchableOpacity>
   );
 }
 
@@ -1935,7 +1985,7 @@ function JournalEntryScreen({
   navigation,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const { ctx, initialTitle, bodyPlaceholder } = readEntrypoint(route.params);
+  const { ctx, initialText, bodyPlaceholder } = readEntrypoint(route.params);
   const currentEntryId = route.params?.entryId ?? null;
   const entryDrawer = useEntryScreenDrawer(navigation);
   const ctl = useJournalEntryController(
@@ -1943,7 +1993,7 @@ function JournalEntryScreen({
     autosaveDelayMs,
     navigation,
     ctx,
-    initialTitle,
+    initialText,
   );
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">
@@ -1956,6 +2006,11 @@ function JournalEntryScreen({
           always reads first. Hidden (renders nothing) on healthy passes. */}
       <ContractionReflectionNote contraction={ctl.resonance.contraction} />
       <LoadErrorBanner message={ctl.autosave.loadError} />
+      <ReturnToReadingLink
+        returnTo={route.params?.returnTo}
+        navigation={navigation}
+        flush={ctl.autosave.flush}
+      />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
       <ReflectionComposer reflection={ctl.reflection} />
       <PrivacyResonanceReason

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreen.test.tsx
@@ -69,6 +69,11 @@ function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
   };
 }
 
+interface ReturnToCourse {
+  screen: 'Course';
+  params: { stageNumber?: number; contentId: number; scrollOffset: number };
+}
+
 function renderScreen(
   params?: {
     entryId?: number;
@@ -77,6 +82,8 @@ function renderScreen(
     prefillTitle?: string;
     practiceSessionId?: number;
     userPracticeId?: number;
+    prefillQuote?: { text: string; sourceTitle: string };
+    returnTo?: ReturnToCourse;
   },
   extraProps: Record<string, unknown> = {},
 ) {
@@ -610,5 +617,78 @@ describe('JournalEntryScreen', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  describe('prefillQuote + returnTo', () => {
+    const quote = {
+      text: 'To open your heart not just to yourself, but to others.',
+      sourceTitle: 'The Mood of Blue',
+    };
+    const formattedQuote =
+      '> To open your heart not just to yourself, but to others.\n> — The Mood of Blue\n\n';
+    const returnTo: ReturnToCourse = {
+      screen: 'Course',
+      params: { stageNumber: 2, contentId: 17, scrollOffset: 480 },
+    };
+
+    it('pre-fills the body with the formatted quote block', () => {
+      const { getByTestId } = renderScreen({ prefillQuote: quote });
+      expect(getByTestId('journal-body-input').props.value).toBe(formattedQuote);
+    });
+
+    it('composes with prefillTitle: title and body both pre-fill', () => {
+      const { getByTestId } = renderScreen({
+        prefillQuote: quote,
+        prefillTitle: 'Reflecting on The Mood of Blue',
+      });
+      expect(getByTestId('journal-title-input').props.value).toBe('Reflecting on The Mood of Blue');
+      expect(getByTestId('journal-body-input').props.value).toBe(formattedQuote);
+    });
+
+    it('shows a Back to reading affordance when returnTo is present', () => {
+      const { getByTestId, getByText } = renderScreen({ returnTo });
+      expect(getByTestId('journal-return-to-reading')).toBeTruthy();
+      expect(getByText('Back to reading')).toBeTruthy();
+    });
+
+    it('navigates back to the Course content on Back to reading', () => {
+      const { getByTestId, navigation } = renderScreen({ returnTo });
+      fireEvent.press(getByTestId('journal-return-to-reading'));
+      expect(navigation.navigate).toHaveBeenCalledWith(
+        'Tabs',
+        expect.objectContaining({
+          screen: 'Course',
+          params: { stageNumber: 2, contentId: 17, scrollOffset: 480 },
+        }),
+      );
+    });
+
+    it('hides the return affordance when returnTo is absent', () => {
+      const { queryByTestId } = renderScreen();
+      expect(queryByTestId('journal-return-to-reading')).toBeNull();
+    });
+
+    it('leaves the body blank and hides the return affordance with no params', () => {
+      const { getByTestId, queryByTestId } = renderScreen();
+      expect(getByTestId('journal-body-input').props.value).toBe('');
+      expect(queryByTestId('journal-return-to-reading')).toBeNull();
+    });
+
+    it('flushes the typed draft before navigating away via Back to reading', async () => {
+      jest.useFakeTimers();
+      try {
+        const { getByTestId } = renderScreen({ returnTo }, { autosaveDelayMs: 100 });
+        fireEvent.changeText(getByTestId('journal-body-input'), 'A thought mid-read.');
+        fireEvent.press(getByTestId('journal-return-to-reading'));
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(100);
+        });
+        expect(mockCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'A thought mid-read.' }),
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 });

--- a/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
+++ b/frontend/src/features/Journal/__tests__/reflectionCopy.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from '@jest/globals';
 
-import { reflectionTitle, formatBlockquote, sourceAttribution } from '../reflectionCopy';
+import {
+  reflectionTitle,
+  formatBlockquote,
+  formatQuotePrefill,
+  sourceAttribution,
+} from '../reflectionCopy';
 
 import type { ReflectionSourceItem } from '@/api';
 
@@ -61,6 +66,38 @@ describe('formatBlockquote', () => {
   it('closes with a blank line so the inserted quote never runs into surrounding prose', () => {
     const block = formatBlockquote('went for a daily walk', 'Runs');
     expect(block.endsWith('\n\n')).toBe(true);
+  });
+});
+
+describe('formatQuotePrefill', () => {
+  it('formats a single-line passage as an exact blockquote prefill', () => {
+    const prefill = formatQuotePrefill(
+      'To open your heart not just to yourself, but to others.',
+      'The Mood of Blue',
+    );
+    expect(prefill).toBe(
+      '> To open your heart not just to yourself, but to others.\n> — The Mood of Blue\n\n',
+    );
+  });
+
+  it('prefixes every line of a multi-line passage with its own marker', () => {
+    const prefill = formatQuotePrefill('line one\nline two', 'Src');
+    expect(prefill).toBe('> line one\n> line two\n> — Src\n\n');
+  });
+
+  it('includes the attribution on its own quoted line', () => {
+    const prefill = formatQuotePrefill('a passage', 'The Mood of Blue');
+    expect(prefill).toContain('> — The Mood of Blue');
+  });
+
+  it('ends with a trailing blank line', () => {
+    const prefill = formatQuotePrefill('a passage', 'Src');
+    expect(prefill.endsWith('\n\n')).toBe(true);
+  });
+
+  it('does not open with a leading newline', () => {
+    const prefill = formatQuotePrefill('a passage', 'Src');
+    expect(prefill.startsWith('\n')).toBe(false);
   });
 });
 

--- a/frontend/src/features/Journal/reflectionCopy.ts
+++ b/frontend/src/features/Journal/reflectionCopy.ts
@@ -51,6 +51,18 @@ export function formatBlockquote(anchorText: string, attribution: string): strin
   return `\n> ${anchorText}\n> — ${attribution}\n\n`;
 }
 
+/**
+ * A Markdown blockquote prefill for a whole passage carried into a fresh entry.
+ * Every line of ``text`` is quoted, the ``sourceTitle`` is attributed on its own
+ * quoted line, and a trailing blank line separates it from anything the writer
+ * adds. Unlike ``formatBlockquote`` it opens with no leading newline — it is the
+ * top of a new body — and quotes multi-line passages line by line.
+ */
+export function formatQuotePrefill(text: string, sourceTitle: string): string {
+  const quotedLines = text.split('\n').map((line) => `> ${line}`);
+  return `${quotedLines.join('\n')}\n> — ${sourceTitle}\n\n`;
+}
+
 /** ``short`` month/day/year attribution date (e.g. "Jun 1, 2026"); '' if unparseable. */
 function formatSourceDate(timestamp: string): string {
   const date = new Date(timestamp);

--- a/frontend/src/navigation/BottomTabs.tsx
+++ b/frontend/src/navigation/BottomTabs.tsx
@@ -30,7 +30,8 @@ import {
 export type RootTabParamList = {
   Habits: undefined;
   Practice: { stageNumber?: number } | undefined;
-  Course: { stageNumber?: number } | undefined;
+  // contentId/scrollOffset are optional restore hints from a Back-to-reading return.
+  Course: { stageNumber?: number; contentId?: number; scrollOffset?: number } | undefined;
   Journal: undefined;
   Map: undefined;
 };

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -50,6 +50,13 @@ export type RootStackParamList = {
         reflectionLevel?: ReflectionLevel;
         /** The scope key the reflection covers (e.g. ``c1:w14``); pairs with ``reflectionLevel``. */
         reflectionScopeKey?: string;
+        /** A passage folded in from the reader; seeds the body as a blockquote. */
+        prefillQuote?: { text: string; sourceTitle: string };
+        /** Where "Back to reading" returns the writer, restoring their scroll. */
+        returnTo?: {
+          screen: 'Course';
+          params: { stageNumber?: number; contentId: number; scrollOffset: number };
+        };
       }
     | undefined;
 };


### PR DESCRIPTION
## Summary

Extends the `JournalEntry` route so a caller (the course reader, via sibling #1781) can open a fresh entry with a passage pre-inserted as a Markdown block quote and a calm "Back to reading" affordance that returns to the source.

- Adds a pure `formatQuotePrefill(text, sourceTitle)` helper in `reflectionCopy.ts` — quotes every line of the passage with `> `, attributes the source on its own quoted line, and ends with a trailing blank line (no leading newline, so it opens a fresh body). Reuses the existing `> — ` attribution idiom without disturbing `formatBlockquote`.
- Extends `RootStackParamList['JournalEntry']` with optional, serializable `prefillQuote: { text; sourceTitle }` and `returnTo: { screen: 'Course'; params: { stageNumber?; contentId; scrollOffset } }`.
- Seeds the entry body through the existing `initialText` threading (`readEntrypoint` → controller → autosave → `useEntryState`), so a prefilled quote seeds `body` state + `bodyRef` exactly like `prefillTitle` seeds the title today — and schedules no save on its own.
- Renders a `ReturnToReadingLink` (styled like existing secondary entry actions) only when `returnTo` is present; pressing it flushes any typed draft in-flight, then navigates back to the Course content — leaving never loses the draft.
- Extends the `Course` tab param with optional `contentId`/`scrollOffset` as type plumbing only; the actual scroll restore is the sibling's scope.

All params stay optional and backward compatible: no params means zero behavior change, and `prefillTitle` still composes with `prefillQuote`.

## Test plan

- `reflectionCopy.test.ts`: `formatQuotePrefill` exact single-line and multi-line output, per-line `> ` prefix, attribution line, trailing blank line, no leading newline.
- `JournalEntryScreen.test.tsx`: body prefilled from `prefillQuote`; composes with `prefillTitle`; "Back to reading" affordance visibility; exact `navigate('Tabs', { screen: 'Course', params })` payload; absent affordance without `returnTo`; no-params regression; draft flushed before navigating away.
- Full `scripts/frontend/check-all.sh` green (4524 tests, lint/format/typecheck/test all pass).

Refs #1779
Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)