### PR TITLE
feat(graph): restore published knowledge graph on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,34 +1,139 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in remote (web) environments
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
+# Install session dependencies only in remote (web) environments; every
+# session continues past this block to the graph-restore step below.
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-/home/user/adepthood}"
+  cd "$PROJECT_DIR"
+
+  echo "Installing frontend dependencies..."
+  cd "$PROJECT_DIR/frontend"
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
+
+  echo "Installing backend dependencies..."
+  cd "$PROJECT_DIR"
+  if [ ! -d .venv ]; then
+    python3 -m venv .venv
+  fi
+  source .venv/bin/activate
+  pip install -q -r backend/requirements.txt -r backend/requirements-dev.txt
+
+  echo "Installing pre-commit hooks..."
+  pip install -q pre-commit
+  pre-commit install
+  pre-commit install --hook-type commit-msg
+  pre-commit install --hook-type pre-push
+
+  echo "Session setup complete."
 fi
 
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-/home/user/adepthood}"
-cd "$PROJECT_DIR"
+# Fail-soft graph restore: refresh graphify-out from the rolling knowledge-graph
+# release unless a local copy is already fresh; never abort the session on error.
+GRAPH_FRESH_MAX_AGE_SECONDS=172800 # 48h
+GRAPH_FETCH_TIMEOUT_SECONDS=8
+GRAPH_RELEASE_BASE_URL="https://github.com/Geoffe-Ga/adepthood/releases/download/knowledge-graph"
 
-echo "Installing frontend dependencies..."
-cd "$PROJECT_DIR/frontend"
-if [ -f package-lock.json ]; then
-  npm ci
-else
-  npm install
-fi
+json_is_valid() { # json_is_valid <path>
+  python3 - "$1" <<'PY'
+import json
+import sys
 
-echo "Installing backend dependencies..."
-cd "$PROJECT_DIR"
-if [ ! -d .venv ]; then
-  python3 -m venv .venv
-fi
-source .venv/bin/activate
-pip install -q -r backend/requirements.txt -r backend/requirements-dev.txt
+try:
+    with open(sys.argv[1]) as handle:
+        json.load(handle)
+except Exception:  # any read/parse error means invalid
+    sys.exit(1)
+PY
+}
 
-echo "Installing pre-commit hooks..."
-pip install -q pre-commit
-pre-commit install
-pre-commit install --hook-type commit-msg
-pre-commit install --hook-type pre-push
+graph_is_fresh() { # graph_is_fresh <graph_dir>
+  local graph_dir="$1"
+  [ -f "$graph_dir/graph.json" ] || return 1
+  [ -f "$graph_dir/graph-meta.json" ] || return 1
+  python3 - "$graph_dir/graph-meta.json" "$GRAPH_FRESH_MAX_AGE_SECONDS" <<'PY'
+import datetime
+import json
+import sys
 
-echo "Session setup complete."
+meta_path = sys.argv[1]
+max_age_seconds = int(sys.argv[2])
+try:
+    with open(meta_path) as handle:
+        built_at = json.load(handle)["built_at"]
+    # macOS python 3.9 rejects a bare trailing "Z"; normalize to an offset.
+    timestamp = datetime.datetime.fromisoformat(built_at.replace("Z", "+00:00"))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    age_seconds = (now - timestamp).total_seconds()
+    sys.exit(0 if 0 <= age_seconds <= max_age_seconds else 1)
+except Exception:  # any parse error means treat as stale
+    sys.exit(1)
+PY
+}
+
+fetch_optional_asset() { # fetch_optional_asset <tmp_dir> <asset>
+  local tmp_dir="$1"
+  local asset="$2"
+  if curl -fsSL --max-time "$GRAPH_FETCH_TIMEOUT_SECONDS" \
+    -o "$tmp_dir/$asset" "$GRAPH_RELEASE_BASE_URL/$asset" &&
+    json_is_valid "$tmp_dir/$asset"; then
+    return 0
+  fi
+  rm -f "$tmp_dir/$asset"
+  return 0
+}
+
+restore_published_graph() {
+  local root=""
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "${CLAUDE_PROJECT_DIR:-}" ]; then
+    root="$CLAUDE_PROJECT_DIR"
+  else
+    root="$(cd "$(dirname "$0")/../.." 2>/dev/null && pwd)" || root=""
+  fi
+  if [ -z "$root" ]; then
+    echo "warning: graph-restore could not resolve the repo root; skipping" >&2
+    return 0
+  fi
+
+  local graph_dir="$root/graphify-out"
+  if graph_is_fresh "$graph_dir"; then
+    return 0
+  fi
+
+  local tmp_dir=""
+  tmp_dir="$(mktemp -d)" || {
+    echo "warning: graph-restore could not create a temp dir; skipping" >&2
+    return 0
+  }
+
+  # graph.json is required: a failed or malformed download must never clobber
+  # an existing graphify-out/graph.json, so validate in the temp dir first.
+  if ! curl -fsSL --max-time "$GRAPH_FETCH_TIMEOUT_SECONDS" \
+    -o "$tmp_dir/graph.json" "$GRAPH_RELEASE_BASE_URL/graph.json"; then
+    echo "warning: graph-restore could not download graph.json; keeping existing graph" >&2
+    rm -rf "$tmp_dir"
+    return 0
+  fi
+  if ! json_is_valid "$tmp_dir/graph.json"; then
+    echo "warning: graph-restore got malformed graph.json; keeping existing graph" >&2
+    rm -rf "$tmp_dir"
+    return 0
+  fi
+
+  # graph-meta.json and pan-graph.json are best-effort; their failure is silent.
+  fetch_optional_asset "$tmp_dir" "graph-meta.json"
+  fetch_optional_asset "$tmp_dir" "pan-graph.json"
+
+  mkdir -p "$graph_dir"
+  mv -f "$tmp_dir/graph.json" "$graph_dir/graph.json"
+  [ -f "$tmp_dir/graph-meta.json" ] && mv -f "$tmp_dir/graph-meta.json" "$graph_dir/graph-meta.json"
+  [ -f "$tmp_dir/pan-graph.json" ] && mv -f "$tmp_dir/pan-graph.json" "$graph_dir/pan-graph.json"
+  rm -rf "$tmp_dir"
+  return 0
+}
+
+restore_published_graph || true

--- a/scripts/graph/test_session_start_restore.sh
+++ b/scripts/graph/test_session_start_restore.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# scripts/graph/test_session_start_restore.sh
+#
+# Offline tests for the graph-restore step in .claude/hooks/session-start.sh:
+# pins that a stale/missing graphify-out/graph.json is re-fetched from the
+# rolling knowledge-graph release, a fresh graph is left alone (no curl call),
+# and every failure mode (curl error, malformed download, optional pan-graph
+# miss) is strictly fail-soft (single warning line, hook still exits 0).
+#
+# Run:  bash scripts/graph/test_session_start_restore.sh
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")/../../.claude/hooks" && pwd)/session-start.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+check_contains() { # check_contains <desc> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then ok "$1"; else bad "$1 (expected '$2' to contain '$3')"; fi
+}
+assert_exists() { # assert_exists <desc> <path>
+  if [[ -e "$2" ]]; then ok "$1"; else bad "$1 (missing: $2)"; fi
+}
+assert_missing() { # assert_missing <desc> <path>
+  if [[ ! -e "$2" ]]; then ok "$1"; else bad "$1 (unexpectedly present: $2)"; fi
+}
+assert_identical() { # assert_identical <desc> <fileA> <fileB>
+  if cmp -s "$2" "$3"; then ok "$1"; else bad "$1 ($2 and $3 differ)"; fi
+}
+assert_valid_json() { # assert_valid_json <desc> <path>
+  local rc=0
+  python3 -c 'import json,sys
+json.load(open(sys.argv[1]))' "$2" >/dev/null 2>&1 || rc=$?
+  check "$1" "0" "$rc"
+}
+log_state() { # log_state <path> -> "empty" or "nonempty"
+  if [[ -s "$1" ]]; then echo "nonempty"; else echo "empty"; fi
+}
+warning_lines() { # warning_lines <path> -> count of lines mentioning warning
+  grep -ci 'warning' "$1" || true
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+PROJ="$WORK/proj"
+LOG="$WORK/curl.log"
+STDOUT="$WORK/stdout.log"
+STDERR="$WORK/stderr.log"
+mkdir -p "$BIN"
+
+unset CLAUDE_CODE_REMOTE
+
+# Fake curl: logs its full argv, then serves ok/malformed/failing bytes to
+# the -o target depending on CURL_MODE (ok|malformed|fail|panfail). panfail
+# only fails the pan-graph.json request, so the required assets still land.
+cat > "$BIN/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$CURL_LOG"
+out=""
+url=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    out="$arg"
+  fi
+  case "$arg" in
+    http*) url="$arg" ;;
+  esac
+  prev="$arg"
+done
+mode="${CURL_MODE:-ok}"
+if [[ "$mode" == "fail" ]]; then
+  exit 22
+fi
+if [[ "$mode" == "panfail" && "$url" == *pan-graph.json* ]]; then
+  exit 22
+fi
+if [[ -n "$out" ]]; then
+  if [[ "$mode" == "malformed" ]]; then
+    printf 'not valid json{' > "$out"
+  else
+    printf '{"ok": true}' > "$out"
+  fi
+fi
+exit 0
+STUB
+chmod +x "$BIN/curl"
+
+NOW="$(python3 -c 'import datetime
+print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+STALE="$(python3 -c 'import datetime
+d = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=3)
+print(d.strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+
+reset_fixture() {
+  rm -rf "$PROJ"
+  mkdir -p "$PROJ"
+  : > "$LOG"
+}
+
+run_hook() { # run_hook <curl_mode>
+  local mode="$1"
+  RC=0
+  env PATH="$BIN:$PATH" CLAUDE_PROJECT_DIR="$PROJ" CURL_LOG="$LOG" CURL_MODE="$mode" \
+    bash "$HOOK" >"$STDOUT" 2>"$STDERR" || RC=$?
+}
+
+# --- scenario 1: missing graph triggers restore, guard preserved -----------
+reset_fixture
+run_hook ok
+check "scenario 1: hook exits 0" "0" "$RC"
+assert_exists "scenario 1: graph.json installed" "$PROJ/graphify-out/graph.json"
+assert_valid_json "scenario 1: installed graph.json is valid JSON" \
+  "$PROJ/graphify-out/graph.json"
+check_contains "scenario 1: curl log requested graph.json" "$(cat "$LOG")" "graph.json"
+
+# --- scenario 2: fresh graph is a no-op -------------------------------------
+reset_fixture
+mkdir -p "$PROJ/graphify-out"
+printf '{"sentinel": true}' > "$PROJ/graphify-out/graph.json"
+printf '{"built_at": "%s"}' "$NOW" > "$PROJ/graphify-out/graph-meta.json"
+cp "$PROJ/graphify-out/graph.json" "$WORK/sentinel-scenario2.json"
+run_hook ok
+check "scenario 2: hook exits 0" "0" "$RC"
+check "scenario 2: curl never invoked when graph is fresh" "empty" "$(log_state "$LOG")"
+assert_identical "scenario 2: fresh graph.json left byte-identical" \
+  "$WORK/sentinel-scenario2.json" "$PROJ/graphify-out/graph.json"
+
+# --- scenario 3: stale meta triggers re-download ----------------------------
+reset_fixture
+mkdir -p "$PROJ/graphify-out"
+printf '{"old": true}' > "$PROJ/graphify-out/graph.json"
+printf '{"built_at": "%s"}' "$STALE" > "$PROJ/graphify-out/graph-meta.json"
+run_hook ok
+check "scenario 3: hook exits 0" "0" "$RC"
+check "scenario 3: curl invoked when meta is stale" "nonempty" "$(log_state "$LOG")"
+check "scenario 3: stale graph.json replaced by fresh download" \
+  '{"ok": true}' "$(cat "$PROJ/graphify-out/graph.json")"
+
+# --- scenario 4: missing/unparseable meta triggers re-download -------------
+reset_fixture
+mkdir -p "$PROJ/graphify-out"
+printf '{"old": true}' > "$PROJ/graphify-out/graph.json"
+printf 'not json' > "$PROJ/graphify-out/graph-meta.json"
+run_hook ok
+check "scenario 4: hook exits 0" "0" "$RC"
+check "scenario 4: curl invoked when meta is unparseable" "nonempty" "$(log_state "$LOG")"
+
+# --- scenario 5: fail-soft on curl failure ----------------------------------
+reset_fixture
+mkdir -p "$PROJ/graphify-out"
+printf '{"sentinel": true}' > "$PROJ/graphify-out/graph.json"
+cp "$PROJ/graphify-out/graph.json" "$WORK/sentinel-scenario5.json"
+run_hook fail
+check "scenario 5: hook exits 0 despite curl failure" "0" "$RC"
+check "scenario 5: exactly one warning line on curl failure" "1" "$(warning_lines "$STDERR")"
+assert_identical "scenario 5: sentinel graph.json left byte-identical" \
+  "$WORK/sentinel-scenario5.json" "$PROJ/graphify-out/graph.json"
+
+# --- scenario 6: fail-soft on malformed download ----------------------------
+reset_fixture
+run_hook malformed
+check "scenario 6: hook exits 0 despite malformed download" "0" "$RC"
+check "scenario 6: exactly one warning line on malformed download" \
+  "1" "$(warning_lines "$STDERR")"
+assert_missing "scenario 6: malformed download never installed as graph.json" \
+  "$PROJ/graphify-out/graph.json"
+
+# --- scenario 7: optional pan-graph failure is tolerated --------------------
+reset_fixture
+run_hook panfail
+check "scenario 7: hook exits 0 when pan-graph download fails" "0" "$RC"
+check "scenario 7: no warning line when only optional pan-graph fails" \
+  "0" "$(warning_lines "$STDERR")"
+assert_exists "scenario 7: graph.json installed despite pan-graph failure" \
+  "$PROJ/graphify-out/graph.json"
+assert_valid_json "scenario 7: installed graph.json is valid JSON" \
+  "$PROJ/graphify-out/graph.json"
+
+# --- scenario 8: curl calls carry a timeout budget --------------------------
+reset_fixture
+run_hook ok
+check "scenario 8: hook exits 0" "0" "$RC"
+check_contains "scenario 8: curl invoked with a --max-time budget" \
+  "$(cat "$LOG")" "--max-time"
+
+# --- summary ------------------------------------------------------------------
+echo
+echo "session-start restore tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Extends the `SessionStart` hook (`.claude/hooks/session-start.sh`) so any fresh
session — Claude web container, new clone, or Ralph worktree — fetches the
latest published knowledge graph instead of building it from scratch.

- The remote-only dependency-install block is now wrapped in
  `if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then … fi` (steps and order
  unchanged) so the script continues past it in every session; a new
  **fail-soft** graph-restore step then runs unconditionally.
- **Freshness gate:** the download is skipped entirely (curl never invoked)
  when `graphify-out/graph.json` and `graphify-out/graph-meta.json` both exist
  and the meta's `built_at` is within 48h. Timestamps are parsed with `python3`,
  normalizing the ISO-8601 `Z` suffix to `+00:00` (macOS python 3.9 rejects a
  bare `Z`); any parse error is treated as stale.
- **Atomic install:** assets download to a temp dir with
  `curl -fsSL --max-time 8` from the public rolling `knowledge-graph` release,
  each required payload is validated as JSON, and only then moved into
  `graphify-out/` — so a failed, partial, or malformed download never clobbers
  an existing graph. `graph.json` is required; `graph-meta.json` and
  `pan-graph.json` are best-effort (their absence is fine).
- **Strictly fail-soft under `set -euo pipefail`:** every failure path (network,
  404, malformed JSON, unparseable timestamp, unresolvable root) prints exactly
  one `warning` line to stderr and the hook still exits 0, so it can never block
  session start. Guarded doubly via `restore_published_graph || true`.
- Adds `scripts/graph/test_session_start_restore.sh`, an offline shell test
  mirroring the existing `scripts/graph/test_hook_guards.sh` harness (stubbed
  `curl` on a fake PATH) that pins the fail-soft, freshness, atomicity, and
  budget invariants across 8 scenarios.

### Known tradeoff

The freshness gate requires `graph-meta.json`, which only the CI workflow emits
(local `build.sh`/`update.sh` produce `graph.json` alone). A meta-less local
graph is therefore treated as stale and replaced by the ≤24h published graph on
the next session start — intended, since distributing the published graph is the
whole point of this hook, and it stays fail-soft. Re-run `./scripts/graph/build.sh`
after a session if a branch-specific local graph is needed.

## Test plan

Run from the worktree root:

```bash
bash scripts/graph/test_session_start_restore.sh   # 24 passed, 0 failed
bash scripts/graph/test_hook_guards.sh             # 14 passed, 0 failed (SessionStart wiring untouched)
pre-commit run --files .claude/hooks/session-start.sh scripts/graph/test_session_start_restore.sh
```

Manual verification matrix (covered by the automated scenarios): asset present +
fresh → no download; asset missing / stale / unparseable meta → download; curl
failure → one warning, existing graph preserved; malformed download → discarded,
existing graph preserved; optional `pan-graph.json` absent → no warning, graph
still installed.

Closes #1808
Refs #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)