### PR TITLE
feat(journal): dismissible "morning pages" tip on the journal shelf

### DIFF
--- a/frontend/src/design/__tests__/interactiveTextFloor.test.ts
+++ b/frontend/src/design/__tests__/interactiveTextFloor.test.ts
@@ -107,6 +107,7 @@ const AUDITED_NON_INTERACTIVE_CAPTIONS = [
   'features/Journal/JournalShelf.styles.ts::sectionHeading',
   'features/Journal/MarginNote.tsx::kind',
   'features/Journal/MarginNote.tsx::staleCaption',
+  'features/Journal/MorningPagesTip.tsx::label',
   'features/Journal/ReflectionInvitationBand.tsx::label',
   'features/Journal/ReflectionSourcesPanel.tsx::groupHeading',
   'features/Journal/ReflectionSourcesPanel.tsx::levelLabel',

--- a/frontend/src/features/Journal/JournalShelfScreen.tsx
+++ b/frontend/src/features/Journal/JournalShelfScreen.tsx
@@ -2,8 +2,8 @@
  * ``JournalShelfScreen`` — the journal's landing surface, restyled as an
  * editorial library: a warm ``ScreenScaffold`` whose scrolling top matter stacks
  * the ``JournalHero``, ``StatTileRow``, ``ReturnStack``, ``InvitationStack``, a
- * serif ``ScreenHeader``, the weekly prompt, a ``ReflectionInvitationBand``, and
- * ``SearchBar`` on the warm palette. Below it, entries group by recency (This
+ * serif ``ScreenHeader``, the weekly prompt, a ``ReflectionInvitationBand``, a
+ * ``MorningPagesTip``, and ``SearchBar`` on the warm palette. Below it, entries group by recency (This
  * week / This month / Earlier) as lifted paper tiles with a reading-time +
  * "saved … ago" caption, over an inviting empty state with a call to action.
  * Tapping a page opens the entry screen by id.
@@ -18,6 +18,7 @@ import { excerpt } from './excerpt';
 import { JournalScreenDrawer } from './JournalDrawer';
 import JournalHero from './JournalHero';
 import styles from './JournalShelf.styles';
+import MorningPagesTip from './MorningPagesTip';
 import { usePressScale } from './motion';
 import { promptTitleForWeek } from './promptTitle';
 import { formatDate, groupByRecency, MONTH_DAYS, type ShelfSection } from './recency';
@@ -311,6 +312,7 @@ function ShelfTopMatter({
       />
       {prompt ? <PromptCard week={week} question={prompt.question} onOpen={onPrompt} /> : null}
       <ReflectionInvitationBand />
+      <MorningPagesTip onBegin={onNew} />
       <View style={styles.searchRow}>
         <SearchBar onSearch={onSearch} searchQuery={query || undefined} resultCount={resultCount} />
       </View>

--- a/frontend/src/features/Journal/MorningPagesTip.tsx
+++ b/frontend/src/features/Journal/MorningPagesTip.tsx
@@ -1,0 +1,154 @@
+/**
+ * ``MorningPagesTip`` — a one-time morning-pages suggestion on the Journal
+ * shelf. Self-contained like ``ReflectionInvitationBand``: it loads its own
+ * persisted dismissal flag and quietly renders nothing while that flag is
+ * still loading (so the band never flashes) or once the tip was set aside.
+ *
+ * "You choose your depth": this is a warm, one-tap-declinable suggestion —
+ * never a gate and never gamified. There is deliberately no streak, no count,
+ * and no guilt copy. Either affordance retires the tip for good; beginning a
+ * page simply also hands off to the shelf's new-entry flow.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  MORNING_PAGES_BODY,
+  MORNING_PAGES_CTA,
+  MORNING_PAGES_CTA_A11Y,
+  MORNING_PAGES_DISMISS,
+  MORNING_PAGES_DISMISS_A11Y,
+  MORNING_PAGES_LABEL,
+  MORNING_PAGES_TITLE,
+} from './morningPagesCopy';
+import ReflectionDismiss from './ReflectionDismiss';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  editorialType,
+  ink,
+  spacing,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+import {
+  loadMorningPagesTipDismissed,
+  saveMorningPagesTipDismissed,
+} from '@/storage/morningPagesTipStorage';
+
+/** The band's identifying warm left rule (matches the shelf's other bands), in dp. */
+const ACCENT_BAR_WIDTH = 3;
+
+export interface MorningPagesTipProps {
+  /** Opens the shelf's new-entry flow so the person can start a page right away. */
+  onBegin: () => void;
+}
+
+/**
+ * Owns the dismissal state, the load-on-mount, and the begin/dismiss actions.
+ * ``dismissed`` starts null while the persisted flag loads; both actions
+ * persist the flag and retire the band, and only ``onBeginPress`` hands off
+ * to ``onBegin``.
+ */
+function useMorningPagesTip(onBegin: () => void) {
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void loadMorningPagesTipDismissed().then((stored) => {
+      if (active) setDismissed(stored);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const onBeginPress = useCallback(() => {
+    void saveMorningPagesTipDismissed(true);
+    setDismissed(true);
+    onBegin();
+  }, [onBegin]);
+
+  const onDismiss = useCallback(() => {
+    void saveMorningPagesTipDismissed(true);
+    setDismissed(true);
+  }, []);
+
+  return { dismissed, onBeginPress, onDismiss };
+}
+
+function MorningPagesTip({ onBegin }: MorningPagesTipProps): React.JSX.Element | null {
+  const { dismissed, onBeginPress, onDismiss } = useMorningPagesTip(onBegin);
+  // Null while loading (no flash) and true once set aside both stay quiet.
+  if (dismissed !== false) return null;
+
+  // A plain container, not a pressable, so the inner "begin" and "decline"
+  // buttons stay independently reachable by assistive tech (a pressable
+  // wrapper would collapse the subtree and hide the one-tap decline).
+  return (
+    <View style={styles.band}>
+      <TouchableOpacity
+        style={styles.openArea}
+        onPress={onBeginPress}
+        accessibilityRole="button"
+        accessibilityLabel={MORNING_PAGES_CTA_A11Y}
+        testID="journal-morning-pages-tip"
+      >
+        <Text style={styles.label}>{MORNING_PAGES_LABEL}</Text>
+        <Text style={styles.title}>{MORNING_PAGES_TITLE}</Text>
+        <Text style={styles.body}>{MORNING_PAGES_BODY}</Text>
+        <Text style={styles.cta}>{MORNING_PAGES_CTA}</Text>
+      </TouchableOpacity>
+      <ReflectionDismiss
+        label={MORNING_PAGES_DISMISS}
+        accessibilityLabel={MORNING_PAGES_DISMISS_A11Y}
+        testID="journal-morning-pages-dismiss"
+        onPress={onDismiss}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  band: {
+    marginTop: SPACING.lg,
+    padding: SPACING.lg,
+    borderRadius: BORDER_RADIUS.md,
+    // A raised sheet with the same warm accent rule as the shelf's invitation
+    // bands, so the tip reads as part of a matched set.
+    backgroundColor: surface.raised,
+    borderLeftWidth: ACCENT_BAR_WIDTH,
+    borderLeftColor: accent.primary,
+    ...surfaceShadow.card,
+  },
+  openArea: {
+    minHeight: touchTarget.minimum,
+  },
+  label: {
+    ...editorialType.caption,
+    color: ink.muted,
+    textTransform: 'uppercase',
+  },
+  title: {
+    ...editorialType.heading,
+    color: ink.primary,
+    paddingTop: spacing(0.5),
+  },
+  body: {
+    ...editorialType.note,
+    color: ink.soft,
+    paddingTop: spacing(0.5),
+  },
+  cta: {
+    // editorialType.action sits at the INTERACTIVE_TEXT_MIN floor, keeping
+    // this tappable label legible without a bespoke size.
+    ...editorialType.action,
+    color: accent.primary,
+    paddingTop: spacing(1),
+  },
+});
+
+export default MorningPagesTip;

--- a/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
+++ b/frontend/src/features/Journal/__tests__/JournalShelfScreen.test.tsx
@@ -78,6 +78,15 @@ jest.mock('@/features/Invitations/InvitationStack', () => {
   return { __esModule: true, default: Stub };
 });
 
+// The morning-pages tip owns its own AsyncStorage-backed dismissal state and a
+// dedicated suite; stub it so its post-mount load never fires setState after
+// these shelf tests resolve, keeping them focused on ordering and list wiring.
+jest.mock('../MorningPagesTip', () => {
+  const { View } = require('react-native');
+  const Stub = () => <View testID="morning-pages-tip-stub" />;
+  return { __esModule: true, default: Stub };
+});
+
 const JournalShelfScreen = require('../JournalShelfScreen').default;
 
 type RenderedNode = {
@@ -554,9 +563,12 @@ describe('JournalShelfScreen', () => {
     const returnIndex = order.indexOf('#return-stack-stub');
     const invitationIndex = order.indexOf('#invitation-stack-stub');
     const headerIndex = order.indexOf('Journal');
+    const tipIndex = order.indexOf('#morning-pages-tip-stub');
     expect(statIndex).toBeGreaterThan(-1);
     expect(returnIndex).toBeGreaterThan(statIndex);
     expect(invitationIndex).toBeGreaterThan(returnIndex);
     expect(headerIndex).toBeGreaterThan(invitationIndex);
+    // The morning-pages tip sits in the shelf's top matter, below the header.
+    expect(tipIndex).toBeGreaterThan(headerIndex);
   });
 });

--- a/frontend/src/features/Journal/__tests__/MorningPagesTip.test.tsx
+++ b/frontend/src/features/Journal/__tests__/MorningPagesTip.test.tsx
@@ -1,0 +1,120 @@
+/* eslint-env jest */
+// RED: `MorningPagesTip` does not exist yet; `require('../MorningPagesTip')` throws until it does.
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import { ranksOrShames } from '@/features/Map/__tests__/copyIntentRule';
+
+const mockLoad = jest.fn() as jest.MockedFunction<() => Promise<boolean>>;
+const mockSave = jest.fn() as jest.MockedFunction<(_v: boolean) => Promise<void>>;
+const mockOnBegin = jest.fn();
+
+jest.mock('@/storage/morningPagesTipStorage', () => ({
+  loadMorningPagesTipDismissed: (...a: unknown[]) =>
+    (mockLoad as unknown as (...x: unknown[]) => unknown)(...a),
+  saveMorningPagesTipDismissed: (...a: unknown[]) =>
+    (mockSave as unknown as (...x: unknown[]) => unknown)(...a),
+}));
+
+const MorningPagesTip = require('../MorningPagesTip').default;
+
+type RenderedNode = {
+  children?: (RenderedNode | string)[] | null;
+  props?: { accessibilityLabel?: unknown };
+};
+
+function collectRenderedStrings(node: RenderedNode | string): string[] {
+  if (typeof node === 'string') {
+    return [node];
+  }
+  const collected: string[] = [];
+  const label = node.props ? node.props.accessibilityLabel : undefined;
+  if (typeof label === 'string') {
+    collected.push(label);
+  }
+  for (const child of node.children ?? []) {
+    collected.push(...collectRenderedStrings(child));
+  }
+  return collected;
+}
+
+beforeEach(() => {
+  mockLoad.mockReset();
+  mockSave.mockReset();
+  mockOnBegin.mockReset();
+  mockLoad.mockResolvedValue(false);
+  mockSave.mockResolvedValue(undefined);
+});
+
+describe('MorningPagesTip', () => {
+  it('renders the tip when the dismissal flag is unset', async () => {
+    const { findByTestId } = render(<MorningPagesTip onBegin={mockOnBegin} />);
+    expect(await findByTestId('journal-morning-pages-tip')).toBeTruthy();
+  });
+
+  it('renders nothing when the tip was already dismissed', async () => {
+    mockLoad.mockResolvedValue(true);
+    const { queryByTestId } = render(<MorningPagesTip onBegin={mockOnBegin} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId('journal-morning-pages-tip')).toBeNull();
+  });
+
+  it('renders nothing while the persisted flag is still loading, so the tip never flashes', () => {
+    mockLoad.mockImplementation(() => new Promise<boolean>(() => undefined));
+    const { queryByTestId } = render(<MorningPagesTip onBegin={mockOnBegin} />);
+    expect(queryByTestId('journal-morning-pages-tip')).toBeNull();
+  });
+
+  it('dismissing persists true and hides the band without invoking onBegin', async () => {
+    const { findByTestId, getByTestId, queryByTestId } = render(
+      <MorningPagesTip onBegin={mockOnBegin} />,
+    );
+    await findByTestId('journal-morning-pages-tip');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-morning-pages-dismiss'));
+    });
+
+    expect(mockSave).toHaveBeenCalledWith(true);
+    expect(mockOnBegin).not.toHaveBeenCalled();
+    await waitFor(() => expect(queryByTestId('journal-morning-pages-tip')).toBeNull());
+  });
+
+  it('the CTA calls onBegin, persists true, and hides the band', async () => {
+    const { findByTestId, getByTestId, queryByTestId } = render(
+      <MorningPagesTip onBegin={mockOnBegin} />,
+    );
+    await findByTestId('journal-morning-pages-tip');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('journal-morning-pages-tip'));
+    });
+
+    expect(mockOnBegin).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledWith(true);
+    await waitFor(() => expect(queryByTestId('journal-morning-pages-tip')).toBeNull());
+  });
+
+  it('renders no streak or shame copy anywhere in the band', async () => {
+    const view = render(<MorningPagesTip onBegin={mockOnBegin} />);
+    await view.findByTestId('journal-morning-pages-tip');
+
+    const json = view.toJSON() as unknown as RenderedNode | RenderedNode[] | null;
+    let roots: RenderedNode[] = [];
+    if (Array.isArray(json)) {
+      roots = json;
+    } else if (json !== null) {
+      roots = [json];
+    }
+    const strings = roots.flatMap((root) => collectRenderedStrings(root));
+
+    expect(strings.length).toBeGreaterThan(0);
+    for (const copy of strings) {
+      expect(ranksOrShames(copy)).toBe(false);
+    }
+    expect(view.queryByText(/streak/i)).toBeNull();
+  });
+});

--- a/frontend/src/features/Journal/__tests__/morningPagesCopy.test.ts
+++ b/frontend/src/features/Journal/__tests__/morningPagesCopy.test.ts
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import { describe, it, expect } from '@jest/globals';
+
+import { MORNING_PAGES_COPY_ENTRIES } from '../morningPagesCopy';
+
+import { ranksOrShames } from '@/features/Map/__tests__/copyIntentRule';
+
+describe('morningPagesCopy — balance-not-altitude intent rule', () => {
+  it('exposes at least one copy entry to sweep', () => {
+    expect(MORNING_PAGES_COPY_ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it('no MORNING_PAGES_COPY_ENTRIES entry ranks or shames the person', () => {
+    for (const entry of MORNING_PAGES_COPY_ENTRIES) {
+      expect(ranksOrShames(entry)).toBe(false);
+    }
+  });
+
+  it('no entry leans on forever, keep-going, or must pressure language', () => {
+    for (const entry of MORNING_PAGES_COPY_ENTRIES) {
+      expect(entry).not.toMatch(/\bforever\b/i);
+      expect(entry).not.toMatch(/keep going/i);
+      expect(entry).not.toMatch(/\bmust\b/i);
+    }
+  });
+});

--- a/frontend/src/features/Journal/morningPagesCopy.ts
+++ b/frontend/src/features/Journal/morningPagesCopy.ts
@@ -1,0 +1,42 @@
+/**
+ * Microcopy for the morning-pages tip — a one-time, declinable suggestion on
+ * the Journal shelf (NORTH-STAR "you choose your depth").
+ *
+ * The tip reads like a friend passing along a practice worth trying, never a
+ * prescription. There is no streak, no count, and no pressure to continue —
+ * so nothing here ranks, shames, or pushes. ``MORNING_PAGES_COPY_ENTRIES``
+ * enumerates every user-facing string for the balance-not-altitude sweep.
+ */
+
+/** The uppercase caption above the tip — frames it as an offer, not a task. */
+export const MORNING_PAGES_LABEL = 'A practice to try';
+
+/** The tip heading — names the practice plainly. */
+export const MORNING_PAGES_TITLE = 'Morning pages';
+
+/** The tip body — what the practice is, framed as an invitation to let it pour. */
+export const MORNING_PAGES_BODY =
+  'Twenty minutes of unfiltered writing, first thing — no editing, no rereading, just let it pour. It clears the fog before the day begins.';
+
+/** The open affordance label — starts a fresh page. */
+export const MORNING_PAGES_CTA = 'Begin a page';
+
+/** The accessibility label for beginning a morning page. */
+export const MORNING_PAGES_CTA_A11Y = 'Begin a morning page';
+
+/** The decline affordance label. */
+export const MORNING_PAGES_DISMISS = 'Not now';
+
+/** The accessibility label for declining the tip. */
+export const MORNING_PAGES_DISMISS_A11Y = 'Set the morning-pages tip aside';
+
+/** Every user-facing morning-pages string, gathered for the balance-not-altitude sweep. */
+export const MORNING_PAGES_COPY_ENTRIES: readonly string[] = [
+  MORNING_PAGES_LABEL,
+  MORNING_PAGES_TITLE,
+  MORNING_PAGES_BODY,
+  MORNING_PAGES_CTA,
+  MORNING_PAGES_CTA_A11Y,
+  MORNING_PAGES_DISMISS,
+  MORNING_PAGES_DISMISS_A11Y,
+];

--- a/frontend/src/storage/__tests__/morningPagesTipStorage.test.ts
+++ b/frontend/src/storage/__tests__/morningPagesTipStorage.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  saveMorningPagesTipDismissed,
+  loadMorningPagesTipDismissed,
+} from '../morningPagesTipStorage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('morningPagesTipStorage', () => {
+  describe('saveMorningPagesTipDismissed', () => {
+    test('stores true when the tip is dismissed', async () => {
+      await saveMorningPagesTipDismissed(true);
+
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@adepthood/morning_pages_tip_dismissed',
+        'true',
+      );
+    });
+  });
+
+  describe('loadMorningPagesTipDismissed', () => {
+    test('returns false when nothing is stored', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(null);
+      const result = await loadMorningPagesTipDismissed();
+      expect(result).toBe(false);
+    });
+
+    test('returns true when the stored flag is true', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce('true');
+      const result = await loadMorningPagesTipDismissed();
+      expect(result).toBe(true);
+    });
+
+    test('returns false on a storage error', async () => {
+      mockAsyncStorage.getItem.mockRejectedValueOnce(new Error('storage error'));
+      const result = await loadMorningPagesTipDismissed();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/frontend/src/storage/morningPagesTipStorage.ts
+++ b/frontend/src/storage/morningPagesTipStorage.ts
@@ -1,0 +1,20 @@
+// Persists the "the morning-pages tip was set aside" flag so a decline is
+// honoured across launches — the tip stays quiet once the person sets it down.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const MORNING_PAGES_TIP_DISMISSED_KEY = '@adepthood/morning_pages_tip_dismissed';
+const FLAG_TRUE = 'true';
+
+export async function saveMorningPagesTipDismissed(value: boolean): Promise<void> {
+  await AsyncStorage.setItem(MORNING_PAGES_TIP_DISMISSED_KEY, String(value));
+}
+
+export async function loadMorningPagesTipDismissed(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(MORNING_PAGES_TIP_DISMISSED_KEY);
+    return raw === FLAG_TRUE;
+  } catch (err) {
+    console.warn('[morningPagesTipStorage] failed to load dismissal flag', err);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a one-time, declinable "morning pages" tip band to the Journal shelf's
top matter. It briefly introduces the practice (~20 minutes of unfiltered
free-writing, first thing) with a **Begin a page** CTA into a new entry and a
**Not now** dismiss. Dismissing via either affordance persists to AsyncStorage,
so the tip never reappears on any later mount or launch; while the persisted
flag is loading the band renders nothing, so it never flashes.

The band mirrors the shelf's existing `ReflectionInvitationBand` — a raised
sheet with the warm accent left rule and shared `ReflectionDismiss` control —
so it reads as a sibling of the shelf's other declinable invitations. Copy and
behaviour follow the NORTH-STAR register: a resonant, declinable invitation
with no urgency, streak, count, or shame language. Candle & Ink tokens only;
the CTA uses the 16px interactive-text floor and the dismiss control meets the
44dp touch target with an accessibility label.

New surfaces (all frontend, no backend):
- `morningPagesTipStorage.ts` — a global one-shot dismissal flag mirroring
  `returnOfferStorage.ts` (resolves `false` on read error, so a failed read
  simply shows the tip).
- `morningPagesCopy.ts` — the tip's user-facing strings plus a copy-entries
  array for the balance-not-altitude tone sweep.
- `MorningPagesTip.tsx` — the band component and its `useMorningPagesTip` hook.
- Wired into `ShelfTopMatter` after `ReflectionInvitationBand`.

## Test plan

- `morningPagesTipStorage.test.ts` — save writes the flag; load returns
  `false`/`true` for unset/set; load returns `false` on a `getItem` rejection
  (error branch).
- `MorningPagesTip.test.tsx` — renders when unset; hidden when dismissed;
  renders nothing while loading (no flash); dismiss persists + hides without
  invoking `onBegin`; CTA invokes `onBegin` and persists + hides; no
  streak/shame copy.
- `morningPagesCopy.test.ts` — every copy entry passes the `ranksOrShames`
  tone sweep and avoids pressure language.
- `JournalShelfScreen.test.tsx` — tip stubbed and asserted present below the
  header; existing ordering/list tests stay green.
- `interactiveTextFloor.test.ts` — the tip's non-interactive eyebrow caption
  registered in the audited allowlist.
- `./scripts/frontend/check-all.sh` passes (eslint, prettier, tsc, jest — all 4).

Closes #1889