### PR TITLE
chore(agents): align subagent model selection to owner policy

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -22,14 +22,14 @@ graph under a conductor is identical:
 ```
 ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
   └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
-       ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
-       ├─ test-specialist ..... L2  sonnet  Gate 1 RED: failing tests          ─┐
-       ├─ implementation-spec.  L2  opus    Gate 1 GREEN + Refactor             │ run per
+       ├─ chief-architect ..... L0  opus    plan + ordered dispatch list (no code)
+       ├─ test-specialist ..... L2  fable   Gate 1 RED: failing tests          ─┐
+       ├─ implementation-spec.  L2  fable   Gate 1 GREEN + Refactor             │ run per
        ├─ security-specialist . L2  opus    harden auth/JWT/CORS/input/DB       │ the
        ├─ performance-spec. ... L2  sonnet  profile/optimize hot paths          │ architect's
        ├─ documentation-spec. . L2  sonnet  docstrings/READMEs/ADRs             │ dispatch
        ├─ dependency-review ... L2  haiku   deps/pins/licenses (read-only)      │ list
-       └─ code-review-orch. ... L1  opus    Gate 2.5 pre-push self-review      ─┘
+       └─ code-review-orch. ... L1  sonnet  Gate 2.5 pre-push self-review      ─┘
 ```
 
 **The tree above is the spawn graph: each conductor (`ralph-worker`, or
@@ -62,25 +62,32 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-**Fable** for the single hardest-reasoning, long-horizon role: `chief-architect`.
-Planning is the highest-leverage decision in a tick — one wrong design compounds
-across every specialist that executes it — so the architect runs on Anthropic's
-most capable model. Fable is ~2× Opus-tier cost and can run minutes-long turns,
-which is acceptable for a once-per-issue planning pass but **not** for scoped
-worker roles. Two Fable caveats shape the fleet: its safety classifiers target
+The mix follows one owner-decided policy — **model by role type**:
+planning/orchestration on **Opus**, implementation on **Fable**, review on
+**Sonnet**, quick read-only checks on **Haiku**.
+
+**Opus** for planning and orchestration, where judgment drives every downstream
+decision: `chief-architect` (one wrong design compounds across every specialist
+that executes it) and `ralph-worker` (the per-issue conductor). Kept here too is
+`security-specialist` — its work is judgment-heavy threat modeling *and* it is
+deliberately barred from Fable (see the caveat below), so it stays on Opus rather
+than the implementation tier.
+
+**Fable** for implementation — the code-writing roles: `implementation-specialist`
+(production code is the core quality lever) and `test-specialist` (test authoring
+is code-writing). Two Fable caveats shape the fleet: its safety classifiers target
 **cyber/bio** content (so the code-writing `security-specialist` stays on **Opus**,
 never Fable — legitimate hardening work can trip a false-positive refusal), and it
-prefers **less-prescriptive prompts** (state the goal and constraints; the
-architect's Output Contract is a format spec, not step-by-step scaffolding).
+prefers **less-prescriptive prompts** (state the goal and constraints; a
+specialist's contract is a format spec, not step-by-step scaffolding).
 
-**Opus** where judgment drives quality:
-`implementation-specialist` (production code is the core quality lever),
-`security-specialist` (threat modeling — and deliberately kept off Fable per the
-caveat above), `code-review-orchestrator` (synthesis).
-**Sonnet** for well-scoped roles guided by an explicit plan: `test-specialist`,
-`performance-specialist`, `documentation-specialist`. **Haiku** for the
-purely mechanical, read-only checklist walk: `dependency-review-specialist`
-(pins/lockfile/license checks need no deep reasoning — spend the cheaper tier).
+**Sonnet** for review — well-scoped roles guided by an explicit plan or diff:
+`code-review-orchestrator` (Gate 2.5 synthesis) and the review-dimension
+specialists `performance-specialist` and `documentation-specialist` (each acts
+primarily as a reviewer; their occasional edits are narrow and plan-guided).
+**Haiku** for the purely mechanical, read-only checklist walk:
+`dependency-review-specialist` (pins/lockfile/license checks need no deep
+reasoning — spend the cheaper tier).
 
 ## Gate → agent invocation matrix
 

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -4,7 +4,7 @@ description: "Strategic brain of a Ralph tick. Select to architect a single back
 level: 0
 phase: Plan
 tools: Read,Grep,Glob,Task
-model: fable
+model: opus
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -4,7 +4,7 @@ description: "Gate 2.5 — the pre-push self-review. Routes a working-tree diff 
 level: 1
 phase: Cleanup
 tools: Read,Grep,Glob,Task
-model: opus
+model: sonnet
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist]
 receives_from: [chief-architect]
 ---
@@ -17,7 +17,7 @@ local checks (Gate 2) pass and before the conductor pushes, you review the diff 
 defects are caught *here* — not in CI (Gate 3) or by the Claude PR reviewer
 (Gate 4). You analyze the change, route each relevant dimension to its specialist
 **in review mode**, then consolidate their findings into one report. Reasoning
-runs on Opus — synthesis and conflict resolution are judgment work.
+runs on Sonnet — review synthesis is well-scoped, plan-guided work.
 
 ## Scope
 
@@ -65,8 +65,8 @@ Route only the dimensions the diff actually touches — no redundant reviews.
    graph was wrong). Those committed Markdown notes feed the weekly `graphify
    reflect` digest; repo Q&A only, never secrets.
 2. **Primary path — review the applicable dimensions yourself** against each
-   specialist's checklist (above) and the shared constraints. You run on Opus
-   precisely so a single agent can carry every dimension. **Enhancement:** where
+   specialist's checklist (above) and the shared constraints. You run on Sonnet
+   so a single agent can carry every dimension at review-tier cost. **Enhancement:** where
    the runtime supports nested spawning, you *may* fan out a specialist in review
    mode per dimension (in parallel, read-only) for deeper coverage — but do not
    depend on it; the Ralph conductor spawns sub-agents, and a tick's review must

--- a/.claude/agents/implementation-specialist.md
+++ b/.claude/agents/implementation-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 GREEN + Refactor — writes the production code that makes 
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: opus
+model: fable
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---
@@ -16,7 +16,7 @@ Level 2 leaf worker who owns **Gate 1 GREEN** and the **Refactor** step: write t
 smallest, cleanest production code that makes the test-specialist's failing tests
 pass while meeting every threshold, then refactor for clarity without breaking
 green. You are the primary lever on "best code possible," so the work runs on
-Opus. You also serve as the **correctness/maintainability reviewer**.
+Fable. You also serve as the **correctness/maintainability reviewer**.
 
 ## Scope
 

--- a/.claude/agents/test-specialist.md
+++ b/.claude/agents/test-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 RED — writes the failing tests that specify a behavior be
 level: 2
 phase: Test
 tools: Read,Write,Edit,Grep,Glob
-model: sonnet
+model: fable
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---


### PR DESCRIPTION
## Summary

Applies the owner-decided **model-by-role-type** policy to every
`.claude/agents/*.md` frontmatter `model:` field and syncs all doc-truth model
claims (README tier tree + prose, self-referential body lines) so they match the
frontmatter exactly.

Policy:
- **Opus — planning/orchestration:** `chief-architect` (was `fable`), `ralph-worker` (already `opus`)
- **Fable — implementation:** `implementation-specialist` (was `opus`), `test-specialist` (was `sonnet`)
- **Sonnet — review:** `code-review-orchestrator` (was `opus`), plus the review-dimension duals below
- **Haiku — quick checks:** `dependency-review-specialist` (already `haiku`)

Only the `model:` line changed in each frontmatter; descriptions, tools, and
body text were left intact except for three now-stale self-referential model
claims that had to move to match (implementation-specialist "runs on Opus" →
Fable; code-review-orchestrator two "run on Opus" → Sonnet).

### Dual-role judgment calls (for owner review)

Each agent that both reviews *and* edits was classified by its **primary
workload** as described in its own file:

| Agent | Value | Call & one-line reasoning |
| --- | --- | --- |
| `security-specialist` | **opus** (unchanged) | Primary role is judgment-heavy hardening/threat-modeling. The implementation tier (Fable) is barred by the documented cyber/bio safety-classifier caveat — legit hardening trips false-positive refusals — so it falls back to Opus rather than dropping to the review tier. |
| `performance-specialist` | **sonnet** (unchanged) | Dominant workload is the performance **review dimension**; it implements optimizations only when the architect flags a real, rare perf risk, and that work is well-scoped and plan-guided → review tier. |
| `documentation-specialist` | **sonnet** (unchanged) | Dominant workload is the documentation **review dimension**; its edits are prose/docstrings (not production logic), well-scoped and plan-guided → review tier. |

Net effect: the three duals keep their current values; the four clear-cut roles
move (chief-architect→opus, code-review-orchestrator→sonnet,
implementation→fable, test→fable).

## Test plan

Docs/config lane — no backend/frontend check-alls apply. Verified:
- All 9 agent frontmatter blocks parse as valid YAML (`yaml.safe_load`), model values match the policy.
- `pre-commit run --files` green on all changed files; commitlint passed.
- Grep of `.claude/` and `scripts/ralph/` for `opus|sonnet|haiku|fable` confirms no stale model claims remain — every remaining mention is accurate (README, self-refs, the generic family list in `adepthood-constraints.md`, and the `claude-opus-4-8` recap-headline/commit-trailer references, which are unrelated to subagent frontmatter and correct).

Closes #1874