### PR TITLE
feat(backend): add is_carryover flag to Habit for pre-program habits

### DIFF
--- a/backend/migrations/versions/c2d3e4f5a6b7_add_habit_is_carryover.py
+++ b/backend/migrations/versions/c2d3e4f5a6b7_add_habit_is_carryover.py
@@ -1,0 +1,56 @@
+"""Add habit.is_carryover pre-program flag.
+
+Revision ID: c2d3e4f5a6b7
+Revises: d9e0f1a2b3c4
+Create Date: 2026-07-10 00:00:00.000000
+
+Adds ``is_carryover`` to ``habit``: ``True`` marks a habit the user brought into
+APTITUDE from before the program (tracked on its own "negative lap" partition),
+``False`` a regular program habit. ``upgrade`` adds it NOT NULL with a temporary
+``server_default=false`` so existing rows can be inserted, then drops the DB
+server default so the app owns the default via the model's ``Field`` default
+(keeping ``alembic check`` drift-free). Existing rows stay ``False`` — accounts
+predating this feature keep every habit on the program partition. ``downgrade``
+drops the column.
+
+The column is added and the default dropped inside ``batch_alter_table`` so the
+SQLite round-trip test stays compatible with the Postgres prod target.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b7"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d9e0f1a2b3c4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``is_carryover`` (NOT NULL, default False), then drop the server default."""
+    # Add with a server_default so the NOT NULL column can be added to a table
+    # that already has rows; existing habits stay on the program partition.
+    op.add_column(
+        "habit",
+        sa.Column("is_carryover", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    # Drop the DB-level server_default (the app owns the default via the model's
+    # Field default, keeping ``alembic check`` drift-free). Batch mode keeps the
+    # ALTER SQLite-compatible for the round-trip test.
+    with op.batch_alter_table("habit") as batch_op:
+        batch_op.alter_column(
+            "is_carryover",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=None,
+        )
+
+
+def downgrade() -> None:
+    """Drop the is_carryover column."""
+    # Batch mode keeps the downgrade SQLite-compatible.
+    with op.batch_alter_table("habit") as batch_op:
+        batch_op.drop_column("is_carryover")

--- a/backend/src/models/habit.py
+++ b/backend/src/models/habit.py
@@ -20,6 +20,10 @@ class Habit(SQLModel, table=True):
     ``revealed`` back to ``False``) preserves logged completions — those live
     on the habit's goals, never on this flag — so a re-locked habit keeps its
     history for when the user unlocks it again.
+
+    ``is_carryover`` marks a habit the user brought into APTITUDE from before
+    the program: ``True`` keeps it on its own partition (tracked without
+    consuming a program stage), ``False`` a regular program habit.
     """
 
     id: int | None = Field(default=None, primary_key=True)
@@ -41,6 +45,7 @@ class Habit(SQLModel, table=True):
     stage: str = Field(default="", max_length=100)
     streak: int = 0
     revealed: bool = Field(default=False)
+    is_carryover: bool = Field(default=False)
     user: "User" = Relationship(back_populates="habits")
     goals: list["Goal"] = Relationship(
         back_populates="habit",

--- a/backend/src/schemas/habit.py
+++ b/backend/src/schemas/habit.py
@@ -42,6 +42,7 @@ class Habit(OwnedResourcePublic):
     stage: str = ""
     streak: int = 0
     revealed: bool = False
+    is_carryover: bool = False
 
 
 class HabitWithGoals(Habit):
@@ -69,3 +70,4 @@ class HabitCreate(BaseModel):
     sort_order: int | None = None
     stage: str = Field(default="", max_length=HABIT_STAGE_MAX_LENGTH)
     revealed: bool = False
+    is_carryover: bool = False

--- a/backend/tests/test_habits_api.py
+++ b/backend/tests/test_habits_api.py
@@ -1085,3 +1085,102 @@ async def test_clear_completions_scoped_to_single_habit(
     survivor = await db_session.get(GoalCompletion, b_completion_id)
     assert survivor is not None
     assert survivor.goal_id == goal_b_id
+
+
+# ── Carryover flag (pre-program habits) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_habit_without_is_carryover_defaults_false(
+    async_client: AsyncClient,
+) -> None:
+    """POST /habits/ omitting ``is_carryover`` marks the habit as a program habit."""
+    headers = await _signup(async_client, "carryover_default")
+    resp = await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["is_carryover"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_habit_with_is_carryover_true_persists(
+    async_client: AsyncClient,
+) -> None:
+    """POST /habits/ with ``is_carryover: true`` stores a pre-program habit."""
+    headers = await _signup(async_client, "carryover_true")
+    resp = await async_client.post(
+        "/habits/", json=sample_payload(is_carryover=True), headers=headers
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["is_carryover"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_habit_toggles_is_carryover(async_client: AsyncClient) -> None:
+    """PUT can move a habit into and back out of the carryover partition."""
+    headers = await _signup(async_client, "carryover_toggle")
+    create_resp = await async_client.post(
+        "/habits/", json=sample_payload(is_carryover=True), headers=headers
+    )
+    habit_id = create_resp.json()["id"]
+
+    put_resp = await async_client.put(
+        f"/habits/{habit_id}", json=sample_payload(is_carryover=False), headers=headers
+    )
+    assert put_resp.status_code == HTTPStatus.OK
+    assert put_resp.json()["is_carryover"] is False
+
+    get_resp = await async_client.get(f"/habits/{habit_id}", headers=headers)
+    assert get_resp.status_code == HTTPStatus.OK
+    assert get_resp.json()["is_carryover"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_habits_includes_is_carryover(async_client: AsyncClient) -> None:
+    """GET /habits/ list items expose the ``is_carryover`` flag."""
+    headers = await _signup(async_client, "carryover_list")
+    await async_client.post("/habits/", json=sample_payload(), headers=headers)
+    resp = await async_client.get("/habits/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    [habit] = resp.json()
+    assert habit["is_carryover"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_orders_within_each_carryover_partition(async_client: AsyncClient) -> None:
+    """Each partition (carryover vs program) stays ordered by ``sort_order`` ascending.
+
+    The frontend slices program habits into stage pages by list index, so the
+    program partition must keep its own ``sort_order`` sequence unchanged while
+    carryover habits carry a parallel sequence. Filtering the single response by
+    ``is_carryover`` must yield each partition in ascending ``sort_order``.
+    """
+    headers = await _signup(async_client, "carryover_order")
+    await async_client.post(
+        "/habits/",
+        json=sample_payload(name="Program B", sort_order=2, is_carryover=False),
+        headers=headers,
+    )
+    await async_client.post(
+        "/habits/",
+        json=sample_payload(name="Carryover Y", sort_order=2, is_carryover=True),
+        headers=headers,
+    )
+    await async_client.post(
+        "/habits/",
+        json=sample_payload(name="Program A", sort_order=1, is_carryover=False),
+        headers=headers,
+    )
+    await async_client.post(
+        "/habits/",
+        json=sample_payload(name="Carryover X", sort_order=1, is_carryover=True),
+        headers=headers,
+    )
+
+    resp = await async_client.get("/habits/", headers=headers)
+    assert resp.status_code == HTTPStatus.OK
+    habits = resp.json()
+
+    program = [h["name"] for h in habits if h["is_carryover"] is False]
+    carryover = [h["name"] for h in habits if h["is_carryover"] is True]
+    assert program == ["Program A", "Program B"]
+    assert carryover == ["Carryover X", "Carryover Y"]

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2854,3 +2854,118 @@ def test_creek_vault_write_migration_adds_and_drops_columns(
     command.upgrade(cfg, _CREEK_VAULT_WRITE_REVISION)
     cols_again = _columns_of(db_url, "journalentry")
     assert {"vault_ref", "vault_tags"}.issubset(cols_again)
+
+
+# -- negative-laps 01 habit.is_carryover column round-trip ------------------
+
+# Revision anchors for the ``habit.is_carryover`` migration round-trip. The
+# base is the current single head; the implementer sets the second anchor to
+# the real revision ID of the migration they author.
+_HABIT_CARRYOVER_BASE_REVISION = "d9e0f1a2b3c4"  # pragma: allowlist secret
+_HABIT_CARRYOVER_REVISION = "c2d3e4f5a6b7"  # pragma: allowlist secret
+
+
+def _bootstrap_habit_table(sync_url: str) -> None:
+    """Pre-create a minimal ``habit`` table for the round-trip fixture.
+
+    Mirrors the schema in place just before the ``is_carryover`` migration,
+    without pulling in every preceding migration. One legacy row is seeded so
+    the additive column's backfill-to-default can be observed.
+    """
+    bootstrap_engine = create_engine(sync_url)
+    with bootstrap_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE habit ("
+                " id INTEGER PRIMARY KEY,"
+                " name VARCHAR(255) NOT NULL,"
+                " icon VARCHAR(100) NOT NULL,"
+                " start_date DATE NOT NULL,"
+                " energy_cost INTEGER NOT NULL,"
+                " energy_return INTEGER NOT NULL,"
+                " user_id INTEGER NOT NULL,"
+                " milestone_notifications BOOLEAN NOT NULL DEFAULT 0,"
+                " sort_order INTEGER,"
+                " stage VARCHAR(100) NOT NULL DEFAULT '',"
+                " streak INTEGER NOT NULL DEFAULT 0,"
+                " revealed BOOLEAN NOT NULL DEFAULT 0"
+                ")"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO habit"
+                " (id, name, icon, start_date, energy_cost, energy_return, user_id)"
+                " VALUES (1, 'Legacy', '*', '2024-01-01', 1, 2, 1)"
+            )
+        )
+    bootstrap_engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_habit_carryover(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config positioned just before the ``is_carryover`` migration."""
+    db_path = tmp_path / "habit_carryover_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_habit_table(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _HABIT_CARRYOVER_BASE_REVISION)
+    return cfg
+
+
+def _habit_row(db_url: str, habit_id: int) -> dict[str, Any]:
+    """Fetch a single ``habit`` row including the ``is_carryover`` column."""
+    engine = create_engine(_sync_url(db_url))
+    try:
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text("SELECT id, is_carryover FROM habit WHERE id = :id"),
+                    {"id": habit_id},
+                )
+                .mappings()
+                .first()
+            )
+            assert row is not None
+            return dict(row)
+    finally:
+        engine.dispose()
+
+
+def test_habit_carryover_migration_round_trip_on_sqlite(
+    alembic_sqlite_config_habit_carryover: Config,
+) -> None:
+    """Round-trip ``is_carryover``: upgrade adds the column defaulting False; downgrade drops it.
+
+    Phase 1: upgrade adds ``is_carryover`` NOT NULL and the pre-existing legacy
+    row reads back ``False`` (the program-habit default).
+    Phase 2: downgrade removes the column.
+    Phase 3: re-upgrade is idempotent.
+    """
+    cfg = alembic_sqlite_config_habit_carryover
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    # Phase 1: upgrade adds the column; the legacy row defaults to a program habit.
+    command.upgrade(cfg, _HABIT_CARRYOVER_REVISION)
+    assert "is_carryover" in _columns_of(db_url, "habit")
+    assert bool(_habit_row(db_url, habit_id=1)["is_carryover"]) is False
+
+    # Phase 2: downgrade removes the column.
+    command.downgrade(cfg, _HABIT_CARRYOVER_BASE_REVISION)
+    assert "is_carryover" not in _columns_of(db_url, "habit")
+
+    # Phase 3: re-upgrade reproduces the additive column (idempotent cycle).
+    command.upgrade(cfg, _HABIT_CARRYOVER_REVISION)
+    assert "is_carryover" in _columns_of(db_url, "habit")
+    assert bool(_habit_row(db_url, habit_id=1)["is_carryover"]) is False


### PR DESCRIPTION
## Summary
Adds an `is_carryover: bool` (default `False`) field to `Habit` so habits a user brings into APTITUDE from before the program can be distinguished from program habits and tracked on their own partition without consuming a program stage.

- **Model** (`backend/src/models/habit.py`): new `is_carryover: bool = Field(default=False)`.
- **Schemas** (`backend/src/schemas/habit.py`): the flag round-trips through the public `Habit` schema, `HabitWithGoals` (inherited), and `HabitCreate` (used for both create and PUT/update); omitted on create → `False`.
- **Router**: no change needed — `create_habit` passes `model_dump()` to the constructor, `update_habit` setattrs every `HabitCreate` field, and the existing `sort_order`-ascending list ordering already keeps each partition internally ordered (filtering a globally-sorted list by the flag yields a still-sorted subsequence), so program-habit ordering is unchanged.
- **Migration** (`c2d3e4f5a6b7_add_habit_is_carryover.py`): additive; adds the column NOT NULL with a temporary server default then drops the default so the app owns it (drift-free), leaving existing rows on the program partition. Chains onto the single current head `d9e0f1a2b3c4`. Reversible downgrade.

No frontend changes (sibling issues cover the Habits screen). `sort_order` sign and `stage` string are not repurposed.

## Test plan
- `test_create_habit_without_is_carryover_defaults_false` / `_with_is_carryover_true_persists` — create with and without the flag.
- `test_update_habit_toggles_is_carryover` — PUT toggles it and it round-trips through a subsequent GET.
- `test_list_habits_includes_is_carryover` / `test_list_orders_within_each_carryover_partition` — list exposes the flag and each partition (carryover vs program) stays ordered by `sort_order` when the two partitions share overlapping `sort_order` values.
- `test_habit_carryover_migration_round_trip_on_sqlite` — upgrade adds the column (legacy row → `False`), downgrade drops it, re-upgrade is idempotent.
- Full `./scripts/backend/check-all.sh` green (2969 passed, 96.90% coverage); xenon/radon A-grade; pre-commit clean on all changed files.

Refs #1891
Closes #1892