### PR TITLE
feat(graph): surface benchmark trend and semantic staleness in the recap

### DIFF
--- a/.github/workflows/graph-build.yml
+++ b/.github/workflows/graph-build.yml
@@ -29,9 +29,11 @@ on:
     - cron: "40 4 * * *"
   workflow_dispatch:
 
-# Only the rolling-release upsert needs write; everything else is read.
+# contents: write for the rolling-release upsert and the benchmark-trend
+# commit; issues: write so the nightly tail can open a staleness issue.
 permissions:
   contents: write
+  issues: write
 
 # Serialize runs so overlapping pushes never race the release asset upload.
 # Never cancel in-progress: a cancelled publish would leave the release stale.
@@ -189,3 +191,136 @@ jobs:
             fi
           fi
           echo "published ${#assets[@]} asset(s) to release $GRAPH_TAG"
+
+      # ---- nightly observability tail (schedule / dispatch only) ------------
+      # One benchmark line per day, a staleness probe of the semantic layer,
+      # and a token-cost summary. Gated off push so incremental main pushes
+      # stay fast and the trend ledger gets exactly one record per day.
+
+      - name: Benchmark and append trend
+        if: github.event_name != 'push'
+        run: |
+          set -uo pipefail
+          # Best-effort: the graph is already published, so a clustering/
+          # benchmark/parse failure (e.g. a future output-format drift) must
+          # warn and move on rather than redden a run whose core job succeeded.
+          # The benchmark needs a clustered node_link graph, so cluster the
+          # LOCAL copy AFTER publish — the workspace is discarded at job end,
+          # and the published raw asset is untouched.
+          if ! graphify cluster-only . --no-viz --no-label; then
+            echo "::warning::cluster-only failed — skipping benchmark trend"
+            exit 0
+          fi
+          if ! graphify benchmark "$OUT_DIR/graph.json" | tee benchmark.txt; then
+            echo "::warning::benchmark failed — skipping benchmark trend"
+            exit 0
+          fi
+          if ! python3 scripts/graph/append_benchmark_trend.py \
+            --benchmark benchmark.txt \
+            --out graph/metrics/benchmark-trend.jsonl; then
+            echo "::warning::could not parse benchmark output — skipping benchmark trend"
+            exit 0
+          fi
+          {
+            echo "### Graph benchmark"
+            echo
+            echo '```'
+            cat benchmark.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit benchmark trend
+        if: github.event_name != 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Stage first: the very first nightly creates the ledger as an
+          # untracked file, which a plain `git diff --quiet` would not see.
+          git add graph/metrics/benchmark-trend.jsonl
+          if git diff --cached --quiet -- graph/metrics/benchmark-trend.jsonl; then
+            echo "benchmark trend unchanged — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(graph): record benchmark trend"
+          # The token rides a per-command remote URL; checkout keeps
+          # persist-credentials: false, so no credential outlives this step.
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if ! (git pull --rebase "$remote" main && git push "$remote" HEAD:main); then
+            echo "::warning::could not push benchmark trend"
+            exit 0
+          fi
+
+      - name: Check semantic layer staleness
+        if: github.event_name != 'push'
+        id: staleness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Cron-safe surface of graphify's own needs_update flag (log only).
+          graphify check-update . || true
+          if gh release download "$GRAPH_TAG" --pattern semantic-meta.json --dir "$OUT_DIR" --clobber; then
+            python3 scripts/graph/semantic_staleness.py --meta "$OUT_DIR/semantic-meta.json"
+          else
+            echo "no semantic-meta.json yet"
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize graph token cost
+        if: github.event_name != 'push'
+        run: |
+          set -euo pipefail
+          python3 - "$OUT_DIR/semantic-meta.json" <<'PY'
+          import json
+          import os
+          import sys
+
+          # Honest label: these are the LAST semantic pass's token totals, not
+          # this run's spend (the nightly code build makes no LLM calls).
+          lines = ["### Graph LLM cost", ""]
+          try:
+              with open(sys.argv[1], encoding="utf-8") as handle:
+                  meta = json.load(handle)
+              tokens_input = int(meta["tokens_input"])
+              tokens_output = int(meta["tokens_output"])
+          except (OSError, ValueError, KeyError):
+              lines.append("no semantic pass yet — no token totals to report.")
+          else:
+              lines.append(
+                  f"last semantic pass: {tokens_input:,} input / {tokens_output:,} output tokens."
+              )
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as handle:
+                  handle.write("\n".join(lines) + "\n")
+          print("\n".join(lines))
+          PY
+
+      - name: Open semantic staleness issue
+        if: github.event_name != 'push' && steps.staleness.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AGE_DAYS: ${{ steps.staleness.outputs.age_days }}
+        run: |
+          set -euo pipefail
+          # Idempotent label bootstrap; create fails harmlessly if it exists.
+          gh label create graph-staleness \
+            --color BFDADC \
+            --description "Knowledge graph semantic layer is overdue for a rebuild" \
+            2>/dev/null || true
+          # Dedup by open-issue search so nightly re-runs never double-file.
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --label graph-staleness --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing" ]]; then
+            echo "staleness issue #$existing already open — skipping"
+            exit 0
+          fi
+          # AGE_DAYS arrives via env, never inlined ${{ }} into the run block.
+          body="$(printf 'The knowledge graph semantic layer is %s days old — past the 14-day staleness threshold.\n\nRun the "Graph semantic" workflow (workflow_dispatch on .github/workflows/graph-semantic.yml) to rebuild the semantic layer, then close this issue.\n' "$AGE_DAYS")"
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "Knowledge graph semantic layer is stale" \
+            --label graph-staleness \
+            --body "$body"

--- a/.github/workflows/graph-semantic.yml
+++ b/.github/workflows/graph-semantic.yml
@@ -203,6 +203,10 @@ jobs:
               handle.write("\n")
           print(f"graph-meta: {meta['nodes']:,} nodes / {meta['edges']:,} edges @ {meta['sha']}")
           PY
+          # Dedicated semantic-provenance asset: the nightly code-only build
+          # rewrites graph-meta.json, so this copy alone dates the last real
+          # semantic pass for the staleness probe and the recap.
+          cp "$OUT_DIR/graph-meta.json" "$OUT_DIR/semantic-meta.json"
 
       - name: Cluster graph (structure only)
         # Recompute communities from graph structure only. `--no-viz` skips the
@@ -275,6 +279,7 @@ jobs:
           assets=(
             "$OUT_DIR/graph.json"
             "$OUT_DIR/graph-meta.json"
+            "$OUT_DIR/semantic-meta.json"
             "$OUT_DIR/semantic-cache.tar.gz"
             "$OUT_DIR/GRAPH_REPORT.md"
             "$OUT_DIR/wiki.tar.gz"

--- a/.github/workflows/graph-tests.yml
+++ b/.github/workflows/graph-tests.yml
@@ -1,0 +1,37 @@
+name: Graph Tests
+
+# Offline tests for the graph tooling under scripts/graph/. These scripts live
+# outside backend/, so the backend-scoped lint/coverage gates don't cover them —
+# this workflow keeps the benchmark-trend ledger and the semantic staleness
+# probe honest.
+
+on:
+  push:
+    paths:
+      - "scripts/graph/**"
+      - ".github/workflows/graph-tests.yml"
+  pull_request:
+    paths:
+      - "scripts/graph/**"
+      - ".github/workflows/graph-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  graph-tests:
+    name: Graph tool shell tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Run graph tool tests
+        run: |
+          bash scripts/graph/test_append_benchmark_trend.sh
+          bash scripts/graph/test_semantic_staleness.sh

--- a/scripts/graph/README.md
+++ b/scripts/graph/README.md
@@ -94,10 +94,21 @@ agent-crawlable wiki from the result:
    bridges. Packed as `wiki.tar.gz`.
 
 Assets republished: `graph.json`, `graph-meta.json` (now `kind:
-code+semantic`, with `tokens_input`/`tokens_output`), `semantic-cache.tar.gz`,
+code+semantic`, with `tokens_input`/`tokens_output`), `semantic-meta.json` (a
+copy of `graph-meta.json` taken the instant it is written), `semantic-cache.tar.gz`,
 `GRAPH_REPORT.md` (now always regenerated with the final community names by the
 label step and verified placeholder-free by the guard, no longer conditional on
 presence), and `wiki.tar.gz` (new — the community wiki).
+
+`graph-meta.json` is one of the three last-writer-wins assets (see "Three
+writers, one release" below) — `graph-build`'s nightly forced rebuild
+republishes it too and resets `kind` back to `code-only`, so on most nights it
+no longer dates the last real semantic pass. `semantic-meta.json` exists to
+dodge that: only this workflow ever writes it, `graph-build` never touches it,
+so its `built_at` reliably dates the last real semantic extraction. It exists
+purely to give the nightly staleness probe and the Discord recap knowledge-graph
+line (both described below) a provenance timestamp that survives the code-only
+rebuild's clobber.
 
 ```bash
 gh release download knowledge-graph --pattern wiki.tar.gz --dir graphify-out
@@ -111,6 +122,61 @@ having two writers on one release, not something this workflow resolves. That
 nightly rebuild does not re-cluster, re-label, or touch the wiki — clustering,
 labelling, and `wiki.tar.gz` are weekly-only, produced solely by this
 workflow.
+
+## Benchmark trend, staleness watch, and token cost (nightly)
+
+`graph-build.yml`'s nightly / `workflow_dispatch` runs (never plain pushes to
+`main`) end with an observability tail, appended right after the
+`graph.json` / `graph-meta.json` publish step:
+
+1. **Benchmark** — the just-published `graph.json` is clustered in a
+   throwaway *local* copy (`graphify cluster-only . --no-viz --no-label`,
+   needed because `graphify benchmark` requires a clustered node_link graph);
+   that workspace is discarded at job end, so the published raw asset is
+   never touched. `graphify benchmark graphify-out/graph.json` then prints
+   its report as plain text — node/edge counts and the average
+   tokens-per-query reduction factor — there is no JSON output mode.
+2. **Trend** — `scripts/graph/append_benchmark_trend.py` parses that text
+   (the `Graph: N nodes, N edges` and `Reduction: N.Nx` lines) and appends
+   one `{date, reduction_avg, nodes, edges}` JSON line to
+   `graph/metrics/benchmark-trend.jsonl`. Unlike `graphify-out/`, this
+   ledger is **committed** — a few dozen bytes a day, append-only (earlier
+   lines are never rewritten), and idempotent per calendar day (re-running
+   on the same UTC date is a no-op, judged by the last line's `date`). The
+   workflow commits it and pushes straight to `main` over a token-scoped
+   remote URL; the push is best-effort — failure only logs a `::warning`
+   and the nightly run stays green, since a missed trend day isn't worth
+   failing the graph publish over.
+3. **Staleness** — `scripts/graph/semantic_staleness.py` downloads
+   `semantic-meta.json` (see above) and reports whether the semantic
+   layer's `built_at` is older than `STALE_AFTER_DAYS` (14) — exactly 14
+   days old is not yet stale, only strictly older is. The script is
+   cron-safe (always exits 0) and reports through `$GITHUB_OUTPUT`, not its
+   exit code. `graphify check-update .` also runs alongside it — its own,
+   separately cron-safe, always-exit-0 check — purely to log graphify's own
+   opinion; it doesn't feed the staleness gate. When the layer is stale,
+   the workflow idempotently bootstraps a `graph-staleness` label, searches
+   for an already-open issue carrying it, and — only if none exists — opens
+   one (title "Knowledge graph semantic layer is stale", body naming the
+   age and pointing at `workflow_dispatch` on `graph-semantic.yml`), so
+   repeated nightly runs never file duplicates.
+4. **Token cost** — the same tail prints the *last* semantic pass's
+   `tokens_input`/`tokens_output` (read from `semantic-meta.json` — not this
+   run's own spend, since the nightly code build makes no LLM calls) to the
+   job summary, alongside the raw benchmark text.
+
+None of this runs on a plain `push` to `main`: gating it to
+`schedule`/`workflow_dispatch` keeps ordinary code pushes fast and guarantees
+the trend ledger gets at most one record per UTC day.
+
+`scripts/graph/test_append_benchmark_trend.sh` and
+`scripts/graph/test_semantic_staleness.sh` are offline shell tests for the
+two scripts above, run by `.github/workflows/graph-tests.yml` on any change
+under `scripts/graph/**` (this tooling lives outside `backend/`, so the
+backend-scoped lint/coverage gates don't otherwise cover it).
+
+The ledger also feeds the Discord Ralph recap's knowledge-graph line — see
+[`scripts/ralph/RECAP.md`](../ralph/RECAP.md).
 
 ## Federation (nightly)
 
@@ -163,10 +229,12 @@ upgrades them to `code+semantic`) **and** `GRAPH_REPORT.md` (build emits a
 code-only report on its nightly full build; semantic's label step rewrites it
 as a clustered, LLM-labelled one, guarded placeholder-free before publish) —
 those three assets are last-writer-wins between the two, the same
-eventual-consistency property noted above. `wiki.tar.gz`
-is exclusive to `graph-semantic`, and `pan-graph.json` / `pan-meta.json`
-are exclusive to `graph-federate`, so neither of those can be clobbered by
-another writer.
+eventual-consistency property noted above. `wiki.tar.gz` and
+`semantic-meta.json` are exclusive to `graph-semantic`, and `pan-graph.json` /
+`pan-meta.json` are exclusive to `graph-federate`, so none of those three can
+be clobbered by another writer — `semantic-meta.json` is precisely what lets
+the nightly staleness probe and the recap see past the `graph-meta.json`
+clobbering described above.
 
 **Known interaction**: like the semantic layer, the pan-graph reflects
 whatever each satellite last published — if a satellite hasn't rebuilt its

--- a/scripts/graph/append_benchmark_trend.py
+++ b/scripts/graph/append_benchmark_trend.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Append one per-day `graphify benchmark` record to a JSONL trend ledger.
+
+Parses the text stdout of `graphify benchmark` (the `Graph:` node/edge counts
+and the `Reduction:` tokens-per-query factor) and appends a single dated JSON
+line to the ledger. The ledger is append-only and idempotent per day: re-running
+on the same date neither duplicates nor rewrites an earlier line, so the file
+is a stable time series the recap can chart deltas from.
+
+Usage:
+
+    graphify benchmark graphify-out/graph.json | \
+        python3 scripts/graph/append_benchmark_trend.py \
+            --out graph/metrics/benchmark-trend.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import sys
+
+# Pinned to `graphify benchmark` stdout: variable space runs, thousands commas.
+_GRAPH_RE = re.compile(r"Graph:\s+([0-9,]+)\s+nodes,\s+([0-9,]+)\s+edges")
+_REDUCTION_RE = re.compile(r"Reduction:\s+([0-9]+(?:\.[0-9]+)?)x")
+
+
+def parse_benchmark(text: str) -> tuple[float, int, int]:
+    """Extract (reduction_avg, nodes, edges) from `graphify benchmark` stdout.
+
+    Raises ValueError when either the Graph: or Reduction: line is absent or
+    unparseable, so callers can fail loudly on malformed input.
+    """
+    graph = _GRAPH_RE.search(text)
+    reduction = _REDUCTION_RE.search(text)
+    if graph is None or reduction is None:
+        raise ValueError("benchmark text is missing the Graph: or Reduction: line")
+    nodes = int(graph.group(1).replace(",", ""))
+    edges = int(graph.group(2).replace(",", ""))
+    return float(reduction.group(1)), nodes, edges
+
+
+def _last_record_date(path: pathlib.Path) -> str | None:
+    """Date of the ledger's last non-blank JSON line, or None when unreadable."""
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not lines:
+        return None
+    try:
+        record = json.loads(lines[-1])
+    except ValueError:
+        return None
+    if not isinstance(record, dict):
+        return None
+    date = record.get("date")
+    return date if isinstance(date, str) else None
+
+
+def append_trend(path: pathlib.Path, *, reduction_avg: float, nodes: int, edges: int, date: str) -> bool:
+    """Append one dated record; return False when that date is already recorded.
+
+    Append-only: earlier lines are never rewritten. Idempotence is judged by the
+    LAST non-blank line only, so a same-day re-run is a no-op.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and _last_record_date(path) == date:
+        return False
+    record = {"date": date, "reduction_avg": reduction_avg, "nodes": nodes, "edges": edges}
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
+    return True
+
+
+def _read_benchmark_text(benchmark: str | None) -> str:
+    """Read the benchmark stdout from a file, or stdin when no path is given."""
+    if benchmark:
+        return pathlib.Path(benchmark).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse benchmark stdout and append today's record to the trend ledger."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--benchmark", help="file holding `graphify benchmark` stdout (default: stdin)")
+    parser.add_argument("--out", required=True, help="JSONL trend ledger to append to")
+    parser.add_argument(
+        "--date",
+        default=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+        help="record date, YYYY-MM-DD (default: today UTC)",
+    )
+    args = parser.parse_args(argv)
+
+    text = _read_benchmark_text(args.benchmark)
+    try:
+        reduction_avg, nodes, edges = parse_benchmark(text)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    wrote = append_trend(
+        pathlib.Path(args.out), reduction_avg=reduction_avg, nodes=nodes, edges=edges, date=args.date
+    )
+    verb = "appended" if wrote else "already recorded"
+    print(f"{verb} {args.date}: reduction {reduction_avg}x, {nodes} nodes, {edges} edges -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/graph/semantic_staleness.py
+++ b/scripts/graph/semantic_staleness.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Report whether the published semantic graph layer is overdue for a rebuild.
+
+Reads a published meta JSON (the `semantic-meta.json` release asset) and judges
+its `built_at` age against STALE_AFTER_DAYS. Only a `code+semantic` meta with a
+timestamp can be stale; a code-only graph or a missing/empty meta is simply not
+a semantic layer and is reported as fresh.
+
+Cron-safe contract: every invocation exits 0. Staleness is reported via stdout
+and, under GitHub Actions, via `stale=` / `age_days=` lines appended to the
+file named by $GITHUB_OUTPUT — never via the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import pathlib
+
+# The weekly semantic pass should land at least this often; older is stale.
+STALE_AFTER_DAYS = 14
+
+
+def age_days(built_at: str, *, now: datetime.datetime) -> int:
+    """Whole days elapsed between an ISO-8601 `built_at` stamp and `now`."""
+    parsed = datetime.datetime.fromisoformat(built_at.replace("Z", "+00:00"))
+    return (now - parsed).days
+
+
+def evaluate(meta: dict, *, now: datetime.datetime, threshold: int = STALE_AFTER_DAYS) -> dict:
+    """Judge a graph meta dict; only an aged code+semantic layer is stale.
+
+    Exactly `threshold` days old is NOT stale — staleness is strictly greater.
+    """
+    kind = meta.get("kind")
+    built_at = meta.get("built_at")
+    if kind != "code+semantic" or not built_at:
+        reason = "not a semantic layer" if kind != "code+semantic" else "no built_at timestamp"
+        return {"kind": kind, "built_at": built_at, "age_days": None, "is_stale": False, "reason": reason}
+    age = age_days(str(built_at), now=now)
+    return {
+        "kind": kind,
+        "built_at": built_at,
+        "age_days": age,
+        "is_stale": age > threshold,
+        "reason": f"semantic layer is {age} days old (threshold {threshold})",
+    }
+
+
+def _load_meta(path: pathlib.Path) -> dict:
+    """Read the meta JSON; a missing or unreadable file degrades to {}."""
+    if not path.exists():
+        return {}
+    try:
+        meta = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return meta if isinstance(meta, dict) else {}
+
+
+def _write_github_output(result: dict) -> None:
+    """Append stale/age lines to $GITHUB_OUTPUT when running under Actions."""
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    age = result["age_days"]
+    with open(out_path, "a", encoding="utf-8") as handle:
+        handle.write(f"stale={'true' if result['is_stale'] else 'false'}\n")
+        handle.write(f"age_days={age if age is not None else ''}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Evaluate the meta file and report; always exits 0 (cron-safe)."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--meta", required=True, help="path to the published semantic meta JSON")
+    args = parser.parse_args(argv)
+
+    meta = _load_meta(pathlib.Path(args.meta))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    result = evaluate(meta, now=now)
+
+    state = "STALE" if result["is_stale"] else "FRESH"
+    age = result["age_days"] if result["age_days"] is not None else "n/a"
+    print(f"semantic layer age: {age} days (kind={result['kind']}) -> {state} ({result['reason']})")
+    _write_github_output(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/graph/test_append_benchmark_trend.sh
+++ b/scripts/graph/test_append_benchmark_trend.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/graph/test_append_benchmark_trend.sh
+#
+# Offline tests for scripts/graph/append_benchmark_trend.py: parses the text
+# stdout of `graphify benchmark` and appends one per-day record to a JSONL
+# trend ledger. The ledger is append-only and idempotent per day - re-running
+# on the same date must neither duplicate nor rewrite an earlier line.
+#
+# Run:  bash scripts/graph/test_append_benchmark_trend.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO/scripts/graph/append_benchmark_trend.py"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The Graph: and Reduction: lines are real `graphify benchmark` stdout verbatim
+# (variable space runs, thousands commas); the rest is surrounding noise.
+cat >"$WORK/bench.txt" <<'EOF'
+Benchmark: graph-assisted retrieval vs full-file reads
+
+  Graph:           16,144 nodes, 36,585 edges
+  Queries:         25 sampled
+  Reduction:       20.9x fewer tokens per query
+
+Done.
+EOF
+
+TREND="$WORK/trend.jsonl"
+LINE_DAY1='{"date": "2026-07-10", "reduction_avg": 20.9, "nodes": 16144, "edges": 36585}'
+LINE_DAY2='{"date": "2026-07-11", "reduction_avg": 20.9, "nodes": 16144, "edges": 36585}'
+
+run_append() { # run_append <date> -> sets RC
+  RC=0
+  python3 "$SCRIPT" --benchmark "$WORK/bench.txt" --out "$TREND" --date "$1" \
+    >"$WORK/append.log" 2>&1 || RC=$?
+}
+
+# --- scenario 1: benchmark stdout -> exact JSONL line ------------------------
+run_append 2026-07-10
+check "scenario 1: append exits 0" "0" "$RC"
+check "scenario 1: exact JSONL line" "$LINE_DAY1" "$(sed -n 1p "$TREND" 2>/dev/null)"
+check "scenario 1: exactly one line" "1" "$(wc -l <"$TREND" 2>/dev/null | tr -d ' ')"
+check "scenario 1: trailing newline" "" "$(tail -c 1 "$TREND" 2>/dev/null)"
+if [[ -s "$WORK/append.log" ]]; then ok "scenario 1: prints a human line"; else bad "scenario 1: prints a human line (log empty)"; fi
+
+# --- scenario 2: same date twice is idempotent -------------------------------
+run_append 2026-07-10
+check "scenario 2: rerun exits 0" "0" "$RC"
+check "scenario 2: still exactly one line" "1" "$(wc -l <"$TREND" 2>/dev/null | tr -d ' ')"
+check "scenario 2: line unchanged" "$LINE_DAY1" "$(sed -n 1p "$TREND" 2>/dev/null)"
+
+# --- scenario 3: new date appends, earlier line preserved --------------------
+run_append 2026-07-11
+check "scenario 3: append exits 0" "0" "$RC"
+check "scenario 3: two lines" "2" "$(wc -l <"$TREND" 2>/dev/null | tr -d ' ')"
+check "scenario 3: first line byte-for-byte preserved" "$LINE_DAY1" "$(sed -n 1p "$TREND" 2>/dev/null)"
+check "scenario 3: second line carries the new date" "$LINE_DAY2" "$(sed -n 2p "$TREND" 2>/dev/null)"
+
+# --- scenario 4: malformed benchmark text exits non-zero ---------------------
+printf 'no benchmark lines here\n' >"$WORK/garbage.txt"
+RC=0
+python3 "$SCRIPT" --benchmark "$WORK/garbage.txt" --out "$WORK/garbage.jsonl" --date 2026-07-10 \
+  >"$WORK/garbage.log" 2>&1 || RC=$?
+if [[ "$RC" -ne 0 ]]; then ok "scenario 4: malformed benchmark exits non-zero"; else bad "scenario 4: malformed benchmark exits non-zero (got 0)"; fi
+
+# --- scenario 5: empty stdin (default input) exits non-zero ------------------
+RC=0
+printf '' | python3 "$SCRIPT" --out "$WORK/empty.jsonl" --date 2026-07-10 \
+  >"$WORK/empty.log" 2>&1 || RC=$?
+if [[ "$RC" -ne 0 ]]; then ok "scenario 5: empty stdin exits non-zero"; else bad "scenario 5: empty stdin exits non-zero (got 0)"; fi
+
+# --- summary -----------------------------------------------------------------
+echo
+echo "benchmark trend tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/graph/test_semantic_staleness.sh
+++ b/scripts/graph/test_semantic_staleness.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/graph/test_semantic_staleness.sh
+#
+# Offline tests for scripts/graph/semantic_staleness.py: reads a published
+# graph-meta.json and reports whether the semantic layer is stale (built more
+# than STALE_AFTER_DAYS = 14 days ago). Cron-safe contract: every invocation
+# exits 0 - staleness is reported via stdout and $GITHUB_OUTPUT, never via
+# the exit code.
+#
+# Run:  bash scripts/graph/test_semantic_staleness.sh
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO/scripts/graph/semantic_staleness.py"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+has_line() { # has_line <desc> <file> <exact line>
+  if grep -qxF -- "$3" "$2" 2>/dev/null; then ok "$1"; else bad "$1 (no line '$3' in $2)"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# built_at fixtures are real timestamps offset from UTC now (no mocked clock),
+# placed well clear of - or exactly on - the 14-day threshold.
+built_at_days_ago() { # built_at_days_ago <days>
+  python3 -c 'import datetime as dt, sys; print((dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=int(sys.argv[1]))).strftime("%Y-%m-%dT%H:%M:%SZ"))' "$1"
+}
+
+write_meta() { # write_meta <path> <kind> <built_at or "">
+  python3 - "$1" "$2" "$3" <<'PY'
+import json
+import sys
+
+path, kind, built_at = sys.argv[1], sys.argv[2], sys.argv[3]
+meta = {"kind": kind}
+if built_at:
+    meta["built_at"] = built_at
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(meta, fh)
+PY
+}
+
+run_staleness() { # run_staleness <meta path> -> sets RC, fills $OUT
+  OUT="$WORK/gh_output.txt"
+  : >"$OUT"
+  RC=0
+  GITHUB_OUTPUT="$OUT" python3 "$SCRIPT" --meta "$1" >"$WORK/staleness.log" 2>&1 || RC=$?
+}
+
+# --- scenario 1: fresh code+semantic meta -> stale=false ---------------------
+write_meta "$WORK/meta_fresh.json" "code+semantic" "$(built_at_days_ago 2)"
+run_staleness "$WORK/meta_fresh.json"
+check "scenario 1: fresh meta exits 0" "0" "$RC"
+has_line "scenario 1: stale=false" "$OUT" "stale=false"
+has_line "scenario 1: age_days=2" "$OUT" "age_days=2"
+if [[ -s "$WORK/staleness.log" ]]; then ok "scenario 1: prints a summary line"; else bad "scenario 1: prints a summary line (log empty)"; fi
+
+# --- scenario 2: aged (>14d) code+semantic meta -> stale=true ----------------
+write_meta "$WORK/meta_aged.json" "code+semantic" "$(built_at_days_ago 20)"
+run_staleness "$WORK/meta_aged.json"
+check "scenario 2: aged meta exits 0" "0" "$RC"
+has_line "scenario 2: stale=true" "$OUT" "stale=true"
+has_line "scenario 2: age_days=20" "$OUT" "age_days=20"
+
+# --- scenario 3: code-only meta is never stale, even when old ----------------
+write_meta "$WORK/meta_code_only.json" "code-only" "$(built_at_days_ago 20)"
+run_staleness "$WORK/meta_code_only.json"
+check "scenario 3: code-only meta exits 0" "0" "$RC"
+has_line "scenario 3: stale=false" "$OUT" "stale=false"
+has_line "scenario 3: empty age_days" "$OUT" "age_days="
+
+# --- scenario 4: missing meta file is graceful -------------------------------
+run_staleness "$WORK/does_not_exist.json"
+check "scenario 4: missing meta exits 0" "0" "$RC"
+has_line "scenario 4: stale=false" "$OUT" "stale=false"
+
+# --- scenario 5: exactly 14 days old is NOT stale ----------------------------
+write_meta "$WORK/meta_boundary.json" "code+semantic" "$(built_at_days_ago 14)"
+run_staleness "$WORK/meta_boundary.json"
+check "scenario 5: boundary meta exits 0" "0" "$RC"
+has_line "scenario 5: stale=false at the threshold" "$OUT" "stale=false"
+has_line "scenario 5: age_days=14" "$OUT" "age_days=14"
+
+# --- summary -----------------------------------------------------------------
+echo
+echo "semantic staleness tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -4,8 +4,10 @@ Whenever a PR merges, this posts a clean Discord embed in two blocks —
 `————THIS PR————` (the just-merged PR: its unlock headline, link, footprint,
 review iterations, review time, and tick length) and `————THE LOOP————` (the
 rolling/all-time figures: busiest day, PRs merged, lines of code, merge rate,
-review iterations, review time, tick length, and backlog remaining). Within each
-block, multi-window stats run smallest window first (24h → 7d → all-time).
+review iterations, review time, tick length, and backlog remaining), plus an
+optional trailing knowledge-graph health line appended to `THE LOOP` block
+whenever graph data is available. Within each block, multi-window stats run
+smallest window first (24h → 7d → all-time).
 
 A "Ralph tick loop" is the autonomous loop driven by `/loop /ralph-tick` (see
 `.claude/commands/ralph-tick.md`): each tick opens a PR, iterates against the
@@ -117,6 +119,19 @@ fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
   When the rate is zero the ETA reads "unknown (stalled)"; an empty backlog
   reads "backlog clear".
 - **Busiest day** (7d) — the UTC calendar day in the window with the most merges.
+- **Knowledge graph** (optional) — a health line for the `scripts/graph/`
+  code knowledge graph, appended after the loop fields only when graph data
+  exists. Node/edge counts and the average query-reduction factor (with a
+  `↑`/`↓` delta versus the most recent ledger record dated at least 7 days
+  earlier) come from the committed `graph/metrics/benchmark-trend.jsonl`
+  ledger that `graph-build.yml`'s nightly tail appends to (see
+  [`scripts/graph/README.md`](../graph/README.md)). A trailing
+  "semantic layer *N* days fresh" clause is fetched from the
+  `semantic-meta.json` release asset and omitted whenever that asset is
+  missing or still `code-only` — it is never dated from `graph-meta.json`,
+  which the nightly code-only rebuild can clobber back to `code-only`.
+  The whole field is best-effort: any failure (no ledger yet, no release,
+  a bad fetch) silently omits it rather than breaking the recap.
 
 The embed groups fields into two labelled blocks so a single merge's numbers are
 never confused with the dataset-wide ones. The `————THIS PR————` block holds:

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -35,6 +35,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import pathlib
 import sys
 import time
 import urllib.error
@@ -81,6 +82,13 @@ RECENT_WINDOW_DAYS = 7
 # (its verdicts), so bound a burst day rather than fan out unbounded.
 DEFAULT_MAX_PRS = 200
 HEADLINE_MODEL = "claude-opus-4-8"
+# Committed JSONL ledger the nightly graph-build workflow appends benchmarks to.
+BENCHMARK_TREND_PATH = "graph/metrics/benchmark-trend.jsonl"
+# Rolling release that carries the knowledge graph and its provenance assets.
+GRAPH_RELEASE_TAG = "knowledge-graph"
+# Provenance asset written only by the weekly semantic pass (never the nightly
+# code build), so its built_at dates the last real semantic extraction.
+SEMANTIC_META_ASSET = "semantic-meta.json"
 
 # Issues carrying any of these labels are not part of Ralph's real backlog, so
 # they are excluded from the open-issue count behind the ETA. Kept in sync with
@@ -270,6 +278,44 @@ def fetch_repo_net_lines(
         if attempt < attempts - 1:  # cold 202 — give the async cache time to warm
             sleep(2.0 * (2**attempt))
     return None
+
+
+def load_benchmark_trend(path: str | pathlib.Path) -> list[dict[str, object]]:
+    """Read the committed benchmark JSONL ledger; a missing file yields [].
+
+    Never raises: an unreadable ledger just means no graph line in the recap.
+    """
+    trend_path = pathlib.Path(path)
+    if not trend_path.exists():
+        return []
+    try:
+        text = trend_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return stats.parse_benchmark_trend(text.splitlines())
+
+
+def fetch_semantic_meta(repo: str, *, token: str) -> dict[str, Any] | None:
+    """Fetch the semantic layer's provenance asset from the rolling graph release.
+
+    Resolves the release by tag, finds the asset by name, and downloads it with
+    the octet-stream Accept header (the asset URL serves bytes, not the asset's
+    API record). Any transport or shape failure degrades to None so the recap
+    simply omits the semantic-freshness clause.
+    """
+    try:
+        release_url = f"{GITHUB_API}/repos/{repo}/releases/tags/{GRAPH_RELEASE_TAG}"
+        release = cast("dict[str, Any]", _request_json(release_url, headers=_gh_headers(token)))
+        asset_url = next(
+            (str(asset["url"]) for asset in release["assets"] if asset.get("name") == SEMANTIC_META_ASSET),
+            None,
+        )
+        if asset_url is None:
+            return None
+        headers = {**_gh_headers(token), "Accept": "application/octet-stream"}
+        return cast("dict[str, Any]", _request_json(asset_url, headers=headers))
+    except (urllib.error.HTTPError, urllib.error.URLError, KeyError, TypeError, ValueError):
+        return None
 
 
 def _excluded_labels() -> set[str]:
@@ -462,6 +508,8 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     latest_ttm_hours = _open_to_merge_hours(latest)
     latest_tick_hours = (merged_at[0] - merged_at[1]).total_seconds() / 3600.0 if len(merged_at) >= 2 else None
 
+    graph_line = _graph_line(repo, token=token, now=now)
+
     return _render_embed(
         repo=repo,
         latest=latest,
@@ -480,6 +528,7 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
         latest_iterations=latest_iterations,
         latest_ttm_hours=latest_ttm_hours,
         latest_tick_hours=latest_tick_hours,
+        graph_line=graph_line,
         now=now,
     )
 
@@ -526,6 +575,51 @@ def _loc_line(loc_24h: dict[str, int], loc_7d: dict[str, int], repo_net: int | N
     return f"{churn(loc_24h)} (24h) · {churn(loc_7d)} (7d) · {full_repo} (full repo)"
 
 
+def _semantic_freshness_clause(meta: dict[str, Any] | None, *, now: dt.datetime) -> str:
+    """Trailing clause dating the last real semantic pass, or "" without one.
+
+    Only a code+semantic meta with a build timestamp earns the clause; the
+    nightly code-only build must never masquerade as semantic freshness.
+    """
+    if not meta or meta.get("kind") != "code+semantic" or not meta.get("built_at"):
+        return ""
+    return f" · semantic layer {stats.days_since(str(meta['built_at']), now=now)} days fresh"
+
+
+def _graph_recap_line(summary: dict[str, Any], meta: dict[str, Any] | None, *, now: dt.datetime) -> str:
+    """One-line knowledge-graph health summary for the loop section.
+
+    Size and query-reduction come from the benchmark trend ledger; the optional
+    trailing clause dates the last real semantic pass from its provenance meta.
+    """
+    line = (
+        f"Knowledge graph: {summary['nodes']:,} nodes / {summary['edges']:,} edges · "
+        f"avg query reduction {summary['reduction_avg']}×"
+    )
+    delta = summary["reduction_delta"]
+    if delta is not None:
+        arrow = "↑" if delta >= 0 else "↓"
+        line += f" ({arrow}{abs(delta)} vs last week)"
+    return line + _semantic_freshness_clause(meta, now=now)
+
+
+def _graph_line(repo: str, *, token: str, now: dt.datetime) -> str | None:
+    """Assemble the knowledge-graph field value, or None when data is absent.
+
+    Graph observability is strictly best-effort garnish: any failure — missing
+    ledger, release, or asset — must never take down the recap itself.
+    """
+    try:
+        trend = load_benchmark_trend(BENCHMARK_TREND_PATH)
+        summary = stats.benchmark_trend_summary(trend)
+        if not summary:
+            return None
+        meta = fetch_semantic_meta(repo, token=token)
+        return _graph_recap_line(summary, meta, now=now)
+    except Exception:  # any graph-data failure degrades to no field, never a crash
+        return None
+
+
 def _render_embed(
     *,
     repo: str,
@@ -545,6 +639,7 @@ def _render_embed(
     latest_iterations: int | None,
     latest_ttm_hours: float,
     latest_tick_hours: float | None,
+    graph_line: str | None,
     now: dt.datetime,
 ) -> dict[str, Any]:
     """Turn computed stats into a Discord embed payload (one message).
@@ -604,6 +699,9 @@ def _render_embed(
             "inline": True,
         },
     ]
+    # Graph observability is optional: no ledger/meta yet means no field at all.
+    if graph_line is not None:
+        fields.append({"name": "🕸️ Knowledge graph", "value": graph_line, "inline": False})
 
     embed = {
         "title": f"🤖 Ralph Recap — {repo}",

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -16,7 +16,9 @@ merge history into the numbers a human wants to see in a recap.
 from __future__ import annotations
 
 import datetime as dt
+import json
 from collections import Counter
+from collections.abc import Iterable
 
 # A Claude reviewer verdict, normalized. The reviewer posts a comment ending in
 # a `Verdict:` line; we collapse it to one of these three tokens.
@@ -213,3 +215,86 @@ def busiest_day(merged_at: list[dt.datetime]) -> tuple[str, int] | None:
     counter: Counter[str] = Counter(ts.date().isoformat() for ts in merged_at)
     day, count = counter.most_common(1)[0]
     return day, count
+
+
+def _coerce_trend_record(line: str) -> dict[str, object] | None:
+    """Coerce one benchmark-trend JSONL line into a typed record, or None.
+
+    A record must be a JSON object carrying all four keys (date, reduction_avg,
+    nodes, edges); anything else — non-JSON, wrong shape, uncoercible values —
+    is treated as malformed and skipped by the caller.
+    """
+    try:
+        record = json.loads(line)
+        if not isinstance(record, dict):
+            return None
+        return {
+            "date": str(record["date"]),
+            "reduction_avg": float(record["reduction_avg"]),
+            "nodes": int(record["nodes"]),
+            "edges": int(record["edges"]),
+        }
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def parse_benchmark_trend(lines: Iterable[str]) -> list[dict[str, object]]:
+    """Parse benchmark-trend JSONL lines, preserving input order.
+
+    Blank and malformed lines are skipped, so a ledger with a stray garbage
+    line still yields every valid record. Never sorts — callers rely on the
+    file's own chronology.
+    """
+    records: list[dict[str, object]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        record = _coerce_trend_record(stripped)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def benchmark_trend_summary(records: list[dict[str, object]], *, week_days: int = 7) -> dict[str, object] | None:
+    """Summarize the latest benchmark record with a week-over-week delta.
+
+    The prior is the most recent OTHER record dated at least `week_days` before
+    the latest; `reduction_delta` is latest minus prior (rounded to one place),
+    or None when no record is old enough to compare against. Returns None for
+    an empty ledger.
+    """
+    if not records:
+        return None
+    latest = records[-1]
+    latest_date = dt.date.fromisoformat(str(latest["date"]))
+    cutoff = latest_date - dt.timedelta(days=week_days)
+    priors = [r for r in records[:-1] if dt.date.fromisoformat(str(r["date"])) <= cutoff]
+    delta: float | None = None
+    if priors:
+        prior = max(priors, key=lambda r: dt.date.fromisoformat(str(r["date"])))
+        delta = round(float(str(latest["reduction_avg"])) - float(str(prior["reduction_avg"])), 1)
+    return {
+        "date": latest["date"],
+        "reduction_avg": latest["reduction_avg"],
+        "nodes": latest["nodes"],
+        "edges": latest["edges"],
+        "reduction_delta": delta,
+    }
+
+
+# Length of a bare YYYY-MM-DD date, used to tell date-only stamps from full ISO.
+_DATE_ONLY_LENGTH = 10
+
+
+def days_since(iso: str, *, now: dt.datetime) -> int:
+    """Whole days from an ISO date or timestamp to `now`.
+
+    A bare date is read as UTC midnight; a full timestamp may carry a trailing
+    `Z` (normalized for `fromisoformat`). Partial days floor toward zero.
+    """
+    if len(iso) == _DATE_ONLY_LENGTH and "T" not in iso:
+        parsed = dt.datetime.fromisoformat(iso).replace(tzinfo=dt.timezone.utc)
+    else:
+        parsed = dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return (now - parsed).days

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -12,6 +12,7 @@ monkeypatched), since everything else is a thin wrapper over `stats`.
 from __future__ import annotations
 
 import datetime as dt
+import pathlib
 from typing import Any
 
 import pytest
@@ -473,3 +474,243 @@ def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
 
     assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+# ---------- parse_benchmark_trend ----------
+
+
+def test_parse_benchmark_trend_parses_lines_in_input_order() -> None:
+    # Newest-first input stays newest-first: the parser never sorts.
+    lines = [
+        '{"date": "2026-07-09", "reduction_avg": 21, "nodes": 16144, "edges": 36585}\n',
+        '{"date": "2026-07-08", "reduction_avg": 16.4, "nodes": 15000, "edges": 35000}\n',
+    ]
+    out = rs.parse_benchmark_trend(lines)
+    assert out == [
+        {"date": "2026-07-09", "reduction_avg": 21.0, "nodes": 16144, "edges": 36585},
+        {"date": "2026-07-08", "reduction_avg": 16.4, "nodes": 15000, "edges": 35000},
+    ]
+    assert isinstance(out[0]["reduction_avg"], float)
+    assert isinstance(out[0]["nodes"], int)
+    assert isinstance(out[0]["edges"], int)
+    assert isinstance(out[0]["date"], str)
+
+
+def test_parse_benchmark_trend_skips_blank_and_malformed_lines() -> None:
+    lines = [
+        "",
+        "\n",
+        "not json",
+        '{"date": "2026-07-08"}',
+        '["not", "an", "object"]',
+        '{"date": "2026-07-09", "reduction_avg": 16.8, "nodes": 15080, "edges": 35598}',
+    ]
+    assert rs.parse_benchmark_trend(lines) == [
+        {"date": "2026-07-09", "reduction_avg": 16.8, "nodes": 15080, "edges": 35598},
+    ]
+
+
+def test_parse_benchmark_trend_empty_input() -> None:
+    assert rs.parse_benchmark_trend([]) == []
+
+
+# ---------- benchmark_trend_summary ----------
+
+
+def _trend_record(date: str, reduction: float, *, nodes: int = 16000, edges: int = 36000) -> dict[str, Any]:
+    return {"date": date, "reduction_avg": reduction, "nodes": nodes, "edges": edges}
+
+
+def test_benchmark_trend_summary_none_for_empty() -> None:
+    assert rs.benchmark_trend_summary([]) is None
+
+
+def test_benchmark_trend_summary_delta_up_from_week_old_prior() -> None:
+    records = [
+        _trend_record("2026-07-01", 16.4),
+        _trend_record("2026-07-10", 16.8, nodes=15080, edges=35598),
+    ]
+    assert rs.benchmark_trend_summary(records) == {
+        "date": "2026-07-10",
+        "reduction_avg": 16.8,
+        "nodes": 15080,
+        "edges": 35598,
+        "reduction_delta": 0.4,
+    }
+
+
+def test_benchmark_trend_summary_delta_down_is_negative() -> None:
+    records = [_trend_record("2026-07-01", 17.1), _trend_record("2026-07-10", 16.8)]
+    summary = rs.benchmark_trend_summary(records)
+    assert summary is not None
+    assert summary["reduction_delta"] == -0.3
+
+
+def test_benchmark_trend_summary_delta_none_without_week_old_prior() -> None:
+    # 2026-07-08 is only 2 days before the latest; no record is >= 7 days old.
+    records = [_trend_record("2026-07-08", 16.6), _trend_record("2026-07-10", 16.8)]
+    summary = rs.benchmark_trend_summary(records)
+    assert summary is not None
+    assert summary["reduction_delta"] is None
+
+
+def test_benchmark_trend_summary_prior_exactly_week_days_old_counts() -> None:
+    records = [_trend_record("2026-07-03", 16.0), _trend_record("2026-07-10", 16.5)]
+    summary = rs.benchmark_trend_summary(records)
+    assert summary is not None
+    assert summary["reduction_delta"] == 0.5
+
+
+def test_benchmark_trend_summary_picks_most_recent_qualifying_prior() -> None:
+    records = [
+        _trend_record("2026-06-25", 15.0),
+        _trend_record("2026-07-02", 16.0),
+        _trend_record("2026-07-10", 16.5),
+    ]
+    summary = rs.benchmark_trend_summary(records)
+    assert summary is not None
+    assert summary["reduction_delta"] == 0.5
+
+
+# ---------- days_since ----------
+
+
+def test_days_since_date_only_is_utc_midnight() -> None:
+    now = dt.datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+    assert rs.days_since("2026-07-07", now=now) == 3
+
+
+def test_days_since_z_suffixed_full_iso() -> None:
+    now = dt.datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+    assert rs.days_since("2026-07-07T12:00:00Z", now=now) == 3
+
+
+def test_days_since_partial_day_floors_to_zero() -> None:
+    now = dt.datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+    assert rs.days_since("2026-07-09T18:00:00Z", now=now) == 0
+
+
+# ---------- _graph_recap_line ----------
+
+_GRAPH_NOW = dt.datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+
+
+def _graph_summary(delta: float | None) -> dict[str, Any]:
+    return {
+        "date": "2026-07-10",
+        "reduction_avg": 16.8,
+        "nodes": 15080,
+        "edges": 35598,
+        "reduction_delta": delta,
+    }
+
+
+def test_graph_recap_line_full_with_semantic_meta_and_positive_delta() -> None:
+    meta = {"kind": "code+semantic", "built_at": "2026-07-07T12:00:00Z"}
+    line = recap._graph_recap_line(_graph_summary(0.4), meta, now=_GRAPH_NOW)
+    assert line == (
+        "Knowledge graph: 15,080 nodes / 35,598 edges · "
+        "avg query reduction 16.8× (↑0.4 vs last week) · "
+        "semantic layer 3 days fresh"
+    )
+    # Pin the deliberate glyphs: MULTIPLICATION SIGN U+00D7 and UPWARDS ARROW U+2191, not ASCII.
+    assert "16.8×" in line
+    assert "16.8x" not in line
+    assert "↑" in line
+
+
+def test_graph_recap_line_negative_delta_uses_down_arrow() -> None:
+    line = recap._graph_recap_line(_graph_summary(-0.3), None, now=_GRAPH_NOW)
+    assert "(↓0.3 vs last week)" in line
+    assert "↑" not in line
+
+
+def test_graph_recap_line_omits_delta_clause_when_none() -> None:
+    line = recap._graph_recap_line(_graph_summary(None), None, now=_GRAPH_NOW)
+    assert "vs last week" not in line
+    assert "16.8×" in line
+
+
+def test_graph_recap_line_omits_semantic_clause_without_meta() -> None:
+    line = recap._graph_recap_line(_graph_summary(0.4), None, now=_GRAPH_NOW)
+    assert "semantic layer" not in line
+
+
+def test_graph_recap_line_omits_semantic_clause_for_code_only_meta() -> None:
+    meta = {"kind": "code-only", "built_at": "2026-07-07T12:00:00Z"}
+    line = recap._graph_recap_line(_graph_summary(0.4), meta, now=_GRAPH_NOW)
+    assert "semantic layer" not in line
+
+
+def test_graph_recap_line_omits_semantic_clause_without_built_at() -> None:
+    meta = {"kind": "code+semantic"}
+    line = recap._graph_recap_line(_graph_summary(0.4), meta, now=_GRAPH_NOW)
+    assert "semantic layer" not in line
+
+
+# ---------- load_benchmark_trend ----------
+
+
+def test_load_benchmark_trend_missing_file_returns_empty(tmp_path: pathlib.Path) -> None:
+    assert recap.load_benchmark_trend(tmp_path / "missing.jsonl") == []
+
+
+def test_load_benchmark_trend_reads_jsonl(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "trend.jsonl"
+    path.write_text(
+        '{"date": "2026-07-09", "reduction_avg": 20.9, "nodes": 16144, "edges": 36585}\n\ngarbage\n',
+        encoding="utf-8",
+    )
+    assert recap.load_benchmark_trend(path) == [
+        {"date": "2026-07-09", "reduction_avg": 20.9, "nodes": 16144, "edges": 36585},
+    ]
+
+
+# ---------- fetch_semantic_meta ----------
+
+
+def test_fetch_semantic_meta_returns_release_asset_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    # semantic-meta.json is the semantic layer's own provenance asset, published
+    # only by the weekly semantic pass so the nightly code build never clobbers it.
+    meta = {"kind": "code+semantic", "built_at": "2026-07-07T12:00:00Z"}
+    release = {
+        "tag_name": "knowledge-graph",
+        "assets": [
+            {
+                "name": "semantic-meta.json",
+                "id": 99,
+                "url": f"{recap.GITHUB_API}/repos/owner/repo/releases/assets/99",
+                "browser_download_url": "https://example.com/download/semantic-meta.json",
+            },
+        ],
+    }
+
+    def _fake(url: str, **_k: Any) -> object:
+        # Any asset-shaped URL yields the meta body; the release lookup itself
+        # yields the release listing.
+        if "semantic-meta.json" in url or "/assets/" in url:
+            return meta
+        return release
+
+    monkeypatch.setattr(recap, "_request_json", _fake)
+    assert recap.fetch_semantic_meta("owner/repo", token="t") == meta
+
+
+def test_fetch_semantic_meta_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise urllib.error.HTTPError("u", 404, "missing", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(recap, "_request_json", _boom)
+    assert recap.fetch_semantic_meta("owner/repo", token="t") is None
+
+
+def test_fetch_semantic_meta_none_on_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise urllib.error.URLError("network down")
+
+    monkeypatch.setattr(recap, "_request_json", _boom)
+    assert recap.fetch_semantic_meta("owner/repo", token="t") is None


### PR DESCRIPTION
## Summary

Graph observability so the recap surfaces graph ROI and rot before humans feel it. **This is the final open sub-issue of the Graphify epic (#1800).**

- **Nightly `graph-build` tail (schedule/dispatch only, `$0`)** — clusters a throwaway post-publish copy (`graphify benchmark` needs a node_link graph; the published raw asset is untouched), runs `graphify benchmark`, and appends **one line/day** to a committed, append-only `graph/metrics/benchmark-trend.jsonl` ledger via a new stdlib helper `scripts/graph/append_benchmark_trend.py` (idempotent per UTC date, never rewrites history). Then probes semantic-layer staleness and prints the benchmark + last-semantic-pass token totals to the job summary. All tail steps are best-effort: a failure warns and continues so a run whose core publish succeeded never turns red.
- **Semantic staleness alarm** — `scripts/graph/semantic_staleness.py` reads the semantic layer's age (`STALE_AFTER_DAYS = 14`, stale only when strictly older) and, when stale, the workflow opens a **deduplicated** `graph-staleness` issue (nightly stays green on known-stale). `graphify check-update .` is run too (cron-safe, log-only). The signal source is a **new dedicated `semantic-meta.json` release asset** published by `graph-semantic` — `graph-meta.json` is last-writer-wins and reset to `code-only` by the nightly build, so it can't date the last real semantic pass; `semantic-meta.json` is never clobbered by `graph-build`.
- **Recap wiring** — `scripts/ralph/stats.py` (pure) + `recap.py` render an optional `THE LOOP` field:
  `Knowledge graph: 15,080 nodes / 35,598 edges · avg query reduction 16.8× (↑0.4 vs last week) · semantic layer 3 days fresh`
  Node/edge counts and the week-over-week reduction delta come from the committed ledger; the freshness clause is fetched from `semantic-meta.json` and omitted when absent or `code-only`. Any graph-data failure degrades to no field — the recap can never be taken down by it.
- **CI** — new `graph-tests.yml` gives the two offline `scripts/graph/test_*.sh` a home (they had none). Docs updated in `scripts/graph/README.md` and `scripts/ralph/RECAP.md`.

## Test plan

- `python -m pytest scripts/ralph -q` → 75 passed (new pure helpers, render line, and graceful-degradation paths).
- `bash scripts/graph/test_append_benchmark_trend.sh` → 14/14 (real benchmark-stdout fixture, per-day idempotency, append-only preservation, malformed/empty → non-zero).
- `bash scripts/graph/test_semantic_staleness.sh` → 15/15 (fresh/aged/code-only/missing/exactly-14-day boundary; always exit 0).
- `pre-commit run` on the changed set → shellcheck, check-yaml, detect-secrets, hygiene all pass (ruff/mypy/etc. are `^backend/`-scoped; the `× ↑ ↓ ·` recap glyphs are deliberate). Helpers smoke-tested against a real locally-built graph.
- Self-review (Gate 2.5): **CLEAN**, no blockers.

## Risk to confirm post-merge

This is the **first direct `git push` to `main`** among the graph workflows (all others upsert via `gh release`). It's token-scoped (checkout keeps `persist-credentials: false`), schedule-only, and best-effort (push failure → `::warning::`, nightly stays green). If `main` has branch protection that rejects Actions pushes, the ledger silently won't grow — worth one manual `workflow_dispatch` run of `graph-build` after merge to confirm the push lands.

Closes #1812
Refs #1800