### PR TITLE
fix(habits): bound notification bootstrap to mounted lifecycle

### DIFF
--- a/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
+++ b/frontend/src/features/Habits/__tests__/OnboardingNextStepsAlert.test.tsx
@@ -65,19 +65,24 @@ jest.mock('expo-notifications', () => ({
 }));
 
 describe('Onboarding completion', () => {
+  let root: ReturnType<typeof renderer.create> | undefined;
+
   beforeEach(() => {
     jest.useFakeTimers();
   });
 
   afterEach(() => {
+    // Unmount so HabitsScreen's bootstrap effect cleanup aborts the in-flight
+    // push-registration retry; otherwise its delay timer escapes the worker.
     renderer.act(() => {
+      root?.unmount();
       jest.runOnlyPendingTimers();
     });
     jest.useRealTimers();
+    root = undefined;
   });
 
   it('shows next steps toast after saving habits', async () => {
-    let root: ReturnType<typeof renderer.create>;
     await renderer.act(async () => {
       root = renderer.create(
         <ToastProvider>

--- a/frontend/src/features/Habits/__tests__/useHabitNotifications.test.ts
+++ b/frontend/src/features/Habits/__tests__/useHabitNotifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import * as Notifications from 'expo-notifications';
 
 import * as notifStorage from '../../../storage/notificationStorage';
@@ -152,6 +152,34 @@ describe('registerForPushNotificationsAsync retry behavior', () => {
     expect(token).toBeUndefined();
     expect(mockNotifications.getPermissionsAsync).toHaveBeenCalledTimes(3);
     jest.useRealTimers();
+  });
+});
+
+describe('registerForPushNotificationsAsync abort behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('cancels the retry wait when aborted, making no second attempt', async () => {
+    mockStorage.loadPushToken.mockResolvedValue(null);
+    mockNotifications.getPermissionsAsync.mockRejectedValue(new Error('always fails'));
+
+    const controller = new AbortController();
+    const promise = registerForPushNotificationsAsync(controller.signal);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(mockNotifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    await jest.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token).toBeUndefined();
+    expect(mockNotifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -399,6 +427,47 @@ describe('reconcileNotifications', () => {
     mockStorage.loadAllNotificationMappings.mockRejectedValue(new Error('storage error'));
 
     await expect(reconcileNotifications()).resolves.toBeUndefined();
+  });
+});
+
+describe('reconcileNotifications abort short-circuit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNotifications.cancelScheduledNotificationAsync.mockResolvedValue(undefined);
+  });
+
+  it('skips orphan cleanup and record rewrites when aborted mid-flight', async () => {
+    mockStorage.loadAllNotificationMappings.mockResolvedValue({ 1: ['a'] });
+    let resolveScheduled: (scheduled: Array<{ identifier: string }>) => void = () => {};
+    mockNotifications.getAllScheduledNotificationsAsync.mockReturnValue(
+      new Promise<Array<{ identifier: string }>>((resolve) => {
+        resolveScheduled = resolve;
+      }),
+    );
+
+    const controller = new AbortController();
+    const promise = reconcileNotifications(controller.signal);
+    controller.abort();
+    resolveScheduled([{ identifier: 'a' }, { identifier: 'orphan-1' }]);
+    await promise;
+
+    expect(mockNotifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+    expect(mockStorage.saveNotificationIds).not.toHaveBeenCalled();
+    expect(mockStorage.clearNotificationIds).not.toHaveBeenCalled();
+  });
+
+  it('still cancels orphans when the provided signal never aborts', async () => {
+    mockStorage.loadAllNotificationMappings.mockResolvedValue({ 1: ['a'] });
+    mockNotifications.getAllScheduledNotificationsAsync.mockResolvedValue([
+      { identifier: 'a' },
+      { identifier: 'orphan-1' },
+    ]);
+
+    const controller = new AbortController();
+    await reconcileNotifications(controller.signal);
+
+    expect(mockNotifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('orphan-1');
+    expect(mockNotifications.cancelScheduledNotificationAsync).not.toHaveBeenCalledWith('a');
   });
 });
 

--- a/frontend/src/features/Habits/hooks/__tests__/useHabitsBootstrap.test.tsx
+++ b/frontend/src/features/Habits/hooks/__tests__/useHabitsBootstrap.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useBootstrapHabits } from '../useHabits';
+
+const mockRegister = jest.fn<(signal?: AbortSignal) => Promise<string | undefined>>();
+const mockReconcile = jest.fn<(signal?: AbortSignal) => Promise<void>>();
+let mockResolveReconcile: () => void = () => {};
+
+jest.mock('../useHabitNotifications', () => ({
+  registerForPushNotificationsAsync: (signal?: AbortSignal) => mockRegister(signal),
+  reconcileNotifications: (signal?: AbortSignal) => mockReconcile(signal),
+}));
+
+jest.mock('../../services/habitManager', () => ({
+  habitManager: {
+    loadHabits: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+beforeEach(() => {
+  mockRegister.mockResolvedValue(undefined);
+  mockReconcile.mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        mockResolveReconcile = resolve;
+      }),
+  );
+});
+
+describe('useBootstrapHabits lifecycle', () => {
+  it('aborts the in-flight notification work when the hook unmounts', async () => {
+    const { unmount } = renderHook(() => useBootstrapHabits('UTC'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+    const signal = mockReconcile.mock.calls[0]?.[0];
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(mockRegister.mock.calls[0]?.[0]).toBe(signal);
+
+    unmount();
+    expect(signal?.aborted).toBe(true);
+
+    await act(async () => {
+      mockResolveReconcile();
+      await Promise.resolve();
+    });
+  });
+});

--- a/frontend/src/features/Habits/hooks/useHabitNotifications.ts
+++ b/frontend/src/features/Habits/hooks/useHabitNotifications.ts
@@ -14,16 +14,39 @@ import type { Habit } from '../Habits.types';
 const MAX_REGISTRATION_RETRIES = 3;
 const REGISTRATION_RETRY_DELAY_MS = 30_000;
 
-const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const isAborted = (signal?: AbortSignal): boolean => signal?.aborted ?? false;
 
-export const registerForPushNotificationsAsync = async (): Promise<string | undefined> => {
+// Cancelable delay: aborting resolves immediately and clears the pending timer.
+const wait = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (isAborted(signal)) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+
+export const registerForPushNotificationsAsync = async (
+  signal?: AbortSignal,
+): Promise<string | undefined> => {
   const cached = await loadPushToken();
   if (cached) return cached;
 
-  return attemptPushRegistration(0);
+  return attemptPushRegistration(0, signal);
 };
 
-const attemptPushRegistration = async (attempt: number): Promise<string | undefined> => {
+const attemptPushRegistration = async (
+  attempt: number,
+  signal?: AbortSignal,
+): Promise<string | undefined> => {
   try {
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
     let finalStatus = existingStatus;
@@ -40,11 +63,20 @@ const attemptPushRegistration = async (attempt: number): Promise<string | undefi
   } catch (error) {
     console.error(`Push registration attempt ${attempt + 1} failed:`, error);
     if (attempt < MAX_REGISTRATION_RETRIES - 1) {
-      await wait(REGISTRATION_RETRY_DELAY_MS);
-      return attemptPushRegistration(attempt + 1);
+      return retryAfterDelay(attempt, signal);
     }
     return undefined;
   }
+};
+
+const retryAfterDelay = async (
+  attempt: number,
+  signal?: AbortSignal,
+): Promise<string | undefined> => {
+  if (isAborted(signal)) return undefined;
+  await wait(REGISTRATION_RETRY_DELAY_MS, signal);
+  if (isAborted(signal)) return undefined;
+  return attemptPushRegistration(attempt + 1, signal);
 };
 
 const buildDailyTrigger = (hours: number, minutes: number): Notifications.DailyTriggerInput => ({
@@ -170,11 +202,14 @@ const scheduleAllTimes = async (habit: Habit): Promise<string[]> => {
   return notificationIds;
 };
 
-export const reconcileNotifications = async (): Promise<void> => {
+export const reconcileNotifications = async (signal?: AbortSignal): Promise<void> => {
   try {
+    if (isAborted(signal)) return;
     const persisted = await loadAllNotificationMappings();
     const allPersistedIds = new Set(Object.values(persisted).flat());
     const scheduled = await Notifications.getAllScheduledNotificationsAsync();
+    // Abort mid-flight (e.g. unmount) must not cancel or rewrite anything.
+    if (isAborted(signal)) return;
     const scheduledIds = new Set(scheduled.map((n) => n.identifier));
 
     // Cancel orphaned notifications (scheduled on device but not in our records)

--- a/frontend/src/features/Habits/hooks/useHabits.ts
+++ b/frontend/src/features/Habits/hooks/useHabits.ts
@@ -10,7 +10,7 @@ import { useHabitActions } from './useHabitActions';
 import { registerForPushNotificationsAsync, reconcileNotifications } from './useHabitNotifications';
 import { useHabitUI } from './useHabitUI';
 
-const useBootstrapHabits = (userTimezone: string): void => {
+export const useBootstrapHabits = (userTimezone: string): void => {
   // Runs twice on cold start (UTC default, then the auth-hydrated zone).
   // The second fetch is intentional, not a bug: day buckets and queued
   // check-in replay days both depend on the zone (#269).
@@ -18,8 +18,13 @@ const useBootstrapHabits = (userTimezone: string): void => {
     void habitManager.loadHabits(userTimezone);
   }, [userTimezone]);
   useEffect(() => {
-    void registerForPushNotificationsAsync();
-    void reconcileNotifications();
+    // Abort on unmount so in-flight notification work cannot mutate stale state.
+    const controller = new AbortController();
+    void registerForPushNotificationsAsync(controller.signal);
+    void reconcileNotifications(controller.signal);
+    return () => {
+      controller.abort();
+    };
   }, []);
 };
 


### PR DESCRIPTION
## Summary

`useBootstrapHabits` fired `registerForPushNotificationsAsync()` and `reconcileNotifications()` fire-and-forget on mount with no lifecycle guard. On a push-registration failure the retry path armed a **real 30s `setTimeout`** (`wait(REGISTRATION_RETRY_DELAY_MS)`) that outlived the Jest test worker — the last remaining `A worker process has failed to exit gracefully` warning under parallel workers, and the final member of the #1843/#1851 async-escape family.

Changes:
- Thread an optional `AbortSignal` through `registerForPushNotificationsAsync` and `reconcileNotifications`. `wait` is now cancelable (aborting clears the pending timer and resolves immediately); an `isAborted` guard short-circuits the retry before/after the delay and skips the reconcile cancel/rewrite work after unmount.
- `useBootstrapHabits` creates an `AbortController` in the notification effect and `abort()`s it on unmount — mirroring PR #1901's `useBeginAgainGuard` and `src/api/index.ts`'s AbortController idiom. Export it for unit testing.
- `OnboardingNextStepsAlert.test.tsx` (the sole suite that armed the retry timer, via a bare `getPermissionsAsync: jest.fn()` returning `undefined`) now unmounts its `react-test-renderer` root in teardown so the abort actually fires — RTL auto-cleanup does not apply to raw `renderer.create()` roots.
- Regression tests pin the unmount-before-settle path: reconcile short-circuit on abort, retry-timer cancellation on abort (observable via a single `getPermissionsAsync` call), and hook-level unmount-aborts-in-flight-work (asserting `signal.aborted`).

No suppression, no `forceExit`.

## Test plan

- `npx jest src/features/Habits/__tests__/useHabitNotifications.test.ts src/features/Habits/hooks/__tests__/useHabitsBootstrap.test.tsx` — RED before the fix, GREEN after (30 tests).
- Repeated **full-repo parallel** runs (`npx jest`, x3) — 434 suites / 4873 tests pass with **zero** `failed to exit gracefully` warnings (was exactly one, traced to the Habits notification retry timer).
- `./scripts/frontend/check-all.sh` — green (lint, prettier, typecheck, tests).

Scope is kept tight to the notifications hook + its tests; no overlap with the concurrent #1893 Habits-screen work.

Closes #1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)