### PR TITLE
feat(frontend): gift-economy onboarding with Gumroad license-key signup

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -217,6 +217,8 @@ In the frontend service's **Variables** tab, add:
 | Variable | Value | Notes |
 |----------|-------|-------|
 | `EXPO_PUBLIC_API_BASE_URL` | `https://your-backend.up.railway.app` | The backend service URL |
+| `EXPO_PUBLIC_GUMROAD_PRODUCT_URL` | `https://adepthood.gumroad.com/l/aptitude` | Optional. Product page the Get Started CTA opens; defaults to this value |
+| `EXPO_PUBLIC_GUMROAD_HELP_URL` | `https://help.gumroad.com/article/76-license-keys` | Optional. License-key help article linked from signup; defaults to this value |
 | `PORT` | `80` | nginx listens on 80 |
 
 > **Important:** `EXPO_PUBLIC_API_BASE_URL` is baked into the JavaScript
@@ -388,6 +390,8 @@ than a migration.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `EXPO_PUBLIC_API_BASE_URL` | Yes | Full URL of the backend API (e.g., `https://api.adepthood.com`). Baked in at build time. |
+| `EXPO_PUBLIC_GUMROAD_PRODUCT_URL` | No | Gumroad product page opened by the Get Started CTA. Defaults to `https://adepthood.gumroad.com/l/aptitude`. |
+| `EXPO_PUBLIC_GUMROAD_HELP_URL` | No | Gumroad help article linked from the signup form's "Where's my key?" link. Defaults to `https://help.gumroad.com/article/76-license-keys`. |
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,31 @@
+# Adepthood Frontend
+
+React Native + Expo client (TypeScript, Zustand, React Navigation).
+
+```bash
+npm ci          # install from the lockfile
+npm start       # Expo dev server
+npm test        # Jest
+npm run lint    # ESLint
+npx tsc --noEmit
+```
+
+## Environment variables
+
+Only `EXPO_PUBLIC_*` variables reach the client. They are read at **build**
+time and baked into the JavaScript bundle, so changing one requires a
+rebuild — and nothing secret should ever go in one, since anyone can read a
+shipped bundle.
+
+| Variable                          | Required          | Dev default                                        | Notes                                                                                                    |
+| --------------------------------- | ----------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `EXPO_PUBLIC_API_BASE_URL`        | Yes in production | `http://localhost:8000`                            | Backend API root. Must be HTTPS in production builds, or the app boots to a visible config-error screen. |
+| `EXPO_PUBLIC_GUMROAD_PRODUCT_URL` | No                | `https://adepthood.gumroad.com/l/aptitude`         | Product page opened by the Get Started CTA.                                                              |
+| `EXPO_PUBLIC_GUMROAD_HELP_URL`    | No                | `https://help.gumroad.com/article/76-license-keys` | License-key help article linked from the signup form.                                                    |
+
+Both Gumroad links are public marketing pages with safe defaults, so a missing
+override is not a misconfiguration — unlike `EXPO_PUBLIC_API_BASE_URL`, they
+never fail the app closed.
+
+For deploy steps and where to set these in Railway, see
+[`../DEPLOYMENT.md`](../DEPLOYMENT.md).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { ThemeProvider, useTheme } from './design/ThemeContext';
 import { colors, SPACING } from './design/tokens';
 import CancelResetScreen from './features/Auth/CancelResetScreen';
 import ForgotPasswordScreen from './features/Auth/ForgotPasswordScreen';
+import GetStartedScreen from './features/Auth/GetStartedScreen';
 import LoginScreen from './features/Auth/LoginScreen';
 import { ReauthSheet } from './features/Auth/ReauthSheet';
 import ResetPasswordScreen from './features/Auth/ResetPasswordScreen';
@@ -41,8 +42,11 @@ import { useHydrateProgramStore } from './store/useProgramStore';
 import { useFirstRun } from './store/useWelcomeStore';
 
 type AuthStackParamList = {
+  GetStarted: undefined;
   Login: undefined;
-  Signup: undefined;
+  // ``licenseKey`` seeds the signup form for a buyer arriving with a key in
+  // hand; undefined for the plain "I have a license key" tap.
+  Signup: { licenseKey?: string } | undefined;
   ForgotPassword: undefined;
   ResetPassword: { token?: string } | undefined;
   CancelReset: { token?: string } | undefined;
@@ -91,6 +95,7 @@ export const linking: LinkingOptions<LinkedRootParamList> = {
       // ``screens`` is keyed strictly on the param-list, but the same
       // linking config drives both AuthStack and RootStack here.
       ...({
+        GetStarted: 'get-started',
         Login: 'login',
         Signup: 'signup',
         ForgotPassword: 'forgot-password', // pragma: allowlist secret
@@ -108,6 +113,10 @@ const AuthStack = createNativeStackNavigator<AuthStackParamList>();
 function AuthNavigator() {
   return (
     <AuthStack.Navigator screenOptions={{ headerShown: false }}>
+      {/* Declared first, so an anonymous visitor opens on the pre-auth
+          Get Started surface rather than a log-in form for an account
+          they do not have yet. */}
+      <AuthStack.Screen name="GetStarted" component={GetStartedScreen} />
       <AuthStack.Screen name="Login" component={LoginScreen} />
       <AuthStack.Screen name="Signup" component={SignupScreen} />
       <AuthStack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />

--- a/frontend/src/__tests__/config.test.ts
+++ b/frontend/src/__tests__/config.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import { API_BASE_URL, CONFIG_ERROR, validateApiBaseUrl } from '../config';
+import type * as ConfigModule from '../config';
 
 const HTTPS_URL = 'https://api.example.com';
 const HTTP_URL = 'http://api.example.com';
 const DEV_DEFAULT = 'http://localhost:8000';
 const ERROR_PREFIX = 'EXPO_PUBLIC_API_BASE_URL must be set to an HTTPS URL in production builds';
+
+/**
+ * Re-evaluate the config module against the current ``process.env``. The
+ * module reads its env vars once at import time, so each env permutation
+ * needs a fresh registry entry.
+ */
+function loadConfig(): typeof ConfigModule {
+  return require('../config') as typeof ConfigModule;
+}
 
 describe('config', () => {
   describe('validateApiBaseUrl in development mode', () => {
@@ -63,6 +73,68 @@ describe('config', () => {
 
     it('does not record a CONFIG_ERROR in development mode', () => {
       expect(CONFIG_ERROR).toBeNull();
+    });
+  });
+
+  describe('Gumroad URLs', () => {
+    const ORIGINAL_ENV = { ...process.env };
+    const CUSTOM_PRODUCT_URL = 'https://store.example.com/l/adepthood';
+    const CUSTOM_HELP_URL = 'https://help.example.com/license-keys';
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.EXPO_PUBLIC_GUMROAD_PRODUCT_URL;
+      delete process.env.EXPO_PUBLIC_GUMROAD_HELP_URL;
+    });
+
+    afterEach(() => {
+      process.env = { ...ORIGINAL_ENV };
+      jest.resetModules();
+    });
+
+    it('falls back to a safe https default for the product URL', () => {
+      const config = loadConfig();
+
+      expect(config.GUMROAD_PRODUCT_URL).toMatch(/^https:\/\//);
+      expect(config.GUMROAD_PRODUCT_URL).toMatch(/gumroad/i);
+    });
+
+    it('falls back to a safe https default for the help URL', () => {
+      const config = loadConfig();
+
+      expect(config.GUMROAD_HELP_URL).toMatch(/^https:\/\//);
+      expect(config.GUMROAD_HELP_URL).toMatch(/gumroad/i);
+    });
+
+    it('points the two defaults at different pages', () => {
+      const config = loadConfig();
+
+      expect(config.GUMROAD_HELP_URL).not.toBe(config.GUMROAD_PRODUCT_URL);
+    });
+
+    it('uses EXPO_PUBLIC_GUMROAD_PRODUCT_URL verbatim when it is set', () => {
+      process.env.EXPO_PUBLIC_GUMROAD_PRODUCT_URL = CUSTOM_PRODUCT_URL;
+
+      const config = loadConfig();
+
+      expect(config.GUMROAD_PRODUCT_URL).toBe(CUSTOM_PRODUCT_URL);
+    });
+
+    it('uses EXPO_PUBLIC_GUMROAD_HELP_URL verbatim when it is set', () => {
+      process.env.EXPO_PUBLIC_GUMROAD_HELP_URL = CUSTOM_HELP_URL;
+
+      const config = loadConfig();
+
+      expect(config.GUMROAD_HELP_URL).toBe(CUSTOM_HELP_URL);
+    });
+
+    // These are public marketing links with safe defaults — unlike the API
+    // base URL, a missing override must never fail the app closed.
+    it('never records a CONFIG_ERROR when both overrides are absent', () => {
+      const config = loadConfig();
+
+      expect(config.CONFIG_ERROR).toBeNull();
     });
   });
 });

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -34,6 +34,14 @@ jest.mock('@/navigation/RootStack', () => {
   return { __esModule: true, default: RootStackMock };
 });
 
+jest.mock('@/features/Auth/GetStartedScreen', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  const GetStartedMock = () =>
+    React.createElement(Text, { testID: 'get-started-screen' }, 'GetStarted');
+  return { __esModule: true, default: GetStartedMock };
+});
+
 jest.mock('@/features/Auth/LoginScreen', () => {
   const React = require('react');
   const { Text } = require('react-native');
@@ -140,10 +148,14 @@ describe('RootNavigator gated on authStatus (BUG-NAV-001 / BUG-NAV-002)', () => 
     expect(queryByTestId('root-stack')).toBeNull();
   });
 
-  it("mounts the AuthNavigator when authStatus is 'anonymous'", () => {
+  // The anonymous stack now opens on the pre-auth Gumroad surface; the
+  // navigator stub renders only the FIRST declared screen, so this also
+  // pins GetStarted as the initial route rather than Login.
+  it("mounts the AuthNavigator on GetStarted when authStatus is 'anonymous'", () => {
     mockAuthStatus('anonymous');
     const { getByTestId, queryByTestId } = render(<RootNavigator />);
-    expect(getByTestId('login-screen')).toBeTruthy();
+    expect(getByTestId('get-started-screen')).toBeTruthy();
+    expect(queryByTestId('login-screen')).toBeNull();
     expect(queryByTestId('root-stack')).toBeNull();
     expect(queryByTestId('reauth-sheet')).toBeNull();
   });
@@ -154,6 +166,7 @@ describe('RootNavigator gated on authStatus (BUG-NAV-001 / BUG-NAV-002)', () => 
     expect(getByTestId('root-stack')).toBeTruthy();
     expect(queryByTestId('reauth-sheet')).toBeNull();
     expect(queryByTestId('login-screen')).toBeNull();
+    expect(queryByTestId('get-started-screen')).toBeNull();
   });
 
   it("mounts RootStack *and* the re-auth sheet when authStatus is 'reauth-required'", () => {

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -19,7 +19,13 @@ describe('USER_FACING_ERROR_MESSAGES', () => {
       // auth
       'invalid_credentials',
       'password_too_short',
+      'password_too_long',
       'unauthorized',
+      // gumroad license verification on signup
+      'invalid_license',
+      'license_required',
+      'too_many_license_attempts',
+      'license_verification_unavailable',
       // admin gate
       'admin_required',
       // resource not found
@@ -104,6 +110,42 @@ describe('practice-selection codes (BUG-PRACTICE-012)', () => {
   it('maps the transient replace conflict to a retry prompt', () => {
     const err = new ApiError(409, 'active_practice_exists_for_stage');
     expect(formatApiError(err)).toMatch(/try (switching )?again/i);
+  });
+});
+
+describe('gumroad license codes', () => {
+  // ``invalid_license`` is deliberately indistinguishable from a duplicate
+  // email on the wire (anti-enumeration), so the copy must not claim to know
+  // which of the two happened.
+  it('maps invalid_license to the approved ambiguous copy', () => {
+    expect(messageForCode('invalid_license')).toBe(
+      "We couldn't verify that key — double-check it matches the email and product.",
+    );
+  });
+
+  it('does not tell the user their email is already registered', () => {
+    expect(messageForCode('invalid_license')).not.toMatch(/already (registered|have an account)/i);
+  });
+
+  it.each([
+    ['license_required'],
+    ['too_many_license_attempts'],
+    ['license_verification_unavailable'],
+    ['password_too_long'], // pragma: allowlist secret
+  ])('gives %p actionable, snake_case-free copy', (code) => {
+    const message = messageForCode(code);
+
+    expect(message).toBeTruthy();
+    expect(message).not.toMatch(/[a-z]_[a-z]/);
+    expect(message).toMatch(/[.!?]$/);
+  });
+
+  it('tells the user the outage is transient rather than their fault', () => {
+    expect(messageForCode('license_verification_unavailable')).toMatch(/try again/i);
+  });
+
+  it('names the concrete password ceiling so the user can act', () => {
+    expect(messageForCode('password_too_long')).toMatch(/64/); // pragma: allowlist secret
   });
 });
 

--- a/frontend/src/api/__tests__/networkAndRefreshEdgeCases.test.ts
+++ b/frontend/src/api/__tests__/networkAndRefreshEdgeCases.test.ts
@@ -162,3 +162,88 @@ describe('error responses without a usable JSON detail', () => {
     });
   });
 });
+
+/**
+ * FastAPI answers a Pydantic rejection with an array-form ``detail``:
+ * ``[{loc, msg, type, input?, ctx?}]``. Only ``msg`` is safe to surface —
+ * ``input`` echoes back whatever the user submitted (which, on signup, is
+ * their license key) and ``loc`` leaks internal field names.
+ */
+describe('array-form Pydantic error detail', () => {
+  const LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
+  const TOO_LONG_MSG = 'String should have at most 128 characters';
+
+  function rejectWith(detail: unknown, status = 422) {
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({ ok: false, status, json: () => Promise.resolve({ detail }) }),
+    );
+  }
+
+  async function detailOf(promise: Promise<unknown>): Promise<string> {
+    let captured: string | undefined;
+    await promise.catch((err: { detail?: string }) => {
+      captured = err.detail;
+    });
+    expect(typeof captured).toBe('string');
+    return captured as string;
+  }
+
+  test('uses the msg of a single entry as the detail', async () => {
+    rejectWith([{ loc: ['body', 'license_key'], msg: TOO_LONG_MSG, type: 'string_too_long' }]);
+
+    await expect(habits.getStats(1)).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 422,
+      detail: TOO_LONG_MSG,
+    });
+  });
+
+  test('joins multiple entries with a semicolon', async () => {
+    rejectWith([
+      { loc: ['body', 'email'], msg: 'Field required', type: 'missing' },
+      { loc: ['body', 'license_key'], msg: TOO_LONG_MSG, type: 'string_too_long' },
+    ]);
+
+    expect(await detailOf(habits.getStats(1))).toBe(`Field required; ${TOO_LONG_MSG}`);
+  });
+
+  test('falls back to a generic message when no entry carries a string msg', async () => {
+    rejectWith([{ loc: ['body', 'license_key'], type: 'missing' }, { msg: 42 }]);
+
+    expect(await detailOf(habits.getStats(1))).toBe('Request failed');
+  });
+
+  test('falls back to a generic message for an empty array', async () => {
+    rejectWith([]);
+
+    expect(await detailOf(habits.getStats(1))).toBe('Request failed');
+  });
+
+  test('never echoes the submitted input or the ctx object back to the client', async () => {
+    rejectWith([
+      {
+        loc: ['body', 'license_key'],
+        msg: TOO_LONG_MSG,
+        type: 'string_too_long',
+        input: LICENSE_KEY,
+        ctx: { max_length: 128 },
+      },
+    ]);
+
+    const detail = await detailOf(habits.getStats(1));
+
+    expect(detail).toBe(TOO_LONG_MSG);
+    expect(detail).not.toContain(LICENSE_KEY);
+    expect(detail).not.toContain('license_key');
+    expect(detail).not.toContain('max_length');
+  });
+
+  test('still prefers a plain string detail over the array branch', async () => {
+    rejectWith('license_required', 400);
+
+    await expect(habits.getStats(1)).rejects.toMatchObject({
+      status: 400,
+      detail: 'license_required',
+    });
+  });
+});

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -25,6 +25,10 @@ const PROVIDER_TROUBLE =
   "BotMason's AI provider is having trouble connecting. Give it a moment and tap retry.";
 const SESSION_EXPIRED = 'Your session has expired. Sign back in to continue.';
 const NO_ACCESS = "You don't have access to this.";
+// The backend caps at 64 characters so bcrypt's 72-byte limit can never
+// silently truncate. Naming the ceiling turns "try again" into a fix. // pragma: allowlist secret
+const PASSWORD_TOO_LONG =
+  'That password is longer than we can store. Shorten it to 64 characters or fewer.';
 
 /**
  * Map of backend ``detail`` strings (see ``backend/src/errors.py`` and each
@@ -36,6 +40,7 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   invalid_credentials:
     "That email and password don't match an account we have. Double-check both fields, or tap Sign Up if you're new.",
   password_too_short: 'Pick a password that is at least 8 characters long.', // pragma: allowlist secret
+  password_too_long: PASSWORD_TOO_LONG, // pragma: allowlist secret
   unauthorized: SESSION_EXPIRED,
   // BUG-API-018: distinct copy when the request was anonymous in the
   // first place -- "your session expired" implies a session that was
@@ -49,6 +54,17 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   // BUG-AUTH-002: synthesised by AuthContext when the backend returns the user_id=0 anti-enumeration sentinel.
   email_in_use:
     'That email may already be registered. Try logging in, or use a different email to sign up.',
+
+  // --- Gumroad license verification (signup) ---------------------------
+  // ``invalid_license`` is deliberately indistinguishable from "this email is
+  // already registered" on the wire (anti-enumeration), so the copy must not
+  // claim to know which of the two happened.
+  invalid_license: "We couldn't verify that key — double-check it matches the email and product.",
+  license_required: 'Add the license key from your Gumroad receipt to continue.',
+  too_many_license_attempts:
+    "That's several tries in a row. Give it an hour, then try again with the key from your receipt.",
+  license_verification_unavailable:
+    "We can't reach Gumroad to check your key right now. Nothing is lost — give it a few minutes and try again.",
 
   // --- Admin -----------------------------------------------------------
   admin_required: 'Admin privileges are required for this action.',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -429,16 +429,44 @@ async function fetchWithTimeout(
   }
 }
 
+/** Last-resort ``detail`` when the body carries nothing we can safely show. */
+const FALLBACK_ERROR_DETAIL = 'Request failed';
+
+/** Joins several Pydantic complaints into one readable line. */
+const ERROR_DETAIL_SEPARATOR = '; ';
+
+/**
+ * Read a FastAPI validation rejection, whose ``detail`` is an array of
+ * ``{loc, msg, type, input?, ctx?}`` entries.
+ *
+ * Only ``msg`` is safe to surface. ``input`` echoes back whatever the user
+ * submitted — on signup that is their license key — and ``loc`` / ``ctx`` leak
+ * internal field names and constraints.
+ */
+function detailFromArray(entries: readonly unknown[]): string {
+  const messages: string[] = [];
+  for (const entry of entries) {
+    const msg = entry == null ? undefined : (entry as { msg?: unknown }).msg;
+    if (typeof msg === 'string' && msg.length > 0) {
+      messages.push(msg);
+    }
+  }
+  return messages.length > 0 ? messages.join(ERROR_DETAIL_SEPARATOR) : FALLBACK_ERROR_DETAIL;
+}
+
 async function extractErrorDetail(res: Response): Promise<string> {
   try {
     const errBody = await res.json();
     if (errBody.detail && typeof errBody.detail === 'string') {
       return errBody.detail;
     }
+    if (Array.isArray(errBody.detail)) {
+      return detailFromArray(errBody.detail);
+    }
   } catch {
     // response body wasn't JSON — use default
   }
-  return 'Request failed';
+  return FALLBACK_ERROR_DETAIL;
 }
 
 /**
@@ -2620,6 +2648,12 @@ export interface AuthRequest {
  */
 export interface SignupRequest extends AuthRequest {
   timezone?: string;
+  /**
+   * Gumroad license key proving the buyer owns the course. Lives on
+   * `SignupRequest` rather than `AuthRequest` so `auth.login` cannot send a
+   * credential the login endpoint has no use for.
+   */
+  license_key?: string;
 }
 
 export interface AuthResponse {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -34,3 +34,39 @@ function resolveApiBaseUrl(): string {
 }
 
 export const API_BASE_URL = resolveApiBaseUrl();
+
+// Gumroad is where the course is bought and where license-key help lives.
+// Both are public marketing pages with safe defaults, so — unlike
+// ``API_BASE_URL`` — a missing override is not a misconfiguration and must
+// never contribute to ``CONFIG_ERROR``.
+const DEFAULT_GUMROAD_PRODUCT_URL = 'https://adepthood.gumroad.com/l/aptitude';
+const DEFAULT_GUMROAD_HELP_URL = 'https://help.gumroad.com/article/76-license-keys';
+
+/**
+ * Resolve an ``EXPO_PUBLIC_*`` override, checking both routes the value can
+ * take.
+ *
+ * ``inlined`` is the result of a *static* ``process.env.EXPO_PUBLIC_…``
+ * reference at the call site: babel-preset-expo rewrites that expression to the
+ * build-time literal, which is the only way an override reaches a production
+ * bundle. ``name`` covers the runtime route, which Metro populates during
+ * development. The computed lookup is deliberate — the inliner only rewrites
+ * statically-keyed member expressions, so this one survives as a real read.
+ */
+function resolveEnvUrl(inlined: string | undefined, name: string, fallback: string): string {
+  return inlined || process.env[name] || fallback;
+}
+
+/** Product page the pre-auth Get Started CTA opens. */
+export const GUMROAD_PRODUCT_URL = resolveEnvUrl(
+  process.env.EXPO_PUBLIC_GUMROAD_PRODUCT_URL,
+  'EXPO_PUBLIC_GUMROAD_PRODUCT_URL',
+  DEFAULT_GUMROAD_PRODUCT_URL,
+);
+
+/** "Where's my key?" help article linked from the signup form. */
+export const GUMROAD_HELP_URL = resolveEnvUrl(
+  process.env.EXPO_PUBLIC_GUMROAD_HELP_URL,
+  'EXPO_PUBLIC_GUMROAD_HELP_URL',
+  DEFAULT_GUMROAD_HELP_URL,
+);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -30,7 +30,14 @@ import {
   shouldRefreshToken,
 } from '@/utils/token';
 
-type LoginOrSignup = (_emailOrUsername: string, _pw: string) => Promise<void>;
+type Login = (_emailOrUsername: string, _pw: string) => Promise<void>;
+
+/**
+ * Signup takes the buyer's Gumroad license key as a REQUIRED third argument:
+ * the paid-content gate is only real if the type system refuses a call that
+ * forgets it.
+ */
+type Signup = (_email: string, _password: string, _licenseKey: string) => Promise<void>;
 
 /**
  * BUG-NAV-001 / BUG-NAV-002: the navigator used to gate on the raw ``token``
@@ -77,8 +84,8 @@ interface AuthContextValue {
    * client-side guesses belong in the request, not here.
    */
   setUserTimezone: (_timezone: string) => void;
-  login: LoginOrSignup;
-  signup: LoginOrSignup;
+  login: Login;
+  signup: Signup;
   logout: () => Promise<void>;
   onUnauthorized: () => void;
   /** User dismissed the re-auth sheet: treat as an explicit logout. */
@@ -352,8 +359,8 @@ function useLoadStoredToken(mutators: AuthMutators): void {
 }
 
 interface AuthActions {
-  login: LoginOrSignup;
-  signup: LoginOrSignup;
+  login: Login;
+  signup: Signup;
   logout: () => Promise<void>;
   onUnauthorized: () => void;
   dismissReauth: () => Promise<void>;
@@ -398,11 +405,20 @@ const DUPLICATE_SIGNUP_SENTINEL_USER_ID = 0;
  * plus the server's record of the stored zone (which the backend may
  * have normalised) so the AuthContext can populate `userTimezone`
  * synchronously with the same value the rest of the API will return.
+ *
+ * The license key rides along verbatim — normalising it is the signup form's
+ * job, and a stray trim or case-fold here could mangle a key the buyer
+ * actually holds before Gumroad ever sees it.
  */
-async function signupWithDeviceTimezone(email: string, password: string): Promise<AuthResponse> {
+async function signupWithDeviceTimezone(
+  email: string,
+  password: string,
+  licenseKey: string,
+): Promise<AuthResponse> {
   const response = await authApi.signup({
     email,
     password,
+    license_key: licenseKey,
     timezone: detectDeviceTimezone(),
   });
   if (response.user_id === DUPLICATE_SIGNUP_SENTINEL_USER_ID) {
@@ -430,7 +446,7 @@ async function tearDownSession(mutators: AuthMutators, where: string): Promise<v
 }
 
 function useAuthActions(mutators: AuthMutators): AuthActions {
-  const login = useCallback<LoginOrSignup>(
+  const login = useCallback<Login>(
     async (email, password) => {
       const response = await authApi.login({ email, password });
       await applyAuthResponse(response, mutators);
@@ -438,9 +454,9 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
     [mutators],
   );
 
-  const signup = useCallback<LoginOrSignup>(
-    async (email, password) => {
-      const response = await signupWithDeviceTimezone(email, password);
+  const signup = useCallback<Signup>(
+    async (email, password, licenseKey) => {
+      const response = await signupWithDeviceTimezone(email, password, licenseKey);
       await applyAuthResponse(response, mutators);
     },
     [mutators],

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/utils/token', () => ({
 }));
 
 import {
+  ApiError,
   auth,
   resetLlmApiKey,
   setOnTokenRefreshed,
@@ -172,6 +173,8 @@ describe('AuthContext', () => {
   });
 
   describe('signup', () => {
+    const LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
+
     it('calls API signup and stores token on success', async () => {
       mockAuth.signup.mockResolvedValue({ token: 'signup-jwt', user_id: 2 });
       const { result } = renderHook(() => useAuth(), { wrapper });
@@ -179,7 +182,7 @@ describe('AuthContext', () => {
       await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
 
       await act(async () => {
-        await result.current.signup('new@test.com', 'password123');
+        await result.current.signup('new@test.com', 'password123', LICENSE_KEY);
       });
 
       // Signup attaches the device's IANA zone so the new account is
@@ -191,10 +194,27 @@ describe('AuthContext', () => {
       expect(mockAuth.signup).toHaveBeenCalledWith({
         email: 'new@test.com',
         password: 'password123', // pragma: allowlist secret
+        license_key: LICENSE_KEY,
         timezone: 'UTC',
       });
       expect(mockSaveToken).toHaveBeenCalledWith('signup-jwt');
       expect(result.current.token).toBe('signup-jwt');
+    });
+
+    // Normalising is the form's job: the context must not trim or case-fold,
+    // or a key the user actually holds could be mangled en route to Gumroad.
+    it('forwards the license key verbatim', async () => {
+      mockAuth.signup.mockResolvedValue({ token: 'signup-jwt', user_id: 2 });
+      const rawKey = '  MiXeD-Case-Key-9  '; // pragma: allowlist secret
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
+
+      await act(async () => {
+        await result.current.signup('new@test.com', 'password123', rawKey);
+      });
+
+      expect(mockAuth.signup.mock.calls[0]![0]!.license_key).toBe(rawKey);
     });
 
     // BUG-AUTH-002: must not persist the user_id=0 anti-enumeration token (see ``authResponseSchema`` in schemas.ts).
@@ -206,9 +226,28 @@ describe('AuthContext', () => {
 
       await expect(
         act(async () => {
-          await result.current.signup('taken@test.com', 'password123');
+          await result.current.signup('taken@test.com', 'password123', LICENSE_KEY);
         }),
       ).rejects.toMatchObject({ status: 409, detail: 'email_in_use' });
+
+      expect(mockSaveToken).not.toHaveBeenCalled();
+      expect(result.current.token).toBeNull();
+      expect(result.current.authStatus).toBe('anonymous');
+    });
+
+    // The signup screen routes ``invalid_license`` to an inline field error,
+    // so the context must not swallow, wrap, or re-code the rejection.
+    it('propagates a license rejection unchanged so the screen can route it', async () => {
+      mockAuth.signup.mockRejectedValue(new ApiError(400, 'invalid_license'));
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.authStatus).not.toBe('loading'));
+
+      await expect(
+        act(async () => {
+          await result.current.signup('new@test.com', 'password123', LICENSE_KEY);
+        }),
+      ).rejects.toMatchObject({ name: 'ApiError', status: 400, detail: 'invalid_license' });
 
       expect(mockSaveToken).not.toHaveBeenCalled();
       expect(result.current.token).toBeNull();

--- a/frontend/src/features/Auth/GetStartedScreen.tsx
+++ b/frontend/src/features/Auth/GetStartedScreen.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+
+import { authStyles as styles } from './auth.styles';
+import { AuthBrandBand } from './AuthBrandBand';
+import { AuthScreenContainer } from './AuthScreenContainer';
+
+import { Button } from '@/components/Button';
+import { CalloutBand } from '@/components/layout/CalloutBand';
+import { GUMROAD_PRODUCT_URL } from '@/config';
+import { openExternalUrl } from '@/utils/openExternalUrl';
+
+const TITLE = 'Choose your depth';
+
+// Gift economy first, price never. Nothing here should read as urgency,
+// scarcity, or a favour owed — the invitation has to be genuinely declinable.
+const LEAD = 'Adepthood is offered in the gift economy: pay what feels right, starting at zero.';
+const BODY =
+  'Take the course home from Gumroad, then bring your license key back here to make an account.';
+
+const BUY_LABEL = 'Get Adepthood on Gumroad';
+const HAVE_KEY_LABEL = 'I have a license key';
+
+interface Props {
+  navigation: { navigate: (_screen: string) => void };
+}
+
+/**
+ * The pre-auth surface: the first thing an anonymous visitor sees. It explains
+ * what Adepthood costs (whatever you decide, including nothing), sends buyers to
+ * Gumroad, and keeps both the signup form and the log-in form one tap away.
+ *
+ * The paid content is real — a license key gates the account, this screen is
+ * the honest telling of that, not a pressure tactic dressed up as one. There
+ * is no OAuth-style callback: the buyer leaves for Gumroad in their own
+ * browser tab and comes back to this app manually, license key in hand, to
+ * tap "I have a license key" themselves.
+ */
+export default function GetStartedScreen({ navigation }: Props): React.JSX.Element {
+  // ``openExternalUrl`` already reports its own failures and resolves false
+  // rather than throwing; the catch guards the screen against an unhandled
+  // rejection so a missing browser can never unmount the CTA.
+  const handleBuy = (): void => {
+    void openExternalUrl(GUMROAD_PRODUCT_URL).catch(() => undefined);
+  };
+
+  return (
+    <AuthScreenContainer testID="get-started">
+      <AuthBrandBand />
+      <Text style={styles.title}>{TITLE}</Text>
+      <Text style={styles.lead}>{LEAD}</Text>
+      <Text style={styles.body}>{BODY}</Text>
+      <CalloutBand label={BUY_LABEL} onPress={handleBuy} testID="get-started-buy" />
+      <Button
+        variant="secondary"
+        label={HAVE_KEY_LABEL}
+        onPress={() => navigation.navigate('Signup')}
+        style={styles.ctaSpacing}
+        testID="get-started-have-key"
+      />
+      <TouchableOpacity
+        accessibilityLabel="Go to log-in screen"
+        accessibilityRole="link"
+        onPress={() => navigation.navigate('Login')}
+      >
+        <Text style={styles.link}>
+          Already have an account? <Text style={styles.linkBold}>Log In</Text>
+        </Text>
+      </TouchableOpacity>
+    </AuthScreenContainer>
+  );
+}

--- a/frontend/src/features/Auth/SignupScreen.tsx
+++ b/frontend/src/features/Auth/SignupScreen.tsx
@@ -1,62 +1,61 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 
 import { authStyles as styles } from './auth.styles';
 import { AuthBrandBand } from './AuthBrandBand';
 import { AuthScreenContainer } from './AuthScreenContainer';
-import { canonicalizeEmail } from './canonicalizeEmail';
 import { EmailField } from './components/EmailField';
+import { LicenseKeyField } from './components/LicenseKeyField';
 import { PasswordField } from './components/PasswordField';
-import { validatePasswordPair } from './passwordValidation';
-import { useAuthSubmit } from './useAuthSubmit';
+import { useSignupForm } from './useSignupForm';
+import type { SignupForm } from './useSignupForm';
 
 import { Button } from '@/components/Button';
-import { useAuth } from '@/context/AuthContext';
-
-const SIGNUP_FALLBACK =
-  "We couldn't create your account. Check your connection, then try again in a moment.";
+import { GUMROAD_HELP_URL } from '@/config';
+import { openExternalUrl } from '@/utils/openExternalUrl';
 
 interface Props {
   navigation: { navigate: (_screen: string) => void };
+  /**
+   * Optional so callers that only pass ``navigation`` still type-check. A
+   * supplied ``licenseKey`` seeds the field — the seam a post-purchase deep
+   * link or a later social-auth flow reuses.
+   */
+  route?: { params?: { licenseKey?: string } };
 }
 
 interface SignupFieldsProps {
-  email: string;
-  setEmail: (_v: string) => void;
-  password: string;
-  setPassword: (_v: string) => void;
-  confirmPassword: string;
-  setConfirmPassword: (_v: string) => void;
+  form: SignupForm;
+  onPressHelp: () => void;
 }
 
-function SignupFields({
-  email,
-  setEmail,
-  password,
-  setPassword,
-  confirmPassword,
-  setConfirmPassword,
-}: SignupFieldsProps) {
+function SignupFields({ form, onPressHelp }: SignupFieldsProps): React.JSX.Element {
   return (
     <>
       <EmailField
         accessibilityLabel="Email"
         style={styles.inputSpacing}
-        value={email}
-        onChangeText={setEmail}
+        value={form.email}
+        onChangeText={form.setEmail}
       />
       <PasswordField
         accessibilityLabel="Password"
         style={styles.inputSpacing}
-        value={password}
-        onChangeText={setPassword}
+        value={form.password}
+        onChangeText={form.setPassword}
       />
       <PasswordField
         accessibilityLabel="Confirm password"
         style={styles.inputSpacing}
         placeholder="Confirm Password"
-        value={confirmPassword}
-        onChangeText={setConfirmPassword}
+        value={form.confirmPassword}
+        onChangeText={form.setConfirmPassword}
+      />
+      <LicenseKeyField
+        error={form.licenseError}
+        onPressHelp={onPressHelp}
+        value={form.licenseKey}
+        onChangeText={form.setLicenseKey}
       />
     </>
   );
@@ -93,25 +92,14 @@ function SignupActions({ onSignup, onNavigateLogin, submitting }: SignupActionsP
   );
 }
 
-export default function SignupScreen({ navigation }: Props) {
-  const { signup } = useAuth();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const { submitting, error, setError, run } = useAuthSubmit(
-    // BUG-AUTH-010: trim at submit so paste/autofill whitespace doesn't
-    // produce a confusing 422 from the backend.
-    () => signup(canonicalizeEmail(email), password),
-    { fallback: SIGNUP_FALLBACK },
-  );
+export default function SignupScreen({ navigation, route }: Props) {
+  const form = useSignupForm(route?.params?.licenseKey ?? '');
 
-  const handleSignup = () => {
-    const validationError = validatePasswordPair(password, confirmPassword);
-    if (validationError) {
-      setError(validationError);
-      return;
-    }
-    void run();
+  // The help page is static config: appending the typed key would leak a
+  // credential into the browser URL bar, history and referrer header.
+  // ``openExternalUrl`` reports its own failures, so the form surfaces nothing.
+  const handlePressHelp = (): void => {
+    void openExternalUrl(GUMROAD_HELP_URL).catch(() => undefined);
   };
 
   return (
@@ -119,19 +107,16 @@ export default function SignupScreen({ navigation }: Props) {
       <AuthBrandBand />
       <Text style={styles.title}>Begin</Text>
       <Text style={styles.lead}>Create your account and start the practice.</Text>
-      <SignupFields
-        email={email}
-        setEmail={setEmail}
-        password={password}
-        setPassword={setPassword}
-        confirmPassword={confirmPassword}
-        setConfirmPassword={setConfirmPassword}
-      />
-      {error && <Text style={styles.error}>{error}</Text>}
+      <SignupFields form={form} onPressHelp={handlePressHelp} />
+      {form.error && (
+        <Text style={styles.error} testID="signup-error">
+          {form.error}
+        </Text>
+      )}
       <SignupActions
-        onSignup={handleSignup}
+        onSignup={form.handleSignup}
         onNavigateLogin={() => navigation.navigate('Login')}
-        submitting={submitting}
+        submitting={form.submitting}
       />
     </AuthScreenContainer>
   );

--- a/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
+++ b/frontend/src/features/Auth/__tests__/AppAuthFlow.test.tsx
@@ -61,6 +61,10 @@ jest.mock('@react-navigation/native-stack', () => ({
 }));
 
 // Mock child screens to simple identifiable components
+jest.mock('@/features/Auth/GetStartedScreen', () => {
+  const { Text } = require('react-native');
+  return () => <Text>GetStartedScreen</Text>;
+});
 jest.mock('@/features/Auth/LoginScreen', () => {
   const { Text } = require('react-native');
   return () => <Text>LoginScreen</Text>;
@@ -135,7 +139,14 @@ beforeEach(() => {
 });
 
 describe('App auth flow', () => {
-  it('shows auth screens when user is anonymous', () => {
+  it('shows the pre-auth Get Started surface when the user is anonymous', () => {
+    mockAuthState = { token: null, authStatus: 'anonymous' };
+    const { getByText } = render(<App />);
+
+    expect(getByText('GetStartedScreen')).toBeTruthy();
+  });
+
+  it('keeps the log-in form reachable in the anonymous stack', () => {
     mockAuthState = { token: null, authStatus: 'anonymous' };
     const { getByText } = render(<App />);
 
@@ -161,6 +172,7 @@ describe('App auth flow', () => {
     const { queryByText } = render(<App />);
 
     expect(queryByText('LoginScreen')).toBeNull();
+    expect(queryByText('GetStartedScreen')).toBeNull();
   });
 
   it('does not show main app when anonymous', () => {

--- a/frontend/src/features/Auth/__tests__/GetStartedScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/GetStartedScreen.test.tsx
@@ -1,0 +1,98 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, jest */
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+const PRODUCT_URL = 'https://gumroad.test/l/adepthood';
+
+jest.mock('@/config', () => ({
+  API_BASE_URL: 'http://test',
+  CONFIG_ERROR: null,
+  GUMROAD_PRODUCT_URL: 'https://gumroad.test/l/adepthood',
+  GUMROAD_HELP_URL: 'https://gumroad.test/help/license-keys',
+}));
+
+jest.mock('@/utils/openExternalUrl', () => ({
+  openExternalUrl: jest.fn(() => Promise.resolve(true)),
+}));
+
+import GetStartedScreen from '../GetStartedScreen';
+
+import { openExternalUrl } from '@/utils/openExternalUrl';
+
+const mockOpenExternalUrl = openExternalUrl as jest.MockedFunction<typeof openExternalUrl>;
+
+const BUY_LABEL = 'Get Adepthood on Gumroad';
+const HAVE_KEY_LABEL = 'I have a license key';
+
+const mockNavigation = { navigate: jest.fn() };
+
+beforeEach(() => {
+  mockOpenExternalUrl.mockResolvedValue(true);
+});
+
+describe('GetStartedScreen', () => {
+  it('is the pre-auth surface, identified by its own screen testID', () => {
+    const { getByTestId } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    expect(getByTestId('get-started-screen')).toBeTruthy();
+  });
+
+  it('leads with the gift-economy framing rather than a price', () => {
+    const { getByText } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    expect(getByText(/pay what feels right/i)).toBeTruthy();
+    expect(getByText(/starting at zero/i)).toBeTruthy();
+  });
+
+  it('opens the Gumroad product page from config when the buy CTA is pressed', async () => {
+    const { getByText } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText(BUY_LABEL));
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(PRODUCT_URL);
+  });
+
+  it('stays mounted when the opener rejects instead of crashing the screen', async () => {
+    mockOpenExternalUrl.mockRejectedValue(new Error('no browser available'));
+    const { getByText, getByTestId } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText(BUY_LABEL));
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(getByTestId('get-started-screen')).toBeTruthy();
+    expect(getByText(BUY_LABEL)).toBeTruthy();
+  });
+
+  it('routes buyers who already have a key to the signup form', () => {
+    const { getByText } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText(HAVE_KEY_LABEL));
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Signup');
+  });
+
+  // GetStarted replaces Login as the initial anonymous route, so returning
+  // users need an explicit way back to the log-in form from here.
+  it('routes returning users to the log-in form', () => {
+    const { getByText } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    fireEvent.press(getByText('Log In'));
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Login');
+  });
+
+  it('exposes both primary CTAs to assistive tech as buttons', () => {
+    const { getByLabelText } = render(<GetStartedScreen navigation={mockNavigation} />);
+
+    expect(getByLabelText(BUY_LABEL).props.accessibilityRole).toBe('button');
+    expect(getByLabelText(HAVE_KEY_LABEL).props.accessibilityRole).toBe('button');
+  });
+
+  it('does not open anything on first render', () => {
+    render(<GetStartedScreen navigation={mockNavigation} />);
+
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SignupScreen.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
 
@@ -11,10 +12,74 @@ jest.mock('@/context/AuthContext', () => {
   };
 });
 
+jest.mock('@/config', () => ({
+  API_BASE_URL: 'http://test',
+  CONFIG_ERROR: null,
+  GUMROAD_PRODUCT_URL: 'https://gumroad.test/l/adepthood',
+  GUMROAD_HELP_URL: 'https://gumroad.test/help/license-keys',
+}));
+
+jest.mock('@/utils/openExternalUrl', () => ({
+  openExternalUrl: jest.fn(() => Promise.resolve(true)),
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const { _mockSignup: mockSignup } = require('@/context/AuthContext') as any;
 
 import SignupScreen from '../SignupScreen';
+
+import { GUMROAD_HELP_URL } from '@/config';
+import { openExternalUrl } from '@/utils/openExternalUrl';
+
+const mockOpenExternalUrl = openExternalUrl as jest.MockedFunction<typeof openExternalUrl>;
+
+const LICENSE_LABEL = 'Gumroad license key';
+const VALID_LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
+const PASSWORD = 'password123'; // pragma: allowlist secret
+const INLINE_ERROR_ID = 'signup-license-error';
+const BANNER_ID = 'signup-error';
+const HELP_LINK_ID = 'signup-license-help';
+const HELP_LINK_LABEL = 'Find your license key';
+const HELP_LINK_COPY = "Where's my key?";
+
+const INVALID_LICENSE_COPY =
+  "We couldn't verify that key — double-check it matches the email and product.";
+const LICENSE_REQUIRED_COPY = 'Add the license key from your Gumroad receipt to continue.';
+const TOO_MANY_ATTEMPTS_COPY =
+  "That's several tries in a row. Give it an hour, then try again with the key from your receipt.";
+const UNAVAILABLE_COPY =
+  "We can't reach Gumroad to check your key right now. Nothing is lost — give it a few minutes and try again.";
+const PASSWORD_TOO_LONG_COPY =
+  'That password is longer than we can store. Shorten it to 64 characters or fewer.';
+
+type Screen = ReturnType<typeof render>;
+
+interface FormValues {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  licenseKey?: string;
+}
+
+function fillForm(screen: Screen, values: FormValues = {}): void {
+  fireEvent.changeText(screen.getByPlaceholderText('Email'), values.email ?? 'new@test.com');
+  fireEvent.changeText(screen.getByPlaceholderText('Password'), values.password ?? PASSWORD);
+  fireEvent.changeText(
+    screen.getByPlaceholderText('Confirm Password'),
+    values.confirmPassword ?? values.password ?? PASSWORD,
+  );
+  if (values.licenseKey !== undefined) {
+    fireEvent.changeText(screen.getByLabelText(LICENSE_LABEL), values.licenseKey);
+  }
+}
+
+function submit(screen: Screen): void {
+  fireEvent.press(screen.getByText('Sign Up'));
+}
+
+function pressHelpLink(screen: Screen): void {
+  fireEvent.press(screen.getByTestId(HELP_LINK_ID));
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -29,6 +94,12 @@ describe('SignupScreen', () => {
     expect(getByPlaceholderText('Email')).toBeTruthy();
     expect(getByPlaceholderText('Password')).toBeTruthy();
     expect(getByPlaceholderText('Confirm Password')).toBeTruthy();
+  });
+
+  it('renders a labelled Gumroad license key field', () => {
+    const { getByLabelText } = render(<SignupScreen navigation={mockNavigation} />);
+
+    expect(getByLabelText(LICENSE_LABEL)).toBeTruthy();
   });
 
   it('opens on the branded editorial cover: serif wordmark + program voice', () => {
@@ -46,46 +117,43 @@ describe('SignupScreen', () => {
   });
 
   it('shows error when passwords do not match', async () => {
-    const { getByPlaceholderText, getByText, findByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), 'user@test.com');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'different');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, {
+      email: 'user@test.com',
+      password: PASSWORD,
+      confirmPassword: 'different', // pragma: allowlist secret
+      licenseKey: VALID_LICENSE_KEY,
+    });
+    submit(screen);
 
-    expect(await findByText(/passwords don't match/i)).toBeTruthy();
+    expect(await screen.findByText(/passwords don't match/i)).toBeTruthy();
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
   it('shows error when password is too short', async () => {
-    const { getByPlaceholderText, getByText, findByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), 'user@test.com');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'short');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'short');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, {
+      email: 'user@test.com',
+      password: 'short', // pragma: allowlist secret
+      licenseKey: VALID_LICENSE_KEY,
+    });
+    submit(screen);
 
-    expect(await findByText(/at least 8 characters/i)).toBeTruthy();
+    expect(await screen.findByText(/at least 8 characters/i)).toBeTruthy();
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
-  it('calls signup with email and password on valid submit', async () => {
+  it('calls signup with email, password, and license key on valid submit', async () => {
     mockSignup.mockResolvedValue(undefined);
-    const { getByPlaceholderText, getByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), 'new@test.com');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, { licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
 
     await waitFor(() => {
-      expect(mockSignup).toHaveBeenCalledWith('new@test.com', 'password123');
+      expect(mockSignup).toHaveBeenCalledWith('new@test.com', PASSWORD, VALID_LICENSE_KEY);
     });
   });
 
@@ -94,46 +162,34 @@ describe('SignupScreen', () => {
     // bundle), the backend still enforces it and returns the stable code
     // ``password_too_short``. The screen must not leak snake_case to the UI.
     mockSignup.mockRejectedValue({ detail: 'password_too_short', status: 400 });
-    const { getByPlaceholderText, getByText, findByText, queryByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), 'taken@test.com');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, { email: 'taken@test.com', licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
 
-    expect(await findByText(/at least 8 characters/i)).toBeTruthy();
-    expect(queryByText('password_too_short')).toBeNull();
+    expect(await screen.findByText(/at least 8 characters/i)).toBeTruthy();
+    expect(screen.queryByText('password_too_short')).toBeNull();
   });
 
   it('falls back to a connection-hint message when the error is unrecognised', async () => {
     mockSignup.mockRejectedValue(new TypeError('Network request failed'));
-    const { getByPlaceholderText, getByText, findByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), 'user@test.com');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, { email: 'user@test.com', licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
 
-    expect(await findByText(/Check your connection/i)).toBeTruthy();
+    expect(await screen.findByText(/Check your connection/i)).toBeTruthy();
   });
 
   it('trims whitespace from the email before submitting (BUG-AUTH-010)', async () => {
     mockSignup.mockResolvedValue(undefined);
-    const { getByPlaceholderText, getByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), '  new@test.com  ');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, { email: '  new@test.com  ', licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
 
     await waitFor(() => {
-      expect(mockSignup).toHaveBeenCalledWith('new@test.com', 'password123');
+      expect(mockSignup).toHaveBeenCalledWith('new@test.com', PASSWORD, VALID_LICENSE_KEY);
     });
   });
 
@@ -141,17 +197,13 @@ describe('SignupScreen', () => {
     // Previously signup submitted email.trim() only, so a "Foo@Bar.com" signup
     // and a "foo@bar.com" login looked like two accounts client-side.
     mockSignup.mockResolvedValue(undefined);
-    const { getByPlaceholderText, getByText } = render(
-      <SignupScreen navigation={mockNavigation} />,
-    );
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
 
-    fireEvent.changeText(getByPlaceholderText('Email'), '  Foo@Bar.COM ');
-    fireEvent.changeText(getByPlaceholderText('Password'), 'password123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'password123');
-    fireEvent.press(getByText('Sign Up'));
+    fillForm(screen, { email: '  Foo@Bar.COM ', licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
 
     await waitFor(() => {
-      expect(mockSignup).toHaveBeenCalledWith('foo@bar.com', 'password123');
+      expect(mockSignup).toHaveBeenCalledWith('foo@bar.com', PASSWORD, VALID_LICENSE_KEY);
     });
   });
 
@@ -165,5 +217,243 @@ describe('SignupScreen', () => {
 
     fireEvent.press(getByText('Log In'));
     expect(mockNavigation.navigate).toHaveBeenCalledWith('Login');
+  });
+});
+
+describe('SignupScreen license key validation', () => {
+  const mockNavigation = { navigate: jest.fn() };
+
+  it('blocks submit and asks for the key when the field is empty', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    fillForm(screen, { licenseKey: '' });
+    submit(screen);
+
+    expect(await screen.findByTestId(INLINE_ERROR_ID)).toHaveTextContent(LICENSE_REQUIRED_COPY);
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it('blocks submit when the key is shorter than the backend minimum', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    fillForm(screen, { licenseKey: 'A1B2C3D' });
+    submit(screen);
+
+    expect(await screen.findByTestId(INLINE_ERROR_ID)).toBeTruthy();
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it('sends the trimmed key as the third signup argument', async () => {
+    mockSignup.mockResolvedValue(undefined);
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    fillForm(screen, { licenseKey: `   ${VALID_LICENSE_KEY}   ` });
+    submit(screen);
+
+    await waitFor(() => expect(mockSignup).toHaveBeenCalledTimes(1));
+    expect(mockSignup).toHaveBeenCalledWith('new@test.com', PASSWORD, VALID_LICENSE_KEY);
+  });
+
+  it('seeds the field from route.params.licenseKey', () => {
+    const { getByLabelText } = render(
+      <SignupScreen
+        navigation={mockNavigation}
+        route={{ params: { licenseKey: VALID_LICENSE_KEY } }}
+      />,
+    );
+
+    expect(getByLabelText(LICENSE_LABEL).props.value).toBe(VALID_LICENSE_KEY);
+  });
+
+  it('renders with navigation alone when no route prop is supplied', () => {
+    const { getByLabelText } = render(<SignupScreen navigation={mockNavigation} />);
+
+    expect(getByLabelText(LICENSE_LABEL).props.value).toBe('');
+  });
+});
+
+describe('SignupScreen license error routing', () => {
+  const mockNavigation = { navigate: jest.fn() };
+
+  async function submitWithRejection(detail: unknown, status: number): Promise<Screen> {
+    mockSignup.mockRejectedValue({ detail, status });
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+    fillForm(screen, { licenseKey: VALID_LICENSE_KEY });
+    submit(screen);
+    await waitFor(() => expect(mockSignup).toHaveBeenCalledTimes(1));
+    return screen;
+  }
+
+  const inlineCases: Array<[string, number, string]> = [
+    ['invalid_license', 400, INVALID_LICENSE_COPY],
+    ['license_required', 400, LICENSE_REQUIRED_COPY],
+    ['too_many_license_attempts', 429, TOO_MANY_ATTEMPTS_COPY],
+  ];
+
+  const bannerCases: Array<[string, number, string]> = [
+    ['license_verification_unavailable', 503, UNAVAILABLE_COPY],
+    ['password_too_long', 400, PASSWORD_TOO_LONG_COPY], // pragma: allowlist secret
+  ];
+
+  it.each(inlineCases)('renders %p inline on the license field', async (detail, status, copy) => {
+    const screen = await submitWithRejection(detail, status);
+
+    const inline = await screen.findByTestId(INLINE_ERROR_ID);
+    expect(inline).toHaveTextContent(copy);
+    expect(screen.queryByTestId(BANNER_ID)).toBeNull();
+  });
+
+  it.each(bannerCases)('renders %p in the generic banner', async (detail, status, copy) => {
+    const screen = await submitWithRejection(detail, status);
+
+    const banner = await screen.findByTestId(BANNER_ID);
+    expect(banner).toHaveTextContent(copy);
+    expect(screen.queryByTestId(INLINE_ERROR_ID)).toBeNull();
+  });
+
+  it('announces the inline license error to assistive tech', async () => {
+    const screen = await submitWithRejection('invalid_license', 400);
+
+    const inline = await screen.findByTestId(INLINE_ERROR_ID);
+    expect(inline.props.accessibilityRole).toBe('alert');
+    expect(inline.props.accessibilityLiveRegion).toBe('polite');
+  });
+
+  it('clears the inline error as soon as the user edits the key', async () => {
+    const screen = await submitWithRejection('invalid_license', 400);
+    await screen.findByTestId(INLINE_ERROR_ID);
+
+    fireEvent.changeText(screen.getByLabelText(LICENSE_LABEL), 'B9C8D7E6-F5A4B3C2');
+
+    expect(screen.queryByTestId(INLINE_ERROR_ID)).toBeNull();
+  });
+
+  it('shows a readable banner for a Pydantic 422 without leaking field names', async () => {
+    const screen = await submitWithRejection('String should have at most 128 characters', 422);
+
+    const banner = await screen.findByTestId(BANNER_ID);
+    expect(banner).toBeTruthy();
+    expect(screen.queryByText(/license_/)).toBeNull();
+    expect(screen.queryByTestId(INLINE_ERROR_ID)).toBeNull();
+  });
+
+  // Defensive: if any layer ever forwards the raw Pydantic array through,
+  // the screen must still render prose — never ``[object Object]``.
+  it('never renders a stringified object when detail is not a string', async () => {
+    const screen = await submitWithRejection(
+      [{ loc: ['body', 'license_key'], msg: 'Field required', type: 'missing' }],
+      422,
+    );
+
+    const banner = await screen.findByTestId(BANNER_ID);
+    expect(banner).not.toHaveTextContent('[object Object]');
+    expect(screen.queryByText(/license_key/)).toBeNull();
+  });
+
+  it('keeps the license key out of logs and local storage on a rejected attempt', async () => {
+    const spies = [
+      jest.spyOn(console, 'log').mockImplementation(() => undefined),
+      jest.spyOn(console, 'warn').mockImplementation(() => undefined),
+      jest.spyOn(console, 'error').mockImplementation(() => undefined),
+    ];
+    const setItem = AsyncStorage.setItem as jest.MockedFunction<typeof AsyncStorage.setItem>;
+
+    const screen = await submitWithRejection('invalid_license', 400);
+    await screen.findByTestId(INLINE_ERROR_ID);
+
+    const recorded = [...spies.flatMap((spy) => spy.mock.calls), ...setItem.mock.calls];
+    for (const call of recorded) {
+      expect(JSON.stringify(call)).not.toContain(VALID_LICENSE_KEY);
+    }
+    for (const spy of spies) spy.mockRestore();
+  });
+});
+
+describe('SignupScreen license key help link', () => {
+  const mockNavigation = { navigate: jest.fn() };
+
+  beforeEach(() => {
+    mockOpenExternalUrl.mockReset();
+    mockOpenExternalUrl.mockResolvedValue(true);
+  });
+
+  it('renders the help affordance as a labelled link', () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    const link = screen.getByTestId(HELP_LINK_ID);
+    expect(link.props.accessibilityRole).toBe('link');
+    expect(link.props.accessibilityLabel).toBe(HELP_LINK_LABEL);
+    expect(screen.getByText(HELP_LINK_COPY)).toBeTruthy();
+  });
+
+  it('opens the help URL from config when pressed', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(GUMROAD_HELP_URL);
+  });
+
+  it('does not open anything on first render', () => {
+    render(<SignupScreen navigation={mockNavigation} />);
+
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  // The help page is static config. Appending the key would leak a credential
+  // into a browser URL bar, history, and any referrer header.
+  it('never appends the typed license key to the help URL', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+    fireEvent.changeText(screen.getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(GUMROAD_HELP_URL);
+    expect(JSON.stringify(mockOpenExternalUrl.mock.calls)).not.toContain(VALID_LICENSE_KEY);
+  });
+
+  it('stays mounted with no error surfaced when the opener rejects', async () => {
+    mockOpenExternalUrl.mockRejectedValue(new Error('no browser available'));
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId(HELP_LINK_ID)).toBeTruthy();
+    expect(screen.queryByTestId(BANNER_ID)).toBeNull();
+    expect(screen.queryByTestId(INLINE_ERROR_ID)).toBeNull();
+  });
+
+  it('surfaces no error when the opener resolves false', async () => {
+    mockOpenExternalUrl.mockResolvedValue(false);
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(screen.queryByTestId(BANNER_ID)).toBeNull();
+    expect(screen.queryByTestId(INLINE_ERROR_ID)).toBeNull();
+  });
+
+  it('does not submit the form', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+    fillForm(screen, { licenseKey: VALID_LICENSE_KEY });
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(mockSignup).not.toHaveBeenCalled();
+  });
+
+  it('preserves the key the user already typed', async () => {
+    const screen = render(<SignupScreen navigation={mockNavigation} />);
+    fireEvent.changeText(screen.getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+
+    pressHelpLink(screen);
+
+    await waitFor(() => expect(mockOpenExternalUrl).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText(LICENSE_LABEL).props.value).toBe(VALID_LICENSE_KEY);
   });
 });

--- a/frontend/src/features/Auth/__tests__/licenseKeyValidation.test.ts
+++ b/frontend/src/features/Auth/__tests__/licenseKeyValidation.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import {
+  MAX_LICENSE_KEY_LENGTH,
+  MIN_LICENSE_KEY_LENGTH,
+  validateLicenseKey,
+} from '../licenseKeyValidation';
+
+// A realistic Gumroad key: four dash-separated uppercase-hex groups, 35 chars.
+const REALISTIC_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
+
+describe('license key length bounds', () => {
+  it('mirrors the backend contract of 8..128 characters', () => {
+    expect(MIN_LICENSE_KEY_LENGTH).toBe(8);
+    expect(MAX_LICENSE_KEY_LENGTH).toBe(128);
+  });
+});
+
+describe('validateLicenseKey', () => {
+  it.each([[''], ['   '], ['\t\n ']])('asks for the key when the field is %p', (value) => {
+    expect(validateLicenseKey(value)).toBe(
+      'Add the license key from your Gumroad receipt to continue.',
+    );
+  });
+
+  it('rejects a key one character below the minimum', () => {
+    const message = validateLicenseKey('A1B2C3D'); // pragma: allowlist secret
+
+    expect(message).toMatch(/at least 8/);
+  });
+
+  it('accepts a key exactly at the minimum length', () => {
+    expect(validateLicenseKey('A1B2C3D4')).toBeNull(); // pragma: allowlist secret
+  });
+
+  it('accepts a key exactly at the maximum length', () => {
+    expect(validateLicenseKey('K'.repeat(MAX_LICENSE_KEY_LENGTH))).toBeNull();
+  });
+
+  it('rejects a key one character above the maximum', () => {
+    const message = validateLicenseKey('K'.repeat(MAX_LICENSE_KEY_LENGTH + 1));
+
+    expect(message).toMatch(/128/);
+  });
+
+  it('accepts a realistic dashed uppercase-hex Gumroad key', () => {
+    expect(validateLicenseKey(REALISTIC_KEY)).toBeNull();
+  });
+
+  it('trims surrounding whitespace before measuring the length', () => {
+    // 8 significant characters padded either side: the pad must not count
+    // toward the minimum, and the value must not be rejected as too long.
+    expect(validateLicenseKey('   A1B2C3D4   ')).toBeNull(); // pragma: allowlist secret
+    expect(validateLicenseKey('  A1B2C3D  ')).toMatch(/at least 8/); // pragma: allowlist secret
+  });
+
+  it('counts only the trimmed key against the maximum', () => {
+    const padded = `  ${'K'.repeat(MAX_LICENSE_KEY_LENGTH)}  `;
+
+    expect(validateLicenseKey(padded)).toBeNull();
+  });
+
+  it('never returns snake_case backend vocabulary to the user', () => {
+    const messages = [validateLicenseKey(''), validateLicenseKey('A1B2C3D')].filter(
+      (message): message is string => message !== null,
+    );
+
+    expect(messages).toHaveLength(2);
+    for (const message of messages) {
+      expect(message).not.toMatch(/[a-z]_[a-z]/);
+      expect(message).toMatch(/[.!?]$/);
+    }
+  });
+});

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -79,6 +79,16 @@ export const authStyles = StyleSheet.create({
   inputSpacing: { marginBottom: SPACING.md },
   buttonSpacing: { marginBottom: SPACING.lg },
   error: { color: colors.danger, marginBottom: SPACING.md, textAlign: 'center' },
+  // Field-scoped error, left-aligned under its input so the eye reads it as
+  // belonging to that one field — unlike the centered form-level ``error``.
+  fieldError: {
+    color: colors.danger,
+    textAlign: 'left',
+    marginTop: SPACING.xs,
+    marginBottom: SPACING.xs,
+  },
+  // "Where's my key?" — a quiet self-serve exit next to the license field.
+  helpLink: { color: accent.primary, fontWeight: '500', marginBottom: SPACING.md },
   link: { textAlign: 'center', color: ink.soft },
   linkBold: { color: accent.primary, fontWeight: '600' },
   forgotLink: {
@@ -87,6 +97,16 @@ export const authStyles = StyleSheet.create({
     fontWeight: '500',
     marginBottom: SPACING.md,
   },
+  // Get Started (pre-auth) layout: a body paragraph under the lead, then the
+  // terracotta callout band with breathing room before the quieter options.
+  body: {
+    ...TYPE.body,
+    color: ink.soft,
+    textAlign: 'center',
+    marginBottom: SPACING.xl,
+  },
+  // Separates the loud terracotta band from the quieter options beneath it.
+  ctaSpacing: { marginTop: SPACING.lg, marginBottom: SPACING.lg },
   successTitle: {
     ...TYPE.title,
     color: ink.primary,

--- a/frontend/src/features/Auth/components/LicenseKeyField.tsx
+++ b/frontend/src/features/Auth/components/LicenseKeyField.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import type { TextInputProps } from 'react-native';
+
+import { authStyles as styles } from '../auth.styles';
+
+import { TextField } from '@/components/TextField';
+import { SPACING, touchTarget } from '@/design/tokens';
+
+// The help link is deliberately quiet type, so its rendered box is a single
+// short line — well under the 44dp accessible minimum. Grow the tap area
+// rather than the glyphs: half the shortfall on every edge, measured against
+// a conservative floor for one line of link copy.
+const HELP_LINK_MIN_LINE_BOX = SPACING.lg;
+const HELP_LINK_SLOP = (touchTarget.minimum - HELP_LINK_MIN_LINE_BOX) / 2;
+const HELP_LINK_HIT_SLOP = {
+  top: HELP_LINK_SLOP,
+  bottom: HELP_LINK_SLOP,
+  left: HELP_LINK_SLOP,
+  right: HELP_LINK_SLOP,
+};
+
+interface LicenseKeyFieldProps extends TextInputProps {
+  /** Inline, field-scoped error copy; hidden when null. */
+  error?: string | null;
+  /** Opens the "where do I find my key" help page. */
+  onPressHelp: () => void;
+}
+
+/**
+ * Gumroad license key input for the signup form, with its inline error and a
+ * self-serve help link.
+ *
+ * Deliberately NOT ``secureTextEntry``: a license key is transcribed or pasted
+ * from a receipt, and masking it only makes typos invisible. For the same
+ * reason autocorrect, capitalisation and spellcheck are all off. Keeping
+ * password managers from offering to autofill — or store — a credential that is
+ * not a password takes both opt-outs: ``textContentType="none"`` covers iOS,
+ * while ``autoComplete="off"`` is what suppresses Android's autofill
+ * heuristics (which otherwise fire regardless of ``textContentType``) and the
+ * browser's form history on web.
+ */
+export function LicenseKeyField({
+  error,
+  onPressHelp,
+  ...rest
+}: LicenseKeyFieldProps): React.JSX.Element {
+  return (
+    <>
+      <TextField
+        placeholder="License key"
+        accessibilityLabel="Gumroad license key"
+        autoCapitalize="none"
+        autoCorrect={false}
+        spellCheck={false}
+        textContentType="none"
+        autoComplete="off"
+        {...rest}
+      />
+      {error ? (
+        <Text
+          // The error appears in place, with no mount/unmount cycle to cue a
+          // screen reader — so pair the alert role with a live region.
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+          style={styles.fieldError}
+          testID="signup-license-error"
+        >
+          {error}
+        </Text>
+      ) : null}
+      <TouchableOpacity
+        accessibilityLabel="Find your license key"
+        accessibilityRole="link"
+        hitSlop={HELP_LINK_HIT_SLOP}
+        onPress={onPressHelp}
+        testID="signup-license-help"
+      >
+        <Text style={styles.helpLink}>Where&apos;s my key?</Text>
+      </TouchableOpacity>
+    </>
+  );
+}

--- a/frontend/src/features/Auth/licenseKeyValidation.ts
+++ b/frontend/src/features/Auth/licenseKeyValidation.ts
@@ -1,0 +1,38 @@
+/**
+ * Shortest key Gumroad ever issues — mirrors the backend's floor. This is a
+ * length sanity check, not real format validation: only Gumroad knows whether
+ * a given key is genuine, so an actual check always happens server-side.
+ */
+export const MIN_LICENSE_KEY_LENGTH = 8;
+
+/**
+ * Ceiling the backend enforces on ``license_key``. Checking it here means an
+ * over-length paste is caught before it costs a round trip.
+ */
+export const MAX_LICENSE_KEY_LENGTH = 128;
+
+/**
+ * Copy shared with the ``license_required`` backend code so the field reads the
+ * same whether the client or the server noticed the key was missing.
+ */
+const KEY_REQUIRED = 'Add the license key from your Gumroad receipt to continue.';
+
+/**
+ * Validate a Gumroad license key. Returns user-facing copy for the inline field
+ * error, or ``null`` when the key is worth sending. Whitespace is trimmed
+ * before measuring: a pasted key routinely arrives with padding, and that pad
+ * must count against neither the minimum nor the maximum.
+ */
+export function validateLicenseKey(value: string): string | null {
+  const key = value.trim();
+  if (key.length === 0) {
+    return KEY_REQUIRED;
+  }
+  if (key.length < MIN_LICENSE_KEY_LENGTH) {
+    return `That key looks too short — a Gumroad key is at least ${MIN_LICENSE_KEY_LENGTH} characters.`;
+  }
+  if (key.length > MAX_LICENSE_KEY_LENGTH) {
+    return `That key is longer than ${MAX_LICENSE_KEY_LENGTH} characters. Paste just the key from your receipt.`;
+  }
+  return null;
+}

--- a/frontend/src/features/Auth/signupErrorRouting.ts
+++ b/frontend/src/features/Auth/signupErrorRouting.ts
@@ -1,0 +1,40 @@
+import { messageForCode } from '@/api/errorMessages';
+
+/**
+ * Backend detail codes that belong on the license field itself rather than the
+ * form-level banner: each one is something the user fixes by editing that one
+ * input. Everything else — an outage, a password problem, a validation
+ * rejection — stays in the banner, where it reads as a whole-form condition.
+ *
+ * Notably absent: ``license_verification_unavailable`` (a Gumroad outage) is
+ * not the user's fault and not about their key, so it is deliberately left out
+ * of this set and falls through to the banner.
+ */
+export const LICENSE_FIELD_DETAILS: ReadonlySet<string> = new Set([
+  'invalid_license',
+  'license_required',
+  'too_many_license_attempts',
+]);
+
+// ``invalid_license`` alone stands in for four distinct backend outcomes —
+// wrong key, wrong product, mismatched email, and an already-registered
+// email — deliberately collapsed into one generic code (anti-enumeration).
+// The UI must not appear to know which of the four happened, so it renders
+// the same inline copy for all of them.
+
+function detailOf(err: unknown): string | undefined {
+  if (err == null || typeof err !== 'object') return undefined;
+  const detail = (err as { detail?: unknown }).detail;
+  return typeof detail === 'string' ? detail : undefined;
+}
+
+/**
+ * Copy for the inline license-field error, or ``undefined`` when this failure
+ * is not the license field's business — in which case the caller should let the
+ * error travel on to the generic banner.
+ */
+export function licenseFieldMessage(err: unknown): string | undefined {
+  const detail = detailOf(err);
+  if (detail === undefined || !LICENSE_FIELD_DETAILS.has(detail)) return undefined;
+  return messageForCode(detail);
+}

--- a/frontend/src/features/Auth/useSignupForm.ts
+++ b/frontend/src/features/Auth/useSignupForm.ts
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+
+import { canonicalizeEmail } from './canonicalizeEmail';
+import { validateLicenseKey } from './licenseKeyValidation';
+import { validatePasswordPair } from './passwordValidation';
+import { licenseFieldMessage } from './signupErrorRouting';
+import { useAuthSubmit } from './useAuthSubmit';
+
+import { useAuth } from '@/context/AuthContext';
+
+const SIGNUP_FALLBACK =
+  "We couldn't create your account. Check your connection, then try again in a moment.";
+
+/** Everything the signup form renders and drives. */
+export interface SignupForm {
+  email: string;
+  setEmail: (_v: string) => void;
+  password: string;
+  setPassword: (_v: string) => void;
+  confirmPassword: string;
+  setConfirmPassword: (_v: string) => void;
+  licenseKey: string;
+  setLicenseKey: (_v: string) => void;
+  /** Field-scoped license error; the form-level banner stays clear. */
+  licenseError: string | null;
+  /** Form-level banner copy. */
+  error: string | null;
+  submitting: boolean;
+  handleSignup: () => void;
+}
+
+/**
+ * State, validation and error routing for the signup form.
+ *
+ * Errors land in one of two places. Anything the user fixes by editing the
+ * license key is caught here and shown inline on that field; everything else is
+ * re-thrown so {@link useAuthSubmit} renders it in the form-level banner
+ * exactly as it does for every other auth screen.
+ *
+ * The license key is handled as a credential, not a form value: it is trimmed
+ * only at submit (never on every keystroke, which would fight a mid-paste
+ * selection) and it is never persisted or logged — it lives in component
+ * state for the lifetime of this screen and nowhere else.
+ *
+ * ``initialLicenseKey`` seeds the field from a route param, which is the seam a
+ * later post-purchase deep link (or social-auth flow) reuses.
+ */
+export function useSignupForm(initialLicenseKey = ''): SignupForm {
+  const { signup } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [licenseKey, setKey] = useState(initialLicenseKey);
+  const [licenseError, setLicenseError] = useState<string | null>(null);
+
+  const { submitting, error, setError, run } = useAuthSubmit(
+    async () => {
+      setLicenseError(null);
+      try {
+        // BUG-AUTH-010 / audit-ux-08: canonicalize the email and trim the key at
+        // submit so paste and autofill whitespace never reaches the backend.
+        await signup(canonicalizeEmail(email), password, licenseKey.trim());
+      } catch (err: unknown) {
+        const inline = licenseFieldMessage(err);
+        if (inline === undefined) throw err;
+        setLicenseError(inline);
+      }
+    },
+    { fallback: SIGNUP_FALLBACK },
+  );
+
+  // Editing the key retracts the verdict on it — a stale "we couldn't verify
+  // that key" under a key the user has since corrected reads as a broken form.
+  const setLicenseKey = useCallback((value: string): void => {
+    setKey(value);
+    setLicenseError(null);
+  }, []);
+
+  const handleSignup = (): void => {
+    const passwordError = validatePasswordPair(password, confirmPassword);
+    const keyError = validateLicenseKey(licenseKey);
+    setError(passwordError);
+    setLicenseError(keyError);
+    if (passwordError !== null || keyError !== null) return;
+    void run();
+  };
+
+  return {
+    email,
+    setEmail,
+    password,
+    setPassword,
+    confirmPassword,
+    setConfirmPassword,
+    licenseKey,
+    setLicenseKey,
+    licenseError,
+    error,
+    submitting,
+    handleSignup,
+  };
+}

--- a/frontend/src/utils/__tests__/openExternalUrl.test.ts
+++ b/frontend/src/utils/__tests__/openExternalUrl.test.ts
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+/* global describe, it, expect, afterEach, jest */
+import { Linking } from 'react-native';
+
+import { openExternalUrl } from '../openExternalUrl';
+
+const PRODUCT_URL = 'https://gumroad.example.com/l/adepthood';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('openExternalUrl', () => {
+  it('opens an https URL and resolves true', async () => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+
+    await expect(openExternalUrl(PRODUCT_URL)).resolves.toBe(true);
+
+    expect(openURL).toHaveBeenCalledTimes(1);
+    expect(openURL).toHaveBeenCalledWith(PRODUCT_URL);
+  });
+
+  it('preserves the query string and fragment of an https URL', async () => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+    const deepUrl = `${PRODUCT_URL}?wanted=true#buy`;
+
+    await expect(openExternalUrl(deepUrl)).resolves.toBe(true);
+
+    expect(openURL).toHaveBeenCalledWith(deepUrl);
+  });
+
+  it('resolves false and warns when the platform refuses to open the URL', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const openURL = jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('no handler'));
+
+    await expect(openExternalUrl(PRODUCT_URL)).resolves.toBe(false);
+
+    expect(openURL).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak the rejection to the caller as an unhandled throw', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Linking, 'openURL').mockImplementation(() => {
+      throw new Error('synchronous explosion');
+    });
+
+    await expect(openExternalUrl(PRODUCT_URL)).resolves.toBe(false);
+  });
+
+  // Only https survives the allowlist: http is downgrade-prone, custom schemes
+  // are an app-hijack vector, and javascript: is straight code execution.
+  it.each([
+    ['http://gumroad.example.com/l/adepthood'],
+    ['javascript:alert(1)'],
+    ['adepthood://signup'],
+    ['file:///etc/passwd'],
+    ['ftp://gumroad.example.com/l/adepthood'],
+    ['https://'],
+    [''],
+    ['   '],
+  ])('refuses %p without calling Linking.openURL', async (url) => {
+    const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+
+    await expect(openExternalUrl(url)).resolves.toBe(false);
+
+    expect(openURL).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/openExternalUrl.ts
+++ b/frontend/src/utils/openExternalUrl.ts
@@ -1,0 +1,44 @@
+import { Linking } from 'react-native';
+
+/**
+ * Only ``https://`` survives the allowlist. ``http`` is downgrade-prone,
+ * custom schemes are an app-hijack vector, and ``javascript:`` is straight
+ * code execution — none of them belong behind a marketing CTA.
+ */
+const HTTPS_PREFIX = 'https://';
+
+/** Bare copy for the log; the URL itself is deliberately not echoed. */
+const REFUSED_MESSAGE = 'openExternalUrl refused a URL that is not https';
+const FAILED_MESSAGE = 'openExternalUrl could not hand the URL to the platform';
+
+function isOpenableHttpsUrl(url: string): boolean {
+  return url.startsWith(HTTPS_PREFIX) && url.length > HTTPS_PREFIX.length;
+}
+
+/**
+ * Hand an external ``https`` URL to the platform browser.
+ *
+ * Resolves ``true`` when the platform accepted the URL and ``false`` for every
+ * failure mode — a refused scheme, a rejected promise, or a synchronous throw
+ * from ``Linking``. It never rejects, so callers can fire it from a press
+ * handler without a try/catch and without risking an unhandled rejection. This
+ * also matters on simulators, which routinely have no browser to hand a URL
+ * to: that failure should not read as a crash any more than a real device's
+ * would.
+ */
+export async function openExternalUrl(url: string): Promise<boolean> {
+  if (!isOpenableHttpsUrl(url)) {
+    console.warn(REFUSED_MESSAGE);
+    return false;
+  }
+  try {
+    await Linking.openURL(url);
+    return true;
+  } catch {
+    // The platform's rejection embeds the URL it could not open, so the error
+    // itself is dropped rather than logged: this helper is caller-agnostic, and
+    // a URL it is handed may one day carry a token or a key.
+    console.warn(FAILED_MESSAGE);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a pre-auth **GetStarted** screen (`features/Auth/GetStartedScreen.tsx`) as the initial anonymous route: gift-economy framing ("pay what feels right, starting at zero") with two declinable CTAs — "Get Adepthood on Gumroad" (opens `EXPO_PUBLIC_GUMROAD_PRODUCT_URL`) and "I have a license key" (→ signup) — plus a "Log In" link so returning users aren't stranded now that Login is no longer the first screen.
- Adds a required **license-key field** to signup (trimmed, min 8 / max 128 client-side, mirroring the backend's cap so an over-length paste never costs a Gumroad verify call) with a "Where's my key?" link to `EXPO_PUBLIC_GUMROAD_HELP_URL`. `AuthContext.signup` gains a required third `licenseKey` argument and forwards `license_key` verbatim; the device-timezone attach is preserved.
- Routes license-scoped backend rejections **inline on the license field** (`invalid_license`, `license_required`, `too_many_license_attempts`) while everything else stays in the generic banner (`license_verification_unavailable`, `password_too_long`, 422). `extractErrorDetail` now handles FastAPI's array-form 422 `detail`.

### Notes for reviewers

- **The existing Welcome feature is deliberately untouched.** `features/Welcome/WelcomeScreen.tsx` is the *post-auth* first-run program intro, mounted by `WelcomeGate` under `authStatus === 'authenticated'` and keyed on a server-authoritative per-account flag — an anonymous user has no token and never reaches it. Hence a new, separately-named pre-auth screen rather than an extension of that one.
- **The license key is treated as a credential.** It is trimmed only at submit, forwarded verbatim in the request body, and never logged, persisted, appended to a URL, or echoed into an error message. `detailFromArray` reads only each 422 entry's `msg`, never `input` — which for this endpoint is the submitted key echoed back by the server. A test spies on `console.*` and `AsyncStorage.setItem` to keep that guarantee executable. The field intentionally has no `secureTextEntry` (users must see what they pasted) but opts out of autofill on both platforms so a password manager never offers to store it.
- **The backend's anti-enumeration collapse is not undone client-side.** An invalid key, a wrong product, an email mismatch, and an already-registered email all arrive as one generic `invalid_license`; the approved copy stays deliberately vague and no client-side heuristic infers "account exists".
- `SignupScreen` accepts an optional `route.params.licenseKey` that only seeds state (never auto-submits) — the reuse seam for a later social-auth flow to land a user directly in license entry.
- `config.ts` reads each Gumroad env var twice (`inlined || process.env[name] || fallback`). This is deliberate and documented: `babel-preset-expo`'s `expo-inline-env-vars` rewrites statically-keyed `process.env.EXPO_PUBLIC_*` to a build-time literal and is active under Jest, so a single form would either break the tests or silently kill the production override.
- New `openExternalUrl` util: `https://`-only allowlist, returns a boolean and never throws (simulators fail silently), and its warning log deliberately omits the URL since callers can mint token-bearing links. The pre-existing bare `Linking.openURL` call in `ApiKeySettingsScreen` was left alone as out of scope.

## Test plan

- `./scripts/frontend/check-all.sh` → **exit 0** (ESLint zero-warning, Prettier, `tsc --noEmit` strict, Jest).
- Full Jest suite: **440 suites / 5029 tests passing**, 0 snapshots. Baseline before this work was 10 failing suites / 50 failing tests (the RED set), and every previously-green test stayed green.
- `pre-commit run --all-files` → **exit 0** (all 29 hooks, including detect-secrets).
- Built TDD-first: the failing tests landed before the implementation. New coverage includes — license field labeled and a11y-announced (`accessibilityRole="alert"` + `accessibilityLiveRegion="polite"`); empty/short key blocks submit with no network call; the trimmed key is sent as the third argument; each of the five backend detail codes renders inline vs. banner as specified; array-form 422 renders without leaking snake_case; editing the field clears the stale inline error; `route.params.licenseKey` seeds the field; the credential-leak guard; `openExternalUrl`'s scheme allowlist and never-throws contract; and the config fallback/override paths.
- Not run locally: `jest --coverage` (fills the disk in this environment) — CI's 90% gate is the first coverage measurement.
- Manual end-to-end against a live Gumroad sale is still worth doing before this is switched on in production.

Closes #1943
Refs #1938
