### PR TITLE
fix(backend): retarget vault write path to creek.journal, drop per-entry classify

### DIFF
--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -55,7 +55,7 @@ class CreekCapability(enum.StrEnum):
     """
 
     HANDSHAKE = "creek.handshake"
-    INGEST = "creek.ingest"
+    JOURNAL = "creek.journal"
     SAVE = "creek.save"
     CLASSIFY = "creek.classify"
     REFLECT = "creek.reflect"
@@ -173,16 +173,21 @@ class HandshakeResult:
 class VaultIngestRequest:
     """A piece of writing plus the metadata Creek needs to store it durably.
 
-    ``tier_ceiling`` is applied by the client before the call so the vault's
-    router can enforce it; ``aspect_tags`` carries any Aspect/Frequency tags
-    already known locally (empty when none). Frozen so the request cannot mutate
-    between building it and sending it.
+    ``entry_id`` is the entry's stable external id: Creek keys the stored
+    fragment off it, so re-sending the same id is idempotent and edits the
+    fragment in place rather than duplicating it. ``tier`` is
+    the entry's own privacy tier and ``tier_ceiling`` is the write ceiling the
+    vault's router enforces; for a journal entry both equal the entry's tier,
+    so Creek stores at exactly that tier and refuses any widening (it never
+    downgrades). Frozen so the request cannot mutate between building it and
+    sending it.
     """
 
+    entry_id: int
     body: str
+    tier: VaultTierCeiling
     tier_ceiling: VaultTierCeiling
     created_at: datetime
-    aspect_tags: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -75,6 +75,7 @@ from services.completion_candidates import gather_candidates
 from services.contraction import gather_contraction_aggregates
 from services.creek_vault_reflect import select_reflection_llm
 from services.creek_vault_write import (
+    VaultWriteOutcome,
     VaultWriteStatus,
     get_creek_vault_client,
     store_and_classify,
@@ -191,25 +192,13 @@ def _resolve_backdated_timestamp(entry_date: date | None) -> datetime | None:
 _VAULT_REINGEST_FIELDS = frozenset({"message", "classification"})
 
 
-def _entry_aspect_tags(entry: JournalEntry) -> tuple[int, ...]:
-    """Collect an entry's chord Aspects (primary then secondary) as ingest tags.
+def _apply_vault_outcome(entry: JournalEntry, outcome: VaultWriteOutcome) -> bool:
+    """Reconcile an entry's ``vault_ref`` / ``vault_tags`` columns to a write outcome.
 
-    Only the set notes of the chord are forwarded, so a scopeless (freeform)
-    entry sends an empty tuple rather than ``None`` placeholders.
-    """
-    return tuple(a for a in (entry.primary_aspect, entry.secondary_aspect) if a is not None)
+    Returns whether a column actually changed, so the caller commits only then:
 
-
-async def _record_vault_outcome(
-    session: AsyncSession, entry: JournalEntry, vault_client: CreekVaultClient
-) -> None:
-    """Store + classify a committed entry via the Creek Vault, reconciling its ref columns.
-
-    Best-effort: :func:`store_and_classify` never raises a vault error, so a
-    missing, unreachable, or intimate-skipped write leaves the entry saved. The
-    persisted ``vault_ref`` / ``vault_tags`` are reconciled to the outcome:
-
-    - ``INGESTED`` writes the new ref + tags (a re-ingest overwrites any prior ref).
+    - ``INGESTED`` writes the new ref + tags (a re-ingest overwrites any prior
+      ref; tags are empty while per-entry vault classification is deferred).
     - ``SKIPPED_INTIMATE`` clears a prior non-intimate ref/tags, since an entry
       re-classified intimate must not retain a handle to plaintext it no longer
       consents to expose (the model documents these columns stay NULL for
@@ -217,26 +206,43 @@ async def _record_vault_outcome(
       capability exists -- see :mod:`services.creek_vault_write`.
     - ``DEGRADED`` / ``UNAVAILABLE`` are transient, so any existing ref is kept
       untouched rather than dropped on a passing network blip.
-
-    Only a real column change re-commits, so the common no-op paths stay free of
-    a redundant write.
     """
-    outcome = await store_and_classify(
-        vault_client,
-        body=entry.message,
-        classification=entry.classification,
-        created_at=entry.timestamp,
-        aspect_tags=_entry_aspect_tags(entry),
-    )
     if outcome.status is VaultWriteStatus.INGESTED:
         entry.vault_ref = outcome.vault_ref
         entry.vault_tags = list(outcome.tags)
-    elif outcome.status is VaultWriteStatus.SKIPPED_INTIMATE and (
+        return True
+    if outcome.status is VaultWriteStatus.SKIPPED_INTIMATE and (
         entry.vault_ref is not None or entry.vault_tags is not None
     ):
         entry.vault_ref = None
         entry.vault_tags = None
-    else:
+        return True
+    return False
+
+
+async def _record_vault_outcome(
+    session: AsyncSession, entry: JournalEntry, vault_client: CreekVaultClient
+) -> None:
+    """Store a committed entry via the Creek Vault, reconciling its ref columns.
+
+    Best-effort: :func:`store_and_classify` never raises a vault error, so a
+    missing, unreachable, or intimate-skipped write leaves the entry saved. An
+    entry with no id yet returns immediately -- the vault keys its stored
+    fragment off the stable entry id, so an unsaved draft has nothing to
+    send. Column reconciliation lives in :func:`_apply_vault_outcome`; only a
+    real column change re-commits, so the common no-op paths stay free of a
+    redundant write.
+    """
+    if entry.id is None:
+        return
+    outcome = await store_and_classify(
+        vault_client,
+        entry_id=entry.id,
+        body=entry.message,
+        classification=entry.classification,
+        created_at=entry.timestamp,
+    )
+    if not _apply_vault_outcome(entry, outcome):
         return
     session.add(entry)
     await session.commit()

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -105,6 +105,10 @@ _TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (
 # can never echo the entry body or the API key.
 _MCP_TOOL_ERROR_CODE = -32000
 
+# The status value a ``creek.journal`` response reports on a durable write. Any
+# other status -- or a missing one -- parses conservatively to "not stored".
+_JOURNAL_OK_STATUS = "ok"
+
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
 _PARSE_ERROR_TYPES: tuple[type[Exception], ...] = (KeyError, TypeError, AttributeError, ValueError)
@@ -249,12 +253,17 @@ def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
 
 
 def _parse_ingest_result(payload: Mapping[str, object]) -> VaultIngestResult:
-    """Parse an ingest response, defaulting missing/odd fields conservatively."""
-    vault_ref = payload.get("vault_ref")
-    return VaultIngestResult(
-        stored=bool(payload.get("stored")),
-        vault_ref=vault_ref if isinstance(vault_ref, str) else None,
-    )
+    """Parse a ``creek.journal`` response, defaulting missing/odd fields conservatively.
+
+    Only an ``"ok"`` status paired with a non-empty string ``fragment_id``
+    counts as durably stored; a missing, empty, or wrong-typed field parses to
+    a not-stored result rather than fabricating a vault ref.
+    """
+    fragment_id = payload.get("fragment_id")
+    status_ok = payload.get("status") == _JOURNAL_OK_STATUS
+    if status_ok and isinstance(fragment_id, str) and fragment_id:
+        return VaultIngestResult(stored=True, vault_ref=fragment_id)
+    return VaultIngestResult(stored=False, vault_ref=None)
 
 
 def _parse_classification(payload: Mapping[str, object]) -> VaultClassification:
@@ -271,13 +280,20 @@ def _content_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, o
 
 
 def _ingest_params(request: VaultIngestRequest) -> Mapping[str, object]:
-    """Map an ingest request onto wire params, applying its tier ceiling."""
+    """Map an ingest request onto the ``creek.journal`` wire fields.
+
+    ``external_id`` carries the entry's stable id so a re-send is idempotent
+    (Creek edits the stored fragment in place); ``tier`` is the entry's own
+    privacy tier and ``privacy_tier_ceiling`` the write ceiling the vault's
+    router enforces. No ``consumer`` key: the vault learns the caller from the
+    MCP session itself.
+    """
     return {
-        "consumer": CONSUMER_ID,
-        "body": request.body,
-        "tier_ceiling": request.tier_ceiling.value,
-        "created_at": request.created_at.isoformat(),
-        "aspect_tags": list(request.aspect_tags),
+        "content": request.body,
+        "external_id": str(request.entry_id),
+        "timestamp": request.created_at.isoformat(),
+        "tier": request.tier.value,
+        "privacy_tier_ceiling": request.tier_ceiling.value,
     }
 
 
@@ -375,8 +391,8 @@ class McpCreekVaultClient:
         return payload
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
-        """Store ``request`` in the vault, requiring the INGEST capability."""
-        payload = await self._invoke(CreekCapability.INGEST, _ingest_params(request))
+        """Store ``request`` in the vault, requiring the JOURNAL capability."""
+        payload = await self._invoke(CreekCapability.JOURNAL, _ingest_params(request))
         return _parse_ingest_result(payload)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/backend/src/services/creek_vault_write.py
+++ b/backend/src/services/creek_vault_write.py
@@ -1,17 +1,17 @@
-"""Creek Vault write path: store a journal entry, then classify it, degrading safely.
+"""Creek Vault write path: store a journal entry durably, degrading safely.
 
 This is the thin orchestration layer the journal router calls after an entry is
 committed. It sits atop the pure :mod:`domain.creek_vault` seam and the concrete
 adapters in :mod:`services.creek_vault_client`, and its whole job is to turn the
-seam's fine-grained handshake/ingest/classify surface into one best-effort call
-that *never raises a vault error* -- so the user's entry is saved regardless of
+seam's fine-grained handshake/ingest surface into one best-effort call that
+*never raises a vault error* -- so the user's entry is saved regardless of
 whether a vault is present, reachable, or capable.
 
 The governing rule is **graceful degradation**: a missing, unreachable, or
 capability-poor vault collapses to a well-defined :class:`VaultWriteStatus`
-rather than an exception the router must special-case. A classify failure never
-undoes a successful ingest -- classification is optional enrichment layered on
-top of durable storage, not a precondition for it.
+rather than an exception the router must special-case. Per-entry vault
+classification is deferred: the write path never calls a classify capability,
+so a successful write always carries an empty tag tuple.
 
 **Intimate content is deliberately not sent here.** An entry classified
 ``intimate`` short-circuits to :attr:`VaultWriteStatus.SKIPPED_INTIMATE` before
@@ -35,7 +35,6 @@ from domain.creek_vault import (
     CreekVaultClient,
     CreekVaultError,
     VaultIngestRequest,
-    VaultTierCeiling,
     tier_ceiling_for,
 )
 from models.journal_entry import JournalClassification
@@ -61,9 +60,9 @@ class VaultWriteOutcome:
     """Immutable result of a vault write attempt: a status plus any earned metadata.
 
     ``vault_ref`` is populated only on :attr:`VaultWriteStatus.INGESTED`; ``tags``
-    carries the vault's classification (empty when the vault does not support, or
-    fails, classification). Frozen so a recorded outcome cannot mutate between the
-    write path and the caller that persists it.
+    is always empty for now, since per-entry vault classification is deferred.
+    Frozen so a recorded outcome cannot mutate between the write path and the
+    caller that persists it.
     """
 
     status: VaultWriteStatus
@@ -86,9 +85,9 @@ def _ingest_ready(client: CreekVaultClient) -> bool:
     """Return whether the last handshake found a vault that can ingest.
 
     Both conditions must hold: the vault is available at all, and it advertised
-    the INGEST capability. Either being false degrades the write to UNAVAILABLE.
+    the JOURNAL capability. Either being false degrades the write to UNAVAILABLE.
     """
-    return client.is_available() and client.supports(CreekCapability.INGEST)
+    return client.is_available() and client.supports(CreekCapability.JOURNAL)
 
 
 async def _try_ingest(client: CreekVaultClient, request: VaultIngestRequest) -> str | None:
@@ -105,34 +104,15 @@ async def _try_ingest(client: CreekVaultClient, request: VaultIngestRequest) -> 
     return result.vault_ref if result.stored else None
 
 
-async def _try_classify(
-    client: CreekVaultClient, body: str, tier_ceiling: VaultTierCeiling
-) -> tuple[str, ...]:
-    """Classify ``body`` when supported, swallowing failure to an empty tag tuple.
-
-    Classification is optional enrichment: a vault that does not advertise
-    CLASSIFY, or one whose classify call raises, yields no tags rather than
-    demoting the already-successful ingest. ``tier_ceiling`` is the resolved
-    :class:`~domain.creek_vault.VaultTierCeiling` passed straight through.
-    """
-    if not client.supports(CreekCapability.CLASSIFY):
-        return ()
-    try:
-        classification = await client.classify(body, tier_ceiling)
-    except CreekVaultError:
-        return ()
-    return classification.tags
-
-
 async def store_and_classify(
     client: CreekVaultClient,
     *,
+    entry_id: int,
     body: str,
     classification: str,
     created_at: datetime,
-    aspect_tags: tuple[int, ...] = (),
 ) -> VaultWriteOutcome:
-    """Store ``body`` in the vault and classify it, degrading rather than raising.
+    """Store ``body`` in the vault, degrading rather than raising.
 
     The order of checks is load-bearing:
 
@@ -146,11 +126,14 @@ async def store_and_classify(
        degrades to :attr:`VaultWriteStatus.UNAVAILABLE`.
     4. Ingest runs; a transport failure or a ``stored=False`` result degrades to
        :attr:`VaultWriteStatus.DEGRADED`.
-    5. On a durable ingest, classification runs as optional enrichment and the
-       call returns :attr:`VaultWriteStatus.INGESTED` with the ref and any tags.
+    5. On a durable ingest the call returns :attr:`VaultWriteStatus.INGESTED`
+       with the ref and an empty tag tuple -- per-entry vault classification is
+       deferred, so no classify capability is ever called here.
 
-    Never raises :class:`~domain.creek_vault.CreekVaultError`: the caller can
-    persist the entry unconditionally and only records vault metadata on INGESTED.
+    The entry's own tier and the write ceiling are both set to the resolved
+    tier, so the vault stores at exactly the tier the writer chose. Never
+    raises :class:`~domain.creek_vault.CreekVaultError`: the caller can persist
+    the entry unconditionally and only records vault metadata on INGESTED.
     """
     if classification == JournalClassification.INTIMATE:
         return _SKIPPED_INTIMATE_OUTCOME
@@ -159,16 +142,16 @@ async def store_and_classify(
     if not _ingest_ready(client):
         return _UNAVAILABLE_OUTCOME
     request = VaultIngestRequest(
+        entry_id=entry_id,
         body=body,
+        tier=tier_ceiling,
         tier_ceiling=tier_ceiling,
         created_at=created_at,
-        aspect_tags=aspect_tags,
     )
     vault_ref = await _try_ingest(client, request)
     if vault_ref is None:
         return _DEGRADED_OUTCOME
-    tags = await _try_classify(client, body, tier_ceiling)
-    return VaultWriteOutcome(status=VaultWriteStatus.INGESTED, vault_ref=vault_ref, tags=tags)
+    return VaultWriteOutcome(status=VaultWriteStatus.INGESTED, vault_ref=vault_ref, tags=())
 
 
 def get_creek_vault_client() -> CreekVaultClient:

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -35,7 +35,9 @@ from services.creek_vault_client import (
     McpCreekVaultClient,
     _extract_tool_payload,
     _handshake_params,
+    _ingest_params,
     _McpStreamableHttpTransport,
+    _parse_ingest_result,
     build_creek_vault_client,
 )
 
@@ -139,7 +141,11 @@ class HandshakeThenNonMappingTransport:
 def _ingest_request() -> VaultIngestRequest:
     """Build a minimal VaultIngestRequest for the ingest-path tests."""
     return VaultIngestRequest(
-        body="hello vault", tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+        entry_id=7,
+        body="hello vault",
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
     )
 
 
@@ -149,7 +155,7 @@ async def test_handshake_happy_path_populates_result() -> None:
     transport = ScriptedTransport(
         responses={
             CreekCapability.HANDSHAKE.value: _handshake_payload(
-                [CreekCapability.INGEST.value, CreekCapability.WHEEL.value],
+                [CreekCapability.JOURNAL.value, CreekCapability.WHEEL.value],
                 attestation={"quote": "sentinel-attestation"},
             )
         }
@@ -159,7 +165,7 @@ async def test_handshake_happy_path_populates_result() -> None:
     assert result.available is True
     assert result.contract_version == CONTRACT_VERSION
     assert result.ontology_version == "1.0.0"
-    assert result.capabilities == frozenset({CreekCapability.INGEST, CreekCapability.WHEEL})
+    assert result.capabilities == frozenset({CreekCapability.JOURNAL, CreekCapability.WHEEL})
     assert result.attestation == {"quote": "sentinel-attestation"}
 
 
@@ -168,7 +174,7 @@ async def test_is_available_true_after_successful_handshake() -> None:
     """is_available() reflects a successful handshake."""
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value])
         }
     )
     client = McpCreekVaultClient(transport=transport)
@@ -181,12 +187,12 @@ async def test_supports_reflects_advertised_capabilities() -> None:
     """supports() is True only for the capabilities the handshake advertised."""
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value])
         }
     )
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
-    assert client.supports(CreekCapability.INGEST) is True
+    assert client.supports(CreekCapability.JOURNAL) is True
     assert client.supports(CreekCapability.WHEEL) is False
 
 
@@ -196,13 +202,13 @@ async def test_unknown_advertised_capability_strings_are_ignored() -> None:
     transport = ScriptedTransport(
         responses={
             CreekCapability.HANDSHAKE.value: _handshake_payload(
-                [CreekCapability.INGEST.value, "creek.unknown-future-capability"]
+                [CreekCapability.JOURNAL.value, "creek.unknown-future-capability"]
             )
         }
     )
     client = McpCreekVaultClient(transport=transport)
     result = await client.handshake()
-    assert result.capabilities == frozenset({CreekCapability.INGEST})
+    assert result.capabilities == frozenset({CreekCapability.JOURNAL})
 
 
 @pytest.mark.asyncio
@@ -261,7 +267,7 @@ async def test_handshake_degrades_to_unavailable_on_non_list_capabilities() -> N
 @pytest.mark.asyncio
 async def test_handshake_degrades_to_unavailable_on_contract_major_mismatch() -> None:
     """A contract-major-version mismatch degrades to unavailable, not a raise."""
-    payload = _handshake_payload([CreekCapability.INGEST.value], contract_version="1.0.0")
+    payload = _handshake_payload([CreekCapability.JOURNAL.value], contract_version="1.0.0")
     client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
     result = await client.handshake()
     assert result == HandshakeResult.unavailable()
@@ -270,7 +276,7 @@ async def test_handshake_degrades_to_unavailable_on_contract_major_mismatch() ->
 @pytest.mark.asyncio
 async def test_handshake_degrades_when_response_marks_unavailable() -> None:
     """A reachable vault that reports available=False degrades to unavailable."""
-    payload = _handshake_payload([CreekCapability.INGEST.value], available=False)
+    payload = _handshake_payload([CreekCapability.JOURNAL.value], available=False)
     client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
     result = await client.handshake()
     assert result == HandshakeResult.unavailable()
@@ -281,7 +287,7 @@ async def test_handshake_ignores_non_string_capability_alongside_valid_ones() ->
     """A non-string capability entry is dropped while valid string entries still parse."""
     payload: dict[str, object] = {
         "available": True,
-        "capabilities": [CreekCapability.INGEST.value, 42, CreekCapability.WHEEL.value],
+        "capabilities": [CreekCapability.JOURNAL.value, 42, CreekCapability.WHEEL.value],
         "contract_version": CONTRACT_VERSION,
         "ontology_version": "1.0.0",
         "attestation": None,
@@ -289,7 +295,7 @@ async def test_handshake_ignores_non_string_capability_alongside_valid_ones() ->
     client = McpCreekVaultClient(transport=GarbagePayloadTransport(payload))
     result = await client.handshake()
     assert result.available is True
-    assert result.capabilities == frozenset({CreekCapability.INGEST, CreekCapability.WHEEL})
+    assert result.capabilities == frozenset({CreekCapability.JOURNAL, CreekCapability.WHEEL})
 
 
 @pytest.mark.asyncio
@@ -297,7 +303,7 @@ async def test_handshake_degrades_to_unavailable_on_malformed_attestation() -> N
     """An attestation field that is neither a mapping nor null degrades to unavailable."""
     payload: dict[str, object] = {
         "available": True,
-        "capabilities": [CreekCapability.INGEST.value],
+        "capabilities": [CreekCapability.JOURNAL.value],
         "contract_version": CONTRACT_VERSION,
         "ontology_version": "1.0.0",
         "attestation": "not-a-mapping",
@@ -313,13 +319,60 @@ def test_handshake_params_sends_only_privacy_tier_ceiling() -> None:
     assert params == {"privacy_tier_ceiling": VaultTierCeiling.OPEN.value}
 
 
+def test_ingest_params_maps_entry_onto_wire_fields() -> None:
+    """Ingest params carry exactly the creek.journal wire fields, with no consumer key."""
+    request = VaultIngestRequest(
+        entry_id=99,
+        body="page",
+        tier=VaultTierCeiling.PERSONAL,
+        tier_ceiling=VaultTierCeiling.PERSONAL,
+        created_at=_CREATED_AT,
+    )
+    assert _ingest_params(request) == {
+        "content": "page",
+        "external_id": "99",
+        "timestamp": _CREATED_AT.isoformat(),
+        "tier": "personal",
+        "privacy_tier_ceiling": "personal",
+    }
+    assert "consumer" not in _ingest_params(request)
+
+
+def test_parse_ingest_result_error_status_is_not_stored() -> None:
+    """A non-ok status parses to stored=False with no vault_ref."""
+    result = _parse_ingest_result({"status": "error", "fragment_id": "x"})
+    assert result == VaultIngestResult(stored=False, vault_ref=None)
+
+
+def test_parse_ingest_result_missing_fragment_id_is_not_stored() -> None:
+    """An ok status with no fragment_id parses to stored=False with no vault_ref."""
+    result = _parse_ingest_result({"status": "ok"})
+    assert result == VaultIngestResult(stored=False, vault_ref=None)
+
+
+def test_parse_ingest_result_empty_fragment_id_is_not_stored() -> None:
+    """An ok status with an empty fragment_id parses to stored=False with no vault_ref."""
+    result = _parse_ingest_result({"status": "ok", "fragment_id": ""})
+    assert result == VaultIngestResult(stored=False, vault_ref=None)
+
+
+def test_parse_ingest_result_ok_with_fragment_id_is_stored() -> None:
+    """An ok status with a non-empty fragment_id parses to stored=True carrying the ref."""
+    result = _parse_ingest_result({"status": "ok", "fragment_id": "frag-1", "action": "created"})
+    assert result == VaultIngestResult(stored=True, vault_ref="frag-1")
+
+
 @pytest.mark.asyncio
 async def test_supported_capability_call_succeeds() -> None:
-    """ingest() succeeds through a transport that advertised INGEST at handshake."""
+    """ingest() succeeds via creek.journal on a transport that advertised JOURNAL."""
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value]),
-            CreekCapability.INGEST.value: {"stored": True, "vault_ref": "vault-ref-1"},
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value]),
+            CreekCapability.JOURNAL.value: {
+                "status": "ok",
+                "fragment_id": "vault-ref-1",
+                "action": "created",
+            },
         }
     )
     client = McpCreekVaultClient(transport=transport)
@@ -333,7 +386,7 @@ async def test_unsupported_capability_raises_unsupported_error() -> None:
     """wheel() raises when the handshake did not advertise WHEEL."""
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value])
         }
     )
     client = McpCreekVaultClient(transport=transport)
@@ -347,9 +400,9 @@ async def test_supported_call_normalizes_transport_error() -> None:
     """A supported call whose transport then raises normalizes to CreekVaultUnavailableError."""
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value])
         },
-        raises={CreekCapability.INGEST.value: OSError("connection reset")},
+        raises={CreekCapability.JOURNAL.value: OSError("connection reset")},
     )
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
@@ -479,11 +532,11 @@ async def test_wheel_over_cap_aspect_count_raises_validation_error() -> None:
 @pytest.mark.asyncio
 async def test_reprobe_picks_up_newly_advertised_capability() -> None:
     """A second handshake() against a transport advertising a new capability flips supports()."""
-    transport = MutableHandshakeTransport(capabilities=[CreekCapability.INGEST.value])
+    transport = MutableHandshakeTransport(capabilities=[CreekCapability.JOURNAL.value])
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     assert client.supports(CreekCapability.WHEEL) is False
-    transport.capabilities = [CreekCapability.INGEST.value, CreekCapability.WHEEL.value]
+    transport.capabilities = [CreekCapability.JOURNAL.value, CreekCapability.WHEEL.value]
     await client.handshake()
     assert client.supports(CreekCapability.WHEEL) is True
     assert transport.handshake_calls == 2
@@ -493,7 +546,7 @@ def test_fresh_client_reports_unavailable_before_handshake() -> None:
     """A client that has never handshaken reports unavailable and unsupported."""
     client = McpCreekVaultClient(transport=RaisingTransport(OSError("never called")))
     assert client.is_available() is False
-    assert client.supports(CreekCapability.INGEST) is False
+    assert client.supports(CreekCapability.JOURNAL) is False
     assert client.supports(CreekCapability.WHEEL) is False
 
 
@@ -595,7 +648,7 @@ def test_factory_accepts_plaintext_loopback_url(monkeypatch: pytest.MonkeyPatch)
 async def test_supported_call_normalizes_non_mapping_payload() -> None:
     """A supported call whose response is not a mapping degrades to CreekVaultUnavailableError."""
     transport = HandshakeThenNonMappingTransport(
-        CreekCapability.INGEST.value, ["not", "a", "mapping"]
+        CreekCapability.JOURNAL.value, ["not", "a", "mapping"]
     )
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
@@ -613,10 +666,10 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
     monkeypatch.setenv("CREEK_VAULT_API_KEY", key_sentinel)
     transport = ScriptedTransport(
         responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.INGEST.value])
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.JOURNAL.value])
         },
         raises={
-            CreekCapability.INGEST.value: OSError(
+            CreekCapability.JOURNAL.value: OSError(
                 f"upstream rejected body: {body_sentinel} key={key_sentinel}"
             )
         },
@@ -624,7 +677,11 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     request = VaultIngestRequest(
-        body=body_sentinel, tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+        entry_id=7,
+        body=body_sentinel,
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
     )
     with pytest.raises(CreekVaultUnavailableError) as exc_info:
         await client.ingest(request)
@@ -646,8 +703,9 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
 class _IngestOut(BaseModel):
     """Typed ingest result used to exercise the structuredContent branch."""
 
-    stored: bool
-    vault_ref: str
+    status: str
+    fragment_id: str
+    action: str
 
 
 def _mem_connect(server: FastMCP) -> Callable[[], AbstractAsyncContextManager[ClientSession]]:
@@ -690,12 +748,12 @@ def _serve_handshake(server: FastMCP, capabilities: Sequence[str]) -> None:
 async def test_real_transport_handshake_populates_result() -> None:
     """The real MCP transport completes a handshake against an in-memory server."""
     server = FastMCP("fake-creek-vault")
-    _serve_handshake(server, [CreekCapability.INGEST.value])
+    _serve_handshake(server, [CreekCapability.JOURNAL.value])
     transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     assert client.is_available() is True
-    assert client.supports(CreekCapability.INGEST) is True
+    assert client.supports(CreekCapability.JOURNAL) is True
 
 
 @pytest.mark.asyncio
@@ -708,7 +766,7 @@ async def test_real_transport_handshake_sends_privacy_tier_ceiling() -> None:
     def _handshake(privacy_tier_ceiling: str = "sentinel") -> dict[str, object]:
         """Record the tier ceiling the client sent, then answer normally."""
         received["privacy_tier_ceiling"] = privacy_tier_ceiling
-        return _handshake_payload([CreekCapability.INGEST.value])
+        return _handshake_payload([CreekCapability.JOURNAL.value])
 
     transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
@@ -733,15 +791,15 @@ async def test_real_transport_degrades_on_connection_exception_group() -> None:
 async def test_real_transport_reads_structured_content() -> None:
     """A tool with a typed result is read from structuredContent."""
     server = FastMCP("fake-creek-vault")
-    _serve_handshake(server, [CreekCapability.INGEST.value])
+    _serve_handshake(server, [CreekCapability.JOURNAL.value])
 
-    @server.tool(name=CreekCapability.INGEST.value)
+    @server.tool(name=CreekCapability.JOURNAL.value)
     def _ingest(
-        consumer: str, body: str, tier_ceiling: str, created_at: str, aspect_tags: list[str]
+        content: str, external_id: str, timestamp: str, tier: str, privacy_tier_ceiling: str
     ) -> _IngestOut:
         """Return a typed ingest result so structuredContent is populated."""
-        del consumer, body, tier_ceiling, created_at, aspect_tags
-        return _IngestOut(stored=True, vault_ref="vault-ref-structured")
+        del content, external_id, timestamp, tier, privacy_tier_ceiling
+        return _IngestOut(status="ok", fragment_id="vault-ref-structured", action="created")
 
     transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
@@ -791,21 +849,25 @@ async def test_real_transport_tool_error_degrades_without_leaking_body() -> None
     """A tool that raises degrades to CreekVaultUnavailableError without leaking the body."""
     body_sentinel = "SENTINEL_BODY_REAL_TRANSPORT_DO_NOT_LEAK"
     server = FastMCP("fake-creek-vault")
-    _serve_handshake(server, [CreekCapability.INGEST.value])
+    _serve_handshake(server, [CreekCapability.JOURNAL.value])
 
-    @server.tool(name=CreekCapability.INGEST.value)
+    @server.tool(name=CreekCapability.JOURNAL.value)
     def _ingest(
-        consumer: str, body: str, tier_ceiling: str, created_at: str, aspect_tags: list[str]
+        content: str, external_id: str, timestamp: str, tier: str, privacy_tier_ceiling: str
     ) -> dict[str, object]:
         """Raise with the body in the message to prove the client never surfaces it."""
-        del consumer, tier_ceiling, created_at, aspect_tags
-        raise RuntimeError(f"vault exploded on {body}")
+        del external_id, timestamp, tier, privacy_tier_ceiling
+        raise RuntimeError(f"vault exploded on {content}")
 
     transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     request = VaultIngestRequest(
-        body=body_sentinel, tier_ceiling=VaultTierCeiling.OPEN, created_at=_CREATED_AT
+        entry_id=7,
+        body=body_sentinel,
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
     )
     with pytest.raises(CreekVaultUnavailableError) as exc_info:
         await client.ingest(request)

--- a/backend/tests/test_creek_vault_domain.py
+++ b/backend/tests/test_creek_vault_domain.py
@@ -84,9 +84,9 @@ class TestCreekCapability:
         """HANDSHAKE's value is the creek.handshake wire name."""
         assert CreekCapability.HANDSHAKE.value == "creek.handshake"
 
-    def test_ingest_value_is_wire_name(self) -> None:
-        """INGEST's value is the creek.ingest wire name."""
-        assert CreekCapability.INGEST.value == "creek.ingest"
+    def test_journal_value_is_wire_name(self) -> None:
+        """JOURNAL's value is the creek.journal wire name."""
+        assert CreekCapability.JOURNAL.value == "creek.journal"
 
     def test_save_value_is_wire_name(self) -> None:
         """SAVE's value is the creek.save wire name."""
@@ -138,13 +138,15 @@ class TestHandshakeResultPopulated:
             available=True,
             contract_version="0.1.0-draft",
             ontology_version="1.0.0",
-            capabilities=frozenset({CreekCapability.HANDSHAKE, CreekCapability.INGEST}),
+            capabilities=frozenset({CreekCapability.HANDSHAKE, CreekCapability.JOURNAL}),
             attestation={"quote": "sentinel-attestation"},
         )
         assert result.available is True
         assert result.contract_version == "0.1.0-draft"
         assert result.ontology_version == "1.0.0"
-        assert result.capabilities == frozenset({CreekCapability.HANDSHAKE, CreekCapability.INGEST})
+        assert result.capabilities == frozenset(
+            {CreekCapability.HANDSHAKE, CreekCapability.JOURNAL}
+        )
         assert result.attestation == {"quote": "sentinel-attestation"}
 
     def test_is_frozen(self) -> None:
@@ -170,14 +172,18 @@ class TestErrorHierarchy:
         assert issubclass(creek_vault.CreekCapabilityUnsupportedError, creek_vault.CreekVaultError)
 
 
-def test_vault_ingest_request_defaults_aspect_tags_to_empty_tuple() -> None:
-    """aspect_tags defaults to an empty tuple when not supplied."""
+def test_vault_ingest_request_round_trips_entry_id_and_tier() -> None:
+    """entry_id, tier, and tier_ceiling are readable back unchanged."""
     request = VaultIngestRequest(
+        entry_id=42,
         body="a private page",
+        tier=VaultTierCeiling.PERSONAL,
         tier_ceiling=VaultTierCeiling.PERSONAL,
         created_at=datetime(2026, 7, 10, tzinfo=UTC),
     )
-    assert request.aspect_tags == ()
+    assert request.entry_id == 42
+    assert request.tier == VaultTierCeiling.PERSONAL
+    assert request.tier_ceiling == VaultTierCeiling.PERSONAL
 
 
 def test_contract_version_constant() -> None:

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -42,7 +42,7 @@ class RecordingVaultClient:
         self,
         *,
         available: bool = True,
-        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.INGEST}),
+        capabilities: frozenset[CreekCapability] = frozenset({CreekCapability.JOURNAL}),
         ingest: VaultIngestResult | Exception | None = None,
         classify: VaultClassification | Exception | None = None,
     ) -> None:
@@ -118,7 +118,7 @@ async def test_intimate_entry_skips_and_never_touches_client() -> None:
     """An intimate entry never calls the vault -- not even handshake()."""
     client = RecordingVaultClient()
     outcome = await store_and_classify(
-        client, body=_BODY, classification="intimate", created_at=_CREATED_AT
+        client, body=_BODY, classification="intimate", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
         status=VaultWriteStatus.SKIPPED_INTIMATE, vault_ref=None, tags=()
@@ -131,7 +131,7 @@ async def test_unavailable_vault_returns_unavailable_status() -> None:
     """A handshake reporting unavailable degrades to UNAVAILABLE, never calling ingest."""
     client = RecordingVaultClient(available=False, capabilities=frozenset())
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
         status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()
@@ -141,10 +141,10 @@ async def test_unavailable_vault_returns_unavailable_status() -> None:
 
 @pytest.mark.asyncio
 async def test_available_but_ingest_unsupported_returns_unavailable_status() -> None:
-    """An available vault that does not advertise INGEST also degrades to UNAVAILABLE."""
+    """An available vault that does not advertise JOURNAL also degrades to UNAVAILABLE."""
     client = RecordingVaultClient(available=True, capabilities=frozenset({CreekCapability.REFLECT}))
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome.status == VaultWriteStatus.UNAVAILABLE
     assert outcome.vault_ref is None
@@ -156,7 +156,9 @@ async def test_available_but_ingest_unsupported_returns_unavailable_status() -> 
 async def test_public_classification_maps_to_open_tier_ceiling() -> None:
     """A public entry's ingest request carries the OPEN tier ceiling."""
     client = RecordingVaultClient(ingest=VaultIngestResult(stored=True, vault_ref="ref-open"))
-    await store_and_classify(client, body=_BODY, classification="public", created_at=_CREATED_AT)
+    await store_and_classify(
+        client, body=_BODY, classification="public", created_at=_CREATED_AT, entry_id=101
+    )
     ingest_call = _ingest_request(client)
     assert ingest_call.tier_ceiling == VaultTierCeiling.OPEN
 
@@ -165,37 +167,40 @@ async def test_public_classification_maps_to_open_tier_ceiling() -> None:
 async def test_personal_classification_maps_to_personal_tier_ceiling() -> None:
     """A personal entry's ingest request carries the PERSONAL tier ceiling."""
     client = RecordingVaultClient(ingest=VaultIngestResult(stored=True, vault_ref="ref-personal"))
-    await store_and_classify(client, body=_BODY, classification="personal", created_at=_CREATED_AT)
+    await store_and_classify(
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
+    )
     ingest_call = _ingest_request(client)
     assert ingest_call.tier_ceiling == VaultTierCeiling.PERSONAL
 
 
 @pytest.mark.asyncio
-async def test_ingest_request_carries_body_created_at_and_aspect_tags() -> None:
-    """The mapped VaultIngestRequest carries the caller's body, timestamp, and aspect tags."""
+async def test_ingest_request_carries_body_created_at_and_entry_id() -> None:
+    """The mapped VaultIngestRequest carries the caller's body, timestamp, id, and tier."""
     client = RecordingVaultClient()
     await store_and_classify(
         client,
         body=_BODY,
         classification="personal",
         created_at=_CREATED_AT,
-        aspect_tags=(3, 7),
+        entry_id=101,
     )
     ingest_call = _ingest_request(client)
     assert ingest_call.body == _BODY
     assert ingest_call.created_at == _CREATED_AT
-    assert ingest_call.aspect_tags == (3, 7)
+    assert ingest_call.entry_id == 101
+    assert ingest_call.tier == VaultTierCeiling.PERSONAL
 
 
 @pytest.mark.asyncio
 async def test_ingest_success_without_classify_support_returns_ingested_empty_tags() -> None:
     """A vault supporting only INGEST returns INGESTED with the vault_ref and empty tags."""
     client = RecordingVaultClient(
-        capabilities=frozenset({CreekCapability.INGEST}),
+        capabilities=frozenset({CreekCapability.JOURNAL}),
         ingest=VaultIngestResult(stored=True, vault_ref="ref-x"),
     )
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
         status=VaultWriteStatus.INGESTED, vault_ref="ref-x", tags=()
@@ -204,33 +209,31 @@ async def test_ingest_success_without_classify_support_returns_ingested_empty_ta
 
 
 @pytest.mark.asyncio
-async def test_ingest_and_classify_success_populates_tags() -> None:
-    """A vault supporting INGEST and CLASSIFY returns INGESTED with the classified tags."""
+async def test_journal_write_never_classifies_even_with_classify_advertised() -> None:
+    """The journal write path never calls classify, even when CLASSIFY is advertised."""
     client = RecordingVaultClient(
-        capabilities=frozenset({CreekCapability.INGEST, CreekCapability.CLASSIFY}),
+        capabilities=frozenset({CreekCapability.JOURNAL, CreekCapability.CLASSIFY}),
         ingest=VaultIngestResult(stored=True, vault_ref="ref-y"),
         classify=VaultClassification(tags=("courage", "shadow")),
     )
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
-        status=VaultWriteStatus.INGESTED, vault_ref="ref-y", tags=("courage", "shadow")
+        status=VaultWriteStatus.INGESTED, vault_ref="ref-y", tags=()
     )
-    assert _call_names(client) == ["handshake", "ingest", "classify"]
-    classify_call = next(args for name, args in client.calls if name == "classify")
-    assert classify_call == (_BODY, VaultTierCeiling.PERSONAL)
+    assert _call_names(client) == ["handshake", "ingest"]
 
 
 @pytest.mark.asyncio
 async def test_ingest_raising_creek_vault_error_returns_degraded_without_raising() -> None:
     """A CreekVaultError from ingest() degrades to DEGRADED rather than propagating."""
     client = RecordingVaultClient(
-        capabilities=frozenset({CreekCapability.INGEST}),
-        ingest=CreekVaultUnavailableError("creek vault call failed: creek.ingest"),
+        capabilities=frozenset({CreekCapability.JOURNAL}),
+        ingest=CreekVaultUnavailableError("creek vault call failed: creek.journal"),
     )
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
 
@@ -239,29 +242,30 @@ async def test_ingest_raising_creek_vault_error_returns_degraded_without_raising
 async def test_ingest_reporting_not_stored_from_available_vault_returns_degraded() -> None:
     """stored=False from an available, supporting vault is a degraded write, not an ingest."""
     client = RecordingVaultClient(
-        capabilities=frozenset({CreekCapability.INGEST}),
+        capabilities=frozenset({CreekCapability.JOURNAL}),
         ingest=VaultIngestResult(stored=False, vault_ref=None),
     )
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
 
 
 @pytest.mark.asyncio
 async def test_classify_error_after_successful_ingest_still_returns_ingested() -> None:
-    """Classification is optional enrichment: its failure never demotes a successful ingest."""
+    """A classify scripted to raise is never even called; the write stays INGESTED."""
     client = RecordingVaultClient(
-        capabilities=frozenset({CreekCapability.INGEST, CreekCapability.CLASSIFY}),
+        capabilities=frozenset({CreekCapability.JOURNAL, CreekCapability.CLASSIFY}),
         ingest=VaultIngestResult(stored=True, vault_ref="ref-z"),
         classify=CreekVaultUnavailableError("creek vault call failed: creek.classify"),
     )
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
         status=VaultWriteStatus.INGESTED, vault_ref="ref-z", tags=()
     )
+    assert _call_names(client) == ["handshake", "ingest"]
 
 
 @pytest.mark.asyncio
@@ -269,7 +273,9 @@ async def test_unknown_classification_raises_value_error_without_touching_client
     """An unrecognized classification fails closed via tier_ceiling_for, before any vault call."""
     client = RecordingVaultClient()
     with pytest.raises(ValueError, match="bogus"):
-        await store_and_classify(client, body=_BODY, classification="bogus", created_at=_CREATED_AT)
+        await store_and_classify(
+            client, body=_BODY, classification="bogus", created_at=_CREATED_AT, entry_id=101
+        )
     assert client.calls == []
 
 
@@ -278,7 +284,7 @@ async def test_local_fallback_client_returns_unavailable_for_non_intimate_entry(
     """The real no-vault LocalFallbackCreekVaultClient degrades a non-intimate write."""
     client = LocalFallbackCreekVaultClient()
     outcome = await store_and_classify(
-        client, body=_BODY, classification="personal", created_at=_CREATED_AT
+        client, body=_BODY, classification="personal", created_at=_CREATED_AT, entry_id=101
     )
     assert outcome == VaultWriteOutcome(
         status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()

--- a/backend/tests/test_journal_vault_read.py
+++ b/backend/tests/test_journal_vault_read.py
@@ -52,7 +52,7 @@ _VAULT_NOTE = "The vault reads: this is written in your own corpus."
 _DISTRESS_BODY = "I keep thinking I want to kill myself and end my life tonight."
 
 _DEFAULT_REFLECT_CAPABILITIES = frozenset(
-    {CreekCapability.INGEST, CreekCapability.CLASSIFY, CreekCapability.REFLECT}
+    {CreekCapability.JOURNAL, CreekCapability.CLASSIFY, CreekCapability.REFLECT}
 )
 
 
@@ -280,7 +280,7 @@ async def test_intimate_entry_never_reaches_the_vault(async_client: AsyncClient)
     ("available", "capabilities"),
     [
         (False, _DEFAULT_REFLECT_CAPABILITIES),
-        (True, frozenset({CreekCapability.INGEST, CreekCapability.CLASSIFY})),
+        (True, frozenset({CreekCapability.JOURNAL, CreekCapability.CLASSIFY})),
     ],
     ids=["handshake_unavailable", "reflect_unsupported"],
 )

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -28,6 +28,7 @@ from domain.creek_vault import (
 )
 from main import app
 from models.journal_entry import JournalEntry
+from routers.journal import _record_vault_outcome
 from services.creek_vault_write import get_creek_vault_client
 
 _SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
@@ -56,7 +57,7 @@ class SequencedVaultClient:
         self,
         *,
         capabilities: frozenset[CreekCapability] = frozenset(
-            {CreekCapability.INGEST, CreekCapability.CLASSIFY}
+            {CreekCapability.JOURNAL, CreekCapability.CLASSIFY}
         ),
         ingest_error: Exception | None = None,
     ) -> None:
@@ -104,10 +105,21 @@ class SequencedVaultClient:
 
 
 @pytest.mark.asyncio
+async def test_record_vault_outcome_skips_when_entry_id_is_none(
+    db_session: AsyncSession,
+) -> None:
+    """An entry that has no id yet returns before any vault call is made."""
+    fake = SequencedVaultClient()
+    entry = JournalEntry(sender="user", user_id=1, message="An unsaved draft.")
+    await _record_vault_outcome(db_session, entry, fake)
+    assert fake.ingest_calls == []
+
+
+@pytest.mark.asyncio
 async def test_create_non_intimate_entry_persists_vault_ref_and_tags(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """A non-intimate create with an available, classifying vault persists ref + tags."""
+    """A non-intimate create with an available vault persists the ref and empty tags."""
     fake = SequencedVaultClient()
     app.dependency_overrides[get_creek_vault_client] = lambda: fake
     headers = await _signup(async_client, "vault_create")
@@ -121,7 +133,7 @@ async def test_create_non_intimate_entry_persists_vault_ref_and_tags(
 
     row = await _entry_row(db_session, int(resp.json()["id"]))
     assert row.vault_ref == "vault-ref-1"
-    assert row.vault_tags == ["courage"]
+    assert row.vault_tags == []
 
 
 @pytest.mark.asyncio
@@ -152,7 +164,7 @@ async def test_create_degrades_gracefully_when_ingest_raises(
 ) -> None:
     """A vault ingest failure never blocks the write -- the entry still saves, unrefed."""
     fake = SequencedVaultClient(
-        ingest_error=CreekVaultUnavailableError("creek vault call failed: creek.ingest")
+        ingest_error=CreekVaultUnavailableError("creek vault call failed: creek.journal")
     )
     app.dependency_overrides[get_creek_vault_client] = lambda: fake
     headers = await _signup(async_client, "vault_degrade")
@@ -259,7 +271,7 @@ async def test_patch_to_intimate_clears_prior_vault_ref_and_tags(
     entry_id = int(created.json()["id"])
     first_row = await _entry_row(db_session, entry_id)
     assert first_row.vault_ref == "vault-ref-1"
-    assert first_row.vault_tags == ["courage"]
+    assert first_row.vault_tags == []
 
     patched = await async_client.patch(
         f"/journal/{entry_id}", json={"classification": "intimate"}, headers=headers

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -69,30 +69,39 @@ handshake itself carries no tiered content, so it is safe to call at
 any privacy tier. If `creek.handshake` fails or times out, adepthood
 falls back fully to the local pipeline — see "Graceful degradation."
 
-### Ingest and store — creek.ingest + creek.save
+### Journal write — creek.journal
 
-Direction: adepthood -> vault. Hands a piece of writing, together with
-its source and metadata (tier, timestamp, Aspect/Frequency tags where
-already known), to the vault for durable storage. Tier semantics:
+Direction: adepthood -> vault. Hands a single journal entry's content
+to the vault, together with its metadata — the entry's own tier, its
+timestamp, and a stable `external_id` derived from the entry's id.
+The `external_id` makes the call idempotent: a re-send is a no-op,
+and an edit rewrites the same vault fragment in place. The response
+carries a `fragment_id`, which adepthood persists as the entry's
+vault ref. Creek's `creek.ingest` and `creek.save` are its bulk,
+file-path staging tools, not the per-entry journal write path;
+adepthood does not use them to write journal entries. Tier semantics:
 callable for any tier, but INTIMATE-tier calls are permitted only
 under the attestation-gated conditions in "Decision (b)" below; OPEN
-and PERSONAL calls carry no such precondition. If these capabilities
-are absent from the handshake, adepthood does not ingest into the
-vault at all and the operator's own Postgres remains the sole system
-of record for that content.
+and PERSONAL calls carry no such precondition. If `creek.journal` is
+absent from the handshake, adepthood does not write to the vault at
+all and the operator's own Postgres remains the sole system of
+record for that content.
 
 ### Classification — creek.classify
 
-Direction: adepthood -> vault, vault -> adepthood. Requests
-Frequency and Wavelength-phase tags for a piece of content, or for the
-user's corpus as a whole (per-content and per-corpus classification
-are both in scope). Tier semantics: classification of INTIMATE content
-follows the same attestation-gated write path as ingest. The existing
-`creek.link` and `creek.report` tools are adjacent to classification
-but are not required capabilities under this contract — they are
-mentioned here only because a vault that implements `creek.classify`
-is likely to expose them too. If `creek.classify` is absent, adepthood
-continues to rely on its own local Aspect/Frequency assignment.
+Direction: adepthood -> vault, vault -> adepthood. A corpus-wide
+re-classification operation: it re-scores the user's existing corpus
+against the Frequency/Wavelength ontology and returns counts, not
+per-entry tags. Adepthood does not call `creek.classify` per journal
+entry. Per-entry Frequency/Wavelength tags are instead expected to
+arrive inline on the `creek.journal` response once that vault-side
+capability ships (creek-vault#874); until then, adepthood's per-entry
+vault tags are empty and it continues to rely on its own local
+Aspect/Frequency assignment. The existing `creek.link` and
+`creek.report` tools are adjacent to classification but are not
+required capabilities under this contract — they are mentioned here
+only because a vault that implements `creek.classify` is likely to
+expose them too.
 
 ### Reflection — creek.reflect
 
@@ -177,8 +186,9 @@ enclave, so the encrypted entry must arrive there somehow.
 
 ### (b) Write-vs-read asymmetry: writes under attestation; read ceiling stands.
 
-`creek.ingest`, `creek.save`, and any reflection-compute call on
-intimate content are permitted only after the vault's enclave has
+`creek.journal` writes of intimate content, together with any bulk
+`creek.ingest`/`creek.save` staging and any reflection-compute call on
+intimate content, are permitted only after the vault's enclave has
 successfully completed remote attestation. This is a write-path rule
 and does not touch #927's read-path guarantee: `TierCeiling` still
 means no remote read of INTIMATE plaintext, and the vault never
@@ -237,12 +247,12 @@ unchanged, and the Wheel of Wholeness is served from local
 depends on a vault being present.
 
 Degradation is also per-capability, not all-or-nothing. A vault that
-implements `creek.handshake`, `creek.ingest`, `creek.save`, and
-`creek.classify` but not `creek.wheel` still gets used for everything
-it supports; adepthood simply keeps computing the wheel locally for
-that user. Capabilities are re-probed on the next handshake, so a
-vault that adds a capability later is picked up automatically without
-any client-side migration.
+implements `creek.handshake`, `creek.journal`, and `creek.reflect` but
+not `creek.wheel` still gets used for everything it supports;
+adepthood simply keeps computing the wheel locally for that user.
+Capabilities are re-probed on the next handshake, so a vault that adds
+a capability later is picked up automatically without any
+client-side migration.
 
 No data is lost in either direction: content written locally while a
 vault is unavailable is not silently dropped when the vault reappears,


### PR DESCRIPTION
## Summary

The Creek Vault **write path** called `creek.ingest` — which in creek-vault is a bulk **file**-ingestion tool `(source_type, input_path, privacy_tier_ceiling)` that ingests a file path on the vault host, not an entry body — so every journal write failed validation. It then called `creek.classify` per entry, whose vault-side semantics are a **corpus-wide re-classification** returning counts (not tags): wrong semantics, a full re-classification per journal write, and no tags in the response anyway.

This retargets per-entry writes to creek-vault's shipped `creek.journal` tool and removes the per-entry `creek.classify` call:

- **`CreekCapability`**: `INGEST` → `JOURNAL = "creek.journal"`; the write path gates on it.
- **`VaultIngestRequest`**: gains `entry_id` + `tier`, drops `aspect_tags`. The wire call now sends `content`, `external_id` (the entry id — Creek keys the fragment off it, so a re-send is idempotent and an edit rewrites in place), `timestamp`, `tier` (the entry's own tier), and `privacy_tier_ceiling`.
- **`_parse_ingest_result`** reads `status` + `fragment_id`, mapping `fragment_id` → `vault_ref`.
- **`store_and_classify`** threads `entry_id`, returns empty tags, and no longer calls `classify`. The intimate short-circuit, `UNAVAILABLE`/`DEGRADED` degradation, and the `VaultWriteStatus`/`VaultWriteOutcome` contract are unchanged.
- **journal router** passes `entry_id` and skips an unsaved (`id`-None) entry.
- **`docs/creek-vault-mcp-contract.md`** reconciled to the `creek.journal` write surface (and `creek.classify` as corpus-wide, not per-entry).

Per-entry Frequency/Wavelength tags stay `()` until the vault ships inline classification on the `creek.journal` response; adepthood keeps using its own local Aspect/Frequency assignment until then.

Preserved invariants: degrade-never-crash, intimate-never-sent (short-circuits before any client touch), fail-closed tier (`tier == tier_ceiling`, never widens), and no entry-body/API-key leakage in error messages.

## Test plan

- TDD RED → GREEN across `test_creek_vault_domain.py`, `test_creek_vault_client.py`, `test_creek_vault_write.py`, `test_journal_vault_write.py`, `test_journal_vault_read.py` — new `creek.journal` wire shape, `_parse_ingest_result` status/fragment_id branches (error / missing / empty / ok), `entry_id`/`tier` request fields, classify-never-called, and the `id`-None early return.
- Full backend suite: **2985 passed, 2 skipped**, 96.94% coverage; the four touched `src` files at 100%.
- `ruff` (select=ALL), `mypy --strict`, `bandit`, `pip-audit`, `radon` MI + `xenon` A-grade all green.

Closes #1935
Refs #1932