### PR TITLE
fix(frontend): pin patched transitives to clear npm audit high+ gate

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4177,9 +4177,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7328,9 +7328,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9462,9 +9462,9 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10879,9 +10879,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13354,9 +13354,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -18349,9 +18349,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.17.tgz",
-      "integrity": "sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,8 +83,13 @@
   "version": "1.0.0",
   "overrides": {
     "@xmldom/xmldom": "0.8.13",
-    "tar": "7.5.17",
+    "tar": "7.5.20",
     "markdown-it": "14.2.0",
-    "linkify-it": "5.0.1"
+    "linkify-it": "5.0.1",
+    "brace-expansion@1": "1.1.16",
+    "brace-expansion@2": "2.1.2",
+    "brace-expansion@5": "5.0.7",
+    "js-yaml@3": "3.15.0",
+    "js-yaml@4": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary

The frontend-quality `Security audit (high+)` step (`npm audit --audit-level=high`, `.github/workflows/frontend-ci.yml:38`) was failing repo-wide on every PR — a new advisory chain reported 18 vulnerabilities (15 moderate, 2 high, 1 critical) against our SDK 52 pins. This is the pipeline unblocker: every frontend lane was red on it.

Fix stays entirely within the Expo SDK 52 pins (`expo ~52.0.43`) — no expo/react-native major bumps; the SDK 53 migration remains deferred to epic #885. Minimal `overrides` added in `frontend/package.json` pin the vulnerable transitives to their patched in-range releases:

| Package | Before | After | Severity |
| --- | --- | --- | --- |
| `tar` | 7.5.17 (still vulnerable — advisory covers `<=7.5.18`) | 7.5.20 | critical |
| `brace-expansion@1` | 1.1.15 | 1.1.16 | high (DoS) |
| `brace-expansion@2` | 2.1.1 | 2.1.2 | high (DoS) |
| `brace-expansion@5` | 5.0.6 | 5.0.7 | high (DoS) |
| `js-yaml@3` | 3.14.2 | 3.15.0 | high (DoS) |
| `js-yaml@4` | 4.2.0 | 4.3.0 | high (DoS) |

Per-major override keys are used for `brace-expansion` and `js-yaml` because a global pin would force cross-major downgrades — notably `js-yaml` v3 and v4 have breaking API differences (`safeLoad` removed in v4), so v3 consumers (`@istanbuljs/load-nyc-config`) must stay on the patched 3.15.0.

### Remaining moderate advisories (out of scope, honest disclosure)
The 14 remaining **moderate** advisories are the `@expo` build-time chain (`postcss` XSS, `uuid` bounds check via `@expo/config-plugins` → `@expo/prebuild-config` → `@expo/rudder-sdk-node`). These have no patched SDK-52-compatible release — npm's only fix is `expo@57` (a SDK 53+ major bump), deferred to epic #885. They are build/prebuild tooling, not runtime-shipped code. The CI gate audits **high+**, so these do not block; the audit level was not lowered and no advisory was suppressed.

## Test plan
- [x] `npm audit --audit-level=high` exits 0 (matches CI step exactly)
- [x] All transitive instances confirmed on patched versions (`npm ls brace-expansion js-yaml tar --all`)
- [x] `./scripts/frontend/check-all.sh` green — eslint, prettier, tsc, and full jest suite (4714 tests, 426 suites)
- [x] `npx expo config --type public` still evaluates (overridden `@expo/config-plugins`/`prebuild-config` chain intact)
- [x] Gate 2.5 dependency-review: CLEAN (lockfile integrity, per-major idiom, license compatibility all verified)

Closes #1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)