### PR TITLE
feat(journal): multi-page capture session — multi-select, thumbnails, drag-reorder, remove, 10-page cap

### DIFF
--- a/frontend/__tests__/App.bootstrap.test.tsx
+++ b/frontend/__tests__/App.bootstrap.test.tsx
@@ -27,6 +27,11 @@ jest.mock('../src/features/Habits/components/MissedDaysModal', () => () => null)
 jest.mock('../src/features/Habits/components/OnboardingModal', () => () => null);
 jest.mock('../src/features/Habits/components/ReorderHabitsModal', () => () => null);
 jest.mock('../src/features/Habits/components/StatsModal', () => () => null);
+jest.mock('../src/features/Journal/CapturePagesStrip', () => ({
+  __esModule: true,
+  CapturePagesStrip: () => null,
+  default: () => null,
+}));
 
 describe('App bootstrap', () => {
   it('includes SafeAreaProvider at the root', () => {

--- a/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
+++ b/frontend/src/__tests__/navigation/welcomeLandsOnJournal.test.tsx
@@ -39,6 +39,12 @@ jest.mock('@/features/Journal/JournalShelfScreen', () => {
   return { __esModule: true, default: Stub };
 });
 
+jest.mock('@/features/Journal/CapturePagesStrip', () => ({
+  __esModule: true,
+  CapturePagesStrip: () => null,
+  default: () => null,
+}));
+
 jest.mock('@/features/Habits/HabitsScreen', () => {
   const React = require('react');
   const { Text } = require('react-native');

--- a/frontend/src/design/__tests__/interactiveTextFloor.test.ts
+++ b/frontend/src/design/__tests__/interactiveTextFloor.test.ts
@@ -100,6 +100,7 @@ const AUDITED_NON_INTERACTIVE_CAPTIONS = [
   'features/Journal/JournalEntry.styles.ts::privacyTierExplainer',
   'features/Journal/JournalEntry.styles.ts::savedHint',
   'features/Journal/JournalHero.styles.ts::eyebrow',
+  'features/Journal/JournalPhotograph.styles.ts::pageBadgeText',
   'features/Journal/JournalShelf.styles.ts::cardCaption',
   'features/Journal/JournalShelf.styles.ts::cardDate',
   'features/Journal/JournalShelf.styles.ts::promptLabel',

--- a/frontend/src/features/Journal/CapturePagesStrip.tsx
+++ b/frontend/src/features/Journal/CapturePagesStrip.tsx
@@ -1,0 +1,176 @@
+/**
+ * The collect-stage view of the multi-page capture session: an ordered, horizontal
+ * strip of page thumbnails the writer can drag to reorder and tap to remove, over
+ * affordances to add more pages or proceed to transcription.
+ *
+ * Reordering is drag-to-commit (long-press a card, drop it), mirroring the Habits
+ * reorder idiom. Transcription is single-page in this iteration: the proceed button
+ * enables only for exactly one page; more than one surfaces a warm, declinable
+ * notice rather than a hard block.
+ */
+import React from 'react';
+import { Image, Pressable, Text, TouchableOpacity, View } from 'react-native';
+import DraggableFlatList from 'react-native-draggable-flatlist';
+import type { RenderItemParams } from 'react-native-draggable-flatlist';
+
+import { capReachedCopy } from './captureSession';
+import type { CapturePage } from './captureSession';
+import styles from './JournalPhotograph.styles';
+
+import { Button } from '@/components/Button';
+
+const ADD_PAGES_LABEL = 'Add pages';
+const REMOVE_GLYPH = '×';
+
+/** Warm, declinable copy shown when a session holds more than one page: reading
+ *  several pages at once is coming; for now, trim to one to transcribe it. */
+const MULTI_PAGE_NOTICE =
+  'Reading several pages together is on its way. For now, keep a single page here to transcribe it — remove the others, or save them in their own entries.';
+
+/** The proceed button's label: one page reads as itself, several are counted. */
+function transcribeLabel(count: number): string {
+  return count === 1 ? 'Transcribe this page' : `Transcribe ${count} pages`;
+}
+
+interface CapturePageCardProps {
+  page: CapturePage;
+  pageNumber: number;
+  drag: () => void;
+  isActive: boolean;
+  onRemove: (_id: string) => void;
+}
+
+/** One draggable page card: thumbnail, 1-based order badge, and a remove tap. */
+function CapturePageCard({
+  page,
+  pageNumber,
+  drag,
+  isActive,
+  onRemove,
+}: CapturePageCardProps): React.JSX.Element {
+  return (
+    <TouchableOpacity
+      onLongPress={drag}
+      disabled={isActive}
+      style={[styles.pageCard, isActive && styles.pageCardActive]}
+    >
+      <Image
+        source={{ uri: page.uri }}
+        style={styles.pageThumbnail}
+        accessibilityIgnoresInvertColors
+      />
+      <View style={styles.pageBadge}>
+        <Text style={styles.pageBadgeText}>{pageNumber}</Text>
+      </View>
+      <Pressable
+        testID={`capture-page-remove-${pageNumber}`}
+        accessibilityRole="button"
+        accessibilityLabel={`Remove page ${pageNumber}`}
+        onPress={() => onRemove(page.id)}
+        style={styles.pageRemove}
+      >
+        <Text style={styles.pageRemoveGlyph}>{REMOVE_GLYPH}</Text>
+      </Pressable>
+    </TouchableOpacity>
+  );
+}
+
+/** Add-pages affordance, plus the cap notice shown once the session is full. */
+function AddPagesControl({
+  canAdd,
+  onAdd,
+}: {
+  canAdd: boolean;
+  onAdd: () => void;
+}): React.JSX.Element {
+  return (
+    <>
+      <Button
+        testID="capture-add-pages"
+        variant="secondary"
+        label={ADD_PAGES_LABEL}
+        accessibilityLabel={ADD_PAGES_LABEL}
+        disabled={!canAdd}
+        onPress={onAdd}
+      />
+      {canAdd ? null : (
+        <Text testID="capture-cap-notice" style={styles.notice}>
+          {capReachedCopy}
+        </Text>
+      )}
+    </>
+  );
+}
+
+/** Proceed affordance: enabled only for a single page; a warm notice explains the
+ *  multi-page case rather than blocking it outright. */
+function TranscribeControl({
+  count,
+  onTranscribe,
+}: {
+  count: number;
+  onTranscribe: () => void;
+}): React.JSX.Element {
+  const label = transcribeLabel(count);
+  return (
+    <>
+      <Button
+        testID="capture-transcribe"
+        label={label}
+        accessibilityLabel={label}
+        disabled={count !== 1}
+        onPress={onTranscribe}
+      />
+      {count > 1 ? (
+        <Text testID="capture-multi-page-notice" style={styles.notice}>
+          {MULTI_PAGE_NOTICE}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+export interface CapturePagesStripProps {
+  pages: CapturePage[];
+  canAdd: boolean;
+  onAdd: () => void;
+  onRemove: (_id: string) => void;
+  onReorder: (_pages: CapturePage[]) => void;
+  onTranscribe: () => void;
+}
+
+/** Render the ordered page strip plus its add-pages and proceed affordances. */
+export function CapturePagesStrip({
+  pages,
+  canAdd,
+  onAdd,
+  onRemove,
+  onReorder,
+  onTranscribe,
+}: CapturePagesStripProps): React.JSX.Element {
+  return (
+    <View style={styles.collect}>
+      <DraggableFlatList
+        testID="capture-pages-list"
+        horizontal
+        data={pages}
+        keyExtractor={(page) => page.id}
+        renderItem={({ item, drag, isActive, getIndex }: RenderItemParams<CapturePage>) => (
+          <CapturePageCard
+            page={item}
+            pageNumber={(getIndex() ?? 0) + 1}
+            drag={drag}
+            isActive={isActive}
+            onRemove={onRemove}
+          />
+        )}
+        onDragEnd={({ data }) => onReorder(data)}
+        contentContainerStyle={styles.stripContent}
+      />
+      <AddPagesControl canAdd={canAdd} onAdd={onAdd} />
+      <TranscribeControl count={pages.length} onTranscribe={onTranscribe} />
+    </View>
+  );
+}
+
+export default CapturePagesStrip;

--- a/frontend/src/features/Journal/JournalPhotograph.styles.ts
+++ b/frontend/src/features/Journal/JournalPhotograph.styles.ts
@@ -4,11 +4,23 @@
  */
 import { StyleSheet } from 'react-native';
 
-import { BORDER_RADIUS, SPACING, colors, editorialType, spacing } from '@/design/tokens';
+import {
+  BORDER_RADIUS,
+  SPACING,
+  colors,
+  editorialType,
+  spacing,
+  touchTarget,
+} from '@/design/tokens';
 
 /** Minimum height for the editable preview so a short transcription still reads
  *  as a full page rather than a cramped single-line field. */
 const PREVIEW_MIN_HEIGHT = spacing(30);
+
+/** Thumbnail footprint for a collected page: a portrait card wide enough to read
+ *  the page number badge and remove affordance without crowding the image. */
+const THUMBNAIL_WIDTH = spacing(12);
+const THUMBNAIL_HEIGHT = spacing(16);
 
 const styles = StyleSheet.create({
   /** Vertical stack for a phase's copy + affordances, with editorial breathing room. */
@@ -60,6 +72,79 @@ const styles = StyleSheet.create({
   /** Stacked action buttons under a phase's copy. */
   actions: {
     gap: SPACING.sm,
+  },
+  /** The collect stage: the page strip over its add/transcribe affordances. */
+  collect: {
+    flex: 1,
+    gap: SPACING.md,
+  },
+  /** Horizontal padding around the strip so end cards aren't flush to the edge. */
+  stripContent: {
+    gap: SPACING.sm,
+    paddingVertical: SPACING.xs,
+  },
+  /** One page card: a portrait thumbnail carrying its number badge and remove tap. */
+  pageCard: {
+    width: THUMBNAIL_WIDTH,
+    height: THUMBNAIL_HEIGHT,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+    backgroundColor: colors.paper.backgroundAlt,
+    overflow: 'hidden',
+  },
+  /** Lifted, softened state while a card is being dragged to a new position. */
+  pageCardActive: {
+    opacity: 0.9,
+    borderColor: colors.paper.ink,
+  },
+  /** The page image itself, filling the card. */
+  pageThumbnail: {
+    width: '100%',
+    height: '100%',
+  },
+  /** A 1-based order badge pinned to the card's top-left corner. */
+  pageBadge: {
+    position: 'absolute',
+    top: SPACING.xs,
+    left: SPACING.xs,
+    minWidth: SPACING.xl,
+    paddingHorizontal: SPACING.xs,
+    borderRadius: BORDER_RADIUS.circle,
+    backgroundColor: colors.paper.ink,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  /** The badge's number, in the paper ground colour for contrast on the ink chip. */
+  pageBadgeText: {
+    ...editorialType.caption,
+    color: colors.paper.background,
+  },
+  /** The remove affordance: a full 44dp tap target in the card's top-right. */
+  pageRemove: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  /** The remove glyph, on a soft paper chip so it reads over any thumbnail. */
+  pageRemoveGlyph: {
+    ...editorialType.body,
+    color: colors.paper.ink,
+    width: SPACING.xl,
+    height: SPACING.xl,
+    borderRadius: BORDER_RADIUS.circle,
+    textAlign: 'center',
+    overflow: 'hidden',
+    backgroundColor: colors.paper.background,
+  },
+  /** Warm, low-pressure notice copy under the strip (cap reached, multi-page gate). */
+  notice: {
+    ...editorialType.note,
+    color: colors.paper.inkSoft,
   },
 });
 

--- a/frontend/src/features/Journal/JournalPhotographScreen.tsx
+++ b/frontend/src/features/Journal/JournalPhotographScreen.tsx
@@ -1,26 +1,34 @@
 /**
- * Photograph a handwritten journal page, transcribe it, and save it as a finished
- * entry. The flow auto-launches the photo picker on mount, sends the picked image
- * to the transcription endpoint, then offers the writer an editable preview of the
- * text before it becomes a real entry.
+ * Photograph handwritten journal pages, transcribe them, and save them as a
+ * finished entry. The flow auto-launches the photo picker on mount into an
+ * ordered, multi-page capture session: the writer collects pages (multi-select),
+ * reorders the thumbnail strip, and trims it before proceeding. Transcription is
+ * single-page in this iteration — the proceed affordance enables only for exactly
+ * one page — after which the writer gets an editable preview before it becomes a
+ * real entry.
  *
  * Every step is warm and declinable (NORTH-STAR): a refused permission, a cancelled
  * pick, an unreadable photo, or a spent transcription wallet each lead to a plain,
  * shame-free offramp — most often "type this entry instead" — never a dead end.
  *
- * PRIVACY: the base64 page image lives in component state only. It is never placed
- * in navigation params or logged, and is released on save and on unmount.
+ * PRIVACY: the base64 page images live in the capture session's reducer state
+ * only. They are never placed in navigation params or logged, and are released
+ * when the session is cleared (on save, on the typed-entry offramp) and on unmount.
  */
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { ActivityIndicator, Linking, Text, TextInput, View } from 'react-native';
 
+import { CapturePagesStrip } from './CapturePagesStrip';
+import { MAX_PAGES_PER_SESSION, canAddPages, captureSessionReducer } from './captureSession';
+import type { CapturePage } from './captureSession';
 import styles from './JournalPhotograph.styles';
-import { pickJournalPhoto } from './pickJournalPhoto';
+import { pickJournalPhotos } from './pickJournalPhoto';
+import type { MultiPickResult, PickedAsset } from './pickJournalPhoto';
 import { saveFinishedEntry } from './saveFinishedEntry';
 
 import { TranscriptionError, journal } from '@/api';
-import type { MediaType, TranscriptionErrorKind } from '@/api';
+import type { TranscriptionErrorKind } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
 import { Button } from '@/components/Button';
 import DatePicker, { toISODate } from '@/components/DatePicker';
@@ -85,17 +93,12 @@ const TYPED_ENTRY_KINDS: ReadonlySet<TranscriptionErrorKind> = new Set<Transcrip
   'model_lacks_vision',
 ]);
 
-/** The picked page held in memory for transcription (never in nav params). */
-interface PickedImage {
-  imageBase64: string;
-  mediaType: MediaType;
-}
-
 /** The screen's mutually-exclusive phases. */
 type Phase =
   | { step: 'preparing' }
   | { step: 'denied' }
   | { step: 'pickFailed' }
+  | { step: 'collect' }
   | { step: 'transcribing' }
   | { step: 'preview' }
   | { step: 'error'; error: TranscriptionError };
@@ -133,6 +136,8 @@ type PhotographNavigation = NativeStackScreenProps<
 
 interface CaptureModel {
   phase: Phase;
+  pages: CapturePage[];
+  canAdd: boolean;
   previewText: string;
   entryDate: string;
   saving: boolean;
@@ -140,6 +145,9 @@ interface CaptureModel {
   onChangeText: (_text: string) => void;
   onChangeEntryDate: (_date: string) => void;
   runPick: () => void;
+  removePage: (_id: string) => void;
+  reorderPages: (_pages: CapturePage[]) => void;
+  transcribe: () => void;
   retryTranscribe: () => void;
   save: () => void;
   openSettings: () => void;
@@ -152,47 +160,97 @@ function entryDateForCreate(entryDate: string): string | undefined {
   return entryDate === toISODate(new Date()) ? undefined : entryDate;
 }
 
-/** Pick a page image and transcribe it into an editable preview, stashing the
- *  picked image in ``imageRef`` so it never rides in nav params. */
-function usePickAndTranscribe(
+/** Give freshly-picked assets stable session ids (a monotonic counter), building
+ *  the {@link CapturePage} list appended to the session. */
+function toCapturePages(
+  assets: readonly PickedAsset[],
+  counterRef: React.MutableRefObject<number>,
+): CapturePage[] {
+  return assets.map((asset) => {
+    counterRef.current += 1;
+    return {
+      id: `page-${counterRef.current}`,
+      uri: asset.uri,
+      imageBase64: asset.imageBase64,
+      mediaType: asset.mediaType,
+      status: 'ready',
+    };
+  });
+}
+
+interface PickDeps {
+  navigation: PhotographNavigation;
+  dispatch: React.Dispatch<Parameters<typeof captureSessionReducer>[1]>;
+  pagesRef: React.MutableRefObject<CapturePage[]>;
+  counterRef: React.MutableRefObject<number>;
+  setPhase: (_phase: Phase) => void;
+}
+
+/** Route an initial (empty-session) pick that yielded no pages to its offramp:
+ *  a refused permission, a shame-free back-out, or an unreadable pick. */
+function applyInitialPickFailure(
+  result: Exclude<MultiPickResult, { kind: 'picked' }>,
   navigation: PhotographNavigation,
   setPhase: (_phase: Phase) => void,
+): void {
+  if (result.kind === 'denied') {
+    setPhase({ step: 'denied' });
+    return;
+  }
+  if (result.kind === 'cancelled') {
+    navigation.goBack();
+    return;
+  }
+  setPhase({ step: 'pickFailed' });
+}
+
+/** Launch the picker for the session's remaining capacity and fold the result in.
+ *  The first pick opens the session; later picks are additive — a cancel or a
+ *  failed pick with pages already collected simply keeps the session intact. */
+function usePickPages({
+  navigation,
+  dispatch,
+  pagesRef,
+  counterRef,
+  setPhase,
+}: PickDeps): () => Promise<void> {
+  return useCallback(async () => {
+    const hadPages = pagesRef.current.length > 0;
+    if (!hadPages) setPhase({ step: 'preparing' });
+    const result = await pickJournalPhotos(MAX_PAGES_PER_SESSION - pagesRef.current.length);
+    if (result.kind === 'picked') {
+      dispatch({ type: 'append', pages: toCapturePages(result.assets, counterRef) });
+    } else if (!hadPages) {
+      applyInitialPickFailure(result, navigation, setPhase);
+      return;
+    }
+    setPhase({ step: 'collect' });
+  }, [navigation, dispatch, pagesRef, counterRef, setPhase]);
+}
+
+/** Transcribe the session's single page into an editable preview. This is the
+ *  seam a later epic widens to multi-page reading; here it handles exactly one
+ *  page and no-ops otherwise (the proceed button is disabled for any other count). */
+function useBeginTranscription(
+  pagesRef: React.MutableRefObject<CapturePage[]>,
+  setPhase: (_phase: Phase) => void,
   setPreviewText: (_text: string) => void,
-  imageRef: React.MutableRefObject<PickedImage | null>,
-): { runPick: () => Promise<void>; transcribe: () => Promise<void> } {
-  const transcribe = useCallback(async () => {
-    const image = imageRef.current;
-    if (image == null) return;
+): () => Promise<void> {
+  return useCallback(async () => {
+    const [page] = pagesRef.current;
+    if (pagesRef.current.length !== 1 || !page) return;
     setPhase({ step: 'transcribing' });
     try {
-      const { text } = await journal.transcribePage(image);
+      const { text } = await journal.transcribePage({
+        imageBase64: page.imageBase64,
+        mediaType: page.mediaType,
+      });
       setPreviewText(text);
       setPhase({ step: 'preview' });
     } catch (err: unknown) {
       setPhase({ step: 'error', error: asTranscriptionError(err) });
     }
-  }, [imageRef, setPhase, setPreviewText]);
-
-  const runPick = useCallback(async () => {
-    setPhase({ step: 'preparing' });
-    const result = await pickJournalPhoto();
-    if (result.kind === 'denied') {
-      setPhase({ step: 'denied' });
-      return;
-    }
-    if (result.kind === 'cancelled') {
-      navigation.goBack();
-      return;
-    }
-    if (result.kind === 'failed') {
-      setPhase({ step: 'pickFailed' });
-      return;
-    }
-    imageRef.current = { imageBase64: result.imageBase64, mediaType: result.mediaType };
-    await transcribe();
-  }, [navigation, transcribe, imageRef, setPhase]);
-
-  return { runPick, transcribe };
+  }, [pagesRef, setPhase, setPreviewText]);
 }
 
 /** Persist the edited transcript. Reuses ``createdIdRef`` across save retries so a
@@ -201,7 +259,7 @@ function useSaveEntry(
   navigation: PhotographNavigation,
   previewText: string,
   entryDate: string,
-  imageRef: React.MutableRefObject<PickedImage | null>,
+  releaseSession: () => void,
   createdIdRef: React.MutableRefObject<number | null>,
 ): { save: () => Promise<void>; saving: boolean; saveFailed: boolean } {
   const [saving, setSaving] = useState(false);
@@ -219,63 +277,72 @@ function useSaveEntry(
         },
         entryDateForCreate(entryDate),
       );
-      imageRef.current = null; // Release the page image the moment it is saved.
+      releaseSession(); // Release every page image the moment the entry is saved.
       navigation.replace('JournalEntry', { entryId: id, justSaved: true });
     } catch {
       setSaveFailed(true);
     } finally {
       setSaving(false);
     }
-  }, [previewText, entryDate, navigation, imageRef, createdIdRef]);
+  }, [previewText, entryDate, navigation, releaseSession, createdIdRef]);
 
   return { save, saving, saveFailed };
 }
 
+/** The navigation offramps that also release the in-memory session: opening
+ *  device settings, backing out, and stepping off to a plain typed entry. */
+function useNavigationOfframps(
+  navigation: PhotographNavigation,
+  releaseSession: () => void,
+): { openSettings: () => void; cancel: () => void; goTypedEntry: () => void } {
+  const openSettings = useCallback(() => void Linking.openSettings(), []);
+  const cancel = useCallback(() => navigation.goBack(), [navigation]);
+  const goTypedEntry = useCallback(() => {
+    releaseSession(); // Release the session when stepping off to a typed entry.
+    navigation.navigate('JournalEntry');
+  }, [navigation, releaseSession]);
+  return { openSettings, cancel, goTypedEntry };
+}
+
 /**
- * The capture state machine: pick → transcribe → editable preview → save. Holds
- * the picked image and the created-entry id in refs so neither survives in nav
- * params, and so a save retry after a failed finish PATCH reuses the created id
- * rather than creating a duplicate page.
+ * The capture state machine: collect pages → transcribe → editable preview → save.
+ * Pages live in a reducer (never in nav params) with a ref mirror so async picks
+ * read the current session; the created-entry id lives in a ref so a save retry
+ * after a failed finish PATCH reuses it rather than creating a duplicate page.
  */
 function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
   const [phase, setPhase] = useState<Phase>({ step: 'preparing' });
+  const [pages, dispatch] = useReducer(captureSessionReducer, []);
   const [previewText, setPreviewText] = useState('');
   const [entryDate, setEntryDate] = useState(() => toISODate(new Date()));
-  const imageRef = useRef<PickedImage | null>(null);
   const createdIdRef = useRef<number | null>(null);
+  const counterRef = useRef(0);
+  const pagesRef = useRef<CapturePage[]>(pages);
+  pagesRef.current = pages;
 
-  const { runPick, transcribe } = usePickAndTranscribe(
-    navigation,
-    setPhase,
-    setPreviewText,
-    imageRef,
-  );
+  const releaseSession = useCallback(() => dispatch({ type: 'clear' }), []);
+  const runPick = usePickPages({ navigation, dispatch, pagesRef, counterRef, setPhase });
+  const beginTranscription = useBeginTranscription(pagesRef, setPhase, setPreviewText);
   const { save, saving, saveFailed } = useSaveEntry(
     navigation,
     previewText,
     entryDate,
-    imageRef,
+    releaseSession,
     createdIdRef,
   );
 
-  const openSettings = useCallback(() => void Linking.openSettings(), []);
-  const cancel = useCallback(() => navigation.goBack(), [navigation]);
-  const goTypedEntry = useCallback(() => {
-    imageRef.current = null; // Release the page image when stepping off to a typed entry.
-    navigation.navigate('JournalEntry');
-  }, [navigation, imageRef]);
+  const { openSettings, cancel, goTypedEntry } = useNavigationOfframps(navigation, releaseSession);
 
   useEffect(() => {
     void runPick();
-    // The device-local cache file the picker copies is cleaned up by a later epic
-    // issue; here we only release our in-memory hold on unmount.
-    return () => {
-      imageRef.current = null;
-    };
+    // The device-local cache files the picker copies are cleaned up by a later
+    // epic; the in-memory session is released by React when this screen unmounts.
   }, [runPick]);
 
   return {
     phase,
+    pages,
+    canAdd: canAddPages(pages),
     previewText,
     entryDate,
     saving,
@@ -283,7 +350,10 @@ function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
     onChangeText: setPreviewText,
     onChangeEntryDate: setEntryDate,
     runPick: () => void runPick(),
-    retryTranscribe: () => void transcribe(),
+    removePage: (id) => dispatch({ type: 'remove', id }),
+    reorderPages: (next) => dispatch({ type: 'reorder', pages: next }),
+    transcribe: () => void beginTranscription(),
+    retryTranscribe: () => void beginTranscription(),
     save: () => void save(),
     openSettings,
     cancel,
@@ -478,6 +548,23 @@ function PreviewView({
   );
 }
 
+/** The collect stage: the ordered page strip over a quiet, declinable date row. */
+function CollectView({ model }: { model: CaptureModel }): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <CapturePagesStrip
+        pages={model.pages}
+        canAdd={model.canAdd}
+        onAdd={model.runPick}
+        onRemove={model.removePage}
+        onReorder={model.reorderPages}
+        onTranscribe={model.transcribe}
+      />
+      <EntryDateRow entryDate={model.entryDate} onChangeEntryDate={model.onChangeEntryDate} />
+    </View>
+  );
+}
+
 /** Route the current phase to its view. */
 function CaptureBody({ model }: { model: CaptureModel }): React.JSX.Element {
   const { phase } = model;
@@ -486,6 +573,8 @@ function CaptureBody({ model }: { model: CaptureModel }): React.JSX.Element {
       return <PermissionDeniedView onOpenSettings={model.openSettings} onCancel={model.cancel} />;
     case 'pickFailed':
       return <PickFailedView onPickAnother={model.runPick} />;
+    case 'collect':
+      return <CollectView model={model} />;
     case 'transcribing':
       return <WorkingBlock testID="photograph-transcribing" caption={TRANSCRIBING_COPY} />;
     case 'preview':

--- a/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Linking } from 'react-native';
 
-import type { PickResult } from '../pickJournalPhoto';
+import type { MultiPickResult, PickedAsset } from '../pickJournalPhoto';
 
 import { TranscriptionError } from '@/api';
 import type { JournalMessage, MediaType, TranscribePageT, TranscriptionErrorKind } from '@/api';
@@ -17,7 +17,7 @@ const isoOffsetFromToday = (days: number): string => {
   return toISODate(date);
 };
 
-const mockPick = jest.fn() as jest.MockedFunction<() => Promise<PickResult>>;
+const mockPick = jest.fn() as jest.MockedFunction<(_limit: number) => Promise<MultiPickResult>>;
 const mockTranscribe = jest.fn() as jest.MockedFunction<
   (_p: { imageBase64: string; mediaType: MediaType }) => Promise<TranscribePageT>
 >;
@@ -29,7 +29,7 @@ const mockUpdate = jest.fn() as jest.MockedFunction<
 jest.mock(
   '../pickJournalPhoto',
   () => ({
-    pickJournalPhoto: (...a: unknown[]) =>
+    pickJournalPhotos: (...a: unknown[]) =>
       (mockPick as unknown as (...x: unknown[]) => unknown)(...a),
   }),
   { virtual: true },
@@ -49,10 +49,40 @@ jest.mock('@/api', () => {
   };
 });
 
+jest.mock('react-native-draggable-flatlist', () => {
+  const ReactLib = require('react');
+  const { View } = require('react-native');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ({ data, renderItem, onDragEnd, testID }: any) =>
+    ReactLib.createElement(
+      View,
+      { testID: testID ?? 'capture-pages-list', data, onDragEnd },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.map((item: any, index: number) =>
+        ReactLib.cloneElement(
+          renderItem({ item, index, drag: jest.fn(), isActive: false, getIndex: () => index }),
+          { key: item.id ?? index },
+        ),
+      ),
+    );
+});
+
 const JournalPhotographScreen = require('../JournalPhotographScreen').default;
 
-function picked(overrides: Partial<Extract<PickResult, { kind: 'picked' }>> = {}): PickResult {
-  return { kind: 'picked', imageBase64: 'abc123', mediaType: 'image/jpeg', ...overrides };
+function pickedAsset(overrides: Partial<PickedAsset> = {}): PickedAsset {
+  return { uri: 'file:///p1.jpg', imageBase64: 'abc123', mediaType: 'image/jpeg', ...overrides };
+}
+
+function uriList(count: number, startAt = 1): string[] {
+  return Array.from({ length: count }, (_v, i) => `file:///p${startAt + i}.jpg`);
+}
+
+function pageAssets(uris: string[]): PickedAsset[] {
+  return uris.map((uri, i) => pickedAsset({ uri, imageBase64: `b64-${i + 1}` }));
+}
+
+function picked(assets: PickedAsset[] = [pickedAsset()]): MultiPickResult {
+  return { kind: 'picked', assets };
 }
 
 function makeEntry(overrides: Partial<JournalMessage> = {}): JournalMessage {
@@ -121,7 +151,7 @@ describe('JournalPhotographScreen — permission denied', () => {
   });
 });
 
-describe('JournalPhotographScreen — cancelled pick', () => {
+describe('JournalPhotographScreen — cancelled initial pick with zero pages', () => {
   it('goes back immediately with no lingering UI', async () => {
     mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
     const { navigation, queryByTestId } = renderScreen();
@@ -129,6 +159,7 @@ describe('JournalPhotographScreen — cancelled pick', () => {
     expect(queryByTestId('photograph-transcribing')).toBeNull();
     expect(queryByTestId('photograph-error')).toBeNull();
     expect(queryByTestId('photograph-permission-denied')).toBeNull();
+    expect(queryByTestId('capture-pages-list')).toBeNull();
   });
 });
 
@@ -142,6 +173,134 @@ describe('JournalPhotographScreen — pick itself failed', () => {
   });
 });
 
+describe('JournalPhotographScreen — collect stage', () => {
+  it('renders picked pages in selection order with a numbered remove affordance each', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(3))));
+    const { findByTestId } = renderScreen();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toEqual(uriList(3));
+    expect(await findByTestId('capture-page-remove-1')).toBeTruthy();
+    expect(await findByTestId('capture-page-remove-2')).toBeTruthy();
+    expect(await findByTestId('capture-page-remove-3')).toBeTruthy();
+  });
+
+  it('renders the entry-date row during collect, and again during preview', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    const { findByTestId } = renderScreen();
+    expect(await findByTestId('capture-entry-date')).toBeTruthy();
+    fireEvent.press(await findByTestId('capture-transcribe'));
+    await findByTestId('photograph-preview-input');
+    expect(await findByTestId('capture-entry-date')).toBeTruthy();
+  });
+
+  it('adds pages additively, appending after the existing pages and requesting only remaining capacity', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2, 3))));
+    fireEvent.press(await findByTestId('capture-add-pages'));
+
+    await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(2));
+    expect(mockPick).toHaveBeenNthCalledWith(2, 8);
+
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toEqual(uriList(4));
+  });
+
+  it('reorders the strip from a drag end without any confirmation step', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(3))));
+    const { findByTestId } = renderScreen();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    const reversed = [...data].reverse();
+
+    act(() => {
+      list.props.onDragEnd({ data: reversed });
+    });
+
+    const reorderedList = await findByTestId('capture-pages-list');
+    const reorderedData = reorderedList.props.data as Array<{ uri: string }>;
+    expect(reorderedData.map((p) => p.uri)).toEqual([...uriList(3)].reverse());
+  });
+
+  it('removes a page by its id, renumbering the remaining remove affordances', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(3))));
+    const { findByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-page-remove-2'));
+
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toEqual(['file:///p1.jpg', 'file:///p3.jpg']);
+    expect(await findByTestId('capture-page-remove-1')).toBeTruthy();
+    expect(await findByTestId('capture-page-remove-2')).toBeTruthy();
+    expect(queryByTestId('capture-page-remove-3')).toBeNull();
+  });
+
+  it('disables Add pages and shows the cap notice once the session holds the maximum pages', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(10))));
+    const { findByTestId } = renderScreen();
+    const addButton = await findByTestId('capture-add-pages');
+    expect(addButton.props.accessibilityState.disabled).toBe(true);
+    expect(await findByTestId('capture-cap-notice')).toHaveTextContent(/10/);
+  });
+});
+
+describe('JournalPhotographScreen — multi-page transcription gate', () => {
+  it('disables Transcribe and shows the multi-page notice for more than one page, never calling transcribePage', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId } = renderScreen();
+    const transcribeButton = await findByTestId('capture-transcribe');
+    expect(transcribeButton.props.accessibilityState.disabled).toBe(true);
+    expect(await findByTestId('capture-multi-page-notice')).toBeTruthy();
+
+    fireEvent.press(transcribeButton);
+    expect(mockTranscribe).not.toHaveBeenCalled();
+
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(2);
+  });
+});
+
+describe('JournalPhotographScreen — single-page transcribe proceed', () => {
+  it('transcribes the single page with imageBase64 + mediaType only, no uri field', async () => {
+    mockPick.mockResolvedValueOnce(
+      picked([
+        pickedAsset({ uri: 'file:///p1.jpg', imageBase64: 'b64-1', mediaType: 'image/png' }),
+      ]),
+    );
+    mockTranscribe.mockResolvedValueOnce({ text: 'x' });
+    const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
+
+    await waitFor(() => expect(mockTranscribe).toHaveBeenCalledTimes(1));
+    expect(mockTranscribe).toHaveBeenCalledWith({ imageBase64: 'b64-1', mediaType: 'image/png' });
+  });
+});
+
+describe('JournalPhotographScreen — cancelled additive pick', () => {
+  it('keeps the session intact and stays in collect, without going back', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId, navigation } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
+    fireEvent.press(await findByTestId('capture-add-pages'));
+
+    await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(2));
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(2);
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});
+
 describe('JournalPhotographScreen — transcribing', () => {
   it('shows the transcribing state while the request is in flight', async () => {
     mockPick.mockResolvedValueOnce(picked());
@@ -152,6 +311,7 @@ describe('JournalPhotographScreen — transcribing', () => {
       }),
     );
     const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     expect(await findByTestId('photograph-transcribing')).toBeTruthy();
     await act(async () => {
       resolveTranscribe({ text: 'done' });
@@ -159,9 +319,12 @@ describe('JournalPhotographScreen — transcribing', () => {
   });
 
   it('sends the picked image + media type to transcribePage', async () => {
-    mockPick.mockResolvedValueOnce(picked({ imageBase64: 'b64data', mediaType: 'image/png' }));
+    mockPick.mockResolvedValueOnce(
+      picked([pickedAsset({ imageBase64: 'b64data', mediaType: 'image/png' })]),
+    );
     mockTranscribe.mockResolvedValueOnce({ text: 'x' });
-    renderScreen();
+    const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await waitFor(() =>
       expect(mockTranscribe).toHaveBeenCalledWith({
         imageBase64: 'b64data',
@@ -176,6 +339,7 @@ describe('JournalPhotographScreen — editable preview', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockResolvedValueOnce({ text: 'A page about the willow.' });
     const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     expect(input.props.value).toBe('A page about the willow.');
     expect(await findByTestId('photograph-save')).toBeTruthy();
@@ -185,6 +349,7 @@ describe('JournalPhotographScreen — editable preview', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
     const { findByTestId, getByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'Original, corrected.');
     expect(getByTestId('photograph-preview-input').props.value).toBe('Original, corrected.');
@@ -204,6 +369,7 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError(kind, null));
     const { findByTestId, queryByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     expect(await findByTestId('photograph-retry')).toBeTruthy();
     expect(queryByTestId('photograph-pick-another')).toBeNull();
   });
@@ -212,6 +378,7 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError(kind, 422));
     const { findByTestId, queryByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     expect(await findByTestId('photograph-pick-another')).toBeTruthy();
     expect(queryByTestId('photograph-retry')).toBeNull();
   });
@@ -220,6 +387,7 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('unknown', null));
     const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     expect(await findByTestId('photograph-retry')).toBeTruthy();
     expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
   });
@@ -228,6 +396,7 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('wallet_exhausted', 402));
     const { findByTestId, queryByTestId, getByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('photograph-error');
     expect(getByTestId('photograph-error')).toHaveTextContent(/this month's free allotment/);
     expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
@@ -238,16 +407,18 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('model_lacks_vision', 422));
     const { findByTestId, queryByTestId, getByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('photograph-error');
     expect(getByTestId('photograph-error')).toHaveTextContent(/isn't available/);
     expect(await findByTestId('photograph-typed-entry')).toBeTruthy();
     expect(queryByTestId('photograph-retry')).toBeNull();
   });
 
-  it('navigates to a plain JournalEntry from the typed-entry offramp', async () => {
+  it('navigates to a plain JournalEntry from the typed-entry offramp, with no second argument', async () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('wallet_exhausted', 402));
     const { findByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     fireEvent.press(await findByTestId('photograph-typed-entry'));
     expect(navigation.navigate).toHaveBeenCalledWith('JournalEntry');
   });
@@ -256,6 +427,7 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('network', null));
     const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('photograph-retry');
     expect(mockTranscribe).toHaveBeenCalledTimes(1);
 
@@ -268,16 +440,25 @@ describe('JournalPhotographScreen — transcription error recovery', () => {
     await waitFor(() => expect(mockTranscribe).toHaveBeenCalledTimes(3));
   });
 
-  it('re-launches the picker from Pick another', async () => {
+  it('re-launches the picker from Pick another, landing back in collect with the new page', async () => {
     mockPick.mockResolvedValueOnce(picked());
     mockTranscribe.mockRejectedValueOnce(new TranscriptionError('invalid_image', 422));
-    const { findByTestId } = renderScreen();
+    const { findByTestId, queryByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('photograph-pick-another');
     expect(mockPick).toHaveBeenCalledTimes(1);
 
-    mockPick.mockResolvedValueOnce({ kind: 'cancelled' });
+    mockPick.mockResolvedValueOnce(
+      picked([pickedAsset({ uri: 'file:///new.jpg', imageBase64: 'b64-new' })]),
+    );
     fireEvent.press(await findByTestId('photograph-pick-another'));
     await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(2));
+
+    expect(queryByTestId('photograph-error')).toBeNull();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toContain('file:///new.jpg');
+    expect(mockTranscribe).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -291,6 +472,7 @@ describe('JournalPhotographScreen — save flow', () => {
     );
 
     const { findByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'Edited by hand.');
     fireEvent.press(await findByTestId('photograph-save'));
@@ -310,6 +492,7 @@ describe('JournalPhotographScreen — save flow', () => {
     mockUpdate.mockResolvedValueOnce(makeEntry({ id: 5, status: 'finished' }));
 
     const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'No entry_date please.');
     fireEvent.press(await findByTestId('photograph-save'));
@@ -325,6 +508,7 @@ describe('JournalPhotographScreen — save flow', () => {
     mockUpdate.mockRejectedValueOnce(new Error('network down'));
 
     const { findByTestId, getByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'My hand-edited page.');
     fireEvent.press(await findByTestId('photograph-save'));
@@ -341,6 +525,7 @@ describe('JournalPhotographScreen — save flow', () => {
     mockUpdate.mockResolvedValueOnce(makeEntry({ id: 99, status: 'finished' }));
 
     const { findByTestId, getByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'Try again please.');
     fireEvent.press(await findByTestId('photograph-save'));
@@ -366,6 +551,7 @@ describe('JournalPhotographScreen — save flow', () => {
     mockUpdate.mockResolvedValueOnce(makeEntry({ id: 99, status: 'finished' }));
 
     const { findByTestId, getByTestId, navigation } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     const input = await findByTestId('photograph-preview-input');
     fireEvent.changeText(input, 'Before the failure.');
     fireEvent.press(await findByTestId('photograph-save'));
@@ -383,14 +569,6 @@ describe('JournalPhotographScreen — save flow', () => {
 });
 
 describe('JournalPhotographScreen — entry date', () => {
-  it('renders the entry-date row in the preview', async () => {
-    mockPick.mockResolvedValueOnce(picked());
-    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
-    const { findByTestId } = renderScreen();
-    await findByTestId('photograph-preview-input');
-    expect(await findByTestId('capture-entry-date')).toBeTruthy();
-  });
-
   it('threads a chosen past entry date to journal.create on Save', async () => {
     const yesterday = isoOffsetFromToday(-1);
     mockPick.mockResolvedValueOnce(picked());
@@ -399,6 +577,7 @@ describe('JournalPhotographScreen — entry date', () => {
     mockUpdate.mockResolvedValueOnce(makeEntry({ id: 21, status: 'finished' }));
 
     const { findByTestId, getByLabelText } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('capture-entry-date');
     fireEvent.changeText(getByLabelText('Date'), yesterday);
     fireEvent.press(await findByTestId('photograph-save'));
@@ -416,6 +595,7 @@ describe('JournalPhotographScreen — entry date', () => {
     mockUpdate.mockResolvedValueOnce(makeEntry({ id: 22, status: 'finished' }));
 
     const { findByTestId, getByLabelText } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('capture-entry-date');
     fireEvent.changeText(getByLabelText('Date'), isoOffsetFromToday(-1));
     fireEvent.changeText(getByLabelText('Date'), isoOffsetFromToday(0));
@@ -430,6 +610,7 @@ describe('JournalPhotographScreen — entry date', () => {
     mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
 
     const { findByTestId, getByLabelText, getByText } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
     await findByTestId('capture-entry-date');
     const todayButton = getByLabelText('Select today');
     expect(todayButton.props.accessibilityState.disabled).toBe(false);

--- a/frontend/src/features/Journal/__tests__/captureSession.test.ts
+++ b/frontend/src/features/Journal/__tests__/captureSession.test.ts
@@ -1,0 +1,101 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  MAX_PAGES_PER_SESSION,
+  canAddPages,
+  capReachedCopy,
+  captureSessionReducer,
+} from '../captureSession';
+import type { CapturePage } from '../captureSession';
+
+function page(id: string, overrides: Partial<CapturePage> = {}): CapturePage {
+  return {
+    id,
+    uri: `file:///${id}.jpg`,
+    imageBase64: `b64-${id}`,
+    mediaType: 'image/jpeg',
+    status: 'ready',
+    ...overrides,
+  };
+}
+
+function pages(ids: string[]): CapturePage[] {
+  return ids.map((id) => page(id));
+}
+
+describe('captureSessionReducer — append', () => {
+  it('appends to an empty session preserving order', () => {
+    const result = captureSessionReducer([], { type: 'append', pages: pages(['a', 'b']) });
+    expect(result.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('appends additively after the existing pages, preserving order', () => {
+    const state = pages(['a', 'b']);
+    const result = captureSessionReducer(state, { type: 'append', pages: pages(['c', 'd']) });
+    expect(result.map((p) => p.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('clamps an append at MAX_PAGES_PER_SESSION, keeping the appended pages in order up to the cap', () => {
+    const state = pages(['e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8']);
+    const incoming = pages(['n1', 'n2', 'n3', 'n4']);
+    const result = captureSessionReducer(state, { type: 'append', pages: incoming });
+
+    expect(result).toHaveLength(MAX_PAGES_PER_SESSION);
+    expect(result.map((p) => p.id)).toEqual([
+      'e1',
+      'e2',
+      'e3',
+      'e4',
+      'e5',
+      'e6',
+      'e7',
+      'e8',
+      'n1',
+      'n2',
+    ]);
+  });
+});
+
+describe('captureSessionReducer — remove', () => {
+  it('removes by id, preserving the order of the rest', () => {
+    const state = pages(['a', 'b', 'c']);
+    const result = captureSessionReducer(state, { type: 'remove', id: 'b' });
+    expect(result.map((p) => p.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('captureSessionReducer — reorder', () => {
+  it('replaces the order wholesale from action.pages', () => {
+    const state = pages(['a', 'b', 'c']);
+    const reordered = [...state].reverse();
+    const result = captureSessionReducer(state, { type: 'reorder', pages: reordered });
+    expect(result.map((p) => p.id)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('captureSessionReducer — clear', () => {
+  it('empties the session', () => {
+    const state = pages(['a', 'b']);
+    const result = captureSessionReducer(state, { type: 'clear' });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('canAddPages', () => {
+  it('is true with nine pages', () => {
+    const nine = pages(Array.from({ length: 9 }, (_v, i) => `p${i}`));
+    expect(canAddPages(nine)).toBe(true);
+  });
+
+  it('is false at exactly ten pages', () => {
+    const ten = pages(Array.from({ length: 10 }, (_v, i) => `p${i}`));
+    expect(canAddPages(ten)).toBe(false);
+  });
+});
+
+describe('capReachedCopy', () => {
+  it('names the maximum page count', () => {
+    expect(capReachedCopy).toContain(String(MAX_PAGES_PER_SESSION));
+  });
+});

--- a/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
+++ b/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
@@ -2,7 +2,7 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import * as ImagePicker from 'expo-image-picker';
 
-import { pickJournalPhoto, toMediaType } from '../pickJournalPhoto';
+import { pickJournalPhotos, toMediaType } from '../pickJournalPhoto';
 
 const requestPermission = jest.mocked(ImagePicker.requestMediaLibraryPermissionsAsync);
 const launchLibrary = jest.mocked(ImagePicker.launchImageLibraryAsync);
@@ -20,7 +20,7 @@ function asset(
   } as ImagePicker.ImagePickerAsset;
 }
 
-describe('pickJournalPhoto', () => {
+describe('pickJournalPhotos', () => {
   beforeEach(() => {
     requestPermission.mockResolvedValue({ granted: true } as ImagePicker.PermissionResponse);
     launchLibrary.mockResolvedValue({ canceled: true, assets: null });
@@ -28,57 +28,78 @@ describe('pickJournalPhoto', () => {
 
   it('returns denied without launching the picker when permission is refused', async () => {
     requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
-    expect(await pickJournalPhoto()).toEqual({ kind: 'denied' });
+    expect(await pickJournalPhotos(10)).toEqual({ kind: 'denied' });
     expect(launchLibrary).not.toHaveBeenCalled();
   });
 
   it('returns cancelled when the user backs out of the picker', async () => {
     launchLibrary.mockResolvedValueOnce({ canceled: true, assets: null });
-    expect(await pickJournalPhoto()).toEqual({ kind: 'cancelled' });
+    expect(await pickJournalPhotos(10)).toEqual({ kind: 'cancelled' });
   });
 
-  it('returns failed when a completed pick has no assets', async () => {
-    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [] });
-    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
-  });
-
-  it('returns failed when the picked asset carries no base64 data', async () => {
-    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [asset({ base64: null })] });
-    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
-  });
-
-  it('returns failed when the picked asset omits base64 entirely', async () => {
-    const noBase64 = asset();
-    delete (noBase64 as { base64?: string | null }).base64;
-    launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [noBase64] });
-    expect(await pickJournalPhoto()).toEqual({ kind: 'failed' });
-  });
-
-  it('returns the base64 payload + resolved media type on a successful pick', async () => {
+  it('returns failed when zero picked assets carry usable base64 data', async () => {
     launchLibrary.mockResolvedValueOnce({
       canceled: false,
-      assets: [asset({ base64: 'xyz', mimeType: 'image/png' })],
+      assets: [asset({ base64: undefined })],
     });
-    expect(await pickJournalPhoto()).toEqual({
+    expect(await pickJournalPhotos(10)).toEqual({ kind: 'failed' });
+  });
+
+  it('maps every picked asset, in selection order, to uri + imageBase64 + mediaType', async () => {
+    launchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        asset({ uri: 'file:///p1.jpg', base64: 'b64-1', mimeType: 'image/jpeg' }),
+        asset({ uri: 'file:///p2.jpg', base64: 'b64-2', mimeType: 'image/png' }),
+        asset({ uri: 'file:///p3.jpg', base64: 'b64-3', mimeType: 'image/webp' }),
+      ],
+    });
+
+    expect(await pickJournalPhotos(10)).toEqual({
       kind: 'picked',
-      imageBase64: 'xyz',
-      mediaType: 'image/png',
+      assets: [
+        { uri: 'file:///p1.jpg', imageBase64: 'b64-1', mediaType: 'image/jpeg' },
+        { uri: 'file:///p2.jpg', imageBase64: 'b64-2', mediaType: 'image/png' },
+        { uri: 'file:///p3.jpg', imageBase64: 'b64-3', mediaType: 'image/webp' },
+      ],
     });
   });
 
-  it('requests images-only, base64-included, 0.8-quality media', async () => {
+  it('skips a base64-less asset among otherwise usable picks, returning only the usable ones', async () => {
+    launchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        asset({ uri: 'file:///p1.jpg', base64: 'b64-1' }),
+        asset({ uri: 'file:///p2.jpg', base64: undefined }),
+        asset({ uri: 'file:///p3.jpg', base64: 'b64-3' }),
+      ],
+    });
+
+    expect(await pickJournalPhotos(10)).toEqual({
+      kind: 'picked',
+      assets: [
+        { uri: 'file:///p1.jpg', imageBase64: 'b64-1', mediaType: 'image/jpeg' },
+        { uri: 'file:///p3.jpg', imageBase64: 'b64-3', mediaType: 'image/jpeg' },
+      ],
+    });
+  });
+
+  it('calls the launcher with multi-select options for the given selection limit', async () => {
     launchLibrary.mockResolvedValueOnce({ canceled: false, assets: [asset()] });
-    await pickJournalPhoto();
+    await pickJournalPhotos(7);
     expect(launchLibrary).toHaveBeenCalledWith({
       mediaTypes: ['images'],
       quality: 0.8,
       base64: true,
+      allowsMultipleSelection: true,
+      selectionLimit: 7,
+      orderedSelection: true,
     });
   });
 
   it('never calls the launcher after permission is denied', async () => {
     requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
-    await pickJournalPhoto();
+    await pickJournalPhotos(10);
     expect(launchLibrary).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/Journal/captureSession.ts
+++ b/frontend/src/features/Journal/captureSession.ts
@@ -1,0 +1,75 @@
+/**
+ * The ordered multi-page capture session for the Journal photograph flow: a pure
+ * reducer over a list of picked pages that a writer collects, reorders, and trims
+ * before transcribing. A session is a working set held only in component state.
+ *
+ * PRIVACY: each page carries its base64 image; that payload lives in reducer
+ * state only, is never logged, and is released when the session is cleared or the
+ * screen unmounts.
+ */
+import type { MediaType } from '@/api';
+
+/** A session holds at most this many pages; beyond it, the writer saves and starts anew. */
+export const MAX_PAGES_PER_SESSION = 10;
+
+/** A page's lifecycle marker. Only `ready` exists today; later epics widen it. */
+export type CapturePageStatus = 'ready';
+
+/** One collected page: a stable id, its on-device uri, and the base64 to transcribe. */
+export interface CapturePage {
+  id: string;
+  uri: string;
+  imageBase64: string;
+  mediaType: MediaType;
+  status: CapturePageStatus;
+}
+
+/**
+ * The transitions a capture session accepts:
+ *
+ *  - `append`  — add a freshly-picked batch after the existing pages.
+ *  - `remove`  — drop the page with the given id.
+ *  - `reorder` — replace the order wholesale (from a drag end).
+ *  - `clear`   — empty the session (on save, offramp, or fresh start).
+ */
+export type CaptureSessionAction =
+  | { type: 'append'; pages: readonly CapturePage[] }
+  | { type: 'remove'; id: string }
+  | { type: 'reorder'; pages: readonly CapturePage[] }
+  | { type: 'clear' };
+
+/**
+ * Advance the session by one action, returning a new page list.
+ *
+ * `append` is additive and clamps the result to {@link MAX_PAGES_PER_SESSION}:
+ * existing pages are kept and incoming pages are appended in order until the cap
+ * is reached, dropping any overflow. `remove` filters by id preserving order,
+ * `reorder` takes the supplied order verbatim, and `clear` empties the session.
+ */
+export function captureSessionReducer(
+  state: CapturePage[],
+  action: CaptureSessionAction,
+): CapturePage[] {
+  switch (action.type) {
+    case 'append': {
+      const room = Math.max(MAX_PAGES_PER_SESSION - state.length, 0);
+      return [...state, ...action.pages.slice(0, room)];
+    }
+    case 'remove':
+      return state.filter((page) => page.id !== action.id);
+    case 'reorder':
+      return [...action.pages];
+    case 'clear':
+      return [];
+    default:
+      return state;
+  }
+}
+
+/** Whether the session has room for at least one more page. */
+export function canAddPages(pages: readonly CapturePage[]): boolean {
+  return pages.length < MAX_PAGES_PER_SESSION;
+}
+
+/** Warm, declinable copy shown once a session is full — save and start another. */
+export const capReachedCopy = `Sessions hold up to ${MAX_PAGES_PER_SESSION} pages — save this entry and start another for more.`;

--- a/frontend/src/features/Journal/pickJournalPhoto.ts
+++ b/frontend/src/features/Journal/pickJournalPhoto.ts
@@ -1,10 +1,11 @@
 /**
  * Wraps `expo-image-picker` for the Journal photograph-capture flow: request
- * permission, open the library, and hand back the picked page as base64 with a
- * server-accepted media type — or a discriminated reason it did not.
+ * permission, open the library for an ordered multi-selection, and hand back the
+ * picked pages as base64 with server-accepted media types — or a discriminated
+ * reason none were usable.
  *
- * PRIVACY: the returned base64 image payload is never logged here; callers hold
- * it in memory only and release it once the page is saved.
+ * PRIVACY: the returned base64 image payloads are never logged here; callers hold
+ * them in memory only and release them once the pages are saved.
  */
 import * as ImagePicker from 'expo-image-picker';
 
@@ -21,19 +22,26 @@ const PASSTHROUGH_MEDIA_TYPES: readonly MediaType[] = ['image/png', 'image/webp'
 /** Default encoding assumed when the picker reports an unknown/absent mime type. */
 const DEFAULT_MEDIA_TYPE: MediaType = 'image/jpeg';
 
+/** A single usable page returned from the picker: its uri, base64, and media type. */
+export interface PickedAsset {
+  uri: string;
+  imageBase64: string;
+  mediaType: MediaType;
+}
+
 /**
- * The outcome of a single pick attempt, discriminated on `kind`:
+ * The outcome of a multi-pick attempt, discriminated on `kind`:
  *
  *  - `denied`    — media-library permission was refused; the picker never opened.
  *  - `cancelled` — the user backed out of the picker.
  *  - `failed`    — the pick completed but yielded no usable base64 image.
- *  - `picked`    — a usable page image with its resolved media type.
+ *  - `picked`    — one or more usable pages, in selection order.
  */
-export type PickResult =
+export type MultiPickResult =
   | { kind: 'denied' }
   | { kind: 'cancelled' }
   | { kind: 'failed' }
-  | { kind: 'picked'; imageBase64: string; mediaType: MediaType };
+  | { kind: 'picked'; assets: PickedAsset[] };
 
 /**
  * Map an image picker mime type to a transcription-accepted {@link MediaType}.
@@ -45,15 +53,33 @@ export function toMediaType(mime?: string): MediaType {
   return match ?? DEFAULT_MEDIA_TYPE;
 }
 
+/** Keep only assets that carry base64, mapping each to a {@link PickedAsset} in order. */
+function toPickedAssets(assets: readonly ImagePicker.ImagePickerAsset[]): PickedAsset[] {
+  const usable: PickedAsset[] = [];
+  for (const asset of assets) {
+    if (asset.base64) {
+      usable.push({
+        uri: asset.uri,
+        imageBase64: asset.base64,
+        mediaType: toMediaType(asset.mimeType),
+      });
+    }
+  }
+  return usable;
+}
+
 /**
- * Open the device media library and return the chosen page as base64.
+ * Open the device media library for an ordered multi-selection and return the
+ * chosen pages as base64.
  *
  * Requests media-library permission first; a refusal short-circuits to `denied`
- * without ever launching the picker. A cancelled pick is `cancelled`; a pick
- * that yields no asset or no base64 is `failed`. Otherwise the first asset's
- * base64 payload and resolved media type are returned as `picked`.
+ * without ever launching the picker. A cancelled pick is `cancelled`. Every
+ * picked asset carrying base64 is mapped, in selection order, to its uri, base64,
+ * and resolved media type; assets without base64 are skipped. A pick that yields
+ * no usable asset is `failed`. `selectionLimit` caps how many pages the picker
+ * offers — the session's remaining capacity.
  */
-export async function pickJournalPhoto(): Promise<PickResult> {
+export async function pickJournalPhotos(selectionLimit: number): Promise<MultiPickResult> {
   const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
   if (!permission.granted) {
     return { kind: 'denied' };
@@ -62,13 +88,16 @@ export async function pickJournalPhoto(): Promise<PickResult> {
     mediaTypes: ['images'],
     quality: IMAGE_QUALITY,
     base64: true,
+    allowsMultipleSelection: true,
+    selectionLimit,
+    orderedSelection: true,
   });
   if (result.canceled) {
     return { kind: 'cancelled' };
   }
-  const asset = result.assets[0];
-  if (!asset || !asset.base64) {
+  const assets = toPickedAssets(result.assets);
+  if (assets.length === 0) {
     return { kind: 'failed' };
   }
-  return { kind: 'picked', imageBase64: asset.base64, mediaType: toMediaType(asset.mimeType) };
+  return { kind: 'picked', assets };
 }


### PR DESCRIPTION
## Summary

Grows the Journal photograph-capture flow from a single page to an ordered multi-page capture session — the session model and UI layer only.

- **Multi-select from the library** — `pickJournalPhotos(selectionLimit)` uses `allowsMultipleSelection` + `orderedSelection`; selection order is preserved as page order and picking more is additive (append).
- **Ordered thumbnail strip** — one thumbnail per page with its 1-based page number, long-press drag-reorder via the existing `DraggableFlatList` idiom (copied from `ReorderHabitsModal`, no new dependency), and a per-page remove affordance (44dp target, `Remove page N` label).
- **10-page cap** — `MAX_PAGES_PER_SESSION` is a named exported constant; the reducer clamps appends at the cap (defense-in-depth beyond the picker's `selectionLimit` hint), and Add disables with warm, declinable copy naming the limit.
- **Session model** — an ordered `CapturePage[]` held in a screen-local `useReducer` (the house journal pattern — not Zustand, not AsyncStorage).
- **Clean downstream seam** — the proceed action behaves byte-identically to the single-page tracer for exactly one page; multi-page transcription is deferred behind a disabled Transcribe + a warm `capture-multi-page-notice` (no dead tap, no dropped pages). Camera and downscaling seams are left untouched.

### Privacy (preserved verbatim from the tracer)
base64 page payloads live only in reducer state — never persisted, never logged, never in nav params — and are released on save success, on the typed-entry offramp, and on unmount. Thumbnails render from the on-device `uri`, never base64.

## Test plan

- New `captureSession.test.ts` — pure reducer: additive append, cap clamp, remove, reorder, clear, `canAddPages`, cap copy.
- Rewritten `pickJournalPhoto.test.ts` — multi-select mapping, ordered assets, skipped base64-less assets, denied/cancelled/failed, exact picker options.
- Extended `JournalPhotographScreen.test.tsx` — multi-select append order, additive add requesting only remaining capacity, drag-reorder renumber, remove renumber, cap enforcement (disabled Add + notice), the N>1 gate (Transcribe disabled, `transcribePage` never called, pages retained), single-page proceed transcribing with `{imageBase64, mediaType}` only, plus the full single-page tracer regression matrix (error recovery, save/retry, entry date).
- Two smoke/nav suites stub `CapturePagesStrip` (mirroring the existing `ReorderHabitsModal` stub) so gesture-handler's native module isn't loaded at import time; one design-governance allowlist entry audits the non-interactive `pageBadgeText` caption.
- `./scripts/frontend/check-all.sh` green (426 suites / 4714 tests, lint + prettier + typecheck clean); pre-push hooks pass.

Closes #1793
Refs #1799