### PR TITLE
feat(practice): render the embedded Catalog tab on the light ground

### DIFF
--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -5,7 +5,7 @@
  * fixed, non-scrolling layout: a centered `Practice | Catalog` tab switcher
  * at the top, the session centered in the middle, and the weekly-progress
  * footer pinned at the foot. The Catalog tab embeds the shared catalog list
- * in place on the dark ground — choosing a practice there flips straight
+ * in place on its light paper ground — choosing a practice there flips straight
  * back to the player with the new practice live, no push navigation. The
  * switcher hides while a session is running or paused so nothing competes
  * with the ritual.
@@ -50,6 +50,7 @@ import {
   editorialType,
   onShowcase,
   showcase,
+  surface,
   touchTarget,
 } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
@@ -192,9 +193,9 @@ const PracticeScreen = (): React.JSX.Element => {
       <View style={[styles.screen, { paddingTop: s.topInset }]} testID="practice-screen-safe-area">
         {s.showSwitcher && <PracticeCatalogSwitcher active={s.tab} onChange={s.setTab} />}
         {s.tab === 'catalog' ? (
-          <View style={styles.catalogRegion}>
+          <View style={styles.catalogRegion} testID="practice-embedded-catalog">
             <PracticeCatalogList
-              variant="dark"
+              embedded
               initialStage={s.stageNumber}
               onActivated={s.onCatalogActivated}
             />
@@ -511,9 +512,9 @@ const ErrorView = ({
 const styles = StyleSheet.create({
   // The screen shell: single owner of the umber ground and the top inset.
   screen: { flex: 1, backgroundColor: showcase.canvas },
-  // The embedded catalog fills the region under the switcher; the ground stays
-  // transparent so the shell's umber shows through the dark variant.
-  catalogRegion: { flex: 1 },
+  // The embedded catalog fills the region under the switcher and paints the
+  // light paper ground the catalog list is designed for.
+  catalogRegion: { flex: 1, backgroundColor: surface.canvas },
   // Leaf wrappers fill the shell without repainting its ground.
   leaf: { flex: 1 },
   playerBody: { flex: 1, padding: SPACING.md },

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -910,9 +910,9 @@ describe('PracticeScreen', () => {
     );
   });
 
-  it('tapping the Catalog tab renders the catalog in place on the dark ground, not as a push', async () => {
+  it('tapping the Catalog tab renders the catalog in place on the light ground, not as a push', async () => {
     const { StyleSheet } = require('react-native');
-    const { onShowcase } = require('../../../design/tokens');
+    const { ink, surface } = require('../../../design/tokens');
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId, queryByTestId } = render(<PracticeScreen />);
     await waitFor(() => expect(getByTestId('active-practice-card')).toBeTruthy());
@@ -926,15 +926,16 @@ describe('PracticeScreen', () => {
     expect(getByTestId('practice-tab-catalog').props.accessibilityState).toEqual(
       expect.objectContaining({ selected: true }),
     );
-    // Embedded dark variant: no pushed screen, no light safe-area wrapper, no
-    // light ScreenHeader Create CTA, and section titles read in onShowcase ink.
+    // Embedded light ground: no push, no safe-area wrapper, no Create CTA.
     expect(mockRootNavigate).not.toHaveBeenCalled();
     expect(queryByTestId('practice-catalog-safe-area')).toBeNull();
     expect(queryByTestId('practice-catalog-create')).toBeNull();
+    const catalogRegion = getByTestId('practice-embedded-catalog');
+    expect(StyleSheet.flatten(catalogRegion.props.style).backgroundColor).toBe(surface.canvas);
     const presetsTitle = within(getByTestId('practice-catalog-section-presets')).getByText(
       'Presets',
     );
-    expect(StyleSheet.flatten(presetsTitle.props.style).color).toBe(onShowcase.soft);
+    expect(StyleSheet.flatten(presetsTitle.props.style).color).toBe(ink.soft);
   });
 
   it('activating a practice from the embedded catalog flips back with a single refresh', async () => {

--- a/frontend/src/features/Practice/screens/PracticeCatalogList.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogList.tsx
@@ -1,8 +1,8 @@
 /**
  * ``PracticeCatalogList`` — the catalog list body shared by the pushed
- * ``PracticeCatalogScreen`` (light) and the Practice player's embedded
- * Catalog tab (dark). Browsable surface for every visible practice
- * (presets + the user's drafts + imported drafts).
+ * ``PracticeCatalogScreen`` and the Practice player's embedded Catalog
+ * tab. Browsable surface for every visible practice (presets + the
+ * user's drafts + imported drafts).
  *
  * Apply ALL custom-practices-07 UX guard-rails:
  *
@@ -18,10 +18,11 @@
  * catalog pages one stage at a time and the stage chip is the primary
  * navigation rather than an optional filter.
  *
- * The ``dark`` variant renders transparently over the host's umber ground and
- * recolors section titles for it; the light editorial header (with the
- * ``+ Create`` CTA) is a light-variant-only affordance. Everything else —
- * search, chips, rows, the copy dialog — is identical in both variants.
+ * The list always renders on the light ``surface.canvas`` ground. When
+ * ``embedded`` in the Practice player, the tab switcher supplies the Catalog
+ * identity, so the editorial header (with the ``+ Create`` CTA) is
+ * suppressed. Everything else — search, chips, rows, the copy dialog — is
+ * identical in both hosts.
  */
 
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
@@ -48,7 +49,6 @@ import {
   accent,
   colors,
   ink,
-  onShowcase,
   surface,
   surfaceShadow,
   touchTarget,
@@ -70,9 +70,6 @@ import type { RecentPractice } from '@/storage/recentPracticesStorage';
 
 type Section = 'presets' | 'drafts' | 'imported';
 
-/** Ground the list renders on: ``light`` paper (pushed) or the ``dark`` player. */
-export type CatalogVariant = 'light' | 'dark';
-
 export interface CatalogProps {
   /** Stage to seed the chip filter with; defaults to ``1``. */
   initialStage?: number;
@@ -87,8 +84,9 @@ export interface CatalogProps {
 }
 
 export interface CatalogListProps extends CatalogProps {
-  /** Rendering ground; defaults to ``light`` (the pushed route). */
-  variant?: CatalogVariant;
+  /** When embedded in the Practice player, the switcher supplies the Catalog
+   * identity, so the editorial header is suppressed. */
+  embedded?: boolean;
   /** Runs after a practice is activated; defaults to popping the pushed route. */
   onActivated?: () => void;
 }
@@ -202,8 +200,6 @@ function CatalogCopyDialog({ use }: { use: CatalogUse }): React.JSX.Element | nu
 /** The catalog list body: the sectioned list plus its copy dialog. */
 export default function PracticeCatalogList(props: CatalogListProps): React.JSX.Element {
   const s = useCatalogScreen(props);
-  const variant = props.variant ?? 'light';
-  const renderSectionHeader = useMemo(() => makeSectionHeader(variant), [variant]);
 
   return (
     <>
@@ -216,7 +212,7 @@ export default function PracticeCatalogList(props: CatalogListProps): React.JSX.
         renderSectionFooter={makeSectionFooter(s.onCreate, s.sections)}
         ListHeaderComponent={
           <CatalogHeader
-            variant={variant}
+            embedded={props.embedded ?? false}
             query={s.query}
             onQueryChange={s.setQuery}
             stageNumber={s.stageNumber}
@@ -407,17 +403,13 @@ interface CatalogSection {
 
 const catalogKeyExtractor = (item: PracticeItem): string => `practice-${item.id}`;
 
-/** Section headers read in paper ink on the light ground, showcase ink on dark. */
-function makeSectionHeader(
-  variant: CatalogVariant,
-): (info: { section: CatalogSection }) => React.JSX.Element | null {
-  const titleStyle = [styles.sectionTitle, variant === 'dark' && styles.sectionTitleDark];
-  return ({ section }) =>
-    section.data.length === 0 ? null : (
-      <View style={styles.section} testID={`practice-catalog-section-${section.section}`}>
-        <Text style={titleStyle}>{section.title}</Text>
-      </View>
-    );
+/** Section header in paper ink on the light ground; hidden while empty. */
+function renderSectionHeader({ section }: { section: CatalogSection }): React.JSX.Element | null {
+  return section.data.length === 0 ? null : (
+    <View style={styles.section} testID={`practice-catalog-section-${section.section}`}>
+      <Text style={styles.sectionTitle}>{section.title}</Text>
+    </View>
+  );
 }
 
 interface SectionFooterProps {
@@ -487,7 +479,7 @@ function buildSections(
 }
 
 interface CatalogHeaderProps {
-  variant: CatalogVariant;
+  embedded: boolean;
   query: string;
   onQueryChange: (next: string) => void;
   stageNumber: number;
@@ -500,36 +492,30 @@ interface CatalogHeaderProps {
 }
 
 /** Non-scrolling-away header for the SectionList (kept as an element so the
- * search TextInput keeps focus across re-renders). The light editorial header
- * belongs to the pushed route; the dark player supplies its own identity. */
+ * search TextInput keeps focus across re-renders). The editorial header
+ * belongs to the pushed route; when embedded, the player's switcher already
+ * names the Catalog, so it is suppressed. */
 const CatalogHeader = (props: CatalogHeaderProps): React.JSX.Element => (
   <View>
-    {props.variant === 'light' && <Header onCreate={props.onCreate} />}
+    {!props.embedded && <Header onCreate={props.onCreate} />}
     <SearchBar value={props.query} onChange={props.onQueryChange} />
     <StageChips selected={props.stageNumber} onSelect={props.onStage} />
     <ModeChips selected={props.modeCategory} onSelect={props.onMode} />
-    <RecentlyUsed variant={props.variant} recents={props.recents} onDetail={props.onDetail} />
+    <RecentlyUsed recents={props.recents} onDetail={props.onDetail} />
   </View>
 );
 
 interface RecentlyUsedProps {
-  variant: CatalogVariant;
   recents: readonly RecentPractice[];
   onDetail: (id: number) => void;
 }
 
 /** A quick "Recently used" shortcut above the full catalog; hidden when empty. */
-const RecentlyUsed = ({
-  variant,
-  recents,
-  onDetail,
-}: RecentlyUsedProps): React.JSX.Element | null => {
+const RecentlyUsed = ({ recents, onDetail }: RecentlyUsedProps): React.JSX.Element | null => {
   if (recents.length === 0) return null;
   return (
     <View style={styles.section} testID="practice-catalog-recently-used">
-      <Text style={[styles.sectionTitle, variant === 'dark' && styles.sectionTitleDark]}>
-        Recently used
-      </Text>
+      <Text style={styles.sectionTitle}>Recently used</Text>
       {recents.map((recent) => (
         <RecentRow key={`recent-${recent.id}`} recent={recent} onDetail={onDetail} />
       ))}
@@ -907,7 +893,6 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     marginBottom: SPACING.sm,
   },
-  sectionTitleDark: { color: onShowcase.soft },
   sectionEmpty: { paddingVertical: SPACING.md, gap: SPACING.sm },
   rowContainer: {
     flexDirection: 'row',

--- a/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
+++ b/frontend/src/features/Practice/screens/PracticeCatalogScreen.tsx
@@ -2,8 +2,8 @@
  * ``PracticeCatalogScreen`` — the pushed RootStack catalog route: a light
  * safe-area shell around the shared ``PracticeCatalogList`` body. The list
  * itself (sections, filters, Use/copy flows) lives in ``PracticeCatalogList``
- * so the Practice player can embed the same catalog on its dark ground; this
- * wrapper keeps the pushed route's light canvas and pop-on-activate defaults.
+ * so the Practice player can embed the same catalog in place; this wrapper
+ * keeps the pushed route's light canvas and pop-on-activate defaults.
  */
 
 import React from 'react';


### PR DESCRIPTION
## Summary

The Practice player's embedded Catalog tab rendered white cards, search, and filter chips directly over the dark `showcase.canvas` umber — a half-dark hybrid that read as visually wrong. This paints the embedded catalog region with the light `surface.canvas` ground it was designed for, matching the pushed Catalog route.

- `PracticeScreen` now paints `catalogRegion` with `surface.canvas` (adds a `practice-embedded-catalog` testID) and passes `embedded` instead of `variant="dark"`.
- `PracticeCatalogList` drops the now-dead `dark` variant (`CatalogVariant`, `variant` plumbing, `sectionTitleDark`, the `onShowcase` import) and replaces the only behavior it drove — editorial-header suppression — with a purpose-named `embedded?: boolean` prop. Section titles and text now always use the light `ink.*` scale.
- In-place activation (the `onActivated` override, no push nav), the `Practice | Catalog` switcher, and the pushed `PracticeCatalogScreen` route are all unchanged. Stale dark-variant docstrings were refreshed.

Contrast verified: `ink.soft` on `surface.canvas` is 7.3:1 (AAA).

## Test plan

- Rewrote the embedded-catalog pinning test in `PracticeScreen.test.tsx` to assert the region background is `surface.canvas` and section titles read in `ink.soft` (was `onShowcase.soft`), keeping the no-push / no-safe-area / no-`+ Create`-CTA invariants — confirmed RED against the old dark code, GREEN after.
- `scripts/frontend/check-all.sh` passes: ESLint, Prettier, strict tsc, and the full Jest suite (4946 tests).

Closes #1919