### PR TITLE
feat(graph): add graph-first scan preambles and /graph skill

### DIFF
--- a/.claude/skills/graph/SKILL.md
+++ b/.claude/skills/graph/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: graph
+description: >-
+  Query the Adepthood knowledge graph to orient before reading code: what
+  connects two modules, the impact of changing a symbol, a plain-language
+  explanation of a node, or the graph's freshness/status. Use when the user
+  says "query the graph", "what connects X and Y", "impact of changing X",
+  "what depends on X", "is the graph fresh", "/graph", or wants a graph-first
+  answer instead of a blind file sweep. Wraps the graphify query, path,
+  explain, and affected subcommands plus a graph-meta.json freshness check, and
+  defaults to the federated pan-graph.json when it is present. Do NOT use to file bugs or
+  features (use flare), to run code-quality or slop audits (use de-slopify),
+  or to build or refresh the graph itself (run scripts/graph/build.sh or
+  scripts/graph/update.sh).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Graph
+
+Answer a codebase question from the knowledge graph before sweeping files by
+hand. This skill is a thin, accurate wrapper over the `graphify` CLI and the
+graph's provenance metadata — it never duplicates the CLI reference, which
+lives in `scripts/graph/README.md`.
+
+## Instructions
+
+### Step 1 — Pick the graph, restore it if missing
+
+Read subcommands default to `graphify-out/graph.json`. Prefer the federated
+`graphify-out/pan-graph.json` when it exists — it also carries the four
+satellite repos — by passing `--graph graphify-out/pan-graph.json`.
+
+```bash
+GRAPH=graphify-out/graph.json
+[ -f graphify-out/pan-graph.json ] && GRAPH=graphify-out/pan-graph.json
+```
+
+If neither file exists, the graph has not been restored. In a normal Claude
+Code session the SessionStart hook (`.claude/hooks/session-start.sh`)
+already fetches it from the rolling `knowledge-graph` release, skipping the
+download when a local copy is under 48h fresh. If it is genuinely absent,
+restore it manually (this is the exact command that hook and
+`scripts/graph/README.md` use):
+
+```bash
+gh release download knowledge-graph --pattern graph.json --dir graphify-out
+gh release download knowledge-graph --pattern 'pan-*.json' --dir graphify-out  # optional: federated graph
+```
+
+If the release is unreachable, build a local code-only graph with
+`./scripts/graph/build.sh` (~2 min, offline). If you cannot get a graph at
+all, say so and fall back to Grep/Glob rather than inventing an answer.
+
+### Step 2 — Choose the verb
+
+| Question | Command |
+| --- | --- |
+| "what does X do / what's near it" | `graphify explain "X" --graph "$GRAPH"` |
+| "how do A and B relate" | `graphify path "A" "B" --graph "$GRAPH"` |
+| "what depends on X / blast radius" | `graphify affected "X" --graph "$GRAPH"` |
+| open-ended "where is Y handled" | `graphify query "<question>" --graph "$GRAPH"` |
+| "is the graph present / fresh" | read `graphify-out/graph-meta.json` (Step 3) |
+
+`query` caps output with `--budget N` (default 2000 tokens); `affected` takes
+`--depth N` and `--relation R`. See `scripts/graph/README.md` for the full flag
+set — do not guess flags.
+
+### Step 3 — Status is a metadata read, not a subcommand
+
+graphify has no `status` subcommand. Report graph status by reading the
+provenance file `graphify-out/graph-meta.json` (or `pan-meta.json` for the
+federated graph), which records `built_at`, `sha`, `kind`
+(`code-only` | `code+semantic` | `pan-graph`), node/edge counts, and the pinned
+`graphifyy` version:
+
+```bash
+cat graphify-out/graph-meta.json   # or graphify-out/pan-meta.json
+```
+
+Report presence, `kind`, the `built_at` age, and the `sha` the graph was built
+from. If `graph.json` exists but `graph-meta.json` does not, it is a local,
+un-provenanced build (e.g. from `build.sh`) — say so rather than claiming a
+release identity. Note the SessionStart hook restores only `graph.json`,
+`graph-meta.json`, and `pan-graph.json`; `pan-meta.json` appears only after
+the manual `--pattern 'pan-*.json'` restore, so when it is absent fall back
+to `graph-meta.json` for freshness.
+
+### Step 4 — Cite `source_location`, treat hits as leads
+
+When you state a fact from the graph, quote the node's `source_location` so it
+is verifiable (`file:line`). The graph is a lead generator, not proof: for
+anything you will act on, confirm the finding by reading the cited code before
+editing or reporting it as certain.
+
+### Step 5 — After code changes, refresh the graph
+
+If you have just modified code and want a current graph, refresh it with
+`./scripts/graph/update.sh` (incremental, AST-only, no cost). This skill only
+queries; building and refreshing are the `scripts/graph/` scripts' job.
+
+## Examples
+
+### Example 1 — Blast radius before a refactor
+User: "what depends on `detect_completion`? I want to change its signature."
+
+```bash
+graphify affected "detect_completion" --graph graphify-out/graph.json
+```
+
+Report each dependent with its `source_location`, then read the top callers to
+confirm the signature change is safe. This is the `graphify affected "X"`
+change-impact path CLAUDE.md points to.
+
+### Example 2 — How two modules connect
+User: "what connects the habits router and the streaks domain?"
+
+```bash
+graphify path "habits router" "streaks" --graph graphify-out/graph.json
+```
+
+Summarize the shortest path (the intermediate calls/imports), quoting each
+node's `source_location`.
+
+### Example 3 — Is the graph fresh enough to trust?
+User: "/graph status"
+
+Read `graphify-out/graph-meta.json`, then answer with presence, `kind`
+(code-only vs code+semantic), the `built_at` age, and whether a
+`pan-graph.json` is also present. If it is stale (older than ~48h) or absent,
+say so and offer to restore via the release or `build.sh`.
+
+## Troubleshooting
+
+### `graphify: command not found`
+The CLI is not installed in the active environment. `scripts/graph/build.sh`
+and `update.sh` install the pinned `graphifyy` toolchain on first use;
+activate your `.venv` first so it lands there. This skill never pins or
+upgrades the CLI itself — that is `scripts/graph/requirements.txt`.
+
+### The graph is missing or stale
+See Step 1: restore from the `knowledge-graph` release, or build locally with
+`./scripts/graph/build.sh`. Never answer from a graph you could not load —
+fall back to Grep/Glob and say the graph was unavailable.
+
+### The user wants to file an issue or fix quality, not query
+Stop and hand off: filing a bug/feature is the `flare` skill; a code-quality
+or slop audit is the `de-slopify` skill. This skill only reads the graph — it
+does not create issues or edit code.
+
+### Looking for a `status` subcommand on the CLI
+graphify has none for the graph — the only `status` it exposes is `hook
+status` (git-hook wiring). Graph freshness comes from reading `graph-meta.json`
+(Step 3), not from the CLI.

--- a/.claude/skills/graph/SKILL.md
+++ b/.claude/skills/graph/SKILL.md
@@ -50,7 +50,8 @@ gh release download knowledge-graph --pattern 'pan-*.json' --dir graphify-out  #
 ```
 
 If the release is unreachable, build a local code-only graph with
-`./scripts/graph/build.sh` (~2 min, offline). If you cannot get a graph at
+`./scripts/graph/build.sh` (~2 min, local AST extract — no LLM or API cost;
+first run pip-installs the pinned toolchain). If you cannot get a graph at
 all, say so and fall back to Grep/Glob rather than inventing an answer.
 
 ### Step 2 — Choose the verb

--- a/prompts/scans/a11y.md
+++ b/prompts/scans/a11y.md
@@ -18,6 +18,12 @@ screen-reader-relevant findings over a long list of theoretical ones. A run that
 finds none is a valid, successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the frontend screen and navigation nodes (the
+  Journal and bottom-tab communities) to fix which screens are core, then audit
+  those for accessibility props. If the graph is absent or stale, skip this
+  step and run the analysis as written.
 - Title-slug prefix: `[scan:a11y]`
 - Priority label for this scan (workflow input): `P2`
 - Standard: WCAG 2.1 AA (RN adaptation).

--- a/prompts/scans/bugs.md
+++ b/prompts/scans/bugs.md
@@ -16,6 +16,12 @@ recently-reverted changes, and swallowed-error gaps — and file one RCA-ready
 issue each, with a reproducing-test idea.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the high-degree hub nodes that recent commits also
+  touched — where many callers meet fresh change — via `graphify query` and
+  `graphify affected`. If the graph is absent or stale, skip this step and run
+  the analysis as written.
 - Title-slug prefix: `[scan:bugs]`. Priority `P1` (passed by the workflow).
 - Signals (read-only):
   - **Flaky/failing tests**: scan recent CI history and re-run signals; grep

--- a/prompts/scans/complexity.md
+++ b/prompts/scans/complexity.md
@@ -17,6 +17,12 @@ attach a concrete, named refactor strategy to each. A run that finds none is a
 valid, successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the highest-degree code nodes — the graph's hubs,
+  surfaced via `graphify query` and `graphify affected` — since they
+  concentrate branching and coupling. If the graph is absent or stale, skip
+  this step and run the analysis as written.
 - Title-slug prefix: `[scan:complexity]`
 - Record the SHA with `git rev-parse HEAD` first.
 - Backend (Python), sorted worst-first:

--- a/prompts/scans/coverage.md
+++ b/prompts/scans/coverage.md
@@ -16,6 +16,11 @@ and branches and a concrete test plan to close them — measured against the
 ≥90% line / ≥80% branch backend gate and the ≥90% Jest frontend gate.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the highest-degree code nodes (god nodes) whose
+  blast radius is widest, then check which of them are under-covered. If the
+  graph is absent or stale, skip this step and run the analysis as written.
 - Title-slug prefix: `[scan:coverage]`. Priority `P2` (passed by the workflow).
 - Tools (read-only):
   - Backend: `scripts/backend/coverage.sh` (or `pytest --cov=src

--- a/prompts/scans/dead-code.md
+++ b/prompts/scans/dead-code.md
@@ -19,6 +19,12 @@ evidence and a classified remediation direction (delete / wire-in /
 decision-needed). A run that finds none is a valid, successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from low-degree and isolated nodes as deletion
+  candidates, cross-checked against the high-degree hubs, then confirm every
+  candidate with vulture/knip/ts-prune. If the graph is absent or stale, skip
+  this step and run the analysis as written.
 - Title-slug prefix: `[scan:dead-code]`
 - First-party source only. Record the SHA with `git rev-parse HEAD` first.
 - Backend (Python), note vulture's confidence percentage per hit:

--- a/prompts/scans/deps.md
+++ b/prompts/scans/deps.md
@@ -19,6 +19,12 @@ issue per MAJOR bump (with breaking-change notes and the affected call sites in
 this repo). Hand each to scan-issue-writer as a finding.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: trace which declared packages are actually reached via import
+  edges with `graphify query` and `graphify affected`, so a bump's real blast
+  radius in this repo is known. If the graph is absent or stale, skip this step
+  and run the analysis as written.
 - Title-slug prefix: `[scan:deps]`.
 - Do NOT duplicate `dependabot-to-ralph-issue.yml`, which already files a Ralph
   issue per individual Dependabot PR. Your value is cross-PR: batching several

--- a/prompts/scans/docs.md
+++ b/prompts/scans/docs.md
@@ -19,6 +19,12 @@ docstring that describes the wrong parameters, return type, or behavior is. A
 run that finds none is a valid, successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from nodes central in the code graph but thin in the doc
+  communities (the wiki `index.md`), where prose is likeliest to have drifted.
+  If the graph is absent or stale, skip this step and run the analysis as
+  written.
 - Title-slug prefix: `[scan:docs]`
 - Priority label for this scan (workflow input): `P3`
 - Record the SHA with `git rev-parse HEAD` before scanning; every issue cites it.

--- a/prompts/scans/docs.md
+++ b/prompts/scans/docs.md
@@ -21,10 +21,10 @@ run that finds none is a valid, successful, zero-issue run.
 ## Context
 - **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
   orient from the graph before the file sweep (see `scripts/graph/README.md`).
-  For this scan: start from nodes central in the code graph but thin in the doc
-  communities (the wiki `index.md`), where prose is likeliest to have drifted.
-  If the graph is absent or stale, skip this step and run the analysis as
-  written.
+  For this scan: start from code nodes central in the graph but thinly linked
+  to doc/prose communities (via `graphify query`/`explain`), where prose is
+  likeliest to have drifted. If the graph is absent or stale, skip this step and
+  run the analysis as written.
 - Title-slug prefix: `[scan:docs]`
 - Priority label for this scan (workflow input): `P3`
 - Record the SHA with `git rev-parse HEAD` before scanning; every issue cites it.

--- a/prompts/scans/groom.md
+++ b/prompts/scans/groom.md
@@ -20,6 +20,12 @@ reproduces at HEAD, collapse duplicates, and promote fully-specified
 toward healthy rather than bloating.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: before closing or promoting a candidate, use `graphify query`
+  or `graphify explain` to check whether its cited symbol still exists at HEAD.
+  If the graph is absent or stale, skip this step and run the analysis as
+  written.
 - Invoke the `backlog-grooming` skill and follow it; this file is the scope.
 - Priority/label vocabulary: `P0`–`P3`, `agent-ready`, `needs-triage`, and the
   `scan:<name>` provenance labels (see `scripts/setup-scan-labels.sh`).

--- a/prompts/scans/mutation.md
+++ b/prompts/scans/mutation.md
@@ -19,6 +19,11 @@ them. A run that finds none — every mutant killed — is a valid, successful,
 zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the highest-degree logic nodes (god nodes), where
+  surviving mutants have the widest blast radius. If the graph
+  is absent or stale, skip this step and run the analysis as written.
 - Title-slug prefix: `[scan:mutation]`
 - IMPORTANT: this scan is EXPENSIVE. Run it on a schedule, not from the hopper.
   Record the SHA with `git rev-parse HEAD` first.

--- a/prompts/scans/perf.md
+++ b/prompts/scans/perf.md
@@ -17,6 +17,11 @@ tracked, agent-ready issue. Prefer a few well-evidenced findings over a long
 speculative list. A run that finds none is a valid, successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from high fan-in hot nodes (`graphify affected`, god
+  nodes) that sit on the busiest call paths. If the graph is absent or stale,
+  skip this step and run the analysis as written.
 - Title-slug prefix: `[scan:perf]`
 - Priority label for this scan (workflow input): `P2`
 - First-party source only — backend `backend/src/`, frontend `frontend/src/`.

--- a/prompts/scans/security.md
+++ b/prompts/scans/security.md
@@ -15,6 +15,12 @@ Produce ONE issue per actionable CVE/advisory (or confirmed secret leak) with
 the affected dependency path(s) and a concrete, upgrade-first fix strategy.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from entry-point nodes (the router and auth communities)
+  and the dependency edges reaching them (`graphify path`, `graphify affected`).
+  If the graph is absent or stale, skip this step and run the analysis as
+  written.
 - Title-slug prefix: `[scan:security]`. Priority is `P0` (passed by the
   workflow) — these preempt everything.
 - Tools (read-only, installed by the core; verify they exist — a missing tool

--- a/prompts/scans/todo.md
+++ b/prompts/scans/todo.md
@@ -18,6 +18,11 @@ the scan-issue-writer skill as a finding. A run that finds none is a valid,
 successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: rank marker-bearing files by graph centrality with `graphify
+  query` so the highest-leverage markers surface first. If the graph
+  is absent or stale, skip this step and run the analysis as written.
 - Title-slug prefix: `[scan:todo]`
 - Search first-party source only:
   - Backend: `backend/src/`

--- a/prompts/scans/types.md
+++ b/prompts/scans/types.md
@@ -19,6 +19,11 @@ missing return/parameter annotations, and every existing `type: ignore` /
 successful, zero-issue run.
 
 ## Context
+- **Graph-first orientation (fail-soft):** if `graphify-out/graph.json` exists,
+  orient from the graph before the file sweep (see `scripts/graph/README.md`).
+  For this scan: start from the highest-degree code nodes (god nodes), where an
+  `Any` leak propagates to the most callers (`graphify affected`). If the graph
+  is absent or stale, skip this step and run the analysis as written.
 - Title-slug prefix: `[scan:types]`
 - Record the SHA with `git rev-parse HEAD` first.
 - Backend (Python), strict-mode delta on first-party source:

--- a/scripts/graph/test_scan_graph_preamble.sh
+++ b/scripts/graph/test_scan_graph_preamble.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# scripts/graph/test_scan_graph_preamble.sh
+#
+# Offline guard tests for two graph-orientation deliverables:
+#   1. Every prompts/scans/<scan>.md carries a fail-soft "Graph-first
+#      orientation" step inside its ## Context section, kept small enough
+#      (<= MAX_PREAMBLE_LINES lines) that it orients without bloating the
+#      self-contained scan prompt the reusable _claude-scan.yml runner reads.
+#   2. The .claude/skills/graph/SKILL.md skill exists, passes the structural
+#      skill-craft bars, links the CLI docs instead of duplicating them, and
+#      never claims a non-existent `graphify status` subcommand.
+#
+# Pure text assertions: no graphify, no network, no build. Run:
+#   bash scripts/graph/test_scan_graph_preamble.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCANS_DIR="$ROOT/prompts/scans"
+SKILL="$ROOT/.claude/skills/graph/SKILL.md"
+MARKER="Graph-first orientation"
+FALLBACK="absent or stale"
+MAX_PREAMBLE_LINES=8
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check_contains() { # check_contains <desc> <file> <needle>
+  if grep -qF -- "$3" "$2"; then ok "$1"; else bad "$1 (missing '$3' in $2)"; fi
+}
+check_absent() { # check_absent <desc> <file> <needle>
+  if grep -qF -- "$3" "$2"; then bad "$1 (found forbidden '$3' in $2)"; else ok "$1"; fi
+}
+
+# --- group 1: every scan prompt carries a bounded, fail-soft preamble ---------
+# while-read instead of mapfile so macOS system bash 3.2 can run this too.
+SCANS=()
+while IFS= read -r f; do SCANS+=("$f"); done \
+  < <(find "$SCANS_DIR" -maxdepth 1 -name '*.md' ! -name '_*' | sort)
+if [[ "${#SCANS[@]}" -eq 0 ]]; then
+  bad "found scan prompts to check"
+fi
+for scan in "${SCANS[@]}"; do
+  name="$(basename "$scan")"
+  check_contains "$name has the graph-orientation marker" "$scan" "$MARKER"
+  check_contains "$name states the fail-soft fallback" "$scan" "$FALLBACK"
+
+  # The marker must land inside ## Context (after its heading, before
+  # ## Output Format), where the analysis strategy lives — not stranded in
+  # Role/Goal.
+  marker_line="$(grep -nF -- "$MARKER" "$scan" | head -1 | cut -d: -f1 || true)"
+  ctx_line="$(grep -nE -- "^## Context" "$scan" | head -1 | cut -d: -f1 || true)"
+  out_line="$(grep -nF -- "## Output Format" "$scan" | head -1 | cut -d: -f1 || true)"
+  if [[ -n "$marker_line" && -n "$ctx_line" && -n "$out_line" \
+        && "$ctx_line" -lt "$marker_line" && "$marker_line" -lt "$out_line" ]]; then
+    ok "$name orientation sits between ## Context and ## Output Format"
+  else
+    bad "$name orientation is not inside the ## Context body"
+  fi
+
+  # Bound the preamble: count from the marker line to the next top-level list
+  # item, blank line, or heading; that span is the orientation block itself.
+  span="$(awk -v marker="$MARKER" '
+    index($0, marker) { started = 1; count = 1; next }
+    started {
+      if ($0 == "" || $0 ~ /^## / || $0 ~ /^- /) { print count; started = 0; exit }
+      count++
+    }
+    END { if (started) print count }
+  ' "$scan")"
+  if [[ -n "$span" && "$span" -le "$MAX_PREAMBLE_LINES" ]]; then
+    ok "$name orientation block is <= $MAX_PREAMBLE_LINES lines ($span)"
+  else
+    bad "$name orientation block exceeds $MAX_PREAMBLE_LINES lines (got '${span:-0}')"
+  fi
+done
+
+# --- group 2: the /graph skill exists and passes structural bars --------------
+if [[ ! -f "$SKILL" ]]; then
+  bad "graph skill exists at .claude/skills/graph/SKILL.md"
+else
+  ok "graph skill exists at .claude/skills/graph/SKILL.md"
+
+  frontmatter="$(awk 'NR==1 && $0=="---"{f=1;next} f&&$0=="---"{exit} f{print}' "$SKILL")"
+  if [[ -n "$frontmatter" ]]; then ok "skill has a YAML frontmatter block"; else bad "skill has a YAML frontmatter block"; fi
+  if printf '%s\n' "$frontmatter" | grep -qE '^name:[[:space:]]*graph[[:space:]]*$'; then
+    ok "frontmatter name is 'graph'"
+  else
+    bad "frontmatter name is 'graph'"
+  fi
+  # Strip the trailing YAML block-scalar indicator (`>-` / `>`) that keys like
+  # `description: >-` legitimately use before checking for XML angle brackets,
+  # so a real `<tag>` in the content still trips this but the block scalar does
+  # not (skill-craft's rule bans XML in frontmatter, not the block scalar).
+  if printf '%s\n' "$frontmatter" | sed -E 's/:[[:space:]]*>-?[[:space:]]*$//' | grep -qE '[<>]'; then
+    bad "frontmatter has no XML angle brackets"
+  else
+    ok "frontmatter has no XML angle brackets"
+  fi
+
+  check_contains "skill description advertises the /graph trigger" "$SKILL" "/graph"
+  check_contains "skill cross-references flare (do-not-use)" "$SKILL" "flare"
+  check_contains "skill cross-references de-slopify (do-not-use)" "$SKILL" "de-slopify"
+  check_contains "skill links the CLI docs, not duplicates them" "$SKILL" "scripts/graph/README.md"
+  check_contains "skill has an Instructions section" "$SKILL" "## Instructions"
+  check_contains "skill has an Examples section" "$SKILL" "## Examples"
+  check_contains "skill has a Troubleshooting section" "$SKILL" "## Troubleshooting"
+  check_contains "skill documents the pan-graph default" "$SKILL" "pan-graph.json"
+
+  # Accuracy guard: there is no `graphify status` subcommand (only `hook
+  # status`); a prior graph PR was rejected for a false CLI claim. The skill's
+  # status verb must read graph-meta.json, never invoke `graphify status`.
+  check_absent "skill never claims a 'graphify status' subcommand" "$SKILL" "graphify status"
+  check_contains "skill status verb reads graph-meta.json" "$SKILL" "graph-meta.json"
+fi
+
+# --- summary ------------------------------------------------------------------
+echo
+echo "scan-graph-preamble tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #1810

## Summary

G4.2 — graph-first orientation for the scan fleet, plus a first-class `/graph` skill.

1. **13 scan-prompt preambles** — every `prompts/scans/*.md` now opens its `## Context` with a bounded (5–6 line), fail-soft **Graph-first orientation** bullet, domain-tailored per scan (e.g. security starts from router/auth entry points; dead-code starts from low-degree nodes; bugs starts from high-degree hubs with recent churn). Each ends with an explicit graph-absent/stale fallback so scans never hard-depend on the graph. The blocks are intentionally repeated per file because the reusable `_claude-scan.yml` runner feeds each scan a single self-contained prompt.
2. **`.claude/skills/graph/SKILL.md`** — the `/graph` skill: pick `pan-graph.json` when present (else `graph.json`), route questions to `graphify query` / `path` / `explain` / `affected`, answer "status" by reading `graphify-out/graph-meta.json` provenance, cite `source_location`, and hand off to `flare` / `de-slopify` where appropriate. Links `scripts/graph/README.md` rather than duplicating the CLI reference.
3. **`scripts/graph/test_scan_graph_preamble.sh`** — offline guard (66 assertions): marker + fallback present inside `## Context` (between the heading and `## Output Format`), block ≤ 8 lines, and the skill's structural/accuracy bars — including that no doc ever claims a `graphify status` subcommand. Runs under macOS system bash 3.2; shellcheck clean.

## CLI-accuracy verification

A prior graph PR was rejected for a false CLI claim, so every flag in the skill was verified against the installed `graphify --help`:

- `--graph <path>` exists on `query`, `path`, `explain`, `affected` (default `graphify-out/graph.json`)
- `query --budget N` (default 2000), `affected --depth N` (default 2) and `--relation R` — all real
- No graph-level `status` subcommand (only `hook status`); the skill's status verb reads `graph-meta.json`
- SessionStart hook restores only `graph.json` / `graph-meta.json` / `pan-graph.json` (`.claude/hooks/session-start.sh:128-134`); the skill and preambles reference nothing outside that set (the `pan-meta.json` caveat is documented in the skill)

## Gate 2.5 self-review

code-review-orchestrator verdict: FIX_REQUIRED → all findings resolved:

- **HIGH** (unverified CLI flags) — resolved by verifying every flag against the live CLI (above); no wording change needed beyond what was already accurate
- **MEDIUM** — complexity.md no longer points at non-restored `GRAPH_REPORT.md`/wiki; skill Step 3 now notes `pan-meta.json` is manual-restore-only with `graph-meta.json` fallback
- **LOW** — placement assertion tightened to "between `## Context` and `## Output Format`"; `mapfile` replaced with a bash-3.2-portable loop

## Test plan

- [x] `bash scripts/graph/test_scan_graph_preamble.sh` — 66/66 pass (also under `/bin/bash` 3.2)
- [x] `shellcheck scripts/graph/test_scan_graph_preamble.sh` — clean
- [x] `pre-commit` full hook run on commit — passed (incl. commitlint, detect-secrets)
- [x] Docs-only change: no backend/frontend code touched, no runtime surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
