### PR TITLE
feat(habits): render negative carryover laps (-10 to -1) with full-lap gating

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -887,6 +887,8 @@ export interface ApiHabit {
   // Persisted unlock flag (revealed === unlocked). Optional so fixtures/payloads
   // predating the column still typecheck; the live backend always sends it.
   revealed?: boolean;
+  // Carryover flag (negative-lap habits). Optional for legacy fixtures/payloads.
+  is_carryover?: boolean;
 }
 
 export interface ApiHabitWithGoals extends ApiHabit {
@@ -972,6 +974,7 @@ export function toLocalHabit(apiHabit: ApiHabitWithGoals): LocalHabit {
     })),
     completions: flattenGoalCompletions(apiHabit.goals),
     revealed: apiHabit.revealed,
+    is_carryover: apiHabit.is_carryover,
     notificationTimes: apiHabit.notification_times ?? undefined,
     notificationFrequency: isNotificationFrequency(apiHabit.notification_frequency)
       ? apiHabit.notification_frequency

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -197,6 +197,10 @@ export const habitSchema = z.object({
   // payloads captured before the column shipped still validate; the live
   // backend always sends it.
   revealed: z.boolean().optional(),
+  // Carryover flag (habit predates the program, shown on negative laps).
+  // Optional on the wire so payloads captured before the column shipped
+  // still validate.
+  is_carryover: z.boolean().optional(),
 });
 
 export const habitWithGoalsSchema = habitSchema.extend({

--- a/frontend/src/features/Habits/HabitUtils.ts
+++ b/frontend/src/features/Habits/HabitUtils.ts
@@ -21,28 +21,90 @@ export { STAGE_ORDER };
 // Re-export so existing call sites stay valid; canonical definition lives in src/constants/program.ts.
 export { STAGE_DURATIONS_DAYS };
 
+/** Number of Spiral-Dynamics stages — one full lap of the gradient. */
+const STAGE_COUNT = STAGE_ORDER.length;
+
 /**
- * Map a habit's zero-based list index to its Spiral-Dynamics stage. Wraps with
- * `% STAGE_ORDER.length` so positions past the tenth cycle back to Beige, and
- * falls back to the final stage when the index cannot resolve — the single
- * source of truth for the index-based stage coloring shared by the Habits
- * screen, the reorder modals, and the onboarding flow.
+ * Map a habit's list slot to its Spiral-Dynamics stage. Wraps with a Euclidean
+ * modulo so positions past the tenth cycle back to Beige and negative
+ * carryover slots wrap backwards from the final stage (slot -1 → Clear Light).
+ * The Euclidean result is always a valid `[0, STAGE_COUNT)` index, so the `??`
+ * is a defensive no-op kept only to narrow the indexed type. The single source
+ * of truth for the slot-based stage coloring shared by the Habits screen, the
+ * reorder modals, and the onboarding flow.
  */
-export const stageAtIndex = (index: number): string =>
-  STAGE_ORDER[index % STAGE_ORDER.length] ?? STAGE_ORDER[STAGE_ORDER.length - 1]!;
+export const stageAtIndex = (index: number): string => {
+  const wrapped = ((index % STAGE_COUNT) + STAGE_COUNT) % STAGE_COUNT;
+  return STAGE_ORDER[wrapped] ?? STAGE_ORDER[STAGE_COUNT - 1]!;
+};
 
 /**
  * 1-based inclusive stage bounds for a habits page/lap: page 0 → stages 1..10,
- * page 1 → 11..20, and so on. Drives the pagination bar's stage-range label and
- * the second-lap invite copy so both name the stretch of stages a page covers.
+ * page 1 → 11..20, and so on. Negative pages produce sign-mirrored carryover
+ * ranges (page -1 → -10..-1, page -2 → -20..-11). Drives the pagination bar's
+ * stage-range label and the lap-invite copy so both name the span a page covers.
  */
 export const stageRangeForPage = (
   page: number,
   pageSize: number,
-): { start: number; end: number } => ({
-  start: page * pageSize + 1,
-  end: (page + 1) * pageSize,
-});
+): { start: number; end: number } => {
+  if (page < 0) {
+    const lap = -page;
+    return { start: -pageSize * lap, end: -(pageSize * lap - (pageSize - 1)) };
+  }
+  return { start: page * pageSize + 1, end: (page + 1) * pageSize };
+};
+
+/** Signed display slot for the nth carryover habit: index 0 → slot -1, the sign-mirror of positive slot 1. */
+export const carryoverSlot = (carryoverIndex: number): number => -(carryoverIndex + 1);
+
+/** Range label text: negative carryover ranges read "-10 to -1"; positive program ranges keep the en-dash. */
+export const formatStageRange = (start: number, end: number): string =>
+  start < 0 || end < 0 ? `${start} to ${end}` : `${start}–${end}`;
+
+/** Number of habits flagged as carryover — sizes the negative lap span. */
+export const countCarryover = (habits: Habit[]): number =>
+  habits.filter((h) => h.is_carryover === true).length;
+
+/** A habit paired with its original position in the flat habits list. */
+interface IndexedHabit {
+  habit: Habit;
+  flatIndex: number;
+}
+
+const partitionByCarryover = (
+  allHabits: Habit[],
+): { program: IndexedHabit[]; carryover: IndexedHabit[] } => {
+  const program: IndexedHabit[] = [];
+  const carryover: IndexedHabit[] = [];
+  allHabits.forEach((habit, flatIndex) => {
+    (habit.is_carryover === true ? carryover : program).push({ habit, flatIndex });
+  });
+  return { program, carryover };
+};
+
+/**
+ * Page view-model for the signed Habits grid. Negative pages slice the
+ * carryover partition onto mirrored negative color slots; non-negative pages
+ * slice the program partition onto its 0-based slots. `flatIndices` are each
+ * habit's true position in `allHabits` (the seam icon editing writes through),
+ * while `colorIndices` are the signed display slots the gradient reads.
+ */
+export const buildPagedHabits = (
+  allHabits: Habit[],
+  page: number,
+  pageSize: number,
+): { habits: Habit[]; flatIndices: number[]; colorIndices: number[] } => {
+  const { program, carryover } = partitionByCarryover(allHabits);
+  const negative = page < 0;
+  const offset = (negative ? -page - 1 : page) * pageSize;
+  const sliced = (negative ? carryover : program).slice(offset, offset + pageSize);
+  return {
+    habits: sliced.map((entry) => entry.habit),
+    flatIndices: sliced.map((entry) => entry.flatIndex),
+    colorIndices: sliced.map((_, j) => (negative ? carryoverSlot(offset + j) : offset + j)),
+  };
+};
 
 /**
  * Calculate the start date for a habit based on its order in the onboarding

--- a/frontend/src/features/Habits/Habits.types.ts
+++ b/frontend/src/features/Habits/Habits.types.ts
@@ -26,6 +26,8 @@ export interface Habit {
    * "unordered" — the backend buckets nulls last in ascending sort.
    */
   sort_order?: number | null;
+  /** Carryover habits predate the program and render on negative laps. */
+  is_carryover?: boolean;
 
   // --- Client-only fields (not from API) ---
   completions?: Completion[];

--- a/frontend/src/features/Habits/HabitsScreen.tsx
+++ b/frontend/src/features/Habits/HabitsScreen.tsx
@@ -26,7 +26,10 @@ import HabitTile, { useTileLayout } from './HabitTile';
 import {
   generateStatsForHabit,
   toLocalHabitStats,
+  buildPagedHabits,
   calculateMissedDays,
+  countCarryover,
+  formatStageRange,
   isHabitUnlocked,
   stageAtIndex,
   stageRangeForPage,
@@ -293,6 +296,11 @@ interface PaginationBarProps {
   scale: number;
   stageStart?: number;
   stageEnd?: number;
+  /** Signed-page bounds flags; legacy callers omit them and fall back to 0-based math. */
+  canPrev?: boolean;
+  canNext?: boolean;
+  /** 1-based position within the signed page span (page - minPage + 1). */
+  pagePosition?: number;
 }
 
 export const PaginationBar = ({
@@ -303,9 +311,10 @@ export const PaginationBar = ({
   scale,
   stageStart,
   stageEnd,
+  canPrev = page > 0,
+  canNext = page < pageCount - 1,
+  pagePosition = page + 1,
 }: PaginationBarProps) => {
-  const canPrev = page > 0;
-  const canNext = page < pageCount - 1;
   const textSize = { fontSize: spacing(1.75, scale) };
   // The visible label names the stage range this page covers; the page position
   // (redundant for sighted users who read the range) is folded into this same
@@ -313,7 +322,8 @@ export const PaginationBar = ({
   // label lives on the Text — an accessibility element — rather than the
   // container, whose own accessibleLabel would be swallowed by its focusable
   // children.
-  const positionLabel = `Stages ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
+  const rangeText = formatStageRange(stageStart!, stageEnd!);
+  const positionLabel = `Stages ${rangeText}, page ${pagePosition} of ${pageCount}`;
   return (
     <View style={styles.paginationBar} testID="habits-pagination">
       <TouchableOpacity
@@ -332,7 +342,7 @@ export const PaginationBar = ({
         testID="pagination-label"
         accessibilityLabel={positionLabel}
       >
-        Stages {stageStart}–{stageEnd}
+        Stages {rangeText}
       </Text>
       <TouchableOpacity
         testID="pagination-next"
@@ -423,7 +433,8 @@ const useHabitTileRenderer = (
   actions: ReturnType<typeof useHabits>['actions'],
   setSelectedHabit: (_h: Habit) => void,
   tz: string,
-  pageOffset = 0,
+  flatIndices: number[],
+  colorIndices: number[],
 ) => {
   const { handleOpenGoals, handleLongPress, handleIconPress } = useTileHandlers(
     mode,
@@ -437,12 +448,14 @@ const useHabitTileRenderer = (
       // Unlock is governed solely by the persisted ``revealed`` flag — locked by
       // default, opened only when the user chooses. Stage/calendar never gate it.
       const isLocked = !isHabitUnlocked(item);
-      const globalIndex = pageOffset + index;
-      // Anchor the tile color to its global position, not the page-relative one:
-      // the mod-wrap inside stageAtIndex (over STAGE_ORDER's length) is what
-      // restarts the Beige → Clear Light gradient on each lap, so a full first
-      // lap and the second lap paint identically without page math here.
-      const stageColor = STAGE_COLORS[stageAtIndex(globalIndex)]!;
+      // globalIndex is the habit's true flat-list position — it drives icon
+      // editing into that array. colorIndex is the signed display slot
+      // (negative on carryover laps): stageAtIndex's Euclidean mod-wrap restarts
+      // the Beige → Clear Light gradient on each lap and mirrors it backwards
+      // on negative laps, so every lap paints consistently.
+      const globalIndex = flatIndices[index] ?? index;
+      const colorIndex = colorIndices[index] ?? index;
+      const stageColor = STAGE_COLORS[stageAtIndex(colorIndex)]!;
       return (
         <HabitTile
           habit={item}
@@ -458,7 +471,16 @@ const useHabitTileRenderer = (
         />
       );
     },
-    [pageOffset, tz, handleOpenGoals, handleLongPress, handleIconPress, unlockHabit, logUnit],
+    [
+      flatIndices,
+      colorIndices,
+      tz,
+      handleOpenGoals,
+      handleLongPress,
+      handleIconPress,
+      unlockHabit,
+      logUnit,
+    ],
   );
   return renderHabitTile;
 };
@@ -585,6 +607,9 @@ const HabitsBody = ({
         scale={pagination.scale}
         stageStart={pagination.stageStart}
         stageEnd={pagination.stageEnd}
+        canPrev={pagination.canPrev}
+        canNext={pagination.canNext}
+        pagePosition={pagination.pagePosition}
       />
     )}
   </>
@@ -626,24 +651,31 @@ export const HabitsContent = ({
   );
 };
 
+/**
+ * Range-aware empty-state bounds for the current page. Page 0 keeps the plain
+ * first-run guidance (undefined bounds); trailing (positive) and leading
+ * (negative) invite pages name the stage span they cover.
+ */
+const lapInviteRange = (page: number): { start?: number; end?: number } => {
+  if (page === 0) return { start: undefined, end: undefined };
+  return stageRangeForPage(page, HABITS_PER_PAGE);
+};
+
 const useHabitsScreenState = () => {
   const habitsReturn = useHabits();
   const modals = useModalCoordinator();
   const habitStats = useHabitStats(modals.stats, habitsReturn.selectedHabit);
   const responsive = useResponsive();
   const { userTimezone } = useAuth();
-  const pagination = usePagination(habitsReturn.habits.length, HABITS_PER_PAGE);
-  // Lap-aware empty-state copy applies only beyond the first page: page 0 keeps
-  // the plain first-run guidance, while a trailing invite page names its stages.
-  const isLapInvitePage = pagination.page > 0;
-  const lapRange = stageRangeForPage(pagination.page, HABITS_PER_PAGE);
-  const emptyStageStart = isLapInvitePage ? lapRange.start : undefined;
-  const emptyStageEnd = isLapInvitePage ? lapRange.end : undefined;
-  const pageOffset = pagination.page * HABITS_PER_PAGE;
-  const pagedHabits = useMemo(
-    () => habitsReturn.habits.slice(pageOffset, pageOffset + HABITS_PER_PAGE),
-    [habitsReturn.habits, pageOffset],
+  const carryoverCount = countCarryover(habitsReturn.habits);
+  const programCount = habitsReturn.habits.length - carryoverCount;
+  const pagination = usePagination(programCount, HABITS_PER_PAGE, carryoverCount);
+  const { start: emptyStageStart, end: emptyStageEnd } = lapInviteRange(pagination.page);
+  const paged = useMemo(
+    () => buildPagedHabits(habitsReturn.habits, pagination.page, HABITS_PER_PAGE),
+    [habitsReturn.habits, pagination.page],
   );
+  const pagedHabits = paged.habits;
   const handleSelectMode = useSelectMode(habitsReturn.setMode, modals.closeAll);
   const renderHabitTile = useHabitTileRenderer(
     habitsReturn.mode,
@@ -651,7 +683,8 @@ const useHabitsScreenState = () => {
     habitsReturn.actions,
     habitsReturn.setSelectedHabit,
     userTimezone,
-    pageOffset,
+    paged.flatIndices,
+    paged.colorIndices,
   );
   const reveal = useToggleReveal(habitsReturn.habits, habitsReturn.actions, modals.closeAll);
   /**
@@ -682,6 +715,10 @@ const useHabitsScreenState = () => {
   };
 };
 
+/** 1-based position of the current page within the signed span, for screen readers. */
+const pagePositionOf = (pagination: ReturnType<typeof usePagination>): number =>
+  pagination.page - pagination.minPage + 1;
+
 const buildPaginationProps = (
   pagination: ReturnType<typeof usePagination>,
   scale: number,
@@ -696,6 +733,9 @@ const buildPaginationProps = (
     scale,
     stageStart: start,
     stageEnd: end,
+    canPrev: pagination.canPrev,
+    canNext: pagination.canNext,
+    pagePosition: pagePositionOf(pagination),
   };
 };
 
@@ -758,6 +798,9 @@ const HabitsScreenDrawer = ({
         pageCount={pagination.pageCount}
         onPrev={pagination.goPrev}
         onNext={pagination.goNext}
+        canPrev={pagination.canPrev}
+        canNext={pagination.canNext}
+        pagePosition={pagePositionOf(pagination)}
         stageStart={drawerRange.start}
         stageEnd={drawerRange.end}
         barVisible={barVisible}

--- a/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
+++ b/frontend/src/features/Habits/__tests__/HabitUtils.test.ts
@@ -22,6 +22,10 @@ import {
   calculateHabitStartDate,
   stageAtIndex,
   stageRangeForPage,
+  carryoverSlot,
+  formatStageRange,
+  countCarryover,
+  buildPagedHabits,
   STAGE_ORDER,
   STAGE_DURATIONS_DAYS,
 } from '../HabitUtils';
@@ -1365,5 +1369,123 @@ describe('stageAtIndex global anchoring contract for the second habit set', () =
 
   test('index 11 anchors to the second stage, matching the second tile of the second lap', () => {
     expect(stageAtIndex(11)).toBe(STAGE_ORDER[1]);
+  });
+});
+
+describe('stageAtIndex signed (Euclidean) wrap for negative carryover slots', () => {
+  test('slot -1 anchors to the final stage and slot -10 to the first', () => {
+    expect(stageAtIndex(-1)).toBe(STAGE_ORDER[9]);
+    expect(stageAtIndex(-10)).toBe(STAGE_ORDER[0]);
+  });
+
+  test('slot -9 resolves via Euclidean modulo, not the undefined fallback', () => {
+    // The final-stage fallback coincides with the right answer at -1/-11; -9
+    // is the discriminating slot (fallback says Clear Light, Euclidean Purple).
+    expect(stageAtIndex(-9)).toBe(STAGE_ORDER[1]);
+  });
+
+  test('slot -11 wraps into the deeper negative lap', () => {
+    expect(stageAtIndex(-11)).toBe(STAGE_ORDER[9]);
+  });
+});
+
+describe('stageRangeForPage signed pages', () => {
+  test('page -1 covers slots -10 through -1', () => {
+    expect(stageRangeForPage(-1, 10)).toEqual({ start: -10, end: -1 });
+  });
+
+  test('page -2 covers slots -20 through -11', () => {
+    expect(stageRangeForPage(-2, 10)).toEqual({ start: -20, end: -11 });
+  });
+});
+
+describe('carryoverSlot', () => {
+  test('mirrors the nth carryover habit to the matching negative slot', () => {
+    expect(carryoverSlot(0)).toBe(-1);
+    expect(carryoverSlot(1)).toBe(-2);
+    expect(carryoverSlot(9)).toBe(-10);
+    expect(carryoverSlot(10)).toBe(-11);
+  });
+});
+
+describe('formatStageRange', () => {
+  test('positive ranges use an en-dash', () => {
+    expect(formatStageRange(1, 10)).toBe('1–10');
+    expect(formatStageRange(11, 20)).toBe('11–20');
+  });
+
+  test('negative ranges use the word "to"', () => {
+    expect(formatStageRange(-10, -1)).toBe('-10 to -1');
+    expect(formatStageRange(-20, -11)).toBe('-20 to -11');
+  });
+});
+
+type CarryoverHabit = Habit & { is_carryover?: boolean };
+
+const makePagedHabit = (id: number, isCarryover: boolean): CarryoverHabit => ({
+  id,
+  name: `H${id}`,
+  icon: 'x',
+  stage: 'Beige',
+  streak: 0,
+  energy_cost: 0,
+  energy_return: 0,
+  start_date: new Date(2020, 0, 1),
+  goals: [],
+  completions: [],
+  ...(isCarryover ? { is_carryover: true } : {}),
+});
+
+describe('countCarryover', () => {
+  test('counts only habits flagged is_carryover', () => {
+    const habits = [
+      makePagedHabit(1, false),
+      makePagedHabit(2, true),
+      makePagedHabit(3, false),
+      makePagedHabit(4, true),
+      makePagedHabit(5, false),
+    ];
+    expect(countCarryover(habits)).toBe(2);
+  });
+
+  test('returns 0 when no habit carries the flag or the list is empty', () => {
+    expect(countCarryover([makePagedHabit(1, false)])).toBe(0);
+    expect(countCarryover([])).toBe(0);
+  });
+});
+
+describe('buildPagedHabits', () => {
+  // Interspersed order: carryover habits sit between program habits, so
+  // program-relative positions and original flat indices differ.
+  const mixed = [
+    makePagedHabit(1, false),
+    makePagedHabit(2, true),
+    makePagedHabit(3, false),
+    makePagedHabit(4, true),
+    makePagedHabit(5, false),
+  ];
+
+  test('page 0 returns program habits with program-position colors and true flat indices', () => {
+    const result = buildPagedHabits(mixed, 0, 10);
+    expect(result.habits.map((h: Habit) => h.id)).toEqual([1, 3, 5]);
+    // flatIndices are original positions in the full list (icon editing seam),
+    // not program-relative positions.
+    expect(result.flatIndices).toEqual([0, 2, 4]);
+    expect(result.colorIndices).toEqual([0, 1, 2]);
+  });
+
+  test('page -1 returns carryover habits with negative slots and true flat indices', () => {
+    const result = buildPagedHabits(mixed, -1, 10);
+    expect(result.habits.map((h: Habit) => h.id)).toEqual([2, 4]);
+    expect(result.flatIndices).toEqual([1, 3]);
+    expect(result.colorIndices).toEqual([-1, -2]);
+  });
+
+  test('page -2 slices the second carryover lap with deeper negative slots', () => {
+    const many = Array.from({ length: 24 }, (_, i) => makePagedHabit(i + 1, i % 2 === 0));
+    const result = buildPagedHabits(many, -2, 10);
+    expect(result.habits.map((h: Habit) => h.id)).toEqual([21, 23]);
+    expect(result.flatIndices).toEqual([20, 22]);
+    expect(result.colorIndices).toEqual([-11, -12]);
   });
 });

--- a/frontend/src/features/Habits/__tests__/HabitsNegativeLaps.test.tsx
+++ b/frontend/src/features/Habits/__tests__/HabitsNegativeLaps.test.tsx
@@ -1,0 +1,264 @@
+/* eslint-env jest */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Carryover habits render on signed negative laps ("-10 to -1", then
+// "-20 to -11") that sit before the positive program lap 1-10; a deeper
+// negative lap opens only when the shallower one holds exactly ten carryover
+// habits (leading-invite mirror of the trailing invite page).
+import { jest, describe, afterEach, it, expect } from '@jest/globals';
+import React from 'react';
+import { Text } from 'react-native';
+import renderer from 'react-test-renderer';
+
+import type * as ApiModule from '../../../api';
+import { STAGE_COLORS } from '../../../design/tokens';
+
+const makeApiHabit = (id: number, overrides: Record<string, unknown> = {}) => ({
+  id,
+  name: `Habit ${id}`,
+  icon: '✨',
+  start_date: '2020-01-01',
+  energy_cost: 1,
+  energy_return: 2,
+  stage: 'Beige',
+  streak: 0,
+  goals: [
+    {
+      id: id * 100,
+      habit_id: id,
+      title: 'Clear',
+      tier: 'clear',
+      target: 1,
+      target_unit: 'u',
+      frequency: 1,
+      frequency_unit: 'per_day',
+      is_additive: true,
+    },
+  ],
+  ...overrides,
+});
+
+const buildProgramHabits = (count: number) =>
+  Array.from({ length: count }, (_, i) => makeApiHabit(i + 1, { sort_order: i }));
+
+const CARRYOVER_ID_BASE = 100;
+
+const buildCarryoverHabits = (count: number, sortBase = 0) =>
+  Array.from({ length: count }, (_, i) =>
+    makeApiHabit(CARRYOVER_ID_BASE + i, { sort_order: sortBase + i, is_carryover: true }),
+  );
+
+// HabitsScreen installs its header-left toggle via useAppNavigation; mock the
+// navigation hooks so the screen renders outside a real NavigationContainer.
+jest.mock('@/navigation/hooks', () => ({
+  useAppNavigation: () => ({ setOptions: jest.fn() }),
+}));
+
+jest.mock('../../../api', () => {
+  // Keep the real ``toLocalHabit`` mapper the load path delegates to; stub only
+  // the network namespaces this screen exercises.
+  const actual: typeof ApiModule = jest.requireActual('../../../api');
+  return {
+    ...actual,
+    // useHabitUI hydrates the energy-CTA flag server-first via uiFlags.get.
+    uiFlags: {
+      get: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+      update: jest.fn(() =>
+        Promise.resolve({
+          has_seen_welcome: false,
+          energy_scaffolding_archived: false,
+        }),
+      ),
+    },
+    habits: {
+      listAll: jest.fn() as any,
+      create: jest.fn() as any,
+      update: jest.fn() as any,
+      delete: jest.fn() as any,
+      getStats: (jest.fn() as any).mockResolvedValue({
+        day_labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        values: [0, 0, 0, 0, 0, 0, 0],
+        completions_by_day: [0, 0, 0, 0, 0, 0, 0],
+        longest_streak: 0,
+        current_streak: 0,
+        total_completions: 0,
+        completion_rate: 0,
+        completion_dates: [],
+      }),
+    },
+    goalCompletions: { create: jest.fn() as any },
+  };
+});
+
+jest.mock('../../../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: (jest.fn() as any).mockResolvedValue({ status: 'granted' }),
+  requestPermissionsAsync: jest.fn() as any,
+  scheduleNotificationAsync: jest.fn() as any,
+  cancelScheduledNotificationAsync: jest.fn() as any,
+  getExpoPushTokenAsync: (jest.fn() as any).mockResolvedValue({ data: 'token' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => {
+  const ReactLib = require('react');
+  return {
+    SafeAreaView: ({ children }: { children: any }) =>
+      ReactLib.createElement(ReactLib.Fragment, null, children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  };
+});
+
+jest.mock('../components/AddHabitModal', () => () => null);
+jest.mock('../components/GoalModal', () => () => null);
+jest.mock('../components/HabitSettingsModal', () => () => null);
+jest.mock('../components/MissedDaysModal', () => () => null);
+jest.mock('../components/OnboardingModal', () => () => null);
+jest.mock('../components/ReorderHabitsModal', () => () => null);
+jest.mock('../components/StatsModal', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+const { habits: habitsApi } = require('../../../api');
+const HabitsScreen = require('../HabitsScreen').default;
+
+const renderScreen = async (apiHabits: Array<ReturnType<typeof makeApiHabit>>) => {
+  habitsApi.listAll.mockResolvedValue(apiHabits);
+  jest
+    .spyOn(require('react-native'), 'useWindowDimensions')
+    .mockReturnValue({ width: 400, height: 800, scale: 1, fontScale: 1 });
+  let testRenderer: any;
+  await renderer.act(async () => {
+    testRenderer = renderer.create(React.createElement(HabitsScreen));
+  });
+  await renderer.act(async () => {
+    await Promise.resolve();
+  });
+  return testRenderer;
+};
+
+const hasTestId = (tree: any, testID: string): boolean =>
+  tree.findAllByProps({ testID }).length > 0;
+
+const visibleTextMatches = (tree: any, pattern: RegExp): boolean =>
+  tree.findAllByType(Text).some((node: any) => {
+    const children = node.props.children;
+    const text = Array.isArray(children) ? children.join('') : String(children ?? '');
+    return pattern.test(text);
+  });
+
+const uniqueTiles = (tree: any): any[] => {
+  // TouchableOpacity forwards testID through wrapper layers; filter to the
+  // composite root so each tile counts exactly once.
+  const { TouchableOpacity } = require('react-native');
+  return tree
+    .findAllByType(TouchableOpacity)
+    .filter((node: any) => node.props.testID === 'habit-tile');
+};
+
+const tileBorderAt = (tree: any, index: number): string => {
+  const tile = uniqueTiles(tree)[index];
+  const style = Array.isArray(tile.props.style)
+    ? tile.props.style.reduce((acc: any, s: any) => ({ ...acc, ...s }), {})
+    : tile.props.style;
+  return style.borderColor as string;
+};
+
+const paginationButton = (tree: any, testID: string): any => {
+  const { TouchableOpacity } = require('react-native');
+  return tree.findAllByType(TouchableOpacity).find((node: any) => node.props.testID === testID);
+};
+
+const pressPrev = async (tree: any) => {
+  const prev = paginationButton(tree, 'pagination-prev');
+  expect(prev).toBeDefined();
+  await renderer.act(async () => {
+    prev.props.onPress();
+  });
+};
+
+describe('Habits screen negative carryover laps', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the program lap first, then Prev steps onto the -10 to -1 carryover lap', async () => {
+    const apiHabits = [
+      makeApiHabit(1, { sort_order: 0 }),
+      makeApiHabit(101, { sort_order: 1, is_carryover: true }),
+      makeApiHabit(2, { sort_order: 2 }),
+      makeApiHabit(102, { sort_order: 3, is_carryover: true }),
+      makeApiHabit(3, { sort_order: 4 }),
+    ];
+    const testRenderer = await renderScreen(apiHabits);
+    const tree = testRenderer.root;
+
+    // Initial render is the program lap: three program tiles, no negative range.
+    expect(visibleTextMatches(tree, /Stages\s*1[\s\S]*10/)).toBe(true);
+    expect(visibleTextMatches(tree, /-10 to -1/)).toBe(false);
+    expect(uniqueTiles(tree)).toHaveLength(3);
+
+    await pressPrev(tree);
+
+    expect(visibleTextMatches(tree, /-10 to -1/)).toBe(true);
+    expect(uniqueTiles(tree)).toHaveLength(2);
+  });
+
+  it('keeps Prev disabled on page 0 when there are no carryover habits', async () => {
+    const testRenderer = await renderScreen(buildProgramHabits(10));
+    const tree = testRenderer.root;
+
+    expect(hasTestId(tree, 'habits-pagination')).toBe(true);
+    const prev = paginationButton(tree, 'pagination-prev');
+    expect(prev.props.accessibilityState.disabled).toBe(true);
+    expect(visibleTextMatches(tree, /-10 to -1/)).toBe(false);
+  });
+
+  it('opens a -20 to -11 leading-invite lap when exactly ten carryover habits fill the first negative lap', async () => {
+    const testRenderer = await renderScreen(buildCarryoverHabits(10));
+    const tree = testRenderer.root;
+
+    await pressPrev(tree);
+    expect(visibleTextMatches(tree, /-10 to -1/)).toBe(true);
+    expect(uniqueTiles(tree)).toHaveLength(10);
+
+    await pressPrev(tree);
+    expect(visibleTextMatches(tree, /-20 to -11/)).toBe(true);
+    expect(hasTestId(tree, 'habits-empty-state')).toBe(true);
+  });
+
+  it('does not open a deeper lap for a partial carryover lap: Prev is disabled on -10 to -1', async () => {
+    const apiHabits = [...buildProgramHabits(2), ...buildCarryoverHabits(3, 2)];
+    const testRenderer = await renderScreen(apiHabits);
+    const tree = testRenderer.root;
+
+    await pressPrev(tree);
+    expect(visibleTextMatches(tree, /-10 to -1/)).toBe(true);
+
+    const prev = paginationButton(tree, 'pagination-prev');
+    expect(prev.props.accessibilityState.disabled).toBe(true);
+    expect(visibleTextMatches(tree, /-20 to -11/)).toBe(false);
+  });
+
+  it('paints the negative lap with the re-anchored gradient: slot -1 Clear Light, slot -10 Beige', async () => {
+    // Every API habit is stage Beige; position-based coloring must override it.
+    const testRenderer = await renderScreen(buildCarryoverHabits(10));
+    const tree = testRenderer.root;
+
+    await pressPrev(tree);
+    expect(uniqueTiles(tree)).toHaveLength(10);
+
+    expect(tileBorderAt(tree, 0)).toBe(STAGE_COLORS['Clear Light']);
+    expect(tileBorderAt(tree, 9)).toBe(STAGE_COLORS.Beige);
+
+    const borders = uniqueTiles(tree).map((_: any, i: number) => tileBorderAt(tree, i));
+    expect(new Set(borders).size).toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/features/Habits/components/HabitsDrawer.tsx
+++ b/frontend/src/features/Habits/components/HabitsDrawer.tsx
@@ -24,6 +24,8 @@ import {
   useWindowDimensions,
 } from 'react-native';
 
+import { formatStageRange } from '../HabitUtils';
+
 import ConfirmDialog from './ConfirmDialog';
 
 import { DrawerItem } from '@/components/drawer';
@@ -44,6 +46,11 @@ export interface HabitsDrawerProps {
   pageCount: number;
   onPrev: () => void;
   onNext: () => void;
+  /** Signed-page bounds flags; legacy callers omit them and fall back to 0-based math. */
+  canPrev?: boolean;
+  canNext?: boolean;
+  /** 1-based position within the signed page span (page - minPage + 1). */
+  pagePosition?: number;
   stageStart: number;
   stageEnd: number;
   barVisible: boolean;
@@ -169,6 +176,9 @@ interface PaginationSectionProps {
   pageCount: number;
   onPrev: () => void;
   onNext: () => void;
+  canPrev?: boolean;
+  canNext?: boolean;
+  pagePosition?: number;
   stageStart: number;
   stageEnd: number;
 }
@@ -176,19 +186,22 @@ interface PaginationSectionProps {
 /**
  * The "Show Habits" pager row: static label on the left, then a right-aligned
  * Prev/range/Next cluster whose range label also announces the page position.
+ * Signed callers pass explicit bounds flags and a 1-based page position;
+ * legacy callers omit them and fall back to the 0-based math.
  */
 function PaginationSection({
   page,
   pageCount,
   onPrev,
   onNext,
+  canPrev = page > 0,
+  canNext = page < pageCount - 1,
+  pagePosition = page + 1,
   stageStart,
   stageEnd,
 }: PaginationSectionProps): React.JSX.Element {
   const { width } = useWindowDimensions();
-  const canPrev = page > 0;
-  const canNext = page < pageCount - 1;
-  const positionLabel = `Show habits ${stageStart} to ${stageEnd}, page ${page + 1} of ${pageCount}`;
+  const positionLabel = `Show habits ${stageStart} to ${stageEnd}, page ${pagePosition} of ${pageCount}`;
   return (
     <View style={styles.settingRow} testID="drawer-pagination">
       <Text style={[type(width).body, styles.rowLabel]}>Show Habits</Text>
@@ -209,7 +222,7 @@ function PaginationSection({
           accessibilityLabel={positionLabel}
           testID="drawer-pagination-label"
         >
-          {stageStart}–{stageEnd}
+          {formatStageRange(stageStart, stageEnd)}
         </Text>
         <TouchableOpacity
           onPress={onNext}
@@ -248,6 +261,9 @@ export default function HabitsDrawer(props: HabitsDrawerProps): React.JSX.Elemen
         pageCount={props.pageCount}
         onPrev={props.onPrev}
         onNext={props.onNext}
+        canPrev={props.canPrev}
+        canNext={props.canNext}
+        pagePosition={props.pagePosition}
         stageStart={props.stageStart}
         stageEnd={props.stageEnd}
       />

--- a/frontend/src/features/Habits/components/HabitsEmptyState.tsx
+++ b/frontend/src/features/Habits/components/HabitsEmptyState.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { colors, radius, spacing, touchTarget } from '../../../design/tokens';
+import { formatStageRange } from '../HabitUtils';
 
 interface HabitsEmptyStateProps {
   /** When provided, renders an "Add a habit" CTA wired to the add-habit modal. */
@@ -23,14 +24,15 @@ const FIRST_RUN_COPY: EmptyStateCopy = {
 };
 
 /**
- * Copy for the empty state. With a stage range supplied (any lap past the
- * first), it names the newly-open stages as a gentle, declinable invitation to
- * start another set — never a nudge. Otherwise it keeps the first-run guidance.
+ * Copy for the empty state. With a stage range supplied (any lap besides the
+ * program's first, negative carryover laps included), it names the newly-open
+ * stages as a gentle, declinable invitation to start another set — never a
+ * nudge. Otherwise it keeps the first-run guidance.
  */
 const selectCopy = (stageStart?: number, stageEnd?: number): EmptyStateCopy =>
   stageStart !== undefined && stageEnd !== undefined
     ? {
-        title: `Stages ${stageStart}–${stageEnd} are open`,
+        title: `Stages ${formatStageRange(stageStart, stageEnd)} are open`,
         subtitle:
           'Begin a new set whenever it feels right — no pressure either way, or simply keep tending the habits you already have.',
       }

--- a/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
+++ b/frontend/src/features/Habits/hooks/__tests__/usePagination.test.ts
@@ -150,3 +150,62 @@ describe('usePagination trailing invite page', () => {
     expect(result.current.page).toBe(1);
   });
 });
+
+// Signed pagination: carryover habits live on negative laps before the program
+// lap. A deeper negative lap opens only when the shallower lap is exactly full
+// (leading-invite mirror of the trailing invite page).
+describe('usePagination signed carryover laps', () => {
+  it('keeps minPage at 0 and the bounds flags when carryoverCount is 0', () => {
+    const { result } = renderHook(() => usePagination(23, PAGE_SIZE, 0));
+    expect(result.current.pageCount).toBe(3);
+    expect(result.current.minPage).toBe(0);
+    expect(result.current.maxPage).toBe(2);
+    expect(result.current.canPrev).toBe(false);
+    expect(result.current.canNext).toBe(true);
+  });
+
+  it('exposes a leading carryover lap alongside the trailing invite page', () => {
+    const { result } = renderHook(() => usePagination(10, PAGE_SIZE, 3));
+    expect(result.current.page).toBe(0);
+    expect(result.current.maxPage).toBe(1);
+    expect(result.current.minPage).toBe(-1);
+    expect(result.current.pageCount).toBe(3);
+    expect(result.current.canPrev).toBe(true);
+    expect(result.current.canNext).toBe(true);
+  });
+
+  it('opens a deeper leading-invite lap only when the shallower lap holds exactly a full page', () => {
+    expect(renderHook(() => usePagination(0, PAGE_SIZE, 10)).result.current.minPage).toBe(-2);
+    expect(renderHook(() => usePagination(0, PAGE_SIZE, 11)).result.current.minPage).toBe(-2);
+    expect(renderHook(() => usePagination(0, PAGE_SIZE, 3)).result.current.minPage).toBe(-1);
+    expect(renderHook(() => usePagination(0, PAGE_SIZE, 0)).result.current.minPage).toBe(0);
+  });
+
+  it('goPrev steps progressively down to minPage and clamps there', () => {
+    const { result } = renderHook(() => usePagination(10, PAGE_SIZE, 10));
+    expect(result.current.minPage).toBe(-2);
+    expect(result.current.page).toBe(0);
+    act(() => result.current.goPrev());
+    expect(result.current.page).toBe(-1);
+    expect(result.current.canPrev).toBe(true);
+    act(() => result.current.goPrev());
+    expect(result.current.page).toBe(-2);
+    expect(result.current.canPrev).toBe(false);
+    act(() => result.current.goPrev());
+    expect(result.current.page).toBe(-2);
+  });
+
+  it('goNext clamps at maxPage with canNext false', () => {
+    const { result } = renderHook(() => usePagination(10, PAGE_SIZE, 3));
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(1);
+    expect(result.current.canNext).toBe(false);
+    act(() => result.current.goNext());
+    expect(result.current.page).toBe(1);
+  });
+
+  it('starts on the program lap (page 0) even when negative laps exist', () => {
+    expect(renderHook(() => usePagination(5, PAGE_SIZE, 5)).result.current.page).toBe(0);
+    expect(renderHook(() => usePagination(10, PAGE_SIZE, 10)).result.current.page).toBe(0);
+  });
+});

--- a/frontend/src/features/Habits/hooks/usePagination.ts
+++ b/frontend/src/features/Habits/hooks/usePagination.ts
@@ -1,57 +1,83 @@
 import { useCallback, useRef, useState } from 'react';
 
 /**
- * Window a list into fixed-size pages. The setters never advance the internal
- * `page` above `pageCount - 1` (`goNext` caps it, `goLast` targets the last
- * content page, `goPrev` only decreases), so `goPrev`/`goNext` always step
- * relative to a valid index.
- * The read site additionally clamps `page` to guard the one case the setters
- * cannot: `habitCount` shrinking beneath the stored index without a setter call
- * (e.g. items are removed) — resolving it on the next read without an extra
- * render.
+ * Window habits into fixed-size **signed** pages. Non-negative pages hold the
+ * program habits (page 0 is stages 1..pageSize); negative pages hold the
+ * carryover habits that predate the program, sitting before page 0. The
+ * setters clamp to `[minPage, maxPage]`, and the read site additionally clamps
+ * `page` to guard the one case the setters cannot: a count shrinking beneath
+ * the stored index without a setter call — resolving it on the next read
+ * without an extra render.
  *
- * When the last lap is completely full (`habitCount` is a positive exact
- * multiple of `pageSize`) the count grows by one trailing **invite page**: an
- * extra navigable empty page that lets the user start the next lap. `goNext`
- * can step onto it, but `goLast` deliberately does not — it retargets to the
- * last *content* page (the page holding the final item), so appending a new
- * item lands the user on the row they just created rather than the empty
+ * When the last program lap is completely full (`programCount` is a positive
+ * exact multiple of `pageSize`) `maxPage` grows by one trailing **invite
+ * page**: an extra navigable empty page that lets the user start the next lap.
+ * The negative side mirrors this with a **leading invite**: a full carryover
+ * lap opens one deeper empty negative lap. `goNext` can step onto the trailing
+ * invite, but `goLast` deliberately does not — it retargets to the last
+ * program *content* page (the page holding the final item), so appending a new
+ * habit lands the user on the row they just created rather than the empty
  * invitation beyond it.
  */
 export interface PaginationState {
-  /** Clamped current page (0-based). */
+  /** Clamped current page (signed; 0 is the first program page). */
   page: number;
-  /** Number of pages (always >= 1). */
+  /** Total navigable pages, negative laps included (always >= 1). */
   pageCount: number;
+  /** Deepest navigable negative lap (0 when there are no carryover habits). */
+  minPage: number;
+  /** Last navigable positive page, trailing invite included. */
+  maxPage: number;
+  /** Whether `goPrev` can still step down. */
+  canPrev: boolean;
+  /** Whether `goNext` can still step up. */
+  canNext: boolean;
   goPrev: () => void;
   goNext: () => void;
   goLast: () => void;
 }
 
-export const usePagination = (habitCount: number, pageSize: number): PaginationState => {
-  const contentPages = Math.max(1, Math.ceil(habitCount / pageSize));
-  const hasInvitePage = habitCount > 0 && habitCount % pageSize === 0;
-  const pageCount = contentPages + (hasInvitePage ? 1 : 0);
+export const usePagination = (
+  programCount: number,
+  pageSize: number,
+  carryoverCount = 0,
+): PaginationState => {
+  const contentPages = Math.max(1, Math.ceil(programCount / pageSize));
+  const hasTrailingInvite = programCount > 0 && programCount % pageSize === 0;
+  const maxPage = contentPages - 1 + (hasTrailingInvite ? 1 : 0);
+
+  const negContentLaps = carryoverCount > 0 ? Math.ceil(carryoverCount / pageSize) : 0;
+  const hasLeadingInvite = carryoverCount > 0 && carryoverCount % pageSize === 0;
+  const negLaps = negContentLaps + (hasLeadingInvite ? 1 : 0);
+  // Guard against negating zero: `-0` fails `Object.is`/`toBe(0)` equality.
+  const minPage = negLaps === 0 ? 0 : -negLaps;
+
+  const pageCount = maxPage - minPage + 1;
   const [page, setPage] = useState(0);
 
-  // Track the live count in a ref so `goLast` reads it at call time rather than
-  // closing over a stale render. The add flow appends a habit and then calls
-  // `goLast` from a callback captured before the append re-rendered; without
-  // the ref that callback would target the pre-append last page and strand the
-  // user on the wrong lap instead of the row they just created.
-  const countRef = useRef(habitCount);
-  countRef.current = habitCount;
+  // Track the live program count in a ref so `goLast` reads it at call time
+  // rather than closing over a stale render. The add flow appends a habit and
+  // then calls `goLast` from a callback captured before the append re-rendered;
+  // without the ref that callback would target the pre-append last page and
+  // strand the user on the wrong lap instead of the row they just created.
+  const countRef = useRef(programCount);
+  countRef.current = programCount;
 
-  const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), []);
-  const goNext = useCallback(() => setPage((p) => Math.min(pageCount - 1, p + 1)), [pageCount]);
+  const goPrev = useCallback(() => setPage((p) => Math.max(minPage, p - 1)), [minPage]);
+  const goNext = useCallback(() => setPage((p) => Math.min(maxPage, p + 1)), [maxPage]);
   const goLast = useCallback(
     () => setPage(Math.floor(Math.max(0, countRef.current - 1) / pageSize)),
     [pageSize],
   );
 
+  const clampedPage = Math.min(Math.max(page, minPage), maxPage);
   return {
-    page: Math.min(page, pageCount - 1),
+    page: clampedPage,
     pageCount,
+    minPage,
+    maxPage,
+    canPrev: clampedPage > minPage,
+    canNext: clampedPage < maxPage,
     goPrev,
     goNext,
     goLast,


### PR DESCRIPTION
## Summary

Extends the Habits screen's lap pagination to **signed pages** so habits with `is_carryover: true` render on their own negative laps ("-10 to -1", then "-20 to -11", ...) that sit *before* the program's 1-10 lap. This keeps program laps aligned to APTITUDE stages for users who brought pre-program habits into the app. Program (non-carryover) behavior is unchanged.

- Threads optional `is_carryover` through `habitSchema` (zod), `ApiHabit`, `toLocalHabit`, and the local `Habit` type — optional, mirroring `revealed`.
- `usePagination` becomes signed: `(programCount, pageSize, carryoverCount = 0)` returning `minPage`/`maxPage`/`canPrev`/`canNext`. A deeper negative lap opens only when the shallower one holds a full page — a **leading-invite mirror** of the existing positive trailing invite. With `carryoverCount = 0` the behavior is byte-for-byte the old one.
- `stageAtIndex` now wraps with Euclidean modulo, so negative carryover slots paint the Beige → Clear Light gradient (slot -1 → Clear Light, slot -10 → Beige) instead of falling through to the undefined-fallback final stage. `stageRangeForPage` returns sign-mirrored ranges; new pure helpers `carryoverSlot`, `formatStageRange`, `countCarryover`, and `buildPagedHabits`.
- `buildPagedHabits` partitions carryover from program while **preserving each habit's flat-array index** (the load-bearing seam that keeps icon editing targeting the right habit); the coloring slot is a separate signed index.
- `PaginationBar` and the drawer pager label negative laps with their signed range ("-10 to -1", "-20 to -11") and retain their accessibility labels/roles/state. Initial page remains the first program lap.

Slot 0 never exists — the negative ranges are the exact sign-mirror of the positive ones. The add-carryover-habit flow is intentionally left to its sibling issue; this PR renders whatever the API returns.

## Test plan

- New `HabitsNegativeLaps.test.tsx` (screen-level): initial page is the program lap; Prev steps onto the "-10 to -1" carryover lap; Prev is disabled at page 0 with zero carryover; the -20 to -11 leading-invite lap opens only at exactly ten carryover habits; negative-lap tiles paint the re-anchored gradient (slot -1 Clear Light, slot -10 Beige, not all one color).
- Extended `HabitUtils.test.ts`: Euclidean `stageAtIndex` for negative indices, signed `stageRangeForPage`, `carryoverSlot`, `formatStageRange`, `countCarryover`, and `buildPagedHabits` (true flat-index vs signed color-index divergence, including an interspersed carryover fixture).
- Extended `usePagination.test.ts`: signed bounds, leading-invite gating, `canPrev`/`canNext`, backward-compat with `carryoverCount = 0`. Existing positive-lap tests untouched and green.
- Full `./scripts/frontend/check-all.sh` passes (4890 jest tests, ESLint zero-warning, prettier, strict tsc).

Closes #1893
Refs #1891