### PR TITLE
feat(journal): pencil icon on the New-entry row in the journal shelf drawer

### DIFF
--- a/frontend/src/components/drawer/DrawerNavSection.tsx
+++ b/frontend/src/components/drawer/DrawerNavSection.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import DrawerItem from './DrawerItem';
+import { NAV_ICON_SIZE, NAV_ICON_STROKE } from './navIcon';
 
 import { accent, ink, SPACING, surface } from '@/design/tokens';
 import type { RootTabParamList } from '@/navigation/BottomTabs';
@@ -22,11 +23,6 @@ import {
   selectEnablePractices,
   useDepthPreferencesStore,
 } from '@/store/useDepthPreferencesStore';
-
-/** Size (px) of the leading lucide icon on each nav row. */
-const NAV_ICON_SIZE = 24;
-/** Stroke width of the leading lucide icon on each nav row. */
-const NAV_ICON_STROKE = 2;
 
 type RootStackNavigation = NativeStackNavigationProp<RootStackParamList>;
 

--- a/frontend/src/components/drawer/index.ts
+++ b/frontend/src/components/drawer/index.ts
@@ -11,6 +11,7 @@ export { default as DrawerItem } from './DrawerItem';
 export type { DrawerItemProps } from './DrawerItem';
 export { default as DrawerNavSection } from './DrawerNavSection';
 export type { DrawerNavSectionProps } from './DrawerNavSection';
+export { NAV_ICON_SIZE, NAV_ICON_STROKE } from './navIcon';
 export { useScreenDrawer } from './useScreenDrawer';
 export type { ScreenDrawerState } from './useScreenDrawer';
 export { default as DrawerSearch } from './DrawerSearch';

--- a/frontend/src/components/drawer/navIcon.ts
+++ b/frontend/src/components/drawer/navIcon.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared sizing for the leading lucide icon on a drawer row, so nav rows and
+ * screen-specific action rows render their icons identically.
+ */
+
+/** Size (px) of the leading lucide icon on a drawer row. */
+export const NAV_ICON_SIZE = 24;
+/** Stroke width of the leading lucide icon on a drawer row. */
+export const NAV_ICON_STROKE = 2;

--- a/frontend/src/features/Journal/JournalDrawer.tsx
+++ b/frontend/src/features/Journal/JournalDrawer.tsx
@@ -8,6 +8,7 @@
  * ``useJournalDrawerEntries`` hook, which lives above the ``ScreenDrawer`` panel
  * so its cache survives close/reopen (mirrors ``useCourseDrawerContent``).
  */
+import { SquarePen } from 'lucide-react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -26,6 +27,8 @@ import {
   DrawerItem,
   DrawerNavSection,
   DrawerSearch,
+  NAV_ICON_SIZE,
+  NAV_ICON_STROKE,
   rankMatches,
   ScreenDrawer,
   type ScreenDrawerState,
@@ -460,7 +463,12 @@ function DrawerActions({
 }): React.JSX.Element {
   return (
     <>
-      <DrawerItem testID="journal-drawer-new-entry" label={NEW_ENTRY_LABEL} onPress={onNewEntry} />
+      <DrawerItem
+        testID="journal-drawer-new-entry"
+        label={NEW_ENTRY_LABEL}
+        icon={<SquarePen color={ink.muted} size={NAV_ICON_SIZE} strokeWidth={NAV_ICON_STROKE} />}
+        onPress={onNewEntry}
+      />
       {onPhotograph ? (
         <DrawerItem
           testID="journal-photograph-entry"

--- a/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalDrawer.test.tsx
@@ -7,10 +7,12 @@
 // close/reopen (mirrors useCourseDrawerContent in Course/CourseDrawer.tsx).
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { SquarePen } from 'lucide-react-native';
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 
 import type { JournalListResponse, JournalMessage } from '@/api';
+import { ink } from '@/design/tokens';
 
 const mockList = jest.fn() as jest.MockedFunction<
   (_p?: { search?: string; limit?: number; offset?: number }) => Promise<JournalListResponse>
@@ -158,6 +160,13 @@ describe('JournalDrawer (presentational)', () => {
     const { getByTestId, onNewEntry } = renderDrawer({ items: [] });
     fireEvent.press(getByTestId('journal-drawer-new-entry'));
     expect(onNewEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a leading pencil icon in the muted ink color on the New entry row', () => {
+    const { getByTestId } = renderDrawer({ items: [] });
+    const icon = getByTestId('journal-drawer-new-entry').findByType(SquarePen);
+    expect(icon).toBeTruthy();
+    expect(icon.props.color).toBe(ink.muted);
   });
 
   it('fires onRowPress with the tapped entry id', () => {


### PR DESCRIPTION
## Summary

Adds a leading lucide `SquarePen` pencil glyph to the "New entry" row in the
Journal header drawer, so it reads as an action at a glance among the drawer's
text rows. The icon uses the same treatment as the drawer nav rows — size 24,
stroke 2, `ink.muted` color (it is an action row, not the selected screen) — via
`DrawerItem`'s existing `icon` slot. The row's accessibility label stays
"New entry" (the icon is a child of the already-labeled touchable, so it adds no
competing label).

The nav-row icon size/stroke constants (`NAV_ICON_SIZE`, `NAV_ICON_STROKE`) were
lifted out of `DrawerNavSection` into a new shared `navIcon` module and
re-exported from the drawer barrel, so the nav rows and this action row draw
from one source of truth (no duplicated magic numbers).

## Test plan

- Added a render test in `JournalDrawer.test.tsx` asserting the New-entry row
  renders a `SquarePen` icon in `ink.muted` (TDD: RED before, GREEN after), using
  the repo's existing `findByType` icon-assertion idiom.
- `./scripts/frontend/check-all.sh` green: ESLint, Prettier, `tsc --noEmit`, and
  the full Jest suite (4834 tests) all pass.

Closes #1775