### PR TITLE
feat(course): condense reader footer to one icon nav row with read toast

### DIFF
--- a/frontend/src/features/Course/ContentViewer.tsx
+++ b/frontend/src/features/Course/ContentViewer.tsx
@@ -1,58 +1,176 @@
+import { ChevronLeft, ChevronRight, DoorOpen } from 'lucide-react-native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Animated, Text, TouchableOpacity, View } from 'react-native';
 
 import { course as courseApi, type ContentItem } from '../../api';
-import { colors } from '../../design/tokens';
+import { NAV_ICON_SIZE, NAV_ICON_STROKE } from '../../components/drawer/navIcon';
+import { accent, colors, ink } from '../../design/tokens';
 
 import type { ChapterNav } from './chapterNav';
 import ChapterReader, { type WriteNotePassage } from './ChapterReader';
 import styles from './Course.styles';
 
-const ChapterNavRow = ({ nav }: { nav: ChapterNav }): React.JSX.Element => (
-  <View style={styles.chapterNavRow}>
-    <TouchableOpacity
-      testID="chapter-nav-back"
-      onPress={nav.onPrev}
-      disabled={!nav.canPrev}
-      accessibilityRole="button"
-      accessibilityLabel="Previous chapter"
-      accessibilityState={{ disabled: !nav.canPrev }}
-      style={[
-        styles.chapterNavButton,
-        styles.chapterNavBack,
-        !nav.canPrev && styles.chapterNavBackDisabled,
-      ]}
-    >
-      <Text style={styles.chapterNavBackLabel}>{'← Back'}</Text>
-    </TouchableOpacity>
+// Read-toast choreography: fade in, hold, fade out. Hold plus exit fade must
+// finish comfortably inside the reader tests' 5s settle window.
+const READ_TOAST_PAUSE_MS = 1800;
+const READ_TOAST_FADE_MS = 250;
+const READ_TOAST_SLIDE_DISTANCE = 12;
+
+const toastFade = (
+  opacity: Animated.Value,
+  translateY: Animated.Value,
+  toOpacity: number,
+  toTranslateY: number,
+): Animated.CompositeAnimation =>
+  Animated.parallel([
+    Animated.timing(opacity, {
+      toValue: toOpacity,
+      duration: READ_TOAST_FADE_MS,
+      useNativeDriver: true,
+    }),
+    Animated.timing(translateY, {
+      toValue: toTranslateY,
+      duration: READ_TOAST_FADE_MS,
+      useNativeDriver: true,
+    }),
+  ]);
+
+// After the on-screen pause, fades the toast out and reports when it finished
+// cleanly (an interrupted fade must not hide state it no longer owns).
+const scheduleToastDismiss = (
+  opacity: Animated.Value,
+  translateY: Animated.Value,
+  onHidden: () => void,
+): ReturnType<typeof setTimeout> =>
+  setTimeout(() => {
+    toastFade(opacity, translateY, 0, READ_TOAST_SLIDE_DISTANCE).start(({ finished }) => {
+      if (finished) onHidden();
+    });
+  }, READ_TOAST_PAUSE_MS);
+
+interface ReadToast {
+  visible: boolean;
+  opacity: Animated.Value;
+  translateY: Animated.Value;
+  trigger: () => void;
+}
+
+/**
+ * Owns the transient "✓ Read" confirmation shown after a successful mark-read:
+ * ``trigger()`` fades the toast in, holds it for a named pause, then fades it
+ * out. An ``itemId``-keyed effect dismisses a stale toast (and its pending
+ * timer) when chapter Next/Back swaps the item while the reader stays mounted.
+ */
+function useReadToast(itemId: number): ReadToast {
+  const [visible, setVisible] = useState(false);
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(READ_TOAST_SLIDE_DISTANCE)).current;
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const hide = useCallback(() => setVisible(false), []);
+
+  const trigger = useCallback(() => {
+    clearTimeout(dismissTimerRef.current);
+    opacity.setValue(0);
+    translateY.setValue(READ_TOAST_SLIDE_DISTANCE);
+    setVisible(true);
+    toastFade(opacity, translateY, 1, 0).start(({ finished }) => {
+      if (finished) dismissTimerRef.current = scheduleToastDismiss(opacity, translateY, hide);
+    });
+  }, [opacity, translateY, hide]);
+
+  // Chapter navigation swaps ``item`` in place: hide any toast celebrating the
+  // outgoing chapter. The cleanup (which also covers unmount) drops the pending
+  // dismiss timer and stops the fades so an interrupted fade-in cannot schedule
+  // a stale dismiss via its finished callback.
+  useEffect(() => {
+    setVisible(false);
+    return () => {
+      clearTimeout(dismissTimerRef.current);
+      opacity.stopAnimation();
+      translateY.stopAnimation();
+    };
+  }, [itemId, opacity, translateY]);
+
+  return { visible, opacity, translateY, trigger };
+}
+
+interface MarkReadToastProps {
+  opacity: Animated.Value;
+  translateY: Animated.Value;
+}
+
+/** Transient confirmation card floated above the footer's single nav row. */
+const MarkReadToast = ({ opacity, translateY }: MarkReadToastProps): React.JSX.Element => (
+  <Animated.View
+    testID="read-toast"
+    accessibilityLiveRegion="polite"
+    accessibilityRole="alert"
+    accessibilityLabel="Marked as read"
+    style={[styles.readToast, { opacity, transform: [{ translateY }] }]}
+  >
+    <Text style={styles.readToastText}>✓ Read</Text>
+  </Animated.View>
+);
+
+const ChapterPrevButton = ({ nav }: { nav: ChapterNav }): React.JSX.Element => (
+  <TouchableOpacity
+    testID="chapter-nav-back"
+    onPress={nav.onPrev}
+    disabled={!nav.canPrev}
+    accessibilityRole="button"
+    accessibilityLabel="Previous chapter"
+    accessibilityState={{ disabled: !nav.canPrev }}
+    style={[styles.footerIconButton, !nav.canPrev && styles.chapterNavBackDisabled]}
+  >
+    <ChevronLeft size={NAV_ICON_SIZE} strokeWidth={NAV_ICON_STROKE} color={ink.soft} />
+  </TouchableOpacity>
+);
+
+const ChapterNextButton = ({ nav }: { nav: ChapterNav }): React.JSX.Element => {
+  const NextGlyph = nav.nextIsDone ? DoorOpen : ChevronRight;
+  return (
     <TouchableOpacity
       testID="chapter-nav-next"
       onPress={nav.onNext}
       accessibilityRole="button"
       accessibilityLabel={nav.nextIsDone ? 'Done' : 'Next chapter'}
-      style={[styles.chapterNavButton, styles.chapterNavNext]}
+      style={styles.footerIconButton}
     >
-      <Text style={styles.chapterNavNextLabel}>{nav.nextIsDone ? 'Done' : 'Next →'}</Text>
+      <NextGlyph size={NAV_ICON_SIZE} strokeWidth={NAV_ICON_STROKE} color={accent.primary} />
     </TouchableOpacity>
-  </View>
-);
+  );
+};
 
-interface ViewerFooterProps {
+interface FooterCenterProps {
   isRead: boolean;
   marking: boolean;
   onMarkRead: () => void;
   onReflect?: () => void;
-  nav: ChapterNav;
 }
 
-const ViewerFooter = ({
+// Center slot: mark-read while unread, reflect once read (when offered),
+// otherwise the quiet "✓ Read" done state.
+const FooterCenter = ({
   isRead,
   marking,
   onMarkRead,
   onReflect,
-  nav,
-}: ViewerFooterProps): React.JSX.Element => (
-  <View style={styles.viewerFooter}>
+}: FooterCenterProps): React.JSX.Element => {
+  if (isRead && onReflect) {
+    return (
+      <TouchableOpacity
+        testID="reflect-button"
+        onPress={onReflect}
+        style={styles.reflectButton}
+        accessibilityRole="button"
+        accessibilityLabel="Reflect in Journal"
+      >
+        <Text style={styles.buttonLabelOnAccent}>Reflect in Journal</Text>
+      </TouchableOpacity>
+    );
+  }
+  return (
     <TouchableOpacity
       testID="mark-read-button"
       onPress={onMarkRead}
@@ -69,18 +187,38 @@ const ViewerFooter = ({
         </Text>
       )}
     </TouchableOpacity>
-    {isRead && onReflect && (
-      <TouchableOpacity
-        testID="reflect-button"
-        onPress={onReflect}
-        style={styles.reflectButton}
-        accessibilityRole="button"
-        accessibilityLabel="Reflect in Journal"
-      >
-        <Text style={styles.buttonLabelOnAccent}>Reflect in Journal</Text>
-      </TouchableOpacity>
-    )}
-    <ChapterNavRow nav={nav} />
+  );
+};
+
+interface ViewerFooterProps {
+  isRead: boolean;
+  marking: boolean;
+  onMarkRead: () => void;
+  onReflect?: () => void;
+  nav: ChapterNav;
+  toast: ReadToast;
+}
+
+const ViewerFooter = ({
+  isRead,
+  marking,
+  onMarkRead,
+  onReflect,
+  nav,
+  toast,
+}: ViewerFooterProps): React.JSX.Element => (
+  <View style={styles.viewerFooter}>
+    {toast.visible && <MarkReadToast opacity={toast.opacity} translateY={toast.translateY} />}
+    <View style={styles.viewerFooterRow}>
+      <ChapterPrevButton nav={nav} />
+      <FooterCenter
+        isRead={isRead}
+        marking={marking}
+        onMarkRead={onMarkRead}
+        onReflect={onReflect}
+      />
+      <ChapterNextButton nav={nav} />
+    </View>
   </View>
 );
 
@@ -97,6 +235,7 @@ interface ContentViewerProps {
 function useMarkReadHandler(
   item: ContentItem,
   onMarkRead: () => void,
+  onMarkedRead: () => void,
 ): { marking: boolean; isRead: boolean; handleMarkRead: () => Promise<void> } {
   const [marking, setMarking] = useState(false);
   const [isRead, setIsRead] = useState(item.is_read);
@@ -144,13 +283,16 @@ function useMarkReadHandler(
       // ``requestedId`` server-side, so its ``is_read`` should update even if the
       // reader has since navigated elsewhere.
       onMarkRead();
-      if (currentItemIdRef.current === requestedId) setIsRead(true);
+      if (currentItemIdRef.current === requestedId) {
+        setIsRead(true);
+        onMarkedRead();
+      }
     } catch (err) {
       console.error('Failed to mark content as read:', err);
     } finally {
       if (isMountedRef.current && currentItemIdRef.current === requestedId) setMarking(false);
     }
-  }, [isRead, marking, item.id, onMarkRead]);
+  }, [isRead, marking, item.id, onMarkRead, onMarkedRead]);
 
   return { marking, isRead, handleMarkRead };
 }
@@ -164,7 +306,8 @@ const ContentViewer = ({
   onWriteNote,
   initialScrollOffset,
 }: ContentViewerProps): React.JSX.Element => {
-  const { marking, isRead, handleMarkRead } = useMarkReadHandler(item, onMarkRead);
+  const toast = useReadToast(item.id);
+  const { marking, isRead, handleMarkRead } = useMarkReadHandler(item, onMarkRead, toast.trigger);
 
   return (
     <ChapterReader
@@ -180,6 +323,7 @@ const ContentViewer = ({
           onMarkRead={handleMarkRead}
           onReflect={onReflect}
           nav={nav}
+          toast={toast}
         />
       }
     />

--- a/frontend/src/features/Course/Course.styles.ts
+++ b/frontend/src/features/Course/Course.styles.ts
@@ -1,7 +1,6 @@
 import { StyleSheet } from 'react-native';
 
 import {
-  INTERACTIVE_TEXT_MIN,
   accent,
   editorialType,
   ink,
@@ -273,17 +272,33 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: ink.primary,
   },
+  // Reader footer — a column so the transient read toast can float above the
+  // single [prev icon] [center action] [next icon] navigation row.
   viewerFooter: {
     paddingHorizontal: SPACING.lg,
     paddingVertical: SPACING.md,
     backgroundColor: surface.canvas,
   },
+  viewerFooterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: SPACING.sm,
+  },
+  footerIconButton: {
+    minWidth: touchTarget.minimum,
+    minHeight: touchTarget.minimum,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   markReadButton: {
+    flex: 1,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.lg,
     borderRadius: radius.md,
     backgroundColor: accent.primary,
     alignItems: 'center',
+    justifyContent: 'center',
   },
   markReadButtonDone: {
     backgroundColor: surface.sunken,
@@ -298,45 +313,32 @@ const styles = StyleSheet.create({
     color: ink.soft,
   },
   reflectButton: {
+    flex: 1,
+    minHeight: touchTarget.minimum,
     paddingVertical: SPACING.sm,
     paddingHorizontal: SPACING.lg,
     borderRadius: radius.md,
     backgroundColor: accent.strong,
     alignItems: 'center',
-    marginTop: SPACING.sm,
-  },
-
-  // Chapter reader footer — Back/Next paired navigation buttons.
-  chapterNavRow: {
-    flexDirection: 'row',
-    gap: SPACING.sm,
-    marginTop: SPACING.sm,
-  },
-  chapterNavButton: {
-    flex: 1,
-    paddingVertical: SPACING.sm,
-    paddingHorizontal: SPACING.lg,
-    borderRadius: radius.md,
-    alignItems: 'center',
-  },
-  chapterNavBack: {
-    backgroundColor: surface.sunken,
+    justifyContent: 'center',
   },
   chapterNavBackDisabled: {
     opacity: CHAPTER_NAV_DISABLED_OPACITY,
   },
-  chapterNavNext: {
-    backgroundColor: accent.primary,
+  // Transient mark-read confirmation card floated above the footer nav row.
+  readToast: {
+    alignItems: 'center',
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    marginBottom: SPACING.sm,
+    borderRadius: radius.md,
+    backgroundColor: surface.raised,
+    ...surfaceShadow.card,
   },
-  chapterNavBackLabel: {
-    fontSize: INTERACTIVE_TEXT_MIN,
+  readToastText: {
+    ...editorialType.note,
     fontWeight: '600',
-    color: ink.soft,
-  },
-  chapterNavNextLabel: {
-    fontSize: INTERACTIVE_TEXT_MIN,
-    fontWeight: '600',
-    color: accent.onPrimary,
+    color: ink.primary,
   },
 
   // Loading and empty/error states

--- a/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
+++ b/frontend/src/features/Course/__tests__/ContentViewer.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native';
 import React from 'react';
 
 import type * as Api from '../../../api';
@@ -34,6 +34,9 @@ const HAPPY_COMPLETION = {
   content_id: 1,
   completed_at: '2026-01-15T10:00:00Z',
 };
+
+// Comfortably past the toast's named auto-dismiss pause plus its fade-out.
+const TOAST_SETTLE_MS = 5000;
 
 function makeItem(overrides: Partial<ContentItem> = {}): ContentItem {
   return {
@@ -122,17 +125,21 @@ describe('ContentViewer', () => {
     await waitFor(() => {
       expect(courseApi.markRead).toHaveBeenCalledWith(1);
       expect(onMarkRead).toHaveBeenCalledTimes(1);
-      expect(getByText('✓ Read')).toBeTruthy();
+      // Scoped: the transient toast also says "✓ Read", so query within the
+      // center done state rather than the whole tree.
+      expect(within(getByTestId('mark-read-button')).getByText('✓ Read')).toBeTruthy();
     });
   });
 
-  it('shows already-read state when item is pre-read', async () => {
+  it('shows the quiet done state without a toast when item is pre-read', async () => {
     const item = makeItem({ is_read: true });
-    const { getByText, findByTestId } = render(
+    const { getByTestId, queryByTestId, findByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
     );
     await findByTestId('reader-markdown');
-    expect(getByText('✓ Read')).toBeTruthy();
+    expect(within(getByTestId('mark-read-button')).getByText('✓ Read')).toBeTruthy();
+    // The toast celebrates the mark-read moment; a pre-read chapter shows none.
+    expect(queryByTestId('read-toast')).toBeNull();
   });
 
   it('disables mark-read when already read', async () => {
@@ -145,10 +152,10 @@ describe('ContentViewer', () => {
     expect(courseApi.markRead).not.toHaveBeenCalled();
   });
 
-  it('shows the reflect button when the item is read', async () => {
+  it('replaces the center slot with the reflect button when the item is read', async () => {
     const item = makeItem({ is_read: true });
     const onReflect = jest.fn();
-    const { getByTestId, getByText, findByTestId } = render(
+    const { getByTestId, getByText, queryByText, findByTestId } = render(
       <ContentViewer
         item={item}
         onBack={onBack}
@@ -160,6 +167,8 @@ describe('ContentViewer', () => {
     await findByTestId('reader-markdown');
     expect(getByTestId('reflect-button')).toBeTruthy();
     expect(getByText('Reflect in Journal')).toBeTruthy();
+    // Reflect occupies the center slot; the quiet done label yields to it.
+    expect(queryByText('✓ Read')).toBeNull();
   });
 
   it('shows the reflect button after marking content as read', async () => {
@@ -292,13 +301,14 @@ describe('ContentViewer', () => {
     await findByText(/retry worked/);
   });
 
-  it('renders the chapter nav buttons below the mark-read button', async () => {
+  it('renders prev, center, and next controls in the single footer row', async () => {
     const item = makeItem();
     const { findByTestId, getByTestId } = render(
       <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
     );
     await findByTestId('reader-markdown');
     expect(getByTestId('chapter-nav-back')).toBeTruthy();
+    expect(getByTestId('mark-read-button')).toBeTruthy();
     expect(getByTestId('chapter-nav-next')).toBeTruthy();
   });
 
@@ -334,6 +344,19 @@ describe('ContentViewer', () => {
     expect(onPrev).toHaveBeenCalledTimes(1);
   });
 
+  it('renders the prev control as an icon labelled Previous chapter', async () => {
+    const item = makeItem();
+    const { findByTestId, getByTestId } = render(
+      <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
+    );
+    await findByTestId('reader-markdown');
+    const backButton = getByTestId('chapter-nav-back');
+    expect(backButton.props.accessibilityLabel).toBe('Previous chapter');
+    // The footer control now shows a glyph, so its old text label is gone.
+    // The reader header keeps its own separate back affordance.
+    expect(within(backButton).queryByText('← Back')).toBeNull();
+  });
+
   it('disables the chapter nav back button when canPrev is false', async () => {
     const onPrev = jest.fn();
     const item = makeItem();
@@ -347,24 +370,30 @@ describe('ContentViewer', () => {
     );
     await findByTestId('reader-markdown');
     const backButton = getByTestId('chapter-nav-back');
+    expect(backButton.props.accessibilityLabel).toBe('Previous chapter');
     expect(backButton.props.accessibilityState.disabled).toBe(true);
     fireEvent.press(backButton);
     expect(onPrev).not.toHaveBeenCalled();
   });
 
-  it('shows Done on the next button when nextIsDone is true', async () => {
+  it('swaps the next slot to an exit icon labelled Done when nextIsDone is true', async () => {
+    const onNext = jest.fn();
     const item = makeItem();
-    const { findByTestId, getByTestId, getByText } = render(
+    const { findByTestId, getByTestId, queryByText } = render(
       <ContentViewer
         item={item}
         onBack={onBack}
         onMarkRead={onMarkRead}
-        nav={makeNav({ nextIsDone: true })}
+        nav={makeNav({ nextIsDone: true, onNext })}
       />,
     );
     await findByTestId('reader-markdown');
-    expect(getByText('Done')).toBeTruthy();
-    expect(getByTestId('chapter-nav-next').props.accessibilityLabel).toBe('Done');
+    const nextButton = getByTestId('chapter-nav-next');
+    expect(nextButton.props.accessibilityLabel).toBe('Done');
+    // Exit is a glyph, not a caption.
+    expect(queryByText('Done')).toBeNull();
+    fireEvent.press(nextButton);
+    expect(onNext).toHaveBeenCalledTimes(1);
   });
 
   it('resets read state when navigating to a different, unread chapter', async () => {
@@ -379,7 +408,7 @@ describe('ContentViewer', () => {
       fireEvent.press(getByTestId('mark-read-button'));
     });
     await waitFor(() => {
-      expect(getByText('✓ Read')).toBeTruthy();
+      expect(within(getByTestId('mark-read-button')).getByText('✓ Read')).toBeTruthy();
     });
 
     // Next → keeps ContentViewer mounted and swaps in an unread chapter two.
@@ -401,7 +430,7 @@ describe('ContentViewer', () => {
     // ContentViewer stays mounted while navigating from an unread chapter to a
     // previously-read one; the read state must follow the incoming item.
     const unread = makeItem({ id: 3, is_read: false });
-    const { getByText, findByTestId, rerender, queryByText } = render(
+    const { getByTestId, getByText, findByTestId, rerender, queryByText } = render(
       <ContentViewer item={unread} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
     );
     await findByTestId('reader-markdown');
@@ -413,7 +442,7 @@ describe('ContentViewer', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('✓ Read')).toBeTruthy();
+      expect(within(getByTestId('mark-read-button')).getByText('✓ Read')).toBeTruthy();
     });
     expect(queryByText('Mark as Read')).toBeNull();
   });
@@ -431,7 +460,7 @@ describe('ContentViewer', () => {
     );
 
     const chapterOne = makeItem({ id: 1, is_read: false });
-    const { getByTestId, getByText, findByTestId, rerender, queryByText } = render(
+    const { getByTestId, getByText, findByTestId, rerender, queryByText, queryByTestId } = render(
       <ContentViewer item={chapterOne} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
     );
     await findByTestId('reader-markdown');
@@ -456,13 +485,15 @@ describe('ContentViewer', () => {
       expect(getByText('Mark as Read')).toBeTruthy();
     });
     expect(queryByText('✓ Read')).toBeNull();
+    // Nor may the late resolution pop a toast over the wrong chapter.
+    expect(queryByTestId('read-toast')).toBeNull();
     const markReadButton = getByTestId('mark-read-button');
     expect(markReadButton.props.accessibilityState?.disabled ?? false).toBe(false);
   });
 
-  it('shows Next chapter on the next button when nextIsDone is false', async () => {
+  it('renders the next control as an icon labelled Next chapter when nextIsDone is false', async () => {
     const item = makeItem();
-    const { findByTestId, getByTestId, getByText } = render(
+    const { findByTestId, getByTestId, queryByText } = render(
       <ContentViewer
         item={item}
         onBack={onBack}
@@ -471,7 +502,100 @@ describe('ContentViewer', () => {
       />,
     );
     await findByTestId('reader-markdown');
-    expect(getByText('Next →')).toBeTruthy();
     expect(getByTestId('chapter-nav-next').props.accessibilityLabel).toBe('Next chapter');
+    // The chevron replaces the old text label entirely.
+    expect(queryByText('Next →')).toBeNull();
+  });
+
+  describe('read toast', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('shows a transient toast after a successful mark-read, then auto-dismisses', async () => {
+      const item = makeItem();
+      const { getByTestId, queryByTestId } = render(
+        <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
+      );
+      // Flush the body fetch (a microtask; fake timers do not block it).
+      await act(async () => {});
+      getByTestId('reader-markdown');
+
+      await act(async () => {
+        fireEvent.press(getByTestId('mark-read-button'));
+      });
+
+      const toast = getByTestId('read-toast');
+      expect(within(toast).getByText('✓ Read')).toBeTruthy();
+
+      await act(async () => {
+        jest.advanceTimersByTime(TOAST_SETTLE_MS);
+      });
+      expect(queryByTestId('read-toast')).toBeNull();
+    });
+
+    it('clears the toast and its timer when navigating to another chapter mid-toast', async () => {
+      const chapterOne = makeItem({ id: 1, is_read: false });
+      const { getByTestId, queryByTestId, getByText, rerender } = render(
+        <ContentViewer item={chapterOne} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
+      );
+      await act(async () => {});
+      getByTestId('reader-markdown');
+
+      await act(async () => {
+        fireEvent.press(getByTestId('mark-read-button'));
+      });
+      expect(getByTestId('read-toast')).toBeTruthy();
+
+      // Navigate mid-toast: the item.id-keyed reset must clear the toast state.
+      const chapterTwo = makeItem({ id: 2, is_read: false });
+      await act(async () => {
+        rerender(
+          <ContentViewer
+            item={chapterTwo}
+            onBack={onBack}
+            onMarkRead={onMarkRead}
+            nav={makeNav()}
+          />,
+        );
+      });
+      expect(queryByTestId('read-toast')).toBeNull();
+      expect(getByText('Mark as Read')).toBeTruthy();
+
+      // The orphaned dismiss timer was cleaned up: advancing time neither
+      // throws nor resurrects a toast for the chapter now on screen.
+      await act(async () => {
+        jest.advanceTimersByTime(TOAST_SETTLE_MS);
+      });
+      expect(queryByTestId('read-toast')).toBeNull();
+    });
+
+    it('clears the pending dismiss timer when unmounted mid-toast', async () => {
+      const item = makeItem();
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { getByTestId, unmount } = render(
+        <ContentViewer item={item} onBack={onBack} onMarkRead={onMarkRead} nav={makeNav()} />,
+      );
+      await act(async () => {});
+      getByTestId('reader-markdown');
+
+      await act(async () => {
+        fireEvent.press(getByTestId('mark-read-button'));
+      });
+      expect(getByTestId('read-toast')).toBeTruthy();
+
+      // Tear the reader down while the dismiss timer is still pending; the
+      // unmount cleanup must drop it so advancing time updates no dead tree.
+      unmount();
+      await act(async () => {
+        jest.advanceTimersByTime(TOAST_SETTLE_MS);
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Condenses the chapter reader footer from two stacked rows (a full-width Mark as Read above a Back/Next row) into a single, calmer row:

`[‹ prev icon] [ Mark as Read ] [ › / ⎋ next-or-exit icon]`

- Prev/next are now lucide icons (`ChevronLeft` / `ChevronRight`), matching the `GoalModal` pairing; when there is no next available chapter (`nav.nextIsDone` — last chapter or next locked) the right slot swaps to a `DoorOpen` exit icon that still calls `nav.onNext` (returns to the Course screen).
- Icons reuse the shared `NAV_ICON_SIZE` / `NAV_ICON_STROKE` constants and design-token colors; all three controls keep `accessibilityRole="button"`, meaningful `accessibilityLabel`s, `accessibilityState.disabled` where applicable, and ≥44dp (`touchTarget.minimum`) hit areas. The first-chapter prev button stays disabled and dimmed.
- The center slot is a three-way state: **Mark as Read** while unread, **Reflect in Journal** once read (when `onReflect` is offered), otherwise a quiet "✓ Read" done state.
- On a successful mark-read, a transient "✓ Read" toast fades in above the row, holds for a named-constant pause, then fades away (RN `Animated`, translateY + opacity). Its dismiss timer is cleaned up on unmount **and** on chapter navigation via an `item.id`-keyed effect; interrupted fades are `finished`-guarded so no stale dismiss fires on a swapped or torn-down tree.
- Existing `testID`s (`chapter-nav-back`, `chapter-nav-next`, `mark-read-button`, `mark-read-loading`, `reflect-button`) are preserved. The hard-won `useMarkReadHandler` guards (id-guarded resync, in-flight race, mounted-ref) are untouched; the toast trigger fires only inside the existing id-match success guard. Dead two-row footer styles were removed.

No new wiring from `CourseScreen` — `ContentViewerProps` is unchanged. No hard-coded hex/px, no magic numbers (toast timings are named constants), no lint/type suppressions.

## Test plan

- `frontend/src/features/Course/__tests__/ContentViewer.test.tsx` migrated + extended (29 tests): single-row layout renders all three controls; prev/next/exit a11y labels and the `nextIsDone` icon swap; disabled prev on the first chapter; the three center-slot states; toast appears after mark-read then auto-dismisses (`jest.useFakeTimers` + advancing timers); and two no-leak tests — toast/timer cleared on mid-toast chapter navigation and on mid-toast unmount (no update-after-unmount).
- `./scripts/frontend/check-all.sh` green: 4901 tests pass, ESLint + prettier + TypeScript strict all clean.

Closes #1912