### PR TITLE
fix(frontend): add editorialType.heading rung and demote journal shelf type

### DIFF
--- a/frontend/src/design/__tests__/editorialTokens.test.ts
+++ b/frontend/src/design/__tests__/editorialTokens.test.ts
@@ -129,6 +129,7 @@ describe('editorial tokens', () => {
       for (const key of [
         'display',
         'title',
+        'heading',
         'body',
         'note',
         'caption',
@@ -140,6 +141,14 @@ describe('editorial tokens', () => {
         expect(style.fontSize).toBeGreaterThan(0);
         expect(style.lineHeight).toBeGreaterThan(style.fontSize);
       }
+    });
+
+    it('slots heading strictly between body and title in size and line height', () => {
+      const { heading } = editorialType;
+      expect(heading.fontSize).toBeGreaterThan(editorialType.body.fontSize);
+      expect(heading.fontSize).toBeLessThan(editorialType.title.fontSize);
+      expect(heading.lineHeight).toBeGreaterThan(editorialType.body.lineHeight);
+      expect(heading.lineHeight).toBeLessThan(editorialType.title.lineHeight);
     });
 
     it('uses a body size in the editorial 17-18px range', () => {

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -569,6 +569,7 @@ export const editorialType = {
   serif: serifStack,
   display: { fontFamily: serifStack, fontSize: 34, lineHeight: 42, fontWeight: '700' as const },
   title: { fontFamily: serifStack, fontSize: 26, lineHeight: 34, fontWeight: '600' as const },
+  heading: { fontFamily: serifStack, fontSize: 20, lineHeight: 30, fontWeight: '600' as const },
   body: { fontFamily: serifStack, fontSize: 18, lineHeight: 29, fontWeight: '400' as const },
   note: { fontFamily: serifStack, fontSize: 15, lineHeight: 24, fontWeight: '400' as const },
   caption: { fontFamily: serifStack, fontSize: 13, lineHeight: 20, fontWeight: '400' as const },

--- a/frontend/src/features/Journal/JournalHero.styles.ts
+++ b/frontend/src/features/Journal/JournalHero.styles.ts
@@ -14,7 +14,7 @@ export const journalHeroStyles = StyleSheet.create({
     marginBottom: SPACING.xs,
   },
   greeting: {
-    ...editorialType.display,
+    ...editorialType.title,
     color: onShowcase.primary,
   },
   position: {

--- a/frontend/src/features/Journal/JournalShelf.styles.ts
+++ b/frontend/src/features/Journal/JournalShelf.styles.ts
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
     alignItems: 'baseline',
   },
   cardTitle: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: ink.primary,
     flexShrink: 1,
   },
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   promptQuestion: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: ink.primary,
     paddingTop: spacing(0.5),
   },

--- a/frontend/src/features/Journal/ReflectionInvitationBand.tsx
+++ b/frontend/src/features/Journal/ReflectionInvitationBand.tsx
@@ -181,7 +181,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   title: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: ink.primary,
     paddingTop: spacing(0.5),
   },

--- a/frontend/src/features/Journal/StatTile.styles.ts
+++ b/frontend/src/features/Journal/StatTile.styles.ts
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   stat: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: ink.primary,
     marginTop: SPACING.xs,
   },

--- a/frontend/src/features/Return/ReturnArcCard.tsx
+++ b/frontend/src/features/Return/ReturnArcCard.tsx
@@ -174,7 +174,7 @@ const styles = StyleSheet.create({
     ...paperShadow.card,
   },
   title: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: colors.paper.ink,
   },
   framing: {

--- a/frontend/src/features/Return/ReturnCompletionCard.tsx
+++ b/frontend/src/features/Return/ReturnCompletionCard.tsx
@@ -125,7 +125,7 @@ const styles = StyleSheet.create({
     ...paperShadow.card,
   },
   heading: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: colors.paper.ink,
   },
   body: {

--- a/frontend/src/features/Return/ReturnLetGoCard.tsx
+++ b/frontend/src/features/Return/ReturnLetGoCard.tsx
@@ -250,7 +250,7 @@ const styles = StyleSheet.create({
     ...paperShadow.card,
   },
   heading: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: colors.paper.ink,
   },
   body: {

--- a/frontend/src/features/Return/ReturnOfferCard.tsx
+++ b/frontend/src/features/Return/ReturnOfferCard.tsx
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
     ...paperShadow.card,
   },
   heading: {
-    ...editorialType.title,
+    ...editorialType.heading,
     color: colors.paper.ink,
   },
   body: {


### PR DESCRIPTION
## Summary

The all-serif `editorialType` scale jumped straight from `body` (18px) to `title` (26px), so every Journal shelf element that wanted a heading below the screen title reached for `title`, and the hero greeting rendered at `display` size (34px) right beside the `ScreenHeader` — the shelf read as a wall of near-display type rather than a quiet editorial library.

- Add an intermediate `heading` rung to `editorialType` — serif, `fontSize: 20 / lineHeight: 30 / fontWeight: '600'` — slotted strictly between `body` and `title`. (Proposed `lineHeight: 28` would fall below `body`'s 29 and break the ramp's lineHeight monotonicity, so this uses 30.)
- Demote `title` → `heading` on the shelf's over-large surfaces: `cardTitle` and `promptQuestion` (JournalShelf), `stat` (StatTile), the `ReflectionInvitationBand` title, and the four Return card titles (Offer/Arc/Completion/LetGo).
- Demote the `JournalHero` greeting `display` → `title` so the screen keeps a single display moment (the shared `ScreenHeader`), which is left untouched.
- Tokens only — no existing face values change, no raw font sizes in feature styles. The interactive-text floor (`INTERACTIVE_TEXT_MIN = 16`) is untouched; none of the demoted surfaces are tappable labels, so #1631's accessibility floor is preserved.

Out of scope by design: full-screen modals and other surfaces on `title`/`display` (Course, Map, Practice, MettaSessionModal, etc.) are unchanged.

## Test plan

- Extended the `editorialTokens` governance test to require `heading` in the scale key-list and to assert it sits strictly between `body` and `title` in both `fontSize` and `lineHeight` (RED → GREEN).
- `interactiveTextFloor` and `Course.styles` governance tests stay green unmodified.
- `./scripts/frontend/check-all.sh` passes: 4851 tests, ESLint, prettier, and `tsc --noEmit` all clean.

Closes #1888