### PR TITLE
fix(map): fit stage-cell text to width so stage-8 (Teal) stops overflowing

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -210,6 +210,11 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
     alignItems: 'flex-end',
   },
+  // Measured wrapper around the label block: stretches to the center cell's
+  // full width (like titleFit) so a label that already fits is never shrunk.
+  labelFit: {
+    alignSelf: 'stretch',
+  },
   arrowLabelText: {
     fontWeight: '700',
     fontSize: 12,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -49,12 +49,16 @@ import { MagnifierLens } from './MagnifierLens';
 import styles from './Map.styles';
 import MapDrawer from './MapDrawer';
 import {
+  ARROW_LABEL_MAX_FONT_SIZE,
   fitRightLabel,
+  fitStageText,
   fittedTitleFontSize,
   labelCorner,
   MAP_ROWS,
   RIGHT_LABEL_LINE_HEIGHT_RATIO,
   STAGE_DISPLAY,
+  STAGE_LINE_MAX_FONT_SIZE,
+  STAGE_PERSONA_MAX_FONT_SIZE,
   TITLE_BY_STAGE,
 } from './mapLayout';
 import type { MapRow, StageDisplay } from './mapLayout';
@@ -152,6 +156,66 @@ interface StageTextBlockProps extends StageCellProps {
 // padlock sits inline on the far left, so the three text lines keep the full
 // height of the box and stay vertically centered.
 
+/**
+ * One left-column stage line, deterministically fitted to the block's measured
+ * width (``fitStageText``); the native ``adjustsFontSizeToFit`` is only a
+ * belt-and-braces net since react-native-web ignores it.
+ */
+const FittedStageLine = ({
+  text,
+  color,
+  width,
+  maxFontSize,
+  baseStyle,
+}: {
+  text: string;
+  color: string;
+  width: number;
+  maxFontSize: number;
+  baseStyle: StyleProp<TextStyle>;
+}): React.JSX.Element => (
+  <Text
+    style={[baseStyle, { color, fontSize: fitStageText(text, width, maxFontSize) }]}
+    numberOfLines={1}
+    adjustsFontSizeToFit
+  >
+    {text}
+  </Text>
+);
+
+/** The three fitted stage lines (persona / descriptor / practice), stacked. */
+const StageLines = ({
+  display,
+  width,
+}: {
+  display: StageDisplay;
+  width: number;
+}): React.JSX.Element => (
+  <>
+    <FittedStageLine
+      text={display.persona}
+      color={display.leftTextColor}
+      width={width}
+      maxFontSize={STAGE_PERSONA_MAX_FONT_SIZE}
+      baseStyle={styles.personaText}
+    />
+    <FittedStageLine
+      text={display.descriptor}
+      color={display.leftTextColor}
+      width={width}
+      maxFontSize={STAGE_LINE_MAX_FONT_SIZE}
+      baseStyle={styles.lineText}
+    />
+    <FittedStageLine
+      text={display.practice}
+      color={display.leftTextColor}
+      width={width}
+      maxFontSize={STAGE_LINE_MAX_FONT_SIZE}
+      baseStyle={styles.lineText}
+    />
+  </>
+);
+
 const StageTextBlock = ({
   stage,
   display,
@@ -159,32 +223,39 @@ const StageTextBlock = ({
   fullness,
   showTopDivider,
   onPress,
-}: StageTextBlockProps): React.JSX.Element => (
-  <TouchableOpacity
-    testID={`stage-hotspot-${display.stageNumber}-0`}
-    style={[
-      styles.stageBlock,
-      showTopDivider ? styles.horizontalDivider : null,
-      locked ? styles.locked : null,
-    ]}
-    onPress={() => onPress(stage)}
-    accessibilityRole="button"
-    accessibilityLabel={stageNodeLabel(display, fullness)}
-  >
-    {locked ? <Text style={styles.lockLeft}>🔒</Text> : null}
-    <View style={styles.stageLines}>
-      <Text style={[styles.personaText, { color: display.leftTextColor }]}>{display.persona}</Text>
-      <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.descriptor}</Text>
-      <Text style={[styles.lineText, { color: display.leftTextColor }]}>{display.practice}</Text>
-    </View>
-  </TouchableOpacity>
-);
+}: StageTextBlockProps): React.JSX.Element => {
+  const [width, setWidth] = useState(0);
+  return (
+    <TouchableOpacity
+      testID={`stage-hotspot-${display.stageNumber}-0`}
+      style={[
+        styles.stageBlock,
+        showTopDivider ? styles.horizontalDivider : null,
+        locked ? styles.locked : null,
+      ]}
+      onPress={() => onPress(stage)}
+      accessibilityRole="button"
+      accessibilityLabel={stageNodeLabel(display, fullness)}
+    >
+      {locked ? <Text style={styles.lockLeft}>🔒</Text> : null}
+      <View
+        style={styles.stageLines}
+        testID={`stage-text-fit-${display.stageNumber}`}
+        onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
+      >
+        <StageLines display={display} width={width} />
+      </View>
+    </TouchableOpacity>
+  );
+};
 
 // --- Center cell: label/title, lock, badge (the -1 tap); the wave overlay now
 // carries the directional/polarity read behind these cells ----------------
 
 // Corner-hugging Aspect-label block: the arrow word plus, when locked, its
 // unlock estimate, grouped against the corner opposite the wave's return pole.
+// A stretch wrapper measures the full center-cell width so the word's fitted
+// size (fitStageText) shrinks only when the cell is genuinely too narrow.
 const AspectLabelBlock = ({
   display,
   locked,
@@ -192,12 +263,28 @@ const AspectLabelBlock = ({
   display: StageDisplay;
   locked: boolean;
 }): React.JSX.Element => {
+  const [width, setWidth] = useState(0);
   const corner = labelCorner(display.stageNumber);
   const blockStyle = corner === 'left' ? styles.labelBlockLeft : styles.labelBlockRight;
   return (
-    <View style={blockStyle} testID={`aspect-label-${display.stageNumber}`}>
-      <Text style={styles.arrowLabelText}>{display.arrowLabel}</Text>
-      {locked ? <UnlockTimeline stageNumber={display.stageNumber} corner={corner} /> : null}
+    <View
+      style={styles.labelFit}
+      testID={`aspect-label-fit-${display.stageNumber}`}
+      onLayout={(e) => setWidth(e.nativeEvent.layout.width)}
+    >
+      <View style={blockStyle} testID={`aspect-label-${display.stageNumber}`}>
+        <Text
+          style={[
+            styles.arrowLabelText,
+            { fontSize: fitStageText(display.arrowLabel, width, ARROW_LABEL_MAX_FONT_SIZE) },
+          ]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+        >
+          {display.arrowLabel}
+        </Text>
+        {locked ? <UnlockTimeline stageNumber={display.stageNumber} corner={corner} /> : null}
+      </View>
     </View>
   );
 };

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -8,13 +8,18 @@ import { ink, surface } from '../../../design/tokens';
 import { unlockTimeline } from '../journeyNarrative';
 import styles from '../Map.styles';
 import {
+  ARROW_LABEL_MAX_FONT_SIZE,
   fitRightLabel,
+  fitStageText,
   fittedTitleFontSize,
   MAP_ROWS,
   RIGHT_LABEL_LINE_HEIGHT_RATIO,
   RIGHT_LABEL_MAX_FONT_SIZE,
   RIGHT_LABEL_MIN_FONT_SIZE,
   STAGE_DISPLAY,
+  STAGE_LINE_MAX_FONT_SIZE,
+  STAGE_PERSONA_MAX_FONT_SIZE,
+  STAGE_TEXT_MIN_FONT_SIZE,
 } from '../mapLayout';
 import MapScreen, { MapBackdrop } from '../MapScreen';
 import { STAGE_COUNT } from '../stageData';
@@ -939,6 +944,123 @@ describe('MapScreen left-column stage text color', () => {
       const flat = StyleSheet.flatten(node.props.style) as { color?: string };
       expect(flat.color).toBe(ink.muted);
     }
+  });
+});
+
+describe('MapScreen stage-text fit-to-width', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.stages = Array.from({ length: 10 }, (_, i) =>
+      mockMakeStage(10 - i, 10 - i === 1 ? { progress: 0.5 } : {}),
+    );
+    jest.spyOn(Image, 'getSize').mockImplementation((_, success) => success(100, 200));
+  });
+
+  // Stage 8 carries the longest left-column and arrow-label copy on the Map.
+  const STAGE = 8;
+  const NARROW_WIDTH = 60;
+  const WIDE_WIDTH = 400;
+
+  const stage8 = (() => {
+    const display = STAGE_DISPLAY[STAGE];
+    if (!display) throw new Error(`no STAGE_DISPLAY entry for stage ${STAGE}`);
+    return display;
+  })();
+
+  const driveLayout = (tree: ReturnType<typeof create>, testID: string, width: number): void => {
+    const wrapper = tree.root.findByProps({ testID });
+    act(() => {
+      (wrapper.props.onLayout as (e: unknown) => void)({
+        nativeEvent: { layout: { width, height: 40 } },
+      });
+    });
+  };
+
+  const leftLineNode = (tree: ReturnType<typeof create>, line: string) => {
+    const hotspot = tree.root.findByProps({ testID: `stage-hotspot-${STAGE}-0` });
+    return hotspot.findAll((n: TestNode) => n.props.children === line)[0];
+  };
+
+  const leftLineFontSize = (tree: ReturnType<typeof create>, line: string): number | undefined => {
+    const flat = StyleSheet.flatten(leftLineNode(tree, line).props.style) as { fontSize?: number };
+    return flat.fontSize;
+  };
+
+  const arrowLabelNode = (tree: ReturnType<typeof create>) => {
+    const block = tree.root.findByProps({ testID: `aspect-label-${STAGE}` });
+    return block.findAll((n: TestNode) => n.props.children === stage8.arrowLabel)[0];
+  };
+
+  it('shrinks the long stage-8 persona and practice below their standard sizes in a narrow cell', () => {
+    const tree = create(<MapScreen />);
+    driveLayout(tree, `stage-text-fit-${STAGE}`, NARROW_WIDTH);
+    const cases: ReadonlyArray<readonly [string, number]> = [
+      [stage8.persona, STAGE_PERSONA_MAX_FONT_SIZE],
+      [stage8.practice, STAGE_LINE_MAX_FONT_SIZE],
+    ];
+    for (const [line, maxFontSize] of cases) {
+      const fontSize = leftLineFontSize(tree, line);
+      expect(fontSize).toBeLessThan(maxFontSize);
+      expect(fontSize).toBeGreaterThanOrEqual(STAGE_TEXT_MIN_FONT_SIZE);
+    }
+  });
+
+  it('keeps every stage-8 left line at its standard size in a wide cell', () => {
+    const tree = create(<MapScreen />);
+    driveLayout(tree, `stage-text-fit-${STAGE}`, WIDE_WIDTH);
+    const cases: ReadonlyArray<readonly [string, number]> = [
+      [stage8.persona, STAGE_PERSONA_MAX_FONT_SIZE],
+      [stage8.descriptor, STAGE_LINE_MAX_FONT_SIZE],
+      [stage8.practice, STAGE_LINE_MAX_FONT_SIZE],
+    ];
+    for (const [line, maxFontSize] of cases) {
+      expect(leftLineFontSize(tree, line)).toBe(fitStageText(line, WIDE_WIDTH, maxFontSize));
+      expect(leftLineFontSize(tree, line)).toBe(maxFontSize);
+    }
+  });
+
+  it('renders the stage-8 left lines at exactly their standard sizes before layout reports', () => {
+    const tree = create(<MapScreen />);
+    expect(leftLineFontSize(tree, stage8.persona)).toBe(STAGE_PERSONA_MAX_FONT_SIZE);
+    expect(leftLineFontSize(tree, stage8.descriptor)).toBe(STAGE_LINE_MAX_FONT_SIZE);
+    expect(leftLineFontSize(tree, stage8.practice)).toBe(STAGE_LINE_MAX_FONT_SIZE);
+  });
+
+  it('shrinks the True Self arrow label below its ceiling in a narrow center cell', () => {
+    const tree = create(<MapScreen />);
+    driveLayout(tree, `aspect-label-fit-${STAGE}`, NARROW_WIDTH);
+    const flat = StyleSheet.flatten(arrowLabelNode(tree).props.style) as { fontSize?: number };
+    expect(flat.fontSize).toBeLessThan(ARROW_LABEL_MAX_FONT_SIZE);
+    expect(flat.fontSize).toBeGreaterThanOrEqual(STAGE_TEXT_MIN_FONT_SIZE);
+  });
+
+  it('keeps the True Self arrow label at its ceiling in a wide center cell', () => {
+    const tree = create(<MapScreen />);
+    driveLayout(tree, `aspect-label-fit-${STAGE}`, WIDE_WIDTH);
+    const flat = StyleSheet.flatten(arrowLabelNode(tree).props.style) as { fontSize?: number };
+    expect(flat.fontSize).toBe(ARROW_LABEL_MAX_FONT_SIZE);
+  });
+
+  it('guards every fitted stage-8 text to a single line with the native shrink net', () => {
+    const tree = create(<MapScreen />);
+    for (const line of [stage8.persona, stage8.descriptor, stage8.practice]) {
+      const node = leftLineNode(tree, line);
+      expect(node.props.numberOfLines).toBe(1);
+      expect(node.props.adjustsFontSizeToFit).toBe(true);
+    }
+    const label = arrowLabelNode(tree);
+    expect(label.props.numberOfLines).toBe(1);
+    expect(label.props.adjustsFontSizeToFit).toBe(true);
+  });
+
+  it('keeps the stage-8 corner hug and nested countdown intact around the fit wrapper', () => {
+    mockMapState.daysUntilStage = 42;
+    const tree = create(<MapScreen />);
+    driveLayout(tree, `aspect-label-fit-${STAGE}`, NARROW_WIDTH);
+    const block = tree.root.findByProps({ testID: `aspect-label-${STAGE}` });
+    const flat = StyleSheet.flatten(block.props.style) as { alignSelf?: string };
+    expect(flat.alignSelf).toBe('flex-end');
+    expect(block.findByProps({ testID: `stage-unlock-${STAGE}` })).toBeTruthy();
   });
 });
 

--- a/frontend/src/features/Map/__tests__/mapLayout.test.ts
+++ b/frontend/src/features/Map/__tests__/mapLayout.test.ts
@@ -2,7 +2,9 @@
 /* global describe, it, expect */
 import { ink, surface } from '../../../design/tokens';
 import {
+  ARROW_LABEL_MAX_FONT_SIZE,
   fitRightLabel,
+  fitStageText,
   fittedTitleFontSize,
   labelCorner,
   MAP_ROWS,
@@ -11,6 +13,10 @@ import {
   RIGHT_LABEL_MAX_FONT_SIZE,
   RIGHT_LABEL_MIN_FONT_SIZE,
   STAGE_DISPLAY,
+  STAGE_LINE_MAX_FONT_SIZE,
+  STAGE_PERSONA_MAX_FONT_SIZE,
+  STAGE_TEXT_GLYPH_EM_WIDTH,
+  STAGE_TEXT_MIN_FONT_SIZE,
   TITLE_MAX_FONT_SIZE,
   TITLE_MIN_FONT_SIZE,
 } from '../mapLayout';
@@ -317,6 +323,81 @@ describe('fitRightLabel', () => {
     // Exactly the label's own two hyphens survive — none inserted elsewhere.
     const hyphenCount = (result.lines.join('').match(/-/g) ?? []).length;
     expect(hyphenCount).toBe(2);
+  });
+});
+
+describe('fitStageText', () => {
+  const stage8 = requireDisplay(8);
+  const WIDE_CELL = 400;
+
+  // Same conservative advance-width idiom the title / right-label fits use,
+  // scoped to the left-column stage text and arrow label glyph budget.
+  const estimatedWidth = (text: string, fontSize: number): number =>
+    text.length * fontSize * STAGE_TEXT_GLYPH_EM_WIDTH;
+
+  it('pins the ceilings to the legacy fixed sizes and the shared floor / glyph budget', () => {
+    expect(STAGE_PERSONA_MAX_FONT_SIZE).toBe(14);
+    expect(STAGE_LINE_MAX_FONT_SIZE).toBe(12);
+    expect(ARROW_LABEL_MAX_FONT_SIZE).toBe(12);
+    expect(STAGE_TEXT_MIN_FONT_SIZE).toBe(9);
+    expect(STAGE_TEXT_GLYPH_EM_WIDTH).toBe(0.62);
+  });
+
+  it('renders at the given ceiling before layout reports a width', () => {
+    expect(fitStageText(stage8.persona, 0, STAGE_PERSONA_MAX_FONT_SIZE)).toBe(
+      STAGE_PERSONA_MAX_FONT_SIZE,
+    );
+  });
+
+  it('renders empty text at the given ceiling', () => {
+    expect(fitStageText('', WIDE_CELL, STAGE_LINE_MAX_FONT_SIZE)).toBe(STAGE_LINE_MAX_FONT_SIZE);
+  });
+
+  it('caps a short line in a wide cell at its own ceiling', () => {
+    expect(fitStageText('Nondual', WIDE_CELL, STAGE_LINE_MAX_FONT_SIZE)).toBe(
+      STAGE_LINE_MAX_FONT_SIZE,
+    );
+    expect(fitStageText(stage8.persona, WIDE_CELL, STAGE_PERSONA_MAX_FONT_SIZE)).toBe(
+      STAGE_PERSONA_MAX_FONT_SIZE,
+    );
+  });
+
+  it('shrinks the stage-8 persona below its ceiling so its estimated width fits a narrow cell', () => {
+    for (const width of [60, 90, 120, 150]) {
+      const size = fitStageText(stage8.persona, width, STAGE_PERSONA_MAX_FONT_SIZE);
+      expect(size).toBeLessThan(STAGE_PERSONA_MAX_FONT_SIZE);
+      expect(size).toBeGreaterThanOrEqual(STAGE_TEXT_MIN_FONT_SIZE);
+      if (size > STAGE_TEXT_MIN_FONT_SIZE) {
+        expect(estimatedWidth(stage8.persona, size)).toBeLessThanOrEqual(width);
+      }
+    }
+  });
+
+  it('shrinks the stage-8 practice below its ceiling so its estimated width fits a narrow cell', () => {
+    for (const width of [60, 90, 120, 150]) {
+      const size = fitStageText(stage8.practice, width, STAGE_LINE_MAX_FONT_SIZE);
+      expect(size).toBeLessThan(STAGE_LINE_MAX_FONT_SIZE);
+      expect(size).toBeGreaterThanOrEqual(STAGE_TEXT_MIN_FONT_SIZE);
+      if (size > STAGE_TEXT_MIN_FONT_SIZE) {
+        expect(estimatedWidth(stage8.practice, size)).toBeLessThanOrEqual(width);
+      }
+    }
+  });
+
+  it('never shrinks below the legibility floor', () => {
+    expect(fitStageText(stage8.persona, 10, STAGE_PERSONA_MAX_FONT_SIZE)).toBe(
+      STAGE_TEXT_MIN_FONT_SIZE,
+    );
+  });
+
+  it('clamps between the floor and each ceiling for every width, including non-positive ones', () => {
+    for (const maxFontSize of [STAGE_PERSONA_MAX_FONT_SIZE, STAGE_LINE_MAX_FONT_SIZE]) {
+      for (const width of [-10, 0, 20, 60, 90, 180, 500]) {
+        const size = fitStageText(stage8.practice, width, maxFontSize);
+        expect(size).toBeGreaterThanOrEqual(STAGE_TEXT_MIN_FONT_SIZE);
+        expect(size).toBeLessThanOrEqual(maxFontSize);
+      }
+    }
   });
 });
 

--- a/frontend/src/features/Map/mapLayout.ts
+++ b/frontend/src/features/Map/mapLayout.ts
@@ -143,6 +143,39 @@ export const fitRightLabel = (
   return { lines: [...fallbackLines], fontSize: fallbackFontSize };
 };
 
+/** Ceiling for the bold persona line — the legacy fixed size (14px). */
+export const STAGE_PERSONA_MAX_FONT_SIZE = 14;
+
+/** Ceiling for the descriptor / practice lines — the legacy fixed size (12px). */
+export const STAGE_LINE_MAX_FONT_SIZE = 12;
+
+/** Ceiling for the center arrow label — the legacy fixed size (12px). */
+export const ARROW_LABEL_MAX_FONT_SIZE = 12;
+
+/** Floor below which the stage text would stop reading as legible copy. */
+export const STAGE_TEXT_MIN_FONT_SIZE = 9;
+
+/**
+ * Conservative average advance width of a mixed-case sans glyph, in ems.
+ * Deliberately generous (err toward smaller) so the fit only ever settles on a
+ * guaranteed-fitting size for the stage copy and arrow labels.
+ */
+export const STAGE_TEXT_GLYPH_EM_WIDTH = 0.62;
+
+/**
+ * Largest size (<= ``maxFontSize``, the line's standard size) at which ``text``
+ * fits ``width`` on one line, mirroring the ``fittedTitleFontSize`` idiom. The
+ * standard size is the ceiling — text that already fits (or an unmeasured
+ * width of 0) renders at exactly that size — and the floor guards legibility.
+ * The native ``adjustsFontSizeToFit`` is a no-op on react-native-web, so this
+ * deterministic size is the real single-line guarantee everywhere.
+ */
+export const fitStageText = (text: string, width: number, maxFontSize: number): number => {
+  if (width <= 0 || text.length === 0) return maxFontSize;
+  const fitted = Math.floor(width / (text.length * STAGE_TEXT_GLYPH_EM_WIDTH));
+  return Math.max(STAGE_TEXT_MIN_FONT_SIZE, Math.min(maxFontSize, fitted));
+};
+
 /**
  * The title line each top stage carries in its own grid row (no absolute
  * overlay): stage 10 reads EMPTINESS, stage 9 reads UNITY. Stages 1–8 have none.


### PR DESCRIPTION
## Summary

Stage-8 (Teal) cell text overflowed its cell on small viewports (iOS Safari / narrow phones). The Map already had a deterministic fit-to-width idiom (`fittedTitleFontSize` for the EMPTINESS/UNITY watermark, `fitRightLabel` for the right-column labels) but the left-column stage text (persona / descriptor / practice) and the center arrow label predated it and rendered at fixed sizes with no measured fitting. On web `adjustsFontSizeToFit` is a documented no-op, so only a deterministic fitted size actually protects a cell.

This extends the same idiom rather than inventing a parallel mechanism:

- Adds `fitStageText(text, width, maxFontSize)` to `mapLayout.ts` — a straight re-parameterization of the existing private `fittedLabelLineFontSize` — plus named ceiling/floor/glyph constants (`STAGE_PERSONA_MAX_FONT_SIZE` 14, `STAGE_LINE_MAX_FONT_SIZE` 12, `ARROW_LABEL_MAX_FONT_SIZE` 12, `STAGE_TEXT_MIN_FONT_SIZE` 9, `STAGE_TEXT_GLYPH_EM_WIDTH` 0.62).
- Measures the left `stageLines` container and applies fitted `fontSize` + `numberOfLines={1}` + `adjustsFontSizeToFit` (belt-and-braces) to each of the three lines.
- Wraps the arrow label in a new `labelFit` stretch wrapper (mirroring `titleFit`) so it measures the full center-cell width; the inner corner-hug block and its nested unlock countdown are unchanged.

The standard sizes remain the ceiling: unmeasured (pre-layout, width 0) and already-fitting text renders pixel-identical to before — no global shrink. The fix is string-agnostic (measured fitting), so it survives any future copy changes and generalizes to every stage cell. The WCAG-audited `leftTextColor` treatment is untouched.

## Test plan

- New unit tests in `mapLayout.test.ts` (`describe('fitStageText')`): ceiling before layout / empty text, cap in a wide cell, shrink-to-fit for the stage-8 persona and practice strings across narrow widths with an independent estimated-width bound, floor clamp, clamp across all widths incl. non-positive.
- New render tests in `MapScreen.test.tsx`: narrow layout shrinks the stage-8 persona/practice/arrow-label below their standard sizes (>= floor); wide layout keeps them at the ceiling; pre-layout regression guard renders the left lines at exactly their standard sizes; single-line native-net guard; corner-hug + nested countdown preserved around the new wrapper.
- Full `scripts/frontend/check-all.sh` green locally: 4849 tests pass, ESLint/prettier/typecheck clean.

Closes #1778