### PR TITLE
fix(frontend): cancel leaked animation frames to end 'environment torn down' teardown flake

### DIFF
--- a/frontend/__tests__/animationFrameCleanup.test.ts
+++ b/frontend/__tests__/animationFrameCleanup.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * Guards the animation-frame straggler cleanup installed by `jest.setup.js`.
+ *
+ * The React Native Jest preset polyfills `requestAnimationFrame` as
+ * `setTimeout(cb, 0)`, so a frame scheduled during one test but never flushed
+ * fires on the next tick — after the test finished. Left uncancelled, that
+ * straggler runs between suites (or, worst case, after the Jest environment is
+ * torn down, raising the "environment torn down" ReferenceError that fails a
+ * whole suite with zero test failures). The setup's `afterEach` must cancel
+ * every outstanding frame so it can never execute past its own test.
+ */
+describe('requestAnimationFrame teardown cleanup', () => {
+  let strayFrameFired = false;
+
+  it('schedules a frame that is never flushed within the test', () => {
+    requestAnimationFrame(() => {
+      strayFrameFired = true;
+    });
+    // The frame is queued but not yet run; nothing has fired inside this test.
+    expect(strayFrameFired).toBe(false);
+  });
+
+  it('cancelled the straggler so it cannot fire on a later macrotask', async () => {
+    // Yield to the macrotask queue. Without the setup's afterEach
+    // cancellation, the previous test's setTimeout(0)-backed frame is still
+    // pending and runs here — before this 1ms timer — flipping the flag.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1);
+    });
+    expect(strayFrameFired).toBe(false);
+  });
+});

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -49,3 +49,46 @@ jest.mock('react-native-safe-area-context', () => {
     SafeAreaView,
   };
 });
+
+// Cancel animation frames that outlive the test that scheduled them.
+//
+// The React Native Jest preset polyfills ``requestAnimationFrame`` as
+// ``setTimeout(cb, 0)`` (see react-native/jest/setup.js). A JS-driven
+// ``Animated`` timing (``useNativeDriver: false``) keeps requesting frames
+// until it finishes, so a component still mounted when its test ends leaves a
+// frame queued. That frame fires on the next tick -- after Jest has torn the
+// environment down -- and throws ``ReferenceError: You are trying to access a
+// property or method of the Jest environment after it has been torn down``,
+// which fails the whole suite even though every ``it()`` passed. Because Jest
+// attributes the error to whichever suite happens to be tearing down at that
+// instant, it lands on a different, innocent suite on almost every run, making
+// the failure a cross-suite flake no per-suite cleanup can reliably contain.
+//
+// Tracking every outstanding frame and cancelling the stragglers after each
+// test bounds that escaping work at its scheduler: anything still pending when
+// a test finishes was, by definition, never awaited, so cancelling it changes
+// no in-test behavior while making the leak structurally impossible.
+const outstandingAnimationFrames = new Set();
+const scheduleAnimationFrame = global.requestAnimationFrame;
+const clearAnimationFrame = global.cancelAnimationFrame;
+
+global.requestAnimationFrame = (callback) => {
+  const handle = scheduleAnimationFrame((time) => {
+    outstandingAnimationFrames.delete(handle);
+    callback(time);
+  });
+  outstandingAnimationFrames.add(handle);
+  return handle;
+};
+
+global.cancelAnimationFrame = (handle) => {
+  outstandingAnimationFrames.delete(handle);
+  return clearAnimationFrame(handle);
+};
+
+afterEach(() => {
+  for (const handle of outstandingAnimationFrames) {
+    clearAnimationFrame(handle);
+  }
+  outstandingAnimationFrames.clear();
+});


### PR DESCRIPTION
## Summary

Fixes the non-deterministic frontend CI flake where the Jest suite reports `Test Suites: 1 failed` with **zero test failures** — repeated `ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down`.

**Root cause:** JS-driven React Native `Animated` timings (`useNativeDriver: false`) keep requesting animation frames until they finish. The RN Jest preset backs `requestAnimationFrame` with `setTimeout(cb, 0)`. A component still mounted when its test ends leaves a frame queued; that frame fires on a later tick — after Jest tears the environment down — and throws. Jest attributes the error to whichever suite happens to be tearing down at that instant, so it lands on a **different, innocent suite nearly every run** (observed across `MapScreen`, `MapHistory`, `HabitsStageColors`, `HabitsSecondLap`, `MapRetry`, `MapScreenColdStart`, `HabitsResponsive`). This is a cross-suite leak that no per-suite cleanup can reliably contain.

**Fix (test-infra only, `frontend/jest.setup.js`):** wrap `global.requestAnimationFrame`/`cancelAnimationFrame` to track outstanding frame handles, and cancel any still pending in a global `afterEach`. Anything unflushed when a test finishes was, by definition, never awaited — so cancelling it changes no in-test behavior while making the leak structurally impossible. This is cancellation at the scheduler, not error suppression: no `try/catch`, no skips, no `eslint-disable`, no threshold changes, no production-code impact.

## Test plan

- Added `frontend/__tests__/animationFrameCleanup.test.ts` — a RED/GREEN regression guard (verified to fail without the `afterEach` cleanup and pass with it).
- Full suite: **493 teardown ReferenceErrors on baseline `main` → 0** across repeated full runs (all 419 suites pass).
- **5 consecutive** scoped runs of the previously-affected Map/Habits suites: clean, zero teardown errors.
- `jest --detectOpenHandles` on those suites: no open handles.
- `./scripts/frontend/check-all.sh`: all four gates green (lint, prettier, typecheck, tests).

Closes #1843