### PR TITLE
chore(backend): pin backend deps to CI-resolved versions

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,20 +1,23 @@
-uvicorn
-bandit
-interrogate>=1.7
-isort
-mypy
-pre-commit
-pytest
-pytest-cov
+# Dev/CI-only tooling. Exact (==) pins matching CI's resolved set so lint,
+# type, and quality gates run identically on every machine. Dependabot's pip
+# ecosystem entry proposes upgrades.
+uvicorn==0.51.0
+bandit==1.9.4
+interrogate==1.7.0
+isort==8.0.1
+mypy==2.3.0
+pre-commit==4.6.0
+pytest==9.1.1
+pytest-cov==7.1.0
 # Type stubs for the runtime jsonschema dependency (issues #389/#390).
-types-jsonschema>=4.26.0.20260518
-radon>=6.0.1
-ruff
-vulture>=2.16
-xenon>=0.9.3
-pydantic
-sqlmodel
-types-cachetools
-types-requests
-types-ujson
-types-orjson
+types-jsonschema==4.26.0.20260518
+radon==6.0.1
+ruff==0.15.22
+vulture==2.16
+xenon==0.9.3
+pydantic==2.13.4
+sqlmodel==0.0.39
+types-cachetools==7.0.0.20260713
+types-requests==2.33.0.20260712
+types-ujson==5.10.0.20250822
+types-orjson==3.6.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,25 +1,29 @@
 # Only used by pip-audit hook in CI; adjust based on your actual deps.
-cachetools
+# All entries carry exact (==) pins matching CI's resolved set (see
+# requirements-lock.txt) so local dev, the compat matrix, and pip-audit all
+# install one identical set. Dependabot's pip ecosystem entry proposes upgrades.
+cachetools==7.1.4
 # Validates backend/content/manifest.json against the frozen contract at
-# startup (issues #389/#390); >=4.0 for JSON Schema draft 2020-12.
-jsonschema>=4.0
-fastapi
-uvicorn
-pydantic
-email-validator
-sqlalchemy
-sqlmodel
-alembic
-asyncpg
-aiosqlite
-bcrypt
-cryptography
-PyJWT
-slowapi
-tzdata
-pytest
-pytest-asyncio
-httpx
+# startup (issues #389/#390); the >=4.0 floor (JSON Schema draft 2020-12) is
+# preserved by this pin, which is >= 4.0.
+jsonschema==4.26.0
+fastapi==0.139.2
+uvicorn==0.51.0
+pydantic==2.13.4
+email-validator==2.3.0
+sqlalchemy==2.0.51
+sqlmodel==0.0.39
+alembic==1.18.5
+asyncpg==0.31.0
+aiosqlite==0.22.1
+bcrypt==5.0.0
+cryptography==49.0.0
+PyJWT==2.13.0
+slowapi==0.1.10
+tzdata==2026.3
+pytest==9.1.1
+pytest-asyncio==1.4.0
+httpx==0.28.1
 # LLM provider SDKs for BotMason (issue #402) — the stub provider stays the
 # default; these activate via BOTMASON_PROVIDER + LLM_API_KEY or a BYOK key.
 openai==2.46.0


### PR DESCRIPTION
## Summary

`backend/requirements.txt` listed direct deps (fastapi, uvicorn, pydantic, …) with no version constraint. This produced a local-vs-CI environment split: PR #1857 failed CI because local dev had `fastapi 0.136` while CI resolved `0.139.2`, where `include_router` stopped flattening child routes into `app.routes` (≥0.137). Any unpinned entry can reproduce this class of failure.

This change converts **every** entry in `backend/requirements.txt` (21) and `backend/requirements-dev.txt` (19) from unpinned/floor specifiers to exact `==` pins matching the versions CI actually resolves.

**How versions were determined (not guessed):**
- **Runtime deps** — read from `backend/requirements-lock.txt`, which is generated by `uv pip compile backend/requirements.txt` and is what CI's main job installs. Confirmed `fastapi==0.139.2`.
- **Dev-only tools** — from a fresh `uv pip compile backend/requirements.txt backend/requirements-dev.txt` (Python 3.12, matching CI). Shared deps (uvicorn, pydantic, sqlmodel, pytest) matched the lock exactly.
- Regenerating `requirements-lock.txt` from the newly-pinned `requirements.txt` produced an **identical** lock (empty diff), confirming the pins equal the already-resolved set — no transitive churn.

**Specifier idiom — exact `==`, not `~=`:** the repo's established idiom in `requirements.txt` is exact pins (`openai==2.46.0`, `anthropic==0.117.0`), so this matches it. Exact `==` is also strictly better for the stated goal than the issue's illustrative `~=0.139.2`: a compatible-release pin still permits *patch* drift (0.139.2 vs 0.139.5) between local and CI — the very failure mode #1857 hit. No exceptions were needed — every entry is pinned.

**Dependabot manages upgrades from here:** the `pip` ecosystem entry in `.github/dependabot.yml` (directory `/backend`) now proposes version bumps deliberately (batched patch/minor, individual majors) instead of CI silently drifting ahead of dev machines.

**Note — greenlet:** `greenlet` is a runtime transitive of async SQLAlchemy present in real environments (shared dev venv, CI) but absent from the lock on a fresh macOS/py3.12 resolve due to its platform marker. This predates this change (the lock diff is empty) and is out of scope here; flagging it for visibility.

## Test plan

All verification run **foreground** in an isolated Python 3.12 venv installing `requirements-lock.txt` + `requirements-dev.txt` (mirroring CI), against the pinned set:
- `./scripts/backend/check-all.sh` — green: lint, format, mypy, bandit, radon, **2962 passed / 2 skipped, 96.95% coverage**.
- `pip-audit -r backend/requirements.txt` — **No known vulnerabilities found**.
- pre-commit `pip-audit (backend dependencies)` hook — Passed on commit.

Closes #1859