### PR TITLE
feat(backend): add Gumroad client, ping webhook with shared-secret auth, and GumroadSale model

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ pip install -r requirements.txt
 uvicorn src.main:app --reload
 ```
 
+To exercise the Gumroad integration (license verification and the sale
+webhook), set `GUMROAD_API_TOKEN`, `GUMROAD_WEBHOOK_SECRET`,
+`GUMROAD_APTITUDE_PRODUCT_IDS`, and `GUMROAD_TOKEN_PACK_PRODUCT_IDS` — see
+`backend/.env.example` for what each does and the [Gumroad API docs](https://gumroad.com/api)
+for how to obtain a seller token.
+
 ## 📖 Program Background
 
 APTITUDE is a 36-week **developmental** journey based on Ken Wilber's _Integral Theory_,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,26 @@ LLM_MODEL=  # Model override, allowlisted per provider (defaults: gpt-4o-mini / 
 # settings, and adepthood sends no user-identifying metadata with vision
 # calls; this is the accepted privacy boundary per epic sign-off.
 
+# Gumroad integration
+#
+# GUMROAD_API_TOKEN is a Gumroad seller API token, sent as the access_token
+# form field when verifying a buyer's license key against Gumroad's
+# /v2/licenses/verify endpoint. GUMROAD_WEBHOOK_SECRET is a shared secret you
+# choose yourself and append as the ?secret= query param on the Gumroad ping
+# (resource-subscription) URL you configure in the Gumroad seller dashboard;
+# the webhook checks it with a constant-time compare and rejects (401) any
+# ping whose secret does not match, and fails closed if unset. Both are
+# REQUIRED in production — the app fails fast at startup (validate_gumroad_config
+# in src/main.py) if either is missing when ENV=production. Never commit a
+# real value for either.
+GUMROAD_API_TOKEN=  # Gumroad seller API token for license verification
+GUMROAD_WEBHOOK_SECRET=  # Shared secret matched against the ping's ?secret= query param
+# Comma-separated allowlists consumed by later features that gate on which
+# Gumroad product a license/sale belongs to; unused by the webhook or
+# license-verification client themselves today.
+GUMROAD_APTITUDE_PRODUCT_IDS=  # APTITUDE course product IDs, e.g. abc123,def456
+GUMROAD_TOKEN_PACK_PRODUCT_IDS=  # Token-pack product IDs, e.g. ghi789,jkl012
+
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production
 # RAILWAY_PUBLIC_DOMAIN=your-app.up.railway.app

--- a/backend/migrations/versions/d0e1f2a3b4c6_add_gumroad_sale.py
+++ b/backend/migrations/versions/d0e1f2a3b4c6_add_gumroad_sale.py
@@ -1,0 +1,53 @@
+"""Add the gumroadsale table for verbatim Gumroad ping persistence.
+
+Revision ID: d0e1f2a3b4c6
+Revises: c2d3e4f5a6b7
+Create Date: 2026-07-22 00:00:00.000000
+
+Creates ``gumroadsale``: one row per received Gumroad ping webhook, keyed by
+Gumroad's ``sale_id`` (unique index — webhook replays collapse onto the
+existing row). ``raw_payload`` stores the posted form verbatim as JSON so
+later features (license grants, refund handling) can re-derive anything the
+typed columns don't cover. Purely additive; ``downgrade`` drops the index and
+table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c6"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "c2d3e4f5a6b7"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the gumroadsale table with a unique index on gumroad_sale_id."""
+    op.create_table(
+        "gumroadsale",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("gumroad_sale_id", sa.String(), nullable=False),
+        sa.Column("product_id", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("resource_name", sa.String(), nullable=False),
+        sa.Column("is_recurring_charge", sa.Boolean(), nullable=False),
+        sa.Column("refunded", sa.Boolean(), nullable=False),
+        sa.Column("raw_payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_gumroadsale_gumroad_sale_id"),
+        "gumroadsale",
+        ["gumroad_sale_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Drop the gumroadsale table and its unique index."""
+    op.drop_index(op.f("ix_gumroadsale_gumroad_sale_id"), table_name="gumroadsale")
+    op.drop_table("gumroadsale")

--- a/backend/src/integrations/__init__.py
+++ b/backend/src/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Outbound third-party service clients (Gumroad, ...).
+
+Each module wraps one external HTTP API behind a small, typed surface with
+normalized errors, so routers and domain code never touch raw transport
+details or vendor-specific failure shapes.
+"""

--- a/backend/src/integrations/gumroad.py
+++ b/backend/src/integrations/gumroad.py
@@ -4,7 +4,10 @@
 maps the outcome onto three states: a parsed :class:`GumroadLicenseResult`
 (2xx), ``None`` (404 — unknown license, a normal answer, not a failure), or
 :class:`GumroadUnavailableError` (anything else). Connection failures get
-exactly one immediate retry; HTTP error responses get none.
+exactly one immediate retry; HTTP error responses and post-send read/write
+timeouts get none. A read/write timeout means Gumroad accepted the request
+then stalled, so it may already have had a server-side effect — retrying is
+unsafe, so it is wrapped as the normalized error on the first occurrence.
 
 Secrets discipline: the API token and license key travel only in the request
 body. Every log line here is static text plus status/latency metadata — the
@@ -44,13 +47,20 @@ _UNAVAILABLE_MESSAGE = "Gumroad license verification is unavailable"
 # hammer a struggling service.
 _CONNECT_FAILURES = (httpx.ConnectError, httpx.ConnectTimeout)
 
+# Timeouts *after* the request left the socket: Gumroad accepted the TCP
+# connection then stalled, so the call may already have had a server-side
+# effect. These are wrapped immediately (never retried) so a stalled verify is
+# not silently issued twice.
+_TIMEOUT_FAILURES = (httpx.ReadTimeout, httpx.WriteTimeout)
+
 
 class GumroadUnavailableError(Exception):
     """Normalized "Gumroad could not answer" failure.
 
-    Raised after the single connection-error retry is exhausted, and for any
-    non-404 4xx/5xx response. Callers get one exception type to handle; the
-    static message keeps credentials out of error text.
+    Raised after the single connection-error retry is exhausted, for any
+    non-404 4xx/5xx response, and for a post-send read/write timeout (wrapped
+    without retry). Callers get one exception type to handle; the static
+    message keeps credentials out of error text.
     """
 
 
@@ -77,7 +87,8 @@ async def verify_license(
 
     Raises:
         GumroadUnavailableError: After the single connection-error retry is
-            exhausted, or on any non-404 4xx/5xx response.
+            exhausted, on any non-404 4xx/5xx response, or on a post-send
+            read/write timeout (wrapped immediately, not retried).
     """
     if client is not None:
         return await _verify_with_client(client, product_id, license_key)
@@ -105,13 +116,40 @@ async def _verify_with_client(
     return _interpret_response(response, latency_ms)
 
 
+async def _post_once(
+    client: httpx.AsyncClient,
+    form: dict[str, str],
+) -> httpx.Response:
+    """POST the form once, wrapping a post-send timeout immediately.
+
+    A read/write timeout means Gumroad accepted the request then stalled, so a
+    retry could double any server-side effect. Such timeouts fail fast as the
+    normalized error; connection failures re-raise for the caller to retry.
+    """
+    try:
+        return await client.post(GUMROAD_VERIFY_URL, data=form)
+    except _TIMEOUT_FAILURES:
+        logger.warning(
+            "gumroad_verify_timeout",
+            extra={"reason_code": "gumroad_timeout"},
+        )
+        # ``from None`` severs the chain: the caught timeout carries a
+        # ``.request`` whose body is the verify form (``access_token`` and
+        # ``license_key``), which any ``exc_info`` logger would surface.
+        raise GumroadUnavailableError(_UNAVAILABLE_MESSAGE) from None
+
+
 async def _post_with_connect_retry(
     client: httpx.AsyncClient,
     form: dict[str, str],
 ) -> httpx.Response:
-    """POST the verification form, retrying a connection failure exactly once."""
+    """POST the verification form, retrying a connection failure exactly once.
+
+    Only connection failures (never reached Gumroad) are retried. Read/write
+    timeouts are wrapped without retry by :func:`_post_once`.
+    """
     try:
-        return await client.post(GUMROAD_VERIFY_URL, data=form)
+        return await _post_once(client, form)
     except _CONNECT_FAILURES:
         # The first attempt never reached Gumroad; one immediate retry
         # rescues transient DNS/TCP blips without hammering a down service.
@@ -120,7 +158,7 @@ async def _post_with_connect_retry(
             extra={"reason_code": "gumroad_connect_retry"},
         )
     try:
-        return await client.post(GUMROAD_VERIFY_URL, data=form)
+        return await _post_once(client, form)
     except _CONNECT_FAILURES:
         logger.warning(
             "gumroad_verify_unreachable",

--- a/backend/src/integrations/gumroad.py
+++ b/backend/src/integrations/gumroad.py
@@ -1,0 +1,176 @@
+"""Gumroad license-verification client.
+
+``verify_license`` POSTs the form-encoded verify call Gumroad documents and
+maps the outcome onto three states: a parsed :class:`GumroadLicenseResult`
+(2xx), ``None`` (404 — unknown license, a normal answer, not a failure), or
+:class:`GumroadUnavailableError` (anything else). Connection failures get
+exactly one immediate retry; HTTP error responses get none.
+
+Secrets discipline: the API token and license key travel only in the request
+body. Every log line here is static text plus status/latency metadata — the
+secrets are never interpolated anywhere loggable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from http import HTTPStatus
+
+import httpx
+
+from schemas.gumroad import GumroadLicenseResult
+
+logger = logging.getLogger(__name__)
+
+# Gumroad's documented license-verification endpoint (form-encoded POST).
+GUMROAD_VERIFY_URL = "https://api.gumroad.com/v2/licenses/verify"
+
+# Wall-clock budget for the default client. License checks sit on interactive
+# paths, so a wedged Gumroad must fail fast rather than hold a request open.
+GUMROAD_TIMEOUT_SECONDS: float = 5.0
+
+# For latency reporting in log metadata.
+_MS_PER_SECOND = 1000.0
+
+# The single message every failure path raises with. Static on purpose: a
+# dynamic message could accidentally echo the API token or license key into
+# logs or client-visible error text.
+_UNAVAILABLE_MESSAGE = "Gumroad license verification is unavailable"
+
+# Failures that mean "we never reached Gumroad" — the only retriable class.
+# An HTTP response, even a 5xx, means Gumroad answered; retrying would just
+# hammer a struggling service.
+_CONNECT_FAILURES = (httpx.ConnectError, httpx.ConnectTimeout)
+
+
+class GumroadUnavailableError(Exception):
+    """Normalized "Gumroad could not answer" failure.
+
+    Raised after the single connection-error retry is exhausted, and for any
+    non-404 4xx/5xx response. Callers get one exception type to handle; the
+    static message keeps credentials out of error text.
+    """
+
+
+async def verify_license(
+    product_id: str,
+    license_key: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> GumroadLicenseResult | None:
+    """Verify a license key against Gumroad's verify endpoint.
+
+    Args:
+        product_id: The Gumroad product the key should belong to.
+        license_key: The key the user supplied.
+        client: Optional preconfigured client (tests inject a MockTransport
+            here). When omitted, a default client pinned to
+            ``GUMROAD_TIMEOUT_SECONDS`` is created and closed per call; an
+            injected client is never closed — its lifecycle belongs to the
+            caller.
+
+    Returns:
+        The parsed result on 2xx, or ``None`` when Gumroad answers 404
+        (license does not exist).
+
+    Raises:
+        GumroadUnavailableError: After the single connection-error retry is
+            exhausted, or on any non-404 4xx/5xx response.
+    """
+    if client is not None:
+        return await _verify_with_client(client, product_id, license_key)
+    timeout = httpx.Timeout(GUMROAD_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(timeout=timeout) as default_client:
+        return await _verify_with_client(default_client, product_id, license_key)
+
+
+async def _verify_with_client(
+    client: httpx.AsyncClient,
+    product_id: str,
+    license_key: str,
+) -> GumroadLicenseResult | None:
+    """Build the form, POST with retry, and interpret Gumroad's answer."""
+    form = {
+        "product_id": product_id,
+        "license_key": license_key,
+        # Read at call time so a rotated token takes effect without a
+        # process restart (and so tests can monkeypatch the environment).
+        "access_token": os.getenv("GUMROAD_API_TOKEN", ""),
+    }
+    started = time.perf_counter()
+    response = await _post_with_connect_retry(client, form)
+    latency_ms = round((time.perf_counter() - started) * _MS_PER_SECOND, 1)
+    return _interpret_response(response, latency_ms)
+
+
+async def _post_with_connect_retry(
+    client: httpx.AsyncClient,
+    form: dict[str, str],
+) -> httpx.Response:
+    """POST the verification form, retrying a connection failure exactly once."""
+    try:
+        return await client.post(GUMROAD_VERIFY_URL, data=form)
+    except _CONNECT_FAILURES:
+        # The first attempt never reached Gumroad; one immediate retry
+        # rescues transient DNS/TCP blips without hammering a down service.
+        logger.info(
+            "gumroad_verify_retrying",
+            extra={"reason_code": "gumroad_connect_retry"},
+        )
+    try:
+        return await client.post(GUMROAD_VERIFY_URL, data=form)
+    except _CONNECT_FAILURES:
+        logger.warning(
+            "gumroad_verify_unreachable",
+            extra={"reason_code": "gumroad_unreachable"},
+        )
+        # ``from None`` (not ``from exc``) mirrors ``services.creek_vault_client``:
+        # the caught ``httpx.ConnectError`` carries a ``.request`` whose body is
+        # the verify form -- it holds ``access_token`` and ``license_key``.
+        # Chaining it would keep that Request reachable through ``__cause__`` for
+        # any ``exc_info`` logger or error tracker, so the chain is severed and
+        # only the static, credential-free message propagates.
+        raise GumroadUnavailableError(_UNAVAILABLE_MESSAGE) from None
+
+
+def _interpret_response(
+    response: httpx.Response,
+    latency_ms: float,
+) -> GumroadLicenseResult | None:
+    """Map Gumroad's HTTP answer onto the client's three-way contract.
+
+    Log lines carry only status and latency — never the token or key.
+    """
+    status = response.status_code
+    if response.is_success:
+        logger.info(
+            "gumroad_verify_completed",
+            extra={
+                "reason_code": "license_verified",
+                "status_code": status,
+                "latency_ms": latency_ms,
+            },
+        )
+        return GumroadLicenseResult.model_validate(response.json())
+    if status == HTTPStatus.NOT_FOUND:
+        # "That license does not exist" is a normal answer, not an outage.
+        logger.info(
+            "gumroad_verify_completed",
+            extra={
+                "reason_code": "license_not_found",
+                "status_code": status,
+                "latency_ms": latency_ms,
+            },
+        )
+        return None
+    logger.warning(
+        "gumroad_verify_failed",
+        extra={
+            "reason_code": "gumroad_error",
+            "status_code": status,
+            "latency_ms": latency_ms,
+        },
+    )
+    raise GumroadUnavailableError(_UNAVAILABLE_MESSAGE)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -37,6 +37,7 @@ from routers.goal_completions import router as goal_completion_router
 from routers.goal_groups import router as goal_groups_router
 from routers.goal_groups import seed_goal_group_templates
 from routers.goals import router as goals_router
+from routers.gumroad import router as gumroad_router
 from routers.habits import router as habits_router
 from routers.invitations import router as invitations_router
 from routers.journal import router as journal_router
@@ -229,6 +230,28 @@ def _assert_credentials_safe(origins: list[str]) -> None:
         )
 
 
+# Both halves of the Gumroad integration: the outbound license-verification
+# client needs the API token, the inbound ping webhook needs the shared secret.
+_REQUIRED_GUMROAD_ENV_VARS = ("GUMROAD_API_TOKEN", "GUMROAD_WEBHOOK_SECRET")
+
+
+def validate_gumroad_config() -> None:
+    """Fail fast on missing Gumroad credentials in production.
+
+    In development/staging the integration may be unconfigured — the webhook
+    fails closed and license checks simply cannot succeed. A production deploy
+    without the token or webhook secret would silently drop real purchase
+    events, so boot refuses instead, mirroring the ``_get_secret_key`` startup
+    check (BUG-AUTH-011's "deploy never goes live" principle).
+    """
+    if os.getenv("ENV", "development") != "production":
+        return
+    missing = [name for name in _REQUIRED_GUMROAD_ENV_VARS if not os.getenv(name)]
+    if missing:
+        msg = f"Missing required Gumroad configuration: {', '.join(missing)}"
+        raise RuntimeError(msg)
+
+
 def _rate_limit_exceeded_handler(_request: Request, exc: Exception) -> JSONResponse:
     """Return a JSON 429 response with Retry-After header when rate limit is exceeded.
 
@@ -366,6 +389,10 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # invoking it here turns "first user pays" into "deploy never goes live".
     _get_secret_key()
 
+    # Gumroad credentials are production-critical the same way SECRET_KEY is:
+    # fail the deploy at boot rather than dropping purchase webhooks later.
+    validate_gumroad_config()
+
     # ritual-practice ops: on every boot, seed the catalog (stages, presets,
     # course content) so a fresh database is immediately usable.
     # Opt-out via ``SKIP_STARTUP_SEED=1`` for tests and contexts where the
@@ -457,6 +484,7 @@ app.include_router(energy_router)
 app.include_router(goal_completion_router)
 app.include_router(goal_groups_router)
 app.include_router(goals_router)
+app.include_router(gumroad_router)
 app.include_router(stages_router)
 app.include_router(users_router)
 app.include_router(depth_preferences_router)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -7,6 +7,7 @@ from .energy_plan import EnergyPlan
 from .goal import Goal
 from .goal_completion import GoalCompletion
 from .goal_group import GoalGroup
+from .gumroad_sale import GumroadSale
 from .habit import Habit
 from .invitation_signal import InvitationSignal
 from .journal_entry import JournalEntry
@@ -42,6 +43,7 @@ __all__ = [
     "Goal",
     "GoalCompletion",
     "GoalGroup",
+    "GumroadSale",
     "Habit",
     "InvitationSignal",
     "JournalEntry",

--- a/backend/src/models/gumroad_sale.py
+++ b/backend/src/models/gumroad_sale.py
@@ -1,0 +1,36 @@
+"""Verbatim persistence of Gumroad ping webhooks.
+
+One row per received ping, keyed by Gumroad's ``sale_id`` so webhook replays
+collapse onto the existing row. The typed columns cover the fields current
+features read; ``raw_payload`` keeps the posted form intact (string values
+stay strings) so later features can re-derive anything else without asking
+Gumroad to resend history.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, Column, DateTime
+from sqlmodel import Field, SQLModel
+
+
+class GumroadSale(SQLModel, table=True):
+    """A single Gumroad ping webhook, stored verbatim plus typed hot fields."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    # Gumroad's sale_id — the idempotency key for webhook replays.
+    gumroad_sale_id: str = Field(index=True, unique=True)
+    product_id: str
+    email: str
+    resource_name: str
+    is_recurring_charge: bool = Field(default=False)
+    refunded: bool = Field(default=False)
+    # The posted form dict exactly as received — Gumroad sends booleans as
+    # the strings "true"/"false", and those strings are preserved here.
+    raw_payload: dict[str, str] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -64,6 +64,8 @@ async def _read_ping_payload(request: Request) -> dict[str, str]:
     or deduplicated, so the payload is rejected as malformed.
     """
     form = await request.form()
+    # Last-value-wins for duplicated keys: Gumroad pings send each field once,
+    # so collapsing to a plain str -> str dict is intentional, not lossy.
     payload = {key: value for key, value in form.multi_items() if isinstance(value, str)}
     if not payload.get("sale_id"):
         logger.warning("gumroad_webhook_rejected reason_code=malformed_payload")

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -1,0 +1,131 @@
+"""Gumroad ping webhook.
+
+Gumroad POSTs a form-encoded "ping" for every sale-related event. The shared
+secret in the ``secret`` query parameter is checked (constant time) BEFORE the
+body is read, so an unauthenticated caller can never drive the parser. Valid
+pings are persisted verbatim into :class:`~models.gumroad_sale.GumroadSale`,
+idempotently keyed by ``sale_id`` — persistence only, no grant or credit side
+effects (those belong to later features reading the stored rows).
+
+Secrets discipline: the webhook secret, buyer email, and raw payload never
+appear in log text — only static markers and non-PII metadata do.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from database import get_session
+from errors import bad_request
+from models.gumroad_sale import GumroadSale
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/webhooks/gumroad", tags=["gumroad"])
+
+# resource_name values Gumroad documents for ping webhooks. Anything else is
+# still persisted (verbatim capture) but flagged with
+# ``reason_code=unhandled_event`` so operators notice new event types.
+KNOWN_RESOURCE_NAMES = frozenset(
+    {"sale", "refund", "dispute", "cancellation", "subscription_ended"}
+)
+
+# Gumroad posts booleans as the form strings "true"/"false".
+_TRUE_FORM_VALUE = "true"
+
+
+def _require_valid_secret(provided: str | None) -> None:
+    """Reject the request (401) unless the shared secret matches.
+
+    ``GUMROAD_WEBHOOK_SECRET`` is read at request time so rotation needs no
+    restart; the comparison is constant-time via :func:`hmac.compare_digest`.
+    An unset secret fails closed — every request is rejected.
+    """
+    expected = os.getenv("GUMROAD_WEBHOOK_SECRET", "")
+    supplied = provided or ""
+    if not expected or not hmac.compare_digest(supplied.encode(), expected.encode()):
+        # Static text only — never echo the supplied or expected secret.
+        logger.warning("gumroad_webhook_rejected reason_code=invalid_signature")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_signature")
+
+
+async def _read_ping_payload(request: Request) -> dict[str, str]:
+    """Read the form body verbatim as str -> str; 400 when ``sale_id`` is absent.
+
+    ``sale_id`` is the idempotency key — without it a ping cannot be stored
+    or deduplicated, so the payload is rejected as malformed.
+    """
+    form = await request.form()
+    payload = {key: value for key, value in form.multi_items() if isinstance(value, str)}
+    if not payload.get("sale_id"):
+        logger.warning("gumroad_webhook_rejected reason_code=malformed_payload")
+        raise bad_request("malformed_payload")
+    return payload
+
+
+def _coerce_form_flag(payload: dict[str, str], key: str) -> bool:
+    """Coerce Gumroad's "true"/"false" form strings to a bool (absent -> False)."""
+    return payload.get(key, "").strip().lower() == _TRUE_FORM_VALUE
+
+
+async def _sale_already_recorded(session: AsyncSession, sale_id: str) -> bool:
+    """Return True when this ``gumroad_sale_id`` was already persisted (replay)."""
+    result = await session.execute(
+        select(GumroadSale).where(GumroadSale.gumroad_sale_id == sale_id)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _persist_sale(session: AsyncSession, payload: dict[str, str]) -> None:
+    """Insert the GumroadSale row; a concurrent replay collapses to a no-op."""
+    sale = GumroadSale(
+        gumroad_sale_id=payload["sale_id"],
+        product_id=payload.get("product_id", ""),
+        email=payload.get("email", ""),
+        resource_name=payload.get("resource_name", ""),
+        is_recurring_charge=_coerce_form_flag(payload, "is_recurring_charge"),
+        refunded=_coerce_form_flag(payload, "refunded"),
+        raw_payload=payload,
+    )
+    session.add(sale)
+    try:
+        await session.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent replay of the same sale_id — the row
+        # already exists, which is exactly the state we wanted.
+        await session.rollback()
+
+
+@router.post("/ping")
+async def receive_ping(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    secret: str | None = None,
+) -> dict[str, str]:
+    """Persist one Gumroad ping, idempotently keyed by ``sale_id``.
+
+    Always answers 200 on an authenticated, well-formed ping — including
+    replays and unknown event types — so Gumroad never re-queues an event we
+    have already captured.
+    """
+    _require_valid_secret(secret)
+    payload = await _read_ping_payload(request)
+    resource_name = payload.get("resource_name", "")
+    if resource_name not in KNOWN_RESOURCE_NAMES:
+        # Persisted anyway (verbatim capture), but flagged for operators.
+        logger.info("gumroad_webhook_event reason_code=unhandled_event")
+    if not await _sale_already_recorded(session, payload["sale_id"]):
+        await _persist_sale(session, payload)
+    logger.info(
+        "gumroad_webhook_accepted",
+        extra={"reason_code": "accepted", "resource_name": resource_name},
+    )
+    return {"status": "ok"}

--- a/backend/src/schemas/gumroad.py
+++ b/backend/src/schemas/gumroad.py
@@ -1,0 +1,30 @@
+"""Pydantic mirrors of Gumroad's license-verification response payloads.
+
+Both models allow extra fields: Gumroad adds fields to its JSON without
+notice, and the client must keep parsing when it does.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GumroadPurchase(BaseModel):
+    """The ``purchase`` object nested in a verify-license response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    email: str
+    product_id: str
+    sale_id: str
+    refunded: bool
+
+
+class GumroadLicenseResult(BaseModel):
+    """Top-level body of a successful ``/v2/licenses/verify`` response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    uses: int
+    purchase: GumroadPurchase

--- a/backend/tests/integrations/__init__.py
+++ b/backend/tests/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for third-party integration clients (integrations package)."""

--- a/backend/tests/integrations/test_gumroad_client.py
+++ b/backend/tests/integrations/test_gumroad_client.py
@@ -117,6 +117,73 @@ async def test_connect_error_is_retried_exactly_once(
 
 
 @pytest.mark.asyncio
+async def test_connect_timeout_is_retried_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect timeout stays in the retried bucket, not the wrapped-timeout one.
+
+    ``ConnectTimeout`` is a sibling of ``ReadTimeout``/``WriteTimeout`` under
+    httpx's ``TimeoutException``; this guards the seam that keeps it retried
+    (never reached Gumroad) rather than failing fast like a post-send timeout.
+    """
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        raise httpx.ConnectTimeout("connect timed out", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 2
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_is_wrapped_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read timeout wraps to a normalized error immediately, without a retry.
+
+    A read/write timeout means Gumroad accepted the request then stalled, so the
+    call may already have had a server-side effect; retrying it is unsafe, so the
+    client fails fast with the normalized error instead of a second attempt.
+    """
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_write_timeout_is_wrapped_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write timeout is normalized the same way a read timeout is."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        raise httpx.WriteTimeout("write timed out", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
 async def test_http_5xx_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     """A 500 response surfaces a normalized error without any retry."""
     monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
@@ -198,6 +265,13 @@ async def test_token_and_license_key_never_logged(
         raise httpx.ConnectError("connection refused", request=request)
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(failing_handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    def timeout_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(timeout_handler)) as client:
         with pytest.raises(GumroadUnavailableError):
             await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
 

--- a/backend/tests/integrations/test_gumroad_client.py
+++ b/backend/tests/integrations/test_gumroad_client.py
@@ -1,0 +1,205 @@
+"""Tests for the Gumroad license-verification client (integrations.gumroad).
+
+All Gumroad HTTP is mocked with ``httpx.MockTransport``; no test touches the
+network.  The client contract: ``verify_license`` POSTs form fields to the
+Gumroad verify endpoint, returns a parsed ``GumroadLicenseResult`` on success,
+``None`` on Gumroad 404, retries a connection error exactly once, and never
+logs the API token or license key.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from integrations.gumroad import (
+    GUMROAD_TIMEOUT_SECONDS,
+    GumroadUnavailableError,
+    verify_license,
+)
+from schemas.gumroad import GumroadLicenseResult
+
+VERIFY_URL = "https://api.gumroad.com/v2/licenses/verify"
+PRODUCT_ID = "prod_abc123"
+LICENSE_KEY = "AAAA1111-BBBB2222-CCCC3333-DDDD4444"  # pragma: allowlist secret
+API_TOKEN = "gumroad-access-token-test-only"  # pragma: allowlist secret
+EXPECTED_USES = 3
+
+
+def _success_payload() -> dict[str, object]:
+    """Build the JSON body Gumroad returns for a valid license."""
+    return {
+        "success": True,
+        "uses": EXPECTED_USES,
+        "purchase": {
+            "email": "buyer@example.com",
+            "product_id": PRODUCT_ID,
+            "sale_id": "S-123",
+            "refunded": False,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_license_valid_returns_parsed_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid license yields a GumroadLicenseResult and a well-formed request."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(httpx.codes.OK, json=_success_payload())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert isinstance(result, GumroadLicenseResult)
+    assert result.success is True
+    assert result.uses == EXPECTED_USES
+    assert result.purchase.email == "buyer@example.com"
+    assert result.purchase.product_id == PRODUCT_ID
+    assert result.purchase.sale_id == "S-123"
+    assert result.purchase.refunded is False
+
+    assert len(captured) == 1
+    request = captured[0]
+    assert str(request.url) == VERIFY_URL
+    form = parse_qs(request.content.decode())
+    assert form["product_id"] == [PRODUCT_ID]
+    assert form["license_key"] == [LICENSE_KEY]
+    assert form["access_token"] == [API_TOKEN]
+
+
+@pytest.mark.asyncio
+async def test_verify_license_gumroad_404_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Gumroad 404 (unknown license) returns None without any retry."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            httpx.codes.NOT_FOUND,
+            json={"success": False, "message": "That license does not exist."},
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert result is None
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_error_is_retried_exactly_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection error triggers exactly one retry, then a normalized error."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 2
+
+
+@pytest.mark.asyncio
+async def test_http_5xx_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 500 response surfaces a normalized error without any retry."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(httpx.codes.INTERNAL_SERVER_ERROR, json={"success": False})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_http_4xx_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-404 4xx response surfaces a normalized error without any retry."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(httpx.codes.UNAUTHORIZED, json={"success": False})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert len(captured) == 1
+
+
+def test_client_timeout_is_five_seconds() -> None:
+    """The module pins a 5-second timeout for its default httpx client."""
+    assert GUMROAD_TIMEOUT_SECONDS == 5.0
+
+
+@pytest.mark.asyncio
+async def test_default_client_is_built_with_the_configured_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no injected client, a default client pinned to the 5s timeout is used."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    real_async_client = httpx.AsyncClient
+    captured_timeouts: list[object] = []
+
+    def factory(*_args: object, **kwargs: object) -> httpx.AsyncClient:
+        captured_timeouts.append(kwargs.get("timeout"))
+        return real_async_client(
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(httpx.codes.OK, json=_success_payload())
+            )
+        )
+
+    monkeypatch.setattr(httpx, "AsyncClient", factory)
+    result = await verify_license(PRODUCT_ID, LICENSE_KEY)
+
+    assert isinstance(result, GumroadLicenseResult)
+    assert captured_timeouts == [httpx.Timeout(GUMROAD_TIMEOUT_SECONDS)]
+
+
+@pytest.mark.asyncio
+async def test_token_and_license_key_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Neither the API token nor the license key appears in any log record."""
+    monkeypatch.setenv("GUMROAD_API_TOKEN", API_TOKEN)
+    caplog.set_level(logging.DEBUG)
+
+    def success_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(httpx.codes.OK, json=_success_payload())
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(success_handler)) as client:
+        await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    def failing_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(failing_handler)) as client:
+        with pytest.raises(GumroadUnavailableError):
+            await verify_license(PRODUCT_ID, LICENSE_KEY, client=client)
+
+    assert API_TOKEN not in caplog.text
+    assert LICENSE_KEY not in caplog.text

--- a/backend/tests/routers/test_gumroad_webhook.py
+++ b/backend/tests/routers/test_gumroad_webhook.py
@@ -1,0 +1,268 @@
+"""Tests for the Gumroad ping webhook (POST /webhooks/gumroad/ping).
+
+Contract: shared-secret query param checked (constant-time) before the form
+body is parsed; valid pings persist exactly one GumroadSale row keyed by
+gumroad_sale_id (idempotent replay); unknown resource_name values still
+persist but log reason_code=unhandled_event; malformed payloads are rejected
+with 400 and write nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.gumroad_sale import GumroadSale
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+WEBHOOK_SECRET = "gumroad-webhook-shared-secret-test-only"  # pragma: allowlist secret
+
+
+def _sale_payload(**overrides: str) -> dict[str, str]:
+    """Build a form-encoded Gumroad ping payload, with optional overrides."""
+    payload = {
+        "sale_id": "S-100",
+        "product_id": "prod_abc123",
+        "email": "buyer@example.com",
+        "resource_name": "sale",
+        "is_recurring_charge": "false",
+        "refunded": "false",
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _count_sales(db_session: AsyncSession) -> int:
+    """Return the number of GumroadSale rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(GumroadSale))
+    return int(result.scalar_one())
+
+
+@pytest.fixture
+def webhook_secret(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set GUMROAD_WEBHOOK_SECRET for the duration of a test."""
+    monkeypatch.setenv("GUMROAD_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    return WEBHOOK_SECRET
+
+
+@pytest.mark.asyncio
+async def test_valid_sale_ping_persists_one_row_with_verbatim_payload(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A valid secret + sale payload returns 200 and stores the payload verbatim."""
+    payload = _sale_payload()
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+
+    row = (await db_session.execute(select(GumroadSale))).scalar_one()
+    assert row.gumroad_sale_id == "S-100"
+    assert row.product_id == "prod_abc123"
+    assert row.email == "buyer@example.com"
+    assert row.resource_name == "sale"
+    assert row.is_recurring_charge is False
+    assert row.refunded is False
+    assert row.raw_payload == payload
+    assert row.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_replaying_identical_payload_keeps_exactly_one_row(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """Replaying the same sale_id returns 200 both times but writes one row."""
+    payload = _sale_payload()
+
+    first = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+    second = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_returns_401_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A wrong secret is rejected with 401, logged, and persists zero rows."""
+    assert webhook_secret == WEBHOOK_SECRET
+    caplog.set_level(logging.DEBUG)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": "not-the-secret"},  # pragma: allowlist secret
+        data=_sale_payload(),
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert "reason_code=invalid_signature" in caplog.text
+    assert await _count_sales(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_returns_401_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A ping without the secret query param is rejected with 401, zero rows."""
+    assert webhook_secret == WEBHOOK_SECRET
+
+    response = await async_client.post(WEBHOOK_PATH, data=_sale_payload())
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert await _count_sales(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_secret_is_checked_before_body_parsing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A wrong secret with a malformed body still yields 401, not 400."""
+    assert webhook_secret == WEBHOOK_SECRET
+    malformed = _sale_payload()
+    del malformed["sale_id"]
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": "not-the-secret"},  # pragma: allowlist secret
+        data=malformed,
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert await _count_sales(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_name_is_persisted_and_flagged(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unknown resource_name still persists the row and logs unhandled_event."""
+    caplog.set_level(logging.DEBUG)
+    payload = _sale_payload(resource_name="weird_event", is_recurring_charge="true")
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert "reason_code=unhandled_event" in caplog.text
+    assert await _count_sales(db_session) == 1
+
+    row = (await db_session.execute(select(GumroadSale))).scalar_one()
+    assert row.resource_name == "weird_event"
+    assert row.is_recurring_charge is True
+    assert row.raw_payload == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_name",
+    ["refund", "dispute", "cancellation", "subscription_ended"],
+)
+async def test_known_event_persists_without_unhandled_flag(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+    resource_name: str,
+) -> None:
+    """Each known event type returns 200, persists one row, no unhandled log."""
+    caplog.set_level(logging.DEBUG)
+    payload = _sale_payload(resource_name=resource_name)
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert "reason_code=unhandled_event" not in caplog.text
+    assert await _count_sales(db_session) == 1
+
+    row = (await db_session.execute(select(GumroadSale))).scalar_one()
+    assert row.resource_name == resource_name
+
+
+@pytest.mark.asyncio
+async def test_payload_missing_sale_id_returns_400_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A payload without sale_id is rejected with 400 and persists zero rows."""
+    caplog.set_level(logging.DEBUG)
+    malformed = _sale_payload()
+    del malformed["sale_id"]
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=malformed
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "reason_code=malformed_payload" in caplog.text
+    assert await _count_sales(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_replay_collapses_via_unique_constraint(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the dedupe pre-check misses a race, the unique index still wins.
+
+    Forcing ``_sale_already_recorded`` to report "new" simulates two concurrent
+    replays where neither saw the other's row yet. The second insert must hit
+    the unique constraint, roll back cleanly (200, not 500), and leave one row.
+    """
+    payload = _sale_payload()
+    first = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+    assert first.status_code == HTTPStatus.OK
+
+    async def _never_recorded(_session: AsyncSession, _sale_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr("routers.gumroad._sale_already_recorded", _never_recorded)
+    second = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+
+    assert second.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+
+
+def test_gumroad_sale_created_at_defaults_to_timezone_aware() -> None:
+    """A freshly constructed GumroadSale gets a timezone-aware created_at."""
+    row = GumroadSale(
+        gumroad_sale_id="S-200",
+        product_id="prod_abc123",
+        email="buyer@example.com",
+        resource_name="sale",
+        is_recurring_charge=False,
+        refunded=False,
+        raw_payload={"sale_id": "S-200"},
+    )
+    assert row.created_at is not None
+    assert row.created_at.tzinfo is not None


### PR DESCRIPTION
## Summary

Adds the shared Gumroad backend infrastructure that later monetization sub-issues of epic #1938 build on, with **zero** changes to signup, entitlements, or BotMason. Persist-only: no grant/credit logic yet.

- **`integrations/gumroad.py`** — async `verify_license(product_id, license_key)` returning a typed `GumroadLicenseResult` on success or `None` on Gumroad 404; 5s timeout; exactly one retry on connection error only (never on 4xx/5xx). Failures normalize to a static-message `GumroadUnavailableError` that never echoes the API token or license key — the exception chain is severed with `from None` so the credential-bearing httpx `Request` can't leak via `__cause__`.
- **`routers/gumroad.py`** — `POST /webhooks/gumroad/ping`, a public unauthenticated surface. Authenticated by a shared-secret query param compared constant-time with `hmac.compare_digest` **before** the body is parsed (reject-before-parse), failing closed when the secret is unset. Each accepted ping persists a `GumroadSale` row, idempotent by a unique `gumroad_sale_id` (pre-check + `IntegrityError` race-collapse → replays return 200 with no second row). Unknown `resource_name` values are still persisted and flagged `reason_code=unhandled_event`; missing `sale_id` → 400. Only static `reason_code` markers are logged — never the secret, buyer email, or raw payload.
- **`models/gumroad_sale.py`** — persists the raw webhook payload verbatim in a JSON column plus typed columns for the fields downstream features read; tz-aware `created_at`.
- **`main.py`** — mounts the router and fails fast at startup on missing `GUMROAD_API_TOKEN` / `GUMROAD_WEBHOOK_SECRET` when `ENV=production`.
- **Migration** `d0e1f2a3b4c6` — additive `create_table` + unique index, chained onto the current single head `c2d3e4f5a6b7`.
- **Docs** — the four `GUMROAD_*` env vars documented in `backend/.env.example` and referenced from `README.md`.

The webhook auth is a query-param shared secret (per the issue's 2026-07-22 spec amendment: Gumroad pings are unsigned form POSTs), not an HMAC header; all payload fields are treated as untrusted (downstream issues re-verify via the license API).

## Test plan

- `backend/tests/integrations/test_gumroad_client.py` — valid license parse + outbound request shape, 404 → `None`, connect-error retried exactly once (2 transport calls) vs. 4xx/5xx not retried (1 call), 5s timeout, default-client construction, and log-redaction of the token + license key.
- `backend/tests/routers/test_gumroad_webhook.py` — valid ping persists one row with verbatim payload, replay stays single-row, concurrent-race collapse via the unique constraint, wrong/missing secret → 401 with zero writes, secret-checked-before-parse, unknown `resource_name` persisted + flagged, all known event types, and missing `sale_id` → 400.
- New files at 100% line + branch coverage. Full backend suite: 3005 passed; `scripts/backend/check-all.sh` green (ruff, ruff-format, mypy strict, bandit, radon); xenon A-grade + all pre-commit hooks (incl. detect-secrets, commitlint) pass. No test hits the real Gumroad API.

Closes #1941
Refs #1938