### PR TITLE
fix(backend): speak MCP streamable-HTTP in the vault client transport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic", "mcp==1.28.1"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -14,7 +14,9 @@ anyio==4.14.2
     # via
     #   anthropic
     #   httpx
+    #   mcp
     #   openai
+    #   sse-starlette
     #   starlette
 asyncpg==0.31.0
     # via -r backend/requirements.txt
@@ -35,7 +37,9 @@ cffi==2.1.0
 click==8.4.2
     # via uvicorn
 cryptography==49.0.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   pyjwt
 deprecated==1.3.1
     # via limits
 distro==1.9.0
@@ -60,7 +64,10 @@ httpx==0.28.1
     # via
     #   -r backend/requirements.txt
     #   anthropic
+    #   mcp
     #   openai
+httpx-sse==0.4.3
+    # via mcp
 idna==3.18
     # via
     #   anyio
@@ -73,7 +80,9 @@ jiter==0.16.0
     #   anthropic
     #   openai
 jsonschema==4.26.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
 limits==5.8.0
@@ -82,6 +91,8 @@ mako==1.3.12
     # via alembic
 markupsafe==3.0.3
     # via mako
+mcp==1.28.1
+    # via -r backend/requirements.txt
 openai==2.46.0
     # via -r backend/requirements.txt
 packaging==26.2
@@ -97,20 +108,30 @@ pydantic==2.13.4
     #   -r backend/requirements.txt
     #   anthropic
     #   fastapi
+    #   mcp
     #   openai
+    #   pydantic-settings
     #   sqlmodel
 pydantic-core==2.46.4
     # via pydantic
+pydantic-settings==2.14.2
+    # via mcp
 pygments==2.20.0
     # via pytest
 pyjwt==2.13.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 pytest==9.1.1
     # via
     #   -r backend/requirements.txt
     #   pytest-asyncio
 pytest-asyncio==1.4.0
     # via -r backend/requirements.txt
+python-dotenv==1.2.2
+    # via pydantic-settings
+python-multipart==0.0.32
+    # via mcp
 referencing==0.37.0
     # via
     #   jsonschema
@@ -132,8 +153,13 @@ sqlalchemy==2.0.51
     #   sqlmodel
 sqlmodel==0.0.39
     # via -r backend/requirements.txt
+sse-starlette==3.4.6
+    # via mcp
 starlette==1.3.1
-    # via fastapi
+    # via
+    #   fastapi
+    #   mcp
+    #   sse-starlette
 tqdm==4.68.4
     # via openai
 typing-extensions==4.16.0
@@ -142,6 +168,7 @@ typing-extensions==4.16.0
     #   anthropic
     #   fastapi
     #   limits
+    #   mcp
     #   openai
     #   pydantic
     #   pydantic-core
@@ -151,10 +178,14 @@ typing-extensions==4.16.0
 typing-inspection==0.4.2
     # via
     #   fastapi
+    #   mcp
     #   pydantic
+    #   pydantic-settings
 tzdata==2026.3
     # via -r backend/requirements.txt
 uvicorn==0.51.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 wrapt==2.2.2
     # via deprecated

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,9 @@ tzdata==2026.3
 pytest==9.1.1
 pytest-asyncio==1.4.0
 httpx==0.28.1
+# MCP SDK powering the Creek Vault streamable-HTTP transport
+# (services/creek_vault_client.py); unconfigured deployments never open it.
+mcp==1.28.1
 # LLM provider SDKs for BotMason (issue #402) — the stub provider stays the
 # default; these activate via BOTMASON_PROVIDER + LLM_API_KEY or a BYOK key.
 openai==2.46.0

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -22,10 +22,12 @@ Two implementations of :class:`~domain.creek_vault.CreekVaultClient` live here:
 :func:`build_creek_vault_client` chooses between them from ``CREEK_VAULT_URL``,
 so an unconfigured deployment transparently gets the local fallback.
 
-Transport security: :class:`_HttpJsonTransport` refuses a plaintext ``http://``
-URL to any non-loopback host, because every call carries the
-``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier metadata) that
-must never cross a network in cleartext. This seam does not itself encrypt the
+Transport security: :class:`_McpStreamableHttpTransport` speaks MCP
+streamable-HTTP framing (initialize, then ``tools/call``) and refuses a
+plaintext ``http://`` URL to any non-loopback host, because every session
+carries the ``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier
+metadata) that must never cross a network in cleartext -- TLS misconfiguration
+fails closed at construction. This seam does not itself encrypt the
 entry *body*: the contract's end-to-end, ciphertext-only intimate-transit rule
 (a client-held key the operator cannot decrypt) is a property of the write path
 built on this seam -- enforced where the body is assembled -- not of the seam's
@@ -39,11 +41,16 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Callable, Iterable, Mapping
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Protocol
 from urllib.parse import urlsplit
 
 import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData
 
 from domain.creek_vault import (
     CONSUMER_ID,
@@ -72,19 +79,31 @@ _VAULT_TIMEOUT_SECONDS = 10.0
 _CONTRACT_MAJOR = CONTRACT_VERSION.split(".")[0]
 
 # Transport-layer failures we normalize to a degraded state. ``OSError`` covers
-# connection/timeout errors, ``httpx.HTTPError`` covers every httpx transport and
-# status failure, and ``json.JSONDecodeError`` covers a non-JSON body (a proxy
-# error page, an empty 200, or any vault bug) that ``response.json()`` cannot
-# decode -- the transport contract is to return a *decoded* mapping, so a decode
-# failure is a transport failure. All three normalize the per-capability path to
-# unavailable exactly as the handshake path already does, keeping one coherent
-# degrade-set (``json.JSONDecodeError`` is a ``ValueError`` subclass, so it is
-# already covered by the handshake's parse-error set).
+# connection/timeout errors, ``httpx.HTTPError`` covers every httpx transport
+# and status failure underneath the MCP session, ``McpError`` covers an MCP
+# protocol failure or a tool call that returned ``isError`` (raised by
+# :func:`_extract_tool_payload` with a static, content-free message),
+# ``ExceptionGroup`` covers a streamable-HTTP connection failure (anyio task
+# groups wrap the underlying ``httpx.ConnectError`` in a builtins
+# ``ExceptionGroup``; catching the ``Exception``-only group -- never
+# ``BaseExceptionGroup`` -- stays safe under cancellation), and
+# ``json.JSONDecodeError`` covers a content-text block whose body is not JSON.
+# All of these normalize the per-capability path to unavailable exactly as the
+# handshake path already does, keeping one coherent degrade-set
+# (``json.JSONDecodeError`` is a ``ValueError`` subclass, so it is already
+# covered by the handshake's parse-error set).
 _TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (
     OSError,
     httpx.HTTPError,
+    McpError,
+    ExceptionGroup,
     json.JSONDecodeError,
 )
+
+# JSON-RPC application-defined server-error code (the -32000..-32099 range) used
+# when a vault tool call reports ``isError``; the paired message is static so it
+# can never echo the entry body or the API key.
+_MCP_TOOL_ERROR_CODE = -32000
 
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
@@ -107,10 +126,11 @@ _LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
 def _require_secure_vault_url(url: str) -> None:
     """Reject a plaintext vault URL to a non-loopback host, failing closed.
 
-    A configured vault is reached over :class:`_HttpJsonTransport`, which sends
-    the ``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier
-    metadata) over the wire. Allowing a plaintext ``http://`` URL to a remote
-    host would expose that credential in cleartext, so a misconfiguration raises
+    A configured vault is reached over :class:`_McpStreamableHttpTransport`,
+    whose MCP streamable-HTTP session sends the ``CREEK_VAULT_API_KEY`` bearer
+    credential (and each call's tier metadata) over the wire. Allowing a
+    plaintext ``http://`` URL to a remote host would expose that credential in
+    cleartext, so a misconfiguration raises
     here rather than silently leaking. Plaintext to a loopback host is permitted
     for local development. The message names only the scheme and host -- never
     the API key.
@@ -141,8 +161,13 @@ class VaultTransport(Protocol):
 
 
 def _handshake_params() -> Mapping[str, object]:
-    """Build the identity/version params adepthood presents at handshake."""
-    return {"consumer": CONSUMER_ID, "contract_version": CONTRACT_VERSION}
+    """Build the privacy-floor params adepthood presents at handshake.
+
+    The handshake carries only the privacy tier ceiling this deployment is
+    willing to expose -- never a consumer identity or contract version, which
+    the vault learns from the MCP session itself.
+    """
+    return {"privacy_tier_ceiling": VaultTierCeiling.OPEN.value}
 
 
 def _require_str(payload: Mapping[str, object], key: str) -> str:
@@ -203,11 +228,16 @@ def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
 
     Reads and version-checks the contract before anything else: a major-version
     mismatch returns unavailable directly (we will not call an incompatible
-    surface). Any missing key or wrong-typed field raises out of the helpers and
-    is caught by :meth:`McpCreekVaultClient.handshake`.
+    surface). Then honors the vault's own ``available`` field, fail-closed: a
+    reachable server is not necessarily an available vault, so anything other
+    than a literal ``True`` (including a missing field) degrades to
+    unavailable. Any missing key or wrong-typed field raises out of the helpers
+    and is caught by :meth:`McpCreekVaultClient.handshake`.
     """
     contract_version = _require_str(payload, "contract_version")
     if contract_version.split(".")[0] != _CONTRACT_MAJOR:
+        return HandshakeResult.unavailable()
+    if payload.get("available") is not True:
         return HandshakeResult.unavailable()
     return HandshakeResult(
         available=True,
@@ -432,22 +462,63 @@ class LocalFallbackCreekVaultClient:
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.WHEEL))
 
 
-class _HttpJsonTransport:
-    """A thin JSON-over-HTTP :class:`VaultTransport` for a configured vault.
+def _first_text_payload(content: Iterable[object]) -> Mapping[str, object]:
+    """Decode the first text content block of a tool result into a mapping.
 
-    POSTs each MCP call as JSON with a bearer ``Authorization`` header sourced
-    from ``CREEK_VAULT_API_KEY``. The key is used only to build that header and
-    is never logged or placed into any exception message (privacy invariant).
-    Construction refuses a plaintext ``http://`` URL to a non-loopback host so
-    the key is never bound to a transport that would send it in cleartext.
+    Iterates rather than indexing so an empty content list falls through to the
+    empty-mapping default instead of raising (``IndexError`` is not in the
+    degrade set). A block whose text is not JSON raises
+    ``json.JSONDecodeError``, which :data:`_TRANSPORT_ERROR_TYPES` degrades; a
+    decoded value that is not a mapping yields the empty mapping.
+    """
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            decoded = json.loads(text)
+            return decoded if isinstance(decoded, Mapping) else {}
+    return {}
 
-    ``call`` has two failure branches the rest of the client depends on:
-    ``response.raise_for_status()`` (a non-2xx status) raises an
-    ``httpx.HTTPError`` and ``response.json()`` (a non-JSON body) raises a
-    ``json.JSONDecodeError``. Both are in :data:`_TRANSPORT_ERROR_TYPES`, so the
-    caller normalizes them to the degraded path rather than crashing. An
-    injectable ``transport`` lets tests exercise those branches with an
-    ``httpx.MockTransport`` instead of a live network.
+
+def _extract_tool_payload(result: CallToolResult) -> Mapping[str, object]:
+    """Extract the response mapping from an MCP tool-call result.
+
+    A result flagged ``isError`` raises :class:`McpError` with a **static**
+    message -- the error content is deliberately never read, because a vault's
+    error text can echo the entry body. Otherwise structured content wins when
+    present; a plain-dict tool result rides the content-text channel and is
+    JSON-decoded via :func:`_first_text_payload`; anything else yields the
+    empty mapping.
+    """
+    if result.isError:
+        error_data = ErrorData(
+            code=_MCP_TOOL_ERROR_CODE, message="creek vault tool call returned an error"
+        )
+        raise McpError(error_data)
+    structured = result.structuredContent
+    if isinstance(structured, Mapping):
+        return structured
+    return _first_text_payload(result.content)
+
+
+class _McpStreamableHttpTransport:
+    """An MCP streamable-HTTP :class:`VaultTransport` for a configured vault.
+
+    Each ``call`` opens an MCP session (streamable-HTTP framing with a bearer
+    ``Authorization`` header sourced from ``CREEK_VAULT_API_KEY``), initializes
+    it, invokes the method as an MCP tool, and extracts the response mapping
+    via :func:`_extract_tool_payload`. The key is used only to build that
+    header and is never logged or placed into any exception message (privacy
+    invariant). Construction refuses a plaintext ``http://`` URL to a
+    non-loopback host so the key is never bound to a transport that would send
+    it in cleartext.
+
+    Every failure branch lands in :data:`_TRANSPORT_ERROR_TYPES`: a connection
+    failure surfaces as an ``ExceptionGroup`` (anyio-wrapped
+    ``httpx.ConnectError``), a protocol failure or ``isError`` tool result as
+    :class:`McpError`, and a non-JSON content-text body as
+    ``json.JSONDecodeError`` -- so the caller normalizes them to the degraded
+    path rather than crashing. The injectable ``connect`` factory lets tests
+    drive the full MCP lifecycle against an in-memory server with no network.
     """
 
     def __init__(
@@ -455,33 +526,49 @@ class _HttpJsonTransport:
         url: str,
         api_key: str,
         *,
-        transport: httpx.AsyncBaseTransport | None = None,
+        connect: Callable[[], AbstractAsyncContextManager[ClientSession]] | None = None,
     ) -> None:
-        """Store the vault base URL and bearer key, refusing an insecure URL.
+        """Store the vault URL, bearer key, and connect factory, refusing an insecure URL.
 
         Delegates to :func:`_require_secure_vault_url`, which raises for a
-        plaintext ``http://`` URL to a non-loopback host before the key is bound.
-        The optional ``transport`` is passed to :class:`httpx.AsyncClient`; it
-        defaults to ``None`` (httpx's own network transport) in production and is
-        supplied as an :class:`httpx.MockTransport` under test.
+        plaintext ``http://`` URL to a non-loopback host before the key is
+        bound. The optional ``connect`` factory defaults to the production
+        streamable-HTTP connection and is supplied as an in-memory session
+        factory under test.
         """
         _require_secure_vault_url(url)
         self._url = url
         self._api_key = api_key
-        self._transport = transport
+        self._connect: Callable[[], AbstractAsyncContextManager[ClientSession]] = (
+            connect if connect is not None else self._connect_streamable_http
+        )
+
+    @asynccontextmanager
+    async def _connect_streamable_http(self) -> AsyncIterator[ClientSession]:
+        """Open the production streamable-HTTP MCP session to the vault.
+
+        The one untestable-without-a-network seam, kept as small as possible:
+        authenticate with the bearer header, open the streamable-HTTP channel
+        (which yields a read stream, a write stream, and a session-id getter),
+        and wrap the streams in a :class:`ClientSession`.
+        """
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        async with (
+            streamablehttp_client(self._url, headers=headers, timeout=_VAULT_TIMEOUT_SECONDS) as (
+                read,
+                write,
+                _get_session_id,
+            ),
+            ClientSession(read, write) as session,
+        ):
+            yield session
 
     async def call(self, method: str, params: Mapping[str, object], /) -> Mapping[str, object]:
-        """POST one MCP call and return the decoded JSON response mapping."""
-        headers = {"Authorization": f"Bearer {self._api_key}"}
-        async with httpx.AsyncClient(
-            timeout=_VAULT_TIMEOUT_SECONDS, transport=self._transport
-        ) as client:
-            response = await client.post(
-                self._url, json={"method": method, "params": dict(params)}, headers=headers
-            )
-            response.raise_for_status()
-            decoded: Mapping[str, object] = response.json()
-            return decoded
+        """Run one MCP tool call over a fresh session and return its payload mapping."""
+        async with self._connect() as session:
+            await session.initialize()
+            result = await session.call_tool(method, dict(params))
+        return _extract_tool_payload(result)
 
 
 def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVaultClient:
@@ -491,7 +578,7 @@ def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVa
     :class:`LocalFallbackCreekVaultClient` is returned so the app runs fully on
     its local pipeline. Otherwise an :class:`McpCreekVaultClient` is returned
     over the injected ``transport`` (tests supply a fake) or a freshly built
-    :class:`_HttpJsonTransport` bound to the configured URL and API key.
+    :class:`_McpStreamableHttpTransport` bound to the configured URL and API key.
     """
     # ``CREEK_VAULT_URL`` being unset or empty is the signal that no vault is
     # configured; the bearer credential is read only to build the transport's
@@ -500,4 +587,4 @@ def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVa
     if not url:
         return LocalFallbackCreekVaultClient()
     api_key = os.getenv("CREEK_VAULT_API_KEY", "")
-    return McpCreekVaultClient(transport=transport or _HttpJsonTransport(url, api_key))
+    return McpCreekVaultClient(transport=transport or _McpStreamableHttpTransport(url, api_key))

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
 from typing import cast
 
 import httpx
 import pytest
-from pydantic import ValidationError
+from mcp import ClientSession
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.exceptions import McpError
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import CallToolResult, ImageContent, TextContent
+from pydantic import BaseModel, ValidationError
 
 from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
@@ -28,7 +33,9 @@ from domain.creek_vault import (
 from services.creek_vault_client import (
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
-    _HttpJsonTransport,
+    _extract_tool_payload,
+    _handshake_params,
+    _McpStreamableHttpTransport,
     build_creek_vault_client,
 )
 
@@ -42,9 +49,12 @@ def _handshake_payload(
     contract_version: str = CONTRACT_VERSION,
     ontology_version: str = "1.0.0",
     attestation: Mapping[str, object] | None = None,
+    *,
+    available: bool = True,
 ) -> dict[str, object]:
     """Build a well-formed creek.handshake response payload."""
     return {
+        "available": available,
         "capabilities": list(capabilities),
         "contract_version": contract_version,
         "ontology_version": ontology_version,
@@ -235,8 +245,9 @@ async def test_handshake_degrades_to_unavailable_on_wrong_typed_fields() -> None
 
 @pytest.mark.asyncio
 async def test_handshake_degrades_to_unavailable_on_non_list_capabilities() -> None:
-    """Valid versions but a non-list capabilities field degrades to unavailable."""
+    """Valid versions and availability but a non-list capabilities field degrades to unavailable."""
     payload = {
+        "available": True,
         "capabilities": "not-a-list",
         "contract_version": CONTRACT_VERSION,
         "ontology_version": "1.0.0",
@@ -257,9 +268,19 @@ async def test_handshake_degrades_to_unavailable_on_contract_major_mismatch() ->
 
 
 @pytest.mark.asyncio
+async def test_handshake_degrades_when_response_marks_unavailable() -> None:
+    """A reachable vault that reports available=False degrades to unavailable."""
+    payload = _handshake_payload([CreekCapability.INGEST.value], available=False)
+    client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
 async def test_handshake_ignores_non_string_capability_alongside_valid_ones() -> None:
     """A non-string capability entry is dropped while valid string entries still parse."""
     payload: dict[str, object] = {
+        "available": True,
         "capabilities": [CreekCapability.INGEST.value, 42, CreekCapability.WHEEL.value],
         "contract_version": CONTRACT_VERSION,
         "ontology_version": "1.0.0",
@@ -275,6 +296,7 @@ async def test_handshake_ignores_non_string_capability_alongside_valid_ones() ->
 async def test_handshake_degrades_to_unavailable_on_malformed_attestation() -> None:
     """An attestation field that is neither a mapping nor null degrades to unavailable."""
     payload: dict[str, object] = {
+        "available": True,
         "capabilities": [CreekCapability.INGEST.value],
         "contract_version": CONTRACT_VERSION,
         "ontology_version": "1.0.0",
@@ -283,6 +305,12 @@ async def test_handshake_degrades_to_unavailable_on_malformed_attestation() -> N
     client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
     result = await client.handshake()
     assert result == HandshakeResult.unavailable()
+
+
+def test_handshake_params_sends_only_privacy_tier_ceiling() -> None:
+    """Handshake params carry only privacy_tier_ceiling, never consumer or contract_version."""
+    params = _handshake_params()
+    assert params == {"privacy_tier_ceiling": VaultTierCeiling.OPEN.value}
 
 
 @pytest.mark.asyncio
@@ -609,31 +637,61 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
     assert exc_info.value.__suppress_context__ is True
 
 
-def _handshake_then(capability_response: httpx.Response) -> httpx.MockTransport:
-    """Build a MockTransport that handshakes cleanly, then scripts the capability call.
+# --- Real MCP streamable-HTTP transport driven against an in-memory vault ---
+# These tests exercise _McpStreamableHttpTransport end to end by injecting an
+# in-memory FastMCP server through its connect seam, so the real MCP lifecycle
+# (initialize -> tools/call -> result) runs with no network.
 
-    The handshake POST is answered with a well-formed payload advertising INGEST
-    so the client marks that capability supported; every other method returns the
-    supplied ``capability_response``, letting a test drive the real transport's
-    failure branches (a non-JSON body or a non-2xx status) without a network.
-    """
 
-    def _handler(request: httpx.Request) -> httpx.Response:
-        method = json.loads(request.content)["method"]
-        if method == CreekCapability.HANDSHAKE.value:
-            return httpx.Response(200, json=_handshake_payload([CreekCapability.INGEST.value]))
-        return capability_response
+class _IngestOut(BaseModel):
+    """Typed ingest result used to exercise the structuredContent branch."""
 
-    return httpx.MockTransport(_handler)
+    stored: bool
+    vault_ref: str
+
+
+def _mem_connect(server: FastMCP) -> Callable[[], AbstractAsyncContextManager[ClientSession]]:
+    """Return a connect factory yielding an in-memory session bound to ``server``."""
+
+    def _factory() -> AbstractAsyncContextManager[ClientSession]:
+        return create_connected_server_and_client_session(server)
+
+    return _factory
+
+
+class _RaisingConnect:
+    """A connect context manager whose entry raises, simulating an unreachable vault."""
+
+    def __init__(self, exc: BaseException) -> None:
+        """Store the exception raised on context entry."""
+        self._exc = exc
+
+    async def __aenter__(self) -> ClientSession:
+        """Raise the stored exception instead of yielding a session."""
+        raise self._exc
+
+    async def __aexit__(self, *_exc_info: object) -> bool:
+        """Return False; never invoked because entry raises."""
+        return False
+
+
+def _serve_handshake(server: FastMCP, capabilities: Sequence[str]) -> None:
+    """Register a creek.handshake tool advertising ``capabilities`` on ``server``."""
+    advertised = list(capabilities)
+
+    @server.tool(name=CreekCapability.HANDSHAKE.value)
+    def _handshake(privacy_tier_ceiling: str = VaultTierCeiling.OPEN.value) -> dict[str, object]:
+        """Answer a handshake with a well-formed advertised-capability payload."""
+        del privacy_tier_ceiling
+        return _handshake_payload(advertised)
 
 
 @pytest.mark.asyncio
-async def test_http_transport_decodes_valid_json_handshake() -> None:
-    """The real HTTP transport decodes a valid JSON handshake and marks INGEST supported."""
-    # This test only exercises the handshake, so the capability response is never invoked.
-    transport = _HttpJsonTransport(
-        _VAULT_URL, "api-key", transport=_handshake_then(httpx.Response(200))
-    )
+async def test_real_transport_handshake_populates_result() -> None:
+    """The real MCP transport completes a handshake against an in-memory server."""
+    server = FastMCP("fake-creek-vault")
+    _serve_handshake(server, [CreekCapability.INGEST.value])
+    transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     assert client.is_available() is True
@@ -641,31 +699,120 @@ async def test_http_transport_decodes_valid_json_handshake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_http_transport_non_json_capability_body_degrades() -> None:
-    """A non-JSON 200 body on the capability path degrades to CreekVaultUnavailableError.
+async def test_real_transport_handshake_sends_privacy_tier_ceiling() -> None:
+    """The real transport passes only privacy_tier_ceiling to the handshake tool."""
+    received: dict[str, object] = {}
+    server = FastMCP("fake-creek-vault")
 
-    ``response.json()`` raises ``json.JSONDecodeError`` (a ``ValueError`` subclass,
-    not an ``httpx.HTTPError``); the client must normalize it rather than crash,
-    upholding the module's degrade-never-crash invariant on the capability path.
-    """
-    transport = _HttpJsonTransport(
-        _VAULT_URL,
-        "api-key",
-        transport=_handshake_then(httpx.Response(200, content=b"<html>proxy error</html>")),
-    )
+    @server.tool(name=CreekCapability.HANDSHAKE.value)
+    def _handshake(privacy_tier_ceiling: str = "sentinel") -> dict[str, object]:
+        """Record the tier ceiling the client sent, then answer normally."""
+        received["privacy_tier_ceiling"] = privacy_tier_ceiling
+        return _handshake_payload([CreekCapability.INGEST.value])
+
+    transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
-    with pytest.raises(CreekVaultUnavailableError):
-        await client.ingest(_ingest_request())
+    assert received == {"privacy_tier_ceiling": VaultTierCeiling.OPEN.value}
+    assert client.is_available() is True
 
 
 @pytest.mark.asyncio
-async def test_http_transport_non_2xx_capability_status_degrades() -> None:
-    """A non-2xx status on the capability path degrades to CreekVaultUnavailableError."""
-    transport = _HttpJsonTransport(
-        _VAULT_URL, "api-key", transport=_handshake_then(httpx.Response(503))
+async def test_real_transport_degrades_on_connection_exception_group() -> None:
+    """A connection failure surfacing as an ExceptionGroup degrades to unavailable."""
+    failure = ExceptionGroup("connect failed", [httpx.ConnectError("unreachable")])
+    transport = _McpStreamableHttpTransport(
+        _VAULT_URL, "api-key", connect=lambda: _RaisingConnect(failure)
     )
     client = McpCreekVaultClient(transport=transport)
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+async def test_real_transport_reads_structured_content() -> None:
+    """A tool with a typed result is read from structuredContent."""
+    server = FastMCP("fake-creek-vault")
+    _serve_handshake(server, [CreekCapability.INGEST.value])
+
+    @server.tool(name=CreekCapability.INGEST.value)
+    def _ingest(
+        consumer: str, body: str, tier_ceiling: str, created_at: str, aspect_tags: list[str]
+    ) -> _IngestOut:
+        """Return a typed ingest result so structuredContent is populated."""
+        del consumer, body, tier_ceiling, created_at, aspect_tags
+        return _IngestOut(stored=True, vault_ref="vault-ref-structured")
+
+    transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
+    client = McpCreekVaultClient(transport=transport)
     await client.handshake()
-    with pytest.raises(CreekVaultUnavailableError):
-        await client.ingest(_ingest_request())
+    result = await client.ingest(_ingest_request())
+    assert result == VaultIngestResult(stored=True, vault_ref="vault-ref-structured")
+
+
+def test_extract_tool_payload_reads_content_text() -> None:
+    """A result with no structuredContent is JSON-decoded from its content text."""
+    result = CallToolResult(
+        content=[TextContent(type="text", text='{"stored": true, "vault_ref": "vault-ref-text"}')]
+    )
+    assert _extract_tool_payload(result) == {"stored": True, "vault_ref": "vault-ref-text"}
+
+
+def test_extract_tool_payload_empty_content_yields_empty_mapping() -> None:
+    """A result with no content blocks yields the empty mapping, never an IndexError."""
+    result = CallToolResult(content=[])
+    assert _extract_tool_payload(result) == {}
+
+
+def test_extract_tool_payload_non_mapping_text_yields_empty_mapping() -> None:
+    """Content text that decodes to a non-mapping JSON value yields the empty mapping."""
+    result = CallToolResult(content=[TextContent(type="text", text="[1, 2, 3]")])
+    assert _extract_tool_payload(result) == {}
+
+
+def test_extract_tool_payload_skips_non_text_block_before_text() -> None:
+    """A leading non-text content block is skipped so a later text block still parses."""
+    image = ImageContent(type="image", data="Zm9v", mimeType="image/png")
+    result = CallToolResult(content=[image, TextContent(type="text", text='{"stored": true}')])
+    assert _extract_tool_payload(result) == {"stored": True}
+
+
+def test_extract_tool_payload_error_result_raises_without_reading_content() -> None:
+    """An isError result raises rather than surfacing its (possibly sensitive) content text."""
+    leak = "SENTINEL_ERROR_CONTENT_DO_NOT_LEAK"
+    result = CallToolResult(content=[TextContent(type="text", text=leak)], isError=True)
+    with pytest.raises(McpError) as exc_info:
+        _extract_tool_payload(result)
+    assert leak not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_real_transport_tool_error_degrades_without_leaking_body() -> None:
+    """A tool that raises degrades to CreekVaultUnavailableError without leaking the body."""
+    body_sentinel = "SENTINEL_BODY_REAL_TRANSPORT_DO_NOT_LEAK"
+    server = FastMCP("fake-creek-vault")
+    _serve_handshake(server, [CreekCapability.INGEST.value])
+
+    @server.tool(name=CreekCapability.INGEST.value)
+    def _ingest(
+        consumer: str, body: str, tier_ceiling: str, created_at: str, aspect_tags: list[str]
+    ) -> dict[str, object]:
+        """Raise with the body in the message to prove the client never surfaces it."""
+        del consumer, tier_ceiling, created_at, aspect_tags
+        raise RuntimeError(f"vault exploded on {body}")
+
+    transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    request = VaultIngestRequest(
+        body=body_sentinel, tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+    )
+    with pytest.raises(CreekVaultUnavailableError) as exc_info:
+        await client.ingest(request)
+    assert body_sentinel not in str(exc_info.value)
+
+
+def test_real_transport_rejects_plaintext_remote_url() -> None:
+    """The real transport refuses a plaintext remote URL before binding the key."""
+    with pytest.raises(ValueError, match="https"):
+        _McpStreamableHttpTransport("http://vault.example.test", "api-key")


### PR DESCRIPTION
## Summary

The Creek Vault client's transport POSTed a bespoke `{"method","params"}` JSON body to the raw URL, which a real MCP streamable-HTTP endpoint cannot service. Because the client degrades-never-crashes by design, every failed handshake collapsed to `unavailable()` and silently masqueraded as "no vault configured" against a live `creek-tools-mcp --transport network` server (P1: the vault seam was dead-on-arrival, invisibly).

This replaces `_HttpJsonTransport` with `_McpStreamableHttpTransport`, which speaks real MCP via the official `mcp` SDK:

- Opens a bearer-authenticated streamable-HTTP session per call, `initialize()`s it, and invokes each capability as an MCP tool (`session.call_tool`), extracting the response from `structuredContent` or the content-text channel.
- Preserves the `VaultTransport` Protocol seam, so all consumers (`creek_vault_write`/`reflect`/`wheel`) and the degrade-never-crash guarantees are untouched — the seam is injected in tests to drive the full MCP lifecycle against an in-memory `FastMCP` server with no network.
- Preserves `_require_secure_vault_url` (TLS fail-closed off-loopback), the bearer key never reaching logs/errors, and `LocalFallbackCreekVaultClient` when `CREEK_VAULT_URL` is unset.

Handshake alignment with creek's shipped `creek.handshake` tool:
- `_handshake_params()` now sends only `privacy_tier_ceiling` (consumer identity comes from the bearer token, contract version from the response), not the rejected `consumer`/`contract_version`.
- `_parse_handshake()` now honors the response `available` flag fail-closed — a reachable server is not necessarily an available vault.

Degrade set (`_TRANSPORT_ERROR_TYPES`) extended with `McpError` and `ExceptionGroup` (anyio wraps a streamable-HTTP connection failure in a builtins `ExceptionGroup` around `httpx.ConnectError`), so handshake still never raises and per-capability failures still normalize to `CreekVaultUnavailableError` with static, body/key-free messages. On a tool `isError`, the transport raises `McpError` with a static message and never reads the (possibly body-echoing) error content.

Dependency: pins `mcp==1.28.1` (the CVE-2026-52869 floor, session-injection fix in older streamable-HTTP) as a direct dep and regenerates `requirements-lock.txt` (adds `mcp` + `httpx-sse`, `pydantic-settings`, `python-dotenv`, `python-multipart`, `sse-starlette`). Adds `mcp==1.28.1` to the mypy pre-commit hook's `additional_dependencies`.

Scope is transport + handshake only; the per-tool call/response param naming (classify/reflect/ingest) stays untouched as sibling sub-issues of the epic.

## Test plan

- Rewrote the real-transport tests to drive `_McpStreamableHttpTransport` end-to-end against an in-memory `FastMCP` server via `mcp.shared.memory.create_connected_server_and_client_session`: happy-path handshake, `privacy_tier_ceiling`-only args, connection-failure `ExceptionGroup` degrades to `unavailable()`, tool `isError` degrades to `CreekVaultUnavailableError` without leaking the entry body, and `structuredContent` extraction.
- Added deterministic unit tests for `_extract_tool_payload`/`_first_text_payload` (content-text JSON, empty content, non-mapping JSON, non-text block skip, static `isError` message).
- Added client-level tests for the fail-closed `available` flag and the `privacy_tier_ceiling`-only handshake params; kept the full Protocol-fake degrade/no-leak suite (including `__cause__ is None` / `__suppress_context__`).
- `./scripts/backend/check-all.sh` green: lint, format, mypy strict, bandit + pip-audit, complexity, `2979 passed / 2 skipped`, total coverage 96.88% (changed module 99%; only the untestable network-glue lines uncovered). Manual `xenon --max-* A` and `radon mi/cc` pass. `interrogate` 100% on changed files.

Closes #1934
Refs #1932