### PR TITLE
feat(habits): reorder drawer rows, switch-style page-controls toggle, and "Show Habits" pager

### DIFF
--- a/frontend/src/features/Habits/components/HabitsDrawer.tsx
+++ b/frontend/src/features/Habits/components/HabitsDrawer.tsx
@@ -1,14 +1,13 @@
 // The Habits header-drawer body. Replaces the removed in-body overflow menu and
-// hosts the pagination controls: action rows, the unlock-all confirm gate, the
-// Prev/Next pager with its stage-range label, and the pagination-visibility
-// toggle. Rendered as ScreenDrawer children by HabitsScreen.
+// hosts, top to bottom: the action rows (Quick Log, Edit, Add Habit, Energy
+// Scaffolding, Stats), the unlock-all confirm gate, the page-controls
+// visibility switch, and the "Show Habits" pager row with its right-aligned
+// Prev/range/Next cluster. Rendered as ScreenDrawer children by HabitsScreen.
 import {
   BarChart2,
   Check,
   ChevronLeft,
   ChevronRight,
-  Eye,
-  EyeOff,
   Lock,
   Pencil,
   Plus,
@@ -16,12 +15,19 @@ import {
   Zap,
 } from 'lucide-react-native';
 import React, { useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
+import {
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
 
 import ConfirmDialog from './ConfirmDialog';
 
 import { DrawerItem } from '@/components/drawer';
-import { accent, ink, SPACING, touchTarget, type } from '@/design/tokens';
+import { accent, ink, SPACING, surface, touchTarget, type } from '@/design/tokens';
 
 /** Lucide glyph size in dp for the drawer's row and pager icons. */
 const ICON_SIZE = 20;
@@ -61,10 +67,10 @@ function ActionRows({
 }: ActionRowsProps): React.JSX.Element {
   const rows: Array<{ Icon: typeof Check; label: string; run: () => void }> = [
     { Icon: Check, label: 'Quick Log', run: () => onSelectMode('quickLog') },
-    { Icon: BarChart2, label: 'Stats', run: () => onSelectMode('stats') },
     { Icon: Pencil, label: 'Edit', run: () => onSelectMode('edit') },
     { Icon: Plus, label: 'Add Habit', run: onOpenAddHabit },
     { Icon: Zap, label: 'Energy Scaffolding', run: onOpenOnboarding },
+    { Icon: BarChart2, label: 'Stats', run: () => onSelectMode('stats') },
   ];
   return (
     <>
@@ -133,6 +139,31 @@ function RevealRow({ allRevealed, onToggleReveal, onClose }: RevealRowProps): Re
   );
 }
 
+interface VisibilityRowProps {
+  barVisible: boolean;
+  onToggleBarVisible: () => void;
+}
+
+/** Label-left, switch-right row governing the in-body pagination bar's visibility. */
+function VisibilityRow({ barVisible, onToggleBarVisible }: VisibilityRowProps): React.JSX.Element {
+  const { width } = useWindowDimensions();
+  const visibilityLabel = barVisible ? 'Hide page controls' : 'Show page controls';
+  return (
+    <View style={styles.settingRow}>
+      <Text style={[type(width).body, styles.rowLabel]}>{visibilityLabel}</Text>
+      <Switch
+        accessibilityRole="switch"
+        accessibilityLabel={visibilityLabel}
+        accessibilityState={{ checked: barVisible }}
+        value={barVisible}
+        onValueChange={onToggleBarVisible}
+        trackColor={{ false: surface.hairline, true: accent.primary }}
+        thumbColor={surface.raised}
+      />
+    </View>
+  );
+}
+
 interface PaginationSectionProps {
   page: number;
   pageCount: number;
@@ -142,7 +173,10 @@ interface PaginationSectionProps {
   stageEnd: number;
 }
 
-/** Prev/Next pager around a stage-range label that also announces the position. */
+/**
+ * The "Show Habits" pager row: static label on the left, then a right-aligned
+ * Prev/range/Next cluster whose range label also announces the page position.
+ */
 function PaginationSection({
   page,
   pageCount,
@@ -154,46 +188,47 @@ function PaginationSection({
   const { width } = useWindowDimensions();
   const canPrev = page > 0;
   const canNext = page < pageCount - 1;
-  const positionLabel = `Stages ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
+  const positionLabel = `Show habits ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
   return (
-    <View style={styles.paginationRow} testID="drawer-pagination">
-      <TouchableOpacity
-        onPress={onPrev}
-        disabled={!canPrev}
-        accessibilityRole="button"
-        accessibilityLabel="Previous page"
-        accessibilityState={{ disabled: !canPrev }}
-        style={styles.pagerButton}
-        testID="drawer-pagination-prev"
-      >
-        <ChevronLeft size={ICON_SIZE} color={canPrev ? accent.primary : ink.muted} />
-      </TouchableOpacity>
-      <Text
-        style={[type(width).body, styles.rangeLabel]}
-        accessibilityLabel={positionLabel}
-        testID="drawer-pagination-label"
-      >
-        Stages {stageStart}–{stageEnd}
-      </Text>
-      <TouchableOpacity
-        onPress={onNext}
-        disabled={!canNext}
-        accessibilityRole="button"
-        accessibilityLabel="Next page"
-        accessibilityState={{ disabled: !canNext }}
-        style={styles.pagerButton}
-        testID="drawer-pagination-next"
-      >
-        <ChevronRight size={ICON_SIZE} color={canNext ? accent.primary : ink.muted} />
-      </TouchableOpacity>
+    <View style={styles.settingRow} testID="drawer-pagination">
+      <Text style={[type(width).body, styles.rowLabel]}>Show Habits</Text>
+      <View style={styles.pagerCluster}>
+        <TouchableOpacity
+          onPress={onPrev}
+          disabled={!canPrev}
+          accessibilityRole="button"
+          accessibilityLabel="Previous page"
+          accessibilityState={{ disabled: !canPrev }}
+          style={styles.pagerButton}
+          testID="drawer-pagination-prev"
+        >
+          <ChevronLeft size={ICON_SIZE} color={canPrev ? accent.primary : ink.muted} />
+        </TouchableOpacity>
+        <Text
+          style={[type(width).body, styles.rangeLabel]}
+          accessibilityLabel={positionLabel}
+          testID="drawer-pagination-label"
+        >
+          {stageStart}–{stageEnd}
+        </Text>
+        <TouchableOpacity
+          onPress={onNext}
+          disabled={!canNext}
+          accessibilityRole="button"
+          accessibilityLabel="Next page"
+          accessibilityState={{ disabled: !canNext }}
+          style={styles.pagerButton}
+          testID="drawer-pagination-next"
+        >
+          <ChevronRight size={ICON_SIZE} color={canNext ? accent.primary : ink.muted} />
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
 
-/** The Habits header-drawer body composed from its action, reveal, and pager sections. */
+/** The drawer body: action rows, the reveal gate, the visibility switch, then the pager. */
 export default function HabitsDrawer(props: HabitsDrawerProps): React.JSX.Element {
-  const visibilityLabel = props.barVisible ? 'Hide page controls' : 'Show page controls';
-  const VisibilityIcon = props.barVisible ? EyeOff : Eye;
   return (
     <View>
       <ActionRows
@@ -207,6 +242,7 @@ export default function HabitsDrawer(props: HabitsDrawerProps): React.JSX.Elemen
         onToggleReveal={props.onToggleReveal}
         onClose={props.onClose}
       />
+      <VisibilityRow barVisible={props.barVisible} onToggleBarVisible={props.onToggleBarVisible} />
       <PaginationSection
         page={props.page}
         pageCount={props.pageCount}
@@ -215,22 +251,25 @@ export default function HabitsDrawer(props: HabitsDrawerProps): React.JSX.Elemen
         stageStart={props.stageStart}
         stageEnd={props.stageEnd}
       />
-      <DrawerItem
-        label={visibilityLabel}
-        icon={<VisibilityIcon size={ICON_SIZE} color={accent.primary} />}
-        onPress={props.onToggleBarVisible}
-      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  paginationRow: {
+  settingRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     minHeight: touchTarget.minimum,
     gap: SPACING.md,
+  },
+  rowLabel: {
+    color: ink.primary,
+  },
+  pagerCluster: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.xs,
   },
   pagerButton: {
     minWidth: touchTarget.minimum,
@@ -239,7 +278,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   rangeLabel: {
-    flex: 1,
     textAlign: 'center',
     color: ink.primary,
   },

--- a/frontend/src/features/Habits/components/__tests__/HabitsDrawer.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/HabitsDrawer.test.tsx
@@ -1,8 +1,5 @@
-// RED: HabitsDrawer does not exist yet -- this import fails until the
-// implementation-specialist adds the component. Specifies the header-drawer
-// replacement for the removed in-body overflow menu and pagination bar:
-// action rows, unlock-all confirm gating, pagination controls, and the
-// pagination-visibility toggle.
+// Specifies the Habits header drawer: action rows, unlock-all confirm gating,
+// row ordering, the page-controls switch, and the "Show Habits" pager row.
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
@@ -26,6 +23,55 @@ const baseProps = {
   barVisible: true,
   onToggleBarVisible: noop,
   onClose: noop,
+};
+
+const ROW_ORDER_LABELS: readonly string[] = [
+  'Quick Log',
+  'Edit',
+  'Add Habit',
+  'Energy Scaffolding',
+  'Stats',
+  'Unlock All Habits',
+  'Show Habits',
+];
+
+interface JsonNode {
+  type?: unknown;
+  props?: { accessibilityRole?: unknown };
+  children?: unknown;
+}
+
+// True when a rendered node represents the RN Switch control.
+const isSwitchNode = (json: JsonNode): boolean => {
+  const role = json.props ? json.props.accessibilityRole : undefined;
+  if (role === 'switch') {
+    return true;
+  }
+  return typeof json.type === 'string' && json.type.includes('Switch');
+};
+
+// Flattens the rendered tree into row markers: known labels plus the switch.
+const collectRowMarkers = (node: unknown, out: string[]): void => {
+  if (typeof node === 'string') {
+    if (ROW_ORDER_LABELS.includes(node)) {
+      out.push(node);
+    }
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node as unknown[]) {
+      collectRowMarkers(child, out);
+    }
+    return;
+  }
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  const json = node as JsonNode;
+  if (isSwitchNode(json)) {
+    out.push('switch');
+  }
+  collectRowMarkers(json.children, out);
 };
 
 afterEach(() => {
@@ -161,20 +207,25 @@ describe('HabitsDrawer unlock-all confirm gating', () => {
 });
 
 describe('HabitsDrawer pagination section', () => {
-  it('shows the stage range as the visible label with the page position folded into its accessibility label', () => {
+  it('renders the static "Show Habits" label on the pager row', () => {
+    const { getByText } = render(<HabitsDrawer {...baseProps} />);
+    expect(getByText('Show Habits')).toBeTruthy();
+  });
+
+  it('shows the bare stage range with the page position folded into its accessibility label', () => {
     const { getByText } = render(
       <HabitsDrawer {...baseProps} page={0} pageCount={2} stageStart={1} stageEnd={10} />,
     );
-    const label = getByText('Stages 1–10');
-    expect(label.props.accessibilityLabel).toBe('Stages 1 to 10, page 1 of 2');
+    const label = getByText('1–10');
+    expect(label.props.accessibilityLabel).toBe('Show habits 1 to 10, page 1 of 2');
   });
 
   it('shows the second-lap stage range and position', () => {
     const { getByText } = render(
       <HabitsDrawer {...baseProps} page={1} pageCount={2} stageStart={11} stageEnd={20} />,
     );
-    const label = getByText('Stages 11–20');
-    expect(label.props.accessibilityLabel).toBe('Stages 11 to 20, page 2 of 2');
+    const label = getByText('11–20');
+    expect(label.props.accessibilityLabel).toBe('Show habits 11 to 20, page 2 of 2');
   });
 
   it('disables Prev on the first page and enables Next', () => {
@@ -219,17 +270,23 @@ describe('HabitsDrawer pagination section', () => {
 });
 
 describe('HabitsDrawer pagination-bar visibility toggle', () => {
-  it('labels the toggle "Hide page controls" when the bar is visible', () => {
+  it('renders a switch that is on and announces "Hide page controls" when the bar is visible', () => {
     const { getByRole } = render(<HabitsDrawer {...baseProps} barVisible />);
-    expect(getByRole('button', { name: 'Hide page controls' })).toBeTruthy();
+    const toggle = getByRole('switch');
+    expect(toggle.props.value).toBe(true);
+    expect(toggle.props.accessibilityLabel).toBe('Hide page controls');
+    expect(toggle.props.accessibilityState.checked).toBe(true);
   });
 
-  it('labels the toggle "Show page controls" when the bar is hidden', () => {
+  it('renders the switch off and announces "Show page controls" when the bar is hidden', () => {
     const { getByRole } = render(<HabitsDrawer {...baseProps} barVisible={false} />);
-    expect(getByRole('button', { name: 'Show page controls' })).toBeTruthy();
+    const toggle = getByRole('switch');
+    expect(toggle.props.value).toBe(false);
+    expect(toggle.props.accessibilityLabel).toBe('Show page controls');
+    expect(toggle.props.accessibilityState.checked).toBe(false);
   });
 
-  it('fires onToggleBarVisible without closing the drawer', () => {
+  it('toggling the switch fires onToggleBarVisible without closing the drawer', () => {
     const onToggleBarVisible = jest.fn();
     const onClose = jest.fn();
     const { getByRole } = render(
@@ -240,8 +297,26 @@ describe('HabitsDrawer pagination-bar visibility toggle', () => {
         onClose={onClose}
       />,
     );
-    fireEvent.press(getByRole('button', { name: 'Hide page controls' }));
+    fireEvent(getByRole('switch'), 'valueChange', false);
     expect(onToggleBarVisible).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('HabitsDrawer row order', () => {
+  it('renders actions, reveal, the visibility switch, then the pager top-to-bottom', () => {
+    const tree = render(<HabitsDrawer {...baseProps} />).toJSON();
+    const markers: string[] = [];
+    collectRowMarkers(tree, markers);
+    expect(markers).toEqual([
+      'Quick Log',
+      'Edit',
+      'Add Habit',
+      'Energy Scaffolding',
+      'Stats',
+      'Unlock All Habits',
+      'switch',
+      'Show Habits',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Refines the Habits header drawer so it reads as one coherent panel:

- **Row order** is now by frequency of use, top to bottom: Quick Log, Edit,
  Add Habit, Energy Scaffolding, Stats, Unlock All Habits (Lock Unstarted
  Habits when all revealed), the page-controls switch, then the pager.
- **Show/Hide Page Controls** is now a labeled React Native `Switch` (the same
  idiom as `HabitSettingsModal`/`ChooseDepthsSection`) reflecting `barVisible`.
  Toggling still calls `onToggleBarVisible` and does not close the drawer. It
  carries `accessibilityRole="switch"`, a dynamic `accessibilityLabel` that
  matches its visible label (WCAG 2.5.3 Label-in-Name), `accessibilityState.checked`,
  and Candle & Ink `trackColor`/`thumbColor`.
- **Pager row** now mirrors the switch layout: a left-aligned "Show Habits"
  label with a right-aligned Prev / range / Next cluster. The range shows the
  bare en-dash range ("1–10", "11–20") while its accessibility label announces
  the page position ("Show habits 1 to 10, page 1 of 2"). Prev/Next keep their
  disabled states and "Previous page"/"Next page" labels.

Presentation-layer only: `HabitsDrawerProps` is unchanged, so `HabitsScreen`
and the out-of-scope in-body `PaginationBar` are untouched.

## Test plan

- Migrated `HabitsDrawer.test.tsx` to the new order, switch role/behavior, and
  "Show Habits" pager copy (button-role assertions → switch-role; range/a11y
  label updates), and added a new test that walks the rendered tree to pin the
  top-to-bottom row order.
- Added assertions that the switch's `accessibilityLabel` and
  `accessibilityState.checked` track the visible label at both `barVisible`
  states.
- `./scripts/frontend/check-all.sh` green: jest 4853/4853 (HabitsDrawer 25/25),
  ESLint zero warnings, tsc strict, prettier.

Closes #1890