### PR TITLE
feat(practice): fade the light ground into the dark player on focus

### DIFF
--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -378,6 +378,7 @@ export const rhythm = {
 export const motion = {
   fast: 90, // ms — press / quick feedback
   base: 220, // ms — entrance fade + settle, celebration pulse
+  threshold: 400, // ms — the light->dark ground fade as the Practice player gains focus
   settleY: 6, // px — the small upward translate an element settles from
 } as const;
 

--- a/frontend/src/features/Practice/PracticeScreen.tsx
+++ b/frontend/src/features/Practice/PracticeScreen.tsx
@@ -28,7 +28,14 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Animated,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import WeeklyProgress from './WeeklyProgress';
@@ -50,6 +57,7 @@ import {
   editorialType,
   onShowcase,
   showcase,
+  surface,
   touchTarget,
 } from '@/design/tokens';
 import { stageService } from '@/features/Map/services/stageService';
@@ -65,6 +73,7 @@ import type { RitualState } from '@/features/Practice/engine/types';
 import { useActivePractice } from '@/features/Practice/hooks/useActivePractice';
 import { useWeeklyProgress } from '@/features/Practice/hooks/useWeeklyProgress';
 import PracticeCatalogList from '@/features/Practice/screens/PracticeCatalogList';
+import { useThresholdFade } from '@/hooks/useThresholdFade';
 import { useAppRoute } from '@/navigation/hooks';
 import type { RootStackParamList } from '@/navigation/RootStack';
 import { useDerivedCurrentStage } from '@/store/useProgramProgression';
@@ -187,6 +196,7 @@ function usePracticeScreenModel(): PracticeScreenModel {
 
 const PracticeScreen = (): React.JSX.Element => {
   const s = usePracticeScreenModel();
+  const { overlayOpacity } = useThresholdFade();
   return (
     <>
       <View style={[styles.screen, { paddingTop: s.topInset }]} testID="practice-screen-safe-area">
@@ -214,6 +224,13 @@ const PracticeScreen = (): React.JSX.Element => {
             onBrowseCatalog={s.openCatalogTab}
           />
         )}
+        {/* top: -s.topInset extends the fade up over the safe-area strip the
+            shell pads for, so the whole ground dims together on focus. */}
+        <Animated.View
+          style={[styles.groundFade, { opacity: overlayOpacity, top: -s.topInset }]}
+          pointerEvents="none"
+          testID="practice-ground-fade"
+        />
       </View>
       <PracticeScreenDrawer
         drawer={s.drawer}
@@ -511,6 +528,14 @@ const ErrorView = ({
 const styles = StyleSheet.create({
   // The screen shell: single owner of the umber ground and the top inset.
   screen: { flex: 1, backgroundColor: showcase.canvas },
+  // The light overlay the threshold fade dissolves on focus (top comes inline).
+  groundFade: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: surface.canvas,
+  },
   // The embedded catalog fills the region under the switcher; the ground stays
   // transparent so the shell's umber shows through the dark variant.
   catalogRegion: { flex: 1 },

--- a/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
+++ b/frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx
@@ -401,6 +401,12 @@ describe('PracticeScreen', () => {
     expect(queryByText('Adjust')).toBeNull();
   });
 
+  it('renders the threshold ground-fade overlay on the shell without blocking touches', async () => {
+    const { getByTestId } = render(<PracticeScreen />);
+    await waitFor(() => expect(getByTestId('practice-empty-state')).toBeTruthy());
+    expect(getByTestId('practice-ground-fade').props.pointerEvents).toBe('none');
+  });
+
   it('renders the session flat on the dark ground with no bottom fade', async () => {
     mockUserPracticesList.mockResolvedValue([sampleUserPractice()]);
     const { getByTestId, queryByTestId } = render(<PracticeScreen />);

--- a/frontend/src/hooks/__tests__/useThresholdFade.test.tsx
+++ b/frontend/src/hooks/__tests__/useThresholdFade.test.tsx
@@ -1,0 +1,85 @@
+/* eslint-env jest */
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react-native';
+import { Animated } from 'react-native';
+
+import { motion } from '@/design/tokens';
+import * as reducedMotion from '@/hooks/useReducedMotion';
+import { useThresholdFade } from '@/hooks/useThresholdFade';
+
+// useFocusEffect is stubbed to run the callback on mount and its cleanup on
+// unmount, mirroring the PracticeScreen test harness.
+jest.mock('@react-navigation/native', () => {
+  const reactMod = jest.requireActual('react') as {
+    useEffect: (_cb: () => undefined | (() => void), _deps: unknown[]) => void;
+  };
+  return {
+    ...(jest.requireActual('@react-navigation/native') as object),
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      reactMod.useEffect(() => {
+        const cleanup = cb();
+        return () => {
+          if (typeof cleanup === 'function') cleanup();
+        };
+      }, [cb]);
+    },
+  };
+});
+
+/** Read an Animated node's current JS value (``__getValue`` is internal/untyped). */
+const animatedValue = (node: Animated.Value): number =>
+  (node as unknown as { __getValue: () => number }).__getValue();
+
+const stubAnimation = (): { start: jest.Mock; stop: jest.Mock } => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+});
+
+const stubTiming = (
+  animation: ReturnType<typeof stubAnimation>,
+): jest.SpiedFunction<typeof Animated.timing> =>
+  jest
+    .spyOn(Animated, 'timing')
+    .mockReturnValue(animation as unknown as Animated.CompositeAnimation);
+
+describe('useThresholdFade', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('resets to the light ground and schedules the threshold fade when motion is allowed', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(false);
+    const timing = stubTiming(stubAnimation());
+
+    const { result } = renderHook(() => useThresholdFade());
+
+    expect(timing).toHaveBeenCalledTimes(1);
+    expect(timing).toHaveBeenCalledWith(
+      result.current.overlayOpacity,
+      expect.objectContaining({ toValue: 0, duration: motion.threshold, useNativeDriver: true }),
+    );
+    // The stub runs no frames, so the value holds the reset-to-opaque light ground.
+    expect(animatedValue(result.current.overlayOpacity)).toBe(1);
+  });
+
+  it('skips the fade entirely under reduced motion (overlay rests transparent)', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(true);
+    const timing = stubTiming(stubAnimation());
+
+    const { result } = renderHook(() => useThresholdFade());
+
+    expect(timing).not.toHaveBeenCalled();
+    expect(animatedValue(result.current.overlayOpacity)).toBe(0);
+  });
+
+  it('stops the running fade when the focus effect cleans up', () => {
+    jest.spyOn(reducedMotion, 'useReducedMotion').mockReturnValue(false);
+    const animation = stubAnimation();
+    stubTiming(animation);
+
+    const { unmount } = renderHook(() => useThresholdFade());
+    unmount();
+
+    expect(animation.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useThresholdFade.ts
+++ b/frontend/src/hooks/useThresholdFade.ts
@@ -1,0 +1,49 @@
+/**
+ * Threshold fade — the "time to practice" moment. When the Practice player
+ * gains focus, a light (canvas-colored) overlay covering the screen dissolves
+ * from opaque to transparent, dimming the ground from the app's light surface
+ * into the dark player: a brief, deliberate crossing of a threshold.
+ *
+ * Fully disabled under reduced motion — the overlay rests transparent (the
+ * dark player shows immediately) and no animation is scheduled.
+ *
+ * The exit is intentionally NOT animated: leaving to another bottom tab lets
+ * React Navigation hide the screen immediately, and delaying that departure
+ * behind a reverse fade would add friction where none is wanted.
+ */
+import { useFocusEffect } from '@react-navigation/native';
+import { useCallback, useRef } from 'react';
+import { Animated } from 'react-native';
+
+import { useReducedMotion } from './useReducedMotion';
+
+import { motion } from '@/design/tokens';
+
+export interface ThresholdFade {
+  /** 1 = light ground fully covers the player; 0 = dark player shown. */
+  overlayOpacity: Animated.Value;
+}
+
+export function useThresholdFade(): ThresholdFade {
+  const reduced = useReducedMotion();
+  const overlayOpacity = useRef(new Animated.Value(reduced ? 0 : 1)).current;
+
+  useFocusEffect(
+    useCallback(() => {
+      if (reduced) {
+        overlayOpacity.setValue(0);
+        return;
+      }
+      overlayOpacity.setValue(1);
+      const animation = Animated.timing(overlayOpacity, {
+        toValue: 0,
+        duration: motion.threshold,
+        useNativeDriver: true,
+      });
+      animation.start();
+      return () => animation.stop();
+    }, [reduced, overlayOpacity]),
+  );
+
+  return { overlayOpacity };
+}


### PR DESCRIPTION
## Summary

Adds a focus-driven "threshold fade" to the dark Practice player. When the Practice screen gains navigation focus, a full-screen light overlay (`surface.canvas`) dissolves opacity 1 -> 0 over a new `motion.threshold` (400ms) token, dimming the app's light ground into the dark umber player — so entering the player reads as an intentional "time to practice" moment rather than an abrupt theme snap.

- New `motion.threshold: 400` token (no magic numbers; within the 300-500ms band).
- New `useThresholdFade` hook next to `useEntrance`/`useReducedMotion`: `Animated.timing` on an overlay opacity, `useNativeDriver: true`, driven by `useFocusEffect`.
- The shell renders the overlay `Animated.View` with `pointerEvents="none"` so controls stay interactive during the fade; `top: -topInset` extends it over the safe-area strip so the whole ground dims together.
- Fully skipped under reduced motion (`useReducedMotion`) — the overlay rests transparent and no animation is scheduled, matching the `useEntrance` precedent.

### Animation hygiene

All frames/timers are lifecycle-bounded: the focus-effect cleanup calls `animation.stop()`, so no frame outlives the screen (honoring the repo's teardown-flake history). The tests stub `Animated.timing` and do not rely on jest.setup's leaked-frame safety net.

### Scope note — AC #2 (tab-flip fade) deferred

The issue's second acceptance criterion (the in-place `Practice | Catalog` tab flip fading dark<->light) depends on #1919 (render the embedded Catalog tab on the light ground), which is **not yet merged** — the Catalog is still `variant="dark"`. Wiring a tab-driven fade now would flash a light overlay over the still-dark catalog. This PR ships the reusable transition primitive plus the focus fade (AC #1, #3, #4, #5); the tab-flip fade is a one-wire follow-up once the Catalog renders light. Bottom-tab navigation away is intentionally not animated (documented in the hook) — React Navigation hides the screen immediately and delaying it would add exactly the friction the request forbids.

## Test plan

- `frontend/src/hooks/__tests__/useThresholdFade.test.tsx` (new): motion-allowed schedules the `toValue: 0`, `motion.threshold`, `useNativeDriver: true` fade and resets the overlay to the opaque light ground (1); reduced-motion skips `Animated.timing` entirely and rests at 0; focus-effect cleanup stops the running animation.
- `frontend/src/features/Practice/__tests__/PracticeScreen.test.tsx` (extended): the ground-fade overlay renders in the shell with `pointerEvents="none"` (controls stay interactive).
- `./scripts/frontend/check-all.sh` green (ESLint, Prettier, tsc, Jest — 437 suites / 4950 tests).

Closes #1920