### PR TITLE
feat(map): magnifier caption shows stage title + subtitle

### DIFF
--- a/frontend/src/features/Map/MagnifierLens.tsx
+++ b/frontend/src/features/Map/MagnifierLens.tsx
@@ -76,8 +76,8 @@ export interface MagnifierLensProps {
   /** The user's live stage — earns the YOU ARE HERE chip when under glass. */
   currentStage: number | null;
   /**
-   * Resolve the caption (polarity + free-will read) for any stage under the
-   * glass. Threaded from ``MapScreen`` so the two facts come from backend
+   * Resolve the caption (the stage's title + subtitle) for any stage under
+   * the glass. Threaded from ``MapScreen`` so the two lines come from backend
    * ``StageData``; missing data resolves to empty strings.
    */
   captionForStage: (_stageNumber: number) => LensCaption;
@@ -422,10 +422,9 @@ const LensGlass = ({
 };
 
 /**
- * Chip + caption block for the stage currently under the glass. The pill shows
- * only the two facts absent everywhere else on the Map: the stage's Divine
- * Gender Polarity (eyebrow-style) over its free-will description (clamped to two
- * lines). Everything the surrounding columns already say is left off.
+ * Chip + caption block for the stage currently under the glass. The pill
+ * mirrors the stage-detail modal header — the stage's title (headline-weight)
+ * over its subtitle — so the glass reads like a preview of the modal.
  */
 const LensCaptionBlock = ({
   caption,
@@ -440,19 +439,19 @@ const LensCaptionBlock = ({
         <Text style={styles.youAreHereText}>YOU ARE HERE</Text>
       </View>
     ) : null}
-    <Text style={styles.magnifierEyebrow} testID="magnifier-polarity" numberOfLines={1}>
-      {caption.polarity}
+    <Text style={styles.magnifierHeadline} testID="magnifier-title" numberOfLines={1}>
+      {caption.title}
     </Text>
-    <Text style={styles.magnifierDetail} testID="magnifier-freewill" numberOfLines={2}>
-      {caption.freeWill}
+    <Text style={styles.magnifierDetail} testID="magnifier-subtitle" numberOfLines={1}>
+      {caption.subtitle}
     </Text>
   </View>
 );
 
 /**
  * Accessibility read for the lens: it identifies the stage (detail the visible
- * pill now sheds but a screen-reader user can't cross-reference) and speaks the
- * two new facts, then names what the lens can do.
+ * pill sheds but a screen-reader user can't cross-reference) and speaks the
+ * title + subtitle, then names what the lens can do.
  */
 const lensAccessibilityLabel = (
   stageNumber: number,
@@ -462,7 +461,7 @@ const lensAccessibilityLabel = (
   const prefix = isCurrent ? 'You are here. ' : '';
   // Skip empty facts (the pre-load / missing-data window) so the spoken label
   // never degrades to stray doubled punctuation.
-  const facts = [caption.polarity, caption.freeWill].filter(Boolean).join('. ');
+  const facts = [caption.title, caption.subtitle].filter(Boolean).join('. ');
   const factsPhrase = facts ? `${facts}. ` : '';
   return (
     `${prefix}Magnifier over ${lensStageIdentity(stageNumber)}. ${factsPhrase}` +

--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -174,15 +174,14 @@ const styles = StyleSheet.create({
     alignItems: CENTER,
     paddingHorizontal: spacing(1),
   },
+  magnifierHeadline: {
+    fontFamily: editorialType.serif,
+    fontSize: 16,
+    fontWeight: '700',
+    color: ink.primary,
+  },
   magnifierDetail: {
     fontSize: 10,
-    color: ink.soft,
-  },
-  magnifierEyebrow: {
-    fontSize: 9,
-    lineHeight: 11,
-    fontWeight: '600',
-    letterSpacing: 1,
     color: ink.soft,
   },
   // "You are here" chip riding the lens when it rests on the current stage.

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -1013,8 +1013,8 @@ const MapGrid = ({
   const [size, onLayout] = useGridSize();
   const { anchors, onRowLayout, onCellLayout } = useStageAnchors(size.height);
   const lensReady = size.width >= MIN_LENS_GRID_EXTENT && size.height >= MIN_LENS_GRID_EXTENT;
-  // Resolve the lens caption from loaded StageData so the pill's polarity +
-  // free-will read reflect the stage under the glass, live as it drags.
+  // Resolve the lens caption from loaded StageData so the pill's title +
+  // subtitle reflect the stage under the glass, live as it drags.
   const captionForStage = useCallback(
     (stageNumber: number): LensCaption => lensCaption(lookup[stageNumber]),
     [lookup],

--- a/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
+++ b/frontend/src/features/Map/__tests__/MagnifierLens.test.tsx
@@ -9,13 +9,12 @@ import type { LensCaption } from '../magnifierGeometry';
 import MagnifierLens from '../MagnifierLens';
 import { stageWavePoint } from '../waveGeometry';
 
-// A deterministic per-stage caption stand-in for the store-fed lookup: even
-// stages read Divine Feminine, odd stages Divine Masculine, and every stage
-// carries a distinct free-will sentence so a test can prove the lens re-captions
-// to the stage under the glass.
+// A deterministic per-stage caption stand-in for the store-fed lookup: each
+// stage carries a distinct title+subtitle so a test can prove the lens
+// re-captions to the stage under the glass.
 const captionForStage = (stageNumber: number): LensCaption => ({
-  polarity: stageNumber % 2 === 0 ? 'Divine Feminine' : 'Divine Masculine',
-  freeWill: `Free-will read for stage ${stageNumber}.`,
+  title: `Title ${stageNumber}`,
+  subtitle: `Subtitle for stage ${stageNumber}.`,
 });
 
 // Mutable reduced-motion knob: default true so lens repositioning is instant
@@ -60,8 +59,8 @@ const renderLens = (options: RenderOptions = {}) => {
 const lensNode = (tree: ReturnType<typeof create>) =>
   tree.root.findByProps({ testID: 'map-magnifier' });
 
-const freeWillText = (tree: ReturnType<typeof create>): string =>
-  tree.root.findByProps({ testID: 'magnifier-freewill' }).props.children as string;
+const subtitleText = (tree: ReturnType<typeof create>): string =>
+  tree.root.findByProps({ testID: 'magnifier-subtitle' }).props.children as string;
 
 const textByTestId = (tree: ReturnType<typeof create>, testID: string) =>
   tree.root.findByProps({ testID });
@@ -138,14 +137,14 @@ describe('MagnifierLens', () => {
     ).toHaveLength(0);
   });
 
-  it('captions the focused stage with only its polarity and free-will read', () => {
+  it('captions the focused stage with its title and subtitle', () => {
     const { tree } = renderLens({ focusedStage: 4 });
-    const polarity = textByTestId(tree, 'magnifier-polarity');
-    expect(polarity.props.children).toBe('Divine Feminine');
-    expect(polarity.props.numberOfLines).toBe(1);
-    const freeWill = textByTestId(tree, 'magnifier-freewill');
-    expect(freeWill.props.children).toBe('Free-will read for stage 4.');
-    expect(freeWill.props.numberOfLines).toBe(2);
+    const title = textByTestId(tree, 'magnifier-title');
+    expect(title.props.children).toBe('Title 4');
+    expect(title.props.numberOfLines).toBe(1);
+    const subtitle = textByTestId(tree, 'magnifier-subtitle');
+    expect(subtitle.props.children).toBe('Subtitle for stage 4.');
+    expect(subtitle.props.numberOfLines).toBe(1);
   });
 
   it('drops the eyebrow, headline, detail, and practice lines from the pill', () => {
@@ -155,6 +154,8 @@ describe('MagnifierLens', () => {
       'magnifier-headline',
       'magnifier-detail',
       'magnifier-practice',
+      'magnifier-polarity',
+      'magnifier-freewill',
     ]) {
       expect(
         tree.root.findAll((n: { props: Record<string, unknown> }) => n.props.testID === testID),
@@ -178,8 +179,8 @@ describe('MagnifierLens', () => {
         />,
       );
     });
-    expect(freeWillText(tree)).toBe('Free-will read for stage 5.');
-    expect(textByTestId(tree, 'magnifier-polarity').props.children).toBe('Divine Masculine');
+    expect(subtitleText(tree)).toBe('Subtitle for stage 5.');
+    expect(textByTestId(tree, 'magnifier-title').props.children).toBe('Title 5');
   });
 
   it('renders a magnified copy of the wave under the glass', () => {
@@ -220,7 +221,7 @@ describe('MagnifierLens', () => {
     expect(style.transform[0].translateX.__getValue()).toBeCloseTo(
       start.x - lensFrame(GRID_WIDTH, GRID_HEIGHT).width / 2,
     );
-    expect(freeWillText(tree)).toBe('Free-will read for stage 2.');
+    expect(subtitleText(tree)).toBe('Subtitle for stage 2.');
   });
 
   it('uses release velocity to coast a fast swipe farther than the finger position', () => {
@@ -256,7 +257,7 @@ describe('MagnifierLens', () => {
       lens.props.onResponderGrant(touch(150, start.y));
       lens.props.onResponderMove(touch(150, start.y - (start.y - stage2Y)));
     });
-    expect(freeWillText(tree)).toBe('Free-will read for stage 2.');
+    expect(subtitleText(tree)).toBe('Subtitle for stage 2.');
   });
 
   it('a drag released back on the focused stage settles without reporting', () => {
@@ -289,8 +290,8 @@ describe('MagnifierLens', () => {
     expect(lens.props.accessibilityLabel).toContain('Agency');
     expect(lens.props.accessibilityLabel).toContain('1 · BEIGE');
     // Both new facts are read aloud.
-    expect(lens.props.accessibilityLabel).toContain('Divine Masculine');
-    expect(lens.props.accessibilityLabel).toContain('Free-will read for stage 1.');
+    expect(lens.props.accessibilityLabel).toContain('Title 1');
+    expect(lens.props.accessibilityLabel).toContain('Subtitle for stage 1.');
     expect(lens.props.accessibilityLabel).toContain('drag to explore');
   });
 
@@ -319,7 +320,7 @@ describe('MagnifierLens', () => {
         );
       });
       // Caption follows immediately; the glide raises the frost wash as it starts.
-      expect(freeWillText(tree)).toBe('Free-will read for stage 8.');
+      expect(subtitleText(tree)).toBe('Subtitle for stage 8.');
       expect(frostRaiseCount(timing)).toBe(1);
     } finally {
       timing.mockRestore();

--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -198,9 +198,9 @@ describe('MapScreen', () => {
     });
     // No modal yet — the tap moved the lens instead.
     expect(() => tree.root.findByProps({ testID: 'stage-modal' })).toThrow();
-    // The lens caption now reads the tapped stage's free-will description.
-    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
-    expect(freeWill.props.children).toBe('Free will at stage 3.');
+    // The lens caption now reads the tapped stage's subtitle.
+    const subtitle = tree.root.findByProps({ testID: 'magnifier-subtitle' });
+    expect(subtitle.props.children).toBe('Subtitle 3');
     // And the chip hides, since the lens left the current stage.
     expect(tree.root.findAll((n: TestNode) => n.props.testID === 'you-are-here')).toHaveLength(0);
   });
@@ -239,8 +239,8 @@ describe('MapScreen', () => {
       lens.props.onResponderMove({ nativeEvent: { pageX: 150, pageY: 450 } });
       lens.props.onResponderRelease({ nativeEvent: { pageX: 150, pageY: 450 } });
     });
-    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
-    expect(freeWill.props.children).toBe('Free will at stage 3.');
+    const subtitle = tree.root.findByProps({ testID: 'magnifier-subtitle' });
+    expect(subtitle.props.children).toBe('Subtitle 3');
     // The settled stage now opens on a single stage tap (it is focused).
     act(() => {
       tree.root.findByProps({ testID: 'stage-hotspot-3-0' }).props.onPress();

--- a/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenDrawer.test.tsx
@@ -128,9 +128,9 @@ describe('MapScreen header drawer', () => {
 
     // Closing unmounts the drawer body (the Modal renders null when hidden).
     expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
-    // The lens caption reflects the newly focused stage (stage 3's free-will read).
-    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
-    expect(freeWill.props.children).toBe('Free will at stage 3.');
+    // The lens caption reflects the newly focused stage (stage 3's subtitle).
+    const subtitle = tree.root.findByProps({ testID: 'magnifier-subtitle' });
+    expect(subtitle.props.children).toBe('Subtitle 3');
   });
 
   it('tapping a locked drawer row still closes the drawer and refocuses the lens', () => {
@@ -144,9 +144,9 @@ describe('MapScreen header drawer', () => {
 
     // Closing unmounts the drawer body (the Modal renders null when hidden).
     expect(() => tree.root.findByProps({ testID: 'map-drawer' })).toThrow();
-    // The lens caption reflects the newly focused stage (stage 8's free-will read).
-    const freeWill = tree.root.findByProps({ testID: 'magnifier-freewill' });
-    expect(freeWill.props.children).toBe('Free will at stage 8.');
+    // The lens caption reflects the newly focused stage (stage 8's subtitle).
+    const subtitle = tree.root.findByProps({ testID: 'magnifier-subtitle' });
+    expect(subtitle.props.children).toBe('Subtitle 8');
   });
 
   it('opens the stage-detail modal for the tapped stage, and closes the drawer', () => {

--- a/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
+++ b/frontend/src/features/Map/__tests__/magnifierGeometry.test.ts
@@ -207,27 +207,25 @@ const makeStage = (overrides: Partial<StageData> = {}): StageData => ({
 });
 
 describe('lensCaption', () => {
-  it('surfaces the stage polarity and free-will description from backend data', () => {
+  it('surfaces the stage title and subtitle from backend data', () => {
     const caption = lensCaption(makeStage());
-    expect(caption.polarity).toBe('Divine Feminine');
-    expect(caption.freeWill).toBe(
-      'Behaviour is determined by the relationships one is embedded in.',
-    );
+    expect(caption.title).toBe('Stage 4');
+    expect(caption.subtitle).toBe('Subtitle');
   });
 
-  it('carries a Divine Masculine polarity through unchanged', () => {
-    const caption = lensCaption(makeStage({ divineGenderPolarity: 'Divine Masculine' }));
-    expect(caption.polarity).toBe('Divine Masculine');
+  it('carries a distinct subtitle through unchanged', () => {
+    const caption = lensCaption(makeStage({ subtitle: 'Active Yes-And-Ness' }));
+    expect(caption.subtitle).toBe('Active Yes-And-Ness');
   });
 
   it('resolves missing stage data to empty strings instead of throwing', () => {
-    expect(lensCaption(undefined)).toEqual({ polarity: '', freeWill: '' });
+    expect(lensCaption(undefined)).toEqual({ title: '', subtitle: '' });
   });
 
-  it('surfaces an empty free-will description without falling over', () => {
-    const caption = lensCaption(makeStage({ freeWillDescription: '' }));
-    expect(caption.freeWill).toBe('');
-    expect(caption.polarity).toBe('Divine Feminine');
+  it('surfaces an empty subtitle without falling over', () => {
+    const caption = lensCaption(makeStage({ subtitle: '' }));
+    expect(caption.subtitle).toBe('');
+    expect(caption.title).toBe('Stage 4');
   });
 });
 

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -65,8 +65,7 @@ export function mockMakeStage(stageNumber: number, overrides: Partial<StageData>
     aspect: 'Aspect',
     spiralDynamicsColor: 'Beige',
     growingUpStage: 'Growing',
-    // Stage-specific so a lens-caption assertion can prove which stage is under
-    // the glass (the pill now shows only polarity + free-will description).
+    // Stage-specific modal metadata; the lens pill itself shows the stage title + subtitle.
     divineGenderPolarity: stageNumber % 2 === 0 ? 'Divine Feminine' : 'Divine Masculine',
     relationshipToFreeWill: 'Free Will',
     freeWillDescription: `Free will at stage ${stageNumber}.`,

--- a/frontend/src/features/Map/magnifierGeometry.ts
+++ b/frontend/src/features/Map/magnifierGeometry.ts
@@ -185,29 +185,27 @@ export const glideDurationMs = (distancePx: number): number =>
   clamp(distancePx * GLIDE_MS_PER_PX, GLIDE_MIN_MS, GLIDE_MAX_MS);
 
 /**
- * The two stage-ontology facts the lens surfaces under the glass — the only
- * pieces of a stage's ontology that appear nowhere else on the Map screen, so
- * the pill adds information rather than repeating the columns beneath it.
+ * The lens caption mirrors the stage-detail modal header's two lines — title
+ * over subtitle — sourced from backend ``StageData`` (never hardcoded) so
+ * ontology corrections flow through automatically; missing data resolves to
+ * empty strings rather than throwing.
  */
 export interface LensCaption {
-  /** The stage's Divine Gender Polarity, eyebrow-style (e.g. "Divine Feminine"). */
-  polarity: string;
-  /** The stage's one-sentence free-will read, clamped within the pill. */
-  freeWill: string;
+  /** The stage's name (e.g. "Survival"). */
+  title: string;
+  /** The stage's subtitle beneath it (e.g. "Active Yes-And-Ness"). */
+  subtitle: string;
 }
 
 /**
- * Resolve the lens caption from a stage's backend data: its Divine Gender
- * Polarity over its free-will description. Both are sourced from ``StageData``
- * (never hardcoded) so ontology corrections flow through automatically. Missing
- * data — a cold start, a fetch error, or an out-of-range hover — resolves to
- * empty strings rather than throwing, so a transient gap can never take the Map
- * down.
+ * Resolve the lens caption from a stage's backend data: its title over its
+ * subtitle. Both are sourced from ``StageData`` (never hardcoded) so ontology
+ * corrections flow through automatically. Missing data — a cold start, a fetch
+ * error, or an out-of-range hover — resolves to empty strings rather than
+ * throwing, so a transient gap can never take the Map down.
  */
 export const lensCaption = (stage: StageData | undefined): LensCaption =>
-  stage
-    ? { polarity: stage.divineGenderPolarity, freeWill: stage.freeWillDescription }
-    : { polarity: '', freeWill: '' };
+  stage ? { title: stage.title, subtitle: stage.subtitle } : { title: '', subtitle: '' };
 
 /**
  * Screen-reader identity for a stage: its Aspect word (or the UNITY / EMPTINESS


### PR DESCRIPTION
## Summary
The Map magnifier lens caption previously showed a stage's Divine-Gender Polarity over its free-will description. Clamped into the pill, the free-will paragraph rendered as an ellipsized fragment with no standalone meaning. This replaces those two lines with the stage's **title** and **subtitle** — the same two lines the stage-detail modal header presents — so the glass reads like a preview of the modal.

- `LensCaption`/`lensCaption` (`magnifierGeometry.ts`) now source `title`/`subtitle` from backend `StageData` via the existing `captionForStage` lookup; missing data still resolves to empty strings.
- `LensCaptionBlock` (`MagnifierLens.tsx`) renders the title (headline-weight) over the subtitle, both `numberOfLines={1}` (testIDs `magnifier-title` / `magnifier-subtitle`); the Polarity and free-will lines are removed.
- The accessibility label now speaks title + subtitle while keeping the `lensStageIdentity` stage identification and the empty-fact skip.
- YOU ARE HERE chip behavior, live drag re-captioning, and the fit-to-a-single-line clamp are preserved.
- Styles: restored `magnifierHeadline`, removed the now-unused `magnifierEyebrow`.

## Test plan
- Migrated (not deleted) the caption tests across `magnifierGeometry.test.ts`, `MagnifierLens.test.tsx`, `MapScreen.test.tsx`, `MapScreenDrawer.test.tsx`, and `mapTestHarness.ts` to pin the title/subtitle shape, the empty-data fallback, live re-captioning, and the a11y label.
- `./scripts/frontend/check-all.sh` green: 4850/4850 tests pass, ESLint + TypeScript + Prettier clean.

Closes #1887