### PR TITLE
feat(practice): player identity header — stage chip and customize pencil

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -17,13 +17,16 @@
  *   - `ActiveRitualSession` owns the engine, mode dispatch, configurator
  *     sheet, and the ritual-12 insight capture modal when a practice is
  *     active.
+ *   - `PracticeIdentityHeader` pins the player identity (title, tappable
+ *     stage chip, effective ritual name, customize pencil) to the top region
+ *     and collapses to the title alone while a session runs.
  *
  * When no practice is set for the stage the screen shows a minimal dark
  * empty state whose only action opens the catalog.
  */
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -53,6 +56,8 @@ import ActiveRitualSession, {
   type ActiveRitualSessionHandle,
 } from '@/features/Practice/components/ActiveRitualSession';
 import PracticeDrawer from '@/features/Practice/components/PracticeDrawer';
+import PracticeIdentityHeader from '@/features/Practice/components/PracticeIdentityHeader';
+import type { RitualState } from '@/features/Practice/engine/types';
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
 import { useAppRoute } from '@/navigation/hooks';
@@ -88,7 +93,12 @@ function useFocusRefresh(refresh: (_opts?: { silent?: boolean }) => Promise<void
 }
 
 const PracticeScreen = (): React.JSX.Element => {
-  const stageNumber = useResolvedStageNumber();
+  const resolvedStage = useResolvedStageNumber();
+  // A stage picked from the identity header's chip overrides the derived
+  // stage locally; route params and the stage store stay untouched so other
+  // screens keep their own resolution.
+  const [stageOverride, setStageOverride] = useState<number | null>(null);
+  const stageNumber = stageOverride ?? resolvedStage;
   const { userTimezone } = useAuth();
   const active = useActivePractice(stageNumber);
   const weekly = useWeeklyProgress();
@@ -96,6 +106,9 @@ const PracticeScreen = (): React.JSX.Element => {
   useFocusRefresh(active.refresh);
   const drawer = useScreenDrawer('Practice');
   const sessionRef = useRef<ActiveRitualSessionHandle>(null);
+  const openConfigurator = useCallback(() => {
+    sessionRef.current?.openConfigurator();
+  }, []);
 
   const hasActivePractice = Boolean(
     active.activeUserPractice && active.practice && active.effectiveConfig,
@@ -110,13 +123,15 @@ const PracticeScreen = (): React.JSX.Element => {
         onWriteReflection={handleWriteReflection}
         stageNumber={stageNumber}
         sessionRef={sessionRef}
+        onStageChange={setStageOverride}
+        onCustomize={openConfigurator}
       />
       <PracticeScreenDrawer
         drawer={drawer}
         hasActivePractice={hasActivePractice}
         stageNumber={stageNumber}
         practiceId={active.practice?.id}
-        onCustomize={() => sessionRef.current?.openConfigurator()}
+        onCustomize={openConfigurator}
       />
     </>
   );
@@ -129,6 +144,8 @@ interface PracticeBodyProps {
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
   stageNumber: number;
   sessionRef: React.Ref<ActiveRitualSessionHandle>;
+  onStageChange: (_stage: number) => void;
+  onCustomize: () => void;
 }
 
 // Selects the screen body for the current load state: a loading/error
@@ -141,6 +158,8 @@ const PracticeBody = ({
   onWriteReflection,
   stageNumber,
   sessionRef,
+  onStageChange,
+  onCustomize,
 }: PracticeBodyProps): React.JSX.Element => {
   if (active.isLoading) return <LoadingView />;
   if (active.error && !active.activeUserPractice) {
@@ -157,7 +176,10 @@ const PracticeBody = ({
         weekly={weekly}
         onUserPracticeUpdated={active.updateActivePractice}
         onWriteReflection={onWriteReflection}
+        stageNumber={stageNumber}
         sessionRef={sessionRef}
+        onStageChange={onStageChange}
+        onCustomize={onCustomize}
       />
     );
   }
@@ -238,14 +260,21 @@ interface ActiveSessionViewProps {
   weekly: WeeklyProgressHook;
   onUserPracticeUpdated: ActivePracticeHook['updateActivePractice'];
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
+  stageNumber: number;
   sessionRef?: React.Ref<ActiveRitualSessionHandle>;
+  onStageChange: (_stage: number) => void;
+  onCustomize: () => void;
 }
 
-// The fixed player layout: no outer scroll. The session floats centered in
-// the flexible middle region; the weekly footer is pinned at the foot inside
-// the safe area.
+// The fixed player layout: no outer scroll. The identity header sits in the
+// top region, the session floats centered in the flexible middle, and the
+// weekly footer is pinned at the foot inside the safe area.
 const ActiveSessionView = (props: ActiveSessionViewProps): React.JSX.Element => {
   const insets = useSafeAreaInsets();
+  // Mirror the engine's status so the identity header can collapse while a
+  // session holds the screen (running or paused); idle and complete both
+  // show the full identity block.
+  const [status, setStatus] = useState<RitualState['status']>('idle');
   return (
     <View
       style={[styles.screen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
@@ -253,6 +282,14 @@ const ActiveSessionView = (props: ActiveSessionViewProps): React.JSX.Element => 
     >
       <ContentContainer fill>
         <View style={styles.playerBody} testID="practice-screen">
+          <PracticeIdentityHeader
+            stageNumber={props.stageNumber}
+            practiceName={props.practiceName}
+            ritualName={props.effectiveName ?? props.practiceName}
+            collapsed={status === 'running' || status === 'paused'}
+            onCustomize={props.onCustomize}
+            onStageChange={props.onStageChange}
+          />
           <View style={styles.sessionRegion}>
             <ActiveRitualSession
               key={`practice-${props.userPractice.id}`}
@@ -266,6 +303,7 @@ const ActiveSessionView = (props: ActiveSessionViewProps): React.JSX.Element => 
               onSessionCommitted={() => void props.weekly.refresh()}
               onUserPracticeUpdated={props.onUserPracticeUpdated}
               onWriteReflection={props.onWriteReflection}
+              onStatusChange={setStatus}
             />
           </View>
           <WeeklyProgress count={props.weekly.count} />
@@ -390,8 +428,8 @@ const ErrorView = ({
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: showcase.canvas },
   playerBody: { flex: 1, padding: SPACING.md },
-  // The flexible middle: the session settles centered between the (future
-  // #1906 identity header) top region and the weekly footer.
+  // The flexible middle: the session settles centered between the identity
+  // header's top region and the weekly footer.
   sessionRegion: { flex: 1, justifyContent: 'center' },
   centered: {
     flex: 1,

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -358,18 +358,27 @@ describe('PracticeScreen', () => {
     expect(getByTestId('practice-error')).toHaveStyle({ paddingTop: 47, paddingBottom: 34 });
   });
 
-  it('renders the active practice card with an "Adjust" control when a practice is selected', async () => {
-    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
-    const { getByTestId, getByText } = render(<PracticeScreen />);
+  it('renders the identity header with title, ritual name, and pencil when a practice is selected', async () => {
+    mockUserPracticesList.mockResolvedValue([
+      sampleUserPractice({ custom_name: 'Morning Sit', effective_name: 'Morning Sit' }),
+    ]);
+    const { getByTestId, queryByTestId, queryByText } = render(<PracticeScreen />);
     await waitFor(() => {
-      expect(getByTestId('active-practice-card')).toBeTruthy();
-      expect(getByTestId('active-practice-configure')).toBeTruthy();
+      expect(getByTestId('practice-identity-header')).toBeTruthy();
       expect(getByTestId('meditation-timer-view')).toBeTruthy();
     });
-    expect(getByText('Adjust')).toBeTruthy();
-    expect(getByTestId('active-practice-configure').props.accessibilityLabel).toBe(
-      "Adjust this practice's settings",
-    );
+    // Title is the underlying practice's name; the ritual name shows the
+    // user's effective (customized) name for it.
+    expect(getByTestId('practice-identity-title')).toHaveTextContent('Breath Awareness');
+    expect(getByTestId('practice-identity-ritual-name')).toHaveTextContent('Morning Sit');
+    const pencil = getByTestId('practice-customize-pencil');
+    expect(pencil.props.accessibilityRole).toBe('button');
+    expect(pencil.props.accessibilityLabel).toBe('Customize this ritual');
+    // The old SessionCard header band (name + gear) is retired.
+    expect(queryByTestId('active-practice-header-band')).toBeNull();
+    expect(queryByTestId('active-practice-name')).toBeNull();
+    expect(queryByTestId('active-practice-configure')).toBeNull();
+    expect(queryByText('Adjust')).toBeNull();
   });
 
   it('renders the session flat on the dark ground with no bottom fade', async () => {
@@ -491,28 +500,78 @@ describe('PracticeScreen', () => {
     expect(within(getByTestId('practice-screen')).getByTestId('weekly-progress')).toBeTruthy();
   });
 
-  it('opens the configurator sheet when the gear is pressed', async () => {
+  it('opens the configurator sheet when the pencil is pressed', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId } = render(<PracticeScreen />);
     await waitFor(() => {
-      expect(getByTestId('active-practice-configure')).toBeTruthy();
+      expect(getByTestId('practice-customize-pencil')).toBeTruthy();
     });
     await act(async () => {
-      fireEvent.press(getByTestId('active-practice-configure'));
+      fireEvent.press(getByTestId('practice-customize-pencil'));
     });
     expect(getByTestId('ritual-configurator-sheet')).toBeTruthy();
   });
 
-  it('retires the frequency banner: no chip renders and the endpoint is never fetched', async () => {
-    // The dark player keeps only the ritual itself on screen (#1905); the
-    // stage identity returns as the tappable stage chip in #1906.
+  it('fetches the frequency and renders the tappable stage chip on the idle player', async () => {
+    mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
+    const { getByTestId, getByText, queryByTestId } = render(<PracticeScreen />);
+    await waitFor(() => {
+      expect(getByTestId('practice-stage-chip')).toBeTruthy();
+    });
+    expect(getByText('BEIGE · Body')).toBeTruthy();
+    expect(mockFrequency).toHaveBeenCalled();
+    expect(mockFrequency.mock.calls[0][0]).toBe(1);
+    const chip = getByTestId('practice-stage-chip');
+    expect(chip.props.accessibilityRole).toBe('button');
+    expect(chip.props.accessibilityLabel).toBe('Change stage. Current: Beige, Body');
+    // The old banner surface stays retired; the chip is the stage identity now.
+    expect(queryByTestId('frequency-banner-content')).toBeNull();
+  });
+
+  it('stage chip opens the picker and picking a stage re-drives the load for it', async () => {
+    const stageThreePractice = samplePractice({ id: 3, stage_number: 3, name: 'Candle Gazing' });
+    mockPracticesList.mockImplementation((options: unknown) => {
+      const stage =
+        typeof options === 'object' && options !== null
+          ? (options as { stageNumber?: number }).stageNumber
+          : undefined;
+      return Promise.resolve(stage === 3 ? [stageThreePractice] : [samplePractice()]);
+    });
+    mockUserPracticesList.mockResolvedValue([
+      sampleUserPractice(),
+      sampleUserPractice({ id: 30, practice_id: 3, stage_number: 3 }),
+    ]);
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-stage-chip')).toBeTruthy());
+
+    fireEvent.press(getByTestId('practice-stage-chip'));
+    expect(getByTestId('practice-stage-pick-3')).toBeTruthy();
+    expect(getByTestId('practice-stage-pick-cancel')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('practice-stage-pick-3'));
+    });
+
+    await waitFor(() => {
+      expect(mockPracticesList).toHaveBeenCalledWith(expect.objectContaining({ stageNumber: 3 }));
+      const frequencyStages = mockFrequency.mock.calls.map((call: unknown[]) => call[0]);
+      expect(frequencyStages).toContain(3);
+    });
+  });
+
+  it('collapses the identity header to the title only while a session runs', async () => {
+    jest.useFakeTimers();
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId, queryByTestId } = render(<PracticeScreen />);
-    await waitFor(() => {
-      expect(getByTestId('active-practice-card')).toBeTruthy();
+    await waitFor(() => expect(getByTestId('practice-stage-chip')).toBeTruthy());
+    await act(async () => {
+      fireEvent.press(getByTestId('ritual-start'));
     });
-    expect(queryByTestId('frequency-banner-content')).toBeNull();
-    expect(mockFrequency).not.toHaveBeenCalled();
+    expect(queryByTestId('practice-stage-chip')).toBeNull();
+    expect(queryByTestId('practice-customize-pencil')).toBeNull();
+    expect(queryByTestId('practice-identity-ritual-name')).toBeNull();
+    expect(getByTestId('practice-identity-title')).toBeTruthy();
+    jest.useRealTimers();
   });
 
   describe.each(modeFixtures)('mode dispatch — $label', ({ practice, mountTestId }) => {
@@ -870,7 +929,7 @@ describe('PracticeScreen header drawer', () => {
     expect(getByTestId('browse-catalog-button')).toBeTruthy();
   });
 
-  it('pressing the drawer "Customize this practice" row opens the same configurator sheet as the gear', async () => {
+  it('pressing the drawer "Customize this practice" row opens the configurator sheet', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId, getByLabelText } = render(<PracticeScreenWithHeader />);
     await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());

--- a/frontend/src/features/Practice/components/ActiveRitualSession.tsx
+++ b/frontend/src/features/Practice/components/ActiveRitualSession.tsx
@@ -36,7 +36,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 import type {
   PracticeSessionCreate,
@@ -46,7 +46,7 @@ import type {
 } from '@/api';
 import { practiceSessions } from '@/api';
 import { formatApiError } from '@/api/errorMessages';
-import { SPACING, colors, onShowcase } from '@/design/tokens';
+import { SPACING, colors } from '@/design/tokens';
 import { InsightCaptureModal } from '@/features/Practice/components/InsightCaptureModal';
 import RitualConfiguratorSheet from '@/features/Practice/configurator/RitualConfiguratorSheet';
 import type { PickedCard } from '@/features/Practice/data/resolveCard';
@@ -106,6 +106,8 @@ export interface ActiveRitualSessionProps {
   onUserPracticeUpdated: (_next: UserPractice) => void;
   /** Open the journal-reflection composer (parent owns the navigator). */
   onWriteReflection: (_args: { session: PracticeSessionResponse; insight: string | null }) => void;
+  /** Observe engine status transitions (e.g. to collapse the identity header mid-session). */
+  onStatusChange?: (_status: RitualState['status']) => void;
   /** Injectable audio adapter for tests; defaults to the bundled bell audio. */
   audio?: AudioAdapter;
 }
@@ -138,12 +140,11 @@ export const ActiveRitualSession = forwardRef<ActiveRitualSessionHandle, ActiveR
   function ActiveRitualSession(props, ref): React.JSX.Element {
     const [showConfigurator, setShowConfigurator] = useState(false);
     const session = useActiveSession(props);
+    useStatusNotifier(session.state.status, props.onStatusChange);
     useImperativeHandle(ref, () => ({ openConfigurator: () => setShowConfigurator(true) }), []);
     return (
       <View testID="active-ritual-session">
         <SessionCard
-          effectiveName={props.effectiveName}
-          onConfigure={() => setShowConfigurator(true)}
           config={props.effectiveConfig}
           state={session.state}
           controls={session.controls}
@@ -169,6 +170,19 @@ export const ActiveRitualSession = forwardRef<ActiveRitualSessionHandle, ActiveR
     );
   },
 );
+
+/**
+ * Report engine status transitions upward (the parent collapses the identity
+ * header while a session runs). Pure observation — no engine-logic change.
+ */
+function useStatusNotifier(
+  status: RitualState['status'],
+  onStatusChange?: (_status: RitualState['status']) => void,
+): void {
+  useEffect(() => {
+    onStatusChange?.(status);
+  }, [status, onStatusChange]);
+}
 
 interface SessionInsightModalProps {
   session: ActiveSession;
@@ -425,8 +439,6 @@ function useSubmitSession({
 }
 
 interface SessionCardProps {
-  effectiveName: string;
-  onConfigure: () => void;
   config: ModeConfig;
   state: RitualState;
   controls: RitualControls;
@@ -438,30 +450,12 @@ interface SessionCardProps {
 }
 
 function SessionCard(props: SessionCardProps): React.JSX.Element {
-  // The session rests flat on the full-bleed umber player ground (#1905): the
-  // header is just the practice name + a quiet Adjust control in on-showcase
-  // ink — no lifted band, no shadow — and the mode view renders below on the
-  // same dark ground. The shared RitualControlsBar plays the completion
-  // Celebration.
+  // The session rests flat on the full-bleed umber player ground: identity
+  // chrome (name, stage chip, customize pencil) lives in the parent's
+  // PracticeIdentityHeader, so the card is just the mode view plus any save
+  // error. The shared RitualControlsBar plays the completion Celebration.
   return (
     <View style={styles.card} testID="active-practice-card">
-      <View style={styles.headerBand} testID="active-practice-header-band">
-        <View style={styles.cardHeader}>
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessibilityLabel="Adjust this practice's settings"
-            onPress={props.onConfigure}
-            style={styles.gearButton}
-            testID="active-practice-configure"
-          >
-            <Text style={styles.gearText}>⚙︎</Text>
-            <Text style={styles.gearLabel}>Adjust</Text>
-          </TouchableOpacity>
-        </View>
-        <Text style={styles.name} testID="active-practice-name">
-          {props.effectiveName}
-        </Text>
-      </View>
       <SessionSurfaceProvider value={UMBER_SURFACE}>
         <ModeView
           config={props.config}
@@ -652,36 +646,6 @@ const styles = StyleSheet.create({
   card: {
     paddingBottom: SPACING.lg,
     marginBottom: SPACING.lg,
-  },
-  // Flat header: the practice name + Adjust in on-showcase ink — no lifted
-  // band or shadow, so the session blends into the dark ground (#1905).
-  headerBand: {
-    paddingHorizontal: SPACING.lg,
-    paddingBottom: SPACING.md,
-    paddingTop: SPACING.xs,
-    marginBottom: SPACING.lg,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    marginBottom: SPACING.xs,
-  },
-  gearButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: SPACING.xs,
-    minWidth: 44,
-    minHeight: 44,
-    paddingHorizontal: SPACING.sm,
-  },
-  gearText: { fontSize: 18, color: onShowcase.soft },
-  gearLabel: { fontSize: 14, fontWeight: '600', color: onShowcase.soft },
-  name: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: onShowcase.primary,
-    marginBottom: SPACING.md,
   },
   error: {
     // The light destructive border swatch doubles as an AA-clearing (~6.3:1)

--- a/frontend/src/features/Practice/components/PracticeIdentityHeader.tsx
+++ b/frontend/src/features/Practice/components/PracticeIdentityHeader.tsx
@@ -1,0 +1,225 @@
+/**
+ * `PracticeIdentityHeader` — the player identity block at the top of the dark
+ * Practice screen: the practice title, a tappable stage chip
+ * (`COLOR · aspect`), the user's effective ritual name when it differs from
+ * the title, and a pencil that opens the ritual configurator. While a session
+ * holds the engine (`collapsed`) it quiets down to the title alone.
+ *
+ * The chip's identity comes from the server frequency payload
+ * (`useFrequency`), falling back to the stage store when the fetch fails;
+ * with neither source the chip is simply omitted — never a crash, never a
+ * dead control. Tapping the chip opens a light stage-picker card over the
+ * dark ground; picking a stage reports it upward and the parent re-drives
+ * the load. All text on the umber ground uses `onShowcase.*` ink so every
+ * label clears WCAG AA contrast.
+ */
+import { Pencil } from 'lucide-react-native';
+import React, { useState } from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  BORDER_RADIUS,
+  SPACING,
+  accent,
+  colors,
+  editorialType,
+  ink,
+  onShowcase,
+  surface,
+  surfaceShadow,
+  touchTarget,
+} from '@/design/tokens';
+import StageSelector from '@/features/Practice/components/StageSelector';
+import { useFrequency } from '@/features/Practice/hooks/useFrequency';
+import { useStageStore } from '@/store/useStageStore';
+
+/** Icon glyph size inside the (44pt-minimum) pencil touch target. */
+const PENCIL_ICON_SIZE = 18;
+
+export interface PracticeIdentityHeaderProps {
+  stageNumber: number;
+  practiceName: string;
+  ritualName: string;
+  collapsed: boolean;
+  onCustomize: () => void;
+  onStageChange: (_stage: number) => void;
+}
+
+/** The color/aspect pairing the stage chip displays. */
+interface StageIdentity {
+  color: string;
+  aspect: string;
+}
+
+/** Server frequency first; the stage store as the offline fallback. */
+function useStageIdentity(stageNumber: number): StageIdentity | null {
+  const { data } = useFrequency(stageNumber);
+  const storeStage = useStageStore((s) => s.stagesByNumber[stageNumber]);
+  if (data) return { color: data.color, aspect: data.aspect };
+  if (storeStage) return { color: storeStage.spiralDynamicsColor, aspect: storeStage.aspect };
+  return null;
+}
+
+interface StageChipProps {
+  identity: StageIdentity;
+  onPress: () => void;
+}
+
+const StageChip = ({ identity, onPress }: StageChipProps): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel={`Change stage. Current: ${identity.color}, ${identity.aspect}`}
+    onPress={onPress}
+    style={styles.stageChip}
+    testID="practice-stage-chip"
+  >
+    <Text style={styles.stageChipText}>
+      {`${identity.color.toUpperCase()} · ${identity.aspect}`}
+    </Text>
+  </TouchableOpacity>
+);
+
+interface StagePickerModalProps {
+  visible: boolean;
+  onPick: (_stage: number) => void;
+  onCancel: () => void;
+}
+
+// A light picker card floating over the dark player: StageSelector's own
+// light-surface tokens are correct here because the card provides the light
+// ground the chips were designed for.
+const StagePickerModal = ({
+  visible,
+  onPick,
+  onCancel,
+}: StagePickerModalProps): React.JSX.Element => (
+  <Modal animationType="fade" onRequestClose={onCancel} transparent visible={visible}>
+    <View style={styles.pickerBackdrop}>
+      <View style={styles.pickerCard}>
+        <Text style={styles.pickerHeading} accessibilityRole="header">
+          Pick a stage
+        </Text>
+        <StageSelector variant="picker" onSelect={onPick} testIDPrefix="practice-stage-pick" />
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
+          onPress={onCancel}
+          style={styles.pickerCancel}
+          testID="practice-stage-pick-cancel"
+        >
+          <Text style={styles.pickerCancelText}>Cancel</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  </Modal>
+);
+
+const PencilButton = ({ onPress }: { onPress: () => void }): React.JSX.Element => (
+  <TouchableOpacity
+    accessibilityRole="button"
+    accessibilityLabel="Customize this ritual"
+    onPress={onPress}
+    style={styles.pencilButton}
+    testID="practice-customize-pencil"
+  >
+    <Pencil color={onShowcase.soft} size={PENCIL_ICON_SIZE} />
+  </TouchableOpacity>
+);
+
+const PracticeIdentityHeader = ({
+  stageNumber,
+  practiceName,
+  ritualName,
+  collapsed,
+  onCustomize,
+  onStageChange,
+}: PracticeIdentityHeaderProps): React.JSX.Element => {
+  const identity = useStageIdentity(stageNumber);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const handlePick = (stage: number): void => {
+    onStageChange(stage);
+    setPickerOpen(false);
+  };
+  return (
+    <View style={styles.header} testID="practice-identity-header">
+      {!collapsed && identity !== null && (
+        <StageChip identity={identity} onPress={() => setPickerOpen(true)} />
+      )}
+      <Text style={styles.title} testID="practice-identity-title">
+        {practiceName}
+      </Text>
+      {!collapsed && (
+        <View style={styles.ritualRow}>
+          {ritualName !== practiceName && (
+            <Text style={styles.ritualName} testID="practice-identity-ritual-name">
+              {ritualName}
+            </Text>
+          )}
+          <PencilButton onPress={onCustomize} />
+        </View>
+      )}
+      {!collapsed && (
+        <StagePickerModal
+          visible={pickerOpen}
+          onPick={handlePick}
+          onCancel={() => setPickerOpen(false)}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: { marginBottom: SPACING.md },
+  stageChip: {
+    alignSelf: 'flex-start',
+    borderColor: onShowcase.muted,
+    borderRadius: BORDER_RADIUS.circle,
+    borderWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'center',
+    marginBottom: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingHorizontal: SPACING.md,
+  },
+  stageChipText: { ...editorialType.action, color: onShowcase.soft, letterSpacing: 1 },
+  title: { ...editorialType.display, color: onShowcase.primary },
+  ritualRow: { alignItems: 'center', flexDirection: 'row', marginTop: SPACING.xs },
+  ritualName: { ...editorialType.note, color: onShowcase.soft, flex: 1 },
+  pencilButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Auto margin keeps the pencil pinned to the trailing edge even when the
+    // ritual name is deduped away.
+    marginLeft: 'auto',
+    minHeight: touchTarget.minimum,
+    minWidth: touchTarget.minimum,
+  },
+  pickerBackdrop: {
+    backgroundColor: colors.mystical.overlay,
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.lg,
+  },
+  pickerCard: {
+    backgroundColor: surface.raised,
+    borderRadius: BORDER_RADIUS.lg,
+    padding: SPACING.md,
+    ...surfaceShadow.card,
+  },
+  pickerHeading: {
+    color: ink.primary,
+    fontSize: 14,
+    fontWeight: '700',
+    marginBottom: SPACING.sm,
+  },
+  pickerCancel: {
+    alignSelf: 'flex-end',
+    justifyContent: 'center',
+    marginTop: SPACING.sm,
+    minHeight: touchTarget.minimum,
+    paddingHorizontal: SPACING.sm,
+  },
+  pickerCancelText: { ...editorialType.action, color: accent.primary },
+});
+
+export default PracticeIdentityHeader;

--- a/frontend/src/features/Practice/components/__tests__/PracticeIdentityHeader.test.tsx
+++ b/frontend/src/features/Practice/components/__tests__/PracticeIdentityHeader.test.tsx
@@ -1,0 +1,179 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { FrequencyResponse } from '@/api';
+import type { StageData } from '@/features/Map/stageData';
+
+// The shape the header consumes from the restored useFrequency hook.
+interface FrequencyHookState {
+  data: FrequencyResponse | null;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+const mockUseFrequency = jest.fn() as jest.MockedFunction<
+  (...args: unknown[]) => FrequencyHookState
+>;
+
+// Mutable store slice consumed through the useStageStore selector mock below.
+const mockStageState: { stagesByNumber: Record<number, StageData> } = { stagesByNumber: {} };
+
+jest.mock('@/features/Practice/hooks/useFrequency', () => {
+  const hook = (...args: unknown[]): FrequencyHookState => mockUseFrequency(...args);
+  return { __esModule: true, useFrequency: hook, default: hook };
+});
+
+jest.mock('@/store/useStageStore', () => ({
+  __esModule: true,
+  useStageStore: (selector?: (_state: unknown) => unknown) =>
+    selector === undefined ? mockStageState : selector(mockStageState),
+}));
+
+// Required after the mocks so the factories are registered before the module loads.
+const PracticeIdentityHeader = require('../PracticeIdentityHeader').default;
+
+const beigeFrequency: FrequencyResponse = {
+  stage_number: 1,
+  color: 'Beige',
+  aspect: 'Body',
+  practice_name: 'Breath Awareness',
+  practice_id: 1,
+  user_practice_id: 10,
+  banner_text: 'You are in the Beige frequency of APTITUDE.',
+};
+
+const stageFixture = (
+  stageNumber: number,
+  spiralDynamicsColor: string,
+  aspect: string,
+): StageData => ({
+  id: stageNumber,
+  title: `Stage ${stageNumber}`,
+  subtitle: 'A stage of the arc',
+  stageNumber,
+  progress: 0,
+  color: '#CDBA88',
+  isUnlocked: true,
+  category: 'Foundation',
+  aspect,
+  spiralDynamicsColor,
+  growingUpStage: 'Egocentric',
+  divineGenderPolarity: 'Feminine',
+  relationshipToFreeWill: 'Emerging',
+  freeWillDescription: 'Free will is emerging.',
+  overviewUrl: 'https://example.com/stage',
+  manifestations: [],
+});
+
+interface HeaderProps {
+  stageNumber: number;
+  practiceName: string;
+  ritualName: string;
+  collapsed: boolean;
+  onCustomize: () => void;
+  onStageChange: (_stage: number) => void;
+}
+
+const onCustomize = jest.fn();
+const onStageChange = jest.fn();
+
+const renderHeader = (overrides: Partial<HeaderProps> = {}) =>
+  render(
+    <PracticeIdentityHeader
+      stageNumber={1}
+      practiceName="Breath Awareness"
+      ritualName="Morning Sit"
+      collapsed={false}
+      onCustomize={onCustomize}
+      onStageChange={onStageChange}
+      {...overrides}
+    />,
+  );
+
+describe('PracticeIdentityHeader', () => {
+  beforeEach(() => {
+    mockStageState.stagesByNumber = {};
+    mockUseFrequency.mockReturnValue({
+      data: beigeFrequency,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  it('renders the title, ritual name, and stage chip from the frequency payload', () => {
+    const { getByTestId, getByText } = renderHeader();
+    expect(getByTestId('practice-identity-header')).toBeTruthy();
+    expect(getByTestId('practice-identity-title')).toHaveTextContent('Breath Awareness');
+    expect(getByTestId('practice-identity-ritual-name')).toHaveTextContent('Morning Sit');
+    expect(getByText('BEIGE · Body')).toBeTruthy();
+    const chip = getByTestId('practice-stage-chip');
+    expect(chip.props.accessibilityRole).toBe('button');
+    expect(chip.props.accessibilityLabel).toBe('Change stage. Current: Beige, Body');
+    const pencil = getByTestId('practice-customize-pencil');
+    expect(pencil.props.accessibilityRole).toBe('button');
+    expect(pencil.props.accessibilityLabel).toBe('Customize this ritual');
+  });
+
+  it('falls back to the stage store for the chip label when the frequency fetch fails', () => {
+    mockUseFrequency.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('offline'),
+      refetch: jest.fn(),
+    });
+    mockStageState.stagesByNumber = { 3: stageFixture(3, 'Red', 'Power') };
+    const { getByTestId, getByText } = renderHeader({ stageNumber: 3 });
+    expect(getByText('RED · Power')).toBeTruthy();
+    expect(getByTestId('practice-stage-chip').props.accessibilityLabel).toBe(
+      'Change stage. Current: Red, Power',
+    );
+  });
+
+  it('renders the title without a chip when neither source has stage data', () => {
+    mockUseFrequency.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    const { getByTestId, queryByTestId } = renderHeader();
+    expect(getByTestId('practice-identity-title')).toHaveTextContent('Breath Awareness');
+    expect(queryByTestId('practice-stage-chip')).toBeNull();
+  });
+
+  it('invokes onCustomize when the pencil is pressed', () => {
+    const { getByTestId } = renderHeader();
+    fireEvent.press(getByTestId('practice-customize-pencil'));
+    expect(onCustomize).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the stage picker from the chip and reports the picked stage', () => {
+    const { getByTestId, queryByTestId } = renderHeader();
+    expect(queryByTestId('practice-stage-pick-1')).toBeNull();
+    fireEvent.press(getByTestId('practice-stage-chip'));
+    expect(getByTestId('practice-stage-pick-1')).toBeTruthy();
+    expect(getByTestId('practice-stage-pick-10')).toBeTruthy();
+    fireEvent.press(getByTestId('practice-stage-pick-3'));
+    expect(onStageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('cancel dismisses the picker without changing the stage', () => {
+    const { getByTestId, queryByTestId } = renderHeader();
+    fireEvent.press(getByTestId('practice-stage-chip'));
+    fireEvent.press(getByTestId('practice-stage-pick-cancel'));
+    expect(queryByTestId('practice-stage-pick-1')).toBeNull();
+    expect(onStageChange).not.toHaveBeenCalled();
+  });
+
+  it('collapsed hides the chip, ritual name, and pencil but keeps the title', () => {
+    const { getByTestId, queryByTestId } = renderHeader({ collapsed: true });
+    expect(getByTestId('practice-identity-title')).toHaveTextContent('Breath Awareness');
+    expect(queryByTestId('practice-stage-chip')).toBeNull();
+    expect(queryByTestId('practice-customize-pencil')).toBeNull();
+    expect(queryByTestId('practice-identity-ritual-name')).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/hooks/__tests__/useFrequency.test.tsx
+++ b/frontend/src/features/Practice/hooks/__tests__/useFrequency.test.tsx
@@ -1,0 +1,156 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { FrequencyResponse } from '@/api';
+
+const sampleFrequency: FrequencyResponse = {
+  stage_number: 5,
+  color: 'Orange',
+  aspect: 'Mind',
+  practice_name: 'Concentration on the breath',
+  practice_id: 17,
+  user_practice_id: 42,
+  banner_text:
+    'You are in the Orange frequency of APTITUDE. That means you are working on Mind. ' +
+    'Your practice is Concentration on the breath but you are encouraged to replace it ' +
+    'if another tradition has a practice that deals with Mind that calls to you more.',
+};
+
+const mockFrequencyCurrent = jest.fn() as jest.MockedFunction<() => Promise<FrequencyResponse>>;
+
+jest.mock('@/api', () => ({
+  frequency: {
+    current: (...args: unknown[]) =>
+      (mockFrequencyCurrent as unknown as (...a: unknown[]) => Promise<FrequencyResponse>)(...args),
+  },
+}));
+
+const { useFrequency } = require('../useFrequency');
+
+describe('useFrequency', () => {
+  beforeEach(() => {
+    mockFrequencyCurrent.mockReset();
+  });
+
+  it('starts loading and resolves with the server payload', async () => {
+    mockFrequencyCurrent.mockResolvedValue(sampleFrequency);
+
+    const { result } = renderHook(() => useFrequency());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(sampleFrequency);
+    expect(result.current.error).toBeNull();
+    expect(mockFrequencyCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a fetch failure as an Error and clears data', async () => {
+    mockFrequencyCurrent.mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useFrequency());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('boom');
+  });
+
+  it('wraps non-Error rejections into a real Error so call sites can read .message', async () => {
+    mockFrequencyCurrent.mockRejectedValueOnce('network down');
+
+    const { result } = renderHook(() => useFrequency());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('network down');
+  });
+
+  it('refetch() re-runs the request and clears any prior error', async () => {
+    mockFrequencyCurrent
+      .mockRejectedValueOnce(new Error('first try'))
+      .mockResolvedValueOnce(sampleFrequency);
+
+    const { result } = renderHook(() => useFrequency());
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.data).toEqual(sampleFrequency);
+    expect(result.current.error).toBeNull();
+    expect(mockFrequencyCurrent).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes a stage_number override into the API client', async () => {
+    // Master-date wiring: the Practice screen passes its
+    // date-derived stage to the hook so the banner pins to the same
+    // stage as the practice card, not whatever the server-stored
+    // current_stage happens to be.
+    mockFrequencyCurrent.mockResolvedValue(sampleFrequency);
+
+    const { result } = renderHook(() => useFrequency(7));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFrequencyCurrent).toHaveBeenCalledWith(7);
+  });
+
+  it('refetches when the stage_number changes', async () => {
+    // Date moves → derived stage changes → banner should re-pin.
+    mockFrequencyCurrent.mockResolvedValue(sampleFrequency);
+
+    const { result, rerender } = renderHook(({ stage }: { stage: number }) => useFrequency(stage), {
+      initialProps: { stage: 1 },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(mockFrequencyCurrent).toHaveBeenLastCalledWith(1);
+
+    rerender({ stage: 3 });
+
+    await waitFor(() => {
+      expect(mockFrequencyCurrent).toHaveBeenLastCalledWith(3);
+    });
+    expect(mockFrequencyCurrent).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a stale response if the component unmounted before it resolved', async () => {
+    let resolveFn: ((value: FrequencyResponse) => void) | undefined;
+    mockFrequencyCurrent.mockReturnValueOnce(
+      new Promise<FrequencyResponse>((resolve) => {
+        resolveFn = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useFrequency());
+    unmount();
+    // Resolve after unmount — `useFrequency` must not call setState.
+    await act(async () => {
+      resolveFn?.(sampleFrequency);
+    });
+    // Final state is whatever was captured pre-unmount — initial loading.
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/frontend/src/features/Practice/hooks/useFrequency.ts
+++ b/frontend/src/features/Practice/hooks/useFrequency.ts
@@ -1,0 +1,55 @@
+/**
+ * `useFrequency` — fetcher for the Practice player's stage-identity chip.
+ *
+ * Wraps `GET /user-practices/current/frequency` (ritual-05). The codebase
+ * does not use React Query; this hook follows the same load-once / refetch
+ * pattern as the other Practice fetchers so the chip + screen share a
+ * mental model.
+ *
+ * The hook returns the *latest* settled state — when `refetch` is called it
+ * does NOT reset `data` to `null` so the chip can keep showing the previous
+ * payload while it revalidates. `error` IS cleared on refetch because
+ * retaining a stale failure would lie about the state of the new request.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+import { frequency, type FrequencyResponse } from '@/api';
+import { useMountedRef } from '@/features/Practice/hooks/useMountedRef';
+import { toError } from '@/features/Practice/utils/toError';
+
+export interface UseFrequencyResult {
+  data: FrequencyResponse | null;
+  isLoading: boolean;
+  error: Error | null;
+  /** Re-run the fetch. Resolves once the request settles (success or failure). */
+  refetch: () => Promise<void>;
+}
+
+export function useFrequency(stageNumber?: number | null): UseFrequencyResult {
+  const [data, setData] = useState<FrequencyResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mountedRef = useMountedRef();
+
+  const fetchOnce = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await frequency.current(stageNumber);
+      if (!mountedRef.current) return;
+      setData(result);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(toError(err));
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, [stageNumber, mountedRef]);
+
+  useEffect(() => {
+    void fetchOnce();
+  }, [fetchOnce]);
+
+  return { data, isLoading, error, refetch: fetchOnce };
+}


### PR DESCRIPTION
## Summary

Adds the player identity header to the dark Practice screen (practice-focus-02, second of the series; built into the full-bleed umber shell from #1910):

- **Practice title** — always visible above the ring, in `editorialType.display` / `onShowcase.primary`.
- **Stage chip** `COLOR · aspect` (e.g. `BEIGE · Body`) — a11y-`button` pill sourced from a restored lean `useFrequency(stageNumber)` (with a `useStageStore` color/aspect fallback when the endpoint fails, and title-only when neither source has data). Tapping it opens a stage picker (a light modal card reusing `StageSelector variant="picker"`); choosing a stage drives a local `stageOverride` so `useActivePractice` loads that stage's saved ritual and the chip re-fetches its frequency.
- **Ritual name + pencil** — the effective (possibly customized) name beside a `lucide-react-native` Pencil (`accessibilityLabel="Customize this ritual"`, ≥ `touchTarget.minimum`) that opens the existing `RitualConfiguratorSheet` via the `ActiveRitualSessionHandle`. The redundant session-card gear ("Adjust") is retired so the pencil is the only on-page customize affordance; the off-page drawer row keeps its own path.
- **Mid-session collapse** — engine status is surfaced from `ActiveRitualSession` via a new optional `onStatusChange`; while running or paused the header reduces to the practice title only, returning on idle/complete.

All header ink uses `onShowcase.*` for AA contrast on the umber ground; the picker's light-theme chips stay inside their own light card. Wiring only — no engine or configurator-internals changes.

Note: switching to a stage with no saved practice falls to the existing empty state (per the acceptance criteria); the header drawer remains available there for navigation, so the chip's absence there is not a dead end.

## Test plan

- New/updated Jest suites (all green): `PracticeIdentityHeader.test.tsx` (chip label, frequency→store→title-only fallback, a11y roles/labels, picker open + select + cancel, collapse), restored `useFrequency.test.tsx` (verbatim), and `PracticeScreen.test.tsx` (chip renders + endpoint now fetched, pencil→configurator, in-place stage switch re-drives the load, mid-session collapse; old gear/banner assertions retargeted).
- `./scripts/frontend/check-all.sh` — 4899 tests pass; eslint, prettier, tsc all clean.

Closes #1906
Refs #1904