### PR TITLE
chore(agents): move code-writing tiers to Opus, architect to Fable

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -22,9 +22,10 @@ graph under a conductor is identical:
 ```
 ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
   └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
-       ├─ chief-architect ..... L0  opus    plan + ordered dispatch list (no code)
-       ├─ test-specialist ..... L2  fable   Gate 1 RED: failing tests          ─┐
-       ├─ implementation-spec.  L2  fable   Gate 1 GREEN + Refactor             │ run per
+       ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
+       │                              ↳ falls back to opus when Fable is unavailable
+       ├─ test-specialist ..... L2  opus    Gate 1 RED: failing tests          ─┐
+       ├─ implementation-spec.  L2  opus    Gate 1 GREEN + Refactor             │ run per
        ├─ security-specialist . L2  opus    harden auth/JWT/CORS/input/DB       │ the
        ├─ performance-spec. ... L2  sonnet  profile/optimize hot paths          │ architect's
        ├─ documentation-spec. . L2  sonnet  docstrings/READMEs/ADRs             │ dispatch
@@ -62,24 +63,33 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-The mix follows one owner-decided policy — **model by role type**:
-planning/orchestration on **Opus**, implementation on **Fable**, review on
+The mix follows one owner-decided policy — **model by role type**: strategic
+planning on **Fable**, orchestration and all code-writing on **Opus**, review on
 **Sonnet**, quick read-only checks on **Haiku**.
 
-**Opus** for planning and orchestration, where judgment drives every downstream
-decision: `chief-architect` (one wrong design compounds across every specialist
-that executes it) and `ralph-worker` (the per-issue conductor). Kept here too is
-`security-specialist` — its work is judgment-heavy threat modeling *and* it is
-deliberately barred from Fable (see the caveat below), so it stays on Opus rather
-than the implementation tier.
+**Fable** for the single highest-leverage strategic role: `chief-architect`. One
+wrong design compounds across every specialist that executes it, so the plan gets
+the strongest reasoning available. Fable is a **metered tier**, so this dispatch
+is fallback-aware — see below. Fable also prefers **less-prescriptive prompts**
+(state the goal and constraints; a contract is a format spec, not step-by-step
+scaffolding), which is why `chief-architect.md` reads as an output contract rather
+than a script.
 
-**Fable** for implementation — the code-writing roles: `implementation-specialist`
-(production code is the core quality lever) and `test-specialist` (test authoring
-is code-writing). Two Fable caveats shape the fleet: its safety classifiers target
-**cyber/bio** content (so the code-writing `security-specialist` stays on **Opus**,
-never Fable — legitimate hardening work can trip a false-positive refusal), and it
-prefers **less-prescriptive prompts** (state the goal and constraints; a
-specialist's contract is a format spec, not step-by-step scaffolding).
+> **Fable fallback (graceful degradation).** When the `Agent(subagent_type:
+> chief-architect)` call fails or comes back empty because Fable is unavailable —
+> credits exhausted, quota/rate limit, model not enabled, or a false-positive
+> refusal from its **cyber/bio** safety classifiers on a security-hardening issue
+> — the conductor **retries the same dispatch once with `model: "opus"`** and
+> continues the tick. A tick never stalls, and never silently skips the plan step,
+> on model availability. Opus is the fallback for every Fable role.
+
+**Opus** for orchestration and every code-writing role, where judgment drives the
+artifact that ships: `ralph-worker` (the per-issue conductor),
+`implementation-specialist` (production code is the core quality lever),
+`test-specialist` (test authoring is code-writing), and `security-specialist`
+(judgment-heavy threat modeling, plus hardening code). Opus is unmetered here and
+doubles as the Fable fallback, so the fleet degrades to a single-tier
+Opus/Sonnet/Haiku mix without any behavior change.
 
 **Sonnet** for review — well-scoped roles guided by an explicit plan or diff:
 `code-review-orchestrator` (Gate 2.5 synthesis) and the review-dimension

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -4,11 +4,21 @@ description: "Strategic brain of a Ralph tick. Select to architect a single back
 level: 0
 phase: Plan
 tools: Read,Grep,Glob,Task
-model: opus
+model: fable
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---
 # Chief Architect
+
+> **Model & fallback.** This agent runs on **Fable**; every other agent in the
+> taxonomy runs on Opus/Sonnet/Haiku. Fable is a metered tier, so the dispatch is
+> **fallback-aware**: if the conductor's `Agent(subagent_type: chief-architect)`
+> call fails or returns nothing because Fable is unavailable (credits exhausted,
+> quota/rate limit, model not enabled for the account), the conductor **retries
+> the same dispatch once with `model: "opus"`** and proceeds — a tick never
+> stalls on model availability. The plan contract below is identical on either
+> model. Fable also prefers **less-prescriptive prompts**: state the goal and
+> constraints, not step-by-step scaffolding.
 
 ## Identity
 

--- a/.claude/agents/implementation-specialist.md
+++ b/.claude/agents/implementation-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 GREEN + Refactor — writes the production code that makes 
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: fable
+model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---
@@ -16,7 +16,7 @@ Level 2 leaf worker who owns **Gate 1 GREEN** and the **Refactor** step: write t
 smallest, cleanest production code that makes the test-specialist's failing tests
 pass while meeting every threshold, then refactor for clarity without breaking
 green. You are the primary lever on "best code possible," so the work runs on
-Fable. You also serve as the **correctness/maintainability reviewer**.
+Opus. You also serve as the **correctness/maintainability reviewer**.
 
 ## Scope
 

--- a/.claude/agents/test-specialist.md
+++ b/.claude/agents/test-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 RED — writes the failing tests that specify a behavior be
 level: 2
 phase: Test
 tools: Read,Write,Edit,Grep,Glob
-model: fable
+model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -77,6 +77,12 @@ graph/memory …` and commit both (small Markdown notes; repo Q&A only).
    design approach, touch-list, TDD test strategy, an **ordered dispatch list**,
    and **risk flags** (security / performance / deps / docs). You execute that
    list — you do not improvise the design.
+   **Fable fallback:** the chief-architect runs on Fable, a metered tier. If the
+   dispatch fails or returns nothing because Fable is unavailable (credits
+   exhausted, quota/rate limit, model not enabled, or a safety-classifier refusal
+   on a hardening issue), retry the **same** dispatch **once** with
+   `model: "opus"` and carry on. Never skip the plan step, and never improvise
+   the design in its place.
 6. **Dispatch the build.** The test- and implementation-specialists *embody* the
    `stay-green` Red→Green→Refactor discipline and `max-quality-no-shortcuts`
    (no bypasses) — that is now the TDD path; you do not separately invoke the


### PR DESCRIPTION
## Summary

- Swap every Fable assignment in the multi-agent router to **Opus**: `test-specialist` and `implementation-specialist` now run on Opus (and the implementation-specialist's identity prose says so).
- Put **`chief-architect` on Fable** — the one strategic role where a wrong design compounds across every specialist that executes it.
- Add a **graceful Fable fallback**: when the architect dispatch fails or returns nothing because Fable is unavailable (credits exhausted, quota/rate limit, model not enabled, or a cyber/bio safety-classifier false positive on a hardening issue), the conductor retries the *same* dispatch once with `model: "opus"` and continues. A tick never stalls, and never silently skips the plan step, on model availability.

Documented in three places so it binds wherever it's read: the agent's own frontmatter note (`chief-architect.md`), the tier policy + spawn graph in `.claude/agents/README.md`, and the conductor's dispatch contract at step 5 of `scripts/ralph/PROMPT.md`.

## Test plan

Docs/config only — no application code touched.

- `pre-commit run --files <the 5 changed files>` — green (whitespace/EOF/secrets hooks ran; all language hooks correctly skipped).
- `grep -rn -i fable .claude scripts prompts docs *.md` — the only remaining mentions are the intended `chief-architect` assignment, its fallback prose, and the model-agnostic commit-trailer note in `shared/adepthood-constraints.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
