### PR TITLE
feat(map): de-duplicate the magnifier lens caption — show only Polarity + Free Will

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -24,14 +24,14 @@ import {
   DRAG_TAP_SLOP,
   glideDurationMs,
   inertialStageTarget,
-  lensCaption,
+  lensStageIdentity,
   lensCenterForStage,
   lensFrame,
   magnifierTransform,
   MAGNIFICATION,
   nearestStage,
 } from './magnifierGeometry';
-import type { LensCenter, LensFrame } from './magnifierGeometry';
+import type { LensCaption, LensCenter, LensFrame } from './magnifierGeometry';
 import styles from './Map.styles';
 import type { StageAnchors } from './waveGeometry';
 import { WaveOverlay } from './WaveOverlay';
@@ -75,6 +75,12 @@ export interface MagnifierLensProps {
   focusedStage: number;
   /** The user's live stage — earns the YOU ARE HERE chip when under glass. */
   currentStage: number | null;
+  /**
+   * Resolve the caption (polarity + free-will read) for any stage under the
+   * glass. Threaded from ``MapScreen`` so the two facts come from backend
+   * ``StageData``; missing data resolves to empty strings.
+   */
+  captionForStage: (_stageNumber: number) => LensCaption;
   /** A drag released over a new stage settles focus there. */
   onSettleStage: (_stageNumber: number) => void;
   /** A tap on the lens opens the focused stage's detail modal. */
@@ -415,44 +421,51 @@ const LensGlass = ({
   );
 };
 
-/** Chip + caption block for the stage currently under the glass. */
+/**
+ * Chip + caption block for the stage currently under the glass. The pill shows
+ * only the two facts absent everywhere else on the Map: the stage's Divine
+ * Gender Polarity (eyebrow-style) over its free-will description (clamped to two
+ * lines). Everything the surrounding columns already say is left off.
+ */
 const LensCaptionBlock = ({
-  stageNumber,
+  caption,
   isCurrent,
 }: {
-  stageNumber: number;
+  caption: LensCaption;
   isCurrent: boolean;
-}): React.JSX.Element => {
-  const caption = lensCaption(stageNumber);
-  return (
-    <View style={styles.magnifierCaption} pointerEvents="none">
-      {isCurrent ? (
-        <View style={styles.youAreHere} testID="you-are-here">
-          <Text style={styles.youAreHereText}>YOU ARE HERE</Text>
-        </View>
-      ) : null}
-      <Text style={styles.magnifierEyebrow} testID="magnifier-eyebrow" numberOfLines={1}>
-        {caption.eyebrow}
-      </Text>
-      <Text style={styles.magnifierHeadline} testID="magnifier-headline" numberOfLines={1}>
-        {caption.headline}
-      </Text>
-      <Text style={styles.magnifierDetail} testID="magnifier-detail" numberOfLines={1}>
-        {caption.detail}
-      </Text>
-      <Text style={styles.magnifierPractice} testID="magnifier-practice" numberOfLines={1}>
-        {caption.practice}
-      </Text>
-    </View>
-  );
-};
+}): React.JSX.Element => (
+  <View style={styles.magnifierCaption} pointerEvents="none">
+    {isCurrent ? (
+      <View style={styles.youAreHere} testID="you-are-here">
+        <Text style={styles.youAreHereText}>YOU ARE HERE</Text>
+      </View>
+    ) : null}
+    <Text style={styles.magnifierEyebrow} testID="magnifier-polarity" numberOfLines={1}>
+      {caption.polarity}
+    </Text>
+    <Text style={styles.magnifierDetail} testID="magnifier-freewill" numberOfLines={2}>
+      {caption.freeWill}
+    </Text>
+  </View>
+);
 
-/** Accessibility read for the lens: where it is and what it can do. */
-const lensAccessibilityLabel = (stageNumber: number, isCurrent: boolean): string => {
-  const caption = lensCaption(stageNumber);
+/**
+ * Accessibility read for the lens: it identifies the stage (detail the visible
+ * pill now sheds but a screen-reader user can't cross-reference) and speaks the
+ * two new facts, then names what the lens can do.
+ */
+const lensAccessibilityLabel = (
+  stageNumber: number,
+  caption: LensCaption,
+  isCurrent: boolean,
+): string => {
   const prefix = isCurrent ? 'You are here. ' : '';
+  // Skip empty facts (the pre-load / missing-data window) so the spoken label
+  // never degrades to stray doubled punctuation.
+  const facts = [caption.polarity, caption.freeWill].filter(Boolean).join('. ');
+  const factsPhrase = facts ? `${facts}. ` : '';
   return (
-    `${prefix}Magnifier over ${caption.headline}, stage ${caption.eyebrow} — ${caption.detail}. Practice: ${caption.practice}. ` +
+    `${prefix}Magnifier over ${lensStageIdentity(stageNumber)}. ${factsPhrase}` +
     'Tap to read about this stage; drag to explore others.'
   );
 };
@@ -529,12 +542,13 @@ export const MagnifierLens = (props: MagnifierLensProps): React.JSX.Element => {
   });
 
   const isCurrent = hoverStage === currentStage;
+  const caption = props.captionForStage(hoverStage);
   return (
     <LensShell
       frame={frame}
       motion={motion}
       handlers={dragHandlers}
-      label={lensAccessibilityLabel(hoverStage, isCurrent)}
+      label={lensAccessibilityLabel(hoverStage, caption, isCurrent)}
     >
       <LensGlass
         motion={motion}
@@ -543,7 +557,7 @@ export const MagnifierLens = (props: MagnifierLensProps): React.JSX.Element => {
         gridHeight={gridHeight}
         anchors={anchors}
       />
-      <LensCaptionBlock stageNumber={hoverStage} isCurrent={isCurrent} />
+      <LensCaptionBlock caption={caption} isCurrent={isCurrent} />
     </LensShell>
   );
 };

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -174,12 +174,6 @@ const styles = StyleSheet.create({
     alignItems: CENTER,
     paddingHorizontal: spacing(1),
   },
-  magnifierHeadline: {
-    fontFamily: editorialType.serif,
-    fontSize: 16,
-    fontWeight: '700',
-    color: ink.primary,
-  },
   magnifierDetail: {
     fontSize: 10,
     color: ink.soft,
@@ -191,7 +185,6 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     color: ink.soft,
   },
-  magnifierPractice: { fontSize: 9, lineHeight: 11, color: ink.soft },
   // "You are here" chip riding the lens when it rests on the current stage.
   youAreHere: {
     marginBottom: spacing(0.25),

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -43,6 +43,8 @@ import {
   rankedStats,
   unlockTimeline,
 } from './journeyNarrative';
+import { lensCaption } from './magnifierGeometry';
+import type { LensCaption } from './magnifierGeometry';
 import { MagnifierLens } from './MagnifierLens';
 import styles from './Map.styles';
 import MapDrawer from './MapDrawer';
@@ -924,6 +926,12 @@ const MapGrid = ({
   const [size, onLayout] = useGridSize();
   const { anchors, onRowLayout, onCellLayout } = useStageAnchors(size.height);
   const lensReady = size.width >= MIN_LENS_GRID_EXTENT && size.height >= MIN_LENS_GRID_EXTENT;
+  // Resolve the lens caption from loaded StageData so the pill's polarity +
+  // free-will read reflect the stage under the glass, live as it drags.
+  const captionForStage = useCallback(
+    (stageNumber: number): LensCaption => lensCaption(lookup[stageNumber]),
+    [lookup],
+  );
   return (
     <View style={styles.grid} testID="map-grid" onLayout={onLayout}>
       <WaveOverlay width={size.width} height={size.height} anchors={anchors} />
@@ -947,6 +955,7 @@ const MapGrid = ({
           anchors={anchors}
           focusedStage={focusedStage}
           currentStage={currentStage}
+          captionForStage={captionForStage}
           onSettleStage={onSettleStage}
           onOpenStage={onOpenStage}
         />

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -5,8 +5,18 @@ import { Animated } from 'react-native';
 import { act, create } from 'react-test-renderer';
 
 import { lensCenterForStage, lensFrame } from '../magnifierGeometry';
+import type { LensCaption } from '../magnifierGeometry';
 import MagnifierLens from '../MagnifierLens';
 import { stageWavePoint } from '../waveGeometry';
+
+// A deterministic per-stage caption stand-in for the store-fed lookup: even
+// stages read Divine Feminine, odd stages Divine Masculine, and every stage
+// carries a distinct free-will sentence so a test can prove the lens re-captions
+// to the stage under the glass.
+const captionForStage = (stageNumber: number): LensCaption => ({
+  polarity: stageNumber % 2 === 0 ? 'Divine Feminine' : 'Divine Masculine',
+  freeWill: `Free-will read for stage ${stageNumber}.`,
+});
 
 // Mutable reduced-motion knob: default true so lens repositioning is instant
 // and deterministic; individual tests flip it to exercise the glide path.
@@ -38,6 +48,7 @@ const renderLens = (options: RenderOptions = {}) => {
         anchors={options.anchors ?? {}}
         focusedStage={options.focusedStage ?? 1}
         currentStage={options.currentStage ?? 1}
+        captionForStage={captionForStage}
         onSettleStage={onSettleStage}
         onOpenStage={onOpenStage}
       />,
@@ -49,8 +60,8 @@ const renderLens = (options: RenderOptions = {}) => {
 const lensNode = (tree: ReturnType<typeof create>) =>
   tree.root.findByProps({ testID: 'map-magnifier' });
 
-const headlineText = (tree: ReturnType<typeof create>): string =>
-  tree.root.findByProps({ testID: 'magnifier-headline' }).props.children as string;
+const freeWillText = (tree: ReturnType<typeof create>): string =>
+  tree.root.findByProps({ testID: 'magnifier-freewill' }).props.children as string;
 
 const textByTestId = (tree: ReturnType<typeof create>, testID: string) =>
   tree.root.findByProps({ testID });
@@ -127,17 +138,28 @@ describe('MagnifierLens', () => {
     ).toHaveLength(0);
   });
 
-  it('captions the focused stage with its Aspect word and persona', () => {
-    const { tree } = renderLens({ focusedStage: 3 });
-    expect(headlineText(tree)).toBe('Self-Love');
-    const detail = tree.root.findByProps({ testID: 'magnifier-detail' });
-    expect(detail.props.children).toBe('Dominator · Power');
-    const eyebrow = textByTestId(tree, 'magnifier-eyebrow');
-    expect(eyebrow.props.children).toBe('3 · RED');
-    expect(eyebrow.props.numberOfLines).toBe(1);
-    const practice = textByTestId(tree, 'magnifier-practice');
-    expect(practice.props.children).toBe('Belly breathing');
-    expect(practice.props.numberOfLines).toBe(1);
+  it('captions the focused stage with only its polarity and free-will read', () => {
+    const { tree } = renderLens({ focusedStage: 4 });
+    const polarity = textByTestId(tree, 'magnifier-polarity');
+    expect(polarity.props.children).toBe('Divine Feminine');
+    expect(polarity.props.numberOfLines).toBe(1);
+    const freeWill = textByTestId(tree, 'magnifier-freewill');
+    expect(freeWill.props.children).toBe('Free-will read for stage 4.');
+    expect(freeWill.props.numberOfLines).toBe(2);
+  });
+
+  it('drops the eyebrow, headline, detail, and practice lines from the pill', () => {
+    const { tree } = renderLens({ focusedStage: 4 });
+    for (const testID of [
+      'magnifier-eyebrow',
+      'magnifier-headline',
+      'magnifier-detail',
+      'magnifier-practice',
+    ]) {
+      expect(
+        tree.root.findAll((n: { props: Record<string, unknown> }) => n.props.testID === testID),
+      ).toHaveLength(0);
+    }
   });
 
   it('re-captions when the focused stage prop changes (stage tap glide)', () => {
@@ -150,13 +172,14 @@ describe('MagnifierLens', () => {
           anchors={{}}
           focusedStage={5}
           currentStage={1}
+          captionForStage={captionForStage}
           onSettleStage={jest.fn()}
           onOpenStage={jest.fn()}
         />,
       );
     });
-    expect(headlineText(tree)).toBe('Intellectual');
-    expect(textByTestId(tree, 'magnifier-eyebrow').props.children).toBe('5 · ORANGE');
+    expect(freeWillText(tree)).toBe('Free-will read for stage 5.');
+    expect(textByTestId(tree, 'magnifier-polarity').props.children).toBe('Divine Masculine');
   });
 
   it('renders a magnified copy of the wave under the glass', () => {
@@ -197,7 +220,7 @@ describe('MagnifierLens', () => {
     expect(style.transform[0].translateX.__getValue()).toBeCloseTo(
       start.x - lensFrame(GRID_WIDTH, GRID_HEIGHT).width / 2,
     );
-    expect(headlineText(tree)).toBe('Receptivity');
+    expect(freeWillText(tree)).toBe('Free-will read for stage 2.');
   });
 
   it('uses release velocity to coast a fast swipe farther than the finger position', () => {
@@ -233,7 +256,7 @@ describe('MagnifierLens', () => {
       lens.props.onResponderGrant(touch(150, start.y));
       lens.props.onResponderMove(touch(150, start.y - (start.y - stage2Y)));
     });
-    expect(headlineText(tree)).toBe('Receptivity');
+    expect(freeWillText(tree)).toBe('Free-will read for stage 2.');
   });
 
   it('a drag released back on the focused stage settles without reporting', () => {
@@ -257,14 +280,17 @@ describe('MagnifierLens', () => {
     expect(onSettleStage).toHaveBeenCalledWith(2);
   });
 
-  it('exposes a button role with a descriptive label', () => {
+  it('exposes a button role with a label that identifies the stage and reads both new facts', () => {
     const { tree } = renderLens({ focusedStage: 1, currentStage: 1 });
     const lens = lensNode(tree);
     expect(lens.props.accessibilityRole).toBe('button');
     expect(lens.props.accessibilityLabel).toContain('You are here');
+    // Identity the visible pill now sheds stays in the spoken label.
     expect(lens.props.accessibilityLabel).toContain('Agency');
     expect(lens.props.accessibilityLabel).toContain('1 · BEIGE');
-    expect(lens.props.accessibilityLabel).toContain('5-4-3-2-1 grounding');
+    // Both new facts are read aloud.
+    expect(lens.props.accessibilityLabel).toContain('Divine Masculine');
+    expect(lens.props.accessibilityLabel).toContain('Free-will read for stage 1.');
     expect(lens.props.accessibilityLabel).toContain('drag to explore');
   });
 
@@ -286,13 +312,14 @@ describe('MagnifierLens', () => {
             anchors={{}}
             focusedStage={8}
             currentStage={1}
+            captionForStage={captionForStage}
             onSettleStage={jest.fn()}
             onOpenStage={jest.fn()}
           />,
         );
       });
       // Caption follows immediately; the glide raises the frost wash as it starts.
-      expect(headlineText(tree)).toBe('True Self');
+      expect(freeWillText(tree)).toBe('Free-will read for stage 8.');
       expect(frostRaiseCount(timing)).toBe(1);
     } finally {
       timing.mockRestore();
@@ -314,6 +341,7 @@ describe('MagnifierLens', () => {
           anchors={{}}
           focusedStage={focusedStage}
           currentStage={1}
+          captionForStage={captionForStage}
           onSettleStage={setFocusedStage}
           onOpenStage={jest.fn()}
         />
@@ -459,6 +487,7 @@ describe('MagnifierLens', () => {
             anchors={{}}
             focusedStage={6}
             currentStage={1}
+            captionForStage={captionForStage}
             onSettleStage={jest.fn()}
             onOpenStage={jest.fn()}
           />,

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -193,9 +193,9 @@ describe('MapScreen', () => {
     });
     // No modal yet — the tap moved the lens instead.
     expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
-    // The lens caption now reads the tapped stage's Aspect word.
-    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
-    expect(headline.props.children).toBe('Self-Love');
+    // The lens caption now reads the tapped stage's free-will description.
+    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
+    expect(freeWill.props.children).toBe('Free will at stage 3.');
     // And the chip hides, since the lens left the current stage.
     expect(tree.root.findAll((n: TestNode) => n.props.testID === 'you-are-here')).toHaveLength(0);
   });
@@ -234,8 +234,8 @@ describe('MapScreen', () => {
       lens.props.onResponderMove({ nativeEvent: { pageX: 150, pageY: 450 } });
       lens.props.onResponderRelease({ nativeEvent: { pageX: 150, pageY: 450 } });
     });
-    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
-    expect(headline.props.children).toBe('Self-Love');
+    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
+    expect(freeWill.props.children).toBe('Free will at stage 3.');
     // The settled stage now opens on a single stage tap (it is focused).
     act(() => {
       tree.root.findByProps({ testID: 'stage-hotspot-3-0' }).props.onPress();

--- a/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
@@ -128,9 +128,9 @@ describe('MapScreen header drawer', () => {
 
     // Closing unmounts the drawer body (the Modal renders null when hidden).
     expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
-    // The lens headline reflects the newly focused stage (stage 3's arrow label).
-    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
-    expect(headline.props.children).toBe('Self-Love');
+    // The lens caption reflects the newly focused stage (stage 3's free-will read).
+    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
+    expect(freeWill.props.children).toBe('Free will at stage 3.');
   });
 
   it('tapping a locked drawer row still closes the drawer and refocuses the lens', () => {
@@ -144,9 +144,9 @@ describe('MapScreen header drawer', () => {
 
     // Closing unmounts the drawer body (the Modal renders null when hidden).
     expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
-    // The lens headline reflects the newly focused stage (stage 8's arrow label).
-    const headline = tree.root.findByProps({ testID: 'magnifier-headline' });
-    expect(headline.props.children).toBe('True Self');
+    // The lens caption reflects the newly focused stage (stage 8's free-will read).
+    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
+    expect(freeWill.props.children).toBe('Free will at stage 8.');
   });
 
   it('opens the stage-detail modal for the tapped stage, and closes the drawer', () => {

--- a/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
@@ -10,12 +10,14 @@ import {
   lensCaption,
   lensCenterForStage,
   lensFrame,
+  lensStageIdentity,
   MAGNIFICATION,
   magnifierTransform,
   nearestStage,
 } from '../magnifierGeometry';
 import { STAGE_DISPLAY, TITLE_BY_STAGE } from '../mapLayout';
 import { STAGE_COUNT } from '../stageData';
+import type { StageData } from '../stageData';
 import { centerColumnBounds, stageWavePoint } from '../waveGeometry';
 
 const GRID_WIDTH = 300;
@@ -184,42 +186,74 @@ describe('glideDurationMs', () => {
   });
 });
 
+const makeStage = (overrides: Partial<StageData> = {}): StageData => ({
+  id: 4,
+  title: 'Stage 4',
+  subtitle: 'Subtitle',
+  stageNumber: 4,
+  progress: 0,
+  color: '#aaa',
+  isUnlocked: true,
+  category: 'Love',
+  aspect: 'Community',
+  spiralDynamicsColor: 'Blue',
+  growingUpStage: 'Conformity',
+  divineGenderPolarity: 'Divine Feminine',
+  relationshipToFreeWill: 'Victim',
+  freeWillDescription: 'Behaviour is determined by the relationships one is embedded in.',
+  overviewUrl: '',
+  manifestations: [],
+  ...overrides,
+});
+
 describe('lensCaption', () => {
-  it('uses the Aspect arrow word for labelled stages', () => {
-    const caption = lensCaption(3);
-    expect(caption.headline).toBe('Self-Love');
-    expect(caption.detail).toBe('Dominator · Power');
+  it('surfaces the stage polarity and free-will description from backend data', () => {
+    const caption = lensCaption(makeStage());
+    expect(caption.polarity).toBe('Divine Feminine');
+    expect(caption.freeWill).toBe(
+      'Behaviour is determined by the relationships one is embedded in.',
+    );
   });
 
-  it('prefixes the stage number and spiral color as the eyebrow', () => {
-    const caption = lensCaption(4);
-    expect(caption.eyebrow).toBe('4 · BLUE');
-    expect(caption.practice).toBe('Metta');
+  it('carries a Divine Masculine polarity through unchanged', () => {
+    const caption = lensCaption(makeStage({ divineGenderPolarity: 'Divine Masculine' }));
+    expect(caption.polarity).toBe('Divine Masculine');
   });
 
-  it('uppercases a two-word spiral color name in the eyebrow', () => {
-    expect(lensCaption(10).eyebrow).toBe('10 · CLEAR LIGHT');
-    expect(lensCaption(10).headline).toBe(TITLE_BY_STAGE[10]);
+  it('resolves missing stage data to empty strings instead of throwing', () => {
+    expect(lensCaption(undefined)).toEqual({ polarity: '', freeWill: '' });
+  });
+
+  it('surfaces an empty free-will description without falling over', () => {
+    const caption = lensCaption(makeStage({ freeWillDescription: '' }));
+    expect(caption.freeWill).toBe('');
+    expect(caption.polarity).toBe('Divine Feminine');
+  });
+});
+
+describe('lensStageIdentity', () => {
+  it('identifies a stage by its Aspect word, number, colour, and persona', () => {
+    const identity = lensStageIdentity(3);
+    expect(identity).toContain('Self-Love');
+    expect(identity).toContain('3 · RED');
+    expect(identity).toContain(STAGE_DISPLAY[3]?.persona ?? '');
   });
 
   it('falls back to the UNITY / EMPTINESS titles for the top stages', () => {
-    expect(lensCaption(9).headline).toBe(TITLE_BY_STAGE[9]);
-    expect(lensCaption(10).headline).toBe(TITLE_BY_STAGE[10]);
+    expect(lensStageIdentity(9)).toContain(TITLE_BY_STAGE[9]);
+    expect(lensStageIdentity(10)).toContain(TITLE_BY_STAGE[10]);
   });
 
-  it('covers every stage with a non-empty headline, detail, eyebrow, and practice', () => {
+  it('names every stage with its number and uppercased spiral colour', () => {
     for (let stage = 1; stage <= STAGE_COUNT; stage += 1) {
-      const caption = lensCaption(stage);
-      expect(caption.headline.length).toBeGreaterThan(0);
-      expect(caption.detail).toContain(STAGE_DISPLAY[stage]?.persona ?? '');
-      expect(caption.eyebrow).toBe(`${stage} · ${(STAGE_ORDER[stage - 1] ?? '').toUpperCase()}`);
-      expect(caption.practice).toBe(STAGE_DISPLAY[stage]?.practice);
-      expect(caption.practice.length).toBeGreaterThan(0);
+      const identity = lensStageIdentity(stage);
+      expect(identity).toContain(`${stage} · ${(STAGE_ORDER[stage - 1] ?? '').toUpperCase()}`);
+      expect(identity).toContain(STAGE_DISPLAY[stage]?.persona ?? '');
     }
   });
 
-  it('resolves unknown stages to empty strings instead of throwing', () => {
-    expect(lensCaption(99)).toEqual({ eyebrow: '', headline: '', detail: '', practice: '' });
+  it('resolves an unknown stage to an empty identity instead of throwing', () => {
+    expect(lensStageIdentity(99)).toBe('');
   });
 });
 

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -65,9 +65,11 @@ export function mockMakeStage(stageNumber: number, overrides: Partial<StageData>
     aspect: 'Aspect',
     spiralDynamicsColor: 'Beige',
     growingUpStage: 'Growing',
-    divineGenderPolarity: 'Polarity',
+    // Stage-specific so a lens-caption assertion can prove which stage is under
+    // the glass (the pill now shows only polarity + free-will description).
+    divineGenderPolarity: stageNumber % 2 === 0 ? 'Divine Feminine' : 'Divine Masculine',
     relationshipToFreeWill: 'Free Will',
-    freeWillDescription: 'Description of free will.',
+    freeWillDescription: `Free will at stage ${stageNumber}.`,
     overviewUrl: '',
     manifestations: defaultManifestations(),
     ...overrides,

--- a/frontend/src/features/Map/magnifierGeometry.ts
+++ b/frontend/src/features/Map/magnifierGeometry.ts
@@ -15,6 +15,7 @@ import { STAGE_ORDER } from '../../design/tokens';
 
 import { STAGE_DISPLAY, TITLE_BY_STAGE } from './mapLayout';
 import { STAGE_COUNT } from './stageData';
+import type { StageData } from './stageData';
 import { centerColumnBounds, stageWavePoint } from './waveGeometry';
 import type { StageAnchors } from './waveGeometry';
 
@@ -183,34 +184,42 @@ export const magnifierTransform = (
 export const glideDurationMs = (distancePx: number): number =>
   clamp(distancePx * GLIDE_MS_PER_PX, GLIDE_MIN_MS, GLIDE_MAX_MS);
 
-/** The enriched caption the lens shows for the stage under the glass. */
+/**
+ * The two stage-ontology facts the lens surfaces under the glass — the only
+ * pieces of a stage's ontology that appear nowhere else on the Map screen, so
+ * the pill adds information rather than repeating the columns beneath it.
+ */
 export interface LensCaption {
-  /** Stage number + Spiral color name, e.g. "4 · BLUE". */
-  eyebrow: string;
-  /** The Aspect word for the stage (or its UNITY / EMPTINESS title). */
-  headline: string;
-  /** The stage's persona and mode of knowing, dot-separated. */
-  detail: string;
-  /** The practice cultivated at this stage. */
-  practice: string;
+  /** The stage's Divine Gender Polarity, eyebrow-style (e.g. "Divine Feminine"). */
+  polarity: string;
+  /** The stage's one-sentence free-will read, clamped within the pill. */
+  freeWill: string;
 }
 
 /**
- * Resolve the caption for a stage under the glass: an eyebrow pairing the stage
- * number with its Spiral color, the Aspect arrow word (or the UNITY / EMPTINESS
- * title carried by stages 9–10) over its persona and descriptor, and the
- * stage's cultivated practice. Unknown stages resolve to empty strings rather
- * than throwing so a transient out-of-range hover can never take the Map down.
+ * Resolve the lens caption from a stage's backend data: its Divine Gender
+ * Polarity over its free-will description. Both are sourced from ``StageData``
+ * (never hardcoded) so ontology corrections flow through automatically. Missing
+ * data — a cold start, a fetch error, or an out-of-range hover — resolves to
+ * empty strings rather than throwing, so a transient gap can never take the Map
+ * down.
  */
-export const lensCaption = (stageNumber: number): LensCaption => {
+export const lensCaption = (stage: StageData | undefined): LensCaption =>
+  stage
+    ? { polarity: stage.divineGenderPolarity, freeWill: stage.freeWillDescription }
+    : { polarity: '', freeWill: '' };
+
+/**
+ * Screen-reader identity for a stage: its Aspect word (or the UNITY / EMPTINESS
+ * title carried by stages 9–10), stage number + Spiral color, and persona. The
+ * visible pill sheds this detail because it duplicates the Map's columns, but a
+ * screen-reader user can't cross-reference those columns, so the spoken label
+ * keeps it. Unknown stages resolve to an empty string rather than throwing.
+ */
+export const lensStageIdentity = (stageNumber: number): string => {
   const display = STAGE_DISPLAY[stageNumber];
-  if (!display) return { eyebrow: '', headline: '', detail: '', practice: '' };
+  if (!display) return '';
   const headline = display.arrowLabel || TITLE_BY_STAGE[display.stageNumber] || '';
   const colorName = (STAGE_ORDER[display.stageNumber - 1] ?? '').toUpperCase();
-  return {
-    eyebrow: `${display.stageNumber} · ${colorName}`,
-    headline,
-    detail: `${display.persona} · ${display.descriptor}`,
-    practice: display.practice,
-  };
+  return `${headline}, stage ${display.stageNumber} · ${colorName}, ${display.persona}`;
 };


### PR DESCRIPTION
## Summary

The Map magnifier lens caption previously showed four lines that duplicated
text already visible elsewhere on the screen:

- eyebrow `4 · BLUE` — stage number is inferable from position; colour is the
  row's text/arrow colour
- Aspect headline (e.g. `Community`) — already on the center cell and right band
- `persona · descriptor` detail — the left column's first two lines
- practice — the left column's third line

This walks that duplication back to the only two stage-ontology facts that
appear **nowhere else** on the Map: the stage's **Divine Gender Polarity**
(eyebrow-style, one line) over its **free-will description** (clamped to two
lines). The `YOU ARE HERE` chip and live drag re-captioning are unchanged.

Both facts are sourced from backend `StageData` via a `captionForStage` lookup
threaded from `MapScreen` (built from the existing `useMapStageStore` lookup),
so ontology corrections flow through automatically — no hardcoded strings.
Missing stage data (cold start, fetch error, out-of-range hover) resolves to
empty strings and never throws. The accessibility label still identifies the
stage (number, colour, Aspect word, persona — detail a screen-reader user can't
cross-reference visually) via a new `lensStageIdentity`, then reads both new
facts.

The now-unused `magnifierHeadline` / `magnifierPractice` styles are removed.

## Test plan

- `magnifierGeometry.test.ts`: `lensCaption(StageData | undefined)` returns the
  two facts (polarity variants, empty free-will, and the `undefined` →
  empty-strings fallback); `lensStageIdentity` covers every stage plus the
  unknown-stage fallback.
- `MagnifierLens.test.tsx`: caption renders exactly `magnifier-polarity`
  (1 line) + `magnifier-freewill` (2 lines); an explicit negative test asserts
  the four old testIDs are gone; live drag re-captioning and the a11y label
  (identity + both facts) are covered.
- `MapScreen.test.tsx` / `MapScreenDrawer.test.tsx`: in-situ lens assertions
  migrated to the free-will line, with `mapTestHarness` fixtures made
  stage-specific so a caption assertion proves which stage is under the glass.
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, 4814 Jest
  tests).

Closes #1839