### PR TITLE
feat(journal): camera capture in the photograph flow

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -17,6 +17,7 @@
       [
         "expo-image-picker",
         {
+          "cameraPermission": "Allow Adepthood to use the camera to photograph handwritten journal pages for transcription.",
           "photosPermission": "Allow Adepthood to access your photos so you can add them as meditation cards."
         }
       ]

--- a/frontend/src/__mocks__/expo-image-picker.js
+++ b/frontend/src/__mocks__/expo-image-picker.js
@@ -6,4 +6,6 @@
 module.exports = {
   requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ granted: true }),
   launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true, assets: null }),
+  requestCameraPermissionsAsync: jest.fn().mockResolvedValue({ granted: true }),
+  launchCameraAsync: jest.fn().mockResolvedValue({ canceled: true, assets: null }),
 };

--- a/frontend/src/features/Journal/CapturePagesStrip.tsx
+++ b/frontend/src/features/Journal/CapturePagesStrip.tsx
@@ -9,7 +9,7 @@
  * notice rather than a hard block.
  */
 import React from 'react';
-import { Image, Pressable, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Platform, Pressable, Text, TouchableOpacity, View } from 'react-native';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import type { RenderItemParams } from 'react-native-draggable-flatlist';
 
@@ -20,6 +20,7 @@ import styles from './JournalPhotograph.styles';
 import { Button } from '@/components/Button';
 
 const ADD_PAGES_LABEL = 'Add pages';
+const TAKE_PHOTO_LABEL = 'Take photo';
 const REMOVE_GLYPH = '×';
 
 /** Warm, declinable copy shown when a session holds more than one page: reading
@@ -102,6 +103,30 @@ function AddPagesControl({
   );
 }
 
+/** Camera affordance beside Add pages — native only: the web build has no
+ *  in-app camera, so the control never renders there. */
+function TakePhotoControl({
+  canAdd,
+  onCapture,
+}: {
+  canAdd: boolean;
+  onCapture: () => void;
+}): React.JSX.Element | null {
+  if (Platform.OS === 'web') {
+    return null;
+  }
+  return (
+    <Button
+      testID="capture-take-photo"
+      variant="secondary"
+      label={TAKE_PHOTO_LABEL}
+      accessibilityLabel={TAKE_PHOTO_LABEL}
+      disabled={!canAdd}
+      onPress={onCapture}
+    />
+  );
+}
+
 /** Proceed affordance: enabled only for a single page; a warm notice explains the
  *  multi-page case rather than blocking it outright. */
 function TranscribeControl({
@@ -134,19 +159,26 @@ export interface CapturePagesStripProps {
   pages: CapturePage[];
   canAdd: boolean;
   onAdd: () => void;
+  onCapture: () => void;
   onRemove: (_id: string) => void;
   onReorder: (_pages: CapturePage[]) => void;
   onTranscribe: () => void;
+  /** Hide the add/capture/proceed controls, leaving only the thumbnail strip —
+   *  used by phases that offer their own forward affordances. */
+  actionsHidden?: boolean;
 }
 
-/** Render the ordered page strip plus its add-pages and proceed affordances. */
+/** Render the ordered page strip plus its add, capture, and proceed affordances
+ *  (or the strip alone when `actionsHidden` is set). */
 export function CapturePagesStrip({
   pages,
   canAdd,
   onAdd,
+  onCapture,
   onRemove,
   onReorder,
   onTranscribe,
+  actionsHidden = false,
 }: CapturePagesStripProps): React.JSX.Element {
   return (
     <View style={styles.collect}>
@@ -167,8 +199,13 @@ export function CapturePagesStrip({
         onDragEnd={({ data }) => onReorder(data)}
         contentContainerStyle={styles.stripContent}
       />
-      <AddPagesControl canAdd={canAdd} onAdd={onAdd} />
-      <TranscribeControl count={pages.length} onTranscribe={onTranscribe} />
+      {actionsHidden ? null : (
+        <>
+          <AddPagesControl canAdd={canAdd} onAdd={onAdd} />
+          <TakePhotoControl canAdd={canAdd} onCapture={onCapture} />
+          <TranscribeControl count={pages.length} onTranscribe={onTranscribe} />
+        </>
+      )}
     </View>
   );
 }

--- a/frontend/src/features/Journal/JournalPhotographScreen.tsx
+++ b/frontend/src/features/Journal/JournalPhotographScreen.tsx
@@ -264,6 +264,8 @@ function applyCaptureResult(result: CaptureResult, deps: CaptureDeps): void {
     setPhase({ step: 'collect' });
     return;
   }
+  // An unusable capture reuses the pick-failed offramp; its "Pick another photo"
+  // retry deliberately switches modality to the library picker, not the camera.
   setPhase({ step: 'pickFailed' });
 }
 

--- a/frontend/src/features/Journal/JournalPhotographScreen.tsx
+++ b/frontend/src/features/Journal/JournalPhotographScreen.tsx
@@ -1,7 +1,8 @@
 /**
  * Photograph handwritten journal pages, transcribe them, and save them as a
  * finished entry. The flow auto-launches the photo picker on mount into an
- * ordered, multi-page capture session: the writer collects pages (multi-select),
+ * ordered, multi-page capture session: the writer collects pages from the
+ * library (multi-select) or photographs them one at a time with the camera,
  * reorders the thumbnail strip, and trims it before proceeding. Transcription is
  * single-page in this iteration — the proceed affordance enables only for exactly
  * one page — after which the writer gets an editable preview before it becomes a
@@ -23,8 +24,8 @@ import { CapturePagesStrip } from './CapturePagesStrip';
 import { MAX_PAGES_PER_SESSION, canAddPages, captureSessionReducer } from './captureSession';
 import type { CapturePage } from './captureSession';
 import styles from './JournalPhotograph.styles';
-import { pickJournalPhotos } from './pickJournalPhoto';
-import type { MultiPickResult, PickedAsset } from './pickJournalPhoto';
+import { captureJournalPhoto, pickJournalPhotos } from './pickJournalPhoto';
+import type { CaptureResult, MultiPickResult, PickedAsset } from './pickJournalPhoto';
 import { saveFinishedEntry } from './saveFinishedEntry';
 
 import { TranscriptionError, journal } from '@/api';
@@ -47,6 +48,12 @@ const TRANSCRIBING_COPY = 'Reading your page…';
 const PICK_FAILED_COPY =
   "We couldn't read that photo. Pick another one and we'll try again — no rush.";
 const PICK_ANOTHER_LABEL = 'Pick another photo';
+const CAMERA_DENIED_COPY =
+  'Adepthood needs the camera to photograph a page. You can turn that on in Settings, add a photo from your library instead, or come back anytime.';
+const ADD_FROM_LIBRARY_LABEL = 'Add from your library';
+const TAKE_ANOTHER_COPY = "That page is in. Take another whenever you're ready.";
+const TAKE_ANOTHER_LABEL = 'Take another';
+const DONE_CAPTURING_LABEL = 'Done';
 const RETRY_LABEL = 'Try again';
 const TYPED_ENTRY_LABEL = 'Type this entry instead';
 const SAVE_LABEL = 'Save this page';
@@ -97,8 +104,10 @@ const TYPED_ENTRY_KINDS: ReadonlySet<TranscriptionErrorKind> = new Set<Transcrip
 type Phase =
   | { step: 'preparing' }
   | { step: 'denied' }
+  | { step: 'cameraDenied' }
   | { step: 'pickFailed' }
   | { step: 'collect' }
+  | { step: 'takeAnother' }
   | { step: 'transcribing' }
   | { step: 'preview' }
   | { step: 'error'; error: TranscriptionError };
@@ -145,6 +154,8 @@ interface CaptureModel {
   onChangeText: (_text: string) => void;
   onChangeEntryDate: (_date: string) => void;
   runPick: () => void;
+  takePhoto: () => void;
+  finishCapturing: () => void;
   removePage: (_id: string) => void;
   reorderPages: (_pages: CapturePage[]) => void;
   transcribe: () => void;
@@ -226,6 +237,42 @@ function usePickPages({
     }
     setPhase({ step: 'collect' });
   }, [navigation, dispatch, pagesRef, counterRef, setPhase]);
+}
+
+/** What a camera capture needs: the session reducer, the id counter, and the phase. */
+interface CaptureDeps {
+  dispatch: React.Dispatch<Parameters<typeof captureSessionReducer>[1]>;
+  counterRef: React.MutableRefObject<number>;
+  setPhase: (_phase: Phase) => void;
+}
+
+/** Fold one camera outcome into the session: a captured page appends and invites
+ *  another; a refusal gets its recovery view; a back-out returns to collect with
+ *  the session untouched; an unusable capture reuses the pick-failed offramp. */
+function applyCaptureResult(result: CaptureResult, deps: CaptureDeps): void {
+  const { dispatch, counterRef, setPhase } = deps;
+  if (result.kind === 'captured') {
+    dispatch({ type: 'append', pages: toCapturePages([result.asset], counterRef) });
+    setPhase({ step: 'takeAnother' });
+    return;
+  }
+  if (result.kind === 'denied') {
+    setPhase({ step: 'cameraDenied' });
+    return;
+  }
+  if (result.kind === 'cancelled') {
+    setPhase({ step: 'collect' });
+    return;
+  }
+  setPhase({ step: 'pickFailed' });
+}
+
+/** Launch the camera for one page and fold the outcome into the session. */
+function useCameraCapture(deps: CaptureDeps): () => Promise<void> {
+  const { dispatch, counterRef, setPhase } = deps;
+  return useCallback(async () => {
+    applyCaptureResult(await captureJournalPhoto(), { dispatch, counterRef, setPhase });
+  }, [dispatch, counterRef, setPhase]);
 }
 
 /** Transcribe the session's single page into an editable preview. This is the
@@ -322,6 +369,7 @@ function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
 
   const releaseSession = useCallback(() => dispatch({ type: 'clear' }), []);
   const runPick = usePickPages({ navigation, dispatch, pagesRef, counterRef, setPhase });
+  const runCapture = useCameraCapture({ dispatch, counterRef, setPhase });
   const beginTranscription = useBeginTranscription(pagesRef, setPhase, setPreviewText);
   const { save, saving, saveFailed } = useSaveEntry(
     navigation,
@@ -337,6 +385,8 @@ function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
     void runPick();
     // The device-local cache files the picker copies are cleaned up by a later
     // epic; the in-memory session is released by React when this screen unmounts.
+    // Camera captures follow the same transient-memory rules, and their device
+    // cache cleanup is likewise a later epic's scope.
   }, [runPick]);
 
   return {
@@ -350,6 +400,8 @@ function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
     onChangeText: setPreviewText,
     onChangeEntryDate: setEntryDate,
     runPick: () => void runPick(),
+    takePhoto: () => void runCapture(),
+    finishCapturing: () => setPhase({ step: 'collect' }),
     removePage: (id) => dispatch({ type: 'remove', id }),
     reorderPages: (next) => dispatch({ type: 'reorder', pages: next }),
     transcribe: () => void beginTranscription(),
@@ -397,6 +449,46 @@ function PermissionDeniedView({
           label={CANCEL_LABEL}
           accessibilityLabel={CANCEL_LABEL}
           onPress={onCancel}
+        />
+      </View>
+    </View>
+  );
+}
+
+/** Camera permission refused: open Settings, fall back to the library, or simply
+ *  return to the session already in hand — never a dead end. */
+function CameraDeniedView({
+  onOpenSettings,
+  onAddFromLibrary,
+  onNotNow,
+}: {
+  onOpenSettings: () => void;
+  onAddFromLibrary: () => void;
+  onNotNow: () => void;
+}): React.JSX.Element {
+  return (
+    <View testID="camera-denied" style={styles.container}>
+      <Text style={styles.message}>{CAMERA_DENIED_COPY}</Text>
+      <View style={styles.actions}>
+        <Button
+          testID="camera-open-settings"
+          label={OPEN_SETTINGS_LABEL}
+          accessibilityLabel={OPEN_SETTINGS_LABEL}
+          onPress={onOpenSettings}
+        />
+        <Button
+          testID="camera-add-from-library"
+          variant="secondary"
+          label={ADD_FROM_LIBRARY_LABEL}
+          accessibilityLabel={ADD_FROM_LIBRARY_LABEL}
+          onPress={onAddFromLibrary}
+        />
+        <Button
+          testID="camera-not-now"
+          variant="tertiary"
+          label={CANCEL_LABEL}
+          accessibilityLabel={CANCEL_LABEL}
+          onPress={onNotNow}
         />
       </View>
     </View>
@@ -556,11 +648,70 @@ function CollectView({ model }: { model: CaptureModel }): React.JSX.Element {
         pages={model.pages}
         canAdd={model.canAdd}
         onAdd={model.runPick}
+        onCapture={model.takePhoto}
         onRemove={model.removePage}
         onReorder={model.reorderPages}
         onTranscribe={model.transcribe}
       />
       <EntryDateRow entryDate={model.entryDate} onChangeEntryDate={model.onChangeEntryDate} />
+    </View>
+  );
+}
+
+/** After a capture lands: a quiet invitation to keep going (while the session has
+ *  room) or settle back into arranging the collected pages. */
+function TakeAnotherPrompt({
+  canAdd,
+  onTakeAnother,
+  onDone,
+}: {
+  canAdd: boolean;
+  onTakeAnother: () => void;
+  onDone: () => void;
+}): React.JSX.Element {
+  return (
+    <View style={styles.actions}>
+      <Text style={styles.notice}>{TAKE_ANOTHER_COPY}</Text>
+      {canAdd ? (
+        <Button
+          testID="capture-take-another"
+          variant="secondary"
+          label={TAKE_ANOTHER_LABEL}
+          accessibilityLabel={TAKE_ANOTHER_LABEL}
+          onPress={onTakeAnother}
+        />
+      ) : null}
+      <Button
+        testID="capture-done"
+        label={DONE_CAPTURING_LABEL}
+        accessibilityLabel={DONE_CAPTURING_LABEL}
+        onPress={onDone}
+      />
+    </View>
+  );
+}
+
+/** The pause right after a capture: the collected thumbnails (collect actions
+ *  hidden, so the only forward affordances are take-another and Done), with the
+ *  take-another loop beneath them. Done settles back into the full collect stage. */
+function TakeAnotherView({ model }: { model: CaptureModel }): React.JSX.Element {
+  return (
+    <View style={styles.container}>
+      <CapturePagesStrip
+        pages={model.pages}
+        canAdd={model.canAdd}
+        onAdd={model.runPick}
+        onCapture={model.takePhoto}
+        onRemove={model.removePage}
+        onReorder={model.reorderPages}
+        onTranscribe={model.transcribe}
+        actionsHidden
+      />
+      <TakeAnotherPrompt
+        canAdd={model.canAdd}
+        onTakeAnother={model.takePhoto}
+        onDone={model.finishCapturing}
+      />
     </View>
   );
 }
@@ -571,10 +722,20 @@ function CaptureBody({ model }: { model: CaptureModel }): React.JSX.Element {
   switch (phase.step) {
     case 'denied':
       return <PermissionDeniedView onOpenSettings={model.openSettings} onCancel={model.cancel} />;
+    case 'cameraDenied':
+      return (
+        <CameraDeniedView
+          onOpenSettings={model.openSettings}
+          onAddFromLibrary={model.runPick}
+          onNotNow={model.finishCapturing}
+        />
+      );
     case 'pickFailed':
       return <PickFailedView onPickAnother={model.runPick} />;
     case 'collect':
       return <CollectView model={model} />;
+    case 'takeAnother':
+      return <TakeAnotherView model={model} />;
     case 'transcribing':
       return <WorkingBlock testID="photograph-transcribing" caption={TRANSCRIBING_COPY} />;
     case 'preview':

--- a/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
@@ -644,6 +644,20 @@ describe('JournalPhotographScreen — camera capture', () => {
     expect(data.map((p) => p.uri)).toEqual(['file:///p1.jpg', 'file:///cam1.jpg']);
   });
 
+  it('routes an unusable capture to the pick-failed offramp with Pick another, no retry', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce({ kind: 'failed' });
+    const { findByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    await waitFor(() => expect(mockCapture).toHaveBeenCalledTimes(1));
+
+    expect(await findByTestId('photograph-error')).toBeTruthy();
+    expect(await findByTestId('photograph-pick-another')).toBeTruthy();
+    expect(queryByTestId('photograph-retry')).toBeNull();
+  });
+
   it('leaves the session unchanged and stays in collect when the camera is cancelled', async () => {
     mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
     mockCapture.mockResolvedValueOnce({ kind: 'cancelled' });

--- a/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
@@ -2,9 +2,9 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Linking } from 'react-native';
+import { Linking, Platform } from 'react-native';
 
-import type { MultiPickResult, PickedAsset } from '../pickJournalPhoto';
+import type { CaptureResult, MultiPickResult, PickedAsset } from '../pickJournalPhoto';
 
 import { TranscriptionError } from '@/api';
 import type { JournalMessage, MediaType, TranscribePageT, TranscriptionErrorKind } from '@/api';
@@ -18,6 +18,7 @@ const isoOffsetFromToday = (days: number): string => {
 };
 
 const mockPick = jest.fn() as jest.MockedFunction<(_limit: number) => Promise<MultiPickResult>>;
+const mockCapture = jest.fn() as jest.MockedFunction<() => Promise<CaptureResult>>;
 const mockTranscribe = jest.fn() as jest.MockedFunction<
   (_p: { imageBase64: string; mediaType: MediaType }) => Promise<TranscribePageT>
 >;
@@ -31,6 +32,8 @@ jest.mock(
   () => ({
     pickJournalPhotos: (...a: unknown[]) =>
       (mockPick as unknown as (...x: unknown[]) => unknown)(...a),
+    captureJournalPhoto: (...a: unknown[]) =>
+      (mockCapture as unknown as (...x: unknown[]) => unknown)(...a),
   }),
   { virtual: true },
 );
@@ -85,6 +88,10 @@ function picked(assets: PickedAsset[] = [pickedAsset()]): MultiPickResult {
   return { kind: 'picked', assets };
 }
 
+function capturedPage(uri: string, imageBase64: string): CaptureResult {
+  return { kind: 'captured', asset: pickedAsset({ uri, imageBase64 }) };
+}
+
 function makeEntry(overrides: Partial<JournalMessage> = {}): JournalMessage {
   return {
     id: 1,
@@ -113,6 +120,7 @@ function renderScreen() {
 
 beforeEach(() => {
   mockPick.mockReset();
+  mockCapture.mockReset();
   mockTranscribe.mockReset();
   mockCreate.mockReset();
   mockUpdate.mockReset();
@@ -617,5 +625,160 @@ describe('JournalPhotographScreen — entry date', () => {
 
     fireEvent.changeText(getByLabelText('Date'), isoOffsetFromToday(1));
     expect(getByText(/Pick a date between/)).toBeTruthy();
+  });
+});
+
+describe('JournalPhotographScreen — camera capture', () => {
+  it('appends a captured photo after the existing pages, preserving order', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce(capturedPage('file:///cam1.jpg', 'cam-b64'));
+    const { findByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    await waitFor(() => expect(mockCapture).toHaveBeenCalledTimes(1));
+
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(2);
+    expect(data.map((p) => p.uri)).toEqual(['file:///p1.jpg', 'file:///cam1.jpg']);
+  });
+
+  it('leaves the session unchanged and stays in collect when the camera is cancelled', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce({ kind: 'cancelled' });
+    const { findByTestId, navigation } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    await waitFor(() => expect(mockCapture).toHaveBeenCalledTimes(1));
+
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(1);
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});
+
+describe('JournalPhotographScreen — camera permission denied', () => {
+  it('shows the camera-denied recovery view and opens device settings once', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce({ kind: 'denied' });
+    const openSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
+    const { findByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    expect(await findByTestId('camera-denied')).toBeTruthy();
+
+    fireEvent.press(await findByTestId('camera-open-settings'));
+    expect(openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns to collect from Not now, keeping the pages and never going back or opening settings', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    mockCapture.mockResolvedValueOnce({ kind: 'denied' });
+    const openSettings = jest.spyOn(Linking, 'openSettings').mockResolvedValue();
+    const { findByTestId, navigation, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    await findByTestId('camera-denied');
+
+    fireEvent.press(await findByTestId('camera-not-now'));
+
+    expect(queryByTestId('camera-denied')).toBeNull();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(2);
+    expect(data.map((p) => p.uri)).toEqual(uriList(2));
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(openSettings).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the library pick from Add from library, landing back in collect', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce({ kind: 'denied' });
+    const { findByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    await findByTestId('camera-denied');
+    expect(mockPick).toHaveBeenCalledTimes(1);
+
+    mockPick.mockResolvedValueOnce(
+      picked([pickedAsset({ uri: 'file:///lib2.jpg', imageBase64: 'b64-lib' })]),
+    );
+    fireEvent.press(await findByTestId('camera-add-from-library'));
+    await waitFor(() => expect(mockPick).toHaveBeenCalledTimes(2));
+
+    expect(queryByTestId('camera-denied')).toBeNull();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toEqual(['file:///p1.jpg', 'file:///lib2.jpg']);
+  });
+});
+
+describe('JournalPhotographScreen — take-another loop', () => {
+  it('offers Take another and Done after a capture, looping until Done returns to collect', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    mockCapture.mockResolvedValueOnce(capturedPage('file:///cam2.jpg', 'cam-b64-2'));
+    const { findByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    expect(await findByTestId('capture-take-another')).toBeTruthy();
+    expect(await findByTestId('capture-done')).toBeTruthy();
+    expect(queryByTestId('capture-take-photo')).toBeNull();
+    expect(queryByTestId('capture-add-pages')).toBeNull();
+    expect(queryByTestId('capture-transcribe')).toBeNull();
+
+    mockCapture.mockResolvedValueOnce(capturedPage('file:///cam3.jpg', 'cam-b64-3'));
+    fireEvent.press(await findByTestId('capture-take-another'));
+    await waitFor(() => expect(mockCapture).toHaveBeenCalledTimes(2));
+
+    fireEvent.press(await findByTestId('capture-done'));
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data.map((p) => p.uri)).toEqual([
+      'file:///p1.jpg',
+      'file:///cam2.jpg',
+      'file:///cam3.jpg',
+    ]);
+    expect(queryByTestId('capture-take-another')).toBeNull();
+  });
+
+  it('hides Take another when the capture fills the session, keeping only Done', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(9))));
+    mockCapture.mockResolvedValueOnce(capturedPage('file:///cam10.jpg', 'cam-b64-10'));
+    const { findByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(await findByTestId('capture-take-photo'));
+    expect(await findByTestId('capture-done')).toBeTruthy();
+    expect(queryByTestId('capture-take-another')).toBeNull();
+
+    fireEvent.press(await findByTestId('capture-done'));
+    expect(await findByTestId('capture-cap-notice')).toBeTruthy();
+    const list = await findByTestId('capture-pages-list');
+    const data = list.props.data as Array<{ uri: string }>;
+    expect(data).toHaveLength(10);
+  });
+});
+
+describe('JournalPhotographScreen — web guard', () => {
+  it('never offers Take photo when running on web', async () => {
+    const osDescriptor = Object.getOwnPropertyDescriptor(Platform, 'OS');
+    Object.defineProperty(Platform, 'OS', { configurable: true, get: () => 'web' });
+    try {
+      mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+      const { findByTestId, queryByTestId } = renderScreen();
+      await findByTestId('capture-pages-list');
+      expect(queryByTestId('capture-take-photo')).toBeNull();
+    } finally {
+      if (osDescriptor) {
+        Object.defineProperty(Platform, 'OS', osDescriptor);
+      }
+    }
   });
 });

--- a/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
+++ b/frontend/src/features/Journal/__tests__/pickJournalPhoto.test.ts
@@ -2,10 +2,12 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import * as ImagePicker from 'expo-image-picker';
 
-import { pickJournalPhotos, toMediaType } from '../pickJournalPhoto';
+import { captureJournalPhoto, pickJournalPhotos, toMediaType } from '../pickJournalPhoto';
 
 const requestPermission = jest.mocked(ImagePicker.requestMediaLibraryPermissionsAsync);
 const launchLibrary = jest.mocked(ImagePicker.launchImageLibraryAsync);
+const requestCameraPermission = jest.mocked(ImagePicker.requestCameraPermissionsAsync);
+const launchCamera = jest.mocked(ImagePicker.launchCameraAsync);
 
 function asset(
   overrides: Partial<ImagePicker.ImagePickerAsset> = {},
@@ -101,6 +103,75 @@ describe('pickJournalPhotos', () => {
     requestPermission.mockResolvedValueOnce({ granted: false } as ImagePicker.PermissionResponse);
     await pickJournalPhotos(10);
     expect(launchLibrary).not.toHaveBeenCalled();
+  });
+});
+
+describe('captureJournalPhoto', () => {
+  beforeEach(() => {
+    requestCameraPermission.mockResolvedValue({
+      granted: true,
+    } as ImagePicker.PermissionResponse);
+    launchCamera.mockResolvedValue({ canceled: true, assets: null });
+  });
+
+  it('returns denied without launching the camera when permission is refused', async () => {
+    requestCameraPermission.mockResolvedValueOnce({
+      granted: false,
+    } as ImagePicker.PermissionResponse);
+    expect(await captureJournalPhoto()).toEqual({ kind: 'denied' });
+    expect(launchCamera).not.toHaveBeenCalled();
+  });
+
+  it('returns cancelled when the user backs out of the camera', async () => {
+    launchCamera.mockResolvedValueOnce({ canceled: true, assets: null });
+    expect(await captureJournalPhoto()).toEqual({ kind: 'cancelled' });
+  });
+
+  it('returns failed when the captured asset carries no usable base64 data', async () => {
+    launchCamera.mockResolvedValueOnce({
+      canceled: false,
+      assets: [asset({ base64: undefined })],
+    });
+    expect(await captureJournalPhoto()).toEqual({ kind: 'failed' });
+  });
+
+  it('maps a granted capture to uri + imageBase64 + mediaType, passing image/png through', async () => {
+    launchCamera.mockResolvedValueOnce({
+      canceled: false,
+      assets: [asset({ uri: 'file:///cam.png', base64: 'cam-b64', mimeType: 'image/png' })],
+    });
+    expect(await captureJournalPhoto()).toEqual({
+      kind: 'captured',
+      asset: { uri: 'file:///cam.png', imageBase64: 'cam-b64', mediaType: 'image/png' },
+    });
+  });
+
+  it('defaults an absent mime type to image/jpeg on a captured asset', async () => {
+    launchCamera.mockResolvedValueOnce({
+      canceled: false,
+      assets: [asset({ uri: 'file:///cam.jpg', base64: 'cam-b64', mimeType: undefined })],
+    });
+    expect(await captureJournalPhoto()).toEqual({
+      kind: 'captured',
+      asset: { uri: 'file:///cam.jpg', imageBase64: 'cam-b64', mediaType: 'image/jpeg' },
+    });
+  });
+
+  it('defaults an unrecognized mime type to image/jpeg on a captured asset', async () => {
+    launchCamera.mockResolvedValueOnce({
+      canceled: false,
+      assets: [asset({ uri: 'file:///cam.heic', base64: 'cam-b64', mimeType: 'image/heic' })],
+    });
+    expect(await captureJournalPhoto()).toEqual({
+      kind: 'captured',
+      asset: { uri: 'file:///cam.heic', imageBase64: 'cam-b64', mediaType: 'image/jpeg' },
+    });
+  });
+
+  it('calls the camera launcher with exactly quality and base64 options', async () => {
+    launchCamera.mockResolvedValueOnce({ canceled: false, assets: [asset()] });
+    await captureJournalPhoto();
+    expect(launchCamera).toHaveBeenCalledWith({ quality: 0.8, base64: true });
   });
 });
 

--- a/frontend/src/features/Journal/pickJournalPhoto.ts
+++ b/frontend/src/features/Journal/pickJournalPhoto.ts
@@ -1,8 +1,8 @@
 /**
  * Wraps `expo-image-picker` for the Journal photograph-capture flow: request
- * permission, open the library for an ordered multi-selection, and hand back the
- * picked pages as base64 with server-accepted media types — or a discriminated
- * reason none were usable.
+ * permission, open the library for an ordered multi-selection or the camera for
+ * a single page, and hand back the pages as base64 with server-accepted media
+ * types — or a discriminated reason none were usable.
  *
  * PRIVACY: the returned base64 image payloads are never logged here; callers hold
  * them in memory only and release them once the pages are saved.
@@ -100,4 +100,48 @@ export async function pickJournalPhotos(selectionLimit: number): Promise<MultiPi
     return { kind: 'failed' };
   }
   return { kind: 'picked', assets };
+}
+
+/**
+ * The outcome of a single camera capture, discriminated on `kind`:
+ *
+ *  - `denied`    — camera permission was refused; the camera never opened.
+ *  - `cancelled` — the user backed out of the camera.
+ *  - `failed`    — the capture completed but yielded no usable base64 image.
+ *  - `captured`  — one usable page, ready to append to the session.
+ */
+export type CaptureResult =
+  | { kind: 'denied' }
+  | { kind: 'cancelled' }
+  | { kind: 'failed' }
+  | { kind: 'captured'; asset: PickedAsset };
+
+/**
+ * Open the device camera to photograph a single page and return it as base64.
+ *
+ * Requests camera permission first; a refusal short-circuits to `denied` without
+ * ever launching the camera. A dismissed camera is `cancelled`. A captured asset
+ * carrying base64 is mapped to its uri, base64, and resolved media type; a
+ * capture that yields no usable asset is `failed`.
+ *
+ * PRIVACY: the returned base64 image payload is never logged here; the caller
+ * holds it in memory only and releases it once the page is saved.
+ */
+export async function captureJournalPhoto(): Promise<CaptureResult> {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  if (!permission.granted) {
+    return { kind: 'denied' };
+  }
+  const result = await ImagePicker.launchCameraAsync({
+    quality: IMAGE_QUALITY,
+    base64: true,
+  });
+  if (result.canceled) {
+    return { kind: 'cancelled' };
+  }
+  const [asset] = toPickedAssets(result.assets);
+  if (!asset) {
+    return { kind: 'failed' };
+  }
+  return { kind: 'captured', asset };
 }


### PR DESCRIPTION
## Summary

Adds a **Take photo** action to the Journal photograph capture session, so a writer can photograph handwritten pages directly from the flow instead of round-tripping through the system photo library. Built on the multi-page capture session (PR #1858) and entry-date row (PR #1856); the library pick path is unchanged.

- **Camera capture wrapper** — new `captureJournalPhoto()` in `pickJournalPhoto.ts` requests camera permission via `requestCameraPermissionsAsync`, then `launchCameraAsync({ quality: 0.8, base64: true })`, returning a discriminated `CaptureResult` (`denied` / `cancelled` / `failed` / `captured`). It reuses the existing `toPickedAssets` / `toMediaType` mapping — no duplicated base64 handling.
- **Session integration** — a captured page appends through the same `captureSessionReducer` `append` action as picked pages, so selection order and the `MAX_PAGES_PER_SESSION` cap are honored for free.
- **Permission-denied recovery** — a dedicated `cameraDenied` phase offers **Open Settings** (`Linking.openSettings`), an **Add from your library** fallback, and a **Not now** return to the session already in hand — warm, declinable, never a dead end (NORTH-STAR tone).
- **Take-another loop** — after a successful capture a focused `takeAnother` phase shows the collected thumbnails plus **Take another** (only while the session has room) / **Done**, so several pages can be shot in sequence; at the cap only **Done** remains and the cap notice shows on return to collect.
- **Permission config** — `app.json` gains the `expo-image-picker` `cameraPermission` string (injects `NSCameraUsageDescription` on iOS and the Android camera permission at prebuild), parallel to the existing `photosPermission`.
- **Web guard** — the camera control never renders on web (`Platform.OS !== 'web'`); the web build keeps the camera disabled.
- **Privacy** — captured base64 lives in reducer state only, is never logged and never placed in navigation params, and is released on save / typed-entry offramp / unmount, exactly like picked pages. Device-cache cleanup remains a later epic's scope.

Out of scope (deferred to their own issues): image downscaling and classification choice.

## Test plan

- `pickJournalPhoto.test.ts` — `captureJournalPhoto` grant/deny (camera never launches on denial), cancel, failed (no base64), captured mapping, mime passthrough/default, and exact launch options `{ quality: 0.8, base64: true }`.
- `JournalPhotographScreen.test.tsx` — take-photo appends through the session API (order preserved); permission-denied view with Open Settings / add-from-library fallback / Not-now return (session intact, no goBack); camera cancel leaves the session unchanged; take-another/done loop; cap-reached-mid-loop hides Take another; a regression guard that the collect-only controls are absent during the take-another phase; and the web platform guard.
- Extended the `expo-image-picker` jest mock with the camera APIs.
- Full frontend suite green (4729 tests), ESLint / prettier / `tsc --noEmit` clean via `scripts/frontend/check-all.sh`; a security audit confirmed the base64 privacy and permission-gate invariants.

Closes #1795
Refs #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)