### PR TITLE
test(backend): pin the transcribe-page no-image-persistence guarantee

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -31,6 +31,16 @@ BOTMASON_PROVIDER=stub  # "stub" (default), "openai", or "anthropic"
 BOTMASON_SYSTEM_PROMPT=  # Path to a prompt file or inline text (optional, has built-in default)
 LLM_API_KEY=  # Server-side API key for the chosen LLM provider (never required for stub)
 LLM_MODEL=  # Model override, allowlisted per provider (defaults: gpt-4o-mini / claude-sonnet-4-20250514)
+#
+# Vision requirement (ADR-3): journal single-page transcription requires a
+# vision-capable LLM_MODEL. A non-vision model is rejected with HTTP 422
+# (model_lacks_vision) rather than silently substituted for a working one.
+#
+# Privacy boundary: image bytes and transcripts are never persisted or logged
+# server-side — they live only in request scope. Provider-side image
+# retention is governed by the provider account's own data-retention
+# settings, and adepthood sends no user-identifying metadata with vision
+# calls; this is the accepted privacy boundary per epic sign-off.
 
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production

--- a/backend/src/schemas/transcription.py
+++ b/backend/src/schemas/transcription.py
@@ -29,7 +29,13 @@ class TranscribePageRequest(BaseModel):
     the bytes live only for the duration of the single vision call.
     """
 
-    image_base64: str = Field(min_length=1, description="Base64-encoded image bytes.")
+    image_base64: str = Field(
+        min_length=1,
+        description="Base64-encoded image bytes.",
+        # Kept out of ``repr()``/``str()`` so the raw image payload can never
+        # leak into logs or tracebacks that stringify the model.
+        repr=False,
+    )
     media_type: TranscribeMediaType = Field(description="Declared image MIME type.")
 
 
@@ -41,4 +47,9 @@ class TranscribePageResponse(BaseModel):
     writes no journal row, keeping the transcription contract stateless.
     """
 
-    text: str = Field(description="Faithful transcribed body text for the page.")
+    text: str = Field(
+        description="Faithful transcribed body text for the page.",
+        # Kept out of ``repr()``/``str()`` so the transcribed page text can never
+        # leak into logs or tracebacks that stringify the model.
+        repr=False,
+    )

--- a/backend/tests/test_transcription_endpoint.py
+++ b/backend/tests/test_transcription_endpoint.py
@@ -9,7 +9,6 @@ transcribed text.
 
 from __future__ import annotations
 
-import base64
 import logging
 from http import HTTPStatus
 
@@ -21,41 +20,25 @@ from sqlmodel import col
 
 from models.llm_usage_log import LLMUsageLog
 from models.user import User
-from services.botmason import LLMProviderError, LLMResponse, LLMVisionUnsupportedError
+from services.botmason import LLMProviderError, LLMVisionUnsupportedError
+from tests.transcription_helpers import JPEG_BYTES as _JPEG_BYTES
+from tests.transcription_helpers import PNG_BYTES as _PNG_BYTES
+from tests.transcription_helpers import SENTINEL_TEXT as _SENTINEL_TEXT
+from tests.transcription_helpers import WEBP_BYTES as _WEBP_BYTES
+from tests.transcription_helpers import b64 as _b64
+from tests.transcription_helpers import patch_generate_response as _patch_generate_response
+from tests.transcription_helpers import (
+    patch_generate_response_raises as _patch_generate_response_raises,
+)
+from tests.transcription_helpers import payload as _payload
+from tests.transcription_helpers import priced_response as _priced_response
+from tests.transcription_helpers import signup as _signup
 
 _ENDPOINT = "/journal/transcribe-page"
 _RATE_LIMIT = 20
 _MAX_IMAGE_BYTES = 5 * 1024 * 1024
 
-_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 64
-_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
-_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 64
 _OVERSIZED_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * (_MAX_IMAGE_BYTES + 10)
-
-_SENTINEL_TEXT = "SENTINEL_TRANSCRIPTION_TEXT_9f3c2a"
-
-
-async def _signup(client: AsyncClient, username: str = "transcriber") -> dict[str, str]:
-    """Create a user and return bearer auth headers."""
-    resp = await client.post(
-        "/auth/signup",
-        json={
-            "email": f"{username}@example.com",
-            "password": "secret12345",  # pragma: allowlist secret
-        },
-    )
-    assert resp.status_code == HTTPStatus.OK
-    return {"Authorization": f"Bearer {resp.json()['token']}"}
-
-
-def _b64(raw: bytes) -> str:
-    """Base64-encode raw image bytes for the request payload."""
-    return base64.b64encode(raw).decode()
-
-
-def _payload(raw: bytes, media_type: str = "image/jpeg") -> dict[str, str]:
-    """Build a transcribe-page request body from raw image bytes."""
-    return {"image_base64": _b64(raw), "media_type": media_type}
 
 
 async def _wallet_snapshot(session: AsyncSession, email: str) -> tuple[int, int]:
@@ -83,33 +66,6 @@ async def _usage_rows_with_null_entry(session: AsyncSession) -> list[LLMUsageLog
         select(LLMUsageLog).where(col(LLMUsageLog.journal_entry_id).is_(None))
     )
     return list(result.scalars().all())
-
-
-def _priced_response(text: str) -> LLMResponse:
-    """Return a non-stub LLMResponse (provider=openai) for usage-log tests."""
-    return LLMResponse(
-        text=text, provider="openai", model="gpt-4o-mini", prompt_tokens=11, completion_tokens=7
-    )
-
-
-def _patch_generate_response(monkeypatch: pytest.MonkeyPatch, response: LLMResponse) -> None:
-    """Patch the router's LLM seam to return a canned response."""
-
-    async def _fake(*args: object, **kwargs: object) -> LLMResponse:
-        del args, kwargs
-        return response
-
-    monkeypatch.setattr("routers.transcription.generate_response", _fake)
-
-
-def _patch_generate_response_raises(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
-    """Patch the router's LLM seam to raise ``exc`` on every call."""
-
-    async def _boom(*args: object, **kwargs: object) -> LLMResponse:
-        del args, kwargs
-        raise exc
-
-    monkeypatch.setattr("routers.transcription.generate_response", _boom)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_transcription_privacy.py
+++ b/backend/tests/test_transcription_privacy.py
@@ -1,0 +1,406 @@
+"""Permanent privacy regression suite for POST /journal/transcribe-page.
+
+The Journal Photographer's stateless transcription endpoint promises that a
+photographed page's image bytes and its transcribed text are never persisted,
+logged, or otherwise leaked anywhere outside the single request that carries
+them. These tests are tripwires: each one pins one facet of that promise so
+that any future change which starts persisting or logging image bytes /
+transcript text turns this suite (and therefore CI) red. Sections:
+
+    A -- the LLMUsageLog table schema stays free of content-bearing columns
+    B -- no log record leaks the base64 payload or the transcribed text on
+         any of the four response paths (success, 422, 402, 502)
+    C -- the source tree carries no multipart/UploadFile upload surface
+    D -- the route carries no image data in its URL, and the access log's
+         structured extras stay inside a closed allow-list
+    E -- the vision provider calls forward a closed set of SDK kwargs
+    F -- the Sentry context allow-list stays closed
+    G -- the request/response DTOs never leak their payload through repr/str
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import re
+from pathlib import Path
+from typing import ClassVar
+
+import anthropic
+import openai
+import pytest
+from fastapi.routing import APIRoute
+from httpx import AsyncClient
+from sqlalchemy import JSON, LargeBinary, Text
+
+from main import app as main_app
+from models.llm_usage_log import LLMUsageLog
+from schemas.transcription import TranscribePageRequest, TranscribePageResponse
+from sentry import SentryContext
+from services.botmason import ImagePayload, LLMProviderError, generate_response
+from tests.transcription_helpers import (
+    JPEG_BYTES,
+    SENTINEL_TEXT,
+    b64,
+    patch_generate_response,
+    patch_generate_response_raises,
+    payload,
+    priced_response,
+    signup,
+)
+
+_ENDPOINT = "/journal/transcribe-page"
+
+# ── A: usage-log stays content-free ────────────────────────────────────────
+
+# Longest metadata string the usage log may hold (provider/model names) --
+# anything unbounded is an admission a content column slipped in.
+_MAX_METADATA_STRING_LENGTH = 128
+
+
+def _is_string_family_column(column_type: object) -> bool:
+    """Return True when ``column_type`` belongs to SQLAlchemy's string family.
+
+    Detects both a plain ``String``/``Text`` type AND SQLModel's ``AutoString``
+    wrapper, which is a ``TypeDecorator`` and therefore NOT an ``isinstance``
+    match for ``sqlalchemy.String`` even though it behaves like one.
+    """
+    length = getattr(column_type, "length", None)
+    return isinstance(length, int) or "String" in type(column_type).__name__
+
+
+def _bounded_length(column_type: object) -> int | None:
+    """Return ``column_type.length`` when it is a bound integer, else ``None``."""
+    length = getattr(column_type, "length", None)
+    return length if isinstance(length, int) else None
+
+
+def test_usage_log_schema_stays_content_free() -> None:
+    """No LLMUsageLog column may hold free-text content, prompts, or images.
+
+    Two failure modes are guarded: an explicit ``Text``/``LargeBinary``/``JSON``
+    column, and the sneakier case of an unbounded ``str`` field (SQLModel's
+    ``AutoString`` with ``length is None``), which behaves like a content
+    column but is not caught by a naive ``isinstance(col.type, String)`` check.
+    """
+    columns = LLMUsageLog.__table__.columns  # type: ignore[attr-defined]
+    for column in columns:
+        column_type = column.type
+        # Adding a content/prompt/response/image column here is a privacy
+        # regression, not a feature -- this table is append-only observability
+        # metadata.
+        assert not isinstance(column_type, Text | LargeBinary | JSON)
+        if _is_string_family_column(column_type):
+            # The bound is a proxy for "short metadata identifier" (provider /
+            # model name), not a content guarantee -- it is deliberately tight
+            # so a wide free-text column cannot masquerade as metadata.
+            length = _bounded_length(column_type)
+            assert length is not None
+            assert length <= _MAX_METADATA_STRING_LENGTH
+
+
+# ── B: no content in logs across all four response paths ──────────────────
+
+_PRIVACY_MARKER = b"PRIVACY_SENTINEL_MARKER_7d1e2a9c"
+_MARKED_JPEG_BYTES = b"\xff\xd8\xff" + _PRIVACY_MARKER + b"\x00" * 64
+
+
+def _assert_no_privacy_leak(
+    records: list[logging.LogRecord], encoded: str, marker_b64: str
+) -> None:
+    """Assert no record's message or ``__dict__`` carries the payload, marker, or reply text.
+
+    Both the base64 forms (full payload and standalone marker) and the raw
+    decoded ASCII marker are checked, so a regression that logs the decoded
+    image bytes is caught as well as one that logs the encoded string.
+    """
+    raw_marker = _PRIVACY_MARKER.decode()
+    for record in records:
+        for blob in (record.getMessage(), str(record.__dict__)):
+            assert encoded not in blob
+            assert marker_b64 not in blob
+            assert raw_marker not in blob
+            assert SENTINEL_TEXT not in blob
+
+
+@pytest.mark.asyncio
+async def test_success_path_logs_no_image_or_text_content(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A successful transcription never logs the base64 payload or the reply text."""
+    patch_generate_response(monkeypatch, priced_response(SENTINEL_TEXT))
+    headers = await signup(async_client, "privacy_success")
+    encoded = b64(_MARKED_JPEG_BYTES)
+    marker_b64 = base64.b64encode(_PRIVACY_MARKER).decode()
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await async_client.post(_ENDPOINT, json=payload(_MARKED_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == 200
+    _assert_no_privacy_leak(caplog.records, encoded, marker_b64)
+
+
+@pytest.mark.asyncio
+async def test_validation_failure_logs_no_image_content(
+    async_client: AsyncClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 422 magic-byte mismatch never logs the offending base64 payload."""
+    headers = await signup(async_client, "privacy_422")
+    encoded = b64(_MARKED_JPEG_BYTES)
+    marker_b64 = base64.b64encode(_PRIVACY_MARKER).decode()
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await async_client.post(
+            _ENDPOINT, json=payload(_MARKED_JPEG_BYTES, "image/png"), headers=headers
+        )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "invalid_image"
+    _assert_no_privacy_leak(caplog.records, encoded, marker_b64)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("zero_monthly_cap")
+async def test_wallet_exhausted_logs_no_image_content(
+    async_client: AsyncClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 402 wallet-exhaustion rejection never logs the base64 payload."""
+    headers = await signup(async_client, "privacy_402")
+    encoded = b64(_MARKED_JPEG_BYTES)
+    marker_b64 = base64.b64encode(_PRIVACY_MARKER).decode()
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await async_client.post(_ENDPOINT, json=payload(_MARKED_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == 402
+    _assert_no_privacy_leak(caplog.records, encoded, marker_b64)
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_logs_no_image_or_text_content(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A 502 provider failure never logs the base64 payload or any reply text."""
+    patch_generate_response_raises(monkeypatch, LLMProviderError("upstream exploded"))
+    headers = await signup(async_client, "privacy_502")
+    encoded = b64(_MARKED_JPEG_BYTES)
+    marker_b64 = base64.b64encode(_PRIVACY_MARKER).decode()
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await async_client.post(_ENDPOINT, json=payload(_MARKED_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == 502
+    _assert_no_privacy_leak(caplog.records, encoded, marker_b64)
+
+
+# ── C: no multipart/upload surface anywhere in the source tree ────────────
+
+_SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+_UPLOAD_FILE_PATTERN = re.compile(r"\bUploadFile\b")
+_FILE_CALL_PATTERN = re.compile(r"\bFile\(")
+_MULTIPART_PATTERN = re.compile(r"multipart", re.IGNORECASE)
+
+
+def test_no_multipart_upload_surface_in_source_tree() -> None:
+    """No backend source file references UploadFile, File(...), or multipart.
+
+    Starlette spools multipart uploads to disk (temp files); the transcribe
+    endpoint takes base64 in the JSON body precisely to keep image bytes in
+    request-scoped memory only, never touching disk. Any of these tokens
+    reappearing in ``src/`` is a regression back toward disk-backed uploads.
+    """
+    for path in _SRC_DIR.rglob("*.py"):
+        text = path.read_text()
+        assert not _UPLOAD_FILE_PATTERN.search(text), path
+        assert not _FILE_CALL_PATTERN.search(text), path
+        assert not _MULTIPART_PATTERN.search(text), path
+
+
+def test_no_python_multipart_dependency() -> None:
+    """``python-multipart`` is absent from both requirement files."""
+    backend_dir = _SRC_DIR.parent
+    for filename in ("requirements.txt", "requirements-dev.txt"):
+        text = (backend_dir / filename).read_text()
+        assert "python-multipart" not in text
+
+
+# ── D: request-log safety ──────────────────────────────────────────────────
+
+
+def test_transcribe_route_has_no_path_parameters() -> None:
+    """The registered route path is body-only -- no image data ever rides the URL."""
+    matching = [
+        route
+        for route in main_app.routes
+        if isinstance(route, APIRoute) and route.path == _ENDPOINT
+    ]
+    assert matching, f"no registered route found for {_ENDPOINT}"
+    assert "{" not in matching[0].path
+
+
+# ``makeLogRecord({})`` omits attributes the logging machinery only populates
+# while a record is emitted (``message`` via ``getMessage``/formatting,
+# ``asctime`` when a formatter renders it, ``taskName`` under asyncio on 3.12+).
+# They are standard LogRecord fields, never caller-supplied ``extra=`` keys, so
+# the allow-list check must not treat them as custom extras.
+_STANDARD_LATE_LOG_RECORD_KEYS = frozenset({"message", "asctime", "taskName"})
+_BASELINE_LOG_RECORD_KEYS = (
+    frozenset(logging.makeLogRecord({}).__dict__) | _STANDARD_LATE_LOG_RECORD_KEYS
+)
+_ALLOWED_ACCESS_LOG_EXTRA_KEYS = frozenset(
+    {"http_method", "http_path", "http_status", "elapsed_ms"}
+)
+
+
+@pytest.mark.asyncio
+async def test_access_log_extras_stay_within_allowlist_and_leak_nothing(
+    async_client: AsyncClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """RequestLoggingMiddleware's access-log extras never grow past the allow-list or leak bytes."""
+    headers = await signup(async_client, "access_log_check")
+    encoded = b64(_MARKED_JPEG_BYTES)
+
+    with caplog.at_level(logging.INFO, logger="adepthood.access"):
+        resp = await async_client.post(_ENDPOINT, json=payload(_MARKED_JPEG_BYTES), headers=headers)
+
+    assert resp.status_code == 200
+    completed = [r for r in caplog.records if r.message == "request_completed"]
+    assert completed, "expected a request_completed record from RequestLoggingMiddleware"
+    record = completed[-1]
+    extra_keys = set(record.__dict__) - _BASELINE_LOG_RECORD_KEYS
+    assert extra_keys <= _ALLOWED_ACCESS_LOG_EXTRA_KEYS
+    for key in extra_keys:
+        assert encoded not in str(getattr(record, key))
+
+
+# ── E: provider call hygiene -- closed set of vision SDK kwargs ───────────
+
+
+class _KwargRecordingOpenAIClient:
+    """Stands in for ``openai.AsyncOpenAI``; records the ``create()`` call kwargs."""
+
+    last_create_kwargs: ClassVar[dict[str, object]] = {}
+
+    def __init__(self, **_ctor_kwargs: object) -> None:
+        outer_cls = type(self)
+
+        class _Completions:
+            @staticmethod
+            async def create(**call_kwargs: object) -> object:
+                outer_cls.last_create_kwargs = call_kwargs
+                message = type("Msg", (), {"content": "vision transcription"})()
+                choice = type("Choice", (), {"message": message})()
+                usage = type("Usage", (), {"prompt_tokens": 5, "completion_tokens": 3})()
+                return type("Completion", (), {"choices": [choice], "usage": usage})()
+
+        self.chat = type("Chat", (), {"completions": _Completions()})()
+
+
+class _KwargRecordingAnthropicClient:
+    """Stands in for ``anthropic.AsyncAnthropic``; records the ``create()`` call kwargs."""
+
+    last_create_kwargs: ClassVar[dict[str, object]] = {}
+
+    def __init__(self, **_ctor_kwargs: object) -> None:
+        outer_cls = type(self)
+
+        class _Messages:
+            @staticmethod
+            async def create(**call_kwargs: object) -> object:
+                outer_cls.last_create_kwargs = call_kwargs
+                block = type("Block", (), {"text": "vision transcription"})()
+                usage = type("Usage", (), {"input_tokens": 5, "output_tokens": 3})()
+                return type("Message", (), {"content": [block], "usage": usage})()
+
+        self.messages = _Messages()
+
+
+_OPENAI_CREATE_KWARGS = frozenset({"model", "messages", "max_tokens"})
+_ANTHROPIC_CREATE_KWARGS = frozenset({"model", "max_tokens", "system", "messages"})
+
+
+@pytest.mark.asyncio
+async def test_openai_vision_call_uses_closed_set_of_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The OpenAI vision call forwards exactly model/messages/max_tokens -- no metadata/user."""
+    monkeypatch.setattr(openai, "AsyncOpenAI", _KwargRecordingOpenAIClient)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    image = ImagePayload(data=b64(JPEG_BYTES), media_type="image/jpeg")
+
+    await generate_response(
+        "",
+        [],
+        system_prompt="Transcribe this page.",
+        api_key="sk-server-key",  # pragma: allowlist secret
+        images=[image],
+    )
+
+    assert set(_KwargRecordingOpenAIClient.last_create_kwargs) == _OPENAI_CREATE_KWARGS
+
+
+@pytest.mark.asyncio
+async def test_anthropic_vision_call_uses_closed_set_of_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Anthropic vision call forwards exactly model/max_tokens/system/messages."""
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", _KwargRecordingAnthropicClient)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    image = ImagePayload(data=b64(JPEG_BYTES), media_type="image/jpeg")
+
+    await generate_response(
+        "",
+        [],
+        system_prompt="Transcribe this page.",
+        api_key="sk-ant-server-key",  # pragma: allowlist secret
+        images=[image],
+    )
+
+    assert set(_KwargRecordingAnthropicClient.last_create_kwargs) == _ANTHROPIC_CREATE_KWARGS
+
+
+# ── F: Sentry allow-list stays closed ──────────────────────────────────────
+
+
+def test_sentry_context_allowlist_is_closed() -> None:
+    """SentryContext's allowed keys are locked to the three request-identity fields."""
+    assert set(SentryContext.__annotations__) == {
+        "request_id",
+        "request_path",
+        "request_method",
+    }
+
+
+# ── G: schema repr redaction -- Field(repr=False) on the payload/text ─────
+
+_REPR_SENTINEL_IMAGE_B64 = "UkVQUl9TRU5USU5FTF9CQVNFNjRfUEFZTE9BRA=="
+_REPR_SENTINEL_TEXT = "REPR_SENTINEL_TRANSCRIPTION_TEXT_4b7f"
+
+
+def test_transcribe_request_repr_never_leaks_image_base64() -> None:
+    """A TranscribePageRequest's repr()/str() must never surface the raw base64 image payload.
+
+    The ``image_base64`` field must keep ``Field(repr=False)`` so pydantic's
+    generated repr (which also backs ``str``) omits the payload; without it the
+    value would leak into any log line or traceback that stringifies the model.
+    """
+    request = TranscribePageRequest(image_base64=_REPR_SENTINEL_IMAGE_B64, media_type="image/jpeg")
+
+    assert _REPR_SENTINEL_IMAGE_B64 not in repr(request)
+    assert _REPR_SENTINEL_IMAGE_B64 not in str(request)
+
+
+def test_transcribe_response_repr_never_leaks_transcribed_text() -> None:
+    """A TranscribePageResponse's repr()/str() must never surface the transcribed text.
+
+    The ``text`` field must keep ``Field(repr=False)`` for the same reason as the
+    request DTO above: the transcript must never leak into a stringified model.
+    """
+    response = TranscribePageResponse(text=_REPR_SENTINEL_TEXT)
+
+    assert _REPR_SENTINEL_TEXT not in repr(response)
+    assert _REPR_SENTINEL_TEXT not in str(response)

--- a/backend/tests/test_transcription_privacy.py
+++ b/backend/tests/test_transcription_privacy.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import base64
 import logging
 import re
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import ClassVar
 
@@ -231,13 +232,31 @@ def test_no_python_multipart_dependency() -> None:
 # ── D: request-log safety ──────────────────────────────────────────────────
 
 
+def _iter_api_routes(routes: Iterable[object]) -> Iterator[APIRoute]:
+    """Yield every APIRoute reachable from ``routes``, descending into included routers.
+
+    FastAPI >= 0.137 stopped flattening an ``include_router`` call's routes into
+    the parent ``app.routes``; it appends one mount-like ``_IncludedRouter`` whose
+    real APIRoutes hang off ``original_router``. Older versions flattened them
+    directly. Walking both shapes keeps the route lookup version-robust, so a
+    shallow ``app.routes`` scan can no longer make the guarantee silently vacuous.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route
+            continue
+        included = getattr(route, "original_router", None)
+        if included is not None:
+            yield from _iter_api_routes(included.routes)
+            continue
+        sub_routes = getattr(route, "routes", None)
+        if sub_routes is not None:
+            yield from _iter_api_routes(sub_routes)
+
+
 def test_transcribe_route_has_no_path_parameters() -> None:
     """The registered route path is body-only -- no image data ever rides the URL."""
-    matching = [
-        route
-        for route in main_app.routes
-        if isinstance(route, APIRoute) and route.path == _ENDPOINT
-    ]
+    matching = [route for route in _iter_api_routes(main_app.routes) if route.path == _ENDPOINT]
     assert matching, f"no registered route found for {_ENDPOINT}"
     assert "{" not in matching[0].path
 

--- a/backend/tests/transcription_helpers.py
+++ b/backend/tests/transcription_helpers.py
@@ -1,0 +1,78 @@
+"""Shared fixtures for the transcribe-page endpoint's test modules.
+
+Extracted from ``test_transcription_endpoint.py`` so the privacy regression
+suite (``test_transcription_privacy.py``) can reuse the same sentinel
+constants, image bytes, and provider-patching helpers without duplicating
+them or creating a circular import between the two test modules. This module
+has no ``test_`` prefix so pytest never collects it as a test file itself.
+"""
+
+from __future__ import annotations
+
+import base64
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from services.botmason import LLMResponse
+
+#: Marker text a stubbed provider response returns so tests can grep logs for it.
+SENTINEL_TEXT = "SENTINEL_TRANSCRIPTION_TEXT_9f3c2a"
+
+#: Minimal valid JPEG magic-byte prefix padded to a plausible body length.
+JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 64
+#: Minimal valid PNG magic-byte prefix padded to a plausible body length.
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+#: Minimal valid RIFF/WEBP container padded to a plausible body length.
+WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 64
+
+
+async def signup(client: AsyncClient, username: str = "transcriber") -> dict[str, str]:
+    """Create a user and return bearer auth headers."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def b64(raw: bytes) -> str:
+    """Base64-encode raw image bytes for the request payload."""
+    return base64.b64encode(raw).decode()
+
+
+def payload(raw: bytes, media_type: str = "image/jpeg") -> dict[str, str]:
+    """Build a transcribe-page request body from raw image bytes."""
+    return {"image_base64": b64(raw), "media_type": media_type}
+
+
+def priced_response(text: str) -> LLMResponse:
+    """Return a non-stub LLMResponse (provider=openai) for usage-log tests."""
+    return LLMResponse(
+        text=text, provider="openai", model="gpt-4o-mini", prompt_tokens=11, completion_tokens=7
+    )
+
+
+def patch_generate_response(monkeypatch: pytest.MonkeyPatch, response: LLMResponse) -> None:
+    """Patch the router's LLM seam to return a canned response."""
+
+    async def _fake(*args: object, **kwargs: object) -> LLMResponse:
+        del args, kwargs
+        return response
+
+    monkeypatch.setattr("routers.transcription.generate_response", _fake)
+
+
+def patch_generate_response_raises(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Patch the router's LLM seam to raise ``exc`` on every call."""
+
+    async def _boom(*args: object, **kwargs: object) -> LLMResponse:
+        del args, kwargs
+        raise exc
+
+    monkeypatch.setattr("routers.transcription.generate_response", _boom)


### PR DESCRIPTION
## Summary

Turns the Journal Photographer epic's server-side privacy promise — image bytes and transcripts are **never persisted or logged** — into a permanent, deterministic, offline regression suite over the shipped stateless `POST /journal/transcribe-page` stack (PR #1849). A future change that introduces persistence or logging now turns CI red.

New `backend/tests/test_transcription_privacy.py` locks **seven leak seams** with closed-set, deny-anything-new assertions:

- **A — usage-log stays content-free**: reflection over `LLMUsageLog.__table__.columns` rejects `Text`/`LargeBinary`/`JSON` **and** any unbounded string column. This deliberately goes beyond the issue's example: SQLModel string columns are `AutoString` (not a `String` subclass), so a plain `content: str` field surfaces as an unbounded VARCHAR that the naive `isinstance(col.type, String)` check misses — the test requires every string-family column to have a bounded length ≤ 128 (a metadata-identifier proxy).
- **B — no content in logs**: caplog across the **success / 422 / 402 / 502** paths asserts no record (any logger) carries the base64 payload, a marker substring, the raw *decoded* marker bytes, or the transcript text (checks both `getMessage()` and `record.__dict__`).
- **C — no multipart/upload surface**: source-tree grep asserts `UploadFile` / `File(` / `multipart` appear nowhere in `backend/src`, and `python-multipart` is absent from the requirements (Starlette spools multipart to disk — the endpoint takes base64 in the JSON body to keep bytes in request scope).
- **D — request-log safety**: the route is body-only (no path params) and `RequestLoggingMiddleware` emits only method / path / status / elapsed.
- **E — provider call hygiene**: the OpenAI/Anthropic vision SDK calls pass an **exact** kwargs set — any added `metadata=` / `user=` side channel fails.
- **F — Sentry allow-list stays closed**: `SentryContext` accepts only `request_id` / `request_path` / `request_method`.
- **G — schema repr redaction**: the DTOs never surface the payload/text via `repr()`/`str()`.

### Additions beyond the issue's stated surfaces
- **`Field(repr=False)`** on `TranscribePageRequest.image_base64` and `TranscribePageResponse.text` (`backend/src/schemas/transcription.py`). Pydantic's default repr leaked the raw payload/text; this is a **latent** seam (no shipped path reprs these DTOs into a sink today), so it is defensive hardening rather than an active-leak fix — the security review ratified this classification. Seam G pins it permanently.
- **Decoded-marker assertion** in the caplog helper, closing the "logs the decoded bytes rather than the base64 string" vector the security review flagged.
- Shared transcription test helpers extracted into `backend/tests/transcription_helpers.py` (behavior-preserving refactor of the endpoint test).
- `backend/.env.example`: vision-capability/422 note (ADR-3) + provider-side retention boundary note.

### Epic coverage
Security review confirms the stateless `/journal/transcribe-page` endpoint has no reachable sink for image bytes or transcript text — persistence, access/application logs, exception envelopes, the Sentry shim, and the OpenAI/Anthropic SDK calls all carry metadata only — and this seven-seam suite pins that guarantee with closed-set tripwires, so **the Journal Photographer epic's backend privacy guarantees are now fully covered and CI-enforced**.

## Test plan

- `pytest tests/test_transcription_privacy.py tests/test_transcription_endpoint.py` → 35 passed.
- Full backend `scripts/backend/check-all.sh` → 2962 passed, coverage 96.90%; formatting, lint, mypy, bandit, detect-secrets all green; xenon `A` and radon pass (manual); interrogate 100% on the new modules.
- Each tripwire A–F was **proven to catch its violation** via induce-then-revert drills (unbounded content column; router logging the payload; `UploadFile` import; extra middleware log key; `metadata=` kwarg on the SDK call; extra `SentryContext` field); seam G was red before the `repr=False` hardening and green after.

Closes #1798
Refs #1799