### PR TITLE
feat(journal): classification choice in the capture flow — intimate tier blocks cloud transcription with a typed-entry offramp

### DIFF
--- a/frontend/src/features/Journal/CaptureClassificationControl.tsx
+++ b/frontend/src/features/Journal/CaptureClassificationControl.tsx
@@ -1,0 +1,90 @@
+/**
+ * The privacy classification chooser for the photograph-capture flow, shown in
+ * the collect stage BEFORE the Transcribe action. It reuses the writing editor's
+ * {@link PrivacyTierControl} (no parallel control) with its built-in explainer
+ * suppressed, and adds a transcription-specific intimate gate.
+ *
+ * PRIVACY: photo transcription is a cloud-LLM call carrying the page's content,
+ * so the ratified intimate-never-cloud promise applies here as it does to
+ * resonance. Choosing ``intimate`` reveals a calm, non-shaming gate: it explains
+ * that transcription would hand the page to an outside AI and offers a typed
+ * entry instead ("Type it instead") or a revert to a transcribable tier ("Keep
+ * as Personal"). The host disables Transcribe while intimate is selected, so the
+ * cloud call is structurally unreachable.
+ */
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import styles from './JournalPhotograph.styles';
+import PrivacyTierControl from './PrivacyTierControl';
+import type { PrivacyTier } from './PrivacyTierControl';
+
+import { Button } from '@/components/Button';
+
+/** The one-promise gate copy: warm, declinable, and specific to transcription. */
+const INTIMATE_GATE_COPY =
+  'Intimate writing is never handed to an outside AI, so photo transcription is off for this entry. You can type it privately instead.';
+const TYPE_INSTEAD_LABEL = 'Type it instead';
+const KEEP_PERSONAL_LABEL = 'Keep as Personal';
+
+export interface CaptureClassificationControlProps {
+  /** The currently-chosen tier for the entry being captured. */
+  value: PrivacyTier;
+  /** Called with the chosen tier when an option is pressed. */
+  onChange: (_tier: PrivacyTier) => void;
+  /** Step off to a fresh typed entry (pre-set intimate); the session is released. */
+  onTypeInstead: () => void;
+  /** Revert the selection to ``personal``, re-enabling transcription. */
+  onKeepPersonal: () => void;
+}
+
+/** The intimate transcription gate: the one-promise copy over its two declinable
+ *  actions. Rendered only while ``intimate`` is the chosen tier. */
+function IntimateGate({
+  onTypeInstead,
+  onKeepPersonal,
+}: {
+  onTypeInstead: () => void;
+  onKeepPersonal: () => void;
+}): React.JSX.Element {
+  return (
+    <View testID="capture-intimate-gate" style={styles.intimateGate}>
+      <Text testID="capture-intimate-explainer" style={styles.intimateGateText}>
+        {INTIMATE_GATE_COPY}
+      </Text>
+      <Button
+        testID="capture-type-instead"
+        label={TYPE_INSTEAD_LABEL}
+        accessibilityLabel={TYPE_INSTEAD_LABEL}
+        onPress={onTypeInstead}
+      />
+      <Button
+        testID="capture-keep-personal"
+        variant="secondary"
+        label={KEEP_PERSONAL_LABEL}
+        accessibilityLabel={KEEP_PERSONAL_LABEL}
+        onPress={onKeepPersonal}
+      />
+    </View>
+  );
+}
+
+/** The capture-flow classification chooser: the reused tier control over its
+ *  intimate transcription gate. */
+export function CaptureClassificationControl({
+  value,
+  onChange,
+  onTypeInstead,
+  onKeepPersonal,
+}: CaptureClassificationControlProps): React.JSX.Element {
+  return (
+    <View testID="capture-classification" style={styles.classification}>
+      <PrivacyTierControl value={value} onChange={onChange} showExplainer={false} />
+      {value === 'intimate' ? (
+        <IntimateGate onTypeInstead={onTypeInstead} onKeepPersonal={onKeepPersonal} />
+      ) : null}
+    </View>
+  );
+}
+
+export default CaptureClassificationControl;

--- a/frontend/src/features/Journal/CapturePagesStrip.tsx
+++ b/frontend/src/features/Journal/CapturePagesStrip.tsx
@@ -121,12 +121,15 @@ function TakePhotoControl({
   );
 }
 
-/** Proceed affordance: enabled for any non-empty session, reading every page. */
+/** Proceed affordance: enabled for any non-empty session, reading every page.
+ *  A ``disabled`` host gate (e.g. an intimate classification) also holds it off. */
 function TranscribeControl({
   count,
+  disabled,
   onTranscribe,
 }: {
   count: number;
+  disabled: boolean;
   onTranscribe: () => void;
 }): React.JSX.Element {
   const label = transcribeLabel(count);
@@ -135,7 +138,7 @@ function TranscribeControl({
       testID="capture-transcribe"
       label={label}
       accessibilityLabel={label}
-      disabled={count < 1}
+      disabled={count < 1 || disabled}
       onPress={onTranscribe}
     />
   );
@@ -149,6 +152,9 @@ export interface CapturePagesStripProps {
   onRemove: (_id: string) => void;
   onReorder: (_pages: CapturePage[]) => void;
   onTranscribe: () => void;
+  /** Holds the proceed affordance off regardless of page count — the host's
+   *  classification gate sets this while an intimate tier is chosen. */
+  transcribeDisabled?: boolean;
   /** Hide the add/capture/proceed controls, leaving only the thumbnail strip —
    *  used by phases that offer their own forward affordances. */
   actionsHidden?: boolean;
@@ -164,6 +170,7 @@ export function CapturePagesStrip({
   onRemove,
   onReorder,
   onTranscribe,
+  transcribeDisabled = false,
   actionsHidden = false,
 }: CapturePagesStripProps): React.JSX.Element {
   return (
@@ -189,7 +196,11 @@ export function CapturePagesStrip({
         <>
           <AddPagesControl canAdd={canAdd} onAdd={onAdd} />
           <TakePhotoControl canAdd={canAdd} onCapture={onCapture} />
-          <TranscribeControl count={pages.length} onTranscribe={onTranscribe} />
+          <TranscribeControl
+            count={pages.length}
+            disabled={transcribeDisabled}
+            onTranscribe={onTranscribe}
+          />
         </>
       )}
     </View>

--- a/frontend/src/features/Journal/JournalEntryScreen.tsx
+++ b/frontend/src/features/Journal/JournalEntryScreen.tsx
@@ -811,12 +811,19 @@ interface EntryState {
   loaded: boolean;
 }
 
-/** The entry's editable state (title/body/status/tier) + one-time load-on-open. */
-function useEntryState(routeEntryId: number | null, initialText: InitialText): EntryState {
+/** The entry's editable state (title/body/status/tier) + one-time load-on-open.
+ *  ``initialClassification`` pre-selects the tier for a fresh entry (e.g. the
+ *  capture flow's intimate offramp); an existing entry's load overrides it. */
+function useEntryState(
+  routeEntryId: number | null,
+  initialText: InitialText,
+  initialClassification: JournalClassification,
+): EntryState {
   const [title, setTitle] = useState(initialText.title);
   const [body, setBody] = useState(initialText.body);
   const [status, setStatus] = useState<EntryStatus>('draft');
-  const [classification, setClassification] = useState<JournalClassification>(DEFAULT_TIER);
+  const [classification, setClassification] =
+    useState<JournalClassification>(initialClassification);
   const [chord, setChord] = useState<AspectChordValue>(EMPTY_CHORD);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -917,16 +924,36 @@ function useSeedPersistOnLoad(
   }, [entry.loaded, entry.classification, entry.chord, seedPersist]);
 }
 
+/**
+ * Seed the persist ref for a NEW entry (no id to load) with the pre-set tier once
+ * on mount, so the first ``journal.create`` carries it — the capture flow's
+ * intimate offramp lands a genuinely intimate entry, not the personal default.
+ * Runs only for a fresh entry; an existing entry is seeded by its load instead.
+ */
+function useSeedPersistOnNew(
+  routeEntryId: number | null,
+  initialClassification: JournalClassification,
+  seedPersist: (_tier: JournalClassification, _chord: AspectChordValue) => void,
+): void {
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || routeEntryId != null) return;
+    seededRef.current = true;
+    seedPersist(initialClassification, EMPTY_CHORD);
+  }, [routeEntryId, initialClassification, seedPersist]);
+}
+
 /** Owns the entry's text + debounced draft autosave (create-then-update). */
 function useJournalAutosave(
   routeEntryId: number | null,
   delayMs: number,
   ctx: SaveContext,
   initialText: InitialText,
+  initialClassification: JournalClassification,
   onSaved?: () => void,
   onConflict?: () => void,
 ): AutosaveApi {
-  const entry = useEntryState(routeEntryId, initialText);
+  const entry = useEntryState(routeEntryId, initialText, initialClassification);
   const { titleRef, bodyRef } = entry;
   // An existing entry is "unsettled" until its load settles: entry.loaded flips
   // true only in the success apply, so it stays false through both the in-flight
@@ -936,6 +963,7 @@ function useJournalAutosave(
   const { saveState, save, flush, finish, changeClassification, changeChord, seedPersist } =
     useDebouncedSave(routeEntryId, delayMs, ctx, entryUnsettled, onSaved, onConflict);
   useSeedPersistOnLoad(entry, seedPersist);
+  useSeedPersistOnNew(routeEntryId, initialClassification, seedPersist);
 
   const { onChangeTitle, onChangeBody } = useFieldHandlers(
     titleRef,
@@ -1674,6 +1702,7 @@ function useJournalEntryController(
   ctx: SaveContext,
   initialText: InitialText,
   justSaved: boolean,
+  initialClassification: JournalClassification,
 ) {
   const { refreshRef, handleSaved, onConfirmEdit } = useRefreshAfterEdit();
   const onCreateConflict = useCreateConflictHandler(ctx, navigation);
@@ -1682,6 +1711,7 @@ function useJournalEntryController(
     autosaveDelayMs,
     ctx,
     initialText,
+    initialClassification,
     handleSaved,
     onCreateConflict,
   );
@@ -1811,6 +1841,9 @@ interface EntryEntrypoint {
   ctx: SaveContext;
   initialText: InitialText;
   bodyPlaceholder: string;
+  /** The tier a fresh entry opens at (from the capture flow's intimate offramp);
+   *  ``personal`` when the route carries no classification. */
+  initialClassification: JournalClassification;
 }
 
 /** Translate the route params into the save context + pre-filled title/body/placeholder. */
@@ -1832,6 +1865,7 @@ function readEntrypoint(params: RootStackParamList['JournalEntry']): EntryEntryp
     },
     initialText: { title, body },
     bodyPlaceholder: p.promptQuestion ?? DEFAULT_BODY_PLACEHOLDER,
+    initialClassification: p.classification ?? DEFAULT_TIER,
   };
 }
 
@@ -2061,7 +2095,7 @@ function JournalEntryScreen({
   navigation,
   autosaveDelayMs = AUTOSAVE_DELAY_MS,
 }: JournalEntryScreenProps): React.JSX.Element {
-  const { ctx, initialText, bodyPlaceholder } = readEntrypoint(route.params);
+  const { ctx, initialText, bodyPlaceholder, initialClassification } = readEntrypoint(route.params);
   const currentEntryId = route.params?.entryId ?? null;
   const justSaved = route.params?.justSaved ?? false;
   const entryDrawer = useEntryScreenDrawer(navigation);
@@ -2072,6 +2106,7 @@ function JournalEntryScreen({
     ctx,
     initialText,
     justSaved,
+    initialClassification,
   );
   return (
     <SafeAreaView style={styles.safeArea} testID="journal-screen">

--- a/frontend/src/features/Journal/JournalPhotograph.styles.ts
+++ b/frontend/src/features/Journal/JournalPhotograph.styles.ts
@@ -187,6 +187,26 @@ const styles = StyleSheet.create({
     ...editorialType.body,
     color: colors.destructive.text,
   },
+  /** The privacy classification chooser above the strip: the tier control over
+   *  its intimate transcription gate, with editorial breathing room. */
+  classification: {
+    gap: SPACING.sm,
+  },
+  /** The intimate gate: a soft paper card carrying the one-promise copy and its
+   *  two declinable actions (type instead / keep as personal). */
+  intimateGate: {
+    gap: SPACING.sm,
+    padding: SPACING.md,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.paper.hairline,
+    backgroundColor: colors.paper.backgroundAlt,
+  },
+  /** The gate's warm, non-shaming explanation copy, in the soft editorial ink. */
+  intimateGateText: {
+    ...editorialType.body,
+    color: colors.paper.inkSoft,
+  },
 });
 
 export default styles;

--- a/frontend/src/features/Journal/JournalPhotographScreen.tsx
+++ b/frontend/src/features/Journal/JournalPhotographScreen.tsx
@@ -33,12 +33,15 @@ import { ActivityIndicator, Linking, Text, View } from 'react-native';
 import { releaseAllPageFiles, releasePageFiles, releaseUris } from './capture/cleanupPageFiles';
 import { preparePageForTranscription } from './capture/prepareImage';
 import type { PreparedPage } from './capture/prepareImage';
+import { CaptureClassificationControl } from './CaptureClassificationControl';
 import { CapturePagesStrip } from './CapturePagesStrip';
 import { MAX_PAGES_PER_SESSION, canAddPages, captureSessionReducer } from './captureSession';
 import type { CapturePage, CaptureSessionAction } from './captureSession';
 import styles from './JournalPhotograph.styles';
 import { captureJournalPhoto, pickJournalPhotos } from './pickJournalPhoto';
 import type { CaptureResult, MultiPickResult, PickedAsset } from './pickJournalPhoto';
+import { DEFAULT_TIER } from './PrivacyTierControl';
+import type { PrivacyTier } from './PrivacyTierControl';
 import { saveFinishedEntry } from './saveFinishedEntry';
 import { TranscriptionPreview } from './TranscriptionPreview';
 import { useTranscriptionRun } from './useTranscriptionRun';
@@ -96,9 +99,12 @@ interface CaptureModel {
   pages: CapturePage[];
   canAdd: boolean;
   entryDate: string;
+  /** The chosen privacy tier; ``intimate`` gates transcription off entirely. */
+  classification: PrivacyTier;
   saving: boolean;
   saveFailed: boolean;
   onChangeEntryDate: (_date: string) => void;
+  onChangeClassification: (_tier: PrivacyTier) => void;
   runPick: () => void;
   takePhoto: () => void;
   finishCapturing: () => void;
@@ -109,6 +115,10 @@ interface CaptureModel {
   openSettings: () => void;
   cancel: () => void;
   goTypedEntry: () => void;
+  /** The intimate offramp: release the session, then open a fresh intimate typed entry. */
+  typeInstead: () => void;
+  /** Revert an intimate selection to ``personal``, re-enabling transcription. */
+  keepPersonal: () => void;
   run: TranscriptionRunModel;
 }
 
@@ -335,6 +345,7 @@ function useSaveEntry(
   navigation: PhotographNavigation,
   mergedText: string,
   entryDate: string,
+  classification: PrivacyTier,
   releaseSession: () => void,
   createdIdRef: React.MutableRefObject<number | null>,
 ): { save: () => Promise<void>; saving: boolean; saveFailed: boolean } {
@@ -352,6 +363,7 @@ function useSaveEntry(
           createdIdRef.current = created;
         },
         entryDateForCreate(entryDate),
+        classification,
       );
       releaseSession(); // Release every page image the moment the entry is saved.
       navigation.replace('JournalEntry', { entryId: id, justSaved: true });
@@ -360,7 +372,7 @@ function useSaveEntry(
     } finally {
       setSaving(false);
     }
-  }, [mergedText, entryDate, navigation, releaseSession, createdIdRef]);
+  }, [mergedText, entryDate, classification, navigation, releaseSession, createdIdRef]);
 
   return { save, saving, saveFailed };
 }
@@ -368,17 +380,24 @@ function useSaveEntry(
 /** The proceed gesture: arm the run and enter review, but only with a page to read.
  *  `started` stays true through a mid-run trim back to one page so a partial removal
  *  never re-arms — but `disarm` returns it to the pre-transcribe state when the whole
- *  session is emptied, so a return to collect re-syncs cleanly and re-entry starts fresh. */
+ *  session is emptied, so a return to collect re-syncs cleanly and re-entry starts fresh.
+ *
+ *  PRIVACY: an ``intimate`` classification refuses here — the single choke point that
+ *  flips `started` — so ``useTranscriptionRun`` (inert until `started`) never issues a
+ *  transcribe call. Paired with the disabled Transcribe button, the cloud read of an
+ *  intimate page is structurally unreachable: no network, no wallet charge, no egress. */
 function useTranscribeGate(
   pagesRef: React.MutableRefObject<CapturePage[]>,
   setPhase: (_phase: Phase) => void,
+  classificationRef: React.MutableRefObject<PrivacyTier>,
 ): { started: boolean; transcribe: () => void; disarm: () => void } {
   const [started, setStarted] = useState(false);
   const transcribe = useCallback(() => {
     if (pagesRef.current.length < 1) return;
+    if (classificationRef.current === 'intimate') return;
     setStarted(true);
     setPhase({ step: 'review' });
-  }, [pagesRef, setPhase]);
+  }, [pagesRef, setPhase, classificationRef]);
   const disarm = useCallback(() => setStarted(false), []);
   return { started, transcribe, disarm };
 }
@@ -392,6 +411,7 @@ function useNavigationOfframps(
   openSettings: () => void;
   cancel: () => void;
   goTypedEntry: () => void;
+  typeInstead: () => void;
 } {
   const openSettings = useCallback(() => void Linking.openSettings(), []);
   const cancel = useCallback(() => {
@@ -402,7 +422,13 @@ function useNavigationOfframps(
     releaseSession(); // Release every page image when stepping off to a typed entry.
     navigation.navigate('JournalEntry');
   }, [navigation, releaseSession]);
-  return { openSettings, cancel, goTypedEntry };
+  // The intimate offramp: release the session, then open a fresh entry pre-set to
+  // intimate. Only the tier scalar rides the nav params — never any page image.
+  const typeInstead = useCallback(() => {
+    releaseSession();
+    navigation.navigate('JournalEntry', { classification: 'intimate' });
+  }, [navigation, releaseSession]);
+  return { openSettings, cancel, goTypedEntry, typeInstead };
 }
 
 /** Keeps the transient device files in lockstep with the in-memory session:
@@ -508,16 +534,69 @@ function useCaptureRun(
   });
 }
 
+/** The privacy tier the writer chooses before transcription, plus a live ref for
+ *  the transcribe gate and the "Keep as Personal" revert. ``intimate`` gates the
+ *  cloud transcription off entirely (see {@link useTranscribeGate}). */
+function useCaptureClassification(): {
+  classification: PrivacyTier;
+  classificationRef: React.MutableRefObject<PrivacyTier>;
+  setClassification: (_tier: PrivacyTier) => void;
+  keepPersonal: () => void;
+} {
+  const [classification, setClassification] = useState<PrivacyTier>(DEFAULT_TIER);
+  const classificationRef = useRef<PrivacyTier>(classification);
+  classificationRef.current = classification;
+  const keepPersonal = useCallback(() => setClassification('personal'), []);
+  return { classification, classificationRef, setClassification, keepPersonal };
+}
+
+/** Auto-launch the photo picker once on mount, opening the flow straight into a pick. */
+function useAutoLaunchPick(runPick: () => Promise<void>): void {
+  useEffect(() => {
+    void runPick();
+  }, [runPick]);
+}
+
+/** The session-and-run inputs the engine drives against: the current phase/pages
+ *  (from the host's state) plus the chosen tier and its live ref for the gate. */
+interface CaptureEngineArgs {
+  navigation: PhotographNavigation;
+  phase: Phase;
+  setPhase: (_phase: Phase) => void;
+  pages: CapturePage[];
+  dispatch: React.Dispatch<CaptureSessionAction>;
+  entryDate: string;
+  classification: PrivacyTier;
+  classificationRef: React.MutableRefObject<PrivacyTier>;
+}
+
+/** The engine surface the model exposes: the session edits, the transcription run,
+ *  the save, and the navigation offramps. */
+interface CaptureEngine {
+  removePage: (_id: string) => void;
+  runPick: () => Promise<void>;
+  runCapture: () => Promise<void>;
+  reorderPages: (_pages: CapturePage[]) => void;
+  transcribe: () => void;
+  run: TranscriptionRunModel;
+  save: () => Promise<void>;
+  saving: boolean;
+  saveFailed: boolean;
+  openSettings: () => void;
+  cancel: () => void;
+  goTypedEntry: () => void;
+  typeInstead: () => void;
+}
+
 /**
- * The capture state machine: collect pages → run the multi-page transcription →
- * review + save. Pages live in a reducer (never in nav params) with a ref mirror so
- * async picks and the run read the current session; the created-entry id lives in a
- * ref so a save retry after a failed finish PATCH reuses it rather than duplicating.
+ * Wire the capture engine: session cleanup, pick/capture, reorder/retake, the
+ * transcribe gate, the progressive run, the save, and the offramps — over
+ * engine-internal refs (page mirror, id counter, created-entry id) so the host
+ * hook holds only the render state.
  */
-function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
-  const [phase, setPhase] = useState<Phase>({ step: 'preparing' });
-  const [pages, dispatch] = useReducer(captureSessionReducer, []);
-  const [entryDate, setEntryDate] = useState(() => toISODate(new Date()));
+function useCaptureEngine(args: CaptureEngineArgs): CaptureEngine {
+  const { navigation, phase, setPhase, pages, dispatch } = args;
+  const { entryDate, classification, classificationRef } = args;
   const createdIdRef = useRef<number | null>(null);
   const counterRef = useRef(0);
   const pagesRef = useRef<CapturePage[]>(pages);
@@ -528,44 +607,85 @@ function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
   const runCapture = useCameraCapture({ dispatch, counterRef, setPhase });
   const reorderPages = useReorderPages(dispatch);
   const retakePage = useRetakePage({ dispatch, pagesRef, counterRef, releasePageById });
-  const { started, transcribe, disarm } = useTranscribeGate(pagesRef, setPhase);
+  const { started, transcribe, disarm } = useTranscribeGate(pagesRef, setPhase, classificationRef);
   useEmptyReviewGuard(phase.step, pages.length, disarm, setPhase);
-
   const run = useCaptureRun(pages, started, retakePage, removePage, releasePageById);
-
   const { save, saving, saveFailed } = useSaveEntry(
     navigation,
     run.mergedText,
     entryDate,
+    classification,
     releaseSession,
     createdIdRef,
   );
+  const { openSettings, cancel, goTypedEntry, typeInstead } = useNavigationOfframps(
+    navigation,
+    releaseSession,
+  );
 
-  const { openSettings, cancel, goTypedEntry } = useNavigationOfframps(navigation, releaseSession);
+  return {
+    removePage,
+    runPick,
+    runCapture,
+    reorderPages,
+    transcribe,
+    run,
+    save,
+    saving,
+    saveFailed,
+    openSettings,
+    cancel,
+    goTypedEntry,
+    typeInstead,
+  };
+}
 
-  useEffect(() => {
-    void runPick();
-  }, [runPick]);
+/**
+ * The capture state machine: collect pages → run the multi-page transcription →
+ * review + save. Render state (phase, pages, entry date, tier) lives here; the
+ * session/run wiring lives in {@link useCaptureEngine}. Pages never enter nav params.
+ */
+function usePhotographCapture(navigation: PhotographNavigation): CaptureModel {
+  const [phase, setPhase] = useState<Phase>({ step: 'preparing' });
+  const [pages, dispatch] = useReducer(captureSessionReducer, []);
+  const [entryDate, setEntryDate] = useState(() => toISODate(new Date()));
+  const { classification, classificationRef, setClassification, keepPersonal } =
+    useCaptureClassification();
+  const engine = useCaptureEngine({
+    navigation,
+    phase,
+    setPhase,
+    pages,
+    dispatch,
+    entryDate,
+    classification,
+    classificationRef,
+  });
+  useAutoLaunchPick(engine.runPick);
 
   return {
     phase,
     pages,
     canAdd: canAddPages(pages),
     entryDate,
-    saving,
-    saveFailed,
+    classification,
+    saving: engine.saving,
+    saveFailed: engine.saveFailed,
     onChangeEntryDate: setEntryDate,
-    runPick: () => void runPick(),
-    takePhoto: () => void runCapture(),
+    onChangeClassification: setClassification,
+    runPick: () => void engine.runPick(),
+    takePhoto: () => void engine.runCapture(),
     finishCapturing: () => setPhase({ step: 'collect' }),
-    removePage,
-    reorderPages,
-    transcribe,
-    save: () => void save(),
-    openSettings,
-    cancel,
-    goTypedEntry,
-    run,
+    removePage: engine.removePage,
+    reorderPages: engine.reorderPages,
+    transcribe: engine.transcribe,
+    save: () => void engine.save(),
+    openSettings: engine.openSettings,
+    cancel: engine.cancel,
+    goTypedEntry: engine.goTypedEntry,
+    typeInstead: engine.typeInstead,
+    keepPersonal,
+    run: engine.run,
   };
 }
 
@@ -718,10 +838,17 @@ function ReviewActions({
   );
 }
 
-/** The collect stage: the ordered page strip over a quiet, declinable date row. */
+/** The collect stage: the classification chooser and page strip over a quiet,
+ *  declinable date row. Choosing ``intimate`` gates transcription off in place. */
 function CollectView({ model }: { model: CaptureModel }): React.JSX.Element {
   return (
     <View style={styles.container}>
+      <CaptureClassificationControl
+        value={model.classification}
+        onChange={model.onChangeClassification}
+        onTypeInstead={model.typeInstead}
+        onKeepPersonal={model.keepPersonal}
+      />
       <CapturePagesStrip
         pages={model.pages}
         canAdd={model.canAdd}
@@ -730,6 +857,7 @@ function CollectView({ model }: { model: CaptureModel }): React.JSX.Element {
         onRemove={model.removePage}
         onReorder={model.reorderPages}
         onTranscribe={model.transcribe}
+        transcribeDisabled={model.classification === 'intimate'}
       />
       <EntryDateRow entryDate={model.entryDate} onChangeEntryDate={model.onChangeEntryDate} />
     </View>

--- a/frontend/src/features/Journal/PrivacyTierControl.tsx
+++ b/frontend/src/features/Journal/PrivacyTierControl.tsx
@@ -48,6 +48,12 @@ export interface PrivacyTierControlProps {
   onChange: (_tier: PrivacyTier) => void;
   /** When true, taps are inert — used while an entry's load has failed. */
   disabled?: boolean;
+  /**
+   * Whether to render the built-in intimate explainer. Defaults to ``true`` for
+   * the writing editor; a host that shows its own intimate copy (e.g. the
+   * capture flow's transcription gate) passes ``false`` to avoid a duplicate.
+   */
+  showExplainer?: boolean;
 }
 
 /**
@@ -58,6 +64,7 @@ function PrivacyTierControl({
   value = DEFAULT_TIER,
   onChange,
   disabled = false,
+  showExplainer = true,
 }: PrivacyTierControlProps): React.JSX.Element {
   return (
     <View style={styles.privacyTierControl}>
@@ -80,7 +87,7 @@ function PrivacyTierControl({
           />
         ))}
       </RadioGroup>
-      {value === 'intimate' ? (
+      {value === 'intimate' && showExplainer ? (
         <Text style={styles.privacyTierExplainer} testID="privacy-tier-explainer">
           {INTIMATE_EXPLAINER}
         </Text>

--- a/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalEntryScreenPrivacy.test.tsx
@@ -101,6 +101,7 @@ function renderScreen(
     promptQuestion?: string;
     prefillTitle?: string;
     practiceSessionId?: number;
+    classification?: 'public' | 'personal' | 'intimate';
   },
   extraProps: Record<string, unknown> = {},
 ) {
@@ -625,6 +626,58 @@ describe('JournalEntryScreen — privacy control a11y (#896)', () => {
       expect(
         within(getByTestId('journal-screen')).getByTestId('privacy-resonance-reason'),
       ).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Classification seeded from the route param (photograph-flow offramp)
+// ---------------------------------------------------------------------------
+
+describe('JournalEntryScreen — classification seeded from the route param', () => {
+  it('pre-selects intimate in the control when the param carries classification="intimate"', () => {
+    const { getByTestId } = renderScreen({ classification: 'intimate' });
+    const page = within(getByTestId('journal-page'));
+    expect(page.getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(true);
+    expect(page.getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(false);
+  });
+
+  it('sends classification="intimate" on the first create without any tier press', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen(
+        { classification: 'intimate' },
+        { autosaveDelayMs: 100 },
+      );
+      fireEvent.changeText(getByTestId('journal-body-input'), 'Typed instead of photographed.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ classification: 'intimate' }),
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('still creates with the personal default when the params carry no classification', async () => {
+    jest.useFakeTimers();
+    try {
+      const { getByTestId } = renderScreen({}, { autosaveDelayMs: 100 });
+      fireEvent.changeText(getByTestId('journal-body-input'), 'A plain typed page.');
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ classification: 'personal' }),
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalPhotographScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
 import React from 'react';
 import { Linking, Platform } from 'react-native';
 
@@ -957,7 +957,12 @@ describe('JournalPhotographScreen — merged save across pages', () => {
     );
     fireEvent.press(getByTestId('photograph-save'));
 
-    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith({ message: 'A\n\nB-edited\n\nC' }));
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        message: 'A\n\nB-edited\n\nC',
+        classification: 'personal',
+      }),
+    );
     expect(navigation.replace).toHaveBeenCalledWith('JournalEntry', {
       entryId: 40,
       justSaved: true,
@@ -981,7 +986,10 @@ describe('JournalPhotographScreen — save flow', () => {
     fireEvent.press(await findByTestId('photograph-save'));
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(99, { status: 'finished' }));
-    expect(mockCreate).toHaveBeenCalledWith({ message: 'Edited by hand.' });
+    expect(mockCreate).toHaveBeenCalledWith({
+      message: 'Edited by hand.',
+      classification: 'personal',
+    });
     expect(navigation.replace).toHaveBeenCalledWith('JournalEntry', {
       entryId: 99,
       justSaved: true,
@@ -1550,5 +1558,174 @@ describe('JournalPhotographScreen — one downscale per page', () => {
     await waitFor(() => expect(mockTranscribe).toHaveBeenCalledTimes(2));
     expect((await findByTestId('photograph-block-1-input')).props.value).toBe('read on retry');
     expect(mockPrepare).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('JournalPhotographScreen — privacy classification in collect', () => {
+  it('renders the classification control in collect with personal selected by default', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId, getByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    const control = getByTestId('capture-classification');
+    expect(within(control).getByTestId('privacy-tier-public')).toBeTruthy();
+    expect(within(control).getByTestId('privacy-tier-personal')).toBeTruthy();
+    expect(within(control).getByTestId('privacy-tier-intimate')).toBeTruthy();
+    expect(
+      within(control).getByTestId('privacy-tier-personal').props.accessibilityState.selected,
+    ).toBe(true);
+  });
+
+  it('disables Transcribe once intimate is selected', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId, getByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+    expect((await findByTestId('capture-transcribe')).props.accessibilityState.disabled).toBe(
+      false,
+    );
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+
+    expect(getByTestId('capture-transcribe').props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('renders the intimate gate: a transcription explainer plus type-instead and keep-personal', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    const { findByTestId, getByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+
+    expect(await findByTestId('capture-intimate-explainer')).toHaveTextContent(/transcri/i);
+    expect(await findByTestId('capture-type-instead')).toBeTruthy();
+    expect(await findByTestId('capture-keep-personal')).toBeTruthy();
+  });
+
+  it('shows no gate block for the personal default or after choosing public', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    const { findByTestId, getByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    expect(queryByTestId('capture-intimate-explainer')).toBeNull();
+    expect(queryByTestId('capture-type-instead')).toBeNull();
+    expect(queryByTestId('capture-keep-personal')).toBeNull();
+
+    fireEvent.press(getByTestId('privacy-tier-public'));
+
+    expect(queryByTestId('capture-intimate-explainer')).toBeNull();
+    expect(queryByTestId('capture-type-instead')).toBeNull();
+    expect(getByTestId('capture-transcribe').props.accessibilityState.disabled).toBe(false);
+  });
+});
+
+describe('JournalPhotographScreen — intimate makes transcription structurally unreachable', () => {
+  it('never calls transcribePage when Transcribe is pressed with intimate selected', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    const { findByTestId, getByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+    // Hostile press: even if the disabled state were bypassed, the run must not start.
+    fireEvent.press(getByTestId('capture-transcribe'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockTranscribe).not.toHaveBeenCalled();
+    expect(queryByTestId('photograph-block-1-skeleton')).toBeNull();
+    expect(queryByTestId('photograph-block-1-input')).toBeNull();
+    expect(queryByTestId('photograph-save')).toBeNull();
+    expect(getByTestId('capture-pages-list')).toBeTruthy();
+  });
+});
+
+describe('JournalPhotographScreen — type-it-instead offramp for intimate', () => {
+  it('releases the session images and leaves for a typed intimate entry without transcribing', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId, getByTestId, navigation } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+    fireEvent.press(await findByTestId('capture-type-instead'));
+
+    await waitFor(() =>
+      expect(navigation.navigate).toHaveBeenCalledWith('JournalEntry', {
+        classification: 'intimate',
+      }),
+    );
+    expect(mockReleaseAllPageFiles).toHaveBeenCalled();
+    expect(mockTranscribe).not.toHaveBeenCalled();
+  });
+
+  it('sends only the scalar classification in the nav params, never any image payload', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(2))));
+    const { findByTestId, getByTestId, navigation } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+    fireEvent.press(await findByTestId('capture-type-instead'));
+    await waitFor(() => expect(navigation.navigate).toHaveBeenCalled());
+
+    const navCall = navigation.navigate.mock.calls.find((call) => call[0] === 'JournalEntry');
+    const navParams = (navCall?.[1] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(navParams)).toEqual(['classification']);
+    expect(navParams.classification).toBe('intimate');
+    expect(JSON.stringify(navParams)).not.toMatch(/base64|image|page|uri|file:|prepared/i);
+  });
+});
+
+describe('JournalPhotographScreen — keep as personal reverts the gate', () => {
+  it('reverts to personal, re-enabling Transcribe and dropping the gate block', async () => {
+    mockPick.mockResolvedValueOnce(picked(pageAssets(uriList(1))));
+    const { findByTestId, getByTestId, queryByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+
+    fireEvent.press(getByTestId('privacy-tier-intimate'));
+    fireEvent.press(await findByTestId('capture-keep-personal'));
+
+    expect(getByTestId('privacy-tier-personal').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('capture-transcribe').props.accessibilityState.disabled).toBe(false);
+    expect(queryByTestId('capture-intimate-explainer')).toBeNull();
+    expect(queryByTestId('capture-type-instead')).toBeNull();
+    expect(queryByTestId('capture-keep-personal')).toBeNull();
+  });
+});
+
+describe('JournalPhotographScreen — classification threaded into save', () => {
+  it('creates with classification personal by default after transcribe and save', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValueOnce(makeEntry({ id: 61 }));
+    mockUpdate.mockResolvedValueOnce(makeEntry({ id: 61, status: 'finished' }));
+
+    const { findByTestId } = renderScreen();
+    fireEvent.press(await findByTestId('capture-transcribe'));
+    await findByTestId('photograph-block-1-input');
+    fireEvent.press(await findByTestId('photograph-save'));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ classification: 'personal' }),
+    );
+  });
+
+  it('creates with classification public when public was chosen in collect', async () => {
+    mockPick.mockResolvedValueOnce(picked());
+    mockTranscribe.mockResolvedValueOnce({ text: 'Original.' });
+    mockCreate.mockResolvedValueOnce(makeEntry({ id: 62 }));
+    mockUpdate.mockResolvedValueOnce(makeEntry({ id: 62, status: 'finished' }));
+
+    const { findByTestId, getByTestId } = renderScreen();
+    await findByTestId('capture-pages-list');
+    fireEvent.press(getByTestId('privacy-tier-public'));
+    fireEvent.press(await findByTestId('capture-transcribe'));
+    await findByTestId('photograph-block-1-input');
+    fireEvent.press(await findByTestId('photograph-save'));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockCreate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ classification: 'public' }),
+    );
   });
 });

--- a/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
+++ b/frontend/src/features/Journal/__tests__/PrivacyTierControl.test.tsx
@@ -144,6 +144,34 @@ describe('PrivacyTierControl — intimate explainer', () => {
 });
 
 // ---------------------------------------------------------------------------
+// showExplainer prop
+// ---------------------------------------------------------------------------
+
+describe('PrivacyTierControl — showExplainer prop', () => {
+  it('defaults showExplainer to true: intimate shows the explainer when the prop is omitted', () => {
+    const { getByTestId } = render(<PrivacyTierControl value="intimate" onChange={jest.fn()} />);
+    expect(getByTestId('privacy-tier-explainer')).toBeTruthy();
+  });
+
+  it('suppresses the explainer for intimate when showExplainer is false', () => {
+    const { queryByTestId } = render(
+      <PrivacyTierControl value="intimate" onChange={jest.fn()} showExplainer={false} />,
+    );
+    expect(queryByTestId('privacy-tier-explainer')).toBeNull();
+  });
+
+  it('keeps selection and onChange behavior intact with showExplainer false', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <PrivacyTierControl value="intimate" onChange={onChange} showExplainer={false} />,
+    );
+    expect(getByTestId('privacy-tier-intimate').props.accessibilityState.selected).toBe(true);
+    fireEvent.press(getByTestId('privacy-tier-personal'));
+    expect(onChange).toHaveBeenCalledWith('personal');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Accessibility — labels + selected state
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/features/Journal/__tests__/saveFinishedEntry.test.ts
+++ b/frontend/src/features/Journal/__tests__/saveFinishedEntry.test.ts
@@ -106,6 +106,13 @@ describe('saveFinishedEntry — retry with an existing id (create already succee
     mockUpdate.mockResolvedValueOnce(entry({ id: 55, status: 'finished' }));
     await expect(saveFinishedEntry('Retried text.', 55)).resolves.toBe(55);
   });
+
+  it('never sends classification on a retry PATCH, even when one is passed', async () => {
+    mockUpdate.mockResolvedValueOnce(entry({ id: 55, status: 'finished' }));
+    await saveFinishedEntry('Retried text.', 55, undefined, undefined, 'intimate');
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith(55, { message: 'Retried text.', status: 'finished' });
+  });
 });
 
 describe('saveFinishedEntry — entry date', () => {

--- a/frontend/src/features/Journal/saveFinishedEntry.ts
+++ b/frontend/src/features/Journal/saveFinishedEntry.ts
@@ -13,7 +13,7 @@
  * finishing PATCH and any retry send only the body and status, never a date.
  */
 import { journal } from '@/api';
-import type { JournalMessageCreate } from '@/api';
+import type { JournalClassification, JournalMessageCreate } from '@/api';
 
 /** The status a fully-captured page is flipped to once its body is saved. */
 const FINISHED_STATUS = 'finished' as const;
@@ -28,7 +28,9 @@ const FINISHED_STATUS = 'finished' as const;
  * edits made after the failure. `onCreated`, when given, fires with the new id
  * the moment the create resolves (before the PATCH), so a caller can hold it for
  * a retry even if the PATCH then rejects. `entryDate`, when given, backdates the
- * created entry; it is sent only on create, never on a retry PATCH. Rejections
+ * created entry; it is sent only on create, never on a retry PATCH. `classification`
+ * is the privacy tier chosen during capture; like `entryDate` it rides only the
+ * create (the tier is set at birth), never the finishing or retry PATCH. Rejections
  * propagate to the caller.
  */
 export async function saveFinishedEntry(
@@ -36,11 +38,14 @@ export async function saveFinishedEntry(
   existingId?: number | null,
   onCreated?: (_id: number) => void,
   entryDate?: string,
+  classification?: JournalClassification,
 ): Promise<number> {
   if (existingId == null) {
-    const payload: JournalMessageCreate = entryDate
-      ? { message: body, entry_date: entryDate }
-      : { message: body };
+    const payload: JournalMessageCreate = {
+      message: body,
+      ...(classification != null && { classification }),
+      ...(entryDate != null && { entry_date: entryDate }),
+    };
     const created = await journal.create(payload);
     onCreated?.(created.id);
     await journal.update(created.id, { status: FINISHED_STATUS });

--- a/frontend/src/navigation/RootStack.tsx
+++ b/frontend/src/navigation/RootStack.tsx
@@ -16,7 +16,7 @@ import TimezoneSettingsScreen from '../features/Settings/TimezoneSettingsScreen'
 import type { RootTabParamList } from './BottomTabs';
 import BottomTabs from './BottomTabs';
 
-import type { ReflectionLevel } from '@/api';
+import type { JournalClassification, ReflectionLevel } from '@/api';
 import { accent, fonts, ink } from '@/design/tokens';
 import type { ModeConfig } from '@/features/Practice/engine/types';
 
@@ -43,6 +43,10 @@ export type RootStackParamList = {
   JournalEntry:
     | {
         entryId?: number;
+        /** Pre-set the privacy tier of a fresh entry (the capture flow's intimate
+         *  "Type it instead" offramp passes ``intimate``). Only the scalar tier is
+         *  carried — never any page image. */
+        classification?: JournalClassification;
         /** Set when arriving fresh from photograph capture: reads as "Saved" and
          *  offers resonance immediately, skipping the usual idle-after-typing wait. */
         justSaved?: boolean;


### PR DESCRIPTION
## Summary

Adds a privacy classification choice to the settled multi-page photograph-capture
flow, and honors the ratified intimate-never-cloud promise (privacy epic #893 /
#927) for transcription — a cloud-LLM call carrying the page's content.

- The collect stage now shows a classification chooser **before** the Transcribe
  action, defaulting to `personal` (testID `capture-classification`). It reuses the
  editor's `PrivacyTierControl` via a new backward-compatible `showExplainer` opt-out
  rather than a parallel control.
- Choosing **intimate** makes cloud transcription **structurally unreachable**: the
  transcribe gate — the single choke point that flips `started`, which
  `useTranscriptionRun` (the sole `transcribePage` call-site) stays inert until —
  refuses while intimate, and the Transcribe button is disabled. Belt-and-suspenders,
  so no network call, no wallet charge, and no base64 ever leaves the device for an
  intimate page.
- The intimate gate offers a calm, non-shaming offramp: **"Type it instead"** releases
  the in-memory session and its device files, then opens a fresh `JournalEntry` carrying
  only the `classification: 'intimate'` scalar (never any image), and **"Keep as
  Personal"** reverts the selection, re-enabling transcription.
- The chosen tier threads into the create call (public/personal via `saveFinishedEntry`,
  create-only like `entry_date`); a fresh entry seeds its tier from the new route param
  so the intimate offramp lands a genuinely intimate entry. `public`/`personal` behavior
  is unchanged.

Tokens-only styling; accessibility props on the gate actions; declinable tone throughout.

This is the **final sub-issue of the Journal Photographer epic #1799** (Phase 5 — privacy
& tier), completing the capture flow.

## Test plan

- `PrivacyTierControl` unit tests: `showExplainer` defaults true (explainer shows on
  intimate); `showExplainer={false}` suppresses it.
- `JournalPhotographScreen` tests: control defaults to personal; intimate disables
  Transcribe and renders the transcription explainer + both actions; **no `transcribePage`
  call while intimate** (structural, incl. a hostile press) and no entry into review;
  "Type it instead" releases the session and navigates with the scalar-only param;
  "Keep as Personal" reverts and re-enables; classification threaded into `journal.create`
  for personal and public.
- `JournalEntryScreen` tests: a fresh entry with `classification: 'intimate'` in the route
  param pre-selects intimate and creates with it; no param still defaults to personal.
- Full frontend `check-all.sh` green (ESLint, Prettier, tsc strict, Jest 4827 tests).

Closes #1797
Refs #1799