### PR TITLE
feat(frontend): journal.transcribePage API client with typed error taxonomy

### DIFF
--- a/frontend/src/api/__tests__/transcribePage.test.ts
+++ b/frontend/src/api/__tests__/transcribePage.test.ts
@@ -1,0 +1,272 @@
+/* eslint-env jest */
+/* global describe, test, expect, beforeEach, afterEach, jest */
+import { journal, TranscriptionError, TRANSCRIBE_TIMEOUT_MS, LLM_API_KEY_HEADER } from '../index';
+import { transcribePageSchema } from '../schemas';
+
+const mockFetch = jest.fn() as jest.Mock;
+global.fetch = mockFetch;
+
+jest.mock('@/config', () => ({ API_BASE_URL: 'http://test' }));
+
+// Distinctive fixture so a leak into logs or error messages is unmistakable.
+const SENTINEL_PAYLOAD = 'ZZZZ_SENTINEL_PAYLOAD_ZZZZ';
+
+type TranscriptionErrorInstance = InstanceType<typeof TranscriptionError>;
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  });
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.catch((e: unknown) => e);
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('journal.transcribePage request shape', () => {
+  test('POSTs the transcribe endpoint with a snake_case body and bearer auth', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ text: 'Today I felt...' }));
+    await journal.transcribePage({ imageBase64: 'abc123', mediaType: 'image/png' }, 'tok');
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://test/journal/transcribe-page');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ image_base64: 'abc123', media_type: 'image/png' });
+    expect(init.headers.Authorization).toBe('Bearer tok');
+  });
+
+  test('resolves with the transcribed text on a 200', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ text: 'Today I felt...' }));
+    const result = await journal.transcribePage(
+      { imageBase64: 'abc123', mediaType: 'image/png' },
+      'tok',
+    );
+    expect(result).toEqual({ text: 'Today I felt...' });
+  });
+});
+
+describe('journal.transcribePage BYOK header', () => {
+  test('attaches the header only when an api key is supplied', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ text: 'x' }));
+    await journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok', 'sk-byok');
+    expect(mockFetch.mock.calls[0][1].headers[LLM_API_KEY_HEADER]).toBe('sk-byok');
+
+    mockFetch.mockReturnValueOnce(jsonResponse({ text: 'x' }));
+    await journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok');
+    expect(mockFetch.mock.calls[1][1].headers[LLM_API_KEY_HEADER]).toBeUndefined();
+  });
+});
+
+describe('journal.transcribePage timeout', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('TRANSCRIBE_TIMEOUT_MS is 60 seconds, double the default fetch timeout', () => {
+    expect(TRANSCRIBE_TIMEOUT_MS).toBe(60_000);
+  });
+
+  test('a stalled fetch survives the 30s default and times out at 60s', async () => {
+    jest.useFakeTimers();
+    mockFetch.mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+
+    const promise = journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok');
+    promise.catch(() => {});
+
+    await jest.advanceTimersByTimeAsync(30_000);
+    const [, initAt30s] = mockFetch.mock.calls[0];
+    expect(initAt30s.signal.aborted).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(30_000);
+    const err = await captureError(promise);
+    expect(err).toBeInstanceOf(TranscriptionError);
+    expect((err as TranscriptionErrorInstance).kind).toBe('timeout');
+    expect((err as TranscriptionErrorInstance).status).toBeNull();
+  });
+});
+
+describe('journal.transcribePage error mapping', () => {
+  const cases: Array<{ name: string; status: number; body: unknown; kind: string }> = [
+    {
+      name: '422 invalid_image',
+      status: 422,
+      body: { detail: 'invalid_image' },
+      kind: 'invalid_image',
+    },
+    {
+      name: '422 image_too_large',
+      status: 422,
+      body: { detail: 'image_too_large' },
+      kind: 'image_too_large',
+    },
+    {
+      name: '422 model_lacks_vision',
+      status: 422,
+      body: { detail: 'model_lacks_vision' },
+      kind: 'model_lacks_vision',
+    },
+    {
+      name: '422 pydantic array detail defaults to invalid_image',
+      status: 422,
+      body: { detail: [{ loc: ['body', 'image_base64'], msg: 'bad image', type: 'value_error' }] },
+      kind: 'invalid_image',
+    },
+    {
+      name: '402 insufficient_offerings maps to wallet_exhausted',
+      status: 402,
+      body: { detail: 'insufficient_offerings' },
+      kind: 'wallet_exhausted',
+    },
+    {
+      name: '402 llm_key_required is NOT wallet exhaustion',
+      status: 402,
+      body: { detail: 'llm_key_required' },
+      kind: 'unknown',
+    },
+    {
+      name: '429 slowapi error key maps to rate_limited',
+      status: 429,
+      body: { error: 'Rate limit exceeded: 20 per 1 minute' },
+      kind: 'rate_limited',
+    },
+    {
+      name: '502 llm_provider_error maps to provider_error',
+      status: 502,
+      body: { detail: 'llm_provider_error' },
+      kind: 'provider_error',
+    },
+    {
+      name: '400 user_not_found maps to unknown',
+      status: 400,
+      body: { detail: 'user_not_found' },
+      kind: 'unknown',
+    },
+  ];
+
+  test.each(cases)('$name', async ({ status, body, kind }) => {
+    mockFetch.mockReturnValueOnce(jsonResponse(body, status));
+    const err = await captureError(
+      journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok'),
+    );
+    expect(err).toBeInstanceOf(TranscriptionError);
+    const transcriptionErr = err as TranscriptionErrorInstance;
+    expect(transcriptionErr.kind).toBe(kind);
+    expect(transcriptionErr.status).toBe(status);
+    expect(transcriptionErr.cause).toBeDefined();
+  });
+
+  test('does not retry a 502 (POST is non-idempotent)', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'llm_provider_error' }, 502));
+    await captureError(
+      journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok'),
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry a 429 (POST is non-idempotent)', async () => {
+    mockFetch.mockReturnValueOnce(
+      jsonResponse({ error: 'Rate limit exceeded: 20 per 1 minute' }, 429),
+    );
+    await captureError(
+      journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok'),
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('maps a network failure to kind network with a null status', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Network request failed'));
+    const err = await captureError(
+      journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok'),
+    );
+    expect(err).toBeInstanceOf(TranscriptionError);
+    const transcriptionErr = err as TranscriptionErrorInstance;
+    expect(transcriptionErr.kind).toBe('network');
+    expect(transcriptionErr.status).toBeNull();
+  });
+});
+
+describe('transcribePageSchema', () => {
+  test('parses a valid text payload', () => {
+    expect(transcribePageSchema.parse({ text: 'x' })).toEqual({ text: 'x' });
+  });
+
+  test('rejects a payload missing the text field', () => {
+    expect(transcribePageSchema.safeParse({ txt: 'x' }).success).toBe(false);
+  });
+
+  test('rejects a payload where text is the wrong type', () => {
+    expect(transcribePageSchema.safeParse({ text: 123 }).success).toBe(false);
+  });
+
+  test('a 200 response that drifts from the schema rejects as kind unknown', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ notText: 1 }));
+    const err = await captureError(
+      journal.transcribePage({ imageBase64: 'abc', mediaType: 'image/png' }, 'tok'),
+    );
+    expect(err).toBeInstanceOf(TranscriptionError);
+    expect((err as TranscriptionErrorInstance).kind).toBe('unknown');
+  });
+});
+
+describe('journal.transcribePage privacy', () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  function assertNoSecretLeak(spy: jest.SpyInstance): void {
+    for (const call of spy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(SENTINEL_PAYLOAD);
+    }
+  }
+
+  test('a failed (502) call never logs the image payload or leaks it into the message', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ detail: 'llm_provider_error' }, 502));
+    const err = await captureError(
+      journal.transcribePage({ imageBase64: SENTINEL_PAYLOAD, mediaType: 'image/png' }, 'tok'),
+    );
+    // A mapped transport error emits no console output at all, so the leak scan
+    // would pass vacuously; assert silence explicitly to lock that in.
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect((err as TranscriptionErrorInstance).message).not.toContain(SENTINEL_PAYLOAD);
+  });
+
+  test('a schema-drift (200) call never logs the image payload or leaks it into the message', async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ notText: 1 }));
+    const err = await captureError(
+      journal.transcribePage({ imageBase64: SENTINEL_PAYLOAD, mediaType: 'image/png' }, 'tok'),
+    );
+    assertNoSecretLeak(logSpy);
+    assertNoSecretLeak(warnSpy);
+    assertNoSecretLeak(errorSpy);
+    expect((err as TranscriptionErrorInstance).message).not.toContain(SENTINEL_PAYLOAD);
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,6 +34,7 @@ import {
   stageProgressRecordSchema,
   stageSchema,
   timezoneReadSchema,
+  transcribePageSchema,
   uiFlagsSchema,
   wheelBalanceSchema,
   type AcceptSuggestionResultT,
@@ -63,6 +64,7 @@ import {
   type SuggestionStatusT,
   type Tier,
   type TimezoneReadT,
+  type TranscribePageT,
   type WheelBalanceT,
 } from './schemas';
 
@@ -130,6 +132,55 @@ export class ApiTimeoutError extends Error {
   constructor(path: string, timeoutMs: number) {
     super(`Request timed out after ${timeoutMs}ms: ${path}`);
     this.name = 'ApiTimeoutError';
+  }
+}
+
+/** Transcribed-text result envelope, re-exported for callers of `journal.transcribePage`. */
+export type { TranscribePageT } from './schemas';
+
+/** Image encodings the transcription endpoint accepts (mirrors the backend allowlist). */
+export type MediaType = 'image/jpeg' | 'image/png' | 'image/webp';
+
+/**
+ * The stable, UI-facing failure taxonomy for handwriting transcription. Every
+ * server / transport error is collapsed into one of these so callers branch on
+ * a small closed set instead of raw HTTP status + detail strings.
+ */
+export type TranscriptionErrorKind =
+  | 'invalid_image'
+  | 'image_too_large'
+  | 'model_lacks_vision'
+  | 'wallet_exhausted'
+  | 'rate_limited'
+  | 'provider_error'
+  | 'network'
+  | 'timeout'
+  | 'unknown';
+
+/**
+ * Transcription timeout: 60s, double {@link FETCH_TIMEOUT_MS}. Vision models
+ * are markedly slower than text completions; this is p95 latency headroom over
+ * the 30s default so a genuinely-working call is not aborted mid-flight.
+ */
+export const TRANSCRIBE_TIMEOUT_MS = 60_000;
+
+/**
+ * Typed failure for {@link journal.transcribePage}. PRIVACY: the message is a
+ * static per-`kind` string and never interpolates the base64 image payload or
+ * the request body, so it is safe to log or surface. The originating error is
+ * preserved on `cause` for diagnostics.
+ */
+export class TranscriptionError extends Error {
+  kind: TranscriptionErrorKind;
+  status: number | null;
+
+  constructor(kind: TranscriptionErrorKind, status: number | null, cause?: unknown) {
+    // Only forward `cause` when present: passing `{ cause: undefined }` would
+    // stamp an explicit `undefined` cause instead of leaving it unset.
+    super(`transcription failed: ${kind}`, cause === undefined ? undefined : { cause });
+    this.name = 'TranscriptionError';
+    this.kind = kind;
+    this.status = status;
   }
 }
 
@@ -1273,6 +1324,69 @@ export interface JournalListParams {
   offset?: number;
 }
 
+/** Optional bring-your-own-key header for the LLM endpoints. */
+// Resolve the bring-your-own-key header: an explicit per-call key wins, else the
+// key registered by the BYOK provider (ApiKeyContext) at call time so rotations
+// apply immediately. Empty/absent → no header (backend falls back to its env).
+const byokHeaders = (apiKey?: string): Record<string, string> | undefined => {
+  const key = apiKey ?? llmApiKeyGetter?.() ?? null;
+  return key ? { [LLM_API_KEY_HEADER]: key } : undefined;
+};
+
+/**
+ * 422 sub-map: the transcription endpoint reuses the generic 422 for several
+ * distinct validation failures, disambiguated by `detail`. Anything not listed
+ * here (including a bare `invalid_image` and the Pydantic array-detail case
+ * that `extractErrorDetail` collapses to `'Request failed'`) is a bad image.
+ */
+const TRANSCRIBE_422_KINDS: Record<string, TranscriptionErrorKind> = {
+  image_too_large: 'image_too_large',
+  model_lacks_vision: 'model_lacks_vision',
+};
+
+/**
+ * Flat status→kind table for the transcription endpoint's `ApiError`s. Statuses
+ * needing detail-level disambiguation (402, 422) are handled before this lookup.
+ */
+const TRANSCRIBE_STATUS_KINDS: Record<number, TranscriptionErrorKind> = {
+  429: 'rate_limited',
+  502: 'provider_error',
+  0: 'network',
+};
+
+/** Classify an `ApiError` from the transcription endpoint into a stable kind. */
+function classifyTranscribeApiError(err: ApiError): TranscriptionErrorKind {
+  // 402 keyless-BYOK is a client misconfiguration, NOT a spent wallet.
+  if (err.status === 402) {
+    return err.detail === 'llm_key_required' ? 'unknown' : 'wallet_exhausted';
+  }
+  if (err.status === 422) {
+    return TRANSCRIBE_422_KINDS[err.detail] ?? 'invalid_image';
+  }
+  return TRANSCRIBE_STATUS_KINDS[err.status] ?? 'unknown';
+}
+
+/**
+ * Map any thrown error to a {@link TranscriptionError} without ever touching the
+ * request body, so the base64 payload cannot leak into a message or log.
+ */
+function toTranscriptionError(err: unknown): TranscriptionError {
+  if (err instanceof ApiTimeoutError) {
+    return new TranscriptionError('timeout', null, err);
+  }
+  if (err instanceof ApiError) {
+    return new TranscriptionError(classifyTranscribeApiError(err), err.status, err);
+  }
+  // A raw fetch failure surfaces as a TypeError on non-idempotent POSTs (which
+  // the core client does not retry) rather than the synthesized ApiError(0).
+  if (err instanceof TypeError && err.message.toLowerCase().includes('network')) {
+    return new TranscriptionError('network', null, err);
+  }
+  // Schema drift (ApiValidationError) and everything unforeseen collapse here.
+  const status = err instanceof ApiValidationError ? err.status : null;
+  return new TranscriptionError('unknown', status, err);
+}
+
 export const journal = {
   list(params: JournalListParams = {}, token?: string): Promise<JournalListResponse> {
     const query = new URLSearchParams();
@@ -1315,6 +1429,33 @@ export const journal = {
   },
   delete(entryId: number, token?: string): Promise<void> {
     return request<void>(`/journal/${entryId}`, { method: 'DELETE', token });
+  },
+  /**
+   * Transcribe one handwritten journal page from a base64 image. Stateless: it
+   * persists nothing and just returns the OCR'd text. Charges one wallet unit,
+   * so it is deliberately NON-idempotent — there is no auto-retry and callers
+   * must not resend on transient failure without user intent. Supports BYOK via
+   * the optional api key. PRIVACY: the image payload is never logged, and a
+   * {@link TranscriptionError} message never carries it. A 402 disambiguates a
+   * spent wallet (`wallet_exhausted`) from a missing BYOK key (`unknown`).
+   */
+  async transcribePage(
+    { imageBase64, mediaType }: { imageBase64: string; mediaType: MediaType },
+    token?: string,
+    apiKey?: string,
+  ): Promise<TranscribePageT> {
+    try {
+      return await request<TranscribePageT>('/journal/transcribe-page', {
+        method: 'POST',
+        body: { image_base64: imageBase64, media_type: mediaType },
+        token,
+        headers: byokHeaders(apiKey),
+        timeoutMs: TRANSCRIBE_TIMEOUT_MS,
+        schema: transcribePageSchema as unknown as z.ZodType<TranscribePageT>,
+      });
+    } catch (err: unknown) {
+      throw toTranscriptionError(err);
+    }
   },
 };
 
@@ -1411,15 +1552,6 @@ export const reflections = {
       },
     );
   },
-};
-
-/** Optional bring-your-own-key header for the resonance LLM endpoints. */
-// Resolve the bring-your-own-key header: an explicit per-call key wins, else the
-// key registered by the BYOK provider (ApiKeyContext) at call time so rotations
-// apply immediately. Empty/absent → no header (backend falls back to its env).
-const byokHeaders = (apiKey?: string): Record<string, string> | undefined => {
-  const key = apiKey ?? llmApiKeyGetter?.() ?? null;
-  return key ? { [LLM_API_KEY_HEADER]: key } : undefined;
 };
 
 /**

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -272,6 +272,10 @@ export const journalListResponseSchema = z.object({
   has_more: z.boolean(),
 });
 
+/** Handwriting-transcription result: the OCR'd text of one journal page. */
+export const transcribePageSchema = z.object({ text: z.string() });
+export type TranscribePageT = z.infer<typeof transcribePageSchema>;
+
 // ---------------------------------------------------------------------------
 // Per-item schemas for paginated endpoints (replacing loosePageSchema casts).
 // The deep ``mode_config`` / ``mode_metadata`` payloads are validated


### PR DESCRIPTION
## Summary

Adds `journal.transcribePage({ imageBase64, mediaType }, token?, apiKey?)` — the typed frontend API client for the shipped `POST /journal/transcribe-page` endpoint (base64 handwritten page in, transcribed `{ text }` out). This is the last plumbing layer before the Journal Photographer capture flow.

- **Zod schema** `transcribePageSchema` (`{ text: string }`) validates the response at the client edge (`ApiValidationError` on drift).
- **`MediaType`** closed union `'image/jpeg' | 'image/png' | 'image/webp'`, mirroring the backend `Literal` allowlist.
- **`TranscriptionError`** class + **`TranscriptionErrorKind`** union collapse every transport/server failure into one stable, UI-facing kind (`invalid_image` / `image_too_large` / `model_lacks_vision` / `wallet_exhausted` / `rate_limited` / `provider_error` / `network` / `timeout` / `unknown`) so the capture screen branches on a small closed set instead of raw status + detail strings. The underlying error is preserved on `.cause`.
- **`TRANSCRIBE_TIMEOUT_MS = 60_000`** — double the 30s default; vision-model latency headroom.
- **Non-idempotent by design:** the call charges one wallet unit, so it carries no idempotency header and never enters the transient-retry path (asserted: fetch called exactly once on 429/502).
- **Privacy:** the base64 payload is never logged nor interpolated into a `TranscriptionError` message (static per-kind message; asserted with a sentinel fixture across `console.log/warn/error`).
- Reuses the existing `request<T>`, `byokHeaders` (relocated above the `journal` object), and error-class idioms — no new deps, no axios, no duplicate plumbing. Scope: API layer + tests only, no UI.

### Divergences from the issue's guessed taxonomy (followed the shipped backend)

The Zod schema and error taxonomy mirror what the backend actually returns (`backend/src/routers/transcription.py`, `schemas/transcription.py`, `errors.py`, `services/wallet.py`, `services/botmason.py`), not the issue's guesses:

1. **402 is ambiguous.** The wallet raises `402 insufficient_offerings` (out of capacity) but `resolve_chat_api_key` also raises `402 llm_key_required` (a BYOK-required provider with no key). A blind status-402 → `wallet_exhausted` would mislabel a keyless config as "out of offerings." Mapping: `402 llm_key_required` → `unknown`; any other 402 → `wallet_exhausted`.
2. **400 `user_not_found`** (user deleted mid-request) and **400 `invalid_llm_api_key_format`** have no taxonomy kind → mapped to `unknown`.
3. **Pydantic array-shaped 422** (empty `image_base64` / bad `media_type`) surfaces a non-string `detail` that `extractErrorDetail` collapses to `'Request failed'` → defaulted to `invalid_image`.

## Test plan

- New `frontend/src/api/__tests__/transcribePage.test.ts` (23 tests, modeled on `resonance.test.ts`): request shape/snake_case body/Bearer auth; BYOK header present/absent; `TRANSCRIBE_TIMEOUT_MS` value + fake-timer proof the call survives 30s and times out at 60s; success parsing; schema valid/invalid + 200-drift → `unknown`; full error-mapping table (422×4, 402×2 incl. the `llm_key_required` carve-out, 429 slowapi shape, 502, 400); network `TypeError` → `network`; no-auto-retry on 429/502; privacy (payload never logged / in message).
- `./scripts/frontend/check-all.sh`: all 4 checks green (eslint, prettier, tsc, jest — 4587 tests pass).
- Gate 2.5 self-review: CLEAN (only NIT-level findings, addressed).

Closes #1790
Refs #1799