### PR TITLE
feat(backend): POST /journal/transcribe-page — stateless single-page transcription with wallet charge

### DIFF
--- a/backend/migrations/versions/f9a0b1c2d3e4_llmusagelog_journal_entry_id_nullable.py
+++ b/backend/migrations/versions/f9a0b1c2d3e4_llmusagelog_journal_entry_id_nullable.py
@@ -1,0 +1,46 @@
+"""make llmusagelog.journal_entry_id nullable for stateless metered calls.
+
+Revision ID: f9a0b1c2d3e4
+Revises: c7d8e9f0a1b3
+Create Date: 2026-07-17 00:00:00.000000
+
+The single-page journal-transcription endpoint meters a real LLM call that has
+no associated journal entry, so ``journal_entry_id`` must accept ``NULL``. This
+is a backward-compatible widening: every existing row already carries a real
+entry id, so relaxing the NOT NULL constraint invalidates nothing.
+
+The change is wrapped in ``batch_alter_table`` so the SQLite round-trip test
+rebuilds the table while Postgres emits a plain ``ALTER COLUMN``.
+
+The downgrade is intentionally lossy: rows written by a stateless call have no
+entry to point at, so restoring NOT NULL requires deleting the ``NULL`` rows
+first. Those rows are cost-audit records only, never user content, and the
+usage log is append-only, so the delete cannot cascade into anything else.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f9a0b1c2d3e4"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c7d8e9f0a1b3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "llmusagelog"
+_COLUMN_NAME = "journal_entry_id"
+
+
+def upgrade() -> None:
+    """Relax ``journal_entry_id`` to nullable so stateless calls can be metered."""
+    with op.batch_alter_table(_TABLE_NAME) as batch_op:
+        batch_op.alter_column(_COLUMN_NAME, existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    """Restore NOT NULL, deleting the entry-less rows first (intentionally lossy)."""
+    op.execute(f"DELETE FROM {_TABLE_NAME} WHERE {_COLUMN_NAME} IS NULL")
+    with op.batch_alter_table(_TABLE_NAME) as batch_op:
+        batch_op.alter_column(_COLUMN_NAME, existing_type=sa.Integer(), nullable=False)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -50,6 +50,7 @@ from routers.promotions import router as promotions_router
 from routers.prompts import router as prompts_router
 from routers.reflections import router as reflections_router
 from routers.stages import router as stages_router
+from routers.transcription import router as transcription_router
 from routers.ui_flags import router as ui_flags_router
 from routers.user_practices import router as user_practices_router
 from routers.users import router as users_router
@@ -448,6 +449,7 @@ app.include_router(user_practices_router)
 app.include_router(practice_sessions_router)
 app.include_router(habits_router)
 app.include_router(journal_router)
+app.include_router(transcription_router)
 app.include_router(reflections_router)
 app.include_router(promotions_router)
 app.include_router(prompts_router)

--- a/backend/src/models/llm_usage_log.py
+++ b/backend/src/models/llm_usage_log.py
@@ -50,7 +50,9 @@ class LLMUsageLog(SQLModel, table=True):
     ``journal_entry_id`` points at the journal entry the call was about — the
     user's source entry on the resonance path, the annotated entry on the essay
     path — so a single JOIN reconstructs the call's context and the soft-delete
-    audit trail stays intact.
+    audit trail stays intact. It is ``None`` for a stateless call that has no
+    associated entry (for example, single-page journal transcription), which
+    meters its cost without ever writing a journal row.
     """
 
     id: int | None = Field(default=None, primary_key=True)
@@ -68,4 +70,4 @@ class LLMUsageLog(SQLModel, table=True):
         default=DEFAULT_COST,
         sa_column=Column(Numeric(precision=_COST_PRECISION, scale=_COST_SCALE), nullable=True),
     )
-    journal_entry_id: int = Field(foreign_key="journalentry.id", index=True)
+    journal_entry_id: int | None = Field(default=None, foreign_key="journalentry.id", index=True)

--- a/backend/src/routers/transcription.py
+++ b/backend/src/routers/transcription.py
@@ -1,0 +1,202 @@
+"""Journal transcription API — stateless single-page handwriting transcription.
+
+The Journal Photographer posts one photographed page (base64 image bytes) and
+receives back the faithful transcribed body text for a draft entry. The endpoint
+is deliberately stateless: it writes no journal row and associates the metered
+LLM call with no ``journal_entry_id``. Ordering is strict — validate the image
+before charging, charge before the LLM call, and roll the charge back on any
+provider failure — so a rejected or failed request never bills the wallet.
+
+Privacy invariant: the base64 payload and the transcribed text are never logged,
+interpolated into an exception message, or otherwise emitted anywhere. Only
+metadata (user id, token count) is logged.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+from collections.abc import Callable
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database import get_session
+from domain.transcription import build_transcription_prompt
+from errors import bad_gateway, unprocessable
+from rate_limit import limiter
+from routers.auth import get_current_user
+from schemas.transcription import TranscribePageRequest, TranscribePageResponse
+from services.botmason import (
+    ImagePayload,
+    LLMProviderError,
+    LLMResponse,
+    LLMVisionUnsupportedError,
+    generate_response,
+    resolve_chat_api_key,
+)
+from services.llm_usage import record_llm_usage
+from services.wallet import preflight_deduction
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/journal", tags=["journal"])
+
+# Anthropic caps a single image at 5 MB of *decoded* bytes; larger attachments
+# are rejected by the provider after we would have already burned the request,
+# so we enforce the same ceiling locally before any wallet or LLM work.
+MAX_TRANSCRIBE_IMAGE_BYTES = 5 * 1024 * 1024
+
+# Cheap oversize pre-guard on the *encoded* string, so a huge payload is rejected
+# without allocating the decoded bytes. Base64 expands raw bytes by 4/3; the
+# ``+ 4`` absorbs the padding block so a legitimately max-sized image is not
+# rejected by rounding.
+_MAX_TRANSCRIBE_BASE64_CHARS = (MAX_TRANSCRIBE_IMAGE_BYTES * 4) // 3 + 4
+
+# Twice the resonance endpoint's 10/minute: a single capture session can fan out
+# to ~10 page calls, so the transcription limit is doubled to admit one whole
+# session without throttling while still bounding abuse.
+TRANSCRIBE_RATE_LIMIT = "20/minute"
+
+# Magic-byte signatures used to confirm the decoded bytes match the declared
+# media type. Literal byte prefixes keep the sniff dependency-free (no
+# python-magic) and branch-light so complexity stays at xenon rank A.
+_JPEG_MAGIC = b"\xff\xd8\xff"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_RIFF_MAGIC = b"RIFF"
+_WEBP_MAGIC = b"WEBP"
+# A WebP header is ``RIFF`` (0-4), a 4-byte size (4-8), then ``WEBP`` (8-12).
+_WEBP_HEADER_LENGTH = 12
+
+
+def _is_jpeg(raw: bytes) -> bool:
+    """Return True when ``raw`` opens with the JPEG magic-byte prefix."""
+    return raw.startswith(_JPEG_MAGIC)
+
+
+def _is_png(raw: bytes) -> bool:
+    """Return True when ``raw`` opens with the 8-byte PNG signature."""
+    return raw.startswith(_PNG_MAGIC)
+
+
+def _is_webp(raw: bytes) -> bool:
+    """Return True when ``raw`` is a RIFF/WEBP container of at least header length."""
+    return len(raw) >= _WEBP_HEADER_LENGTH and raw[0:4] == _RIFF_MAGIC and raw[8:12] == _WEBP_MAGIC
+
+
+# Dispatch table mapping a declared media type to its pure magic-byte predicate,
+# so the sniff is a single table lookup rather than a branch cascade.
+_MAGIC_SNIFFERS: dict[str, Callable[[bytes], bool]] = {
+    "image/jpeg": _is_jpeg,
+    "image/png": _is_png,
+    "image/webp": _is_webp,
+}
+
+
+def _decode_base64(image_base64: str) -> bytes:
+    """Strictly decode base64, mapping any malformed input to 422 ``invalid_image``."""
+    try:
+        return base64.b64decode(image_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise unprocessable("invalid_image") from exc
+
+
+def _build_attachment(image_base64: str, media_type: str) -> ImagePayload:
+    """Build the vision attachment, mapping its size-cap failure to ``image_too_large``.
+
+    ``media_type`` is Literal-guarded upstream, so the only construction failure is
+    the attachment's stricter encoded-length cap — a near-maximal payload that
+    slips past the decoded cap by rounding — mapped to a clean 422 rather than
+    surfacing later as a 500. This keeps :class:`ImagePayload` the single canonical
+    size authority.
+    """
+    try:
+        return ImagePayload(data=image_base64, media_type=media_type)
+    except ValueError as exc:
+        raise unprocessable("image_too_large") from exc
+
+
+def _validate_image(image_base64: str, media_type: str) -> ImagePayload:
+    """Validate the payload before any wallet or LLM work; return the attachment.
+
+    Runs the cheapest checks first: an oversize pre-guard on the encoded string
+    (no decode), then a strict base64 decode, then a decoded-size cap, then a
+    magic-byte sniff against the declared ``media_type``. A mismatch or a decode
+    failure is ``invalid_image``; an oversize payload is ``image_too_large``. The
+    attachment is constructed here, before any charge, so no valid-looking payload
+    reaches the wallet or LLM without passing every size gate. Never logs or
+    interpolates the payload (privacy invariant).
+    """
+    if len(image_base64) > _MAX_TRANSCRIBE_BASE64_CHARS:
+        raise unprocessable("image_too_large")
+    raw = _decode_base64(image_base64)
+    if len(raw) > MAX_TRANSCRIBE_IMAGE_BYTES:
+        raise unprocessable("image_too_large")
+    if not _MAGIC_SNIFFERS[media_type](raw):
+        raise unprocessable("invalid_image")
+    return _build_attachment(image_base64, media_type)
+
+
+async def _run_transcription(
+    session: AsyncSession, image: ImagePayload, api_key: str | None
+) -> LLMResponse:
+    """Run the vision LLM for one page; roll the charge back on any provider error.
+
+    The wallet was already deducted, so a failure here must un-deduct it: both
+    branches roll the session back before mapping the error. ``LLMVisionUnsupportedError``
+    is checked first because it subclasses :class:`LLMProviderError` — a
+    text-only model is a well-formed request the model cannot serve (422
+    ``model_lacks_vision``), distinct from a genuine upstream failure (502
+    ``llm_provider_error``).
+    """
+    try:
+        return await generate_response(
+            "",
+            [],
+            system_prompt=build_transcription_prompt(),
+            api_key=resolve_chat_api_key(api_key),
+            images=[image],
+        )
+    except LLMVisionUnsupportedError as exc:
+        await session.rollback()
+        raise unprocessable("model_lacks_vision") from exc
+    except LLMProviderError as exc:
+        await session.rollback()
+        raise bad_gateway("llm_provider_error") from exc
+
+
+@router.post("/transcribe-page", response_model=TranscribePageResponse)
+@limiter.limit(TRANSCRIBE_RATE_LIMIT)
+async def transcribe_page(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    payload: TranscribePageRequest,
+    current_user: Annotated[int, Depends(get_current_user)],
+    session: Annotated[AsyncSession, Depends(get_session)],
+    x_llm_api_key: Annotated[str | None, Header(alias="X-LLM-API-Key")] = None,
+) -> TranscribePageResponse:
+    """Transcribe one photographed handwritten page, charging one message.
+
+    Stateless: no journal row is written and the metered call carries no
+    ``journal_entry_id``. Strict ordering — the image is validated first (422
+    without any charge), the wallet is deducted next (402 when out of capacity),
+    then the vision LLM runs; a provider failure rolls the charge back so a
+    failed pass never bills. Usage is metered (one row per real, non-stub call)
+    and committed atomically with the charge.
+
+    Only metadata (user id, total tokens) is logged — never the base64 image
+    payload or the transcribed text.
+    """
+    image = _validate_image(payload.image_base64, payload.media_type)
+    await preflight_deduction(session, current_user)
+    response = await _run_transcription(session, image, x_llm_api_key)
+    await record_llm_usage(
+        session, user_id=current_user, journal_entry_id=None, responses=[response]
+    )
+    await session.commit()
+    logger.info(
+        "journal_page_transcribed",
+        extra={"user_id": current_user, "total_tokens": response.total_tokens},
+    )
+    return TranscribePageResponse(text=response.text)

--- a/backend/src/schemas/transcription.py
+++ b/backend/src/schemas/transcription.py
@@ -1,0 +1,44 @@
+"""Request/response DTOs for the stateless single-page transcription endpoint.
+
+The Journal Photographer sends one photographed page as base64 image bytes and
+receives back the faithful transcribed body text. The contract is deliberately
+*stateless*: nothing on either DTO is persisted as a journal entry. The endpoint
+runs the vision LLM and returns the text for the client to place into a draft;
+no row is written for the image or its transcription, and no ``journal_entry_id``
+is associated with the (metered) call.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# The only image media types the vision path accepts, mirroring
+# ``services.botmason._ALLOWED_IMAGE_MEDIA_TYPES``. Declaring them as a
+# ``Literal`` rejects any other value at the schema layer with a FastAPI-shaped
+# 422 before the handler runs (and before any wallet or LLM work).
+TranscribeMediaType = Literal["image/jpeg", "image/png", "image/webp"]
+
+
+class TranscribePageRequest(BaseModel):
+    """One photographed handwritten page submitted for transcription.
+
+    ``image_base64`` is the base64-encoded image bytes and ``media_type`` its
+    declared MIME type. Neither field is stored: the request is stateless, so
+    the bytes live only for the duration of the single vision call.
+    """
+
+    image_base64: str = Field(min_length=1, description="Base64-encoded image bytes.")
+    media_type: TranscribeMediaType = Field(description="Declared image MIME type.")
+
+
+class TranscribePageResponse(BaseModel):
+    """The transcribed body text for one page.
+
+    ``text`` is the faithful transcription the client places into a draft
+    journal entry. It is returned only, never persisted here: the endpoint
+    writes no journal row, keeping the transcription contract stateless.
+    """
+
+    text: str = Field(description="Faithful transcribed body text for the page.")

--- a/backend/src/services/llm_usage.py
+++ b/backend/src/services/llm_usage.py
@@ -27,14 +27,16 @@ async def record_llm_usage(
     session: AsyncSession,
     *,
     user_id: int,
-    journal_entry_id: int,
+    journal_entry_id: int | None,
     responses: Sequence[LLMResponse],
 ) -> None:
     """Stage an ``LLMUsageLog`` row for each real (non-stub) response.
 
     ``journal_entry_id`` is the entry the calls were about — the user's source
     entry on the resonance path, the annotated entry on the essay path — so the
-    audit trail reconstructs each call's context with a single JOIN.  Stub
+    audit trail reconstructs each call's context with a single JOIN.  It is
+    ``None`` for a stateless call with no associated entry (for example,
+    single-page journal transcription), which still meters its cost.  Stub
     responses are skipped (zero real tokens, no pricing-table lookup).  No commit
     is issued here; the row shares the caller's transaction with the reflection.
     """

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -297,8 +297,9 @@ async def require_user_fresh(session: AsyncSession, user_id: int) -> User:
 async def preflight_deduction(session: AsyncSession, user_id: int) -> SpendResult:
     """Roll over the monthly counter and deduct one BotMason message.
 
-    Pre-flight for the BotMason reflection write path (the ``/resonance``
-    endpoint in :mod:`routers.journal`), its sole caller.
+    Pre-flight for the metered LLM write paths — the BotMason reflection
+    ``/resonance`` endpoint in :mod:`routers.journal` and the stateless
+    single-page transcription endpoint in :mod:`routers.transcription`.
     Raises ``400 user_not_found`` if the authenticated user disappeared
     between auth and spend and ``402 insufficient_offerings`` when neither
     wallet has capacity.  Returns the post-deduction :class:`SpendResult`

--- a/backend/tests/test_transcription_endpoint.py
+++ b/backend/tests/test_transcription_endpoint.py
@@ -1,0 +1,401 @@
+"""Tests for POST /journal/transcribe-page (stateless single-page transcription).
+
+Specifies the endpoint before it exists: authentication, wallet metering (one
+unit per success, rollback on provider failure), image validation (base64,
+magic-byte / declared-type match, size cap), rate limiting, and the privacy
+invariant that no log record ever carries the base64 payload or the
+transcribed text.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from models.llm_usage_log import LLMUsageLog
+from models.user import User
+from services.botmason import LLMProviderError, LLMResponse, LLMVisionUnsupportedError
+
+_ENDPOINT = "/journal/transcribe-page"
+_RATE_LIMIT = 20
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 64
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 64
+_OVERSIZED_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * (_MAX_IMAGE_BYTES + 10)
+
+_SENTINEL_TEXT = "SENTINEL_TRANSCRIPTION_TEXT_9f3c2a"
+
+
+async def _signup(client: AsyncClient, username: str = "transcriber") -> dict[str, str]:
+    """Create a user and return bearer auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _b64(raw: bytes) -> str:
+    """Base64-encode raw image bytes for the request payload."""
+    return base64.b64encode(raw).decode()
+
+
+def _payload(raw: bytes, media_type: str = "image/jpeg") -> dict[str, str]:
+    """Build a transcribe-page request body from raw image bytes."""
+    return {"image_base64": _b64(raw), "media_type": media_type}
+
+
+async def _wallet_snapshot(session: AsyncSession, email: str) -> tuple[int, int]:
+    """Return (monthly_messages_used, offering_balance) for the user."""
+    user = (await session.execute(select(User).where(col(User.email) == email))).scalar_one()
+    return user.monthly_messages_used, user.offering_balance
+
+
+def _units_spent(before: tuple[int, int], after: tuple[int, int]) -> int:
+    """Return net wallet units consumed between two snapshots, either bucket."""
+    before_monthly, before_offering = before
+    after_monthly, after_offering = after
+    return (after_monthly - before_monthly) + (before_offering - after_offering)
+
+
+async def _usage_row_count(session: AsyncSession) -> int:
+    """Return the total number of persisted LLMUsageLog rows."""
+    result = await session.execute(select(func.count()).select_from(LLMUsageLog))
+    return result.scalar_one()
+
+
+async def _usage_rows_with_null_entry(session: AsyncSession) -> list[LLMUsageLog]:
+    """Return LLMUsageLog rows written with no journal_entry_id (stateless calls)."""
+    result = await session.execute(
+        select(LLMUsageLog).where(col(LLMUsageLog.journal_entry_id).is_(None))
+    )
+    return list(result.scalars().all())
+
+
+def _priced_response(text: str) -> LLMResponse:
+    """Return a non-stub LLMResponse (provider=openai) for usage-log tests."""
+    return LLMResponse(
+        text=text, provider="openai", model="gpt-4o-mini", prompt_tokens=11, completion_tokens=7
+    )
+
+
+def _patch_generate_response(monkeypatch: pytest.MonkeyPatch, response: LLMResponse) -> None:
+    """Patch the router's LLM seam to return a canned response."""
+
+    async def _fake(*args: object, **kwargs: object) -> LLMResponse:
+        del args, kwargs
+        return response
+
+    monkeypatch.setattr("routers.transcription.generate_response", _fake)
+
+
+def _patch_generate_response_raises(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Patch the router's LLM seam to raise ``exc`` on every call."""
+
+    async def _boom(*args: object, **kwargs: object) -> LLMResponse:
+        del args, kwargs
+        raise exc
+
+    monkeypatch.setattr("routers.transcription.generate_response", _boom)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_stub_provider_charges_one_unit(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A stub-provider transcription returns text and spends exactly one unit."""
+    headers = await _signup(async_client, "happy")
+    before = await _wallet_snapshot(db_session, "happy@example.com")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert isinstance(resp.json()["text"], str)
+    after = await _wallet_snapshot(db_session, "happy@example.com")
+    assert _units_spent(before, after) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw", "media_type"),
+    [
+        (_JPEG_BYTES, "image/jpeg"),
+        (_PNG_BYTES, "image/png"),
+        (_WEBP_BYTES, "image/webp"),
+    ],
+    ids=["jpeg", "png", "webp"],
+)
+async def test_happy_path_per_media_type(
+    async_client: AsyncClient, raw: bytes, media_type: str
+) -> None:
+    """Each declared media type with matching magic bytes succeeds."""
+    username = f"media_{media_type.rsplit('/', maxsplit=1)[-1]}"
+    headers = await _signup(async_client, username)
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(raw, media_type), headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_is_401(async_client: AsyncClient) -> None:
+    """A request with no Authorization header is rejected."""
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES))
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("zero_monthly_cap")
+async def test_wallet_exhausted_is_402_and_uncharged(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """With no wallet capacity the call is 402 and neither bucket moves."""
+    headers = await _signup(async_client, "broke_transcribe")
+    before = await _wallet_snapshot(db_session, "broke_transcribe@example.com")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.PAYMENT_REQUIRED
+    assert resp.json()["detail"] == "insufficient_offerings"
+    after = await _wallet_snapshot(db_session, "broke_transcribe@example.com")
+    assert _units_spent(before, after) == 0
+    assert await _usage_row_count(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_base64_is_422(async_client: AsyncClient) -> None:
+    """Non-base64 image content is rejected as invalid_image."""
+    headers = await _signup(async_client, "badb64")
+
+    resp = await async_client.post(
+        _ENDPOINT,
+        json={"image_base64": "not!!base64!!", "media_type": "image/jpeg"},
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "invalid_image"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw", "declared_media_type"),
+    [
+        (_PNG_BYTES, "image/jpeg"),
+        (_WEBP_BYTES, "image/png"),
+        (_JPEG_BYTES, "image/webp"),
+    ],
+    ids=["png-bytes-declared-jpeg", "webp-bytes-declared-png", "jpeg-bytes-declared-webp"],
+)
+async def test_magic_byte_mismatch_is_422(
+    async_client: AsyncClient, raw: bytes, declared_media_type: str
+) -> None:
+    """Valid base64 whose magic bytes disagree with the declared type is rejected."""
+    username = f"mismatch_{declared_media_type.rsplit('/', maxsplit=1)[-1]}"
+    headers = await _signup(async_client, username)
+
+    resp = await async_client.post(
+        _ENDPOINT, json=_payload(raw, declared_media_type), headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "invalid_image"
+
+
+@pytest.mark.asyncio
+async def test_oversized_image_is_422(async_client: AsyncClient) -> None:
+    """A decoded payload over 5 MiB is rejected as image_too_large."""
+    headers = await _signup(async_client, "oversized")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_OVERSIZED_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "image_too_large"
+
+
+@pytest.mark.asyncio
+async def test_boundary_image_is_422_not_500(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A near-maximal image caps out cleanly as image_too_large, never a 500.
+
+    Exactly 5 MiB of decoded bytes encodes to a base64 string whose length slips
+    past the decoded-size cap by rounding but exceeds the shared attachment's
+    stricter encoded-length cap. It must surface as a clean 422 image_too_large
+    with no charge, not an unhandled 500.
+    """
+    headers = await _signup(async_client, "boundary")
+    before = await _wallet_snapshot(db_session, "boundary@example.com")
+    boundary = b"\xff\xd8\xff" + b"\x00" * (_MAX_IMAGE_BYTES - 3)
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(boundary), headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "image_too_large"
+    after = await _wallet_snapshot(db_session, "boundary@example.com")
+    assert _units_spent(before, after) == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_media_type_is_422(async_client: AsyncClient) -> None:
+    """An unsupported media_type fails Pydantic's Literal validation with 422."""
+    headers = await _signup(async_client, "gifuser")
+
+    resp = await async_client.post(
+        _ENDPOINT, json=_payload(_JPEG_BYTES, "image/gif"), headers=headers
+    )
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "username"),
+    [
+        ({"image_base64": "not!!base64!!", "media_type": "image/jpeg"}, "nocharge_badb64"),
+        (_payload(_OVERSIZED_JPEG_BYTES), "nocharge_oversized"),
+    ],
+    ids=["invalid-base64", "oversized"],
+)
+async def test_validation_failure_does_not_charge(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    body: dict[str, str],
+    username: str,
+) -> None:
+    """A 422 validation failure never touches either wallet bucket."""
+    headers = await _signup(async_client, username)
+    email = f"{username}@example.com"
+    before = await _wallet_snapshot(db_session, email)
+
+    resp = await async_client.post(_ENDPOINT, json=body, headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    after = await _wallet_snapshot(db_session, email)
+    assert _units_spent(before, after) == 0
+
+
+@pytest.mark.asyncio
+async def test_model_lacks_vision_is_422_and_rolls_back_charge(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vision-incapable model/provider surfaces model_lacks_vision and refunds."""
+    _patch_generate_response_raises(monkeypatch, LLMVisionUnsupportedError("provider lacks vision"))
+    headers = await _signup(async_client, "novision")
+    before = await _wallet_snapshot(db_session, "novision@example.com")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert resp.json()["detail"] == "model_lacks_vision"
+    after = await _wallet_snapshot(db_session, "novision@example.com")
+    assert _units_spent(before, after) == 0
+    assert await _usage_row_count(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_error_is_502_and_rolls_back_charge(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An upstream provider failure surfaces llm_provider_error and refunds."""
+    _patch_generate_response_raises(monkeypatch, LLMProviderError("provider down"))
+    headers = await _signup(async_client, "providerdown")
+    before = await _wallet_snapshot(db_session, "providerdown@example.com")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
+    assert resp.json()["detail"] == "llm_provider_error"
+    after = await _wallet_snapshot(db_session, "providerdown@example.com")
+    assert _units_spent(before, after) == 0
+    assert await _usage_row_count(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_priced_call_writes_one_usage_row_with_null_entry(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-stub response writes one LLMUsageLog row with no journal_entry_id."""
+    _patch_generate_response(monkeypatch, _priced_response("transcribed body text"))
+    headers = await _signup(async_client, "priced_transcribe")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    rows = await _usage_rows_with_null_entry(db_session)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.provider == "openai"
+    assert row.model == "gpt-4o-mini"
+    assert row.prompt_tokens == 11
+    assert row.completion_tokens == 7
+    assert row.total_tokens == 18
+
+
+@pytest.mark.asyncio
+async def test_stub_provider_writes_no_usage_row(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A stub-provider success writes zero LLMUsageLog rows."""
+    headers = await _signup(async_client, "stub_transcribe")
+
+    resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    assert await _usage_row_count(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_pinned_at_20_per_minute(async_client: AsyncClient) -> None:
+    """The endpoint's rate limit is pinned at exactly 20 requests/minute."""
+    headers = await _signup(async_client, "ratelimited")
+
+    async def send() -> Response:
+        return await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    for _ in range(_RATE_LIMIT - 1):
+        await send()
+
+    admitted = await send()
+    assert admitted.status_code != HTTPStatus.TOO_MANY_REQUESTS
+
+    throttled = await send()
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_no_log_record_leaks_base64_or_transcription_text(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No captured log record ever carries the base64 payload or the reply text."""
+    _patch_generate_response(monkeypatch, _priced_response(_SENTINEL_TEXT))
+    headers = await _signup(async_client, "privacy_check")
+    encoded = _b64(_JPEG_BYTES)
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await async_client.post(_ENDPOINT, json=_payload(_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == HTTPStatus.OK
+    for record in caplog.records:
+        message = record.getMessage()
+        assert encoded not in message
+        assert _SENTINEL_TEXT not in message
+        dict_blob = str(record.__dict__)
+        assert encoded not in dict_blob
+        assert _SENTINEL_TEXT not in dict_blob


### PR DESCRIPTION
## Summary

Adds `POST /journal/transcribe-page`: an authenticated, stateless single-page journal-transcription endpoint. It accepts one base64 image in a JSON body, validates it, charges one wallet unit, calls the shipped vision LLM path with the transcription prompt, and returns the transcribed body text as `{"text": ...}`. Nothing image-related is persisted — only a token-count `LLMUsageLog` row is written (with `journal_entry_id=None`).

- **Validation before any wallet/LLM work** (422s never charge): a cheap encoded-length pre-guard, a strict base64 decode (`validate=True`), a 5 MiB decoded-size cap (`MAX_TRANSCRIBE_IMAGE_BYTES`), and a magic-byte sniff (literal byte comparisons — JPEG/PNG/WebP — **no new dependency**, no python-magic) that must match the declared `media_type`. The shared `ImagePayload` is the single canonical size authority, so a near-maximal payload caps out as a clean `422 image_too_large` rather than a 500.
- **Wallet** mirrors the resonance preflight-deduct-then-rollback pattern: charge one unit before the LLM call; a vision-incapable model surfaces `422 model_lacks_vision` and a provider failure surfaces `502 llm_provider_error`, both rolling the charge back so a failed pass never bills.
- **Statelessness is structural**: base64-in-JSON only (no multipart / `UploadFile` / temp files, so Starlette never spools to disk); the handler holds bytes in memory only; success and error logs emit metadata (user id, token count) only — never the payload or the transcribed text.
- **BYOK** honored via `resolve_chat_api_key` (`X-LLM-API-Key`); rate limited at `TRANSCRIBE_RATE_LIMIT = "20/minute"` (2× resonance, sized for a full capture session).
- The metered call has no associated entry, so `llmusagelog.journal_entry_id` becomes nullable (model + widened `record_llm_usage` signature + backward-compatible Alembic migration `f9a0b1c2d3e4`; existing callers pass an int and are unaffected).

## Test plan

New `backend/tests/test_transcription_endpoint.py` (22 tests, all green):

- Stub-provider happy path (+ per-media-type jpeg/png/webp); exactly one unit charged.
- 401 unauthenticated · 402 wallet exhausted (no LLM call, no charge).
- 422 `invalid_image` (bad base64; magic-byte mismatch across all three sniffers) · 422 `image_too_large` (over-cap and the exact-boundary near-maximal case) · 422 unknown media_type (Literal) · no-charge-on-422.
- 422 `model_lacks_vision` and 502 `llm_provider_error` both roll the charge back **and** write no usage row.
- Usage-log row shape: one row, `journal_entry_id IS NULL`, correct token counts; stub path writes no row.
- Rate limit pinned at 20/minute; caplog privacy regression asserting no log record contains the base64 payload or the transcription text.

Gate 2 locally: full backend suite 2922 passed, coverage 96.88%, xenon rank A, radon MI A, interrogate 96.1%, mypy/ruff clean.

Closes #1789
Refs #1799