### PR TITLE
fix(frontend): restore the high+ audit gate with a scoped, expiring allowlist

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -39,6 +39,12 @@ jobs:
       # the whole gate off. The gate narrows exceptions to specific GHSA ids
       # listed in frontend/.audit-allowlist.json, each with an expiry it
       # enforces — everything else still fails.
+      # The gate decides whether real vulnerabilities block a merge, so its own
+      # logic is tested — including that an unusable npm audit payload fails
+      # closed rather than reporting a clean tree.
+      - name: Audit gate tests
+        run: node --test scripts/frontend/test_audit_gate.mjs
+
       - name: Security audit (high+)
         run: node scripts/frontend/audit-gate.mjs
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -31,11 +31,16 @@ jobs:
         run: npm ci
 
       # Regression gate (audit-ci-07): fail if any high/critical advisory is
-      # reintroduced. The 41 moderate advisories (Expo SDK 52 toolchain) are
-      # below this threshold and tracked for the SDK upgrade.
+      # reintroduced. The moderate advisories (Expo SDK 52 toolchain) are below
+      # this threshold and tracked for the SDK upgrade.
+      #
+      # Runs through audit-gate.mjs rather than `npm audit --audit-level=high`
+      # directly: a single unfixable transitive advisory would otherwise force
+      # the whole gate off. The gate narrows exceptions to specific GHSA ids
+      # listed in frontend/.audit-allowlist.json, each with an expiry it
+      # enforces — everything else still fails.
       - name: Security audit (high+)
-        working-directory: frontend
-        run: npm audit --audit-level=high
+        run: node scripts/frontend/audit-gate.mjs
 
       - name: Lint
         working-directory: frontend

--- a/frontend/.audit-allowlist.json
+++ b/frontend/.audit-allowlist.json
@@ -1,0 +1,19 @@
+{
+  "$comment": [
+    "Advisories deliberately not failing the high+ audit gate, each scoped to one",
+    "GHSA id and each with a hard expiry the gate ENFORCES. An expired entry fails",
+    "the build exactly like an unallowlisted advisory would — the time box is real,",
+    "not a comment. Adding an entry here is an owner-level policy decision, not an",
+    "engineering convenience: everything else, including anything newly introduced,",
+    "still fails the gate. See scripts/frontend/audit-gate.mjs."
+  ],
+  "allow": [
+    {
+      "id": "GHSA-mh99-v99m-4gvg",
+      "package": "brace-expansion",
+      "expires": "2026-10-22",
+      "issue": 1975,
+      "reason": "Patched only in brace-expansion@5.0.8 with no 1.1.x/2.x backport (latest 2.x is 2.1.2). Unreachable: eslint-plugin-react@7.37.5 is the latest published version and pins minimatch ^3.1.2, and minimatch@3 calls brace-expansion as a function while v5 exports a non-callable __esModule object. Probed across the whole Expo ladder (SDK 52 -> 53 -> 57 ceiling); the advisory survives every rung, so #885 does not fix it. A blanket brace-expansion@5.0.8 override makes the audit pass and provably breaks the toolchain (minimatch@3.1.5 throws 'expand is not a function' at call time, after lint and tests look green)."
+    }
+  ]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14899,9 +14899,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -15786,9 +15786,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15805,7 +15805,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -93,6 +93,7 @@
     "brace-expansion@2": "2.1.2",
     "brace-expansion@5": "5.0.7",
     "js-yaml@3": "3.15.0",
-    "js-yaml@4": "4.3.0"
+    "js-yaml@4": "4.3.0",
+    "postcss": "^8.5.23"
   }
 }

--- a/scripts/frontend/audit-gate.mjs
+++ b/scripts/frontend/audit-gate.mjs
@@ -8,16 +8,78 @@
 // exactly like an unallowlisted advisory, so a suppression cannot quietly
 // become permanent.
 //
-// Exit codes: 0 clean, 1 gate failed, 2 could not run the audit.
+// Fails CLOSED. `npm audit` exits non-zero both when it finds advisories and
+// when it could not run at all (registry unreachable, auth failure, corrupt
+// lockfile), and the latter yields a payload with an `error` and no
+// `vulnerabilities`. Reading that as "no advisories" would make the security
+// backstop pass precisely when it learned nothing, so an unusable payload
+// exits UNAVAILABLE rather than CLEAN.
+//
+// Logic is exported for scripts/frontend/test_audit_gate.mjs; running the file
+// directly performs the check.
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { argv } from "node:process";
 import { fileURLToPath } from "node:url";
 
-const FRONTEND_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = join(HERE, "..", "..", "frontend");
 const ALLOWLIST_PATH = join(FRONTEND_DIR, ".audit-allowlist.json");
 const BLOCKING_SEVERITIES = new Set(["high", "critical"]);
+
+export const EXIT = { CLEAN: 0, FAILED: 1, UNAVAILABLE: 2 };
+
+/**
+ * Collect every GHSA id at high or critical severity, with the packages it
+ * reaches. npm nests the real advisory under each vulnerability's `via`;
+ * string entries there are pointers to other packages, not advisories.
+ */
+export function advisoryReport(report) {
+  const found = new Map();
+  for (const [name, vuln] of Object.entries(report?.vulnerabilities ?? {})) {
+    for (const via of vuln?.via ?? []) {
+      if (typeof via !== "object" || via === null) continue;
+      if (!BLOCKING_SEVERITIES.has(via.severity)) continue;
+      const id = via.url?.split("/").pop() ?? via.source?.toString() ?? via.title;
+      if (!found.has(id)) found.set(id, { title: via.title, packages: new Set() });
+      found.get(id).packages.add(name);
+    }
+  }
+  return found;
+}
+
+/** True when the payload cannot be trusted to describe the dependency tree. */
+function isUnusable(report) {
+  if (typeof report !== "object" || report === null) return true;
+  if (report.error) return true;
+  // A genuinely clean tree still reports `vulnerabilities: {}`; a missing key
+  // means npm did not get far enough to tell us anything.
+  return typeof report.vulnerabilities !== "object" || report.vulnerabilities === null;
+}
+
+/**
+ * Decide the gate outcome. Pure — takes the audit payload, the allowlist, and
+ * today's date, and returns what failed and why.
+ */
+export function evaluate({ report, allowlist, today }) {
+  if (isUnusable(report)) {
+    return { exitCode: EXIT.UNAVAILABLE, expired: [], unallowed: [], suppressed: [] };
+  }
+
+  const expired = allowlist.filter((entry) => entry.expires <= today);
+  const active = new Set(
+    allowlist.filter((entry) => entry.expires > today).map((entry) => entry.id),
+  );
+
+  const advisories = [...advisoryReport(report)];
+  const unallowed = advisories.filter(([id]) => !active.has(id));
+  const suppressed = advisories.filter(([id]) => active.has(id));
+  const exitCode = expired.length > 0 || unallowed.length > 0 ? EXIT.FAILED : EXIT.CLEAN;
+
+  return { exitCode, expired, unallowed, suppressed };
+}
 
 /** Run `npm audit --json`, which exits non-zero whenever findings exist. */
 function runAudit() {
@@ -31,76 +93,72 @@ function runAudit() {
     );
   } catch (error) {
     if (typeof error.stdout === "string" && error.stdout.trim()) {
-      return JSON.parse(error.stdout);
+      try {
+        return JSON.parse(error.stdout);
+      } catch {
+        return null; // Unparseable output — isUnusable() turns this into EXIT.UNAVAILABLE.
+      }
     }
     console.error(`audit-gate: could not run npm audit — ${error.message}`);
-    process.exit(2);
+    return null;
   }
 }
 
 function loadAllowlist() {
   try {
-    const parsed = JSON.parse(readFileSync(ALLOWLIST_PATH, "utf8"));
-    return parsed.allow ?? [];
+    return JSON.parse(readFileSync(ALLOWLIST_PATH, "utf8")).allow ?? [];
   } catch {
     return [];
   }
 }
 
-/**
- * Collect every GHSA id at high or critical severity, with the packages it
- * reaches. npm nests the real advisory under each vulnerability's `via`.
- */
-function blockingAdvisories(report) {
-  const found = new Map();
-  for (const [name, vuln] of Object.entries(report.vulnerabilities ?? {})) {
-    for (const via of vuln.via ?? []) {
-      if (typeof via !== "object" || !BLOCKING_SEVERITIES.has(via.severity)) continue;
-      const id = via.url?.split("/").pop() ?? via.source?.toString() ?? via.title;
-      if (!found.has(id)) found.set(id, { title: via.title, packages: new Set() });
-      found.get(id).packages.add(name);
-    }
+function main() {
+  const report = runAudit();
+  const allowlist = loadAllowlist();
+  const today = new Date().toISOString().slice(0, 10);
+  const { exitCode, expired, unallowed, suppressed } = evaluate({ report, allowlist, today });
+
+  if (exitCode === EXIT.UNAVAILABLE) {
+    console.error(
+      "audit-gate: npm audit did not return a usable report (registry, auth, or lockfile\n" +
+        "  problem — not a clean tree). Failing closed: a gate that passes when it learned\n" +
+        "  nothing is worse than no gate at all.",
+    );
+    return EXIT.UNAVAILABLE;
   }
-  return found;
-}
 
-const today = new Date().toISOString().slice(0, 10);
-const allowlist = loadAllowlist();
-const expired = allowlist.filter((entry) => entry.expires <= today);
-const active = new Set(
-  allowlist.filter((entry) => entry.expires > today).map((entry) => entry.id),
-);
+  for (const entry of expired) {
+    console.error(
+      `audit-gate: allowlist entry ${entry.id} (${entry.package}) EXPIRED on ${entry.expires}.\n` +
+        `  The time box is up. Re-evaluate the advisory — see issue #${entry.issue}.\n` +
+        `  Extending a suppression is a policy decision, not an engineering one: ask the owner.`,
+    );
+  }
 
-const advisories = blockingAdvisories(runAudit());
-const unallowed = [...advisories].filter(([id]) => !active.has(id));
+  for (const [id, { title, packages }] of unallowed) {
+    console.error(`audit-gate: ${id} — ${title}\n  reaches: ${[...packages].sort().join(", ")}`);
+  }
 
-for (const entry of expired) {
-  console.error(
-    `audit-gate: allowlist entry ${entry.id} (${entry.package}) EXPIRED on ${entry.expires}.\n` +
-      `  The time box is up. Re-evaluate the advisory — see issue #${entry.issue}.\n` +
-      `  Extending a suppression is a policy decision, not an engineering one: ask the owner.`,
+  for (const [id] of suppressed) {
+    const entry = allowlist.find((candidate) => candidate.id === id);
+    console.warn(`audit-gate: allowing ${id} until ${entry.expires} (tracked in #${entry.issue})`);
+  }
+
+  if (exitCode === EXIT.FAILED) {
+    console.error(
+      `\naudit-gate: FAILED — ${unallowed.length} unallowed high/critical advisor${
+        unallowed.length === 1 ? "y" : "ies"
+      }, ${expired.length} expired allowlist entr${expired.length === 1 ? "y" : "ies"}.`,
+    );
+    return EXIT.FAILED;
+  }
+
+  console.log(
+    `audit-gate: clean — no unallowed high/critical advisories (${suppressed.length} allowlisted).`,
   );
+  return EXIT.CLEAN;
 }
 
-for (const [id, { title, packages }] of unallowed) {
-  console.error(`audit-gate: ${id} — ${title}\n  reaches: ${[...packages].sort().join(", ")}`);
+if (argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main());
 }
-
-const suppressed = [...advisories].filter(([id]) => active.has(id));
-for (const [id] of suppressed) {
-  const entry = allowlist.find((candidate) => candidate.id === id);
-  console.warn(`audit-gate: allowing ${id} until ${entry.expires} (tracked in #${entry.issue})`);
-}
-
-if (expired.length > 0 || unallowed.length > 0) {
-  console.error(
-    `\naudit-gate: FAILED — ${unallowed.length} unallowed high/critical advisor${
-      unallowed.length === 1 ? "y" : "ies"
-    }, ${expired.length} expired allowlist entr${expired.length === 1 ? "y" : "ies"}.`,
-  );
-  process.exit(1);
-}
-
-console.log(
-  `audit-gate: clean — no unallowed high/critical advisories (${suppressed.length} allowlisted).`,
-);

--- a/scripts/frontend/audit-gate.mjs
+++ b/scripts/frontend/audit-gate.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// High+ npm audit gate with a per-advisory allowlist.
+//
+// `npm audit --audit-level=high` is all-or-nothing: one unfixable transitive
+// advisory turns the whole gate off for everyone. This keeps the gate on and
+// narrows the exception to specific GHSA ids, each of which must carry an
+// expiry date that this script enforces — an expired entry fails the build
+// exactly like an unallowlisted advisory, so a suppression cannot quietly
+// become permanent.
+//
+// Exit codes: 0 clean, 1 gate failed, 2 could not run the audit.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+const ALLOWLIST_PATH = join(FRONTEND_DIR, ".audit-allowlist.json");
+const BLOCKING_SEVERITIES = new Set(["high", "critical"]);
+
+/** Run `npm audit --json`, which exits non-zero whenever findings exist. */
+function runAudit() {
+  try {
+    return JSON.parse(
+      execFileSync("npm", ["audit", "--json"], {
+        cwd: FRONTEND_DIR,
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      }),
+    );
+  } catch (error) {
+    if (typeof error.stdout === "string" && error.stdout.trim()) {
+      return JSON.parse(error.stdout);
+    }
+    console.error(`audit-gate: could not run npm audit — ${error.message}`);
+    process.exit(2);
+  }
+}
+
+function loadAllowlist() {
+  try {
+    const parsed = JSON.parse(readFileSync(ALLOWLIST_PATH, "utf8"));
+    return parsed.allow ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect every GHSA id at high or critical severity, with the packages it
+ * reaches. npm nests the real advisory under each vulnerability's `via`.
+ */
+function blockingAdvisories(report) {
+  const found = new Map();
+  for (const [name, vuln] of Object.entries(report.vulnerabilities ?? {})) {
+    for (const via of vuln.via ?? []) {
+      if (typeof via !== "object" || !BLOCKING_SEVERITIES.has(via.severity)) continue;
+      const id = via.url?.split("/").pop() ?? via.source?.toString() ?? via.title;
+      if (!found.has(id)) found.set(id, { title: via.title, packages: new Set() });
+      found.get(id).packages.add(name);
+    }
+  }
+  return found;
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const allowlist = loadAllowlist();
+const expired = allowlist.filter((entry) => entry.expires <= today);
+const active = new Set(
+  allowlist.filter((entry) => entry.expires > today).map((entry) => entry.id),
+);
+
+const advisories = blockingAdvisories(runAudit());
+const unallowed = [...advisories].filter(([id]) => !active.has(id));
+
+for (const entry of expired) {
+  console.error(
+    `audit-gate: allowlist entry ${entry.id} (${entry.package}) EXPIRED on ${entry.expires}.\n` +
+      `  The time box is up. Re-evaluate the advisory — see issue #${entry.issue}.\n` +
+      `  Extending a suppression is a policy decision, not an engineering one: ask the owner.`,
+  );
+}
+
+for (const [id, { title, packages }] of unallowed) {
+  console.error(`audit-gate: ${id} — ${title}\n  reaches: ${[...packages].sort().join(", ")}`);
+}
+
+const suppressed = [...advisories].filter(([id]) => active.has(id));
+for (const [id] of suppressed) {
+  const entry = allowlist.find((candidate) => candidate.id === id);
+  console.warn(`audit-gate: allowing ${id} until ${entry.expires} (tracked in #${entry.issue})`);
+}
+
+if (expired.length > 0 || unallowed.length > 0) {
+  console.error(
+    `\naudit-gate: FAILED — ${unallowed.length} unallowed high/critical advisor${
+      unallowed.length === 1 ? "y" : "ies"
+    }, ${expired.length} expired allowlist entr${expired.length === 1 ? "y" : "ies"}.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `audit-gate: clean — no unallowed high/critical advisories (${suppressed.length} allowlisted).`,
+);

--- a/scripts/frontend/check-all.sh
+++ b/scripts/frontend/check-all.sh
@@ -22,10 +22,11 @@ Usage: $(basename "$0") [OPTIONS]
 Run all quality checks in sequence.
 
 Runs:
-  1. Linting (ESLint)
-  2. Formatting (Prettier)
-  3. Type checking (TypeScript)
-  4. Tests (Jest)
+  1. Security audit (npm audit, high+, via audit-gate.mjs)
+  2. Linting (ESLint)
+  3. Formatting (Prettier)
+  4. Type checking (TypeScript)
+  5. Tests (Jest)
 
 OPTIONS:
     --verbose   Show detailed output
@@ -75,6 +76,10 @@ run_check() {
     echo ""
 }
 
+# Mirrors the CI job's first step. Without it, check-all.sh could report green
+# while CI's audit gate failed on the same commit — which is exactly what
+# happened on the Gumroad onboarding PR.
+run_check "Security audit" "audit-gate.mjs"
 run_check "Linting" "lint.sh" --check
 run_check "Formatting" "format.sh" --check
 run_check "Type checking" "typecheck.sh"

--- a/scripts/frontend/test_audit_gate.mjs
+++ b/scripts/frontend/test_audit_gate.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Tests for the high+ audit gate. Run: node --test scripts/frontend/
+//
+// This gate decides whether real vulnerabilities block a merge, so the cases
+// that matter most are the ones where it must NOT say "clean": an expired
+// allowlist entry, an advisory nobody allowlisted, and — the subtle one — an
+// npm audit that failed for a reason unrelated to vulnerabilities.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { advisoryReport, evaluate, EXIT } from "./audit-gate.mjs";
+
+const GHSA_ALLOWED = "GHSA-mh99-v99m-4gvg";
+const GHSA_OTHER = "GHSA-6g55-p6wh-862q";
+const TODAY = "2026-07-24";
+
+/** Minimal shape of `npm audit --json`: the advisory lives under `via`. */
+function reportWith(...advisories) {
+  const vulnerabilities = {};
+  for (const { pkg, id, severity, title } of advisories) {
+    vulnerabilities[pkg] = {
+      via: [{ url: `https://github.com/advisories/${id}`, severity, title: title ?? id }],
+    };
+  }
+  return { vulnerabilities };
+}
+
+const allowlist = [
+  { id: GHSA_ALLOWED, package: "brace-expansion", expires: "2026-10-22", issue: 1975 },
+];
+
+test("an allowlisted advisory is suppressed and the gate passes", () => {
+  const result = evaluate({
+    report: reportWith({ pkg: "brace-expansion", id: GHSA_ALLOWED, severity: "high" }),
+    allowlist,
+    today: TODAY,
+  });
+
+  assert.equal(result.exitCode, EXIT.CLEAN);
+  assert.deepEqual(
+    result.suppressed.map(([id]) => id),
+    [GHSA_ALLOWED],
+  );
+  assert.equal(result.unallowed.length, 0);
+});
+
+test("an advisory nobody allowlisted fails the gate", () => {
+  const result = evaluate({
+    report: reportWith({ pkg: "postcss", id: GHSA_OTHER, severity: "high" }),
+    allowlist,
+    today: TODAY,
+  });
+
+  assert.equal(result.exitCode, EXIT.FAILED);
+  assert.deepEqual(
+    result.unallowed.map(([id]) => id),
+    [GHSA_OTHER],
+  );
+});
+
+test("critical severity blocks just like high", () => {
+  const result = evaluate({
+    report: reportWith({ pkg: "postcss", id: GHSA_OTHER, severity: "critical" }),
+    allowlist,
+    today: TODAY,
+  });
+
+  assert.equal(result.exitCode, EXIT.FAILED);
+});
+
+test("moderate and low advisories are below the gate", () => {
+  const result = evaluate({
+    report: reportWith(
+      { pkg: "tar", id: "GHSA-r292-9mhp-454m", severity: "moderate" },
+      { pkg: "uuid", id: "GHSA-w5hq-g745-h8pq", severity: "low" },
+    ),
+    allowlist,
+    today: TODAY,
+  });
+
+  assert.equal(result.exitCode, EXIT.CLEAN);
+  assert.equal(result.unallowed.length, 0);
+});
+
+test("an expired allowlist entry fails even though the advisory is listed", () => {
+  const result = evaluate({
+    report: reportWith({ pkg: "brace-expansion", id: GHSA_ALLOWED, severity: "high" }),
+    allowlist,
+    today: "2026-10-23",
+  });
+
+  assert.equal(result.exitCode, EXIT.FAILED);
+  assert.deepEqual(
+    result.expired.map((entry) => entry.id),
+    [GHSA_ALLOWED],
+  );
+});
+
+test("an entry expiring today is already expired — the boundary does not grant a free day", () => {
+  const result = evaluate({
+    report: reportWith({ pkg: "brace-expansion", id: GHSA_ALLOWED, severity: "high" }),
+    allowlist,
+    today: "2026-10-22",
+  });
+
+  assert.equal(result.exitCode, EXIT.FAILED);
+});
+
+test("an expired entry fails even when its advisory is no longer in the tree", () => {
+  const result = evaluate({ report: reportWith(), allowlist, today: "2026-10-23" });
+
+  assert.equal(result.exitCode, EXIT.FAILED);
+  assert.equal(result.expired.length, 1);
+});
+
+test("a clean tree with a live allowlist entry passes", () => {
+  const result = evaluate({ report: reportWith(), allowlist, today: TODAY });
+
+  assert.equal(result.exitCode, EXIT.CLEAN);
+});
+
+// The regression that matters most: npm can exit non-zero for reasons that have
+// nothing to do with vulnerabilities (registry unreachable, auth failure,
+// corrupt lockfile). Its JSON payload then carries an `error` and no
+// `vulnerabilities` key. Treating that as "no advisories found" would turn the
+// security backstop fail-open, which is strictly worse than the plain
+// `npm audit --audit-level=high` this gate replaced.
+test("an errored audit payload fails closed rather than reporting clean", () => {
+  const result = evaluate({
+    report: { error: { code: "ENETUNREACH", summary: "request to registry failed" } },
+    allowlist,
+    today: TODAY,
+  });
+
+  assert.equal(result.exitCode, EXIT.UNAVAILABLE);
+});
+
+test("an audit payload missing vulnerabilities entirely fails closed", () => {
+  const result = evaluate({ report: {}, allowlist, today: TODAY });
+
+  assert.equal(result.exitCode, EXIT.UNAVAILABLE);
+});
+
+test("a non-object payload fails closed", () => {
+  const result = evaluate({ report: null, allowlist, today: TODAY });
+
+  assert.equal(result.exitCode, EXIT.UNAVAILABLE);
+});
+
+test("advisories are keyed by GHSA id and collect every package they reach", () => {
+  const report = {
+    vulnerabilities: {
+      minimatch: {
+        via: [{ url: `https://github.com/advisories/${GHSA_ALLOWED}`, severity: "high", title: "t" }],
+      },
+      glob: {
+        via: [{ url: `https://github.com/advisories/${GHSA_ALLOWED}`, severity: "high", title: "t" }],
+      },
+    },
+  };
+
+  const found = advisoryReport(report);
+
+  assert.deepEqual([...found.keys()], [GHSA_ALLOWED]);
+  assert.deepEqual([...found.get(GHSA_ALLOWED).packages].sort(), ["glob", "minimatch"]);
+});
+
+test("string `via` entries (transitive pointers, not advisories) are ignored", () => {
+  const report = { vulnerabilities: { glob: { via: ["minimatch"] } } };
+
+  assert.equal(advisoryReport(report).size, 0);
+});


### PR DESCRIPTION
## Summary

Frontend CI has been red on `main` itself — `cd frontend && npm audit --audit-level=high` exits 1 with 60 vulnerabilities (9 moderate, 51 high) — so **every** frontend PR failed Gate 3 regardless of its contents. PR #1972 is complete and Gate-2.5 CLEAN but unmergeable behind it.

`npm audit --audit-level=high` is all-or-nothing: one unfixable transitive advisory switches the entire gate off for everyone. This replaces it with `scripts/frontend/audit-gate.mjs`, which **keeps the gate on** and narrows exceptions to specific GHSA ids listed in `frontend/.audit-allowlist.json`. Every other advisory — including anything newly introduced — still fails.

**The time box is enforced, not documented.** Each allowlist entry carries an `expires` date, and an expired entry fails the build exactly like an unallowlisted advisory. A suppression cannot quietly become permanent.

### One allowlisted advisory (owner-approved)

`GHSA-mh99-v99m-4gvg` (`brace-expansion`), expiring **2026-10-22**, tracked for removal in #1975. It is genuinely unreachable, verified against the live registry rather than inferred:

- Patched only in `5.0.8`. No `1.1.x` or `2.x` backport exists — latest 2.x is `2.1.2`.
- `eslint-plugin-react@7.37.5` **is the latest published version** and still pins `minimatch ^3.1.2`; `minimatch@3` calls `brace-expansion` as a function, while v5 exports a non-callable `__esModule` object. There is nowhere to upgrade to.
- Probed across the whole Expo ladder: baseline 51 high → overrides 49 → SDK 53: 47 → SDK 57 ceiling (RN 0.83.10 / React 19.2 / eslint 10 / jest 30): 28–33. It survives every rung, and at the ceiling Expo's own packages drop out entirely. This was never an Expo problem, so #885 does not fix it.

⚠️ **A blanket `"brace-expansion": "5.0.8"` override makes the audit exit 0 and produces a provably broken toolchain** — `minimatch@3.1.5` throws `TypeError: expand is not a function`. It fails at call time, so lint and tests still look green. That trap is documented in the allowlist entry and in #1975 so the next person doesn't reach for it.

### PostCSS was *not* allowlisted — it was fixed

The two PostCSS advisories (`GHSA-6g55-p6wh-862q`, `GHSA-r28c-9q8g-f849`) are genuinely fixable, so they get a real upgrade instead of an exception: `postcss` overridden to `^8.5.23` (same major; installed was `8.4.49`). The gate surfaced them individually, which the old all-or-nothing command could not.

### Closing a real reporting gap

`check-all.sh` never ran an audit, which is exactly why #1972 could honestly report "`check-all.sh` → exit 0" while CI's audit step failed on the same commit — the reviewer flagged that contradiction. The gate now runs as check #1 locally, mirroring the CI job.

## Test plan

- `node scripts/frontend/audit-gate.mjs` → exit **0**, reporting `1 allowlisted`. Before the postcss override it correctly exited 1 on the two PostCSS advisories while already suppressing the allowlisted one — so the scoping demonstrably works in both directions.
- `./scripts/frontend/check-all.sh` → exit 0, all **5** checks green (Security audit, Linting, Formatting, Type checking, Tests: 437 suites / 4950 tests).
- `npm ci` clean; `npm ls postcss --all` confirms `postcss@8.5.23` resolved.
- `pre-commit run --files <changed>` → green.
- Registry claims verified live: `npm view brace-expansion versions`, `npm view eslint-plugin-react version`, `npm view eslint-plugin-react@latest dependencies.minimatch`.

Unblocks #1972. Refs #885, #1974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
