### PR TITLE
feat(journal): photograph capture flow — library photo to transcribed, editable, finished entry

### DIFF
--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -114,6 +114,14 @@ jest.mock('@/features/Journal/JournalEntryScreen', () => {
   const Stub = () => <Text>JournalEntryScreen</Text>;
   return { __esModule: true, default: Stub };
 });
+// RootStack now mounts JournalPhotographScreen as a pushed sibling route; it
+// runs a photo-pick on mount and reads ``navigation`` -- stub it for the same
+// reason as the routes above so this suite stays focused on auth gating.
+jest.mock('@/features/Journal/JournalPhotographScreen', () => {
+  const { Text } = require('react-native');
+  const Stub = () => <Text>JournalPhotographScreen</Text>;
+  return { __esModule: true, default: Stub };
+});
 
 import App, { linking } from '@/App';
 import { useWelcomeStore } from '@/store/useWelcomeStore';

--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -34,6 +34,8 @@ import { accent, ink, radius, SPACING, surface, touchTarget, type } from '@/desi
 
 /** Row that starts a fresh, blank entry. */
 const NEW_ENTRY_LABEL = 'New entry';
+/** Row that opens the photograph-a-page capture flow. */
+const PHOTOGRAPH_LABEL = 'Photograph a page';
 /** Row that fetches and appends the next page of older entries. */
 const LOAD_MORE_LABEL = 'Load older entries';
 /** Fallback label for an entry saved without a title. */
@@ -396,6 +398,8 @@ export interface JournalDrawerProps {
   onRowPress: (_id: number) => void;
   /** Start a fresh, blank entry. */
   onNewEntry: () => void;
+  /** Open the photograph-a-page capture flow. Omitted where the flow is unavailable. */
+  onPhotograph?: () => void;
   /** Fetch and append the next older page. */
   onLoadMore: () => void;
   /** Refetch the first page after a failure. */
@@ -445,6 +449,29 @@ function useDrawerSearch(
   return { bodySearchActive, isSearching, matches, handleQueryChange, handleConfirmDeepSearch };
 }
 
+/** The drawer's top action rows: start a blank entry, and (from the shelf) begin
+ *  a photograph capture. The photograph row appears only when a handler is wired. */
+function DrawerActions({
+  onNewEntry,
+  onPhotograph,
+}: {
+  onNewEntry: () => void;
+  onPhotograph?: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <DrawerItem testID="journal-drawer-new-entry" label={NEW_ENTRY_LABEL} onPress={onNewEntry} />
+      {onPhotograph ? (
+        <DrawerItem
+          testID="journal-photograph-entry"
+          label={PHOTOGRAPH_LABEL}
+          onPress={onPhotograph}
+        />
+      ) : null}
+    </>
+  );
+}
+
 /** The Journal header drawer's contents: New entry, a search field, then the list. */
 export default function JournalDrawer({
   items,
@@ -455,6 +482,7 @@ export default function JournalDrawer({
   currentEntryId,
   onRowPress,
   onNewEntry,
+  onPhotograph,
   onLoadMore,
   onRetry,
   onConfirmBodySearch,
@@ -464,7 +492,7 @@ export default function JournalDrawer({
 
   return (
     <View testID="journal-drawer">
-      <DrawerItem testID="journal-drawer-new-entry" label={NEW_ENTRY_LABEL} onPress={onNewEntry} />
+      <DrawerActions onNewEntry={onNewEntry} onPhotograph={onPhotograph} />
       <DrawerSearchField
         resultCount={isSearching ? matches.length : undefined}
         bodySearchActive={bodySearchActive}
@@ -506,6 +534,8 @@ export interface JournalScreenDrawerProps {
   onSelectEntry: (_id: number) => void;
   /** Start a fresh entry, then close the drawer. */
   onNewEntry: () => void;
+  /** Open the photograph-a-page capture flow. Omitted where it is unavailable. */
+  onPhotograph?: () => void;
 }
 
 /** The Journal header drawer wired to its lazy, cache-above-the-panel entry fetch. */
@@ -514,6 +544,7 @@ export function JournalScreenDrawer({
   currentEntryId,
   onSelectEntry,
   onNewEntry,
+  onPhotograph,
 }: JournalScreenDrawerProps): React.JSX.Element {
   const { items, loading, error, hasMore, loadMore, retry, confirmBodySearch } =
     useJournalDrawerEntries(drawer.isOpen);
@@ -534,6 +565,7 @@ export function JournalScreenDrawer({
         currentEntryId={currentEntryId}
         onRowPress={onSelectEntry}
         onNewEntry={onNewEntry}
+        onPhotograph={onPhotograph}
         onLoadMore={loadMore}
         onRetry={retry}
         onConfirmBodySearch={confirmBodySearch}

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -96,11 +96,17 @@ export type JournalEntryScreenProps = NativeStackScreenProps<RootStackParamList,
   autosaveDelayMs?: number;
 };
 
+/** The "Saved" confirmation, shared by the edit-mode autosave hint and the
+ *  read-mode photograph-capture handoff so both read identically. */
+const SAVED_HINT = 'Saved';
+/** A blank hint line that reserves the row's height without showing any text. */
+const BLANK_HINT = ' ';
+
 function savedHintLabel(state: SaveState): string {
   if (state === 'saving') return 'Saving…';
-  if (state === 'saved') return 'Saved';
+  if (state === 'saved') return SAVED_HINT;
   if (state === 'error') return "Couldn't save — keep writing, we'll retry";
-  return ' ';
+  return BLANK_HINT;
 }
 
 /**
@@ -1318,12 +1324,42 @@ function QuotePromotionFeedback({ quote }: { quote: QuotePromotion }): React.JSX
   return null;
 }
 
+/** The read-mode passage tree: highlighted body plus the promote-lifecycle notice. */
+function ReadBodyContent({
+  body,
+  notes,
+  quote,
+  onOpen,
+}: {
+  body: string;
+  notes: Marginalia[];
+  quote: QuotePromotion;
+  onOpen: (_note: Marginalia) => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <HighlightedBody
+        body={body}
+        notes={notes}
+        onOpen={onOpen}
+        quotes={quote.quotes}
+        onQuotePress={quote.onQuotePress}
+        removeTargetId={quote.removeTargetId}
+        onConfirmRemove={quote.confirmRemove}
+        onDismissRemove={quote.dismissRemove}
+      />
+      <QuotePromotionFeedback quote={quote} />
+    </>
+  );
+}
+
 /** Read-mode body: the title + the highlighted passage tree + an Edit affordance. */
 function ReadColumn({
   title,
   body,
   notes,
   quote,
+  justSaved,
   onOpen,
   onEdit,
 }: {
@@ -1331,6 +1367,8 @@ function ReadColumn({
   body: string;
   notes: Marginalia[];
   quote: QuotePromotion;
+  /** True when this entry was just saved from photograph capture; shows "Saved". */
+  justSaved: boolean;
   onOpen: (_note: Marginalia) => void;
   onEdit: () => void;
 }) {
@@ -1350,20 +1388,11 @@ function ReadColumn({
           onCancel={quote.cancelSelecting}
         />
       ) : (
-        <>
-          <HighlightedBody
-            body={body}
-            notes={notes}
-            onOpen={onOpen}
-            quotes={quote.quotes}
-            onQuotePress={quote.onQuotePress}
-            removeTargetId={quote.removeTargetId}
-            onConfirmRemove={quote.confirmRemove}
-            onDismissRemove={quote.dismissRemove}
-          />
-          <QuotePromotionFeedback quote={quote} />
-        </>
+        <ReadBodyContent body={body} notes={notes} quote={quote} onOpen={onOpen} />
       )}
+      <Text style={styles.savedHint} testID="journal-save-hint">
+        {justSaved ? SAVED_HINT : BLANK_HINT}
+      </Text>
       {quote.selecting ? null : <ReadModeControls quote={quote} onEdit={onEdit} />}
     </ScrollView>
   );
@@ -1644,6 +1673,7 @@ function useJournalEntryController(
   navigation: ScreenNavigation,
   ctx: SaveContext,
   initialText: InitialText,
+  justSaved: boolean,
 ) {
   const { refreshRef, handleSaved, onConfirmEdit } = useRefreshAfterEdit();
   const onCreateConflict = useCreateConflictHandler(ctx, navigation);
@@ -1664,7 +1694,9 @@ function useJournalEntryController(
   const editGate = useEntryEditGate(autosave, navigation, onConfirmEdit);
   const { handleTitle, handleBody } = useBumpedHandlers(bump, autosave);
   const gate = deriveResonanceGate({
-    isIdle,
+    // A photograph-capture handoff (justSaved) offers resonance immediately,
+    // without waiting for the usual post-typing idle pause.
+    isIdle: isIdle || justSaved,
     isLoading: resonance.loading,
     body: autosave.body,
     classification: autosave.classification,
@@ -1682,6 +1714,7 @@ function useJournalEntryController(
     handleBody,
     modal,
     editGate,
+    justSaved,
     // Weekly-prompt compose withholds Finish (no local id); title stays editable.
     isPromptCompose: ctx.weekNumber != null,
   };
@@ -1726,6 +1759,7 @@ function PageBodyColumn({ ctl, bodyPlaceholder }: { ctl: Controller; bodyPlaceho
       body={body}
       notes={ctl.resonance.marginalia}
       quote={ctl.quote}
+      justSaved={ctl.justSaved}
       onOpen={ctl.modal.onOpenNote}
       onEdit={requestEdit}
     />
@@ -1980,6 +2014,48 @@ function EntryOverlays({
   );
 }
 
+/** The privacy-tier reason line paired with the floating resonance affordance. */
+function ResonanceControls({
+  visible,
+  disabled,
+  loading,
+  reason,
+  onPress,
+}: {
+  visible: boolean;
+  disabled: boolean;
+  loading: boolean;
+  reason: string;
+  onPress: () => Promise<void>;
+}): React.JSX.Element {
+  return (
+    <>
+      <PrivacyResonanceReason visible={visible && disabled} reason={reason} />
+      <GetResonanceButton
+        visible={visible}
+        loading={loading}
+        disabled={disabled}
+        onPress={onPress}
+      />
+    </>
+  );
+}
+
+/**
+ * The two screen-level care siblings rendered ABOVE the page (NORTH-STAR §10):
+ * the acute-distress support surface first, then the warmer foundation reflection,
+ * so a distress signal always reads before the gentler nudge. Both are siblings of
+ * the page — never nested in the margin column — and hide on a healthy pass.
+ */
+function EntryCareSurfaces({ ctl }: { ctl: Controller }): React.JSX.Element {
+  return (
+    <>
+      <CareSupportNote care={ctl.resonance.care} />
+      <ContractionReflectionNote contraction={ctl.resonance.contraction} />
+    </>
+  );
+}
+
 function JournalEntryScreen({
   route,
   navigation,
@@ -1987,6 +2063,7 @@ function JournalEntryScreen({
 }: JournalEntryScreenProps): React.JSX.Element {
   const { ctx, initialText, bodyPlaceholder } = readEntrypoint(route.params);
   const currentEntryId = route.params?.entryId ?? null;
+  const justSaved = route.params?.justSaved ?? false;
   const entryDrawer = useEntryScreenDrawer(navigation);
   const ctl = useJournalEntryController(
     currentEntryId,
@@ -1994,17 +2071,11 @@ function JournalEntryScreen({
     navigation,
     ctx,
     initialText,
+    justSaved,
   );
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">
-      {/* Screen-level care surface (NORTH-STAR §10): a sibling ABOVE the page,
-          never nested in the margin column — so on an acute-distress signal the
-          human + professional support reads as the page's own, not a margin note. */}
-      <CareSupportNote care={ctl.resonance.care} />
-      {/* Foundation reflection: a warm, declinable "tend your foundation"
-          sibling rendered AFTER the care surface so an acute-distress signal
-          always reads first. Hidden (renders nothing) on healthy passes. */}
-      <ContractionReflectionNote contraction={ctl.resonance.contraction} />
+      <EntryCareSurfaces ctl={ctl} />
       <LoadErrorBanner message={ctl.autosave.loadError} />
       <ReturnToReadingLink
         returnTo={route.params?.returnTo}
@@ -2013,14 +2084,11 @@ function JournalEntryScreen({
       />
       <JournalPage ctl={ctl} bodyPlaceholder={bodyPlaceholder} />
       <ReflectionComposer reflection={ctl.reflection} />
-      <PrivacyResonanceReason
-        visible={ctl.visible && ctl.resonanceDisabled}
-        reason={ctl.resonanceReason}
-      />
-      <GetResonanceButton
+      <ResonanceControls
         visible={ctl.visible}
-        loading={ctl.resonance.loading}
         disabled={ctl.resonanceDisabled}
+        loading={ctl.resonance.loading}
+        reason={ctl.resonanceReason}
         onPress={ctl.resonance.requestResonance}
       />
       <EntryOverlays

--- a/frontend/src/features/Journal/JournalPhotograph.styles.ts
+++ b/frontend/src/features/Journal/JournalPhotograph.styles.ts
@@ -1,0 +1,57 @@
+/**
+ * Styles for the Journal photograph-capture screen — the editorial "paper" idiom
+ * shared with the writing surface (warm paper ground, serif body). Tokens only.
+ */
+import { StyleSheet } from 'react-native';
+
+import { BORDER_RADIUS, SPACING, colors, editorialType, spacing } from '@/design/tokens';
+
+/** Minimum height for the editable preview so a short transcription still reads
+ *  as a full page rather than a cramped single-line field. */
+const PREVIEW_MIN_HEIGHT = spacing(30);
+
+const styles = StyleSheet.create({
+  /** Vertical stack for a phase's copy + affordances, with editorial breathing room. */
+  container: {
+    flex: 1,
+    gap: SPACING.md,
+  },
+  heading: {
+    ...editorialType.title,
+    color: colors.paper.ink,
+  },
+  message: {
+    ...editorialType.body,
+    color: colors.paper.inkSoft,
+  },
+  /** The quiet "reading your page" block shown while transcription is in flight. */
+  fillingBlock: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: SPACING.sm,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+    backgroundColor: colors.paper.background,
+  },
+  /** The editable transcription preview: a growing, top-aligned paper field. */
+  previewInput: {
+    flexGrow: 1,
+    minHeight: PREVIEW_MIN_HEIGHT,
+    ...editorialType.body,
+    color: colors.paper.ink,
+    backgroundColor: colors.paper.background,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+    padding: SPACING.md,
+    textAlignVertical: 'top',
+  },
+  /** Stacked action buttons under a phase's copy. */
+  actions: {
+    gap: SPACING.sm,
+  },
+});
+
+export default styles;

--- a/frontend/src/features/Journal/JournalPhotographScreen.tsx
+++ b/frontend/src/features/Journal/JournalPhotographScreen.tsx
@@ -1,0 +1,470 @@
+/**
+ * Photograph a handwritten journal page, transcribe it, and save it as a finished
+ * entry. The flow auto-launches the photo picker on mount, sends the picked image
+ * to the transcription endpoint, then offers the writer an editable preview of the
+ * text before it becomes a real entry.
+ *
+ * Every step is warm and declinable (NORTH-STAR): a refused permission, a cancelled
+ * pick, an unreadable photo, or a spent transcription wallet each lead to a plain,
+ * shame-free offramp — most often "type this entry instead" — never a dead end.
+ *
+ * PRIVACY: the base64 page image lives in component state only. It is never placed
+ * in navigation params or logged, and is released on save and on unmount.
+ */
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Linking, Text, TextInput, View } from 'react-native';
+
+import styles from './JournalPhotograph.styles';
+import { pickJournalPhoto } from './pickJournalPhoto';
+import { saveFinishedEntry } from './saveFinishedEntry';
+
+import { TranscriptionError, journal } from '@/api';
+import type { MediaType, TranscriptionErrorKind } from '@/api';
+import { formatApiError } from '@/api/errorMessages';
+import { Button } from '@/components/Button';
+import { ScreenScaffold } from '@/components/layout/ScreenScaffold';
+import { accent } from '@/design/tokens';
+import type { RootStackParamList } from '@/navigation/RootStack';
+
+// --- Copy (warm, declinable — NORTH-STAR) ---------------------------------
+
+const PERMISSION_DENIED_COPY =
+  'Adepthood needs permission to open your photos so it can read a page. You can turn that on in Settings, or come back anytime.';
+const OPEN_SETTINGS_LABEL = 'Open Settings';
+const CANCEL_LABEL = 'Not now';
+const PREPARING_COPY = 'Opening your photos…';
+const TRANSCRIBING_COPY = 'Reading your page…';
+const PICK_FAILED_COPY =
+  "We couldn't read that photo. Pick another one and we'll try again — no rush.";
+const PICK_ANOTHER_LABEL = 'Pick another photo';
+const RETRY_LABEL = 'Try again';
+const TYPED_ENTRY_LABEL = 'Type this entry instead';
+const SAVE_LABEL = 'Save this page';
+const RETRY_SAVE_LABEL = 'Try saving again';
+const PREVIEW_HEADING = 'Your page';
+const PREVIEW_INPUT_A11Y = 'Edit the transcribed text of your page';
+
+/** Friendly terminal copy when the configured model cannot read images at all. */
+const MODEL_LACKS_VISION_COPY =
+  "Reading photos isn't available with the configured AI model. You can still write this page by hand.";
+
+/** Per-kind copy for a recoverable transcription failure (wallet copy is sourced
+ *  from the shared 402 message instead, so it stays a single source of truth). */
+const TRANSCRIBE_ERROR_COPY: Readonly<Record<TranscriptionErrorKind, string>> = {
+  provider_error: 'The transcription helper had trouble just now. Give it a moment and try again.',
+  network: "We couldn't reach the transcription helper. Check your connection and try again.",
+  timeout: "That took longer than expected. Try again whenever you're ready.",
+  rate_limited: 'The transcription helper is catching its breath. Try again in a moment.',
+  invalid_image: "We couldn't quite read that page. Try another photo with clearer handwriting.",
+  image_too_large: 'That photo is a little large to read. Try another, or a lower-resolution shot.',
+  wallet_exhausted: '',
+  model_lacks_vision: MODEL_LACKS_VISION_COPY,
+  unknown: "Something didn't work while reading your page. Try again, or type this entry instead.",
+};
+
+/** Kinds a fresh transcription attempt might clear — offer a single retry tap. */
+const RETRY_KINDS: ReadonlySet<TranscriptionErrorKind> = new Set<TranscriptionErrorKind>([
+  'provider_error',
+  'network',
+  'timeout',
+  'rate_limited',
+  'unknown',
+]);
+/** Kinds where the photo itself is the problem — offer a different photo. */
+const PICK_ANOTHER_KINDS: ReadonlySet<TranscriptionErrorKind> = new Set<TranscriptionErrorKind>([
+  'invalid_image',
+  'image_too_large',
+]);
+/** Kinds with no photo path forward — offer the typed-entry offramp. */
+const TYPED_ENTRY_KINDS: ReadonlySet<TranscriptionErrorKind> = new Set<TranscriptionErrorKind>([
+  'unknown',
+  'wallet_exhausted',
+  'model_lacks_vision',
+]);
+
+/** The picked page held in memory for transcription (never in nav params). */
+interface PickedImage {
+  imageBase64: string;
+  mediaType: MediaType;
+}
+
+/** The screen's mutually-exclusive phases. */
+type Phase =
+  | { step: 'preparing' }
+  | { step: 'denied' }
+  | { step: 'pickFailed' }
+  | { step: 'transcribing' }
+  | { step: 'preview' }
+  | { step: 'error'; error: TranscriptionError };
+
+/** The recovery affordances a given transcription error offers. */
+interface Recovery {
+  message: string;
+  showRetry: boolean;
+  showPickAnother: boolean;
+  showTypedEntry: boolean;
+}
+
+/** Derive a failure's message + which offramps to show, from its stable kind. */
+function recoveryFor(error: TranscriptionError): Recovery {
+  const { kind } = error;
+  const message = kind === 'wallet_exhausted' ? formatApiError(error) : TRANSCRIBE_ERROR_COPY[kind];
+  return {
+    message,
+    showRetry: RETRY_KINDS.has(kind),
+    showPickAnother: PICK_ANOTHER_KINDS.has(kind),
+    showTypedEntry: TYPED_ENTRY_KINDS.has(kind),
+  };
+}
+
+/** Coerce any thrown value into a {@link TranscriptionError} (the API already
+ *  throws these; this guards the unforeseen so `.kind` is always readable). */
+function asTranscriptionError(err: unknown): TranscriptionError {
+  return err instanceof TranscriptionError ? err : new TranscriptionError('unknown', null, err);
+}
+
+type PhotographNavigation = NativeStackScreenProps<
+  RootStackParamList,
+  'JournalPhotograph'
+>['navigation'];
+
+interface CaptureModel {
+  phase: Phase;
+  previewText: string;
+  saving: boolean;
+  saveFailed: boolean;
+  onChangeText: (_text: string) => void;
+  runPick: () => void;
+  retryTranscribe: () => void;
+  save: () => void;
+  openSettings: () => void;
+  cancel: () => void;
+  goTypedEntry: () => void;
+}
+
+/** Pick a page image and transcribe it into an editable preview, stashing the
+ *  picked image in ``imageRef`` so it never rides in nav params. */
+function usePickAndTranscribe(
+  navigation: PhotographNavigation,
+  setPhase: (_phase: Phase) => void,
+  setPreviewText: (_text: string) => void,
+  imageRef: React.MutableRefObject<PickedImage | null>,
+): { runPick: () => Promise<void>; transcribe: () => Promise<void> } {
+  const transcribe = useCallback(async () => {
+    const image = imageRef.current;
+    if (image == null) return;
+    setPhase({ step: 'transcribing' });
+    try {
+      const { text } = await journal.transcribePage(image);
+      setPreviewText(text);
+      setPhase({ step: 'preview' });
+    } catch (err: unknown) {
+      setPhase({ step: 'error', error: asTranscriptionError(err) });
+    }
+  }, [imageRef, setPhase, setPreviewText]);
+
+  const runPick = useCallback(async () => {
+    setPhase({ step: 'preparing' });
+    const result = await pickJournalPhoto();
+    if (result.kind === 'denied') {
+      setPhase({ step: 'denied' });
+      return;
+    }
+    if (result.kind === 'cancelled') {
+      navigation.goBack();
+      return;
+    }
+    if (result.kind === 'failed') {
+      setPhase({ step: 'pickFailed' });
+      return;
+    }
+    imageRef.current = { imageBase64: result.imageBase64, mediaType: result.mediaType };
+    await transcribe();
+  }, [navigation, transcribe, imageRef, setPhase]);
+
+  return { runPick, transcribe };
+}
+
+/** Persist the edited transcript. Reuses ``createdIdRef`` across save retries so a
+ *  retry after a failed finish PATCH updates the created page rather than duplicating it. */
+function useSaveEntry(
+  navigation: PhotographNavigation,
+  previewText: string,
+  imageRef: React.MutableRefObject<PickedImage | null>,
+  createdIdRef: React.MutableRefObject<number | null>,
+): { save: () => Promise<void>; saving: boolean; saveFailed: boolean } {
+  const [saving, setSaving] = useState(false);
+  const [saveFailed, setSaveFailed] = useState(false);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setSaveFailed(false);
+    try {
+      const id = await saveFinishedEntry(previewText, createdIdRef.current, (created) => {
+        createdIdRef.current = created;
+      });
+      imageRef.current = null; // Release the page image the moment it is saved.
+      navigation.replace('JournalEntry', { entryId: id, justSaved: true });
+    } catch {
+      setSaveFailed(true);
+    } finally {
+      setSaving(false);
+    }
+  }, [previewText, navigation, imageRef, createdIdRef]);
+
+  return { save, saving, saveFailed };
+}
+
+/**
+ * The capture state machine: pick → transcribe → editable preview → save. Holds
+ * the picked image and the created-entry id in refs so neither survives in nav
+ * params, and so a save retry after a failed finish PATCH reuses the created id
+ * rather than creating a duplicate page.
+ */
+function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
+  const [phase, setPhase] = useState<Phase>({ step: 'preparing' });
+  const [previewText, setPreviewText] = useState('');
+  const imageRef = useRef<PickedImage | null>(null);
+  const createdIdRef = useRef<number | null>(null);
+
+  const { runPick, transcribe } = usePickAndTranscribe(
+    navigation,
+    setPhase,
+    setPreviewText,
+    imageRef,
+  );
+  const { save, saving, saveFailed } = useSaveEntry(
+    navigation,
+    previewText,
+    imageRef,
+    createdIdRef,
+  );
+
+  const openSettings = useCallback(() => void Linking.openSettings(), []);
+  const cancel = useCallback(() => navigation.goBack(), [navigation]);
+  const goTypedEntry = useCallback(() => {
+    imageRef.current = null; // Release the page image when stepping off to a typed entry.
+    navigation.navigate('JournalEntry');
+  }, [navigation, imageRef]);
+
+  useEffect(() => {
+    void runPick();
+    // The device-local cache file the picker copies is cleaned up by a later epic
+    // issue; here we only release our in-memory hold on unmount.
+    return () => {
+      imageRef.current = null;
+    };
+  }, [runPick]);
+
+  return {
+    phase,
+    previewText,
+    saving,
+    saveFailed,
+    onChangeText: setPreviewText,
+    runPick: () => void runPick(),
+    retryTranscribe: () => void transcribe(),
+    save: () => void save(),
+    openSettings,
+    cancel,
+    goTypedEntry,
+  };
+}
+
+// --- Views ----------------------------------------------------------------
+
+/** A quiet, centred "we're working" block with a spinner and a caption. */
+function WorkingBlock({ testID, caption }: { testID: string; caption: string }): React.JSX.Element {
+  return (
+    <View testID={testID} style={styles.fillingBlock} accessibilityRole="progressbar">
+      <ActivityIndicator size="small" color={accent.primary} />
+      <Text style={styles.message}>{caption}</Text>
+    </View>
+  );
+}
+
+/** Permission-refused view: open Settings, or step away without pressure. */
+function PermissionDeniedView({
+  onOpenSettings,
+  onCancel,
+}: {
+  onOpenSettings: () => void;
+  onCancel: () => void;
+}): React.JSX.Element {
+  return (
+    <View testID="photograph-permission-denied" style={styles.container}>
+      <Text style={styles.message}>{PERMISSION_DENIED_COPY}</Text>
+      <View style={styles.actions}>
+        <Button
+          testID="photograph-open-settings"
+          label={OPEN_SETTINGS_LABEL}
+          accessibilityLabel={OPEN_SETTINGS_LABEL}
+          onPress={onOpenSettings}
+        />
+        <Button
+          testID="photograph-cancel"
+          variant="tertiary"
+          label={CANCEL_LABEL}
+          accessibilityLabel={CANCEL_LABEL}
+          onPress={onCancel}
+        />
+      </View>
+    </View>
+  );
+}
+
+/** The pick itself failed (no usable image): only a different photo helps. */
+function PickFailedView({ onPickAnother }: { onPickAnother: () => void }): React.JSX.Element {
+  return (
+    <View testID="photograph-error" style={styles.container}>
+      <Text style={styles.message}>{PICK_FAILED_COPY}</Text>
+      <Button
+        testID="photograph-pick-another"
+        label={PICK_ANOTHER_LABEL}
+        accessibilityLabel={PICK_ANOTHER_LABEL}
+        onPress={onPickAnother}
+      />
+    </View>
+  );
+}
+
+/** A transcription failure with its per-kind recovery offramps. */
+function TranscribeErrorView({
+  recovery,
+  onRetry,
+  onPickAnother,
+  onTypedEntry,
+}: {
+  recovery: Recovery;
+  onRetry: () => void;
+  onPickAnother: () => void;
+  onTypedEntry: () => void;
+}): React.JSX.Element {
+  return (
+    <View testID="photograph-error" style={styles.container}>
+      <Text style={styles.message}>{recovery.message}</Text>
+      <View style={styles.actions}>
+        {recovery.showRetry ? (
+          <Button
+            testID="photograph-retry"
+            label={RETRY_LABEL}
+            accessibilityLabel={RETRY_LABEL}
+            onPress={onRetry}
+          />
+        ) : null}
+        {recovery.showPickAnother ? (
+          <Button
+            testID="photograph-pick-another"
+            label={PICK_ANOTHER_LABEL}
+            accessibilityLabel={PICK_ANOTHER_LABEL}
+            onPress={onPickAnother}
+          />
+        ) : null}
+        {recovery.showTypedEntry ? (
+          <Button
+            testID="photograph-typed-entry"
+            variant="tertiary"
+            label={TYPED_ENTRY_LABEL}
+            accessibilityLabel={TYPED_ENTRY_LABEL}
+            onPress={onTypedEntry}
+          />
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+/** The editable transcription preview + Save (and a retry when a save fails). */
+function PreviewView({
+  value,
+  onChangeText,
+  onSave,
+  saving,
+  saveFailed,
+}: {
+  value: string;
+  onChangeText: (_text: string) => void;
+  onSave: () => void;
+  saving: boolean;
+  saveFailed: boolean;
+}): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>{PREVIEW_HEADING}</Text>
+      <TextInput
+        testID="photograph-preview-input"
+        style={styles.previewInput}
+        value={value}
+        onChangeText={onChangeText}
+        multiline
+        accessibilityLabel={PREVIEW_INPUT_A11Y}
+      />
+      <View style={styles.actions}>
+        <Button
+          testID="photograph-save"
+          label={SAVE_LABEL}
+          accessibilityLabel={SAVE_LABEL}
+          busy={saving}
+          onPress={onSave}
+        />
+        {saveFailed ? (
+          <Button
+            testID="photograph-retry-save"
+            variant="secondary"
+            label={RETRY_SAVE_LABEL}
+            accessibilityLabel={RETRY_SAVE_LABEL}
+            busy={saving}
+            onPress={onSave}
+          />
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+/** Route the current phase to its view. */
+function CaptureBody({ model }: { model: CaptureModel }): React.JSX.Element {
+  const { phase } = model;
+  switch (phase.step) {
+    case 'denied':
+      return <PermissionDeniedView onOpenSettings={model.openSettings} onCancel={model.cancel} />;
+    case 'pickFailed':
+      return <PickFailedView onPickAnother={model.runPick} />;
+    case 'transcribing':
+      return <WorkingBlock testID="photograph-transcribing" caption={TRANSCRIBING_COPY} />;
+    case 'preview':
+      return (
+        <PreviewView
+          value={model.previewText}
+          onChangeText={model.onChangeText}
+          onSave={model.save}
+          saving={model.saving}
+          saveFailed={model.saveFailed}
+        />
+      );
+    case 'error':
+      return (
+        <TranscribeErrorView
+          recovery={recoveryFor(phase.error)}
+          onRetry={model.retryTranscribe}
+          onPickAnother={model.runPick}
+          onTypedEntry={model.goTypedEntry}
+        />
+      );
+    default:
+      return <WorkingBlock testID="photograph-preparing" caption={PREPARING_COPY} />;
+  }
+}
+
+/** The photograph-capture route: pick a page, transcribe it, then save it. */
+export default function JournalPhotographScreen({
+  navigation,
+}: NativeStackScreenProps<RootStackParamList, 'JournalPhotograph'>): React.JSX.Element {
+  const model = usePhotographCapture(navigation);
+  return (
+    <ScreenScaffold testID="journal-photograph">
+      <CaptureBody model={model} />
+    </ScreenScaffold>
+  );
+}

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -321,6 +321,7 @@ function ShelfTopMatter({
 interface ShelfNav {
   openEntry: (_id: number) => void;
   newEntry: () => void;
+  openPhotograph: () => void;
   openPrompt: () => void;
   openWithPrompt: () => void;
 }
@@ -336,6 +337,7 @@ function useShelfNavigation(
     [navigation],
   );
   const newEntry = useCallback(() => navigation.navigate('JournalEntry'), [navigation]);
+  const openPhotograph = useCallback(() => navigation.navigate('JournalPhotograph'), [navigation]);
   const openWithPrompt = useCallback(
     () => navigation.navigate('JournalEntry', { promptQuestion: FIRST_PROMPT }),
     [navigation],
@@ -348,7 +350,7 @@ function useShelfNavigation(
       prefillTitle: promptTitleForWeek(week),
     });
   }, [navigation, prompt, week]);
-  return { openEntry, newEntry, openPrompt, openWithPrompt };
+  return { openEntry, newEntry, openPhotograph, openPrompt, openWithPrompt };
 }
 
 function renderSectionHeader({
@@ -363,6 +365,7 @@ interface ShelfDrawer {
   drawer: ReturnType<typeof useScreenDrawer>;
   onSelectEntry: (_id: number) => void;
   onNewEntry: () => void;
+  onPhotograph: () => void;
 }
 
 /** The header drawer's open state plus its open-then-close row callbacks. From
@@ -380,7 +383,11 @@ function useShelfDrawer(nav: ShelfNav): ShelfDrawer {
     nav.newEntry();
     drawer.close();
   }, [nav, drawer]);
-  return { drawer, onSelectEntry, onNewEntry };
+  const onPhotograph = useCallback(() => {
+    nav.openPhotograph();
+    drawer.close();
+  }, [nav, drawer]);
+  return { drawer, onSelectEntry, onNewEntry, onPhotograph };
 }
 
 interface ShelfBodyProps {
@@ -456,6 +463,7 @@ function JournalShelfScreen(): React.JSX.Element {
         drawer={shelfDrawer.drawer}
         onSelectEntry={shelfDrawer.onSelectEntry}
         onNewEntry={shelfDrawer.onNewEntry}
+        onPhotograph={shelfDrawer.onPhotograph}
       />
     </ScreenScaffold>
   );

--- a/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
@@ -62,6 +62,7 @@ interface DrawerHarness {
   currentEntryId?: number | null;
   onRowPress?: (_id: number) => void;
   onNewEntry?: () => void;
+  onPhotograph?: () => void;
 }
 
 function renderDrawer(props: Partial<DrawerHarness> = {}) {
@@ -80,6 +81,7 @@ function renderDrawer(props: Partial<DrawerHarness> = {}) {
       currentEntryId={props.currentEntryId}
       onRowPress={onRowPress}
       onNewEntry={onNewEntry}
+      onPhotograph={props.onPhotograph}
       onLoadMore={onLoadMore}
       onRetry={onRetry}
       onConfirmBodySearch={onConfirmBodySearch}
@@ -216,6 +218,24 @@ describe('JournalDrawer (presentational)', () => {
     const { getByTestId, onRetry } = renderDrawer({ items: [], error: true });
     fireEvent.press(getByTestId('journal-drawer-retry'));
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the Photograph row when onPhotograph is absent', () => {
+    const { queryByTestId } = renderDrawer({ items: [] });
+    expect(queryByTestId('journal-photograph-entry')).toBeNull();
+  });
+
+  it('renders a Photograph row beside New entry when onPhotograph is provided', () => {
+    const onPhotograph = jest.fn();
+    const { getByTestId } = renderDrawer({ items: [], onPhotograph });
+    expect(getByTestId('journal-photograph-entry')).toBeTruthy();
+  });
+
+  it('fires onPhotograph when the Photograph row is pressed', () => {
+    const onPhotograph = jest.fn();
+    const { getByTestId } = renderDrawer({ items: [], onPhotograph });
+    fireEvent.press(getByTestId('journal-photograph-entry'));
+    expect(onPhotograph).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenJustSaved.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenJustSaved.test.tsx
@@ -1,0 +1,102 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import type { JournalMessage } from '@/api';
+
+/**
+ * The photograph-capture handoff: JournalEntryScreen opened with
+ * ``{ entryId, justSaved: true }`` after JournalPhotographScreen finishes a
+ * page. A finished, personal entry loaded this way must read as "Saved" and
+ * offer resonance immediately, without the usual idle-after-typing wait.
+ */
+const mockGet = jest.fn() as jest.MockedFunction<(_id: number) => Promise<JournalMessage>>;
+const mockList = jest.fn() as jest.MockedFunction<(_id: number) => Promise<{ items: unknown[] }>>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    get: (...a: unknown[]) => (mockGet as unknown as (...x: unknown[]) => unknown)(...a),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  prompts: {
+    respond: jest.fn(),
+  },
+  resonance: {
+    list: (...a: unknown[]) => (mockList as unknown as (...x: unknown[]) => unknown)(...a),
+    generate: jest.fn(),
+  },
+  completionSuggestions: {
+    list: jest.fn(() => Promise.resolve({ items: [] })),
+    accept: jest.fn(),
+    dismiss: jest.fn(),
+  },
+  promotions: {
+    create: jest.fn(),
+    remove: jest.fn(),
+    setIncluded: jest.fn(),
+    list: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+jest.mock('@/navigation/hooks', () => ({
+  ...(jest.requireActual('@/navigation/hooks') as Record<string, unknown>),
+  useAppNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn() }),
+}));
+
+const JournalEntryScreen = require('../JournalEntryScreen').default;
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 7,
+    message: 'A finished page about the river.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    title: 'Rivers',
+    status: 'finished',
+    classification: 'personal',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderScreen(params: { entryId: number; justSaved?: boolean }) {
+  const route = { key: 'k', name: 'JournalEntry' as const, params };
+  const navigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+  const Screen = JournalEntryScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return { ...render(<Screen navigation={navigation} route={route} />), navigation };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockList.mockReset();
+  mockList.mockResolvedValue({ items: [] });
+});
+
+describe('JournalEntryScreen — justSaved (photograph capture handoff)', () => {
+  it('shows the "Saved" hint once a finished personal entry loads with justSaved', async () => {
+    mockGet.mockResolvedValue(entry());
+    const { getByTestId, queryByTestId } = renderScreen({ entryId: 7, justSaved: true });
+    await waitFor(() => expect(queryByTestId('journal-edit-button')).not.toBeNull());
+    expect(getByTestId('journal-save-hint').props.children).toBe('Saved');
+  });
+
+  it('shows the resonance button visible and enabled for the same load', async () => {
+    mockGet.mockResolvedValue(entry());
+    const { getByTestId, queryByTestId } = renderScreen({ entryId: 7, justSaved: true });
+    await waitFor(() => expect(queryByTestId('journal-edit-button')).not.toBeNull());
+    const btn = getByTestId('get-resonance-button');
+    expect(btn.props.accessibilityState.disabled).toBe(false);
+  });
+
+  it('does not force the "Saved" hint when justSaved is absent (control)', async () => {
+    mockGet.mockResolvedValue(entry());
+    const { getByTestId, queryByTestId } = renderScreen({ entryId: 7 });
+    await waitFor(() => expect(queryByTestId('journal-edit-button')).not.toBeNull());
+    expect(getByTestId('journal-save-hint').props.children).not.toBe('Saved');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
@@ -1,0 +1,375 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Linking } from 'react-native';
+
+import type { PickResult } from '../pickJournalPhoto';
+
+import { TranscriptionError } from '@/api';
+import type { JournalMessage, MediaType, TranscribePageT, TranscriptionErrorKind } from '@/api';
+
+const mockPick = jest.fn() as jest.MockedFunction<() => Promise<PickResult>>;
+const mockTranscribe = jest.fn() as jest.MockedFunction<
+  (_p: { imageBase64: string; mediaType: MediaType }) => Promise<TranscribePageT>
+>;
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+jest.mock(
+  '../pickJournalPhoto',
+  () => ({
+    pickJournalPhoto: (...a: unknown[]) =>
+      (mockPick as unknown as (...x: unknown[]) => unknown)(...a),
+  }),
+  { virtual: true },
+);
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api') as Record<string, unknown>;
+  return {
+    ...actual,
+    journal: {
+      ...(actual.journal as Record<string, unknown>),
+      transcribePage: (...a: unknown[]) =>
+        (mockTranscribe as unknown as (...x: unknown[]) => unknown)(...a),
+      create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+      update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+    },
+  };
+});
+
+const JournalPhotographScreen = require('../JournalPhotographScreen').default;
+
+function picked(overrides: Partial<Extract<PickResult, { kind: 'picked' }>> = {}): PickResult {
+  return { kind: 'picked', imageBase64: 'abc123', mediaType: 'image/jpeg', ...overrides };
+}
+
+function makeEntry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 1,
+    message: 'x',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    status: 'draft',
+    ...overrides,
+  };
+}
+
+function renderScreen() {
+  const route = { key: 'k', name: 'JournalPhotograph' as const, params: undefined };
+  const navigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    replace: jest.fn(),
+    push: jest.fn(),
+  };
+  const Screen = JournalPhotographScreen as unknown as React.ComponentType<Record<string, unknown>>;
+  return { ...render(<Screen navigation={navigation} route={route} />), navigation };
+}
+
+beforeEach(() => {
+  mockPick.mockReset();
+  mockTranscribe.mockReset();
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+});
+
+describe('JournalPhotographScreen — auto-launch', () => {
+  it('launches the photo picker automatically on mount', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
+    renderScreen();
+    await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('JournalPhotographScreen — permission denied', () => {
+  it('shows the permission-denied view', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'denied' });
+    const { findByTestId } = renderScreen();
+    expect(await findByTestId('photograph-permission-denied')).toBeTruthy();
+  });
+
+  it('opens device settings from Open Settings', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'denied' });
+    const openSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
+    const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('photograph-open-settings'));
+    expect(openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('goes back from Cancel without opening settings', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'denied' });
+    const openSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
+    const { findByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('photograph-cancel'));
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+    expect(openSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('JournalPhotographScreen — cancelled pick', () => {
+  it('goes back immediately with no lingering UI', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
+    const { navigation, queryByTestId } = renderScreen();
+    await waitFor(() => expect(navigation.goBack).toHaveBeenCalledTimes(1));
+    expect(queryByTestId('photograph-transcribing')).toBeNull();
+    expect(queryByTestId('photograph-error')).toBeNull();
+    expect(queryByTestId('photograph-permission-denied')).toBeNull();
+  });
+});
+
+describe('JournalPhotographScreen — pick itself failed', () => {
+  it('shows the error container with Pick another, no retry', async () => {
+    mockPick.mockResolvedValueOnce({ kind: 'failed' });
+    const { findByTestId, queryByTestId } = renderScreen();
+    expect(await findByTestId('photograph-error')).toBeTruthy();
+    expect(await findByTestId('photograph-pick-another')).toBeTruthy();
+    expect(queryByTestId('photograph-retry')).toBeNull();
+  });
+});
+
+describe('JournalPhotographScreen — transcribing', () => {
+  it('shows the transcribing state while the request is in flight', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    let resolveTranscribe!: (_v: TranscribePageT) => void;
+    mockTranscribe.mockReturnValueOnce(
+      new Promise<TranscribePageT>((res) => {
+        resolveTranscribe = res;
+      }),
+    );
+    const { findByTestId } = renderScreen();
+    expect(await findByTestId('photograph-transcribing')).toBeTruthy();
+    await act(async () => {
+      resolveTranscribe({ text: 'done' });
+    });
+  });
+
+  it('sends the picked image + media type to transcribePage', async () => {
+    mockPick.mockResolvedValueOnce(picked({ imageBase64: 'b64data', mediaType: 'image/png' }));
+    mockTranscribe.mockResolvedValueOnce({ text: 'x' });
+    renderScreen();
+    await waitFor(() =>
+      expect(mockTranscribe).toHaveBeenCalledWith({
+        imageBase64: 'b64data',
+        mediaType: 'image/png',
+      }),
+    );
+  });
+});
+
+describe('JournalPhotographScreen — editable preview', () => {
+  it('seeds the preview input with the transcribed text', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'A page about the willow.' });
+    const { findByTestId } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    expect(input.props.value).toBe('A page about the willow.');
+    expect(await findByTestId('photograph-save')).toBeTruthy();
+  });
+
+  it('lets the writer edit the seeded text', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    const { findByTestId, getByTestId } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'Original, corrected.');
+    expect(getByTestId('photograph-preview-input').props.value).toBe('Original, corrected.');
+  });
+});
+
+const RETRY_KINDS: TranscriptionErrorKind[] = [
+  'provider_error',
+  'network',
+  'timeout',
+  'rate_limited',
+];
+const PICK_ANOTHER_KINDS: TranscriptionErrorKind[] = ['invalid_image', 'image_too_large'];
+
+describe('JournalPhotographScreen — transcription error recovery', () => {
+  it.each(RETRY_KINDS)('offers retry (not pick-another) for a %s failure', async (kind) => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError(kind, null));
+    const { findByTestId, queryByTestId } = renderScreen();
+    expect(await findByTestId('photograph-retry')).toBeTruthy();
+    expect(queryByTestId('photograph-pick-another')).toBeNull();
+  });
+
+  it.each(PICK_ANOTHER_KINDS)('offers Pick another (not retry) for a %s failure', async (kind) => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError(kind, 422));
+    const { findByTestId, queryByTestId } = renderScreen();
+    expect(await findByTestId('photograph-pick-another')).toBeTruthy();
+    expect(queryByTestId('photograph-retry')).toBeNull();
+  });
+
+  it('offers both retry and a typed-entry offramp for an unknown failure', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('unknown', null));
+    const { findByTestId } = renderScreen();
+    expect(await findByTestId('photograph-retry')).toBeTruthy();
+    expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
+  });
+
+  it('shows the wallet-exhausted copy with a typed-entry offramp and no retry', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('wallet_exhausted', 402));
+    const { findByTestId, queryByTestId, getByTestId } = renderScreen();
+    await findByTestId('photograph-error');
+    expect(getByTestId('photograph-error')).toHaveTextContent(/this month's free allotment/);
+    expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
+    expect(queryByTestId('photograph-retry')).toBeNull();
+  });
+
+  it('shows a terminal, friendly message for model_lacks_vision with a typed-entry offramp, no retry', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('model_lacks_vision', 422));
+    const { findByTestId, queryByTestId, getByTestId } = renderScreen();
+    await findByTestId('photograph-error');
+    expect(getByTestId('photograph-error')).toHaveTextContent(/isn't available/);
+    expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
+    expect(queryByTestId('photograph-retry')).toBeNull();
+  });
+
+  it('navigates to a plain JournalEntry from the typed-entry offramp', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('wallet_exhausted', 402));
+    const { findByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('photograph-typed-entry'));
+    expect(navigation.navigate).toHaveBeenCalledWith('JournalEntry');
+  });
+
+  it('calls transcribePage exactly once more per retry tap, never auto-retrying', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('network', null));
+    const { findByTestId } = renderScreen();
+    await findByTestId('photograph-retry');
+    expect(mockTranscribe).toHaveBeenCalledTimes(1);
+
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('network', null));
+    fireEvent.press(await findByTestId('photograph-retry'));
+    await waitFor(() => expect(mockTranscribe).toHaveBeenCalledTimes(2));
+
+    mockTranscribe.mockResolvedValueOnce({ text: 'ok' });
+    fireEvent.press(await findByTestId('photograph-retry'));
+    await waitFor(() => expect(mockTranscribe).toHaveBeenCalledTimes(3));
+  });
+
+  it('re-launches the picker from Pick another', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockRejectedValueOnce(new TranscriptionError('invalid_image', 422));
+    const { findByTestId } = renderScreen();
+    await findByTestId('photograph-pick-another');
+    expect(mockPick).toHaveBeenCalledTimes(1);
+
+    mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
+    fireEvent.press(await findByTestId('photograph-pick-another'));
+    await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('JournalPhotographScreen — save flow', () => {
+  it('saves the edited preview text (not the original transcription) and replaces to the finished entry', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original transcribed text.' });
+    mockCreate.mockResolvedValueOnce(makeEntry({ id: 99, message: 'Edited by hand.' }));
+    mockUpdate.mockResolvedValueOnce(
+      makeEntry({ id: 99, message: 'Edited by hand.', status: 'finished' }),
+    );
+
+    const { findByTestId, navigation } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'Edited by hand.');
+    fireEvent.press(await findByTestId('photograph-save'));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(99, { status: 'finished' }));
+    expect(mockCreate).toHaveBeenCalledWith({ message: 'Edited by hand.' });
+    expect(navigation.replace).toHaveBeenCalledWith('JournalEntry', {
+      entryId: 99,
+      justSaved: true,
+    });
+  });
+
+  it('never sends entry_date on the create triggered by Save', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValueOnce(makeEntry({ id: 5 }));
+    mockUpdate.mockResolvedValueOnce(makeEntry({ id: 5, status: 'finished' }));
+
+    const { findByTestId } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'No entry_date please.');
+    fireEvent.press(await findByTestId('photograph-save'));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0]?.[0]).not.toHaveProperty('entry_date');
+  });
+
+  it('keeps the edited text visible and offers Retry-save when saving fails', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValueOnce(makeEntry({ id: 99 }));
+    mockUpdate.mockRejectedValueOnce(new Error('network down'));
+
+    const { findByTestId, getByTestId } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'My hand-edited page.');
+    fireEvent.press(await findByTestId('photograph-save'));
+
+    expect(await findByTestId('photograph-retry-save')).toBeTruthy();
+    expect(getByTestId('photograph-preview-input').props.value).toBe('My hand-edited page.');
+  });
+
+  it('re-invokes save when Retry-save is tapped', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValue(makeEntry({ id: 99 }));
+    mockUpdate.mockRejectedValueOnce(new Error('network down'));
+    mockUpdate.mockResolvedValueOnce(makeEntry({ id: 99, status: 'finished' }));
+
+    const { findByTestId, getByTestId, navigation } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'Try again please.');
+    fireEvent.press(await findByTestId('photograph-save'));
+    await findByTestId('photograph-retry-save');
+    fireEvent.press(getByTestId('photograph-retry-save'));
+
+    await waitFor(() =>
+      expect(navigation.replace).toHaveBeenCalledWith('JournalEntry', {
+        entryId: 99,
+        justSaved: true,
+      }),
+    );
+    // The retry reuses the created id (no second create), so the page is never
+    // duplicated and the wallet is never charged twice.
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists text edited after a failed save on the retry, without re-creating', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValue(makeEntry({ id: 99 }));
+    mockUpdate.mockRejectedValueOnce(new Error('network down'));
+    mockUpdate.mockResolvedValueOnce(makeEntry({ id: 99, status: 'finished' }));
+
+    const { findByTestId, getByTestId, navigation } = renderScreen();
+    const input = await findByTestId('photograph-preview-input');
+    fireEvent.changeText(input, 'Before the failure.');
+    fireEvent.press(await findByTestId('photograph-save'));
+    await findByTestId('photograph-retry-save');
+    fireEvent.changeText(getByTestId('photograph-preview-input'), 'Edited after the failure.');
+    fireEvent.press(getByTestId('photograph-retry-save'));
+
+    await waitFor(() => expect(navigation.replace).toHaveBeenCalled());
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenLastCalledWith(99, {
+      message: 'Edited after the failure.',
+      status: 'finished',
+    });
+  });
+});

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreenDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreenDrawer.test.tsx
@@ -210,4 +210,18 @@ describe('Journal header drawer from JournalShelfScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('JournalEntry');
     expect(queryByTestId('screen-drawer')).toBeNull();
   });
+
+  it('navigates to JournalPhotograph when Photograph is tapped in the drawer', async () => {
+    const { getByTestId, getByLabelText } = render(<ShelfScreenWithHeader />);
+    await waitFor(() => expect(getByTestId('journal-shelf-card-1')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Open Journal menu'));
+    await waitFor(() => expect(getByTestId('journal-photograph-entry')).toBeTruthy());
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-photograph-entry'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('JournalPhotograph');
+  });
 });

--- a/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
+++ b/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import * as ImagePicker from 'expo-image-picker';
+
+import { pickJournalPhoto, toMediaType } from '../pickJournalPhoto';
+
+const requestPermission = jest.mocked(ImagePicker.requestMediaLibraryPermissionsAsync);
+const launchLibrary = jest.mocked(ImagePicker.launchImageLibraryAsync);
+
+function asset(
+  overrides: Partial<ImagePicker.ImagePickerAsset> = {},
+): ImagePicker.ImagePickerAsset {
+  return {
+    uri: 'file:///page.jpg',
+    width: 1,
+    height: 1,
+    base64: 'abc123',
+    mimeType: 'image/jpeg',
+    ...overrides,
+  } as ImagePicker.ImagePickerAsset;
+}
+
+describe('pickJournalPhoto', () => {
+  beforeEach(() => {
+    requestPermission.mockResolvedValue({ granted: true } as ImagePicker.PermissionResponse);
+    launchLibrary.mockResolvedValue({ canceled: true, assets: null });
+  });
+
+  it('returns denied without launching the picker when permission is refused', async () => {
+    requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
+    expect(await pickJournalPhoto()).toEqual({ kind: 'denied' });
+    expect(launchLibrary).not.toHaveBeenCalled();
+  });
+
+  it('returns cancelled when the user backs out of the picker', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: true, assets: null });
+    expect(await pickJournalPhoto()).toEqual({ kind: 'cancelled' });
+  });
+
+  it('returns failed when a completed pick has no assets', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [] });
+    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
+  });
+
+  it('returns failed when the picked asset carries no base64 data', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [asset({ base64: null })] });
+    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
+  });
+
+  it('returns failed when the picked asset omits base64 entirely', async () => {
+    const noBase64 = asset();
+    delete (noBase64 as { base64?: string | null }).base64;
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [noBase64] });
+    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
+  });
+
+  it('returns the base64 payload + resolved media type on a successful pick', async () => {
+    launchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [asset({ base64: 'xyz', mimeType: 'image/png' })],
+    });
+    expect(await pickJournalPhoto()).toEqual({
+      kind: 'picked',
+      imageBase64: 'xyz',
+      mediaType: 'image/png',
+    });
+  });
+
+  it('requests images-only, base64-included, 0.8-quality media', async () => {
+    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [asset()] });
+    await pickJournalPhoto();
+    expect(launchLibrary).toHaveBeenCalledWith({
+      mediaTypes: ['images'],
+      quality: 0.8,
+      base64: true,
+    });
+  });
+
+  it('never calls the launcher after permission is denied', async () => {
+    requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
+    await pickJournalPhoto();
+    expect(launchLibrary).not.toHaveBeenCalled();
+  });
+});
+
+describe('toMediaType', () => {
+  it('maps image/png through unchanged', () => {
+    expect(toMediaType('image/png')).toBe('image/png');
+  });
+
+  it('maps image/webp through unchanged', () => {
+    expect(toMediaType('image/webp')).toBe('image/webp');
+  });
+
+  it('maps image/jpeg through unchanged', () => {
+    expect(toMediaType('image/jpeg')).toBe('image/jpeg');
+  });
+
+  it('defaults an unrecognized mime type to image/jpeg', () => {
+    expect(toMediaType('image/heic')).toBe('image/jpeg');
+  });
+
+  it('defaults an absent mime type to image/jpeg', () => {
+    expect(toMediaType(undefined)).toBe('image/jpeg');
+  });
+});

--- a/frontend/src/features/Journal/__tests__/saveFinishedEntry.test.ts
+++ b/frontend/src/features/Journal/__tests__/saveFinishedEntry.test.ts
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+import { saveFinishedEntry } from '../saveFinishedEntry';
+
+import type { JournalMessage } from '@/api';
+
+const mockCreate = jest.fn() as jest.MockedFunction<(_e: unknown) => Promise<JournalMessage>>;
+const mockUpdate = jest.fn() as jest.MockedFunction<
+  (_id: number, _p: unknown) => Promise<JournalMessage>
+>;
+
+jest.mock('@/api', () => ({
+  journal: {
+    create: (...a: unknown[]) => (mockCreate as unknown as (...x: unknown[]) => unknown)(...a),
+    update: (...a: unknown[]) => (mockUpdate as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+function entry(overrides: Partial<JournalMessage> = {}): JournalMessage {
+  return {
+    id: 42,
+    message: 'A page.',
+    sender: 'user',
+    timestamp: '2026-06-01T00:00:00Z',
+    tag: 'freeform' as JournalMessage['tag'],
+    practice_session_id: null,
+    user_practice_id: null,
+    status: 'draft',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockCreate.mockReset();
+  mockUpdate.mockReset();
+});
+
+describe('saveFinishedEntry — new entry (no existingId)', () => {
+  it('creates the entry with just the message body', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 7 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 7, status: 'finished' }));
+    await saveFinishedEntry('A fresh page.');
+    expect(mockCreate).toHaveBeenCalledWith({ message: 'A fresh page.' });
+  });
+
+  it('never sends entry_date on create', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 7 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 7, status: 'finished' }));
+    await saveFinishedEntry('A fresh page.');
+    expect(mockCreate.mock.calls[0]?.[0]).not.toHaveProperty('entry_date');
+  });
+
+  it('never overrides classification on create (backend defaults personal)', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 7 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 7, status: 'finished' }));
+    await saveFinishedEntry('A fresh page.');
+    expect(mockCreate.mock.calls[0]?.[0]).not.toHaveProperty('classification');
+  });
+
+  it('flips the newly-created entry to finished via update', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 7 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 7, status: 'finished' }));
+    await saveFinishedEntry('A fresh page.');
+    expect(mockUpdate).toHaveBeenCalledWith(7, { status: 'finished' });
+  });
+
+  it('resolves the newly-created entry id', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 7 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 7, status: 'finished' }));
+    await expect(saveFinishedEntry('A fresh page.')).resolves.toBe(7);
+  });
+
+  it('treats a null existingId the same as no id at all (still creates)', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 8 }));
+    mockUpdate.mockResolvedValueOnce(entry({ id: 8, status: 'finished' }));
+    await saveFinishedEntry('Fresh again.', null);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(8, { status: 'finished' });
+  });
+});
+
+describe('saveFinishedEntry — retry with an existing id (create already succeeded)', () => {
+  it('skips create and PATCHes the existing entry with the body and finished status', async () => {
+    mockUpdate.mockResolvedValueOnce(entry({ id: 55, status: 'finished' }));
+    await saveFinishedEntry('Retried text.', 55);
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith(55, { message: 'Retried text.', status: 'finished' });
+  });
+
+  it('persists a body edited after the failed first attempt, not the original', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 55 }));
+    mockUpdate.mockRejectedValueOnce(new Error('PATCH failed'));
+    await expect(saveFinishedEntry('First draft.')).rejects.toThrow('PATCH failed');
+
+    mockUpdate.mockResolvedValueOnce(entry({ id: 55, status: 'finished' }));
+    await saveFinishedEntry('First draft, edited after the failure.', 55);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenLastCalledWith(55, {
+      message: 'First draft, edited after the failure.',
+      status: 'finished',
+    });
+  });
+
+  it('resolves the given existing id, not a freshly-created one', async () => {
+    mockUpdate.mockResolvedValueOnce(entry({ id: 55, status: 'finished' }));
+    await expect(saveFinishedEntry('Retried text.', 55)).resolves.toBe(55);
+  });
+});
+
+describe('saveFinishedEntry — failure propagation', () => {
+  it('rejects rather than swallowing when the finishing update fails on a fresh create', async () => {
+    mockCreate.mockResolvedValueOnce(entry({ id: 9 }));
+    mockUpdate.mockRejectedValueOnce(new Error('PATCH failed'));
+    await expect(saveFinishedEntry('Doomed page.')).rejects.toThrow('PATCH failed');
+  });
+
+  it('rejects rather than swallowing when the retry PATCH on an existing id fails', async () => {
+    mockUpdate.mockRejectedValueOnce(new Error('PATCH failed again'));
+    await expect(saveFinishedEntry('Doomed retry.', 55)).rejects.toThrow('PATCH failed again');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Journal/pickJournalPhoto.ts
+++ b/frontend/src/features/Journal/pickJournalPhoto.ts
@@ -1,0 +1,74 @@
+/**
+ * Wraps `expo-image-picker` for the Journal photograph-capture flow: request
+ * permission, open the library, and hand back the picked page as base64 with a
+ * server-accepted media type — or a discriminated reason it did not.
+ *
+ * PRIVACY: the returned base64 image payload is never logged here; callers hold
+ * it in memory only and release it once the page is saved.
+ */
+import * as ImagePicker from 'expo-image-picker';
+
+import type { MediaType } from '@/api';
+
+// Slight compression: a full-resolution page photo can be several MB, and the
+// transcription request carries the base64 inline. 0.8 is visually lossless for
+// legible handwriting while keeping the upload small.
+const IMAGE_QUALITY = 0.8;
+
+/** The media types the transcription endpoint accepts, unchanged when mapped. */
+const PASSTHROUGH_MEDIA_TYPES: readonly MediaType[] = ['image/png', 'image/webp', 'image/jpeg'];
+
+/** Default encoding assumed when the picker reports an unknown/absent mime type. */
+const DEFAULT_MEDIA_TYPE: MediaType = 'image/jpeg';
+
+/**
+ * The outcome of a single pick attempt, discriminated on `kind`:
+ *
+ *  - `denied`    — media-library permission was refused; the picker never opened.
+ *  - `cancelled` — the user backed out of the picker.
+ *  - `failed`    — the pick completed but yielded no usable base64 image.
+ *  - `picked`    — a usable page image with its resolved media type.
+ */
+export type PickResult =
+  | { kind: 'denied' }
+  | { kind: 'cancelled' }
+  | { kind: 'failed' }
+  | { kind: 'picked'; imageBase64: string; mediaType: MediaType };
+
+/**
+ * Map an image picker mime type to a transcription-accepted {@link MediaType}.
+ * Known encodings pass through unchanged; anything else (or a missing mime)
+ * defaults to `image/jpeg`, the safest broadly-supported fallback.
+ */
+export function toMediaType(mime?: string): MediaType {
+  const match = PASSTHROUGH_MEDIA_TYPES.find((accepted) => accepted === mime);
+  return match ?? DEFAULT_MEDIA_TYPE;
+}
+
+/**
+ * Open the device media library and return the chosen page as base64.
+ *
+ * Requests media-library permission first; a refusal short-circuits to `denied`
+ * without ever launching the picker. A cancelled pick is `cancelled`; a pick
+ * that yields no asset or no base64 is `failed`. Otherwise the first asset's
+ * base64 payload and resolved media type are returned as `picked`.
+ */
+export async function pickJournalPhoto(): Promise<PickResult> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) {
+    return { kind: 'denied' };
+  }
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ['images'],
+    quality: IMAGE_QUALITY,
+    base64: true,
+  });
+  if (result.canceled) {
+    return { kind: 'cancelled' };
+  }
+  const asset = result.assets[0];
+  if (!asset || !asset.base64) {
+    return { kind: 'failed' };
+  }
+  return { kind: 'picked', imageBase64: asset.base64, mediaType: toMediaType(asset.mimeType) };
+}

--- a/frontend/src/features/Journal/saveFinishedEntry.ts
+++ b/frontend/src/features/Journal/saveFinishedEntry.ts
@@ -1,0 +1,43 @@
+/**
+ * Persist a transcribed journal page as a finished entry.
+ *
+ * The write is two steps — create the entry from the body, then flip it to
+ * `finished` — so a failure between them can strand a freshly-created draft. To
+ * keep a retry from creating a duplicate, callers pass the id returned by the
+ * first successful create back in as `existingId`: with an id in hand this
+ * PATCHes the existing entry instead of creating again. Because a
+ * PATCH failure rejects before the id can be returned, `onCreated` lets a caller
+ * latch the fresh id the instant the create succeeds, so a subsequent retry can
+ * supply it. Nothing beyond the message body is sent; the backend defaults
+ * classification and entry date, so we never override them here.
+ */
+import { journal } from '@/api';
+
+/** The status a fully-captured page is flipped to once its body is saved. */
+const FINISHED_STATUS = 'finished' as const;
+
+/**
+ * Save `body` as a finished journal entry and resolve its id.
+ *
+ * With no `existingId` (or `null`), create the entry then PATCH it to finished.
+ * With an `existingId` — a create that already succeeded on a prior attempt —
+ * skip the create and re-run the finishing PATCH with the current `body`, so a
+ * retry after a failed PATCH never re-creates the page yet still persists any
+ * edits made after the failure. `onCreated`, when given, fires with the new id
+ * the moment the create resolves (before the PATCH), so a caller can hold it for
+ * a retry even if the PATCH then rejects. Rejections propagate to the caller.
+ */
+export async function saveFinishedEntry(
+  body: string,
+  existingId?: number | null,
+  onCreated?: (_id: number) => void,
+): Promise<number> {
+  if (existingId == null) {
+    const created = await journal.create({ message: body });
+    onCreated?.(created.id);
+    await journal.update(created.id, { status: FINISHED_STATUS });
+    return created.id;
+  }
+  await journal.update(existingId, { message: body, status: FINISHED_STATUS });
+  return existingId;
+}

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 
 import JournalEntryScreen from '../features/Journal/JournalEntryScreen';
+import JournalPhotographScreen from '../features/Journal/JournalPhotographScreen';
 import { CreatePracticeWizard } from '../features/Practice/screens/CreatePracticeWizard';
 import { PracticeCatalogScreen } from '../features/Practice/screens/PracticeCatalogScreen';
 import { PracticeDetailScreen } from '../features/Practice/screens/PracticeDetailScreen';
@@ -38,9 +39,13 @@ export type RootStackParamList = {
   PracticeDetail: { practiceId: number; assignError?: string };
   CreatePractice: { prefill?: CreatePracticePrefill } | undefined;
   Catalog: { stageNumber?: number } | undefined;
+  JournalPhotograph: undefined;
   JournalEntry:
     | {
         entryId?: number;
+        /** Set when arriving fresh from photograph capture: reads as "Saved" and
+         *  offers resonance immediately, skipping the usual idle-after-typing wait. */
+        justSaved?: boolean;
         weekNumber?: number;
         promptQuestion?: string;
         practiceSessionId?: number;
@@ -82,6 +87,23 @@ const NAV_SCREEN_OPTIONS = {
  * import -- can pass ``{ screen, params }`` through ``navigation.navigate``
  * with full type safety.
  */
+/** The Journal routes pushed as siblings of the tab shell: the entry editor and
+ *  the photograph-capture flow. Grouped in a fragment to keep ``RootStack`` lean. */
+const JournalScreens = (): React.JSX.Element => (
+  <>
+    <Stack.Screen
+      name="JournalEntry"
+      component={JournalEntryScreen}
+      options={{ title: 'Journal' }}
+    />
+    <Stack.Screen
+      name="JournalPhotograph"
+      component={JournalPhotographScreen}
+      options={{ title: 'Photograph journal' }}
+    />
+  </>
+);
+
 const RootStack = (): React.JSX.Element => (
   <Stack.Navigator screenOptions={NAV_SCREEN_OPTIONS}>
     <Stack.Screen name="Tabs" component={BottomTabs} options={{ headerShown: false }} />
@@ -121,11 +143,7 @@ const RootStack = (): React.JSX.Element => (
       component={PracticeCatalogScreen}
       options={{ title: 'Practices' }}
     />
-    <Stack.Screen
-      name="JournalEntry"
-      component={JournalEntryScreen}
-      options={{ title: 'Journal' }}
-    />
+    {JournalScreens()}
   </Stack.Navigator>
 );
 


### PR DESCRIPTION
Closes #1791

## What

The journal's tracer capture flow: photograph a handwritten page and land on a finished, editable entry.

- **`JournalPhotograph` route** (pushed sibling in `RootStack`) auto-launches an expo-image-picker library pick on mount. Denied permission gets an Open Settings / Cancel view; a cancelled pick goes straight back.
- **Transcription** via the existing `journal.transcribePage` client (#1852). The picked base64 image lives only in a `useRef` — never in nav params, state, or logs — and is released on save and unmount.
- **Editable preview** seeds a multiline input with the transcribed text before anything is persisted.
- **Save** (`saveFinishedEntry`) creates the entry then PATCHes it to `finished`. The created id is latched via an `onCreated` callback the instant the create resolves, so a retry after a failed finishing PATCH re-PATCHes the same entry — with the current body, persisting post-failure edits — and never creates a duplicate.
- **Error recovery** maps each `TranscriptionErrorKind` to its offramp: retry (provider/network/timeout/rate-limit/unknown), pick-another (invalid/too-large image), or a typed-entry offramp (unknown, wallet-exhausted, model-lacks-vision). The wallet 402 copy is resolved through `formatApiError`'s shared status fallback — single source of truth.
- **Entry points**: a Photograph row in the Journal shelf drawer beside New entry.
- **`justSaved`**: after a photograph save, `JournalEntry` opens with the resonance gate immediately available (no idle wait) and a read-mode "Saved" hint.

## Testing

- New suites: `pickJournalPhoto`, `saveFinishedEntry`, `JournalPhotographScreen` (28 cases incl. the full error-kind matrix and the edited-body-on-retry regression), `JournalEntryScreenJustSaved`, plus drawer/shelf entry-point coverage.
- Full frontend gate green: 424 suites / 4645 tests, eslint, prettier, `tsc --noEmit`.
- Gate 2.5 self-review ran (security, correctness, test dimensions); its one blocking finding — the retry PATCH dropping post-failure edits — is fixed with a regression test at both the helper and screen level.

## Notes for review

- `saveFinishedEntry` carries an optional third `onCreated` param: the only way to expose the created id to the caller when the finishing PATCH rejects (a rejected promise can't return it), which the no-duplicate-create guarantee requires.
- Optional follow-ups deliberately not taken here: releasing the image ref on entering preview (slightly shorter in-memory retention), and disabling Save on an empty preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
