### PR TITLE
feat(course): passage selection in the chapter reader with write-a-note flow

### DIFF
--- a/frontend/src/features/Course/ChapterReader.tsx
+++ b/frontend/src/features/Course/ChapterReader.tsx
@@ -1,14 +1,40 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Image, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
 import Markdown from 'react-native-markdown-display';
 
 import { course as courseApi, type ContentBody } from '../../api';
 import { BottomFade } from '../../components/layout/BottomFade';
 import { colors, rhythm, surface } from '../../design/tokens';
+import ConfirmDialog from '../Habits/components/ConfirmDialog';
+import QuoteSelectionSurface, { type CodePointSpan } from '../Journal/QuoteSelectionSurface';
 
 import styles, { markdownStyles } from './Course.styles';
 import RetryButton from './RetryButton';
 import { stripLeadingTitleHeading } from './stripLeadingTitleHeading';
+
+/** A passage folded out of the reader into the journal, with its scroll anchor. */
+export interface WriteNotePassage {
+  text: string;
+  sourceTitle: string;
+  scrollOffset: number;
+}
+
+const SCROLL_EVENT_THROTTLE = 16;
+const PASSAGE_SELECT_TEST_ID = 'passage-select';
+const WRITE_NOTE_AFFORDANCE_LABEL = 'Write a note on a passage';
+const WRITE_NOTE_CONFIRM_LABEL = 'Write a note';
+const WRITE_NOTE_DIALOG_TITLE = 'Write a note on this passage?';
+const WRITE_NOTE_DIALOG_MESSAGE = 'You can pick up right where you left off.';
+const WRITE_NOTE_DIALOG_CANCEL = 'Keep reading';
 
 /**
  * Small-caps eyebrow shown above the sheet title, keyed by content type.
@@ -41,6 +67,10 @@ interface ChapterReaderProps {
    *  mark-read / reflect actions; omitted for untracked site resources. */
   footer?: React.ReactNode;
   onBack: () => void;
+  /** When provided, offers a calm "write a note on a passage" affordance. */
+  onWriteNote?: (_passage: WriteNotePassage) => void;
+  /** Restores the reading ScrollView to this offset on a warm return. */
+  initialScrollOffset?: number;
 }
 
 /**
@@ -232,35 +262,218 @@ function useContentBody(source: ChapterReaderSource): {
   return { body, loading, error, retry };
 }
 
-function renderBody(body: ContentBody): React.ReactElement {
-  const markdown = stripLeadingTitleHeading(body.body_markdown, body.title);
+interface PassageSelection {
+  selecting: boolean;
+  dialogVisible: boolean;
+  onScroll: (_event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  beginSelection: () => void;
+  cancelSelection: () => void;
+  handleSelectionChange: (_span: CodePointSpan) => void;
+  openDialog: () => Promise<void>;
+  closeDialog: () => void;
+  confirmNote: () => void;
+}
+
+/**
+ * Own the write-note gesture: track the latest scroll offset, snapshot it at the
+ * moment the affordance is pressed, hold the emitted code-point span, and slice
+ * the passage by code points when the reader confirms.
+ */
+function usePassageSelection(
+  markdown: string,
+  sourceTitle: string,
+  onWriteNote?: (_passage: WriteNotePassage) => void,
+): PassageSelection {
+  const [selecting, setSelecting] = useState(false);
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const [span, setSpan] = useState<CodePointSpan | null>(null);
+  const [capturedOffset, setCapturedOffset] = useState(0);
+  const scrollOffsetRef = useRef(0);
+
+  const onScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+  }, []);
+
+  const beginSelection = useCallback(() => {
+    setCapturedOffset(scrollOffsetRef.current);
+    setSelecting(true);
+  }, []);
+
+  const cancelSelection = useCallback(() => setSelecting(false), []);
+  const handleSelectionChange = useCallback((next: CodePointSpan) => setSpan(next), []);
+  const openDialog = useCallback(async () => setDialogVisible(true), []);
+  const closeDialog = useCallback(() => setDialogVisible(false), []);
+
+  const confirmNote = useCallback(() => {
+    if (onWriteNote && span) {
+      const text = Array.from(markdown).slice(span.start, span.end).join('');
+      onWriteNote({ text, sourceTitle, scrollOffset: capturedOffset });
+    }
+    setDialogVisible(false);
+    setSelecting(false);
+  }, [onWriteNote, span, markdown, sourceTitle, capturedOffset]);
+
+  return {
+    selecting,
+    dialogVisible,
+    onScroll,
+    beginSelection,
+    cancelSelection,
+    handleSelectionChange,
+    openDialog,
+    closeDialog,
+    confirmNote,
+  };
+}
+
+interface ReadingSheetProps {
+  markdown: string;
+  eyebrow: string | undefined;
+  title: string;
+  canWriteNote: boolean;
+  initialScrollOffset: number | undefined;
+  onScroll: (_event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onBeginNote: () => void;
+}
+
+/** The reading view: the markdown sheet plus the calm write-note invitation. */
+const ReadingSheet = ({
+  markdown,
+  eyebrow,
+  title,
+  canWriteNote,
+  initialScrollOffset,
+  onScroll,
+  onBeginNote,
+}: ReadingSheetProps): React.JSX.Element => (
+  <ScrollView
+    style={styles.readerScroll}
+    contentContainerStyle={{ paddingBottom: rhythm.bottomFadeHeight }}
+    testID="reader-markdown"
+    onScroll={onScroll}
+    scrollEventThrottle={SCROLL_EVENT_THROTTLE}
+    contentOffset={initialScrollOffset != null ? { x: 0, y: initialScrollOffset } : undefined}
+  >
+    <View style={styles.readerSheet}>
+      <ReaderSheetHeader eyebrow={eyebrow} title={title} />
+      {canWriteNote && (
+        <TouchableOpacity
+          testID="reader-write-note-affordance"
+          onPress={onBeginNote}
+          accessibilityRole="button"
+          accessibilityLabel={WRITE_NOTE_AFFORDANCE_LABEL}
+        >
+          <Text style={styles.readerWriteNoteLink}>{WRITE_NOTE_AFFORDANCE_LABEL}</Text>
+        </TouchableOpacity>
+      )}
+      <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={isExternalWebUrl}>
+        {markdown}
+      </Markdown>
+    </View>
+  </ScrollView>
+);
+
+interface SelectingSheetProps {
+  markdown: string;
+  eyebrow: string | undefined;
+  title: string;
+  selection: PassageSelection;
+}
+
+/** The selection view: the passage-select surface over the confirm dialog. */
+const SelectingSheet = ({
+  markdown,
+  eyebrow,
+  title,
+  selection,
+}: SelectingSheetProps): React.JSX.Element => (
+  <>
+    <ScrollView
+      style={styles.readerScroll}
+      contentContainerStyle={{ paddingBottom: rhythm.bottomFadeHeight }}
+    >
+      <View style={styles.readerSheet}>
+        <ReaderSheetHeader eyebrow={eyebrow} title={title} />
+        <QuoteSelectionSurface
+          body={markdown}
+          testID={PASSAGE_SELECT_TEST_ID}
+          confirmLabel={WRITE_NOTE_CONFIRM_LABEL}
+          onSelectionChange={selection.handleSelectionChange}
+          onCancel={selection.cancelSelection}
+          onConfirm={selection.openDialog}
+        />
+      </View>
+    </ScrollView>
+    <ConfirmDialog
+      visible={selection.dialogVisible}
+      testID="write-note-dialog"
+      title={WRITE_NOTE_DIALOG_TITLE}
+      message={WRITE_NOTE_DIALOG_MESSAGE}
+      cancelLabel={WRITE_NOTE_DIALOG_CANCEL}
+      cancelTestID="write-note-dialog-cancel"
+      confirmLabel={WRITE_NOTE_CONFIRM_LABEL}
+      confirmTestID="write-note-dialog-confirm"
+      onCancel={selection.closeDialog}
+      onConfirm={selection.confirmNote}
+    />
+  </>
+);
+
+interface ReaderBodyProps {
+  body: ContentBody;
+  onWriteNote?: (_passage: WriteNotePassage) => void;
+  initialScrollOffset?: number;
+}
+
+/** Renders the loaded body: empty notice, reading sheet, or selection surface. */
+const ReaderBody = ({
+  body,
+  onWriteNote,
+  initialScrollOffset,
+}: ReaderBodyProps): React.JSX.Element => {
+  const markdown = useMemo(
+    () => stripLeadingTitleHeading(body.body_markdown, body.title),
+    [body.body_markdown, body.title],
+  );
+  const selection = usePassageSelection(markdown, body.title, onWriteNote);
+  const eyebrow = READER_EYEBROWS[body.content_type];
+
   if (markdown.trim() === '') {
     return <EmptyView />;
   }
+
   return (
     <View style={styles.readerScrollRegion}>
-      <ScrollView
-        style={styles.readerScroll}
-        contentContainerStyle={{ paddingBottom: rhythm.bottomFadeHeight }}
-        testID="reader-markdown"
-      >
-        <View style={styles.readerSheet}>
-          <ReaderSheetHeader eyebrow={READER_EYEBROWS[body.content_type]} title={body.title} />
-          <Markdown style={markdownStyles} rules={markdownRules} onLinkPress={isExternalWebUrl}>
-            {markdown}
-          </Markdown>
-        </View>
-      </ScrollView>
+      {selection.selecting ? (
+        <SelectingSheet
+          markdown={markdown}
+          eyebrow={eyebrow}
+          title={body.title}
+          selection={selection}
+        />
+      ) : (
+        <ReadingSheet
+          markdown={markdown}
+          eyebrow={eyebrow}
+          title={body.title}
+          canWriteNote={onWriteNote != null}
+          initialScrollOffset={initialScrollOffset}
+          onScroll={selection.onScroll}
+          onBeginNote={selection.beginSelection}
+        />
+      )}
       <BottomFade color={surface.desk} testID="reader-bottom-fade" />
     </View>
   );
-}
+};
 
 const ChapterReader = ({
   source,
   fallbackTitle,
   footer,
   onBack,
+  onWriteNote,
+  initialScrollOffset,
 }: ChapterReaderProps): React.JSX.Element => {
   const { body, loading, error, retry } = useContentBody(source);
   const headerTitle = body?.title || fallbackTitle;
@@ -274,7 +487,13 @@ const ChapterReader = ({
         </View>
       )}
       {!loading && error !== null && <ErrorView message={error} onRetry={retry} />}
-      {!loading && error === null && body !== null && renderBody(body)}
+      {!loading && error === null && body !== null && (
+        <ReaderBody
+          body={body}
+          onWriteNote={onWriteNote}
+          initialScrollOffset={initialScrollOffset}
+        />
+      )}
       {footer}
     </View>
   );

--- a/frontend/src/features/Course/ContentViewer.tsx
+++ b/frontend/src/features/Course/ContentViewer.tsx
@@ -4,7 +4,7 @@ import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
 import { course as courseApi, type ContentItem } from '../../api';
 import { colors } from '../../design/tokens';
 
-import ChapterReader from './ChapterReader';
+import ChapterReader, { type WriteNotePassage } from './ChapterReader';
 import styles from './Course.styles';
 
 interface ViewerFooterProps {
@@ -56,6 +56,8 @@ interface ContentViewerProps {
   onBack: () => void;
   onMarkRead: () => void;
   onReflect?: () => void;
+  onWriteNote?: (_passage: WriteNotePassage) => void;
+  initialScrollOffset?: number;
 }
 
 function useMarkReadHandler(
@@ -101,6 +103,8 @@ const ContentViewer = ({
   onBack,
   onMarkRead,
   onReflect,
+  onWriteNote,
+  initialScrollOffset,
 }: ContentViewerProps): React.JSX.Element => {
   const { marking, isRead, handleMarkRead } = useMarkReadHandler(item, onMarkRead);
 
@@ -109,6 +113,8 @@ const ContentViewer = ({
       source={{ kind: 'content', id: item.id }}
       fallbackTitle={item.title}
       onBack={onBack}
+      onWriteNote={onWriteNote}
+      initialScrollOffset={initialScrollOffset}
       footer={
         <ViewerFooter
           isRead={isRead}

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -377,6 +377,14 @@ const styles = StyleSheet.create({
     color: ink.primary,
     marginBottom: SPACING.sm,
   },
+  // Calm, declinable "write a note" invitation shown near the sheet header.
+  readerWriteNoteLink: {
+    ...editorialType.action,
+    color: accent.primary,
+    marginBottom: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingVertical: SPACING.xs,
+  },
   readerError: {
     flex: 1,
     alignItems: 'center',

--- a/frontend/src/features/Course/CourseScreen.tsx
+++ b/frontend/src/features/Course/CourseScreen.tsx
@@ -31,7 +31,7 @@ import { useAppRoute } from '../../navigation/hooks';
 import type { RootStackParamList } from '../../navigation/RootStack';
 import { useProgramStore, programStage } from '../../store/useProgramStore';
 
-import ChapterReader from './ChapterReader';
+import ChapterReader, { type WriteNotePassage } from './ChapterReader';
 import ContentCard from './ContentCard';
 import ContentViewer from './ContentViewer';
 import styles from './Course.styles';
@@ -327,14 +327,64 @@ const ContentArea = ({
 
 // --- Hook: viewer actions ---
 
-function useCourseViewer(selectedStage: number) {
+/** The two journal hand-offs from an open chapter: the title-only reflect, and
+ *  the passage-note flow that keeps the reader mounted for a warm return. */
+function useJournalHandoff(
+  selectedStage: number,
+  viewingItem: ContentItem | null,
+  clearViewingItem: () => void,
+) {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const handleReflect = useCallback(() => {
+    if (!viewingItem) return;
+    navigation.navigate('JournalEntry', {
+      prefillTitle: `Stage ${selectedStage} reflection — ${viewingItem.title}`,
+    });
+    clearViewingItem();
+  }, [viewingItem, selectedStage, navigation, clearViewingItem]);
+
+  // Fold the chosen passage into the journal while the reader stays mounted, so
+  // "Back to reading" is a cheap warm return to the same scroll position.
+  const handleWriteNote = useCallback(
+    (passage: WriteNotePassage) => {
+      if (!viewingItem) return;
+      navigation.navigate('JournalEntry', {
+        prefillQuote: { text: passage.text, sourceTitle: passage.sourceTitle },
+        returnTo: {
+          screen: 'Course',
+          params: {
+            stageNumber: selectedStage,
+            contentId: viewingItem.id,
+            scrollOffset: passage.scrollOffset,
+          },
+        },
+      });
+    },
+    [viewingItem, selectedStage, navigation],
+  );
+
+  return { handleReflect, handleWriteNote };
+}
+
+function useCourseViewer(selectedStage: number) {
   const [viewingItem, setViewingItem] = useState<ContentItem | null>(null);
   const [viewingResource, setViewingResource] = useState<SiteResource | null>(null);
   const [viewingIntro, setViewingIntro] = useState<number | null>(null);
+  // Only set on a warm return; a manual open clears it so no stale scroll leaks.
+  const [restoreOffset, setRestoreOffset] = useState<number | undefined>(undefined);
+
+  const clearViewingItem = useCallback(() => setViewingItem(null), []);
 
   const handleContentPress = useCallback((item: ContentItem) => {
-    if (!item.is_locked) setViewingItem(item);
+    if (item.is_locked) return;
+    setRestoreOffset(undefined);
+    setViewingItem(item);
+  }, []);
+
+  const openForRestore = useCallback((item: ContentItem, offset: number) => {
+    setRestoreOffset(offset);
+    setViewingItem(item);
   }, []);
 
   const handleResourcePress = useCallback((resource: SiteResource) => {
@@ -349,26 +399,55 @@ function useCourseViewer(selectedStage: number) {
     setViewingItem(null);
     setViewingResource(null);
     setViewingIntro(null);
+    setRestoreOffset(undefined);
   }, []);
 
-  const handleReflect = useCallback(() => {
-    if (!viewingItem) return;
-    navigation.navigate('JournalEntry', {
-      prefillTitle: `Stage ${selectedStage} reflection — ${viewingItem.title}`,
-    });
-    setViewingItem(null);
-  }, [viewingItem, selectedStage, navigation]);
+  const { handleReflect, handleWriteNote } = useJournalHandoff(
+    selectedStage,
+    viewingItem,
+    clearViewingItem,
+  );
 
   return {
     viewingItem,
     viewingResource,
     viewingIntro,
+    restoreOffset,
+    openForRestore,
     handleContentPress,
     handleResourcePress,
     handleIntroPress,
     handleBack,
     handleReflect,
+    handleWriteNote,
   };
+}
+
+/** On a return from the journal, auto-open the returned content restored to its
+ *  scroll offset once the stage's content has loaded. The restore is one-shot per
+ *  ``contentId``: the param persists on the route indefinitely, so a ref records
+ *  the id already restored and refuses to re-fire — otherwise backing out of the
+ *  reader (viewing id → null) or revisiting the tab would re-open it unbidden.
+ *  Keyed on primitive params + loaded content (never object identity) so it fires
+ *  once and never loops. */
+function useReaderRestore(
+  content: ContentItem[],
+  currentViewingId: number | null,
+  openForRestore: (_item: ContentItem, _offset: number) => void,
+): void {
+  const route = useAppRoute<'Course'>();
+  const contentId = route.params?.contentId ?? null;
+  const scrollOffset = route.params?.scrollOffset ?? 0;
+  const restoredIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (contentId === null || restoredIdRef.current === contentId) return;
+    if (currentViewingId === contentId) return;
+    const item = content.find((c) => c.id === contentId);
+    if (!item || item.is_locked) return;
+    restoredIdRef.current = contentId;
+    openForRestore(item, scrollOffset);
+  }, [contentId, scrollOffset, currentViewingId, content, openForRestore]);
 }
 
 // --- Main component ---
@@ -384,6 +463,8 @@ function renderOverlay(
         onBack={viewer.handleBack}
         onMarkRead={onMarkRead}
         onReflect={viewer.handleReflect}
+        onWriteNote={viewer.handleWriteNote}
+        initialScrollOffset={viewer.restoreOffset}
       />
     );
   }
@@ -599,6 +680,7 @@ const CourseScreen = (): React.JSX.Element => {
   const { allStages, selectedStage, setSelectedStage, loading, error, retry } = useStagesLoader();
   const stageContent = useStageContent(selectedStage, allStages.length > 0);
   const viewer = useCourseViewer(selectedStage);
+  useReaderRestore(stageContent.content, viewer.viewingItem?.id ?? null, viewer.openForRestore);
   const drawer = useScreenDrawer('Course');
   const { handleStageSelect, handleChapterPress } = useCourseNavigation(
     setSelectedStage,

--- a/frontend/src/features/Course/__tests__/ChapterReaderPassageSelection.test.tsx
+++ b/frontend/src/features/Course/__tests__/ChapterReaderPassageSelection.test.tsx
@@ -1,0 +1,257 @@
+/* eslint-env jest */
+// RED: ChapterReader does not yet accept onWriteNote / initialScrollOffset,
+// so every testID below (reader-write-note-affordance, passage-select-*,
+// write-note-dialog-*) is missing until the implementation-specialist wires
+// the selection mode + confirm dialog through.
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, within } from '@testing-library/react-native';
+import React from 'react';
+
+import type * as Api from '../../../api';
+import ChapterReader from '../ChapterReader';
+
+jest.mock('../../../api', () => ({
+  course: {
+    contentBody: jest.fn(),
+    siteResourceBody: jest.fn(),
+    stageIntroBody: jest.fn(),
+  },
+}));
+
+const { course: courseApi } = jest.requireMock('../../../api') as {
+  course: {
+    contentBody: jest.MockedFunction<typeof Api.course.contentBody>;
+    siteResourceBody: jest.MockedFunction<typeof Api.course.siteResourceBody>;
+    stageIntroBody: jest.MockedFunction<typeof Api.course.stageIntroBody>;
+  };
+};
+
+const { contentBody: mockContentBody } = courseApi;
+
+// A leading astral emoji shifts every later UTF-16 offset by +1 relative to
+// its code-point index -- the fixture pins that "riff" is sliced by code
+// points, not raw UTF-16 units.
+const NOTE_CHAPTER = {
+  title: 'Chapter One',
+  content_type: 'chapter',
+  body_markdown: '# Chapter One\n\n\u{1F3B8} solo riff selected here.\n',
+};
+
+const DIALOG_TITLE = 'Write a note on this passage?';
+
+// UTF-16 selection over "riff" in the stripped body; the surface converts
+// this to the code-point span {7, 11}, and a correct Array.from slice reads
+// "riff" while a naive raw-index slice of those numbers reads " rif".
+const RIFF_SELECTION = { start: 8, end: 12 };
+
+type RenderResult = ReturnType<typeof render>;
+
+async function renderReader(
+  overrides: Partial<React.ComponentProps<typeof ChapterReader>> = {},
+): Promise<RenderResult & { onBack: jest.Mock; onWriteNote: jest.Mock }> {
+  const onBack = jest.fn();
+  const onWriteNote = jest.fn();
+  const utils = render(
+    <ChapterReader
+      source={{ kind: 'content', id: 1 }}
+      fallbackTitle="x"
+      onBack={onBack}
+      onWriteNote={onWriteNote}
+      {...overrides}
+    />,
+  );
+  await utils.findByTestId('reader-markdown');
+  return { ...utils, onBack, onWriteNote };
+}
+
+function selectRiff(getByTestId: RenderResult['getByTestId']): void {
+  const input = getByTestId('passage-select-input');
+  fireEvent(input, 'selectionChange', { nativeEvent: { selection: RIFF_SELECTION } });
+}
+
+describe('ChapterReader -- write-note affordance visibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue(NOTE_CHAPTER);
+  });
+
+  it('renders the affordance when onWriteNote is provided and the body is non-empty', async () => {
+    const { findByTestId } = await renderReader();
+    await findByTestId('reader-write-note-affordance');
+  });
+
+  it('omits the affordance when onWriteNote is not provided', async () => {
+    const { queryByTestId } = await renderReader({ onWriteNote: undefined });
+    expect(queryByTestId('reader-write-note-affordance')).toBeNull();
+  });
+
+  it('omits the affordance for an empty body even when onWriteNote is provided', async () => {
+    mockContentBody.mockResolvedValueOnce({
+      title: 'Empty Chapter',
+      content_type: 'chapter',
+      body_markdown: '   \n',
+    });
+    const { findByTestId, queryByTestId } = render(
+      <ChapterReader
+        source={{ kind: 'content', id: 1 }}
+        fallbackTitle="x"
+        onBack={jest.fn()}
+        onWriteNote={jest.fn()}
+      />,
+    );
+    await findByTestId('reader-empty');
+    expect(queryByTestId('reader-write-note-affordance')).toBeNull();
+  });
+});
+
+describe('ChapterReader -- entering and leaving selection mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue(NOTE_CHAPTER);
+  });
+
+  it('replaces the markdown view with the passage-select surface on affordance press', async () => {
+    const { getByTestId, queryByTestId } = await renderReader();
+    fireEvent.press(getByTestId('reader-write-note-affordance'));
+
+    expect(queryByTestId('reader-markdown')).toBeNull();
+    expect(getByTestId('passage-select-input')).toBeTruthy();
+    within(getByTestId('passage-select-confirm')).getByText('Write a note');
+  });
+
+  it('returns to reading on surface cancel without calling onWriteNote', async () => {
+    const { getByTestId, queryByTestId, findByTestId, onWriteNote } = await renderReader();
+    fireEvent.press(getByTestId('reader-write-note-affordance'));
+    fireEvent.press(getByTestId('passage-select-cancel'));
+
+    await findByTestId('reader-markdown');
+    expect(queryByTestId('passage-select-input')).toBeNull();
+    expect(onWriteNote).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChapterReader -- the write-note confirm dialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue(NOTE_CHAPTER);
+  });
+
+  async function enterDialog(): Promise<RenderResult & { onWriteNote: jest.Mock }> {
+    const utils = await renderReader();
+    fireEvent.press(utils.getByTestId('reader-write-note-affordance'));
+    selectRiff(utils.getByTestId);
+    await act(async () => {
+      fireEvent.press(utils.getByTestId('passage-select-confirm'));
+    });
+    return utils;
+  }
+
+  it('opens on a non-empty confirm, titled exactly "Write a note on this passage?"', async () => {
+    const { getByTestId, getByText } = await enterDialog();
+    expect(getByTestId('write-note-dialog')).toBeTruthy();
+    expect(getByText(DIALOG_TITLE)).toBeTruthy();
+    within(getByTestId('write-note-dialog-cancel')).getByText('Keep reading');
+    within(getByTestId('write-note-dialog-confirm')).getByText('Write a note');
+  });
+
+  it('cancel returns to the selection surface without calling onWriteNote', async () => {
+    const { getByTestId, queryByTestId, onWriteNote } = await enterDialog();
+    fireEvent.press(getByTestId('write-note-dialog-cancel'));
+
+    expect(queryByTestId('write-note-dialog')).toBeNull();
+    expect(getByTestId('passage-select-input')).toBeTruthy();
+    expect(onWriteNote).not.toHaveBeenCalled();
+  });
+
+  it('confirm calls onWriteNote once with the code-point-correct passage and exits to reading', async () => {
+    const { getByTestId, queryByTestId, findByTestId, onWriteNote } = await enterDialog();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('write-note-dialog-confirm'));
+    });
+
+    expect(onWriteNote).toHaveBeenCalledTimes(1);
+    expect(onWriteNote).toHaveBeenCalledWith({
+      text: 'riff',
+      sourceTitle: 'Chapter One',
+      scrollOffset: 0,
+    });
+
+    await findByTestId('reader-markdown');
+    expect(queryByTestId('passage-select-input')).toBeNull();
+    expect(queryByTestId('write-note-dialog')).toBeNull();
+  });
+});
+
+describe('ChapterReader -- scrollOffset snapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue(NOTE_CHAPTER);
+  });
+
+  async function writeNoteAfterScroll(
+    scrollTo: number | null,
+  ): Promise<RenderResult & { onWriteNote: jest.Mock }> {
+    const utils = await renderReader();
+    const { getByTestId } = utils;
+    if (scrollTo !== null) {
+      fireEvent.scroll(getByTestId('reader-markdown'), {
+        nativeEvent: { contentOffset: { y: scrollTo } },
+      });
+    }
+    fireEvent.press(getByTestId('reader-write-note-affordance'));
+    selectRiff(getByTestId);
+    await act(async () => {
+      fireEvent.press(getByTestId('passage-select-confirm'));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('write-note-dialog-confirm'));
+    });
+    return utils;
+  }
+
+  it('captures the scroll position at the moment the affordance is pressed', async () => {
+    const { onWriteNote } = await writeNoteAfterScroll(240);
+    expect(onWriteNote).toHaveBeenCalledWith(expect.objectContaining({ scrollOffset: 240 }));
+  });
+
+  it('defaults scrollOffset to 0 when the reader was never scrolled', async () => {
+    const { onWriteNote } = await writeNoteAfterScroll(null);
+    expect(onWriteNote).toHaveBeenCalledWith(expect.objectContaining({ scrollOffset: 0 }));
+  });
+
+  it('does not let a scroll delivered after entering selection mode change the already-captured offset', async () => {
+    const utils = await renderReader();
+    const { getByTestId } = utils;
+    const scrollView = getByTestId('reader-markdown');
+    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 240 } } });
+    fireEvent.press(getByTestId('reader-write-note-affordance'));
+
+    // A late-delivered scroll event on the (now-replaced) reading ScrollView
+    // must not overwrite the offset already snapshotted at press time.
+    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 999 } } });
+
+    selectRiff(getByTestId);
+    await act(async () => {
+      fireEvent.press(getByTestId('passage-select-confirm'));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('write-note-dialog-confirm'));
+    });
+
+    expect(utils.onWriteNote).toHaveBeenCalledWith(expect.objectContaining({ scrollOffset: 240 }));
+  });
+});
+
+describe('ChapterReader -- initialScrollOffset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockContentBody.mockResolvedValue(NOTE_CHAPTER);
+  });
+
+  it('applies initialScrollOffset as the reading ScrollView contentOffset', async () => {
+    const { findByTestId } = await renderReader({ initialScrollOffset: 125 });
+    const scrollView = await findByTestId('reader-markdown');
+    expect(scrollView.props.contentOffset).toEqual({ x: 0, y: 125 });
+  });
+});

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -206,6 +206,43 @@ describe('ContentViewer', () => {
     expect(queryByTestId('reader-markdown')).not.toBeNull();
   });
 
+  it('forwards onWriteNote to the reader so the write-note affordance appears', async () => {
+    const item = makeItem();
+    const onWriteNote = jest.fn();
+    const { findByTestId } = render(
+      <ContentViewer
+        item={item}
+        onBack={onBack}
+        onMarkRead={onMarkRead}
+        onWriteNote={onWriteNote}
+      />,
+    );
+    await findByTestId('reader-write-note-affordance');
+  });
+
+  it('omits the write-note affordance when onWriteNote is not forwarded', async () => {
+    const item = makeItem();
+    const { findByTestId, queryByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} />,
+    );
+    await findByTestId('reader-markdown');
+    expect(queryByTestId('reader-write-note-affordance')).toBeNull();
+  });
+
+  it('forwards initialScrollOffset to the reader as the ScrollView contentOffset', async () => {
+    const item = makeItem();
+    const { findByTestId } = render(
+      <ContentViewer
+        item={item}
+        onBack={onBack}
+        onMarkRead={onMarkRead}
+        initialScrollOffset={90}
+      />,
+    );
+    const scrollView = await findByTestId('reader-markdown');
+    expect(scrollView.props.contentOffset).toEqual({ x: 0, y: 90 });
+  });
+
   it('surfaces a retry UI when the content body fails to load', async () => {
     courseApi.contentBody.mockRejectedValueOnce({ detail: 'content_unavailable' });
     const item = makeItem();

--- a/frontend/src/features/Course/__tests__/CourseScreenWriteNote.test.tsx
+++ b/frontend/src/features/Course/__tests__/CourseScreenWriteNote.test.tsx
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-env jest */
+// RED: CourseScreen does not yet wire the write-note flow -- no
+// reader-write-note-affordance, no returnTo navigate payload, no warm-return
+// auto-open of a restored contentId/scrollOffset.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import type { ContentItem, CourseProgress, Stage } from '../../../api';
+
+const makeStage = (overrides: Partial<Stage> = {}): Stage => ({
+  id: 1,
+  title: 'Stage 1',
+  subtitle: 'First stage',
+  stage_number: 1,
+  overview_url: 'https://example.com',
+  category: 'foundation',
+  aspect: 'body',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Archaic',
+  divine_gender_polarity: 'neutral',
+  relationship_to_free_will: 'reactive',
+  free_will_description: 'Instinctual survival',
+  is_unlocked: true,
+  progress: 0,
+  ...overrides,
+});
+
+const sampleStages: Stage[] = [makeStage({ id: 1, stage_number: 1 })];
+
+const sampleContent: ContentItem[] = [
+  {
+    id: 5,
+    title: 'Welcome Essay',
+    content_type: 'chapter',
+    release_day: 0,
+    url: 'content://beige-5',
+    is_locked: false,
+    is_read: false,
+  },
+  {
+    id: 6,
+    title: 'Locked Chapter',
+    content_type: 'chapter',
+    release_day: 3,
+    url: null,
+    is_locked: true,
+    is_read: false,
+  },
+];
+
+const sampleProgress: CourseProgress = {
+  total_items: 2,
+  read_items: 0,
+  progress_percent: 0,
+  next_unlock_day: 3,
+};
+
+// Same astral-emoji fixture as ChapterReaderPassageSelection.test.tsx: the
+// leading emoji shifts UTF-16 offsets by +1 versus code-point offsets, so
+// "riff" only comes out right when the passage is sliced by code points.
+const NOTE_BODY = {
+  title: 'Welcome Essay',
+  content_type: 'chapter',
+  body_markdown: '# Welcome Essay\n\n\u{1F3B8} solo riff selected here.\n',
+};
+const RIFF_SELECTION = { start: 8, end: 12 };
+
+const mockStagesList = (jest.fn() as any).mockResolvedValue(sampleStages);
+const mockStageContent = (jest.fn() as any).mockResolvedValue(sampleContent);
+const mockStageProgress = (jest.fn() as any).mockResolvedValue(sampleProgress);
+const mockMarkRead = (jest.fn() as any).mockResolvedValue({
+  id: 1,
+  user_id: 1,
+  content_id: 5,
+  completed_at: '2026-01-15T10:00:00Z',
+});
+const mockSiteResources = (jest.fn() as any).mockResolvedValue([]);
+const mockContentBody = (jest.fn() as any).mockResolvedValue(NOTE_BODY);
+const mockSiteResourceBody = (jest.fn() as any).mockResolvedValue({
+  title: 'Philosophy',
+  content_type: 'resource',
+  body_markdown: 'philosophy\n',
+});
+const mockStageIntro = (jest.fn() as any).mockRejectedValue({ detail: 'content_not_found' });
+const mockStageIntroBody = (jest.fn() as any).mockResolvedValue({
+  title: 'Welcome to Beige',
+  content_type: 'introduction',
+  body_markdown: '# Welcome to Beige\n\nintro\n',
+});
+
+jest.mock('../../../api', () => ({
+  stages: {
+    listAll: (...args: unknown[]) => mockStagesList(...args),
+  },
+  course: {
+    stageContentAll: (...args: unknown[]) => mockStageContent(...args),
+    stageProgress: (...args: unknown[]) => mockStageProgress(...args),
+    markRead: (...args: unknown[]) => mockMarkRead(...args),
+    contentBody: (...args: unknown[]) => mockContentBody(...args),
+    siteResources: (...args: unknown[]) => mockSiteResources(...args),
+    siteResourceBody: (...args: unknown[]) => mockSiteResourceBody(...args),
+    stageIntro: (...args: unknown[]) => mockStageIntro(...args),
+    stageIntroBody: (...args: unknown[]) => mockStageIntroBody(...args),
+  },
+}));
+
+const mockNavigate = jest.fn() as any;
+let mockRouteParams:
+  { stageNumber?: number; contentId?: number; scrollOffset?: number } | undefined;
+
+jest.mock('../../../navigation/hooks', () => ({
+  useAppRoute: () => ({ key: 'Course-test', name: 'Course', params: mockRouteParams }),
+  useAppNavigation: () => ({ navigate: mockNavigate, setOptions: jest.fn() }),
+}));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: any }) =>
+      React.createElement(React.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+// eslint-disable-next-line import/order
+const { render, waitFor, fireEvent, act } = require('@testing-library/react-native');
+const CourseScreen = require('../CourseScreen').default;
+
+function selectRiff(getByTestId: any): void {
+  const input = getByTestId('passage-select-input');
+  fireEvent(input, 'selectionChange', { nativeEvent: { selection: RIFF_SELECTION } });
+}
+
+describe('CourseScreen -- write a note on a passage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams = undefined;
+    mockStagesList.mockResolvedValue(sampleStages);
+    mockStageContent.mockResolvedValue(sampleContent);
+    mockStageProgress.mockResolvedValue(sampleProgress);
+    mockContentBody.mockResolvedValue(NOTE_BODY);
+    mockStageIntro.mockRejectedValue({ detail: 'content_not_found' });
+  });
+
+  it('navigates to JournalEntry with the returnTo params and keeps the reader mounted', async () => {
+    mockRouteParams = { stageNumber: 1 };
+    const { getByTestId, findByTestId } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('content-card-5')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-5'));
+    });
+
+    const scrollView = await findByTestId('reader-markdown');
+    fireEvent.scroll(scrollView, { nativeEvent: { contentOffset: { y: 300 } } });
+
+    fireEvent.press(getByTestId('reader-write-note-affordance'));
+    selectRiff(getByTestId);
+    await act(async () => {
+      fireEvent.press(getByTestId('passage-select-confirm'));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('write-note-dialog-confirm'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('JournalEntry', {
+      prefillQuote: { text: 'riff', sourceTitle: 'Welcome Essay' },
+      returnTo: { screen: 'Course', params: { stageNumber: 1, contentId: 5, scrollOffset: 300 } },
+    });
+    expect(getByTestId('chapter-reader')).toBeTruthy();
+  });
+
+  it('auto-opens the returned content restored to its scroll offset once the stage content has loaded', async () => {
+    mockRouteParams = { stageNumber: 1, contentId: 5, scrollOffset: 300 };
+    const { findByTestId } = render(<CourseScreen />);
+
+    await findByTestId('chapter-reader');
+    const scrollView = await findByTestId('reader-markdown');
+    expect(scrollView.props.contentOffset).toEqual({ x: 0, y: 300 });
+  });
+
+  it('lets the reader be closed after a restore without re-opening from the stale param', async () => {
+    mockRouteParams = { stageNumber: 1, contentId: 5, scrollOffset: 300 };
+    const { getByTestId, findByTestId, queryByTestId } = render(<CourseScreen />);
+
+    await findByTestId('chapter-reader');
+    await act(async () => {
+      fireEvent.press(getByTestId('reader-back-button'));
+    });
+
+    await waitFor(() => expect(queryByTestId('chapter-reader')).toBeNull());
+    // The stale contentId param must not drag the reader back open.
+    expect(queryByTestId('chapter-reader')).toBeNull();
+  });
+
+  it('renders the landing normally for an unknown contentId, without crashing', async () => {
+    mockRouteParams = { stageNumber: 1, contentId: 9999, scrollOffset: 10 };
+    const { findByTestId, queryByTestId } = render(<CourseScreen />);
+
+    await findByTestId('content-list');
+    expect(queryByTestId('chapter-reader')).toBeNull();
+  });
+
+  it('does not open a locked item from a warm return', async () => {
+    mockRouteParams = { stageNumber: 1, contentId: 6, scrollOffset: 20 };
+    const { findByTestId, queryByTestId } = render(<CourseScreen />);
+
+    await findByTestId('content-list');
+    expect(queryByTestId('chapter-reader')).toBeNull();
+  });
+
+  it('does not re-open or re-apply the scroll offset when a warm return matches the already-open item', async () => {
+    mockRouteParams = { stageNumber: 1 };
+    const { getByTestId, findByTestId, rerender } = render(<CourseScreen />);
+
+    await waitFor(() => expect(getByTestId('content-card-5')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(getByTestId('content-card-5'));
+    });
+    await findByTestId('reader-markdown');
+    expect(mockContentBody).toHaveBeenCalledTimes(1);
+
+    mockRouteParams = { stageNumber: 1, contentId: 5, scrollOffset: 777 };
+    rerender(<CourseScreen />);
+
+    const scrollView = getByTestId('reader-markdown');
+    expect(scrollView.props.contentOffset).not.toEqual({ x: 0, y: 777 });
+    expect(mockContentBody).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/Journal/QuoteSelectionSurface.tsx
+++ b/frontend/src/features/Journal/QuoteSelectionSurface.tsx
@@ -51,6 +51,7 @@ const DEFAULT_TEST_ID = 'quote-select';
 
 const INSTRUCTION_COPY = 'Touch and hold a passage, then drag to choose it.';
 const EMPTY_HINT_COPY = 'Choose a passage first — touch and hold the text.';
+const DEFAULT_CONFIRM_LABEL = 'Promote selection';
 
 export interface QuoteSelectionSurfaceProps {
   body: string;
@@ -59,6 +60,8 @@ export interface QuoteSelectionSurfaceProps {
   onConfirm: () => Promise<void>;
   onCancel: () => void;
   testID?: string;
+  /** Label on the confirm Button; defaults to the promote-flow wording. */
+  confirmLabel?: string;
 }
 
 /** The derived view state the surface chrome renders from. */
@@ -166,6 +169,7 @@ interface SelectionActionsProps {
   onCancel: () => void;
   showHint: () => void;
   testID: string;
+  confirmLabel: string;
 }
 
 /**
@@ -178,6 +182,7 @@ function SelectionActions({
   onCancel,
   showHint,
   testID,
+  confirmLabel,
 }: SelectionActionsProps): React.JSX.Element {
   return (
     <View style={styles.quoteSelectActions}>
@@ -189,7 +194,7 @@ function SelectionActions({
       >
         <Button
           variant="primary"
-          label="Promote selection"
+          label={confirmLabel}
           disabled={isEmpty}
           onPress={() => void onConfirm()}
           testID={`${testID}-confirm`}
@@ -214,6 +219,7 @@ function QuoteSelectionSurface({
   onConfirm,
   onCancel,
   testID = DEFAULT_TEST_ID,
+  confirmLabel = DEFAULT_CONFIRM_LABEL,
 }: QuoteSelectionSurfaceProps): React.JSX.Element {
   const { isEmpty, previewSlice, hintVisible, emitSpan, handleSelectionChange, showHint } =
     useSelectionSurfaceState(body, onSelectionChange);
@@ -244,6 +250,7 @@ function QuoteSelectionSurface({
         onCancel={onCancel}
         showHint={showHint}
         testID={testID}
+        confirmLabel={confirmLabel}
       />
       {hintVisible && (
         <Text style={styles.quoteSelectHint} testID={`${testID}-hint`}>

--- a/frontend/src/features/Journal/__tests__/QuoteSelectionSurface.test.tsx
+++ b/frontend/src/features/Journal/__tests__/QuoteSelectionSurface.test.tsx
@@ -3,7 +3,7 @@
 // preview, a guarded "Promote selection" Button, or an empty-tap hint -- every
 // testID below is missing until the implementation-specialist adds them.
 import { jest, describe, it, expect } from '@jest/globals';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, within } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
 
@@ -138,5 +138,17 @@ describe('QuoteSelectionSurface -- custom testID prefix', () => {
     expect(getByTestId('src-1-confirm-guard')).toBeTruthy();
     expect(getByTestId('src-1-cancel')).toBeTruthy();
     expect(getByTestId('src-1-input')).toBeTruthy();
+  });
+});
+
+describe('QuoteSelectionSurface -- confirmLabel', () => {
+  it('defaults the confirm button label to "Promote selection"', () => {
+    const { getByTestId } = renderSurface();
+    within(getByTestId('quote-select-confirm')).getByText('Promote selection');
+  });
+
+  it('renders the given confirmLabel when provided', () => {
+    const { getByTestId } = renderSurface({ confirmLabel: 'Write a note' });
+    within(getByTestId('quote-select-confirm')).getByText('Write a note');
   });
 });


### PR DESCRIPTION
## Summary

Lets a reader select a passage inside a course chapter and accept a calm, declinable **"Write a note on this passage?"** invitation that opens a fresh journal entry with the passage folded in as a block quote (via the merged #1780 `prefillQuote`/`returnTo` contract) and a **"Back to reading"** return that restores the exact scroll position.

- `ChapterReader` gains an opt-in selection mode, gated on a new `onWriteNote` prop so the affordance appears only for tracked content and stays hidden for site resources and stage intros (graceful degradation, per the acceptance criteria). In selection mode the raw markdown renders through the reused `QuoteSelectionSurface`; a non-empty selection opens the calm `ConfirmDialog`; declining returns to reading with nothing lost; accepting reports the code-point-sliced passage text, the chapter title, and the scroll offset captured at the moment the affordance was pressed.
- `ChapterReader` accepts an `initialScrollOffset` and applies it to the reading `ScrollView`'s `contentOffset` to restore position on return.
- `QuoteSelectionSurface` gains an additive, backward-compatible optional `confirmLabel` prop (default unchanged) so the course flow can read "Write a note".
- `CourseScreen` navigates to `JournalEntry` with `prefillQuote` + `returnTo` while keeping the reader mounted for a cheap warm return, and a **one-shot** `useReaderRestore` reopens the returned chapter at its offset on a cold return — recording the restored `contentId` in a ref so backing out of the reader or revisiting the tab never re-opens it from the stale route param.

The invitation copy is a resonant, declinable Candle & Ink invitation — no gamified pressure, opt-in selection, no interruption while scrolling. No reader regressions (mark-read footer, image rules, link handling, and the H1/H2 title strip are untouched). `ChapterReader` edits stay off the header/back/footer plumbing to minimize the sync with sibling lane #1784.

Completes epic #1779 (`epic:course-highlight-note`).

## Test plan

- New `ChapterReaderPassageSelection.test.tsx`: affordance visibility gating (present for content with `onWriteNote`, absent otherwise), enter/leave selection mode, the confirm dialog (title/labels, cancel keeps the surface, confirm fires `onWriteNote` once and exits), code-point-correct passage extraction (astral-emoji fixture that discriminates code-point from UTF-16 slicing), press-time scroll snapshot (unaffected by later scrolls), and `initialScrollOffset` → `contentOffset`.
- New `CourseScreenWriteNote.test.tsx`: end-to-end quote → dialog → `navigate('JournalEntry', { prefillQuote, returnTo })` with the reader still mounted; cold-return auto-open restored to offset; **back-out-after-restore stays closed** (regression for the one-shot guard); unknown-`contentId`, locked-item, and warm-return-match guards.
- Extended `QuoteSelectionSurface.test.tsx` (default + `confirmLabel` override) and `ContentViewer.test.tsx` (prop forwarding).
- Full frontend `check-all.sh` green: ESLint (zero warnings), prettier, `tsc --noEmit` strict, and the full Jest suite (4547 tests).

Closes #1781
Refs #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)