### PR TITLE
fix(habits): dismiss tier tooltip when a long-press star log commits

### DIFF
--- a/frontend/src/features/Habits/HabitTile.tsx
+++ b/frontend/src/features/Habits/HabitTile.tsx
@@ -661,6 +661,9 @@ const TileProgressSection = ({
     tz,
     progressPercent: progressPercentage,
     onLogUnit: onLogUnit ?? NOOP_LOG_UNIT,
+    // A committed long-press fill dismisses its own tooltip, so the label never
+    // lingers when the touch-end event fails to arrive (the reported symptom).
+    onSettle: () => setTooltip(null),
   });
 
   return (

--- a/frontend/src/features/Habits/__tests__/HabitTileStarLongPress.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitTileStarLongPress.test.tsx
@@ -175,6 +175,23 @@ describe('HabitTile star long-press fill', () => {
     expect(props.onLogUnit).not.toHaveBeenCalled();
   });
 
+  it('dismisses the tooltip when the long-press fill commits, without a pressOut event', () => {
+    const { getByTestId, queryByTestId, props } = renderTile(makeHabit());
+    const marker = getByTestId(MARKER_STRETCH);
+
+    // A long-press starts with a press-in that reveals the tier tooltip.
+    fireEvent(marker, 'pressIn');
+    expect(getByTestId(TOOLTIP_STRETCH)).toBeTruthy();
+
+    // The fill arms and sweeps to a committed log. The press-end event is never
+    // delivered (the browser bug this guards): the commit alone must clear it.
+    fireEvent(marker, 'longPress');
+    advance(FULL_SWEEP_MS + 100);
+
+    expect(props.onLogUnit).toHaveBeenCalledWith(HABIT_ID, 3);
+    expect(queryByTestId(TOOLTIP_STRETCH)).toBeNull();
+  });
+
   it('does not open the tile settings menu or the goal modal from a star long-press', () => {
     const { getByTestId, props } = renderTile(makeHabit());
 

--- a/frontend/src/features/Habits/hooks/useStarFill.ts
+++ b/frontend/src/features/Habits/hooks/useStarFill.ts
@@ -29,6 +29,12 @@ interface UseStarFillArgs {
   /** The bar's static (prop-derived) percent, owned by the caller. */
   progressPercent: number;
   onLogUnit: GoalModalProps['onLogUnit'];
+  /**
+   * Called once a fill commits its log, so the gesture layer can tear down UI
+   * (e.g. dismiss the tier tooltip) without waiting on a press-end event that a
+   * browser may never deliver. Optional; a no-op when omitted.
+   */
+  onSettle?: () => void;
 }
 
 /** One linear constant-speed leg of the sweep; `onEnd` gets Animated's `finished`. */
@@ -59,6 +65,7 @@ export const useStarFill = ({
   tz,
   progressPercent,
   onLogUnit,
+  onSettle,
 }: UseStarFillArgs): StarFill => {
   const anim = useRef(new Animated.Value(0)).current;
   const [displayPercent, setDisplayPercent] = useState<number | null>(null);
@@ -88,6 +95,7 @@ export const useStarFill = ({
       if (!finished || activeRef.current !== plan) return;
       activeRef.current = null;
       onLogUnit(plan.habitId, plan.deltaUnits);
+      onSettle?.();
     });
   };
 


### PR DESCRIPTION
## Summary

The tier-star tooltip on a Habits tile lingered on screen — semi-transparent — after a long-press quick-log committed its fill. Its dismissal was bound solely to press-end events (`onPressOut` / `onMouseLeave`), which the iOS-Safari web build can drop after a suppressed long-press callout, leaving the label (and the wrapper's pressed dim) stuck until the next interaction.

The fix makes tooltip dismissal independent of press-end delivery:

- `useStarFill` gains an optional `onSettle` callback, invoked right after a fill commits its `onLogUnit`. Omitted by default, so it is a safe no-op for consumers that don't need it.
- `HabitTile`'s `TileProgressSection` wires `onSettle: () => setTooltip(null)`, so a committed fill dismisses its own tooltip regardless of whether the touch-end event ever arrives.

The shared `GoalModal` consumer does not pass `onSettle`, so its behavior is unchanged. The normal quick-tap tooltip flow (show on press-in, hide on press-out) and the early-release revert sweep are untouched — `onSettle` fires only on a genuine commit, never on an interrupted/reverted fill.

## Test plan

- Added a regression test in `HabitTileStarLongPress.test.tsx` that reproduces the reported symptom: press-in reveals the tooltip, a long-press arms the fill, timers advance to a committed log, and — with **no** `pressOut` fired — the tooltip is asserted absent. It fails on the pre-fix code (commit happens, tooltip lingers) and passes after.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, tsc, and the full Jest suite (4832 tests) all pass. No lint/type suppressions.

Closes #1768