### PR TITLE
fix(map): bound begin-again promise to mounted lifecycle

### DIFF
--- a/frontend/src/features/Map/__tests__/MapScreen.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreen.test.tsx
@@ -347,16 +347,27 @@ describe('MapScreen', () => {
     expect(btn).toBeTruthy();
   });
 
-  it('pressing begin-again-button calls stageService.beginAgain', () => {
+  it('pressing begin-again-button calls stageService.beginAgain', async () => {
     mockMapState.isEndOfCycle = jest.fn<boolean, [Record<number, { progress: number }>, number]>(
       () => true,
     );
-    mockBeginAgain.mockResolvedValue(undefined);
+    // Deferred handshake: settle the request inside act so the guard's
+    // finally-time setState lands while mounted, leaking no post-test microtask.
+    let resolveBeginAgain: () => void = () => {};
+    mockBeginAgain.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveBeginAgain = resolve;
+      }),
+    );
     const tree = create(<MapScreen />);
     act(() => {
       tree.root.findByProps({ testID: 'begin-again-button' }).props.onPress();
     });
     expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveBeginAgain();
+      await Promise.resolve();
+    });
   });
 
   it('double-pressing begin-again-button sends exactly one request', () => {

--- a/frontend/src/features/Map/hooks/__tests__/useBeginAgainGuard.test.tsx
+++ b/frontend/src/features/Map/hooks/__tests__/useBeginAgainGuard.test.tsx
@@ -1,0 +1,119 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import type { useBeginAgainGuard as UseBeginAgainGuard } from '../useBeginAgainGuard';
+
+type RealUseState = (_initial: unknown) => [unknown, (_next: unknown) => void];
+
+// When armed, record every state dispatch so the unmount-guard test can assert
+// that no dispatch reaches the hook after teardown — the one signal React 18
+// leaves observable (a post-unmount setState is otherwise a silent no-op).
+let mockUnmountTrackingArmed = false;
+const mockPostUnmountDispatches: unknown[] = [];
+
+function mockWrapUseState(realUseState: unknown): (_initial: unknown) => [unknown, unknown] {
+  const useStateFn = realUseState as RealUseState;
+  return (initial) => {
+    const [value, setValue] = useStateFn(initial);
+    const trackedSetValue = (next: unknown): void => {
+      if (mockUnmountTrackingArmed) mockPostUnmountDispatches.push(next);
+      setValue(next);
+    };
+    return [value, trackedSetValue];
+  };
+}
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react') as Record<string, unknown>;
+  return { ...actual, useState: mockWrapUseState(actual.useState) };
+});
+
+const mockBeginAgain = jest.fn() as jest.MockedFunction<(_token?: string) => Promise<void>>;
+jest.mock('../../services/stageService', () => ({
+  stageService: {
+    beginAgain: (...a: unknown[]) =>
+      (mockBeginAgain as unknown as (...x: unknown[]) => unknown)(...a),
+  },
+}));
+
+const { useBeginAgainGuard } = require('../useBeginAgainGuard') as {
+  useBeginAgainGuard: typeof UseBeginAgainGuard;
+};
+
+let resolveBeginAgain: () => void = () => {};
+
+beforeEach(() => {
+  mockBeginAgain.mockReset();
+  resolveBeginAgain = () => {};
+  mockBeginAgain.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveBeginAgain = resolve;
+      }),
+  );
+  mockUnmountTrackingArmed = false;
+  mockPostUnmountDispatches.length = 0;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useBeginAgainGuard', () => {
+  it('flips beginning true while in flight and back to false once resolved while mounted', async () => {
+    const { result } = renderHook(() => useBeginAgainGuard());
+    expect(result.current.beginning).toBe(false);
+
+    act(() => {
+      result.current.handleBeginAgain();
+    });
+    expect(result.current.beginning).toBe(true);
+    expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveBeginAgain();
+      await Promise.resolve();
+    });
+    expect(result.current.beginning).toBe(false);
+  });
+
+  it('sends exactly one beginAgain request for a same-tick double press', async () => {
+    const { result } = renderHook(() => useBeginAgainGuard());
+
+    act(() => {
+      result.current.handleBeginAgain();
+      result.current.handleBeginAgain();
+    });
+    expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveBeginAgain();
+      await Promise.resolve();
+    });
+  });
+
+  it('skips the state update when the promise settles after unmount', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, unmount } = renderHook(() => useBeginAgainGuard());
+
+    act(() => {
+      result.current.handleBeginAgain();
+    });
+    expect(mockBeginAgain).toHaveBeenCalledTimes(1);
+
+    unmount();
+    mockUnmountTrackingArmed = true;
+
+    await act(async () => {
+      resolveBeginAgain();
+      await Promise.resolve();
+    });
+
+    expect(mockPostUnmountDispatches).toHaveLength(0);
+    const lifecycleWarnings = consoleErrorSpy.mock.calls.filter((call) =>
+      /unmounted|not wrapped in act/i.test(String(call[0])),
+    );
+    expect(lifecycleWarnings).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/Map/hooks/useBeginAgainGuard.ts
+++ b/frontend/src/features/Map/hooks/useBeginAgainGuard.ts
@@ -1,6 +1,6 @@
 /** Ref-guarded single-flight begin-again: blocks same-tick double-press, state drives disabled UI. */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { stageService } from '../services/stageService';
 
@@ -11,6 +11,18 @@ export function useBeginAgainGuard(): { beginning: boolean; handleBeginAgain: ()
   const [beginning, setBeginning] = useState(false);
   const beginningRef = useRef(false);
 
+  // The begin-again POST is fire-and-forget: unmounting the Map screen while it
+  // is in flight must not land setBeginning on a torn-down component. This guard
+  // skips the settle-time state update after unmount, mirroring ContentViewer's
+  // mark-read handler, without changing the happy-path behaviour.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const handleBeginAgain = useCallback(() => {
     // Ref guard blocks a same-tick double-press; state drives the disabled UI.
     if (beginningRef.current) return;
@@ -18,6 +30,7 @@ export function useBeginAgainGuard(): { beginning: boolean; handleBeginAgain: ()
     setBeginning(true);
     void stageService.beginAgain().finally(() => {
       beginningRef.current = false;
+      if (!isMountedRef.current) return;
       setBeginning(false);
     });
   }, []);


### PR DESCRIPTION
## Summary

`useBeginAgainGuard`'s fire-and-forget `stageService.beginAgain().finally(() => setBeginning(false))` had no mounted-lifecycle guard. Unmounting the Map screen while the begin-again POST was in flight landed `setBeginning` on a torn-down component, leaking a post-teardown microtask that surfaced as Jest's `A worker process has failed to exit gracefully` warning under parallel workers (the same escape class as the #1843 teardown leak).

Changes:
- Add an `isMountedRef` guard to `useBeginAgainGuard` so the `.finally`-time `setBeginning(false)` is skipped after unmount — mirroring `ContentViewer`'s mark-read handler, with `ChapterReader`'s reset-on-mount defensiveness (StrictMode-safe). The mounted happy path is unchanged.
- Add a regression test pinning the unmount-before-resolution path via a `useState` dispatch tracker (an observable assertion, not a silent no-op), plus mounted happy-path and double-press coverage.
- Convert the existing `MapScreen` begin-again test to a deferred-promise handshake so it awaits the settled promise inside `act()` and leaks no post-test microtask.

No suppression, no `forceExit`.

## Test plan

- `npx jest src/features/Map/hooks/__tests__/useBeginAgainGuard.test.tsx` — RED without the guard (tracker records the post-unmount `[false]` dispatch), GREEN with it.
- Repeated parallel-worker runs (`npx jest src/features/Map --maxWorkers=2`, x3) — 24 Map suites / 412 tests pass with no `failed to exit gracefully` warning.
- `./scripts/frontend/check-all.sh` — green (lint, prettier, typecheck, tests all pass).

Note: the full-repo suite still emits one `failed to exit gracefully` warning, but it traces to the Habits notification-timer domain (`useHabitNotifications`), unrelated to this change and pre-existing — out of scope here.

Closes #1851