### PR TITLE
feat(backend): Entitlement model + Gumroad-license-gated signup

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -239,6 +239,7 @@ def _stub_signup_license_gate(
             product_id=_STUB_LICENSE_PRODUCT_ID,
             sale_id=f"{_STUB_LICENSE_SALE_PREFIX}{email}",
             refunded=False,
+            chargebacked=False,
         )
         return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -34,9 +34,20 @@ from sqlalchemy.ext.asyncio import (  # noqa: E402
 from sqlmodel import SQLModel  # noqa: E402
 
 import models as _models  # noqa: E402, F401
+import routers.auth as _auth_router  # noqa: E402
 from database import get_session  # noqa: E402
+from domain.entitlements import AptitudeLicenseCheck, LicenseOutcome  # noqa: E402
 from main import app  # noqa: E402
-from rate_limit import limiter  # noqa: E402
+from rate_limit import limiter, reset_invalid_license_attempts  # noqa: E402
+from schemas.gumroad import GumroadPurchase  # noqa: E402
+
+# The default signup license gate stubbed into every test that does not opt into
+# the real gate (via the ``real_license_gate`` marker). Feature-specific tests in
+# ``tests/routers/test_auth_signup_license.py`` and
+# ``tests/routers/test_gumroad_sale_dispatch.py`` mark themselves to exercise the
+# genuine Gumroad-backed gate; every other test just needs signup to succeed.
+_STUB_LICENSE_PRODUCT_ID = "prod_stub_aptitude"
+_STUB_LICENSE_SALE_PREFIX = "stub-sale-"
 
 # ---------------------------------------------------------------------------
 # Test database: SQLite in-memory (no external services needed)
@@ -187,12 +198,51 @@ def _reset_rate_limiter() -> Generator[None, None, None]:
     runs in the same process.  Forcing ``enabled = True`` here makes the
     autouse contract a single source of truth: every test starts with the
     limiter on and storage empty, regardless of what its predecessors did.
+
+    The second-layer invalid-license counter (``rate_limit``'s moving-window
+    limiter for signup license failures) is cleared alongside for the same
+    reason: its hourly window would otherwise leak 429s across tests.
     """
     limiter.enabled = True
     limiter.reset()
+    reset_invalid_license_attempts()
     yield
     limiter.enabled = True
     limiter.reset()
+    reset_invalid_license_attempts()
+
+
+@pytest.fixture(autouse=True)
+def _stub_signup_license_gate(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stub the signup license gate open for tests that do not opt into it.
+
+    Account creation now requires a verified Gumroad license, so the dozens of
+    suites that create users via ``POST /auth/signup`` would otherwise all fail
+    the gate. This autouse fixture replaces ``verify_aptitude_license`` (as the
+    auth router looks it up) with a stub that verifies any request, echoing the
+    submitted email so the email-match check always passes. Tests carrying the
+    ``real_license_gate`` marker are skipped so they exercise the genuine gate.
+    """
+    if request.node.get_closest_marker("real_license_gate") is not None:
+        return
+
+    async def _verify_stub(
+        email: str,
+        license_key: str | None,  # noqa: ARG001 — stub verifies unconditionally
+        *,
+        client: object | None = None,  # noqa: ARG001 — matches the real signature
+    ) -> AptitudeLicenseCheck:
+        purchase = GumroadPurchase(
+            email=email,
+            product_id=_STUB_LICENSE_PRODUCT_ID,
+            sale_id=f"{_STUB_LICENSE_SALE_PREFIX}{email}",
+            refunded=False,
+        )
+        return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)
+
+    monkeypatch.setattr(_auth_router, "verify_aptitude_license", _verify_stub)
 
 
 @pytest.fixture

--- a/backend/migrations/versions/a6b7c8d9e0f1_add_entitlement.py
+++ b/backend/migrations/versions/a6b7c8d9e0f1_add_entitlement.py
@@ -1,0 +1,67 @@
+"""Add the entitlement table for per-user course-access grants.
+
+Revision ID: a6b7c8d9e0f1
+Revises: d0e1f2a3b4c6
+Create Date: 2026-07-22 00:00:00.000000
+
+Purely additive: creates ``entitlement`` — one row per grant of an access
+kind (today only ``course_access``) with lifecycle timestamps, a nullable
+provenance link to the funding ``gumroadsale`` row (no ondelete cascade:
+deleting a sale must never silently revoke access), and a JSON ``metadata``
+extensibility bag. The partial unique index on ``(user_id, kind)`` WHERE
+``revoked_at IS NULL`` allows at most one active grant per user per kind
+while keeping revoked history. ``downgrade`` drops the indexes then the
+table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a6b7c8d9e0f1"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d0e1f2a3b4c6"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Mirrors ``models.entitlement._KIND_MAX``.
+_KIND_MAX = 32
+
+
+def upgrade() -> None:
+    """Create the entitlement table, its kind CHECK, and both indexes."""
+    op.create_table(
+        "entitlement",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(length=_KIND_MAX), nullable=False),
+        sa.Column("product_id", sa.String(), nullable=True),
+        sa.Column("source_sale_id", sa.Integer(), nullable=True),
+        sa.Column("granted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.CheckConstraint("kind IN ('course_access')", name="ck_entitlement_kind_valid"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["source_sale_id"], ["gumroadsale.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_entitlement_user_id"), "entitlement", ["user_id"])
+    # Partial unique index: at most one active (``revoked_at IS NULL``)
+    # entitlement per (user, kind), while revoked history rows may pile up so
+    # revoke-then-regrant always works.
+    op.create_index(
+        "ix_entitlement_user_kind_active",
+        "entitlement",
+        ["user_id", "kind"],
+        unique=True,
+        postgresql_where=sa.text("revoked_at IS NULL"),
+        sqlite_where=sa.text("revoked_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the entitlement indexes then the table."""
+    op.drop_index("ix_entitlement_user_kind_active", table_name="entitlement")
+    op.drop_index(op.f("ix_entitlement_user_id"), table_name="entitlement")
+    op.drop_table("entitlement")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -105,6 +105,9 @@ addopts = "-q --strict-markers --strict-config --cov=src --cov=scripts --cov-rep
 testpaths = ["tests"]
 pythonpath = ["."]
 xfail_strict = true
+markers = [
+  "real_license_gate: exercise the real Gumroad signup license gate instead of the default test stub-open fixture",
+]
 
 [tool.coverage.run]
 branch = true

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,6 +19,10 @@ aiosqlite==0.22.1
 bcrypt==5.0.0
 cryptography==49.0.0
 PyJWT==2.13.0
+# Moving-window counters for the invalid-license signup throttle
+# (rate_limit.py). Already a transitive slowapi dependency; pinned here
+# because the app now imports it directly.
+limits==5.8.0
 slowapi==0.1.10
 tzdata==2026.3
 pytest==9.1.1

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -48,6 +48,7 @@ __all__ = [
     "LicenseOutcome",
     "grant_course_access",
     "has_course_access",
+    "is_aptitude_product_id",
     "revoke_course_access",
     "verify_aptitude_license",
 ]
@@ -196,6 +197,19 @@ def _allowlisted_product_ids() -> list[str]:
     return [
         product_id.strip() for product_id in raw.split(_PRODUCT_IDS_SEPARATOR) if product_id.strip()
     ]
+
+
+def is_aptitude_product_id(product_id: str | None) -> bool:
+    """Return True when ``product_id`` is on the APTITUDE course allowlist.
+
+    Shares the single allowlist source (``GUMROAD_APTITUDE_PRODUCT_IDS``) with
+    the signup verifier so the webhook sale-grant path and the signup path can
+    never diverge on what counts as "the course". A blank or unallowlisted id
+    (including an unset allowlist) returns False, so the grant fails closed for
+    any non-APTITUDE product sold on the same Gumroad account.
+    """
+    normalized = (product_id or "").strip()
+    return bool(normalized) and normalized in _allowlisted_product_ids()
 
 
 async def verify_aptitude_license(

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -224,9 +224,10 @@ async def verify_aptitude_license(
 
     A missing or blank ``license_key`` short-circuits to LICENSE_REQUIRED
     before any Gumroad call. Otherwise walks ``GUMROAD_APTITUDE_PRODUCT_IDS``
-    in order, stopping on the first ``success`` answer: a refunded or
-    charged-back purchase yields INVALID, a case-insensitive email match on a
-    live purchase yields VERIFIED (with the purchase attached), any other
+    in order, stopping on the first ``success`` answer: a reversed purchase
+    (refunded, charged back, or under an unresolved dispute) yields INVALID, a
+    case-insensitive email match on a live purchase yields VERIFIED (with the
+    purchase attached), any other
     holder yields EMAIL_MISMATCH. A ``None`` / ``success=False`` answer moves
     on to the next product; no match across the whole allowlist is INVALID.
 
@@ -241,19 +242,33 @@ async def verify_aptitude_license(
     return await _first_license_match(key, normalized_email, client)
 
 
+def _is_reversed_purchase(purchase: GumroadPurchase) -> bool:
+    """Return whether a verified purchase has been reversed by the buyer.
+
+    Gumroad's documented verify response (app.gumroad.com/api) exposes reversal
+    as four booleans; a purchase counts as reversed when it was refunded,
+    charged back, or is under an unresolved chargeback dispute — ``disputed``
+    that the seller has not yet won (``dispute_won``). A won dispute leaves the
+    sale legitimate, so it does not reject. This is best-effort pre-grant
+    screening only.
+    """
+    unresolved_dispute = purchase.disputed and not purchase.dispute_won
+    return purchase.refunded or purchase.chargebacked or unresolved_dispute
+
+
 def _classify_verified_purchase(
     purchase: GumroadPurchase,
     normalized_email: str,
 ) -> AptitudeLicenseCheck:
     """Map a successful verify result onto INVALID, VERIFIED, or EMAIL_MISMATCH.
 
-    A refunded or charged-back purchase folds to INVALID before the email is
-    even compared, so the rejection is byte-for-byte identical to an unknown
-    key and never leaks that the license was once valid. This is pre-grant
-    verification only; revoking an already-granted entitlement after a later
-    refund is separate, deferred work.
+    A reversed purchase folds to INVALID before the email is even compared, so
+    the rejection is byte-for-byte identical to an unknown key and never leaks
+    that the license was once valid. This is pre-grant verification only;
+    revoking an already-granted entitlement after a later refund is separate,
+    deferred work.
     """
-    if purchase.refunded or purchase.chargebacked:
+    if _is_reversed_purchase(purchase):
         return AptitudeLicenseCheck(LicenseOutcome.INVALID)
     if purchase.email.strip().lower() == normalized_email:
         return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -1,0 +1,247 @@
+"""Course-access entitlement domain logic: grant, check, revoke, verify.
+
+The grant is idempotent (at most one active ``course_access`` row per user,
+backed by the partial unique index on the model) and every grant / revoke
+emits a structured log line carrying a ``reason_code`` — never a raw email
+or license key, only ids.
+
+:func:`verify_aptitude_license` is the signup gate's verifier: it walks the
+``GUMROAD_APTITUDE_PRODUCT_IDS`` allowlist calling the Gumroad client's
+``verify_license`` (tests patch ``domain.entitlements.verify_license``) and
+folds the answers into a three-way :class:`LicenseOutcome`. A Gumroad outage
+(:class:`GumroadUnavailableError`, re-exported here for callers) propagates
+untouched so the route can fail closed.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlmodel import col, select
+
+from integrations.gumroad import GumroadUnavailableError, verify_license
+from models.entitlement import Entitlement, EntitlementKind
+
+if TYPE_CHECKING:
+    import httpx
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from models.gumroad_sale import GumroadSale
+    from models.user import User
+    from schemas.gumroad import GumroadPurchase
+
+__all__ = [
+    "PRODUCT_IDS_ENV_VAR",
+    "REASON_ADMIN_OVERRIDE",
+    "REASON_DUPLICATE_SIGNUP",
+    "REASON_EMAIL_MISMATCH",
+    "REASON_REFUND",
+    "REASON_SIGNUP_REDEMPTION",
+    "REASON_WEBHOOK_SALE",
+    "AptitudeLicenseCheck",
+    "GumroadUnavailableError",
+    "LicenseOutcome",
+    "grant_course_access",
+    "has_course_access",
+    "revoke_course_access",
+    "verify_aptitude_license",
+]
+
+logger = logging.getLogger(__name__)
+
+# Structured-log reason codes for every entitlement transition. One constant
+# per code so grep-by-reason in log aggregation has a single spelling.
+REASON_SIGNUP_REDEMPTION = "signup_redemption"
+REASON_WEBHOOK_SALE = "webhook_sale"
+REASON_REFUND = "refund"
+REASON_ADMIN_OVERRIDE = "admin_override"
+REASON_DUPLICATE_SIGNUP = "duplicate_signup"
+REASON_EMAIL_MISMATCH = "email_mismatch"
+
+# Comma-separated allowlist of Gumroad product ids that count as "the
+# APTITUDE course". Read at call time so a rotation needs no restart (and so
+# tests can monkeypatch the environment).
+PRODUCT_IDS_ENV_VAR = "GUMROAD_APTITUDE_PRODUCT_IDS"
+_PRODUCT_IDS_SEPARATOR = ","
+
+
+class LicenseOutcome(enum.Enum):
+    """Outcome of an APTITUDE license verification."""
+
+    VERIFIED = "verified"
+    INVALID = "invalid"
+    EMAIL_MISMATCH = "email_mismatch"
+    LICENSE_REQUIRED = "license_required"
+
+
+@dataclass(frozen=True)
+class AptitudeLicenseCheck:
+    """A verification outcome plus, on VERIFIED, the matched purchase."""
+
+    outcome: LicenseOutcome
+    purchase: GumroadPurchase | None = None
+
+
+async def _find_active_entitlement(session: AsyncSession, user_id: int) -> Entitlement | None:
+    """Return the user's active ``course_access`` entitlement, if any."""
+    result = await session.execute(
+        select(Entitlement).where(
+            Entitlement.user_id == user_id,
+            Entitlement.kind == EntitlementKind.COURSE_ACCESS,
+            col(Entitlement.revoked_at).is_(None),
+        )
+    )
+    return result.scalars().first()
+
+
+def _apply_grant_provenance(
+    entitlement: Entitlement,
+    sale: GumroadSale | None,
+    product_id: str | None,
+) -> None:
+    """Stamp sale/product provenance onto ``entitlement`` without erasing it.
+
+    A passed ``sale`` supplies both the sale link and the product id; with no
+    sale the explicit ``product_id`` alone applies. Existing values survive a
+    bare re-grant because only non-``None`` sources overwrite them.
+    """
+    if sale is not None:
+        entitlement.source_sale_id = sale.id
+        entitlement.product_id = sale.product_id
+    elif product_id is not None:
+        entitlement.product_id = product_id
+
+
+async def grant_course_access(
+    session: AsyncSession,
+    user: User,
+    sale: GumroadSale | None = None,
+    *,
+    product_id: str | None = None,
+    reason_code: str = REASON_SIGNUP_REDEMPTION,
+) -> Entitlement:
+    """Grant (or refresh) the user's active ``course_access`` entitlement.
+
+    Idempotent: when an active grant already exists its sale link is updated
+    in place — never a duplicate row. When ``sale`` is passed the link
+    (``source_sale_id`` and ``product_id``) is derived from it; otherwise the
+    explicit ``product_id`` keyword applies. Existing link values are only
+    overwritten by non-``None`` derivations so a bare re-grant cannot erase
+    provenance. Commits, then logs ``entitlement_granted`` with
+    ``reason_code`` (ids only — never emails or keys).
+    """
+    if user.id is None:
+        msg = "user id missing before entitlement grant"
+        raise ValueError(msg)
+    entitlement = await _find_active_entitlement(session, user.id)
+    if entitlement is None:
+        entitlement = Entitlement(user_id=user.id)
+    _apply_grant_provenance(entitlement, sale, product_id)
+    session.add(entitlement)
+    await session.commit()
+    await session.refresh(entitlement)
+    logger.info(
+        "entitlement_granted",
+        extra={
+            "reason_code": reason_code,
+            "user_id": user.id,
+            "entitlement_id": entitlement.id,
+        },
+    )
+    return entitlement
+
+
+async def has_course_access(session: AsyncSession, user_id: int) -> bool:
+    """Return True when ``user_id`` holds an active ``course_access`` grant."""
+    return await _find_active_entitlement(session, user_id) is not None
+
+
+async def revoke_course_access(session: AsyncSession, user_id: int, reason: str) -> None:
+    """Revoke the user's active ``course_access`` entitlement, if any.
+
+    Sets ``revoked_at`` on the active row (freeing the partial-unique slot so
+    a later re-grant creates a fresh row), commits, and logs
+    ``entitlement_revoked`` with ``reason_code=reason``. A user with no
+    active grant is a silent no-op.
+    """
+    entitlement = await _find_active_entitlement(session, user_id)
+    if entitlement is None:
+        return
+    entitlement.revoked_at = datetime.now(UTC)
+    session.add(entitlement)
+    await session.commit()
+    logger.info(
+        "entitlement_revoked",
+        extra={
+            "reason_code": reason,
+            "user_id": user_id,
+            "entitlement_id": entitlement.id,
+        },
+    )
+
+
+def _allowlisted_product_ids() -> list[str]:
+    """Read the APTITUDE product allowlist from the environment at call time.
+
+    Splits on commas, strips whitespace, and skips blanks so trailing
+    separators in the deployment config are harmless. An unset variable
+    yields an empty allowlist, which makes every key verify as INVALID.
+    """
+    raw = os.getenv(PRODUCT_IDS_ENV_VAR, "")
+    return [
+        product_id.strip() for product_id in raw.split(_PRODUCT_IDS_SEPARATOR) if product_id.strip()
+    ]
+
+
+async def verify_aptitude_license(
+    email: str,
+    license_key: str | None,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> AptitudeLicenseCheck:
+    """Verify ``license_key`` against every allowlisted APTITUDE product.
+
+    A missing or blank ``license_key`` short-circuits to LICENSE_REQUIRED
+    before any Gumroad call. Otherwise walks ``GUMROAD_APTITUDE_PRODUCT_IDS``
+    in order, stopping on the first ``success`` answer: a case-insensitive
+    email match yields VERIFIED (with the purchase attached), any other holder
+    yields EMAIL_MISMATCH. A ``None`` / ``success=False`` answer moves on to
+    the next product; no match across the whole allowlist is INVALID.
+
+    Raises:
+        GumroadUnavailableError: propagated untouched from ``verify_license``
+            so the caller can fail closed (the route maps it to 503).
+    """
+    key = (license_key or "").strip()
+    if not key:
+        return AptitudeLicenseCheck(LicenseOutcome.LICENSE_REQUIRED)
+    normalized_email = email.strip().lower()
+    return await _first_license_match(key, normalized_email, client)
+
+
+def _classify_verified_purchase(
+    purchase: GumroadPurchase,
+    normalized_email: str,
+) -> AptitudeLicenseCheck:
+    """Map a successful verify result onto VERIFIED or EMAIL_MISMATCH."""
+    if purchase.email.strip().lower() == normalized_email:
+        return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)
+    return AptitudeLicenseCheck(LicenseOutcome.EMAIL_MISMATCH)
+
+
+async def _first_license_match(
+    license_key: str,
+    normalized_email: str,
+    client: httpx.AsyncClient | None,
+) -> AptitudeLicenseCheck:
+    """Return the first allowlisted product's verdict, or INVALID if none match."""
+    for product_id in _allowlisted_product_ids():
+        result = await verify_license(product_id, license_key, client=client)
+        if result is not None and result.success:
+            return _classify_verified_purchase(result.purchase, normalized_email)
+    return AptitudeLicenseCheck(LicenseOutcome.INVALID)

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -59,6 +59,8 @@ logger = logging.getLogger(__name__)
 # per code so grep-by-reason in log aggregation has a single spelling.
 REASON_SIGNUP_REDEMPTION = "signup_redemption"
 REASON_WEBHOOK_SALE = "webhook_sale"
+# Forward-reserved for the post-grant revocation paths (refund-driven and
+# manual admin override); exported now so those code paths share this spelling.
 REASON_REFUND = "refund"
 REASON_ADMIN_OVERRIDE = "admin_override"
 REASON_DUPLICATE_SIGNUP = "duplicate_signup"
@@ -222,10 +224,11 @@ async def verify_aptitude_license(
 
     A missing or blank ``license_key`` short-circuits to LICENSE_REQUIRED
     before any Gumroad call. Otherwise walks ``GUMROAD_APTITUDE_PRODUCT_IDS``
-    in order, stopping on the first ``success`` answer: a case-insensitive
-    email match yields VERIFIED (with the purchase attached), any other holder
-    yields EMAIL_MISMATCH. A ``None`` / ``success=False`` answer moves on to
-    the next product; no match across the whole allowlist is INVALID.
+    in order, stopping on the first ``success`` answer: a refunded or
+    charged-back purchase yields INVALID, a case-insensitive email match on a
+    live purchase yields VERIFIED (with the purchase attached), any other
+    holder yields EMAIL_MISMATCH. A ``None`` / ``success=False`` answer moves
+    on to the next product; no match across the whole allowlist is INVALID.
 
     Raises:
         GumroadUnavailableError: propagated untouched from ``verify_license``
@@ -242,7 +245,16 @@ def _classify_verified_purchase(
     purchase: GumroadPurchase,
     normalized_email: str,
 ) -> AptitudeLicenseCheck:
-    """Map a successful verify result onto VERIFIED or EMAIL_MISMATCH."""
+    """Map a successful verify result onto INVALID, VERIFIED, or EMAIL_MISMATCH.
+
+    A refunded or charged-back purchase folds to INVALID before the email is
+    even compared, so the rejection is byte-for-byte identical to an unknown
+    key and never leaks that the license was once valid. This is pre-grant
+    verification only; revoking an already-granted entitlement after a later
+    refund is separate, deferred work.
+    """
+    if purchase.refunded or purchase.chargebacked:
+        return AptitudeLicenseCheck(LicenseOutcome.INVALID)
     if purchase.email.strip().lower() == normalized_email:
         return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)
     return AptitudeLicenseCheck(LicenseOutcome.EMAIL_MISMATCH)

--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -78,6 +78,16 @@ def bad_gateway(reason: str) -> HTTPException:
     return HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=reason)
 
 
+def service_unavailable(reason: str) -> HTTPException:
+    """Return a 503 HTTPException for a temporarily unusable dependency.
+
+    Use this when a required upstream (e.g. Gumroad license verification)
+    cannot answer and the endpoint must fail closed rather than guess, so
+    the caller sees a stable snake_case token and knows to retry later.
+    """
+    return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=reason)
+
+
 async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Catch-all handler — log, report to Sentry, return a sanitised envelope.
 

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -4,6 +4,7 @@ from .completion_suggestion import CompletionSuggestion
 from .content_completion import ContentCompletion
 from .course_stage import CourseStage
 from .energy_plan import EnergyPlan
+from .entitlement import Entitlement
 from .goal import Goal
 from .goal_completion import GoalCompletion
 from .goal_group import GoalGroup
@@ -40,6 +41,7 @@ __all__ = [
     "ContentCompletion",
     "CourseStage",
     "EnergyPlan",
+    "Entitlement",
     "Goal",
     "GoalCompletion",
     "GoalGroup",

--- a/backend/src/models/entitlement.py
+++ b/backend/src/models/entitlement.py
@@ -1,0 +1,99 @@
+"""Per-user entitlements — the "may access paid content" ledger.
+
+An ``Entitlement`` row records that a user holds one kind of access (today
+only ``course_access``), where it came from (the Gumroad sale that funded
+it, when known), and its lifecycle (granted, optionally revoked). A
+dedicated table rather than a boolean on ``User`` because entitlements have
+their own lifecycle and more kinds are anticipated (BotMason tokens,
+cohort-gated content).
+
+At most one *active* entitlement (``revoked_at IS NULL``) may exist per
+``(user_id, kind)``, enforced by a partial unique index declared with both
+``postgresql_where`` and ``sqlite_where`` so ``metadata.create_all`` renders
+the same constraint on the SQLite test database — no conftest mirror needed.
+"""
+
+import enum
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, CheckConstraint, Column, DateTime, ForeignKey, Index
+from sqlmodel import Field, SQLModel
+
+# Generous ceiling for the ``kind`` discriminator column; the longest current
+# member ("course_access") is 13 characters.
+_KIND_MAX = 32
+
+
+class EntitlementKind(enum.StrEnum):
+    """The kinds of access an entitlement can grant.
+
+    ``COURSE_ACCESS`` is the paid-course gate; future kinds (e.g. BotMason
+    token bundles) extend this enum and the derived CHECK constraint follows
+    automatically.
+    """
+
+    COURSE_ACCESS = "course_access"
+
+
+def _kind_check() -> CheckConstraint:
+    """CHECK derived from ``EntitlementKind`` so the DB set can't drift."""
+    quoted = ", ".join(f"'{kind.value}'" for kind in EntitlementKind)
+    return CheckConstraint(f"kind IN ({quoted})", name="ck_entitlement_kind_valid")
+
+
+# Bound at module scope so :class:`Index`'s ``*_where`` predicate can resolve
+# the column at table-creation time (mirrors ``models.metta_return_arc``).
+# Both Postgres and SQLite accept the same ``IS NULL`` form, so the partial
+# unique index renders on the test SQLite DB via ``metadata.create_all`` and
+# stays drift-free against the migration.
+_REVOKED_AT_COLUMN = Column("revoked_at", DateTime(timezone=True), nullable=True)
+
+
+class Entitlement(SQLModel, table=True):
+    """One user's grant of a single access kind, with lifecycle timestamps.
+
+    The partial unique index ``ix_entitlement_user_kind_active`` on
+    ``(user_id, kind)`` WHERE ``revoked_at IS NULL`` guarantees a single live
+    grant per user per kind while permitting any number of revoked historical
+    rows, so revoke-then-regrant always works.
+
+    Naming note: SQLModel reserves the attribute name ``metadata`` (it is the
+    SQLAlchemy ``MetaData`` registry), so the JSON extensibility bag lives on
+    the Python attribute ``entitlement_metadata`` mapped to the database
+    column ``metadata``.
+    """
+
+    __table_args__ = (
+        _kind_check(),
+        Index(
+            "ix_entitlement_user_kind_active",
+            "user_id",
+            "kind",
+            unique=True,
+            postgresql_where=_REVOKED_AT_COLUMN.is_(None),
+            sqlite_where=_REVOKED_AT_COLUMN.is_(None),
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE", index=True)
+    kind: str = Field(default=EntitlementKind.COURSE_ACCESS, max_length=_KIND_MAX)
+    # The Gumroad SKU that funded the grant, when known (manual grants omit it).
+    product_id: str | None = Field(default=None)
+    # Nullable FK, no ondelete cascade: deleting a sale row must never
+    # silently revoke access — the link is provenance, not a dependency.
+    source_sale_id: int | None = Field(
+        default=None,
+        sa_column=Column(ForeignKey("gumroadsale.id"), nullable=True),
+    )
+    granted_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    revoked_at: datetime | None = Field(default=None, sa_column=_REVOKED_AT_COLUMN)
+    # Extensibility bag so future per-grant facts need no migration; see the
+    # class docstring for the attribute-vs-column naming.
+    entitlement_metadata: dict[str, object] = Field(
+        default_factory=dict,
+        sa_column=Column("metadata", JSON, nullable=False),
+    )

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -1,5 +1,8 @@
-"""Shared rate limiter instance for the application."""
+"""Shared rate limiter instances for the application."""
 
+from limits import RateLimitItemPerHour
+from limits.storage import MemoryStorage
+from limits.strategies import MovingWindowRateLimiter
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -11,3 +14,27 @@ DEFAULT_RATE_LIMIT = "60/minute"
 # Rate limiter keyed by client IP address. Shared across routers so all
 # endpoints use a single limiter with consistent state.
 limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_RATE_LIMIT])
+
+# Second-layer throttle for signup attempts that fail license verification:
+# distinct from the 3/minute signup limit above so a license brute-forcer is
+# capped per hour even if they pace themselves under the per-minute limit.
+INVALID_LICENSE_MAX_PER_HOUR = 10
+
+_invalid_license_storage = MemoryStorage()
+_invalid_license_limiter = MovingWindowRateLimiter(_invalid_license_storage)
+_INVALID_LICENSE_ITEM = RateLimitItemPerHour(INVALID_LICENSE_MAX_PER_HOUR)
+
+
+def record_invalid_license_attempt(client_ip: str) -> bool:
+    """Count one invalid-license signup attempt for ``client_ip``.
+
+    Returns True while the client remains under the hourly cap (the attempt
+    is recorded against the moving window); returns False once the cap is
+    exceeded, at which point the caller should answer 429.
+    """
+    return _invalid_license_limiter.hit(_INVALID_LICENSE_ITEM, client_ip)
+
+
+def reset_invalid_license_attempts() -> None:
+    """Clear every invalid-license counter (test isolation between cases)."""
+    _invalid_license_storage.reset()

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -351,22 +351,6 @@ def _create_token(user_id: int) -> tuple[str, str]:
     return token, jti
 
 
-def _create_dummy_token() -> str:
-    """Generate a structurally-valid JWT that will never decode with the real secret.
-
-    Used to return an indistinguishable response when a signup is attempted
-    with an already-registered email, preventing account enumeration.
-    """
-    now = datetime.now(UTC)
-    nonce_key = secrets.token_hex(32)
-    payload = {
-        "sub": "0",
-        "exp": int((now + _TOKEN_TTL).timestamp()),
-        "iat": now.timestamp(),
-    }
-    return str(jwt.encode(payload, nonce_key, algorithm=_JWT_ALGORITHM))
-
-
 def _get_client_ip(request: Request) -> str:
     """Extract client IP from the request, respecting X-Forwarded-For."""
     forwarded = request.headers.get("x-forwarded-for")
@@ -526,17 +510,6 @@ async def _serialize_login(session: AsyncSession, email: str) -> AsyncIterator[N
         yield
 
 
-def _duplicate_signup_response() -> AuthResponse:
-    """Identical-shape response for an email already in use.
-
-    Returned both when the pre-empted insert would conflict and when a
-    concurrent request wins the race and our insert raises
-    ``IntegrityError``.  The dummy token is signed with a random key so
-    it cannot be exchanged for access to the existing account.
-    """
-    return AuthResponse(token=_create_dummy_token(), user_id=0)
-
-
 async def _reject_invalid_license(
     request: Request,
     email: str,
@@ -638,9 +611,10 @@ async def _create_signup_user(session: AsyncSession, payload: SignupRequest) -> 
         # The ``ix_user_lower_email_unique`` functional unique index (or
         # the case-sensitive ``ix_user_email`` for legacy schemas) raised
         # because a concurrent request won the race after our duplicate
-        # check.  The caller answers with the anti-enumeration dummy —
-        # same shape, same timing — so the client cannot tell whether the
-        # email was new or already registered.
+        # check.  The caller answers with the same generic invalid-license
+        # rejection the pre-check path returns — same status, same body — so
+        # the client cannot tell whether the email was new or already
+        # registered, nor which duplicate-detection path fired.
         await session.rollback()
         return None
     await session.refresh(user)
@@ -694,7 +668,12 @@ async def signup(
     await _reject_duplicate_signup_email(session, payload.email)
     user = await _create_signup_user(session, payload)
     if user is None:
-        return _duplicate_signup_response()
+        # A concurrent request won the unique-index race after our pre-check
+        # passed.  Answer with the exact rejection the pre-check path returns
+        # so a duplicate email is indistinguishable from an invalid license on
+        # every path.  ``_create_signup_user`` already spent one real bcrypt
+        # hash, matching the dummy verify the pre-check spends — timing holds.
+        raise bad_request(_DETAIL_INVALID_LICENSE)
 
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -137,6 +137,14 @@ _BCRYPT_MAX_PASSWORD_BYTES = 72
 # encourages long passphrases).
 _MAX_PASSWORD_LENGTH = 64
 
+# Cap on the signup license_key length.  A non-blank key drives a real
+# outbound POST to Gumroad per allowlisted product before the invalid-license
+# throttle applies, so an unbounded string is a free upstream-amplification /
+# DoS lever — mirror the password field's explicit bound.  Real Gumroad
+# license keys are ~35-char dashed uppercase-hex, so 128 is a generous ceiling
+# that still rejects abuse well before the string reaches the verifier.
+_MAX_LICENSE_KEY_LENGTH = 128
+
 # Client-visible detail strings for the license-gated signup flow. The two
 # rejection details are deliberately generic (no "wrong product" / "wrong
 # email" / "account exists" variants) so no path leaks account or license
@@ -193,12 +201,18 @@ class AuthRequest(BaseModel):
 
     ``license_key`` is optional at the schema level so login's payload is
     unchanged, but the signup handler requires it — signup is gated on a
-    verified APTITUDE Gumroad license.
+    verified APTITUDE Gumroad license.  It carries an explicit
+    ``_MAX_LICENSE_KEY_LENGTH`` bound for the same DoS reason ``password``
+    does: a non-blank key is forwarded into a per-product loop of outbound
+    Gumroad verify calls before the invalid-license throttle applies, so an
+    unbounded string would amplify each attempt upstream.  Over-length input
+    is rejected with a 422 (a schema-shape rejection, like an over-length
+    password) that says nothing about whether the key is valid.
     """
 
     email: EmailStr
     password: str = Field(min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH)
-    license_key: str | None = None
+    license_key: str | None = Field(default=None, max_length=_MAX_LICENSE_KEY_LENGTH)
 
     @field_validator("email", mode="before")
     @classmethod

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -673,6 +673,9 @@ async def signup(
     outage fails closed with 503.  Only the JWT leaves the backend — never
     any Gumroad verify-response field.
     """
+    # Verify the license (a live Gumroad call) before the duplicate-email DB
+    # check is deliberate: running the same first check for every email keeps an
+    # attacker from inferring account existence from which check ran first.
     purchase = await _verify_signup_license(request, payload)
     await _reject_duplicate_signup_email(session, payload.email)
     user = await _create_signup_user(session, payload)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -10,7 +10,7 @@ import secrets
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, NoReturn
 
 import bcrypt
 import jwt
@@ -24,13 +24,23 @@ from sqlmodel import col, select
 
 from database import get_session
 from domain.dates import ensure_aware
+from domain.entitlements import (
+    REASON_DUPLICATE_SIGNUP,
+    REASON_EMAIL_MISMATCH,
+    REASON_SIGNUP_REDEMPTION,
+    GumroadUnavailableError,
+    LicenseOutcome,
+    grant_course_access,
+    verify_aptitude_license,
+)
 from domain.timezone import normalize_timezone
-from errors import bad_request
+from errors import bad_request, service_unavailable
+from models.gumroad_sale import GumroadSale
 from models.login_attempt import LoginAttempt
 from models.password_reset_token import PasswordResetToken
 from models.revoked_token import RevokedToken
 from models.user import DEFAULT_USER_TIMEZONE, User
-from rate_limit import limiter
+from rate_limit import limiter, record_invalid_license_attempt
 from schemas.password_reset import (
     PasswordResetAccepted,
     PasswordResetCancel,
@@ -44,6 +54,9 @@ from services.email import (
     get_email_sender,
 )
 from services.users import get_user_timezone
+
+if TYPE_CHECKING:
+    from schemas.gumroad import GumroadPurchase
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +137,15 @@ _BCRYPT_MAX_PASSWORD_BYTES = 72
 # encourages long passphrases).
 _MAX_PASSWORD_LENGTH = 64
 
+# Client-visible detail strings for the license-gated signup flow. The two
+# rejection details are deliberately generic (no "wrong product" / "wrong
+# email" / "account exists" variants) so no path leaks account or license
+# state — the specific cause is logged server-side only.
+_DETAIL_LICENSE_REQUIRED = "license_required"
+_DETAIL_INVALID_LICENSE = "invalid_license"
+_DETAIL_LICENSE_UNAVAILABLE = "license_verification_unavailable"
+_DETAIL_TOO_MANY_LICENSE_ATTEMPTS = "too_many_license_attempts"
+
 # Account lockout: lock after this many consecutive failed attempts.
 MAX_FAILED_ATTEMPTS = 5
 
@@ -168,10 +190,15 @@ class AuthRequest(BaseModel):
     The bounds also keep the field aligned with the
     ``_BCRYPT_MAX_PASSWORD_BYTES`` ceiling so a request that would
     silently be truncated by bcrypt is rejected with 422 instead.
+
+    ``license_key`` is optional at the schema level so login's payload is
+    unchanged, but the signup handler requires it — signup is gated on a
+    verified APTITUDE Gumroad license.
     """
 
     email: EmailStr
     password: str = Field(min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH)
+    license_key: str | None = None
 
     @field_validator("email", mode="before")
     @classmethod
@@ -496,20 +523,91 @@ def _duplicate_signup_response() -> AuthResponse:
     return AuthResponse(token=_create_dummy_token(), user_id=0)
 
 
-@router.post("/signup", response_model=AuthResponse)
-@limiter.limit("3/minute")
-async def signup(
-    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
-    payload: SignupRequest,
-    session: Annotated[AsyncSession, Depends(get_session)],
-) -> AuthResponse:
-    # Pydantic enforces ``_MIN_PASSWORD_LENGTH`` / ``_MAX_PASSWORD_LENGTH``
-    # before we get here (BUG-AUTH-017), so the only failure mode left is a
-    # multi-byte UTF-8 password whose char-count fits the cap but whose
-    # byte-length blows the bcrypt 72-byte limit.  Translate that into a
-    # 422 instead of a 500 so the client gets a uniform validation
-    # response and we never store a row that bcrypt has silently
-    # truncated (BUG-AUTH-004).
+async def _reject_invalid_license(
+    request: Request,
+    email: str,
+    outcome: LicenseOutcome,
+) -> NoReturn:
+    """Reject a signup whose license failed verification (anti-enumeration).
+
+    Counts the attempt toward the per-IP invalid-license cap, records an
+    email-mismatch marker server-side (fingerprint only — never the raw
+    email or key), spends the dummy bcrypt verify for timing parity, then
+    raises the generic 400 — or 429 once the hourly cap is exceeded.
+    """
+    allowed = record_invalid_license_attempt(_get_client_ip(request))
+    if outcome is LicenseOutcome.EMAIL_MISMATCH:
+        logger.info(
+            "signup_license_rejected",
+            extra={
+                "reason_code": REASON_EMAIL_MISMATCH,
+                "email_fingerprint": _email_log_fingerprint(email),
+            },
+        )
+    await _consume_dummy_password_verify()
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=_DETAIL_TOO_MANY_LICENSE_ATTEMPTS,
+        )
+    raise bad_request(_DETAIL_INVALID_LICENSE)
+
+
+async def _verify_signup_license(request: Request, payload: SignupRequest) -> GumroadPurchase:
+    """Run the verify-then-create license gate; return the matched purchase.
+
+    Every rejection path spends the same dummy bcrypt verify the success
+    path spends on the real hash, so timing does not leak which check
+    failed. A Gumroad outage fails closed with 503 before any row is
+    written; ``from None`` severs the chain so the caught error's Request
+    body (which carries the license key) is unreachable via ``__cause__``.
+    """
+    try:
+        check = await verify_aptitude_license(payload.email, payload.license_key)
+    except GumroadUnavailableError:
+        raise service_unavailable(_DETAIL_LICENSE_UNAVAILABLE) from None
+    if check.outcome is LicenseOutcome.LICENSE_REQUIRED:
+        await _consume_dummy_password_verify()
+        raise bad_request(_DETAIL_LICENSE_REQUIRED)
+    if check.outcome is not LicenseOutcome.VERIFIED or check.purchase is None:
+        await _reject_invalid_license(request, payload.email, check.outcome)
+    return check.purchase
+
+
+async def _reject_duplicate_signup_email(session: AsyncSession, email: str) -> None:
+    """Reject a signup for an already-registered email with the generic 400.
+
+    Because the sale webhook never creates ``User`` rows, an existing email
+    here is always a genuine duplicate — and re-granting or issuing a JWT
+    for the existing account off a license alone would be an
+    account-takeover lever, so this path always rejects. Same generic
+    detail, same dummy verify, no token: the caller cannot tell the account
+    exists; only the server log carries ``duplicate_signup``.
+    """
+    result = await session.execute(select(User).where(User.email == email))
+    if result.scalars().first() is None:
+        return
+    logger.info(
+        "signup_license_rejected",
+        extra={
+            "reason_code": REASON_DUPLICATE_SIGNUP,
+            "email_fingerprint": _email_log_fingerprint(email),
+        },
+    )
+    await _consume_dummy_password_verify()
+    raise bad_request(_DETAIL_INVALID_LICENSE)
+
+
+async def _create_signup_user(session: AsyncSession, payload: SignupRequest) -> User | None:
+    """Hash the password and persist the new user; ``None`` when a racer won.
+
+    Pydantic enforces ``_MIN_PASSWORD_LENGTH`` / ``_MAX_PASSWORD_LENGTH``
+    before we get here (BUG-AUTH-017), so the only failure mode left is a
+    multi-byte UTF-8 password whose char-count fits the cap but whose
+    byte-length blows the bcrypt 72-byte limit.  Translate that into a 400
+    instead of a 500 so the client gets a uniform validation response and
+    we never store a row that bcrypt has silently truncated (BUG-AUTH-004).
+    """
     try:
         password_hash = await _hash_password(payload.password)
     except ValueError as exc:
@@ -525,17 +623,66 @@ async def signup(
     except IntegrityError:
         # The ``ix_user_lower_email_unique`` functional unique index (or
         # the case-sensitive ``ix_user_email`` for legacy schemas) raised
-        # because either an earlier signup or a concurrent request won
-        # the race.  Either way the response is the anti-enumeration
-        # dummy — same shape, same timing — so the client cannot tell
-        # whether the email was new or already registered.
+        # because a concurrent request won the race after our duplicate
+        # check.  The caller answers with the anti-enumeration dummy —
+        # same shape, same timing — so the client cannot tell whether the
+        # email was new or already registered.
         await session.rollback()
-        return _duplicate_signup_response()
+        return None
     await session.refresh(user)
+    return user
+
+
+async def _grant_signup_entitlement(
+    session: AsyncSession,
+    user: User,
+    purchase: GumroadPurchase,
+) -> None:
+    """Link the fresh account to its verified purchase.
+
+    The matching ``GumroadSale`` row may not exist yet (the signup can beat
+    the webhook), so the grant falls back to the purchase's product id and
+    the sale link converges later when the webhook replays the grant.
+    """
+    result = await session.execute(
+        select(GumroadSale).where(GumroadSale.gumroad_sale_id == purchase.sale_id)
+    )
+    sale = result.scalars().first()
+    await grant_course_access(
+        session,
+        user,
+        sale=sale,
+        product_id=purchase.product_id,
+        reason_code=REASON_SIGNUP_REDEMPTION,
+    )
+
+
+@router.post("/signup", response_model=AuthResponse)
+@limiter.limit("3/minute")
+async def signup(
+    request: Request,
+    payload: SignupRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AuthResponse:
+    """Create an account gated on a verified APTITUDE Gumroad license.
+
+    Verify-then-create: no ``User`` or ``Entitlement`` row is written until
+    the license verifies against the product allowlist, its purchase email
+    matches, and the signup email is unclaimed.  Every rejection returns a
+    generic detail with matched timing (anti-enumeration), and a Gumroad
+    outage fails closed with 503.  Only the JWT leaves the backend — never
+    any Gumroad verify-response field.
+    """
+    purchase = await _verify_signup_license(request, payload)
+    await _reject_duplicate_signup_email(session, payload.email)
+    user = await _create_signup_user(session, payload)
+    if user is None:
+        return _duplicate_signup_response()
 
     if user.id is None:
         msg = "User ID unexpectedly None after database commit"
         raise RuntimeError(msg)
+    await _grant_signup_entitlement(session, user, purchase)
     token, _ = _create_token(user.id)
     return AuthResponse(token=token, user_id=user.id, timezone=user.timezone)
 

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -4,8 +4,9 @@ Gumroad POSTs a form-encoded "ping" for every sale-related event. The shared
 secret in the ``secret`` query parameter is checked (constant time) BEFORE the
 body is read, so an unauthenticated caller can never drive the parser. Valid
 pings are persisted verbatim into :class:`~models.gumroad_sale.GumroadSale`,
-idempotently keyed by ``sale_id`` — persistence only, no grant or credit side
-effects (those belong to later features reading the stored rows).
+idempotently keyed by ``sale_id``. A ``sale`` event additionally grants the
+buyer's ``course_access`` entitlement when a user with that email already
+exists — an idempotent side effect, so replays stay safe.
 
 Secrets discipline: the webhook secret, buyer email, and raw payload never
 appear in log text — only static markers and non-PII metadata do.
@@ -19,23 +20,29 @@ import os
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
+from domain.entitlements import REASON_WEBHOOK_SALE, grant_course_access
 from errors import bad_request
 from models.gumroad_sale import GumroadSale
+from models.user import User
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhooks/gumroad", tags=["gumroad"])
 
+# The one resource_name that carries an entitlement side effect (below).
+_SALE_RESOURCE_NAME = "sale"
+
 # resource_name values Gumroad documents for ping webhooks. Anything else is
 # still persisted (verbatim capture) but flagged with
 # ``reason_code=unhandled_event`` so operators notice new event types.
 KNOWN_RESOURCE_NAMES = frozenset(
-    {"sale", "refund", "dispute", "cancellation", "subscription_ended"}
+    {_SALE_RESOURCE_NAME, "refund", "dispute", "cancellation", "subscription_ended"}
 )
 
 # Gumroad posts booleans as the form strings "true"/"false".
@@ -106,6 +113,28 @@ async def _persist_sale(session: AsyncSession, payload: dict[str, str]) -> None:
         await session.rollback()
 
 
+async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> None:
+    """Grant course access for a sale ping when the buyer already signed up.
+
+    Matches the buyer email against stored users case-insensitively; with no
+    match the sale row alone is the outcome (the buyer's later license-gated
+    signup converges by linking to it). The grant is idempotent, so webhook
+    replays never duplicate an entitlement.
+    """
+    email = payload.get("email", "").strip().lower()
+    if not email:
+        return
+    user_result = await session.execute(select(User).where(func.lower(User.email) == email))
+    user = user_result.scalars().first()
+    if user is None:
+        return
+    sale_result = await session.execute(
+        select(GumroadSale).where(GumroadSale.gumroad_sale_id == payload["sale_id"])
+    )
+    sale = sale_result.scalars().first()
+    await grant_course_access(session, user, sale=sale, reason_code=REASON_WEBHOOK_SALE)
+
+
 @router.post("/ping")
 async def receive_ping(
     request: Request,
@@ -116,7 +145,8 @@ async def receive_ping(
 
     Always answers 200 on an authenticated, well-formed ping — including
     replays and unknown event types — so Gumroad never re-queues an event we
-    have already captured.
+    have already captured. A ``sale`` event additionally dispatches the
+    (idempotent) entitlement grant for an already-registered buyer.
     """
     _require_valid_secret(secret)
     payload = await _read_ping_payload(request)
@@ -126,6 +156,8 @@ async def receive_ping(
         logger.info("gumroad_webhook_event reason_code=unhandled_event")
     if not await _sale_already_recorded(session, payload["sale_id"]):
         await _persist_sale(session, payload)
+    if resource_name == _SALE_RESOURCE_NAME:
+        await _grant_for_sale(session, payload)
     logger.info(
         "gumroad_webhook_accepted",
         extra={"reason_code": "accepted", "resource_name": resource_name},

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -26,7 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
-from domain.entitlements import REASON_WEBHOOK_SALE, grant_course_access
+from domain.entitlements import (
+    REASON_WEBHOOK_SALE,
+    grant_course_access,
+    is_aptitude_product_id,
+)
 from errors import bad_request
 from models.gumroad_sale import GumroadSale
 from models.user import User
@@ -116,11 +120,17 @@ async def _persist_sale(session: AsyncSession, payload: dict[str, str]) -> None:
 async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> None:
     """Grant course access for a sale ping when the buyer already signed up.
 
-    Matches the buyer email against stored users case-insensitively; with no
-    match the sale row alone is the outcome (the buyer's later license-gated
-    signup converges by linking to it). The grant is idempotent, so webhook
-    replays never duplicate an entitlement.
+    Grants only for a sale of an APTITUDE product (the ping's ``product_id``
+    must be on ``GUMROAD_APTITUDE_PRODUCT_IDS`` — the same allowlist the signup
+    path enforces), so a future non-APTITUDE product sold on the same Gumroad
+    account never silently grants course access. Matches the buyer email
+    against stored users case-insensitively; with no match the sale row alone
+    is the outcome (the buyer's later license-gated signup converges by linking
+    to it). The grant is idempotent, so webhook replays never duplicate an
+    entitlement.
     """
+    if not is_aptitude_product_id(payload.get("product_id")):
+        return
     email = payload.get("email", "").strip().lower()
     if not email:
         return

--- a/backend/src/schemas/gumroad.py
+++ b/backend/src/schemas/gumroad.py
@@ -17,7 +17,11 @@ class GumroadPurchase(BaseModel):
     email: str
     product_id: str
     sale_id: str
+    # Gumroad reports refunds and chargebacks as two independent booleans on the
+    # purchase; a verify call still answers ``success: true`` for either state
+    # unless the seller enabled auto-disable, so both are parsed and checked.
     refunded: bool
+    chargebacked: bool
 
 
 class GumroadLicenseResult(BaseModel):

--- a/backend/src/schemas/gumroad.py
+++ b/backend/src/schemas/gumroad.py
@@ -17,11 +17,20 @@ class GumroadPurchase(BaseModel):
     email: str
     product_id: str
     sale_id: str
-    # Gumroad reports refunds and chargebacks as two independent booleans on the
-    # purchase; a verify call still answers ``success: true`` for either state
-    # unless the seller enabled auto-disable, so both are parsed and checked.
-    refunded: bool
-    chargebacked: bool
+    # Gumroad's documented "Verify" license example (app.gumroad.com/api) reports
+    # reversal state as four independent booleans on the purchase object, spelled
+    # exactly ``refunded``, ``disputed``, ``dispute_won``, and ``chargebacked``;
+    # a verify call still answers ``success: true`` for any of them unless the
+    # seller enabled auto-disable, so each is parsed and checked. Every flag
+    # defaults to ``False`` so a response that omits one degrades to "not known
+    # reversed" instead of raising a ValidationError that would 500 the signup
+    # happy path — absence must never block a legitimate signup. The reversal
+    # gate is best-effort pre-grant screening only; revoking an already-granted
+    # entitlement after a later refund is separate, deferred work.
+    refunded: bool = False
+    disputed: bool = False
+    dispute_won: bool = False
+    chargebacked: bool = False
 
 
 class GumroadLicenseResult(BaseModel):

--- a/backend/tests/domain/test_entitlements.py
+++ b/backend/tests/domain/test_entitlements.py
@@ -19,8 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import SQLModel, col, select
 
 from domain.entitlements import (
+    PRODUCT_IDS_ENV_VAR,
     grant_course_access,
     has_course_access,
+    is_aptitude_product_id,
     revoke_course_access,
 )
 from models.entitlement import Entitlement, EntitlementKind
@@ -90,6 +92,27 @@ def test_course_access_kind_is_the_stored_string() -> None:
     """EntitlementKind.COURSE_ACCESS is a StrEnum member equal to its column value."""
     assert EntitlementKind.COURSE_ACCESS == COURSE_ACCESS_KIND
     assert EntitlementKind.COURSE_ACCESS.value == COURSE_ACCESS_KIND
+
+
+def test_is_aptitude_product_id_matches_only_allowlisted_products(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared allowlist check accepts a listed id and rejects everything else."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, f" {PRODUCT_ID} , prod_beta ")
+    assert is_aptitude_product_id(PRODUCT_ID) is True
+    assert is_aptitude_product_id("prod_beta") is True
+    assert is_aptitude_product_id("prod_not_listed") is False
+
+
+def test_is_aptitude_product_id_rejects_blank_and_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank id, and any id under an unset allowlist, fail closed to False."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, PRODUCT_ID)
+    assert is_aptitude_product_id("") is False
+    assert is_aptitude_product_id(None) is False
+    monkeypatch.delenv(PRODUCT_IDS_ENV_VAR, raising=False)
+    assert is_aptitude_product_id(PRODUCT_ID) is False
 
 
 def test_new_entitlement_defaults_to_active_course_access() -> None:

--- a/backend/tests/domain/test_entitlements.py
+++ b/backend/tests/domain/test_entitlements.py
@@ -1,0 +1,256 @@
+"""Domain tests for course-access entitlements: grant, check, revoke.
+
+Contract: at most one ACTIVE course_access entitlement per user, enforced by
+a partial unique index on (user_id, kind) WHERE revoked_at IS NULL that the
+model also renders on the SQLite test database; grant_course_access is
+idempotent and updates the sale link in place; revoke-then-regrant yields a
+fresh active row; every grant and revoke emits a structured reason_code log.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import SQLModel, col, select
+
+from domain.entitlements import (
+    grant_course_access,
+    has_course_access,
+    revoke_course_access,
+)
+from models.entitlement import Entitlement, EntitlementKind
+from models.gumroad_sale import GumroadSale
+from models.user import User
+
+COURSE_ACCESS_KIND = "course_access"
+ENTITLEMENT_TABLE = "entitlement"
+METADATA_COLUMN = "metadata"
+USER_EMAIL = "seeker@example.com"
+SECOND_USER_EMAIL = "other-seeker@example.com"
+PRODUCT_ID = "prod_alpha"
+SALE_ID = "S-500"
+GRANT_REASON_DEFAULT = "signup_redemption"
+REVOKE_REASON = "refund"
+STUB_USER_ID = 1
+
+
+def _log_carries_reason(caplog: pytest.LogCaptureFixture, reason: str) -> bool:
+    """Return True when a captured log record carries ``reason`` as its reason_code."""
+    if f"reason_code={reason}" in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == reason for record in caplog.records)
+
+
+async def _persist_user(db_session: AsyncSession, email: str = USER_EMAIL) -> tuple[User, int]:
+    """Create and commit a user; return the row plus its non-null id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user, user.id
+
+
+async def _persist_sale(
+    db_session: AsyncSession, sale_id: str = SALE_ID
+) -> tuple[GumroadSale, int]:
+    """Create and commit a GumroadSale; return the row plus its non-null id."""
+    sale = GumroadSale(
+        gumroad_sale_id=sale_id,
+        product_id=PRODUCT_ID,
+        email=USER_EMAIL,
+        resource_name="sale",
+        raw_payload={"sale_id": sale_id},
+    )
+    db_session.add(sale)
+    await db_session.commit()
+    await db_session.refresh(sale)
+    if sale.id is None:
+        msg = "sale id missing after commit"
+        raise RuntimeError(msg)
+    return sale, sale.id
+
+
+async def _count_entitlements(db_session: AsyncSession, user_id: int) -> int:
+    """Return the number of Entitlement rows persisted for ``user_id``."""
+    result = await db_session.execute(
+        select(func.count()).select_from(Entitlement).where(Entitlement.user_id == user_id)
+    )
+    return int(result.scalar_one())
+
+
+def test_course_access_kind_is_the_stored_string() -> None:
+    """EntitlementKind.COURSE_ACCESS is a StrEnum member equal to its column value."""
+    assert EntitlementKind.COURSE_ACCESS == COURSE_ACCESS_KIND
+    assert EntitlementKind.COURSE_ACCESS.value == COURSE_ACCESS_KIND
+
+
+def test_new_entitlement_defaults_to_active_course_access() -> None:
+    """A bare Entitlement defaults to active course_access with tz-aware granted_at."""
+    row = Entitlement(user_id=STUB_USER_ID)
+    assert row.kind == COURSE_ACCESS_KIND
+    assert row.revoked_at is None
+    assert row.entitlement_metadata == {}
+    assert row.granted_at is not None
+    assert row.granted_at.tzinfo is not None
+
+
+def test_metadata_attribute_maps_to_metadata_db_column() -> None:
+    """The Python attribute entitlement_metadata is stored in a column named metadata."""
+    columns = SQLModel.metadata.tables[ENTITLEMENT_TABLE].c
+    assert METADATA_COLUMN in columns
+
+
+@pytest.mark.asyncio
+async def test_grant_creates_active_entitlement_linked_to_sale(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Granting with a sale links source_sale_id and product_id and logs the reason."""
+    caplog.set_level(logging.DEBUG)
+    user, user_id = await _persist_user(db_session)
+    sale, sale_id = await _persist_sale(db_session)
+
+    entitlement = await grant_course_access(db_session, user, sale)
+
+    assert entitlement.user_id == user_id
+    assert entitlement.kind == COURSE_ACCESS_KIND
+    assert entitlement.source_sale_id == sale_id
+    assert entitlement.product_id == sale.product_id
+    assert entitlement.revoked_at is None
+    assert entitlement.granted_at is not None
+    assert await _count_entitlements(db_session, user_id) == 1
+    assert _log_carries_reason(caplog, GRANT_REASON_DEFAULT)
+
+
+@pytest.mark.asyncio
+async def test_grant_is_idempotent_and_updates_sale_link_in_place(
+    db_session: AsyncSession,
+) -> None:
+    """A second grant for the same user updates the existing row, never duplicates."""
+    user, user_id = await _persist_user(db_session)
+    first = await grant_course_access(db_session, user)
+    sale, sale_id = await _persist_sale(db_session)
+
+    second = await grant_course_access(db_session, user, sale)
+
+    assert second.id == first.id
+    assert second.source_sale_id == sale_id
+    assert second.product_id == PRODUCT_ID
+    assert await _count_entitlements(db_session, user_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_a_persisted_user(db_session: AsyncSession) -> None:
+    """Granting for a user that was never committed (no id) is a programmer error."""
+    unsaved_user = User(email=USER_EMAIL, password_hash="x")  # pragma: allowlist secret
+
+    with pytest.raises(ValueError, match="user id"):
+        await grant_course_access(db_session, unsaved_user)
+
+
+@pytest.mark.asyncio
+async def test_revoke_without_active_grant_is_a_silent_no_op(db_session: AsyncSession) -> None:
+    """Revoking when there is no active entitlement neither raises nor writes a row."""
+    _user, user_id = await _persist_user(db_session)
+
+    await revoke_course_access(db_session, user_id, REVOKE_REASON)
+
+    assert await has_course_access(db_session, user_id) is False
+    assert await _count_entitlements(db_session, user_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_has_course_access_reflects_grant_and_revoke(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """has_course_access flips False -> True on grant and back to False on revoke."""
+    caplog.set_level(logging.DEBUG)
+    user, user_id = await _persist_user(db_session)
+    assert await has_course_access(db_session, user_id) is False
+
+    await grant_course_access(db_session, user)
+    assert await has_course_access(db_session, user_id) is True
+
+    await revoke_course_access(db_session, user_id, REVOKE_REASON)
+    assert await has_course_access(db_session, user_id) is False
+    assert _log_carries_reason(caplog, REVOKE_REASON)
+
+
+@pytest.mark.asyncio
+async def test_revoke_then_regrant_creates_fresh_active_row(
+    db_session: AsyncSession,
+) -> None:
+    """Regranting after a revoke adds a new active row and keeps the revoked one."""
+    user, user_id = await _persist_user(db_session)
+    original = await grant_course_access(db_session, user)
+    original_id = original.id
+    await revoke_course_access(db_session, user_id, REVOKE_REASON)
+
+    regranted = await grant_course_access(db_session, user)
+
+    assert regranted.id != original_id
+    assert regranted.revoked_at is None
+    assert await has_course_access(db_session, user_id) is True
+    result = await db_session.execute(
+        select(Entitlement).where(col(Entitlement.revoked_at).is_not(None))
+    )
+    revoked_rows = result.scalars().all()
+    assert len(revoked_rows) == 1
+    assert revoked_rows[0].id == original_id
+    assert await _count_entitlements(db_session, user_id) == 2
+
+
+@pytest.mark.asyncio
+async def test_second_active_row_is_rejected_by_partial_unique_index(
+    db_session: AsyncSession,
+) -> None:
+    """Inserting a second active course_access row for one user raises IntegrityError."""
+    _user, user_id = await _persist_user(db_session)
+    db_session.add(Entitlement(user_id=user_id))
+    await db_session.commit()
+
+    db_session.add(Entitlement(user_id=user_id))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+    assert await _count_entitlements(db_session, user_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_revoked_row_does_not_block_a_new_active_row(
+    db_session: AsyncSession,
+) -> None:
+    """The partial index only guards active rows, so revoked history can coexist."""
+    _user, user_id = await _persist_user(db_session)
+    db_session.add(Entitlement(user_id=user_id, revoked_at=datetime.now(UTC)))
+    await db_session.commit()
+
+    db_session.add(Entitlement(user_id=user_id))
+    await db_session.commit()
+
+    assert await _count_entitlements(db_session, user_id) == 2
+
+
+@pytest.mark.asyncio
+async def test_distinct_users_hold_active_entitlements_simultaneously(
+    db_session: AsyncSession,
+) -> None:
+    """The unique index is scoped per user, not global per kind."""
+    _first, first_id = await _persist_user(db_session)
+    _second, second_id = await _persist_user(db_session, email=SECOND_USER_EMAIL)
+    db_session.add(Entitlement(user_id=first_id))
+    db_session.add(Entitlement(user_id=second_id))
+    await db_session.commit()
+
+    assert await _count_entitlements(db_session, first_id) == 1
+    assert await _count_entitlements(db_session, second_id) == 1

--- a/backend/tests/integrations/test_gumroad_client.py
+++ b/backend/tests/integrations/test_gumroad_client.py
@@ -44,6 +44,100 @@ def _success_payload() -> dict[str, object]:
     }
 
 
+# The canonical successful-verify example transcribed verbatim from Gumroad's
+# own API docs (POST /v2/licenses/verify), captured from
+# https://app.gumroad.com/api (Wayback snapshot 2024-12-28). The purchase
+# object's reversal state is spelled exactly ``refunded``, ``disputed``,
+# ``dispute_won``, and ``chargebacked`` there; the ``#`` inline comments in the
+# published example are dropped here because JSON carries no comments. This
+# fixture exists to break test circularity: it is sourced from the docs, not
+# from our own schema, so a field-name drift with the real API fails CI here.
+DOCUMENTED_VERIFY_EXAMPLE: dict[str, object] = {
+    "success": True,
+    "uses": 3,
+    "purchase": {
+        "seller_id": "kL0psVL2admJSYRNs-OCMg==",
+        "product_id": "32-nPAicqbLj8B_WswVlMw==",
+        "product_name": "licenses demo product",
+        "permalink": "QMGY",
+        "product_permalink": "https://sahil.gumroad.com/l/pencil",
+        "email": "customer@example.com",
+        "price": 0,
+        "gumroad_fee": 0,
+        "currency": "usd",
+        "quantity": 1,
+        "discover_fee_charged": False,
+        "can_contact": True,
+        "referrer": "direct",
+        "card": {"visual": None, "type": None},
+        "order_number": 524459935,
+        "sale_id": "FO8TXN-dbxYaBdahG97Y-Q==",
+        "sale_timestamp": "2021-01-05T19:38:56Z",
+        "purchaser_id": "5550321502811",
+        "subscription_id": "GDzW4_aBdQc-o7Gbjng7lw==",
+        "variants": "",
+        "license_key": "85DB562A-C11D4B06-A2335A6B-8C079166",  # pragma: allowlist secret
+        "is_multiseat_license": False,
+        "ip_country": "United States",
+        "recurrence": "monthly",
+        "is_gift_receiver_purchase": False,
+        "refunded": False,
+        "disputed": False,
+        "dispute_won": False,
+        "id": "FO8TXN-dvaYbBbahG97a-Q==",
+        "created_at": "2021-01-05T19:38:56Z",
+        "custom_fields": [],
+        "chargebacked": False,
+        "subscription_ended_at": None,
+        "subscription_cancelled_at": None,
+        "subscription_failed_at": None,
+    },
+}
+
+
+def test_documented_verify_example_parses_with_all_reversal_flags() -> None:
+    """The verbatim documented Gumroad example validates and is not reversed.
+
+    Guards against a field-name drift between ``GumroadPurchase`` and Gumroad's
+    real response: parsing the docs' own example must succeed and surface the
+    documented ``refunded``/``disputed``/``dispute_won``/``chargebacked`` flags.
+    """
+    result = GumroadLicenseResult.model_validate(DOCUMENTED_VERIFY_EXAMPLE)
+
+    assert result.success is True
+    assert result.uses == EXPECTED_USES
+    assert result.purchase.email == "customer@example.com"
+    assert result.purchase.refunded is False
+    assert result.purchase.disputed is False
+    assert result.purchase.dispute_won is False
+    assert result.purchase.chargebacked is False
+
+
+def test_verify_response_missing_reversal_flags_parses_with_safe_defaults() -> None:
+    """A purchase that omits every reversal flag parses; absence is not reversed.
+
+    If Gumroad drops one of the reversal booleans from a response, the schema
+    must degrade to "not known reversed" (all flags ``False``) rather than raise
+    a ``ValidationError`` that would 500 the signup happy path.
+    """
+    payload = {
+        "success": True,
+        "uses": EXPECTED_USES,
+        "purchase": {
+            "email": "buyer@example.com",
+            "product_id": PRODUCT_ID,
+            "sale_id": "S-123",
+        },
+    }
+
+    result = GumroadLicenseResult.model_validate(payload)
+
+    assert result.purchase.refunded is False
+    assert result.purchase.disputed is False
+    assert result.purchase.dispute_won is False
+    assert result.purchase.chargebacked is False
+
+
 @pytest.mark.asyncio
 async def test_verify_license_valid_returns_parsed_result(
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/integrations/test_gumroad_client.py
+++ b/backend/tests/integrations/test_gumroad_client.py
@@ -39,6 +39,7 @@ def _success_payload() -> dict[str, object]:
             "product_id": PRODUCT_ID,
             "sale_id": "S-123",
             "refunded": False,
+            "chargebacked": False,
         },
     }
 

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -1,0 +1,404 @@
+"""License-gated signup tests for POST /auth/signup.
+
+Contract: signup requires a license_key; every rejection path returns the
+same generic detail (license_required for a missing key, invalid_license for
+everything else) without creating User or Entitlement rows or leaking that
+an account exists; the verifier is consulted only for products on the
+GUMROAD_APTITUDE_PRODUCT_IDS allowlist and stops on the first success; a
+Gumroad outage fails closed with 503; more than ten invalid-license attempts
+per client per hour are throttled with 429; every failure path still spends
+a dummy bcrypt verify for timing parity.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from http import HTTPStatus
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from integrations.gumroad import GumroadUnavailableError
+from models.entitlement import Entitlement
+from models.user import User
+from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
+
+pytestmark = pytest.mark.real_license_gate
+
+SIGNUP_PATH = "/auth/signup"
+PRODUCT_IDS_ENV = "GUMROAD_APTITUDE_PRODUCT_IDS"
+VERIFY_SEAM = "domain.entitlements.verify_license"
+ALLOWED_PRODUCT_ALPHA = "prod_alpha"
+ALLOWED_PRODUCT_BETA = "prod_beta"
+ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
+UNLISTED_PRODUCT = "prod_unlisted"
+SIGNUP_EMAIL = "seeker@example.com"
+MIXED_CASE_LICENSE_EMAIL = "Seeker@Example.COM"
+OTHER_EMAIL = "someone-else@example.com"
+SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
+LICENSE_KEY = "ABCD1234-EF56-7890-TEST"  # pragma: allowlist secret
+SALE_ID = "S-900"
+COURSE_ACCESS_KIND = "course_access"
+LICENSE_USES = 1
+JWT_SEGMENT_COUNT = 3
+INVALID_LICENSE_ATTEMPT_CAP = 10
+
+DETAIL_LICENSE_REQUIRED = "license_required"
+DETAIL_INVALID_LICENSE = "invalid_license"
+DETAIL_UNAVAILABLE = "license_verification_unavailable"
+DETAIL_THROTTLED = "too_many_license_attempts"
+EMAIL_MISMATCH_MARKER = "email_mismatch"
+DUPLICATE_SIGNUP_MARKER = "duplicate_signup"
+GUMROAD_DOWN_MESSAGE = "gumroad unavailable in test"
+
+VerifyStub = Callable[..., Awaitable[GumroadLicenseResult | None]]
+
+
+@pytest.fixture
+def allowlisted_products(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point the APTITUDE product allowlist at the two test product ids."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV, ALLOWLIST)
+    return ALLOWLIST
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+def _license_result(
+    email: str = SIGNUP_EMAIL,
+    product_id: str = ALLOWED_PRODUCT_ALPHA,
+    sale_id: str = SALE_ID,
+    *,
+    success: bool = True,
+) -> GumroadLicenseResult:
+    """Build a Gumroad verify result for the given purchase identity."""
+    return GumroadLicenseResult(
+        success=success,
+        uses=LICENSE_USES,
+        purchase=GumroadPurchase(
+            email=email,
+            product_id=product_id,
+            sale_id=sale_id,
+            refunded=False,
+        ),
+    )
+
+
+def _make_verify_stub(
+    results: Mapping[str, GumroadLicenseResult | None],
+    calls: list[tuple[str, str]],
+    *,
+    unavailable: bool = False,
+) -> VerifyStub:
+    """Build a network-free verify_license stand-in that records its calls."""
+
+    async def _verify(
+        product_id: str,
+        license_key: str,
+        **_kwargs: object,
+    ) -> GumroadLicenseResult | None:
+        calls.append((product_id, license_key))
+        if unavailable:
+            raise GumroadUnavailableError(GUMROAD_DOWN_MESSAGE)
+        return results.get(product_id)
+
+    return _verify
+
+
+def _signup_payload(
+    email: str = SIGNUP_EMAIL,
+    license_key: str | None = LICENSE_KEY,
+) -> dict[str, str]:
+    """Build a signup JSON body; ``license_key=None`` omits the field entirely."""
+    payload = {"email": email, "password": SIGNUP_PASSWORD}
+    if license_key is not None:
+        payload["license_key"] = license_key
+    return payload
+
+
+async def _count_users(db_session: AsyncSession) -> int:
+    """Return the number of User rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(User))
+    return int(result.scalar_one())
+
+
+async def _count_entitlements(db_session: AsyncSession) -> int:
+    """Return the number of Entitlement rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(Entitlement))
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("license_key", [None, ""])
+async def test_signup_without_license_key_returns_license_required(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_key: str | None,
+) -> None:
+    """A missing or empty license_key is rejected with 400 license_required."""
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload(license_key=license_key))
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_LICENSE_REQUIRED
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_unmatched_license_returns_invalid_license_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no allowlisted product verifies the key, signup is 400 with zero rows."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert [product for product, _ in calls] == [ALLOWED_PRODUCT_ALPHA, ALLOWED_PRODUCT_BETA]
+    assert all(key == LICENSE_KEY for _, key in calls)
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_success_false_result_is_invalid_license(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A verify answer with success=False counts as no match, not as a grant."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(success=False)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_products_off_the_allowlist_are_never_verified(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key valid only for a non-allowlisted product yields invalid_license."""
+    calls: list[tuple[str, str]] = []
+    results = {UNLISTED_PRODUCT: _license_result(product_id=UNLISTED_PRODUCT)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    called_products = {product for product, _ in calls}
+    assert UNLISTED_PRODUCT not in called_products
+    assert called_products == {ALLOWED_PRODUCT_ALPHA, ALLOWED_PRODUCT_BETA}
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_verification_stops_on_the_first_matching_product(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A match on the first allowlisted product short-circuits the loop."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result()}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert [product for product, _ in calls] == [ALLOWED_PRODUCT_ALPHA]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_license_email_mismatch_is_invalid_license_and_logged(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A valid key issued to another email is rejected generically but logged."""
+    caplog.set_level(logging.DEBUG)
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(email=OTHER_EMAIL)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert _log_carries_marker(caplog, EMAIL_MISMATCH_MARKER)
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_license_email_match_is_case_insensitive(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A license issued to a mixed-case spelling of the signup email still matches."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(email=MIXED_CASE_LICENSE_EMAIL)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_users(db_session) == 1
+    assert await _count_entitlements(db_session) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_successful_signup_creates_user_entitlement_and_jwt(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The happy path returns 200 with a JWT and persists one user + one entitlement."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result()}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert isinstance(body["token"], str)
+    assert len(body["token"].split(".")) == JWT_SEGMENT_COUNT
+    assert body["user_id"] > 0
+    assert body["timezone"]
+
+    users = (await db_session.execute(select(User))).scalars().all()
+    assert len(users) == 1
+    assert users[0].email == SIGNUP_EMAIL
+    assert users[0].id == body["user_id"]
+
+    entitlements = (await db_session.execute(select(Entitlement))).scalars().all()
+    assert len(entitlements) == 1
+    assert entitlements[0].kind == COURSE_ACCESS_KIND
+    assert entitlements[0].user_id == body["user_id"]
+    assert entitlements[0].revoked_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_duplicate_signup_is_invalid_license_without_leaking(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second signup for the same email returns the generic 400, no token, no rows."""
+    caplog.set_level(logging.DEBUG)
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result()}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    first = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+    assert first.status_code == HTTPStatus.OK
+
+    second = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert second.status_code == HTTPStatus.BAD_REQUEST
+    body = second.json()
+    assert body["detail"] == DETAIL_INVALID_LICENSE
+    assert "token" not in body
+    assert await _count_users(db_session) == 1
+    assert await _count_entitlements(db_session) == 1
+    assert _log_carries_marker(caplog, DUPLICATE_SIGNUP_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_gumroad_outage_fails_closed_with_503(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GumroadUnavailableError maps to 503 and no account is created."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls, unavailable=True))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == DETAIL_UNAVAILABLE
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_eleventh_invalid_license_attempt_is_throttled(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ten invalid-license attempts in the hour, the next one returns 429."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+
+    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
+        response = await async_client.post(
+            SIGNUP_PATH,
+            json=_signup_payload(email=f"attempt-{attempt}@example.com"),
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+
+    throttled = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email="attempt-final@example.com"),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_invalid_license_path_consumes_a_dummy_bcrypt_verify(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invalid-license rejection spends a dummy bcrypt for timing parity."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+    password_verify_spy = AsyncMock(return_value=None)
+    reset_token_spy = AsyncMock(return_value=None)
+    monkeypatch.setattr("routers.auth._consume_dummy_password_verify", password_verify_spy)
+    monkeypatch.setattr("routers.auth._consume_dummy_bcrypt", reset_token_spy)
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert password_verify_spy.await_count + reset_token_spy.await_count >= 1

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -33,6 +33,7 @@ pytestmark = pytest.mark.real_license_gate
 SIGNUP_PATH = "/auth/signup"
 PRODUCT_IDS_ENV = "GUMROAD_APTITUDE_PRODUCT_IDS"
 VERIFY_SEAM = "domain.entitlements.verify_license"
+REJECT_DUPLICATE_SEAM = "routers.auth._reject_duplicate_signup_email"
 ALLOWED_PRODUCT_ALPHA = "prod_alpha"
 ALLOWED_PRODUCT_BETA = "prod_beta"
 ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
@@ -385,6 +386,46 @@ async def test_duplicate_signup_is_invalid_license_without_leaking(
     assert await _count_users(db_session) == 1
     assert await _count_entitlements(db_session) == 1
     assert _log_carries_marker(caplog, DUPLICATE_SIGNUP_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_race_duplicate_matches_precheck_rejection_shape(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The IntegrityError race fallback returns the identical 400 shape as the pre-check.
+
+    A duplicate email caught by the concurrent-insert race must be
+    indistinguishable from one caught by the up-front existence check: same
+    status, same JSON body, no token. Silencing the pre-check forces the
+    insert to reach the unique index and raise ``IntegrityError``, so the
+    fallback branch runs — and its response must match the pre-check's byte
+    for byte, or an observer could tell which path fired.
+    """
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result()}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    first = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+    assert first.status_code == HTTPStatus.OK
+
+    # Pre-check path: the second signup finds the existing row up front.
+    precheck = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+    assert precheck.status_code == HTTPStatus.BAD_REQUEST
+    assert precheck.json()["detail"] == DETAIL_INVALID_LICENSE
+
+    # Race path: silence the pre-check so the insert reaches the unique
+    # index and raises IntegrityError, exercising the fallback branch.
+    monkeypatch.setattr(REJECT_DUPLICATE_SEAM, AsyncMock(return_value=None))
+    race = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert race.status_code == precheck.status_code
+    assert race.json() == precheck.json()
+    assert "token" not in race.json()
+    assert await _count_users(db_session) == 1
+    assert await _count_entitlements(db_session) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 
@@ -77,13 +78,25 @@ def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
     return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
 
 
+@dataclass(frozen=True)
+class _Reversal:
+    """The four documented Gumroad reversal-state flags for a purchase fixture."""
+
+    refunded: bool = False
+    chargebacked: bool = False
+    disputed: bool = False
+    dispute_won: bool = False
+
+
+_NO_REVERSAL = _Reversal()
+
+
 def _license_result(
     email: str = SIGNUP_EMAIL,
     product_id: str = ALLOWED_PRODUCT_ALPHA,
     *,
     success: bool = True,
-    refunded: bool = False,
-    chargebacked: bool = False,
+    reversal: _Reversal = _NO_REVERSAL,
 ) -> GumroadLicenseResult:
     """Build a Gumroad verify result for the given purchase identity."""
     return GumroadLicenseResult(
@@ -93,8 +106,10 @@ def _license_result(
             email=email,
             product_id=product_id,
             sale_id=SALE_ID,
-            refunded=refunded,
-            chargebacked=chargebacked,
+            refunded=reversal.refunded,
+            chargebacked=reversal.chargebacked,
+            disputed=reversal.disputed,
+            dispute_won=reversal.dispute_won,
         ),
     )
 
@@ -211,7 +226,7 @@ async def test_refunded_license_is_invalid_license_and_writes_nothing(
     """A refunded purchase is rejected exactly like an invalid key, no rows written."""
     caplog.set_level(logging.DEBUG)
     calls: list[tuple[str, str]] = []
-    results = {ALLOWED_PRODUCT_ALPHA: _license_result(refunded=True)}
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(reversal=_Reversal(refunded=True))}
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
 
     response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
@@ -234,7 +249,9 @@ async def test_chargebacked_license_is_invalid_license_and_writes_nothing(
 ) -> None:
     """A charged-back purchase is rejected like an invalid key, no rows written."""
     calls: list[tuple[str, str]] = []
-    results = {ALLOWED_PRODUCT_ALPHA: _license_result(chargebacked=True)}
+    results = {
+        ALLOWED_PRODUCT_ALPHA: _license_result(reversal=_Reversal(chargebacked=True)),
+    }
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
 
     response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
@@ -243,6 +260,49 @@ async def test_chargebacked_license_is_invalid_license_and_writes_nothing(
     assert response.json()["detail"] == DETAIL_INVALID_LICENSE
     assert await _count_users(db_session) == 0
     assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_disputed_unresolved_license_is_invalid_license_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A purchase under an unresolved chargeback dispute is rejected, no rows written."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(reversal=_Reversal(disputed=True))}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_dispute_won_license_is_accepted_and_creates_user(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispute the seller won leaves the sale legitimate: signup still succeeds."""
+    calls: list[tuple[str, str]] = []
+    results = {
+        ALLOWED_PRODUCT_ALPHA: _license_result(
+            reversal=_Reversal(disputed=True, dispute_won=True),
+        ),
+    }
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_users(db_session) == 1
+    assert await _count_entitlements(db_session) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -47,6 +47,9 @@ COURSE_ACCESS_KIND = "course_access"
 LICENSE_USES = 1
 JWT_SEGMENT_COUNT = 3
 INVALID_LICENSE_ATTEMPT_CAP = 10
+# One character past the schema's license_key ceiling; must be rejected by
+# Pydantic before any outbound Gumroad verify runs.
+OVER_LENGTH_LICENSE_KEY = "A" * 129
 
 DETAIL_LICENSE_REQUIRED = "license_required"
 DETAIL_INVALID_LICENSE = "invalid_license"
@@ -428,6 +431,34 @@ async def test_eleventh_invalid_license_attempt_is_throttled(
 
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_over_length_license_key_is_rejected_before_any_gumroad_call(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An over-length license_key is a 422 schema rejection, no verify runs.
+
+    The unbounded string never reaches the per-product outbound verify loop,
+    so the mocked verifier must never be invoked and no rows are written. The
+    rejection is a schema-shape one (same as an over-length password), so no
+    timing-parity obligation applies and nothing leaks about key validity.
+    """
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+
+    response = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(license_key=OVER_LENGTH_LICENSE_KEY),
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert calls == []
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -76,9 +76,10 @@ def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
 def _license_result(
     email: str = SIGNUP_EMAIL,
     product_id: str = ALLOWED_PRODUCT_ALPHA,
-    sale_id: str = SALE_ID,
     *,
     success: bool = True,
+    refunded: bool = False,
+    chargebacked: bool = False,
 ) -> GumroadLicenseResult:
     """Build a Gumroad verify result for the given purchase identity."""
     return GumroadLicenseResult(
@@ -87,8 +88,9 @@ def _license_result(
         purchase=GumroadPurchase(
             email=email,
             product_id=product_id,
-            sale_id=sale_id,
-            refunded=False,
+            sale_id=SALE_ID,
+            refunded=refunded,
+            chargebacked=chargebacked,
         ),
     )
 
@@ -184,6 +186,51 @@ async def test_success_false_result_is_invalid_license(
     """A verify answer with success=False counts as no match, not as a grant."""
     calls: list[tuple[str, str]] = []
     results = {ALLOWED_PRODUCT_ALPHA: _license_result(success=False)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_refunded_license_is_invalid_license_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refunded purchase is rejected exactly like an invalid key, no rows written."""
+    caplog.set_level(logging.DEBUG)
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(refunded=True)}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
+
+    response = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+    # The email matches the purchase, so a refund must not leak via the
+    # email-mismatch marker: the rejection is indistinguishable from a bad key.
+    assert not _log_carries_marker(caplog, EMAIL_MISMATCH_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products")
+async def test_chargebacked_license_is_invalid_license_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A charged-back purchase is rejected like an invalid key, no rows written."""
+    calls: list[tuple[str, str]] = []
+    results = {ALLOWED_PRODUCT_ALPHA: _license_result(chargebacked=True)}
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(results, calls))
 
     response = await async_client.post(SIGNUP_PATH, json=_signup_payload())

--- a/backend/tests/routers/test_gumroad_sale_dispatch.py
+++ b/backend/tests/routers/test_gumroad_sale_dispatch.py
@@ -1,0 +1,257 @@
+"""Sale-event dispatch tests for POST /webhooks/gumroad/ping.
+
+Contract: an authenticated sale ping grants an idempotent active
+course_access entitlement when a user with the buyer's email already exists
+(matched case-insensitively) and links it to the persisted GumroadSale row;
+with no matching user only the sale row is persisted; a later license-gated
+signup for that email converges by linking its entitlement to the stored
+sale; non-sale events never grant.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from models.entitlement import Entitlement
+from models.gumroad_sale import GumroadSale
+from models.user import User
+from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
+
+pytestmark = pytest.mark.real_license_gate
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+WEBHOOK_SECRET = "gumroad-webhook-shared-secret-test-only"  # pragma: allowlist secret
+SIGNUP_PATH = "/auth/signup"
+PRODUCT_IDS_ENV = "GUMROAD_APTITUDE_PRODUCT_IDS"
+VERIFY_SEAM = "domain.entitlements.verify_license"
+BUYER_EMAIL = "buyer@example.com"
+MIXED_CASE_BUYER_EMAIL = "Buyer@Example.COM"
+SALE_ID = "S-100"
+PRODUCT_ID = "prod_abc123"
+NON_SALE_RESOURCE = "refund"
+LICENSE_KEY = "WEBHOOK-CONVERGENCE-TEST-KEY"  # pragma: allowlist secret
+SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
+COURSE_ACCESS_KIND = "course_access"
+LICENSE_USES = 1
+WEBHOOK_SALE_MARKER = "webhook_sale"
+
+
+@pytest.fixture
+def webhook_secret(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set GUMROAD_WEBHOOK_SECRET for the duration of a test."""
+    monkeypatch.setenv("GUMROAD_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    return WEBHOOK_SECRET
+
+
+def _sale_payload(**overrides: str) -> dict[str, str]:
+    """Build a form-encoded Gumroad ping payload, with optional overrides."""
+    payload = {
+        "sale_id": SALE_ID,
+        "product_id": PRODUCT_ID,
+        "email": BUYER_EMAIL,
+        "resource_name": "sale",
+        "is_recurring_charge": "false",
+        "refunded": "false",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+def _make_success_stub() -> Callable[..., Awaitable[GumroadLicenseResult | None]]:
+    """Build a verify_license stand-in that succeeds only for the webhook's sale."""
+
+    async def _verify(
+        product_id: str,
+        license_key: str,
+        **_kwargs: object,
+    ) -> GumroadLicenseResult | None:
+        assert license_key == LICENSE_KEY
+        if product_id != PRODUCT_ID:
+            return None
+        return GumroadLicenseResult(
+            success=True,
+            uses=LICENSE_USES,
+            purchase=GumroadPurchase(
+                email=BUYER_EMAIL,
+                product_id=PRODUCT_ID,
+                sale_id=SALE_ID,
+                refunded=False,
+            ),
+        )
+
+    return _verify
+
+
+async def _persist_user(db_session: AsyncSession, email: str = BUYER_EMAIL) -> tuple[User, int]:
+    """Create and commit a user; return the row plus its non-null id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user, user.id
+
+
+async def _count_sales(db_session: AsyncSession) -> int:
+    """Return the number of GumroadSale rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(GumroadSale))
+    return int(result.scalar_one())
+
+
+async def _count_entitlements(db_session: AsyncSession) -> int:
+    """Return the number of Entitlement rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(Entitlement))
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+async def test_sale_ping_grants_entitlement_to_existing_user(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A sale ping for a registered email grants an active linked entitlement."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_sale_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    sale_row = (await db_session.execute(select(GumroadSale))).scalar_one()
+    entitlement = (await db_session.execute(select(Entitlement))).scalar_one()
+    assert entitlement.user_id == user_id
+    assert entitlement.kind == COURSE_ACCESS_KIND
+    assert entitlement.source_sale_id == sale_row.id
+    assert entitlement.revoked_at is None
+    assert _log_carries_marker(caplog, WEBHOOK_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_replayed_sale_ping_keeps_a_single_entitlement(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """Replaying an identical sale ping stays 200 and never duplicates the grant."""
+    _user, _user_id = await _persist_user(db_session)
+    payload = _sale_payload()
+
+    first = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+    second = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _count_entitlements(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_sale_ping_email_match_is_case_insensitive(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A mixed-case buyer email still matches the lowercased stored user email."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_sale_payload(email=MIXED_CASE_BUYER_EMAIL),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    entitlement = (await db_session.execute(select(Entitlement))).scalar_one()
+    assert entitlement.user_id == user_id
+    assert entitlement.kind == COURSE_ACCESS_KIND
+
+
+@pytest.mark.asyncio
+async def test_sale_ping_without_user_persists_sale_only(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """With no matching user the ping stores the sale row and grants nothing."""
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_sale_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_non_sale_event_does_not_grant_entitlement(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A non-sale resource_name is persisted but never dispatches a grant."""
+    _user, _user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_sale_payload(resource_name=NON_SALE_RESOURCE),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_first_then_signup_links_entitlement_to_stored_sale(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sale that arrives before signup is linked once the buyer redeems a license."""
+    ping = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_sale_payload()
+    )
+    assert ping.status_code == HTTPStatus.OK
+    sale_row = (await db_session.execute(select(GumroadSale))).scalar_one()
+    assert await _count_entitlements(db_session) == 0
+
+    monkeypatch.setenv(PRODUCT_IDS_ENV, PRODUCT_ID)
+    monkeypatch.setattr(VERIFY_SEAM, _make_success_stub())
+
+    signup = await async_client.post(
+        SIGNUP_PATH,
+        json={
+            "email": BUYER_EMAIL,
+            "password": SIGNUP_PASSWORD,
+            "license_key": LICENSE_KEY,
+        },
+    )
+
+    assert signup.status_code == HTTPStatus.OK
+    entitlement = (await db_session.execute(select(Entitlement))).scalar_one()
+    assert entitlement.source_sale_id == sale_row.id
+    assert entitlement.user_id == signup.json()["user_id"]
+    assert entitlement.kind == COURSE_ACCESS_KIND
+    assert entitlement.revoked_at is None

--- a/backend/tests/routers/test_gumroad_sale_dispatch.py
+++ b/backend/tests/routers/test_gumroad_sale_dispatch.py
@@ -36,6 +36,7 @@ BUYER_EMAIL = "buyer@example.com"
 MIXED_CASE_BUYER_EMAIL = "Buyer@Example.COM"
 SALE_ID = "S-100"
 PRODUCT_ID = "prod_abc123"
+OFF_ALLOWLIST_PRODUCT_ID = "prod_token_packs"
 NON_SALE_RESOURCE = "refund"
 LICENSE_KEY = "WEBHOOK-CONVERGENCE-TEST-KEY"  # pragma: allowlist secret
 SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
@@ -49,6 +50,20 @@ def webhook_secret(monkeypatch: pytest.MonkeyPatch) -> str:
     """Set GUMROAD_WEBHOOK_SECRET for the duration of a test."""
     monkeypatch.setenv("GUMROAD_WEBHOOK_SECRET", WEBHOOK_SECRET)
     return WEBHOOK_SECRET
+
+
+@pytest.fixture(autouse=True)
+def aptitude_allowlist(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Put the sale's product on the APTITUDE allowlist for the whole suite.
+
+    The webhook grant path filters the ping's ``product_id`` against
+    ``GUMROAD_APTITUDE_PRODUCT_IDS`` — the same allowlist the signup path
+    enforces — so a grant only happens for an APTITUDE product. Every
+    grant-expecting test here therefore needs the sale product allowlisted;
+    off-allowlist behaviour is asserted with a product left off this list.
+    """
+    monkeypatch.setenv(PRODUCT_IDS_ENV, PRODUCT_ID)
+    return PRODUCT_ID
 
 
 def _sale_payload(**overrides: str) -> dict[str, str]:
@@ -195,6 +210,32 @@ async def test_sale_ping_without_user_persists_sale_only(
     """With no matching user the ping stores the sale row and grants nothing."""
     response = await async_client.post(
         WEBHOOK_PATH, params={"secret": webhook_secret}, data=_sale_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_sale_ping_off_allowlist_product_persists_sale_without_granting(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A sale for a non-APTITUDE product stores the sale but grants no access.
+
+    A pre-registered user whose email matches must not receive course_access
+    from a product that is not on ``GUMROAD_APTITUDE_PRODUCT_IDS`` (e.g. a
+    future token-pack product on the same Gumroad account); the verbatim sale
+    row is still captured.
+    """
+    _user, _user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_sale_payload(product_id=OFF_ALLOWLIST_PRODUCT_ID),
     )
 
     assert response.status_code == HTTPStatus.OK

--- a/backend/tests/routers/test_gumroad_sale_dispatch.py
+++ b/backend/tests/routers/test_gumroad_sale_dispatch.py
@@ -106,6 +106,7 @@ def _make_success_stub() -> Callable[..., Awaitable[GumroadLicenseResult | None]
                 product_id=PRODUCT_ID,
                 sale_id=SALE_ID,
                 refunded=False,
+                chargebacked=False,
             ),
         )
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1008,25 +1008,34 @@ async def test_concurrent_signups_for_same_email_create_one_user(
     concurrent signups could both pass the existence check and both
     insert.  The case-insensitive unique index on ``lower(email)`` plus
     the ``IntegrityError`` rollback keeps the row count at one and the
-    losing requests still receive the anti-enumeration dummy response.
+    losing requests receive the generic invalid-license rejection — the
+    same 400, no token, that the up-front duplicate pre-check returns, so
+    a timing/shape oracle cannot single out the winner.
     """
     payloads = [
-        {"email": "race@example.com", "password": "securepassword123"}  # pragma: allowlist secret
+        {
+            "email": "race@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+            "license_key": "RACE-LICENSE-KEY",  # pragma: allowlist secret
+        }
         for _ in range(_CONCURRENT_SIGNUP_FANOUT)
     ]
     responses = await asyncio.gather(
         *[concurrent_async_client.post(SIGNUP_URL, json=p) for p in payloads]
     )
 
-    # Every attempt returns the same status + shape (anti-enumeration).
-    assert all(r.status_code == HTTPStatus.OK for r in responses)
-    assert all(set(r.json().keys()) >= {"token", "user_id"} for r in responses)
-
-    # Exactly one of them owns a real ``user_id``; the rest get the
-    # dummy ``user_id == 0`` so a timing/shape oracle cannot distinguish
-    # the winner from the duplicates.
-    real_ids = [r.json()["user_id"] for r in responses if r.json()["user_id"] != 0]
-    assert len(real_ids) == 1, real_ids
+    # Exactly one attempt creates the account (200 + real user_id + JWT);
+    # every loser gets the generic invalid-license rejection — the same 400,
+    # no token — that the up-front duplicate pre-check returns, so nothing
+    # distinguishes the race fallback from the pre-check path.
+    winners = [r for r in responses if r.status_code == HTTPStatus.OK]
+    losers = [r for r in responses if r.status_code == HTTPStatus.BAD_REQUEST]
+    assert len(winners) == 1
+    assert len(winners) + len(losers) == _CONCURRENT_SIGNUP_FANOUT
+    assert winners[0].json()["user_id"] > 0
+    assert winners[0].json()["token"]
+    assert all("token" not in r.json() for r in losers)
+    assert all(r.json()["detail"] == "invalid_license" for r in losers)
 
     # The DB has exactly one row for the contested email.
     async with concurrent_session_factory() as session:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -216,10 +216,12 @@ async def test_signup_returns_token_and_user_id(async_client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
-async def test_signup_duplicate_email_returns_same_shape(async_client: AsyncClient) -> None:
-    """Signup with an existing email returns the same status and response shape as a fresh signup.
+async def test_signup_duplicate_email_is_rejected_generically(async_client: AsyncClient) -> None:
+    """Signup for an already-registered email returns the generic license rejection.
 
-    This prevents information leakage about registered emails.
+    Under the license gate a duplicate email is indistinguishable from any
+    other license failure: both answer 400 ``invalid_license`` with no token,
+    so an attacker cannot learn from the response that the account exists.
     """
     first_resp = await async_client.post(
         SIGNUP_URL,
@@ -235,18 +237,11 @@ async def test_signup_duplicate_email_returns_same_shape(async_client: AsyncClie
             "password": "anotherpassword456",  # pragma: allowlist secret
         },
     )
-    assert second_resp.status_code == first_resp.status_code
-    first_data = first_resp.json()
+    assert first_resp.status_code == HTTPStatus.OK
+    assert second_resp.status_code == HTTPStatus.BAD_REQUEST
     second_data = second_resp.json()
-    assert set(first_data.keys()) == set(second_data.keys())
-    assert "token" in second_data
-    assert "user_id" in second_data
-    assert isinstance(second_data["user_id"], int)
-    # The duplicate response uses ``user_id=0`` as a sentinel. The frontend
-    # ``authResponseSchema`` accepts non-negative integers so this sentinel
-    # does not trip Zod validation and surface the generic "server changed"
-    # error instead of completing the signup flow. Keep these in lock-step.
-    assert second_data["user_id"] == 0
+    assert second_data["detail"] == "invalid_license"
+    assert "token" not in second_data
 
 
 @pytest.mark.asyncio
@@ -269,8 +264,8 @@ async def test_signup_duplicate_email_does_not_create_second_user(
 
 
 @pytest.mark.asyncio
-async def test_signup_duplicate_email_token_is_not_valid(async_client: AsyncClient) -> None:
-    """The token returned for a duplicate signup must not grant access."""
+async def test_signup_duplicate_email_returns_no_token(async_client: AsyncClient) -> None:
+    """A duplicate signup returns no token at all — there is nothing to replay."""
     await _signup(async_client, email="invalid-tok@example.com")
     resp = await async_client.post(
         SIGNUP_URL,
@@ -279,10 +274,8 @@ async def test_signup_duplicate_email_token_is_not_valid(async_client: AsyncClie
             "password": "anotherpassword456",  # pragma: allowlist secret
         },
     )
-    fake_token = resp.json()["token"]
-    headers = {"Authorization": f"Bearer {fake_token}"}
-    protected_resp = await async_client.get("/habits/", headers=headers)
-    assert protected_resp.status_code == HTTPStatus.UNAUTHORIZED
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert "token" not in resp.json()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Introduces a per-user course-access `Entitlement` and binds account creation to a verified APTITUDE Gumroad license, so no Adepthood account can exist without a Gumroad sale (the $0 tier counts). Implements Scope sections 1–5 of `prompts/github-issues/phase-6-02-course-entitlement-and-signup-gating.md`, incorporating the 2026-07-22 amendment (two membership tiers, no starter-token grant).

- **Entitlement model + migration** (`models/entitlement.py`, `a6b7c8d9e0f1`): `kind` enum (starting `course_access`), nullable `source_sale_id` FK to `gumroadsale`, `granted_at`/`revoked_at`, JSON `metadata` bag, and a partial unique index on `(user_id, kind) WHERE revoked_at IS NULL` rendered on both Postgres and SQLite. Chains onto the Gumroad head `d0e1f2a3b4c6`; additive with a reversible downgrade.
- **Domain logic** (`domain/entitlements.py`): idempotent `grant_course_access`, `has_course_access`, `revoke_course_access` with `reason_code` structured logging, plus an allowlist-walking license verifier reusable by the future social-auth gate.
- **Signup gate** (`routers/auth.py`): `AuthRequest` gains an optional `license_key`, required at signup. Verify-then-create — no `User`/`Entitlement` row is written until the license verifies against `GUMROAD_APTITUDE_PRODUCT_IDS` and the purchase email matches (case-insensitive). Fails **closed**: an unset allowlist or a Gumroad outage rejects signup (503 on outage). Every rejection path returns a generic `invalid_license`/`license_required` with the existing dummy-bcrypt timing parity, so no path leaks whether an email/account exists. A second-layer `10/hour` per-IP throttle blunts license brute-forcing.
- **Webhook** (`routers/gumroad.py`): a `sale` ping for an existing user grants entitlement idempotently, so webhook-first and signup-first converge on the same end state.
- **Supporting**: `errors.service_unavailable` (503) helper; `rate_limit` moving-window invalid-license counter (`limits==5.8.0` added as an explicit dependency); `Entitlement` registered in `models/__init__.py`.

Credential hygiene is preserved throughout: license keys and raw emails are never logged, echoed, or returned (only fingerprints and the JWT leave the backend), reusing #1941's `from None` chain-severing idioms.

## Test plan

- New tests: `tests/domain/test_entitlements.py`, `tests/routers/test_auth_signup_license.py`, `tests/routers/test_gumroad_sale_dispatch.py` (the latter two carry a `real_license_gate` marker to exercise the genuine gate). They cover: grant idempotency, revoke-then-regrant, partial-unique enforcement; no-license/invalid/off-allowlist/email-mismatch/duplicate rejections (400, generic, no rows); Gumroad-unavailable fail-closed (503); the 10/hour throttle (429); and webhook-first-then-signup convergence.
- The ~70 existing suites that create users via `POST /auth/signup` keep working via an autouse conftest fixture (`_stub_signup_license_gate`) that stubs the gate open for any test **not** marked `real_license_gate` — a test-only seam that cannot affect production.
- Full backend suite green; `scripts/backend/check-all.sh` equivalents pass: ruff, mypy (strict), xenon A-grade, radon MI A, bandit (0 issues), pip-audit (clean), interrogate (96.4%), coverage 96.86% total (new files ≥94%), and `pre-commit run` on all changed files.

## Follow-ups (non-blocking, from self-review)

- Email **ownership** is not proven (no confirmation-link flow yet — `User.email_verified` remains the reserved stub), so a Gumroad sale attributed to an unowned email could squat that email at signup. Pre-existing deferred gap; worth tracking email verification or a squatting-dispute runbook.
- `_grant_signup_entitlement` commits separately from user creation; a failure between the two could orphan a `User` row. Consider a single transaction or an idempotent backfill.
- `frontend/src/api/types.ts` regeneration for the new optional `license_key` field is deferred (backend-only PR).

## Rollout

This backend gate is **merge-safe** for the repository because Adepthood is **pre-launch and not distributed**: there is no production deployment and no shipped app in users' hands, so merging this PR cannot break a live signup flow. The change only takes production effect when a deploy is cut, and **no deploy of the signup gate happens before the frontend license-key flow lands**.

- The frontend license-key work is sibling issue **#1943** (`epic:gumroad-access`, queued next), which adds `license_key` to `frontend/src/api/index.ts`'s `signup()` call and regenerates `frontend/src/api/types.ts`.
- Rollout sequencing: **#1943 merges before (or in the same deploy window as) the first production deploy of this gate**, so the shipped app never sends a `license_key`-less signup against a gated backend.
- Until then this is dormant backend code behind an env-configured allowlist (`GUMROAD_APTITUDE_PRODUCT_IDS`), exercised only by tests.

Closes #1942
Refs #1938
