### PR TITLE
feat(backend): consume Creek Vault classification for the wheel and invitations

### DIFF
--- a/backend/src/domain/invitations.py
+++ b/backend/src/domain/invitations.py
@@ -1,10 +1,18 @@
 """Pure readiness-signal computation — coordinates for resonant invitations.
 
 Given a snapshot of a user's cross-feature engagement (habit streaks, sustained
-practice weeks, active-day count in a rolling window), decide which deeper
-depths the moment invites the user to *consider*. The output is a list of
-plain coordinates — target ring, optional concrete target, and why the moment
-qualifies — that a later persistence pass turns into ``InvitationSignal`` rows.
+practice weeks, active-day count in a rolling window) plus any Creek Vault
+corpus-theme readings, decide which deeper depths the moment invites the user to
+*consider*. The output is a list of plain coordinates — target ring, optional
+concrete target, and why the moment qualifies — that a later persistence pass
+turns into ``InvitationSignal`` rows.
+
+The behavioral signals (habit / practice / community) are computed purely from
+local engagement and stay local. The corpus-theme source is the one outward
+input: a Wheel-of-Wholeness reading gathered from a connected vault, which the
+caller passes in already validated. This module applies the fullness threshold
+and picks the single strongest theme, so at most one course invitation is ever
+offered from it.
 
 This module encodes NO shaming and NO FOMO: it never counts what the user
 *failed* to do, never compares them to anyone, and stays silent by default.
@@ -21,7 +29,7 @@ unit-test without fixtures.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from models.invitation_signal import InvitationKind, InvitationTargetType
 
@@ -45,11 +53,17 @@ HIGH_ENGAGEMENT_ACTIVE_DAYS = 25
 # the signal reflects the present season, not a distant past.
 ENGAGEMENT_WINDOW_DAYS = 30
 
+# A corpus theme this full is a genuinely lived Aspect, not a passing mention —
+# high enough that the course invitation reads as recognition of where the
+# user's own writing already dwells, never a nudge to "complete" a stage.
+CORPUS_THEME_FULLNESS_THRESHOLD = 0.75
+
 # Reference the model enum *values* (not bare string literals) so the candidate
 # coordinates can never drift from the persisted vocabulary — the drift-guard
 # test asserts exactly this coupling.
 _HABIT = InvitationTargetType.HABIT.value
 _PRACTICE = InvitationTargetType.PRACTICE.value
+_COURSE = InvitationTargetType.COURSE.value
 _EMBODIED_COMMUNITY = InvitationTargetType.EMBODIED_COMMUNITY.value
 _CONSISTENCY = InvitationKind.CONSISTENCY.value
 _MASTERY = InvitationKind.MASTERY.value
@@ -86,12 +100,26 @@ class PracticeSignal:
 
 
 @dataclass(frozen=True)
+class CorpusThemeSignal:
+    """One Aspect's fullness in a vault Wheel-of-Wholeness reading of the user's corpus."""
+
+    stage_number: int
+    fullness: float
+
+
+@dataclass(frozen=True)
 class ReadinessAggregates:
-    """A snapshot of one user's cross-feature engagement for candidate math."""
+    """A snapshot of one user's cross-feature engagement for candidate math.
+
+    ``corpus_themes`` defaults to empty and is appended last so every existing
+    positional construction (behavioral-only) stays valid and behaves exactly as
+    before — the vault source is purely additive.
+    """
 
     habits: list[HabitSignal]
     practices: list[PracticeSignal]
     active_days_in_window: int
+    corpus_themes: list[CorpusThemeSignal] = field(default_factory=list)
 
 
 def _habit_candidates(habits: list[HabitSignal]) -> list[InvitationCandidate]:
@@ -121,6 +149,23 @@ def _community_candidates(active_days_in_window: int) -> list[InvitationCandidat
     return []
 
 
+def _corpus_theme_candidates(themes: list[CorpusThemeSignal]) -> list[InvitationCandidate]:
+    """Emit at most one course candidate for the strongest above-threshold corpus theme.
+
+    Filters to themes at or above :data:`CORPUS_THEME_FULLNESS_THRESHOLD`; with
+    none, stays silent. Otherwise the single strongest wins — highest fullness
+    first, lowest ``stage_number`` breaking a tie — so the offer points at the
+    one Aspect the user's own corpus most fully embodies.
+    """
+    eligible = [t for t in themes if t.fullness >= CORPUS_THEME_FULLNESS_THRESHOLD]
+    if not eligible:
+        return []
+    strongest = max(eligible, key=lambda t: (t.fullness, -t.stage_number))
+    return [
+        InvitationCandidate(target_type=_COURSE, target_id=strongest.stage_number, kind=_READINESS)
+    ]
+
+
 def compute_invitation_candidates(
     aggregates: ReadinessAggregates,
 ) -> list[InvitationCandidate]:
@@ -128,11 +173,13 @@ def compute_invitation_candidates(
 
     Silent by default: aggregates below every threshold yield ``[]``. Each
     source contributes independently — one candidate per qualifying habit, one
-    per qualifying practice, and at most one outward community candidate — so
-    the three signals coexist without interfering.
+    per qualifying practice, at most one outward community candidate, and at most
+    one course candidate for the strongest above-threshold corpus theme — so the
+    behavioral and corpus-theme signals coexist without interfering.
     """
     return [
         *_habit_candidates(aggregates.habits),
         *_practice_candidates(aggregates.practices),
         *_community_candidates(aggregates.active_days_in_window),
+        *_corpus_theme_candidates(aggregates.corpus_themes),
     ]

--- a/backend/src/routers/invitations.py
+++ b/backend/src/routers/invitations.py
@@ -26,10 +26,12 @@ from sqlmodel import col, select
 
 from database import get_session
 from dependencies.timezone import current_user_timezone
+from domain.creek_vault import CreekVaultClient
 from errors import not_found
 from models.invitation_signal import InvitationSignal
 from routers.auth import get_current_user
 from schemas.invitations import InvitationResponse
+from services.creek_vault_write import get_creek_vault_client
 from services.invitations import generate_invitation_signals
 
 router = APIRouter(prefix="/invitations", tags=["invitations"])
@@ -54,16 +56,18 @@ async def list_invitations(
     user_id: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
     user_timezone: Annotated[str, Depends(current_user_timezone)],
+    vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],
 ) -> list[InvitationResponse]:
     """Generate newly-warranted invitations, then return the caller's pending ones.
 
     The generation pass runs first and is idempotent — it inserts only
     coordinates that have no prior row (dismissed rows included), so polling
-    this endpoint never accumulates duplicates. The listing that follows
-    returns only the caller's rows with ``dismissed_at IS NULL``, ordered by
-    ``created_at``; declined and other users' invitations are excluded.
+    this endpoint never accumulates duplicates. A connected vault also feeds a
+    corpus-theme source into that pass. The listing that follows returns only
+    the caller's rows with ``dismissed_at IS NULL``, ordered by ``created_at``;
+    declined and other users' invitations are excluded.
     """
-    await generate_invitation_signals(session, user_id, user_timezone)
+    await generate_invitation_signals(session, user_id, user_timezone, vault_client=vault_client)
     result = await session.execute(
         select(InvitationSignal)
         .where(

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -15,6 +15,7 @@ from curriculum import CurriculumDataError, stage_curriculum
 from database import get_session
 from dependencies.timezone import current_user_timezone
 from domain.constants import TOTAL_STAGES
+from domain.creek_vault import CreekVaultClient
 from domain.program_calendar import calendar_stage, calendar_week, resolve_program_anchor
 from domain.stage_progress import (
     AllStagesCompletedError,
@@ -28,7 +29,6 @@ from domain.stage_progress import (
     next_stage_for,
     stage_exists,
 )
-from domain.wheel import compute_wheel_balance
 from errors import bad_request, conflict, forbidden, not_found
 from models.course_stage import CourseStage
 from models.stage_progress import StageProgress
@@ -46,6 +46,8 @@ from schemas.stage import (
     StageResponse,
 )
 from schemas.wheel import WheelAspect, WheelBalanceResponse
+from services.creek_vault_wheel import select_wheel_balance
+from services.creek_vault_write import get_creek_vault_client
 
 logger = logging.getLogger(__name__)
 
@@ -193,14 +195,17 @@ async def get_program_calendar(
 async def get_wheel_balance(
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
+    vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],
 ) -> WheelBalanceResponse:
     """Per-Aspect fullness for all ten stages, in canonical stage order.
 
     Registered ABOVE ``/{stage_number}`` so the static ``wheel`` path wins
-    route matching. Fullness reuses each stage's ``overall_progress`` signal;
-    a new user sees all zeros.
+    route matching. A connected, capable vault's own reading of the user's
+    corpus wins; otherwise the balance is computed locally, where fullness
+    reuses each stage's ``overall_progress`` signal and a new user sees all
+    zeros.
     """
-    balance = await compute_wheel_balance(session, current_user)
+    balance = await select_wheel_balance(vault_client, session, current_user)
     return WheelBalanceResponse(aspects=[WheelAspect(**item) for item in balance])
 
 

--- a/backend/src/schemas/wheel.py
+++ b/backend/src/schemas/wheel.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from domain.constants import TOTAL_STAGES
 
 
 class WheelAspect(BaseModel):
@@ -14,6 +16,13 @@ class WheelAspect(BaseModel):
 
 
 class WheelBalanceResponse(BaseModel):
-    """The ten Aspect fullness values in canonical stage order."""
+    """The ten Aspect fullness values in canonical stage order.
 
-    aspects: list[WheelAspect]
+    The Aspect list is capped at ``TOTAL_STAGES`` so a vault-supplied wheel read
+    parsed through this schema cannot materialize an unbounded number of rows;
+    an over-cap payload fails validation and the consumer degrades to the local
+    balance. The local producer always emits exactly ``TOTAL_STAGES`` rows, so
+    the cap never constrains the in-app path.
+    """
+
+    aspects: list[WheelAspect] = Field(max_length=TOTAL_STAGES)

--- a/backend/src/services/creek_vault_wheel.py
+++ b/backend/src/services/creek_vault_wheel.py
@@ -1,0 +1,120 @@
+"""Creek Vault read path: source a Wheel-of-Wholeness balance, degrading safely.
+
+This is the read-path consumer of the seam's ``wheel`` capability. Where the
+seam adapter deliberately defers field-level validation of a wheel payload, this
+module owns it: the adapter validates the wire *shape* against its Pydantic
+schema and, on a malformed field, surfaces a :class:`pydantic.ValidationError`
+rather than normalizing it to :class:`~domain.creek_vault.CreekVaultError`. This
+module catches that error alongside the vault's own error hierarchy and falls
+back, so a malformed-field wheel is indistinguishable from an absent vault to the
+caller.
+
+The governing rule is the same **graceful degradation** as the rest of the seam:
+an absent, unreachable, capability-poor, or malformed-payload vault never raises
+into the read path -- it collapses to ``None`` from :func:`fetch_vault_wheel`, and
+:func:`select_wheel_balance` then computes the balance locally. Validation is
+all-or-nothing: a single field or structural violation rejects the whole payload
+rather than partially accepting it, so the frontend never renders a wheel spliced
+from a trusted local half and an untrusted vault half.
+"""
+
+from __future__ import annotations
+
+import pydantic
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.constants import TOTAL_STAGES
+from domain.creek_vault import (
+    CreekCapability,
+    CreekVaultClient,
+    CreekVaultError,
+    VaultWheelAspect,
+    VaultWheelBalance,
+)
+from domain.wheel import WheelItem, compute_wheel_balance
+
+# The wheel carries exactly one aspect per curriculum stage; a payload of any
+# other length is rejected outright.
+VAULT_WHEEL_EXPECTED_ASPECTS = TOTAL_STAGES
+
+# The stage-number range a valid aspect must fall within (inclusive), and the
+# inclusive bounds on a fullness value.
+VAULT_WHEEL_STAGE_MIN = 1
+VAULT_WHEEL_FULLNESS_MIN = 0.0
+VAULT_WHEEL_FULLNESS_MAX = 1.0
+
+
+def _aspect_ok(aspect: VaultWheelAspect) -> bool:
+    """Return whether a single aspect passes every field-level check.
+
+    The fullness bound is a chained comparison, which is ``False`` for ``NaN``
+    on either side -- so a ``NaN`` fullness is rejected without a special case.
+    """
+    return (
+        VAULT_WHEEL_STAGE_MIN <= aspect.stage_number <= TOTAL_STAGES
+        and bool(aspect.aspect.strip())
+        and VAULT_WHEEL_FULLNESS_MIN <= aspect.fullness <= VAULT_WHEEL_FULLNESS_MAX
+    )
+
+
+def _stage_set_complete(aspects: tuple[VaultWheelAspect, ...]) -> bool:
+    """Return whether the stage numbers are exactly ``{1 .. TOTAL_STAGES}`` (no dupes/gaps)."""
+    return {aspect.stage_number for aspect in aspects} == set(
+        range(VAULT_WHEEL_STAGE_MIN, TOTAL_STAGES + 1)
+    )
+
+
+def _balance_valid(aspects: tuple[VaultWheelAspect, ...]) -> bool:
+    """Return whether a whole balance passes structural and field validation."""
+    return (
+        len(aspects) == VAULT_WHEEL_EXPECTED_ASPECTS
+        and all(_aspect_ok(aspect) for aspect in aspects)
+        and _stage_set_complete(aspects)
+    )
+
+
+def _to_items(aspects: tuple[VaultWheelAspect, ...]) -> list[WheelItem]:
+    """Project validated aspects onto canonical-ordered wheel items (ascending by stage)."""
+    return [
+        WheelItem(stage_number=aspect.stage_number, aspect=aspect.aspect, fullness=aspect.fullness)
+        for aspect in sorted(aspects, key=lambda item: item.stage_number)
+    ]
+
+
+async def _read_balance(client: CreekVaultClient) -> VaultWheelBalance | None:
+    """Call the vault's wheel, mapping any seam or field-validation error to ``None``.
+
+    A :class:`~domain.creek_vault.CreekVaultError` (unavailable or unsupported)
+    and a :class:`pydantic.ValidationError` (a malformed field the adapter
+    deliberately did not normalize) both degrade to ``None``.
+    """
+    try:
+        return await client.wheel()
+    except (CreekVaultError, pydantic.ValidationError):
+        return None
+
+
+async def fetch_vault_wheel(client: CreekVaultClient) -> list[WheelItem] | None:
+    """Return the vault's validated wheel in canonical order, or ``None`` to fall back.
+
+    Mirrors the gate order of the reflection read path: a handshake precedes any
+    wheel call, and an unavailable vault or one that does not advertise WHEEL
+    degrades before the call is made. A transport/field error from the call, or
+    any field-level or structural validation violation on the returned balance,
+    all collapse to ``None`` -- the signal for the caller to compute locally.
+    """
+    await client.handshake()
+    if not (client.is_available() and client.supports(CreekCapability.WHEEL)):
+        return None
+    balance = await _read_balance(client)
+    if balance is None or not _balance_valid(balance.aspects):
+        return None
+    return _to_items(balance.aspects)
+
+
+async def select_wheel_balance(
+    client: CreekVaultClient, session: AsyncSession, user_id: int
+) -> list[WheelItem]:
+    """Return the vault's wheel when available and valid, else the locally-computed balance."""
+    items = await fetch_vault_wheel(client)
+    return items if items is not None else await compute_wheel_balance(session, user_id)

--- a/backend/src/services/invitations.py
+++ b/backend/src/services/invitations.py
@@ -24,10 +24,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from domain.creek_vault import CreekVaultClient
 from domain.dates import now_in_tz, to_user_date_bucket
 from domain.invitations import (
     ENGAGEMENT_WINDOW_DAYS,
     SUSTAINED_PRACTICE_WEEKS,
+    CorpusThemeSignal,
     HabitSignal,
     InvitationCandidate,
     PracticeSignal,
@@ -41,6 +43,7 @@ from models.invitation_signal import InvitationSignal
 from models.journal_entry import JournalEntry
 from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
+from services.creek_vault_wheel import fetch_vault_wheel
 
 # Sentinel standing in for a ``None`` target_id in the dedup key, so the
 # outward (null-target) embodied-community candidate dedups against its prior
@@ -162,14 +165,37 @@ async def _gather_active_days(session: AsyncSession, user_id: int, user_timezone
     return len({to_user_date_bucket(ts, user_timezone) for ts in timestamps})
 
 
+async def _gather_corpus_themes(vault_client: CreekVaultClient | None) -> list[CorpusThemeSignal]:
+    """Read the vault's Wheel-of-Wholeness balance as corpus-theme signals, or none.
+
+    With no vault client, or a vault that degrades (unavailable, unsupported, or
+    a malformed payload — all surfaced as a ``None`` wheel), returns ``[]`` so the
+    pass stays behavioral-only. Every validated aspect passes through unfiltered:
+    the domain owns the fullness threshold and the strongest-wins selection.
+    """
+    if vault_client is None:
+        return []
+    items = await fetch_vault_wheel(vault_client)
+    if items is None:
+        return []
+    return [
+        CorpusThemeSignal(stage_number=item["stage_number"], fullness=item["fullness"])
+        for item in items
+    ]
+
+
 async def _gather_aggregates(
-    session: AsyncSession, user_id: int, user_timezone: str
+    session: AsyncSession,
+    user_id: int,
+    user_timezone: str,
+    vault_client: CreekVaultClient | None = None,
 ) -> ReadinessAggregates:
     """Assemble the readiness snapshot from the batched per-source gathers."""
     return ReadinessAggregates(
         habits=await _gather_habit_signals(session, user_id),
         practices=await _gather_practice_signals(session, user_id, user_timezone),
         active_days_in_window=await _gather_active_days(session, user_id, user_timezone),
+        corpus_themes=await _gather_corpus_themes(vault_client),
     )
 
 
@@ -240,6 +266,7 @@ async def generate_invitation_signals(
     session: AsyncSession,
     user_id: int,
     user_timezone: str = "UTC",
+    vault_client: CreekVaultClient | None = None,
 ) -> list[InvitationSignal]:
     """Detect readiness, persist the newly-warranted invitations, and return them.
 
@@ -248,8 +275,12 @@ async def generate_invitation_signals(
     already exists as a signal (dismissed rows included), and inserts only the
     survivors. Returns the rows created by this call — ``[]`` when nothing new
     is warranted, making repeat calls idempotent.
+
+    An optional ``vault_client`` adds the corpus-theme source: a connected,
+    capable vault's Wheel-of-Wholeness reading can warrant a course invitation.
+    A missing or degraded vault leaves the pass behavioral-only.
     """
-    aggregates = await _gather_aggregates(session, user_id, user_timezone)
+    aggregates = await _gather_aggregates(session, user_id, user_timezone, vault_client)
     candidates = compute_invitation_candidates(aggregates)
     if not candidates:
         return []

--- a/backend/tests/domain/test_invitations.py
+++ b/backend/tests/domain/test_invitations.py
@@ -25,9 +25,11 @@ import inspect
 import pytest
 
 from domain.invitations import (
+    CORPUS_THEME_FULLNESS_THRESHOLD,
     HIGH_ENGAGEMENT_ACTIVE_DAYS,
     SUSTAINED_HABIT_STREAK_DAYS,
     SUSTAINED_PRACTICE_WEEKS,
+    CorpusThemeSignal,
     HabitSignal,
     InvitationCandidate,
     PracticeSignal,
@@ -252,3 +254,129 @@ def test_candidate_is_frozen_dataclass() -> None:
     c = InvitationCandidate(target_type="habit", target_id=1, kind="consistency")
     with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
         c.__setattr__("target_type", "mutated")
+
+
+# ---------------------------------------------------------------------------
+# 8. Corpus-theme signal: vault Wheel-of-Wholeness readings feed readiness too
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_theme_signal_is_frozen_dataclass() -> None:
+    """CorpusThemeSignal is a frozen dataclass (immutable value object)."""
+    assert dataclasses.is_dataclass(CorpusThemeSignal), "CorpusThemeSignal must be a dataclass"
+    signal = CorpusThemeSignal(stage_number=1, fullness=0.9)
+    with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+        signal.__setattr__("fullness", 0.1)
+
+
+def test_corpus_theme_below_threshold_produces_no_candidate() -> None:
+    """A theme fullness just under CORPUS_THEME_FULLNESS_THRESHOLD must stay silent."""
+    below = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[
+            CorpusThemeSignal(stage_number=3, fullness=CORPUS_THEME_FULLNESS_THRESHOLD - 0.0001)
+        ],
+    )
+    candidates = compute_invitation_candidates(below)
+    assert not any(c.target_type == "course" for c in candidates)
+
+
+def test_corpus_theme_at_threshold_produces_one_candidate() -> None:
+    """A theme fullness of exactly CORPUS_THEME_FULLNESS_THRESHOLD (0.75) fires."""
+    at_threshold = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[CorpusThemeSignal(stage_number=6, fullness=CORPUS_THEME_FULLNESS_THRESHOLD)],
+    )
+    candidates = compute_invitation_candidates(at_threshold)
+    assert len(candidates) == 1
+    assert candidates[0].target_type == "course"
+    assert candidates[0].target_id == 6
+    assert candidates[0].kind == "readiness"
+
+
+def test_empty_corpus_themes_produces_no_course_candidate() -> None:
+    """An empty corpus_themes list yields no course candidate."""
+    empty_themes = ReadinessAggregates(
+        habits=[], practices=[], active_days_in_window=0, corpus_themes=[]
+    )
+    candidates = compute_invitation_candidates(empty_themes)
+    assert not any(c.target_type == "course" for c in candidates)
+
+
+def test_corpus_theme_strongest_wins_among_several_above_threshold() -> None:
+    """At most one course candidate: the highest-fullness theme wins."""
+    agg = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[
+            CorpusThemeSignal(stage_number=2, fullness=0.8),
+            CorpusThemeSignal(stage_number=5, fullness=0.95),
+            CorpusThemeSignal(stage_number=9, fullness=0.76),
+        ],
+    )
+    candidates = compute_invitation_candidates(agg)
+    course_candidates = [c for c in candidates if c.target_type == "course"]
+    assert len(course_candidates) == 1
+    assert course_candidates[0].target_id == 5
+
+
+def test_corpus_theme_tie_break_picks_lowest_stage_number() -> None:
+    """Two themes tied at the max fullness resolve to the lowest stage_number."""
+    agg = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[
+            CorpusThemeSignal(stage_number=8, fullness=0.9),
+            CorpusThemeSignal(stage_number=2, fullness=0.9),
+            CorpusThemeSignal(stage_number=5, fullness=0.85),
+        ],
+    )
+    candidates = compute_invitation_candidates(agg)
+    course_candidates = [c for c in candidates if c.target_type == "course"]
+    assert len(course_candidates) == 1
+    assert course_candidates[0].target_id == 2
+
+
+def test_corpus_theme_candidate_shape_is_exact() -> None:
+    """The emitted candidate is exactly the course/stage/readiness coordinate."""
+    agg = ReadinessAggregates(
+        habits=[],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[CorpusThemeSignal(stage_number=4, fullness=1.0)],
+    )
+    candidates = compute_invitation_candidates(agg)
+    assert candidates == [InvitationCandidate(target_type="course", target_id=4, kind="readiness")]
+
+
+def test_corpus_theme_coexists_with_behavioral_candidates() -> None:
+    """A theme candidate and behavioral candidates from the same pass both appear."""
+    agg = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=1, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[],
+        active_days_in_window=0,
+        corpus_themes=[CorpusThemeSignal(stage_number=7, fullness=0.8)],
+    )
+    candidates = compute_invitation_candidates(agg)
+    types = {c.target_type for c in candidates}
+    assert types == {"habit", "course"}
+
+
+def test_readiness_aggregates_default_corpus_themes_is_empty_and_backward_compatible() -> None:
+    """Constructing ReadinessAggregates without corpus_themes yields prior behavioral output."""
+    agg = ReadinessAggregates(
+        habits=[HabitSignal(habit_id=1, streak_days=SUSTAINED_HABIT_STREAK_DAYS)],
+        practices=[PracticeSignal(practice_id=2, sustained_weeks=SUSTAINED_PRACTICE_WEEKS)],
+        active_days_in_window=HIGH_ENGAGEMENT_ACTIVE_DAYS,
+    )
+    assert agg.corpus_themes == []
+    candidates = compute_invitation_candidates(agg)
+    types = {c.target_type for c in candidates}
+    assert types == {"habit", "practice", "embodied_community"}
+    assert not any(c.target_type == "course" for c in candidates)

--- a/backend/tests/routers/test_invitations.py
+++ b/backend/tests/routers/test_invitations.py
@@ -10,11 +10,25 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from domain.constants import TOTAL_STAGES
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
+)
+from main import app
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.invitation_signal import InvitationSignal
 from models.user import User
+from services.creek_vault_write import get_creek_vault_client
 
 _LIST_URL = "/invitations"
 _SUSTAINED_STREAK = 21  # mirrors SUSTAINED_HABIT_STREAK_DAYS in the domain
@@ -527,3 +541,97 @@ async def test_response_shape_has_required_keys_and_excludes_user_id(
         assert isinstance(item["target_type"], str)
         assert isinstance(item["kind"], str)
         assert isinstance(item["created_at"], str)
+
+
+# ---------------------------------------------------------------------------
+# 9. GET /invitations surfaces a Creek Vault corpus-theme candidate
+# ---------------------------------------------------------------------------
+
+
+class _ThemeVaultClient:
+    """A minimal fake CreekVaultClient exposing only the wheel path."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.WHEEL}),
+        wheel_result: VaultWheelBalance | None = None,
+    ) -> None:
+        """Store the scripted handshake outcome and wheel result."""
+        self._available = available
+        self._capabilities = capabilities
+        self._wheel_result = wheel_result
+
+    async def handshake(self) -> HandshakeResult:
+        """Return the scripted availability/capabilities."""
+        return HandshakeResult(
+            available=self._available,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Return the scripted availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the scripted capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Return the scripted balance."""
+        assert self._wheel_result is not None
+        return self._wheel_result
+
+
+@pytest.mark.asyncio
+async def test_get_invitations_includes_vault_theme_candidate(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A valid vault wheel with an above-threshold theme surfaces alongside behavioral ones."""
+    theme_stage = 6
+    aspects = tuple(
+        VaultWheelAspect(
+            stage_number=n,
+            aspect=f"Aspect-{n}",
+            fullness=0.9 if n == theme_stage else 0.1,
+        )
+        for n in range(1, TOTAL_STAGES + 1)
+    )
+    fake_vault = _ThemeVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake_vault
+    headers = await _signup(async_client, "inv_vault_theme9")
+
+    user_result = await db_session.execute(
+        select(User).where(col(User.email) == "inv_vault_theme9@example.com")
+    )
+    user = user_result.scalars().one()
+    assert user.id is not None
+    habit_id = await _make_habit_with_streak(db_session, user.id, streak_days=_SUSTAINED_STREAK)
+
+    resp = await async_client.get(_LIST_URL, headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    items = resp.json()
+    course_items = [i for i in items if i["target_type"] == "course"]
+    habit_items = [i for i in items if i["target_type"] == "habit"]
+    assert len(course_items) == 1
+    assert course_items[0]["target_id"] == theme_stage
+    assert course_items[0]["kind"] == "readiness"
+    assert habit_id in [i["target_id"] for i in habit_items]

--- a/backend/tests/services/test_invitations_service.py
+++ b/backend/tests/services/test_invitations_service.py
@@ -24,6 +24,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from conftest import test_engine
+from domain.constants import TOTAL_STAGES
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
+)
 from domain.dates import now_in_tz, to_user_date_bucket
 from domain.invitations import SUSTAINED_PRACTICE_WEEKS
 from domain.practice_insights import PracticeInsights
@@ -703,3 +715,167 @@ async def test_practice_gather_excludes_sessions_older_than_the_sustained_window
     # _make_practice_with_sessions(weeks=1) seeds 4 rows in the current week;
     # the stale row placed far outside the window must not be among them.
     assert fetched_counts == [4]
+
+
+# ---------------------------------------------------------------------------
+# 18. Creek Vault corpus-theme source: an optional trailing vault_client param
+# ---------------------------------------------------------------------------
+
+
+class _ThemeVaultClient:
+    """A minimal fake CreekVaultClient exposing only the wheel path."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.WHEEL}),
+        wheel_result: VaultWheelBalance | None = None,
+    ) -> None:
+        """Store the scripted handshake outcome and wheel result."""
+        self.wheel_calls = 0
+        self._available = available
+        self._capabilities = capabilities
+        self._wheel_result = wheel_result
+
+    async def handshake(self) -> HandshakeResult:
+        """Return the scripted availability/capabilities."""
+        return HandshakeResult(
+            available=self._available,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Return the scripted availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the scripted capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Record the call and return the scripted balance."""
+        self.wheel_calls += 1
+        assert self._wheel_result is not None
+        return self._wheel_result
+
+
+def _valid_vault_wheel(theme_stage: int, theme_fullness: float) -> VaultWheelBalance:
+    """Ten valid VaultWheelAspect rows with one stage carrying the given fullness."""
+    aspects = tuple(
+        VaultWheelAspect(
+            stage_number=n,
+            aspect=f"Aspect-{n}",
+            fullness=theme_fullness if n == theme_stage else 0.1,
+        )
+        for n in range(1, TOTAL_STAGES + 1)
+    )
+    return VaultWheelBalance(aspects=aspects)
+
+
+@pytest.mark.asyncio
+async def test_valid_vault_wheel_persists_course_readiness_row(
+    db_session: AsyncSession,
+) -> None:
+    """A vault-classified corpus theme above threshold persists a COURSE/readiness row."""
+    user_id = await _make_user(db_session)
+    theme_stage = 8
+    client = _ThemeVaultClient(wheel_result=_valid_vault_wheel(theme_stage, 0.9))
+
+    result = await generate_invitation_signals(db_session, user_id, vault_client=client)
+
+    course_rows = [r for r in result if r.target_type == "course"]
+    assert len(course_rows) == 1
+    assert course_rows[0].target_id == theme_stage
+    assert course_rows[0].kind == "readiness"
+
+    persisted = await _signals_for(db_session, user_id)
+    persisted_course = [r for r in persisted if r.target_type == "course"]
+    assert len(persisted_course) == 1
+    assert persisted_course[0].target_id == theme_stage
+
+
+@pytest.mark.asyncio
+async def test_no_vault_client_yields_behavioral_only(db_session: AsyncSession) -> None:
+    """vault_client=None -> no course candidate is ever considered."""
+    user_id = await _make_user(db_session)
+    await _make_habit_with_streak(db_session, user_id, streak_days=_SUSTAINED_STREAK)
+
+    result = await generate_invitation_signals(db_session, user_id, vault_client=None)
+
+    assert not any(r.target_type == "course" for r in result)
+    assert any(r.target_type == "habit" for r in result)
+
+
+@pytest.mark.asyncio
+async def test_degraded_vault_yields_behavioral_only(db_session: AsyncSession) -> None:
+    """A vault whose wheel read fails degrades to behavioral-only candidates."""
+    user_id = await _make_user(db_session)
+    await _make_habit_with_streak(db_session, user_id, streak_days=_SUSTAINED_STREAK)
+    client = _ThemeVaultClient(available=False, wheel_result=_valid_vault_wheel(3, 0.95))
+
+    result = await generate_invitation_signals(db_session, user_id, vault_client=client)
+
+    assert not any(r.target_type == "course" for r in result)
+    assert any(r.target_type == "habit" for r in result)
+
+
+@pytest.mark.asyncio
+async def test_dismissed_course_readiness_row_blocks_regeneration(
+    db_session: AsyncSession,
+) -> None:
+    """A dismissed COURSE/readiness row is never regenerated even if the theme persists."""
+    user_id = await _make_user(db_session)
+    theme_stage = 5
+    client = _ThemeVaultClient(wheel_result=_valid_vault_wheel(theme_stage, 0.9))
+
+    first_batch = await generate_invitation_signals(db_session, user_id, vault_client=client)
+    course_rows = [r for r in first_batch if r.target_type == "course"]
+    assert len(course_rows) == 1
+    row = course_rows[0]
+    row.dismissed_at = datetime.now(UTC)
+    db_session.add(row)
+    await db_session.commit()
+
+    second_batch = await generate_invitation_signals(db_session, user_id, vault_client=client)
+
+    assert not any(r.target_type == "course" for r in second_batch)
+    persisted = await _signals_for(db_session, user_id)
+    course_persisted = [r for r in persisted if r.target_type == "course"]
+    assert len(course_persisted) == 1
+    assert course_persisted[0].dismissed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_behavioral_candidates_identical_with_and_without_vault(
+    db_session: AsyncSession,
+) -> None:
+    """The same shape of habit/practice/community candidates appear with or without a vault."""
+    user_a = await _make_user(db_session, "inv_vault_a@example.com")
+    user_b = await _make_user(db_session, "inv_vault_b@example.com")
+    await _make_habit_with_streak(db_session, user_a, streak_days=_SUSTAINED_STREAK)
+    await _make_habit_with_streak(db_session, user_b, streak_days=_SUSTAINED_STREAK)
+    # Below-threshold theme: no course candidate should leak into the comparison.
+    client = _ThemeVaultClient(wheel_result=_valid_vault_wheel(2, 0.1))
+
+    without_vault = await generate_invitation_signals(db_session, user_a, vault_client=None)
+    with_vault = await generate_invitation_signals(db_session, user_b, vault_client=client)
+
+    without_shapes = {(r.target_type, r.kind) for r in without_vault}
+    with_shapes = {(r.target_type, r.kind) for r in with_vault}
+    assert without_shapes == with_shapes == {("habit", "consistency")}

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
+from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
@@ -420,6 +421,25 @@ async def test_wheel_malformed_fields_raise_validation_error() -> None:
         responses={
             CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
             CreekCapability.WHEEL.value: {"aspects": [{"stage_number": "not-an-int"}]},
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    with pytest.raises(ValidationError):
+        await client.wheel()
+
+
+@pytest.mark.asyncio
+async def test_wheel_over_cap_aspect_count_raises_validation_error() -> None:
+    """wheel() rejects an aspect list larger than the schema ceiling."""
+    over_cap = [
+        {"stage_number": n, "aspect": f"Aspect-{n}", "fullness": 0.5}
+        for n in range(1, TOTAL_STAGES + 2)
+    ]
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
+            CreekCapability.WHEEL.value: {"aspects": over_cap},
         }
     )
     client = McpCreekVaultClient(transport=transport)

--- a/backend/tests/test_creek_vault_wheel.py
+++ b/backend/tests/test_creek_vault_wheel.py
@@ -1,0 +1,422 @@
+"""Unit tests for the Creek Vault wheel-of-wholeness seam.
+
+RED: ``services.creek_vault_wheel`` does not exist yet, so every test here
+fails at collection with a ``ModuleNotFoundError`` until ``fetch_vault_wheel``
+and ``select_wheel_balance`` are implemented.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.constants import TOTAL_STAGES
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
+)
+from domain.wheel import compute_wheel_balance
+from models.course_stage import CourseStage
+from models.goal import Goal
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+from models.user import User
+from schemas.wheel import WheelAspect
+from services.creek_vault_wheel import (
+    VAULT_WHEEL_EXPECTED_ASPECTS,
+    VAULT_WHEEL_FULLNESS_MAX,
+    VAULT_WHEEL_FULLNESS_MIN,
+    VAULT_WHEEL_STAGE_MIN,
+    fetch_vault_wheel,
+    select_wheel_balance,
+)
+
+_CANONICAL_ASPECTS = [
+    "Body",
+    "Body",
+    "Emotion",
+    "Emotion",
+    "Mind",
+    "Mind",
+    "Spirit",
+    "Spirit",
+    "Nondual",
+    "Nondual",
+]
+
+
+class RecordingWheelVaultClient:
+    """A scriptable, call-recording fake CreekVaultClient (wheel path only)."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.WHEEL}),
+        wheel_result: VaultWheelBalance | None = None,
+        wheel_error: Exception | None = None,
+    ) -> None:
+        """Store the scripted handshake outcome and wheel behavior."""
+        self.handshake_calls = 0
+        self.wheel_calls = 0
+        self._available = available
+        self._capabilities = capabilities
+        self._wheel_result = wheel_result
+        self._wheel_error = wheel_error
+
+    async def handshake(self) -> HandshakeResult:
+        """Record the call and return the scripted availability/capabilities."""
+        self.handshake_calls += 1
+        return HandshakeResult(
+            available=self._available,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Return the scripted availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the scripted capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Record the call, then raise the scripted error or return the scripted balance."""
+        self.wheel_calls += 1
+        if self._wheel_error is not None:
+            raise self._wheel_error
+        assert self._wheel_result is not None
+        return self._wheel_result
+
+
+def _valid_aspects() -> tuple[VaultWheelAspect, ...]:
+    """Ten valid, distinct aspects in canonical ascending order."""
+    return tuple(
+        VaultWheelAspect(stage_number=n, aspect=f"Aspect-{n}", fullness=round(n / 10, 2))
+        for n in range(1, VAULT_WHEEL_EXPECTED_ASPECTS + 1)
+    )
+
+
+def _override_field(
+    position: int,
+    *,
+    stage_number: int | None = None,
+    aspect: str | None = None,
+    fullness: float | None = None,
+) -> tuple[VaultWheelAspect, ...]:
+    """Ten valid aspects with the aspect at ``position`` (1-based) mutated by the given fields.
+
+    Each keyword left as ``None`` keeps the original field, so a single call can
+    inject one out-of-range value while the rest of the wheel stays valid.
+    """
+    base = list(_valid_aspects())
+    idx = position - 1
+    original = base[idx]
+    base[idx] = VaultWheelAspect(
+        stage_number=original.stage_number if stage_number is None else stage_number,
+        aspect=original.aspect if aspect is None else aspect,
+        fullness=original.fullness if fullness is None else fullness,
+    )
+    return tuple(base)
+
+
+def _malformed_validation_error() -> ValidationError:
+    """Obtain a real pydantic.ValidationError from the wheel adapter's response schema."""
+    try:
+        WheelAspect.model_validate(
+            {"stage_number": "not-a-number", "aspect": "Body", "fullness": 0.5}
+        )
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected a ValidationError from a malformed payload")
+
+
+_INVALID_PAYLOADS: list[tuple[str, tuple[VaultWheelAspect, ...]]] = [
+    ("stage_number_zero", _override_field(1, stage_number=0)),
+    ("stage_number_eleven", _override_field(1, stage_number=11)),
+    ("fullness_below_min", _override_field(1, fullness=-0.01)),
+    ("fullness_above_max", _override_field(1, fullness=1.01)),
+    ("fullness_nan", _override_field(1, fullness=float("nan"))),
+    ("aspect_empty", _override_field(1, aspect="")),
+    ("aspect_whitespace_only", _override_field(1, aspect="   ")),
+    (
+        "duplicate_stage_missing_other",
+        tuple(
+            VaultWheelAspect(stage_number=n, aspect=f"Aspect-{n}", fullness=0.5)
+            for n in (1, 2, 3, 3, 5, 6, 7, 8, 9, 10)
+        ),
+    ),
+    ("nine_aspects", _valid_aspects()[:-1]),
+    (
+        "eleven_aspects",
+        (*_valid_aspects(), VaultWheelAspect(stage_number=1, aspect="Extra", fullness=0.1)),
+    ),
+]
+
+
+def _stage_data(stage_number: int) -> dict[str, object]:
+    """Valid CourseStage fields for direct DB insertion."""
+    return {
+        "title": f"Stage {stage_number}",
+        "subtitle": "sub",
+        "stage_number": stage_number,
+        "overview_url": "",
+        "category": "test",
+        "aspect": _CANONICAL_ASPECTS[stage_number - 1],
+        "spiral_dynamics_color": "beige",
+        "growing_up_stage": "archaic",
+        "divine_gender_polarity": "masculine",
+        "relationship_to_free_will": "active",
+        "free_will_description": "desc",
+    }
+
+
+async def _seed_all_stages(session: AsyncSession) -> None:
+    """Insert all ten CourseStage rows."""
+    for n in range(1, TOTAL_STAGES + 1):
+        session.add(CourseStage(**_stage_data(n)))
+    await session.commit()
+
+
+async def _make_user(session: AsyncSession, email: str = "wheelvault@example.com") -> int:
+    """Insert a User row and return its id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    assert user.id is not None
+    return user.id
+
+
+async def _seed_habit_with_completion(
+    session: AsyncSession, user_id: int, stage_number: int
+) -> None:
+    """Seed one habit with one goal and one completion for the given stage."""
+    habit = Habit(
+        name=f"HW-{stage_number}-{user_id}",
+        icon="x",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+        user_id=user_id,
+        stage=str(stage_number),
+        streak=0,
+    )
+    session.add(habit)
+    await session.commit()
+    await session.refresh(habit)
+    goal = Goal(
+        habit_id=habit.id,
+        title="g",
+        tier="t",
+        target=1,
+        target_unit="rep",
+        frequency=1,
+        frequency_unit="per_day",
+    )
+    session.add(goal)
+    await session.commit()
+    await session.refresh(goal)
+    session.add(GoalCompletion(goal_id=goal.id, user_id=user_id, completed_units=1))
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Constants pinning
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_validation_constants_match_curriculum_and_range() -> None:
+    """The module's validation constants match the design's pinned values."""
+    assert VAULT_WHEEL_EXPECTED_ASPECTS == TOTAL_STAGES
+    assert VAULT_WHEEL_STAGE_MIN == 1
+    assert VAULT_WHEEL_FULLNESS_MIN == 0.0
+    assert VAULT_WHEEL_FULLNESS_MAX == 1.0
+
+
+# ---------------------------------------------------------------------------
+# fetch_vault_wheel: happy path + canonical reordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_returns_canonical_order_from_shuffled_input() -> None:
+    """A valid vault payload in shuffled order is returned sorted ascending by stage_number."""
+    shuffled_order = [7, 2, 9, 1, 10, 4, 3, 6, 5, 8]
+    aspects = tuple(
+        VaultWheelAspect(stage_number=n, aspect=f"Aspect-{n}", fullness=round(n / 10, 2))
+        for n in shuffled_order
+    )
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is not None
+    assert [item["stage_number"] for item in result] == list(range(1, TOTAL_STAGES + 1))
+    for item in result:
+        n = item["stage_number"]
+        assert item["aspect"] == f"Aspect-{n}"
+        assert item["fullness"] == round(n / 10, 2)
+    assert client.wheel_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch_vault_wheel: fallback to None on unavailable / unsupported / errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_returns_none_when_not_available() -> None:
+    """An unavailable vault falls back without ever calling wheel()."""
+    client = RecordingWheelVaultClient(
+        available=False, wheel_result=VaultWheelBalance(aspects=_valid_aspects())
+    )
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is None
+    assert client.wheel_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_returns_none_when_wheel_unsupported() -> None:
+    """A vault that never advertises WHEEL falls back without calling wheel()."""
+    client = RecordingWheelVaultClient(
+        capabilities=frozenset(), wheel_result=VaultWheelBalance(aspects=_valid_aspects())
+    )
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is None
+    assert client.wheel_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        CreekVaultUnavailableError("creek vault call failed: creek.wheel"),
+        CreekCapabilityUnsupportedError("capability not advertised: creek.wheel"),
+        _malformed_validation_error(),
+    ],
+    ids=["unavailable_error", "capability_unsupported_error", "field_validation_error"],
+)
+async def test_fetch_vault_wheel_returns_none_on_wheel_call_error(error: Exception) -> None:
+    """A CreekVaultError or a pydantic ValidationError from wheel() both fall back to None."""
+    client = RecordingWheelVaultClient(wheel_error=error)
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is None
+    assert client.wheel_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch_vault_wheel: field-level and structural validation failures (all-or-nothing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "aspects", [p[1] for p in _INVALID_PAYLOADS], ids=[p[0] for p in _INVALID_PAYLOADS]
+)
+async def test_fetch_vault_wheel_returns_none_on_invalid_payload(
+    aspects: tuple[VaultWheelAspect, ...],
+) -> None:
+    """Any single validation violation is all-or-nothing: the whole read falls back."""
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_accepts_fullness_boundary_zero_and_one() -> None:
+    """Fullness exactly 0.0 and exactly 1.0 both pass validation (inclusive bounds)."""
+    boundary_fullness = {1: VAULT_WHEEL_FULLNESS_MIN, 2: VAULT_WHEEL_FULLNESS_MAX}
+    aspects = tuple(
+        VaultWheelAspect(
+            stage_number=a.stage_number,
+            aspect=a.aspect,
+            fullness=boundary_fullness.get(a.stage_number, a.fullness),
+        )
+        for a in _valid_aspects()
+    )
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is not None
+    stage1 = next(item for item in result if item["stage_number"] == 1)
+    stage2 = next(item for item in result if item["stage_number"] == 2)
+    assert stage1["fullness"] == VAULT_WHEEL_FULLNESS_MIN
+    assert stage2["fullness"] == VAULT_WHEEL_FULLNESS_MAX
+
+
+# ---------------------------------------------------------------------------
+# select_wheel_balance: vault-or-local selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_wheel_balance_falls_back_to_local_when_vault_unavailable(
+    db_session: AsyncSession,
+) -> None:
+    """No usable vault -> select_wheel_balance returns compute_wheel_balance's result verbatim."""
+    await _seed_all_stages(db_session)
+    user_id = await _make_user(db_session)
+    await _seed_habit_with_completion(db_session, user_id, stage_number=4)
+    client = RecordingWheelVaultClient(available=False)
+
+    expected = await compute_wheel_balance(db_session, user_id)
+    result = await select_wheel_balance(client, db_session, user_id)
+
+    assert result == expected
+    assert client.wheel_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_select_wheel_balance_returns_vault_items_when_valid(
+    db_session: AsyncSession,
+) -> None:
+    """A valid vault payload wins over the local computation."""
+    await _seed_all_stages(db_session)
+    user_id = await _make_user(db_session)
+    aspects = _valid_aspects()
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+
+    result = await select_wheel_balance(client, db_session, user_id)
+
+    assert result == [
+        {"stage_number": a.stage_number, "aspect": a.aspect, "fullness": a.fullness}
+        for a in aspects
+    ]
+    assert client.wheel_calls == 1

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -9,10 +9,23 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
+)
+from main import app
 from models.course_stage import CourseStage
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
+from services.creek_vault_write import get_creek_vault_client
 
 _TOTAL_STAGES = 10
 
@@ -266,3 +279,114 @@ async def test_wheel_endpoint_user_isolation(
     bob_stage2 = next(a for a in bob_resp.json()["aspects"] if a["stage_number"] == 2)
     assert alice_stage2["fullness"] > 0.0
     assert bob_stage2["fullness"] == 0.0
+
+
+# ── C. Creek Vault classification source ────────────────────────────────────
+
+
+class _WheelVaultClient:
+    """A minimal fake CreekVaultClient exposing only the wheel path."""
+
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.WHEEL}),
+        wheel_result: VaultWheelBalance | None = None,
+    ) -> None:
+        """Store the scripted handshake outcome and wheel result."""
+        self.handshake_calls = 0
+        self._available = available
+        self._capabilities = capabilities
+        self._wheel_result = wheel_result
+
+    async def handshake(self) -> HandshakeResult:
+        """Record the call and return the scripted availability/capabilities."""
+        self.handshake_calls += 1
+        return HandshakeResult(
+            available=self._available,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Return the scripted availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether ``capability`` is in the scripted capability set."""
+        return capability in self._capabilities
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
+        """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError((body, tier_ceiling))
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Return the scripted balance."""
+        assert self._wheel_result is not None
+        return self._wheel_result
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_uses_vault_values_when_connected(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A connected, valid vault's fullness values win over local math."""
+    await _seed_all_stages(db_session)
+    headers, user_id = await _signup(async_client, "wheel_vault_connected")
+    # Local computation would give stage 1 fullness == 0.0 (no engagement); the
+    # vault reports a distinct, non-zero value that must win instead.
+    await _seed_habit_with_completion(db_session, user_id, 1)
+    vault_aspects = tuple(
+        VaultWheelAspect(stage_number=n, aspect=f"VaultAspect-{n}", fullness=0.42)
+        for n in range(1, _TOTAL_STAGES + 1)
+    )
+    fake_vault = _WheelVaultClient(wheel_result=VaultWheelBalance(aspects=vault_aspects))
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake_vault
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    aspects = resp.json()["aspects"]
+    assert len(aspects) == _TOTAL_STAGES
+    for item in aspects:
+        assert item["fullness"] == 0.42
+        assert item["aspect"] == f"VaultAspect-{item['stage_number']}"
+
+
+@pytest.mark.asyncio
+async def test_wheel_endpoint_falls_back_to_local_when_vault_unavailable(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """No usable vault -> the endpoint keeps serving local math, same as before."""
+    await _seed_all_stages(db_session)
+    headers, user_id = await _signup(async_client, "wheel_vault_unavailable")
+    engaged_stage = 3
+    await _seed_habit_with_completion(db_session, user_id, engaged_stage)
+    fake_vault = _WheelVaultClient(available=False)
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake_vault
+
+    resp = await async_client.get("/stages/wheel", headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    aspects = resp.json()["aspects"]
+    engaged = next(a for a in aspects if a["stage_number"] == engaged_stage)
+    assert engaged["fullness"] > 0.0
+    for item in aspects:
+        if item["stage_number"] != engaged_stage:
+            assert item["fullness"] == 0.0
+    # The router must still probe the vault (and degrade) rather than never
+    # wiring it in at all -- this is the delta the vault-consuming wiring adds.
+    assert fake_vault.handshake_calls == 1


### PR DESCRIPTION
## Summary

Routes the Wheel of Wholeness balance and the invitation corpus-theme signal through an optional Creek Vault classification read, degrading to today's local behavior whenever no vault is connected, the vault is unavailable, or it returns a malformed payload. This is the final backend sub-issue of the Creek Vault epic and **completes the backend arc of #949**.

- **New `backend/src/services/creek_vault_wheel.py`** owns the field-level validation and response-size ceiling the #951 seam deliberately deferred to this consumer. `fetch_vault_wheel` gates on the handshake plus the `WHEEL` capability, then applies all-or-nothing validation (exact stage coverage `{1..TOTAL_STAGES}`, per-field bounds, non-blank aspect, no NaN/±inf), catching `CreekVaultError` and `pydantic.ValidationError` and falling back to `compute_wheel_balance` on any failure. `select_wheel_balance` is what `/stages/wheel` now calls.
- **Invitation corpus-theme source** (`domain/invitations.py` + `services/invitations.py`): a conservative, silent-by-default signal that emits at most one `course`/`readiness` candidate from the strongest above-threshold Aspect, sourced from the vault only. Behavioral signals (streaks, cadence) stay local regardless of vault presence. No local ontology classifier is built, and no migration is needed — the candidate reuses existing `InvitationTargetType.COURSE` + `InvitationKind.READINESS` coordinates, so the existing dedup keeps a dismissed invitation from regenerating.
- **`schemas/wheel.py`**: the wheel response `aspects` list is capped at `TOTAL_STAGES`, so an over-cap vault payload is rejected at parse and degrades locally (the local path always emits exactly `TOTAL_STAGES`, so the cap never constrains it).

Degradation is total: vault absence, transport failure, and malformed payload are all indistinguishable from "no vault" to the caller, and existing local wheel/invitation behavior is unchanged.

## Test plan

- New `backend/tests/test_creek_vault_wheel.py`: unit coverage of `fetch_vault_wheel`/`select_wheel_balance` against a scriptable fake vault client — vault path used when available + `WHEEL` + valid payload (canonical order restored from shuffled input); fallback on unavailable, unsupported, `CreekVaultUnavailableError`, `CreekCapabilityUnsupportedError`, `pydantic.ValidationError`, and each field/structural violation (out-of-range stage, out-of-range/NaN fullness, empty/whitespace aspect, duplicate stage, 9 and 11 aspects); inclusive 0.0/1.0 boundaries accepted.
- Extended `test_wheel_api.py` (endpoint surfaces vault values when connected, local otherwise, both 200), `test_creek_vault_client.py` (over-cap payload raises at parse), `domain/test_invitations.py` (threshold boundary, strongest-wins + lowest-stage tie-break, exact candidate shape, behavioral backward-compat), `services/test_invitations_service.py` (persists the theme row, behavioral-only without a vault or on a degraded vault, dismissed row blocks regeneration), and `routers/test_invitations.py` (theme invitation alongside behavioral ones).
- Full `./scripts/backend/check-all.sh` green: 2900 passed, coverage 96.87%, lint + mypy clean. Manual xenon A-grade and radon MI A on the changed modules.

Closes #954
Refs #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)