### PR TITLE
feat(backend): credit offering_balance for Gumroad token-pack sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ uvicorn src.main:app --reload
 
 To exercise the Gumroad integration (license verification and the sale
 webhook), set `GUMROAD_API_TOKEN`, `GUMROAD_WEBHOOK_SECRET`,
-`GUMROAD_APTITUDE_PRODUCT_IDS`, and `GUMROAD_TOKEN_PACK_PRODUCT_IDS` — see
+`GUMROAD_APTITUDE_PRODUCT_IDS`, `GUMROAD_TOKEN_PACK_PRODUCT_IDS`, and
+`GUMROAD_TOKEN_PACK_SIZES` — see
 `backend/.env.example` for what each does and the [Gumroad API docs](https://gumroad.com/api)
 for how to obtain a seller token.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -59,11 +59,22 @@ LLM_MODEL=  # Model override, allowlisted per provider (defaults: gpt-4o-mini / 
 # Never commit a real value for either.
 GUMROAD_API_TOKEN=  # Gumroad seller API token for license verification
 GUMROAD_WEBHOOK_SECRET=  # Shared secret matched against the ping's ?secret= query param
-# Comma-separated allowlists consumed by later features that gate on which
-# Gumroad product a license/sale belongs to; unused by the webhook or
-# license-verification client themselves today.
+# Comma-separated allowlists classifying which Gumroad product a license or
+# sale belongs to. Both are read at request time, so rotating a product ID
+# needs no restart, and both fail closed: unset means the allowlist matches
+# nothing. Neither is part of the all-or-nothing credentials check above --
+# a deployment that sells no token packs must still boot.
+#
+# GUMROAD_APTITUDE_PRODUCT_IDS gates the course-access grant (license-gated
+# signup and the sale webhook). GUMROAD_TOKEN_PACK_PRODUCT_IDS marks which
+# products are BotMason credit packs, and GUMROAD_TOKEN_PACK_SIZES prices
+# them as product_id:count entries. The two are separate on purpose: a
+# product on the allowlist but absent from the sizes map credits NOTHING
+# (logged as token_pack_size_unconfigured) rather than guessing an amount.
+# Sizes must be positive integers; any other entry is dropped, not defaulted.
 GUMROAD_APTITUDE_PRODUCT_IDS=  # APTITUDE course product IDs, e.g. abc123,def456
 GUMROAD_TOKEN_PACK_PRODUCT_IDS=  # Token-pack product IDs, e.g. ghi789,jkl012
+GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -63,6 +63,7 @@ _RAW_SQL_MANAGED_INDEXES: frozenset[str] = frozenset(
         "ix_practice_preset_stage_lower_name_unique",  # d2e3f4a5b6c7: lower(trim(name)) WHERE submitted_by_user_id IS NULL
         "ix_coursestage_stage_number_unique",  # e8f9a0b1c2d3: (stage_number)
         "ix_stagecontent_stage_content_ref_unique",  # e8f9a0b1c2d3: (course_stage_id, url) WHERE url LIKE 'content://%'
+        "ix_gumroadsale_lower_email",  # b8c9d0e1f2a3: lower(email)
     }
 )
 

--- a/backend/migrations/versions/b8c9d0e1f2a3_gumroad_sale_token_pack_credit.py
+++ b/backend/migrations/versions/b8c9d0e1f2a3_gumroad_sale_token_pack_credit.py
@@ -1,0 +1,70 @@
+"""Add the token-pack credit claim columns to gumroadsale.
+
+Revision ID: b8c9d0e1f2a3
+Revises: a6b7c8d9e0f1
+Create Date: 2026-07-24 00:00:00.000000
+
+Issue #1944: a Gumroad token-pack sale credits the buyer's BotMason
+``offering_balance`` exactly once. ``token_pack_credited_at`` is the claim
+guard a crediting transaction takes with a single
+``UPDATE ... WHERE token_pack_credited_at IS NULL``;
+``token_pack_credited_user_id`` records which account received the credits
+(``ON DELETE SET NULL`` so the trail outlives the account, matching
+``walletaudit.actor_user_id``).
+
+Purely additive. Every pre-existing row lands ``NULL`` on both columns, i.e.
+unclaimed — which is correct: no token pack has ever been sold, because this
+change is the first consumer of the token-pack product allowlist.
+
+The non-unique functional index on ``lower(email)`` backs the signup-time
+sweep, which looks up every waiting sale for a freshly-created account
+case-insensitively.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8c9d0e1f2a3"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "a6b7c8d9e0f1"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "gumroadsale"
+_CREDITED_AT_COLUMN = "token_pack_credited_at"
+_CREDITED_USER_COLUMN = "token_pack_credited_user_id"
+_CREDITED_USER_INDEX = "ix_gumroadsale_token_pack_credited_user_id"
+_CREDITED_USER_FK = "gumroadsale_token_pack_credited_user_id_fkey"
+_LOWER_EMAIL_INDEX = "ix_gumroadsale_lower_email"
+
+
+def upgrade() -> None:
+    """Add both claim columns, the actor FK, and the lower(email) lookup index."""
+    # Batch mode keeps this SQLite-safe (table rebuild) while emitting plain
+    # ALTERs on Postgres, which is what production runs.
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(
+            sa.Column(_CREDITED_AT_COLUMN, sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.add_column(sa.Column(_CREDITED_USER_COLUMN, sa.Integer(), nullable=True))
+        batch_op.create_index(_CREDITED_USER_INDEX, [_CREDITED_USER_COLUMN])
+        batch_op.create_foreign_key(
+            _CREDITED_USER_FK,
+            "user",
+            [_CREDITED_USER_COLUMN],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    op.create_index(_LOWER_EMAIL_INDEX, _TABLE, [sa.text("lower(email)")])
+
+
+def downgrade() -> None:
+    """Drop the lookup index, then the FK, its index, and both columns."""
+    op.drop_index(_LOWER_EMAIL_INDEX, table_name=_TABLE)
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_constraint(_CREDITED_USER_FK, type_="foreignkey")
+        batch_op.drop_index(_CREDITED_USER_INDEX)
+        batch_op.drop_column(_CREDITED_USER_COLUMN)
+        batch_op.drop_column(_CREDITED_AT_COLUMN)

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -1,9 +1,19 @@
-"""Course-access entitlement domain logic: grant, check, revoke, verify.
+"""Gumroad product classification plus course-access entitlement logic.
 
-The grant is idempotent (at most one active ``course_access`` row per user,
-backed by the partial unique index on the model) and every grant / revoke
-emits a structured log line carrying a ``reason_code`` — never a raw email
-or license key, only ids.
+Two concerns live together here on purpose. The first is classifying what a
+Gumroad product id *is* — the APTITUDE course
+(``GUMROAD_APTITUDE_PRODUCT_IDS``) or a BotMason token pack
+(``GUMROAD_TOKEN_PACK_PRODUCT_IDS`` plus its per-product sizes in
+``GUMROAD_TOKEN_PACK_SIZES``). One module owning every allowlist is what
+keeps the classifications from drifting apart, so a product can never both
+grant the course and mint credits by accident. Every allowlist is read at
+call time, so a rotation needs no restart, and every one fails closed: unset
+means "matches nothing".
+
+The second is the course-access entitlement itself: the grant is idempotent
+(at most one active ``course_access`` row per user, backed by the partial
+unique index on the model) and every grant / revoke emits a structured log
+line carrying a ``reason_code`` — never a raw email or license key, only ids.
 
 :func:`verify_aptitude_license` is the signup gate's verifier: it walks the
 ``GUMROAD_APTITUDE_PRODUCT_IDS`` allowlist calling the Gumroad client's
@@ -43,13 +53,18 @@ __all__ = [
     "REASON_REFUND",
     "REASON_SIGNUP_REDEMPTION",
     "REASON_WEBHOOK_SALE",
+    "TOKEN_PACK_PRODUCT_IDS_ENV_VAR",
+    "TOKEN_PACK_SIZES_ENV_VAR",
     "AptitudeLicenseCheck",
     "GumroadUnavailableError",
     "LicenseOutcome",
     "grant_course_access",
     "has_course_access",
     "is_aptitude_product_id",
+    "is_token_pack_product_id",
     "revoke_course_access",
+    "token_pack_product_ids",
+    "token_pack_size",
     "verify_aptitude_license",
 ]
 
@@ -71,6 +86,23 @@ REASON_EMAIL_MISMATCH = "email_mismatch"
 # tests can monkeypatch the environment).
 PRODUCT_IDS_ENV_VAR = "GUMROAD_APTITUDE_PRODUCT_IDS"
 _PRODUCT_IDS_SEPARATOR = ","
+
+# The token-pack half of the classification: which products are credit packs,
+# and how many credits each one is worth. Kept as two variables because the
+# allowlist is the security gate (is this a pack at all?) while the size map
+# is the money (how much?) — an operator can add a product to the allowlist
+# and see it credit nothing until they price it, rather than have a typo in
+# one variable silently mint an unintended amount.
+#
+# Both values are environment-variable *names*, not credentials; S105 fires
+# only because the constant names contain "token", the same false positive
+# ``_SECRET_PLACEHOLDER`` in the auth router silences.
+TOKEN_PACK_PRODUCT_IDS_ENV_VAR = "GUMROAD_TOKEN_PACK_PRODUCT_IDS"  # noqa: S105  # nosec B105  # pragma: allowlist secret
+TOKEN_PACK_SIZES_ENV_VAR = "GUMROAD_TOKEN_PACK_SIZES"  # noqa: S105  # nosec B105  # pragma: allowlist secret
+# ``GUMROAD_TOKEN_PACK_SIZES`` is ``product_id:count`` entries joined by
+# ``_PRODUCT_IDS_SEPARATOR``. Gumroad product ids never contain a colon, so
+# the first colon is an unambiguous field boundary.
+_SIZE_FIELD_SEPARATOR = ":"
 
 
 class LicenseOutcome(enum.Enum):
@@ -188,17 +220,98 @@ async def revoke_course_access(session: AsyncSession, user_id: int, reason: str)
     )
 
 
-def _allowlisted_product_ids() -> list[str]:
-    """Read the APTITUDE product allowlist from the environment at call time.
+def _split_ids(raw: str) -> list[str]:
+    """Parse one comma-separated product allowlist into stripped, non-blank ids.
 
-    Splits on commas, strips whitespace, and skips blanks so trailing
-    separators in the deployment config are harmless. An unset variable
-    yields an empty allowlist, which makes every key verify as INVALID.
+    Shared by both allowlists so they cannot diverge on tolerance: padding,
+    empty entries, and a trailing separator in the deployment config are all
+    harmless, and an empty string yields an empty list rather than one blank
+    id that would match a product-less ping.
     """
-    raw = os.getenv(PRODUCT_IDS_ENV_VAR, "")
     return [
         product_id.strip() for product_id in raw.split(_PRODUCT_IDS_SEPARATOR) if product_id.strip()
     ]
+
+
+def _allowlisted_product_ids() -> list[str]:
+    """Read the APTITUDE product allowlist from the environment at call time.
+
+    An unset variable yields an empty allowlist, which makes every key verify
+    as INVALID.
+    """
+    return _split_ids(os.getenv(PRODUCT_IDS_ENV_VAR, ""))
+
+
+def token_pack_product_ids() -> list[str]:
+    """Read the token-pack product allowlist from the environment at call time.
+
+    An unset variable yields an empty allowlist, so no sale can be classified
+    as a token pack until an operator configures one.
+    """
+    return _split_ids(os.getenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, ""))
+
+
+def is_token_pack_product_id(product_id: str | None) -> bool:
+    """Return True when ``product_id`` is on the token-pack allowlist.
+
+    Mirrors :func:`is_aptitude_product_id`: a blank or unallowlisted id
+    (including an unset allowlist) returns False, so a sale of any other
+    product sold on the same Gumroad account can never mint wallet credits.
+    """
+    normalized = (product_id or "").strip()
+    return bool(normalized) and normalized in token_pack_product_ids()
+
+
+def _is_positive_count(raw: str) -> bool:
+    """Return True when ``raw`` is a plain ASCII decimal integer above zero.
+
+    ``isascii()`` rejects the non-ASCII digits ``isdigit()`` otherwise
+    accepts (full-width numerals, for instance) so the value that reaches
+    ``int()`` is always the one an operator can read back out of the config.
+    Zero and anything negative are rejected too: a non-positive pack size
+    would turn a purchase into a no-op or, worse, a debit.
+    """
+    return raw.isascii() and raw.isdigit() and int(raw) > 0
+
+
+def _parse_size_entry(entry: str) -> tuple[str, int] | None:
+    """Parse one ``product_id:count`` entry, or ``None`` when it is malformed.
+
+    Malformed entries are dropped rather than defaulted — there is no safe
+    fallback size for real money, and a neighbouring well-formed entry must
+    stay usable regardless of a typo elsewhere in the variable.
+    """
+    product_id, separator, raw_count = entry.partition(_SIZE_FIELD_SEPARATOR)
+    normalized_id = product_id.strip()
+    count = raw_count.strip()
+    if not separator or not normalized_id or not _is_positive_count(count):
+        return None
+    return normalized_id, int(count)
+
+
+def _token_pack_sizes() -> dict[str, int]:
+    """Read the token-pack size map from the environment at call time.
+
+    An unset variable yields an empty map, which makes every pack credit
+    nothing. A product id repeated across entries resolves to the right-most
+    one, matching how ``dict`` folds duplicate keys.
+    """
+    raw = os.getenv(TOKEN_PACK_SIZES_ENV_VAR, "")
+    parsed = (_parse_size_entry(entry) for entry in raw.split(_PRODUCT_IDS_SEPARATOR))
+    return dict(entry for entry in parsed if entry is not None)
+
+
+def token_pack_size(product_id: str | None) -> int | None:
+    """Return the configured credit count for ``product_id``, or ``None``.
+
+    ``None`` means "no size is configured", which every caller must treat as
+    "credit nothing" — a missing or malformed size is never substituted with
+    a default. A blank or absent id answers ``None`` rather than raising.
+    """
+    normalized = (product_id or "").strip()
+    if not normalized:
+        return None
+    return _token_pack_sizes().get(normalized)
 
 
 def is_aptitude_product_id(product_id: str | None) -> bool:

--- a/backend/src/models/gumroad_sale.py
+++ b/backend/src/models/gumroad_sale.py
@@ -5,12 +5,21 @@ collapse onto the existing row. The typed columns cover the fields current
 features read; ``raw_payload`` keeps the posted form intact (string values
 stay strings) so later features can re-derive anything else without asking
 Gumroad to resend history.
+
+The row also carries the token-pack credit claim: ``token_pack_credited_at``
+is the exactly-once guard a wallet credit takes before moving any money, and
+``token_pack_credited_user_id`` records which account received it.
 """
 
 from datetime import UTC, datetime
 
 from sqlalchemy import JSON, Column, DateTime
 from sqlmodel import Field, SQLModel
+
+# Gumroad's ``resource_name`` for a purchase event — the only ping that
+# carries an entitlement or wallet side effect. Public so the router and the
+# token-pack sweep filter on one spelling.
+SALE_RESOURCE_NAME = "sale"
 
 
 class GumroadSale(SQLModel, table=True):
@@ -33,4 +42,23 @@ class GumroadSale(SQLModel, table=True):
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
+    )
+    # The token-pack claim guard. NULL means "no wallet credit has been taken
+    # for this sale yet"; a guarded UPDATE stamps it, so only one writer can
+    # ever move the credits. It deliberately outlives the crediting account:
+    # a deleted-then-re-registered email must not re-mint the same pack.
+    token_pack_credited_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+    )
+    # Provenance for the credit — which account the pack landed in. ``SET
+    # NULL`` on user deletion mirrors ``WalletAudit.actor_user_id``: the
+    # financial trail survives the account, and the guard above still blocks
+    # a second credit.
+    token_pack_credited_user_id: int | None = Field(
+        default=None,
+        foreign_key="user.id",
+        ondelete="SET NULL",
+        index=True,
+        nullable=True,
     )

--- a/backend/src/models/wallet_audit.py
+++ b/backend/src/models/wallet_audit.py
@@ -48,6 +48,14 @@ REASON_SELF_GRANT = "self_grant"
 # the same as ``user_id`` for resets — they're scheduled
 # system-initiated mutations rather than admin actions.
 REASON_MONTHLY_RESET = "monthly_reset"
+# ``gumroad_purchase`` — a token pack the buyer paid for on Gumroad,
+# credited to ``BUCKET_OFFERING`` as a positive ``delta``.  Like the
+# monthly reset it is system-initiated, so ``actor_user_id`` equals
+# ``user_id``: nobody granted these credits, the buyer bought them.
+# Distinct from ``self_grant`` so revenue-backed credits can be summed
+# apart from courtesy top-ups, and so a later refund claw-back can find
+# exactly the rows it must reverse.
+REASON_GUMROAD_PURCHASE = "gumroad_purchase"
 
 # Bucket tokens — which side of the wallet was changed.  ``monthly`` is
 # the free per-calendar-month allocation; ``offering`` is the durable

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -53,6 +53,7 @@ from services.email import (
     EmailSender,
     get_email_sender,
 )
+from services.token_packs import claim_token_pack_sales
 from services.users import get_user_timezone
 
 if TYPE_CHECKING:
@@ -660,6 +661,9 @@ async def signup(
     generic detail with matched timing (anti-enumeration), and a Gumroad
     outage fails closed with 503.  Only the JWT leaves the backend — never
     any Gumroad verify-response field.
+
+    Once the account exists, any token pack bought under the same email
+    before signup is swept into the new wallet.
     """
     # Verify the license (a live Gumroad call) before the duplicate-email DB
     # check is deliberate: running the same first check for every email keeps an
@@ -679,6 +683,7 @@ async def signup(
         msg = "User ID unexpectedly None after database commit"
         raise RuntimeError(msg)
     await _grant_signup_entitlement(session, user, purchase)
+    await claim_token_pack_sales(session, user)
     token, _ = _create_token(user.id)
     return AuthResponse(token=token, user_id=user.id, timezone=user.timezone)
 

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -4,9 +4,14 @@ Gumroad POSTs a form-encoded "ping" for every sale-related event. The shared
 secret in the ``secret`` query parameter is checked (constant time) BEFORE the
 body is read, so an unauthenticated caller can never drive the parser. Valid
 pings are persisted verbatim into :class:`~models.gumroad_sale.GumroadSale`,
-idempotently keyed by ``sale_id``. A ``sale`` event additionally grants the
-buyer's ``course_access`` entitlement when a user with that email already
-exists — an idempotent side effect, so replays stay safe.
+idempotently keyed by ``sale_id``.
+
+A ``sale`` event additionally dispatches two side effects guarded by disjoint
+product allowlists, so at most one fires: the buyer's ``course_access``
+entitlement for an APTITUDE product, and a BotMason wallet credit for a token
+pack. Both are idempotent, so replays stay safe. The credited amount comes
+solely from the operator-configured pack-size map — never from a payload
+field, which a forged ping would control.
 
 Secrets discipline: the webhook secret, buyer email, and raw payload never
 appear in log text — only static markers and non-PII metadata do.
@@ -30,27 +35,40 @@ from domain.entitlements import (
     REASON_WEBHOOK_SALE,
     grant_course_access,
     is_aptitude_product_id,
+    is_token_pack_product_id,
+    token_pack_size,
 )
 from errors import bad_request
-from models.gumroad_sale import GumroadSale
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
 from models.user import User
+from services.token_packs import credit_token_pack_sale
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhooks/gumroad", tags=["gumroad"])
 
-# The one resource_name that carries an entitlement side effect (below).
-_SALE_RESOURCE_NAME = "sale"
-
 # resource_name values Gumroad documents for ping webhooks. Anything else is
 # still persisted (verbatim capture) but flagged with
 # ``reason_code=unhandled_event`` so operators notice new event types.
 KNOWN_RESOURCE_NAMES = frozenset(
-    {_SALE_RESOURCE_NAME, "refund", "dispute", "cancellation", "subscription_ended"}
+    {SALE_RESOURCE_NAME, "refund", "dispute", "cancellation", "subscription_ended"}
 )
 
 # Gumroad posts booleans as the form strings "true"/"false".
 _TRUE_FORM_VALUE = "true"
+
+# Payload keys this router reads by name more than once.
+_PRODUCT_ID_FIELD = "product_id"
+_EMAIL_FIELD = "email"
+_REFUNDED_FIELD = "refunded"
+
+# Structured-log reason codes for the sale-dispatch outcomes an operator
+# needs to be able to grep for. Each marks a ping that was accepted and
+# stored but deliberately moved nothing.
+_REASON_UNKNOWN_PRODUCT = "unknown_product"
+_REASON_REFUNDED_SALE = "refunded_sale"
+_REASON_SIZE_UNCONFIGURED = "token_pack_size_unconfigured"
+_REASON_PACK_CREDITED = "token_pack_credited"
 
 
 def _require_valid_secret(provided: str | None) -> None:
@@ -101,11 +119,11 @@ async def _persist_sale(session: AsyncSession, payload: dict[str, str]) -> None:
     """Insert the GumroadSale row; a concurrent replay collapses to a no-op."""
     sale = GumroadSale(
         gumroad_sale_id=payload["sale_id"],
-        product_id=payload.get("product_id", ""),
-        email=payload.get("email", ""),
+        product_id=payload.get(_PRODUCT_ID_FIELD, ""),
+        email=payload.get(_EMAIL_FIELD, ""),
         resource_name=payload.get("resource_name", ""),
         is_recurring_charge=_coerce_form_flag(payload, "is_recurring_charge"),
-        refunded=_coerce_form_flag(payload, "refunded"),
+        refunded=_coerce_form_flag(payload, _REFUNDED_FIELD),
         raw_payload=payload,
     )
     session.add(sale)
@@ -117,25 +135,34 @@ async def _persist_sale(session: AsyncSession, payload: dict[str, str]) -> None:
         await session.rollback()
 
 
+async def _find_user_by_email(session: AsyncSession, email: str) -> User | None:
+    """Return the account registered under ``email``, matched case-insensitively.
+
+    Gumroad reports the buyer's address as they typed it while accounts are
+    stored normalized, so every lookup from a ping has to fold case. A blank
+    address short-circuits rather than matching a row with an empty email.
+    """
+    normalized = email.strip().lower()
+    if not normalized:
+        return None
+    result = await session.execute(select(User).where(func.lower(User.email) == normalized))
+    return result.scalars().first()
+
+
 async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> None:
     """Grant course access for a sale ping when the buyer already signed up.
 
     Grants only for a sale of an APTITUDE product (the ping's ``product_id``
     must be on ``GUMROAD_APTITUDE_PRODUCT_IDS`` — the same allowlist the signup
     path enforces), so a future non-APTITUDE product sold on the same Gumroad
-    account never silently grants course access. Matches the buyer email
-    against stored users case-insensitively; with no match the sale row alone
-    is the outcome (the buyer's later license-gated signup converges by linking
-    to it). The grant is idempotent, so webhook replays never duplicate an
-    entitlement.
+    account never silently grants course access. With no matching user the
+    sale row alone is the outcome (the buyer's later license-gated signup
+    converges by linking to it). The grant is idempotent, so webhook replays
+    never duplicate an entitlement.
     """
-    if not is_aptitude_product_id(payload.get("product_id")):
+    if not is_aptitude_product_id(payload.get(_PRODUCT_ID_FIELD)):
         return
-    email = payload.get("email", "").strip().lower()
-    if not email:
-        return
-    user_result = await session.execute(select(User).where(func.lower(User.email) == email))
-    user = user_result.scalars().first()
+    user = await _find_user_by_email(session, payload.get(_EMAIL_FIELD, ""))
     if user is None:
         return
     sale_result = await session.execute(
@@ -143,6 +170,80 @@ async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> Non
     )
     sale = sale_result.scalars().first()
     await grant_course_access(session, user, sale=sale, reason_code=REASON_WEBHOOK_SALE)
+
+
+def _token_pack_credit_amount(payload: dict[str, str]) -> int | None:
+    """Return how many credits this ping should mint, or ``None`` for none.
+
+    Three gates, each failing closed: the product must be an allowlisted
+    token pack, the sale must not be refunded, and the pack must have a
+    configured size. The amount comes from that configured size alone —
+    never from ``price``, ``quantity``, or any other payload field, all of
+    which a forged ping would control.
+    """
+    product_id = payload.get(_PRODUCT_ID_FIELD)
+    if not is_token_pack_product_id(product_id):
+        return None
+    if _coerce_form_flag(payload, _REFUNDED_FIELD):
+        logger.info("gumroad_token_pack_skipped", extra={"reason_code": _REASON_REFUNDED_SALE})
+        return None
+    amount = token_pack_size(product_id)
+    if amount is None:
+        logger.info("gumroad_token_pack_skipped", extra={"reason_code": _REASON_SIZE_UNCONFIGURED})
+    return amount
+
+
+async def _credit_token_pack_for_sale(session: AsyncSession, payload: dict[str, str]) -> None:
+    """Credit the buyer's wallet for a sized, non-refunded token-pack sale.
+
+    With no account for the buyer's email yet the sale simply stays
+    unclaimed; the signup sweep delivers the credits when they register. The
+    credit itself is exactly-once per sale, so a replayed ping moves nothing.
+    """
+    amount = _token_pack_credit_amount(payload)
+    if amount is None:
+        return
+    user = await _find_user_by_email(session, payload.get(_EMAIL_FIELD, ""))
+    if user is None or user.id is None:
+        return
+    credited = await credit_token_pack_sale(
+        session, sale_id=payload["sale_id"], user_id=user.id, amount=amount
+    )
+    if credited is not None:
+        logger.info(
+            "gumroad_token_pack_credited",
+            extra={
+                "reason_code": _REASON_PACK_CREDITED,
+                "user_id": user.id,
+                "amount": amount,
+            },
+        )
+
+
+def _log_if_unknown_product(payload: dict[str, str]) -> None:
+    """Flag a sale whose product is on neither allowlist, since it is inert.
+
+    Both allowlists are operator configuration, so a product on neither is
+    either a new SKU nobody wired up or a rotation that dropped an id. The
+    ping is still stored verbatim; the log line is what makes the silence
+    noticeable.
+    """
+    product_id = payload.get(_PRODUCT_ID_FIELD)
+    if is_aptitude_product_id(product_id) or is_token_pack_product_id(product_id):
+        return
+    logger.info("gumroad_webhook_event", extra={"reason_code": _REASON_UNKNOWN_PRODUCT})
+
+
+async def _dispatch_sale(session: AsyncSession, payload: dict[str, str]) -> None:
+    """Run every side effect a ``sale`` ping carries, in order.
+
+    Classification first, so an unrecognised product is flagged even though
+    nothing follows it; then the course grant; then the token-pack credit.
+    The two grants are guarded by disjoint allowlists, so at most one fires.
+    """
+    _log_if_unknown_product(payload)
+    await _grant_for_sale(session, payload)
+    await _credit_token_pack_for_sale(session, payload)
 
 
 @router.post("/ping")
@@ -155,8 +256,8 @@ async def receive_ping(
 
     Always answers 200 on an authenticated, well-formed ping — including
     replays and unknown event types — so Gumroad never re-queues an event we
-    have already captured. A ``sale`` event additionally dispatches the
-    (idempotent) entitlement grant for an already-registered buyer.
+    have already captured. A ``sale`` event additionally dispatches its
+    (idempotent) entitlement grant and token-pack credit.
     """
     _require_valid_secret(secret)
     payload = await _read_ping_payload(request)
@@ -166,8 +267,8 @@ async def receive_ping(
         logger.info("gumroad_webhook_event reason_code=unhandled_event")
     if not await _sale_already_recorded(session, payload["sale_id"]):
         await _persist_sale(session, payload)
-    if resource_name == _SALE_RESOURCE_NAME:
-        await _grant_for_sale(session, payload)
+    if resource_name == SALE_RESOURCE_NAME:
+        await _dispatch_sale(session, payload)
     logger.info(
         "gumroad_webhook_accepted",
         extra={"reason_code": "accepted", "resource_name": resource_name},

--- a/backend/src/services/token_packs.py
+++ b/backend/src/services/token_packs.py
@@ -1,0 +1,148 @@
+"""Exactly-once crediting of Gumroad token-pack purchases.
+
+A token pack is bought on Gumroad and paid for before Adepthood hears about
+it, and Gumroad re-delivers any ping it believes went unacknowledged. The
+buyer may also not have an account yet. Both realities point at the same
+requirement: the credit must be idempotent per *sale*, not per delivery and
+not per account, and it must survive the purchase arriving before the buyer.
+
+The guard is ``GumroadSale.token_pack_credited_at``. Taking it is a single
+conditional ``UPDATE ... WHERE token_pack_credited_at IS NULL``; only the
+writer whose ``rowcount`` comes back 1 goes on to move any money, and the
+claim, the balance, and the audit row all commit in one transaction.
+
+Lives in ``services`` rather than ``domain`` because it owns that
+transaction boundary: it commits, and it rolls back.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlalchemy import CursorResult, func, update
+from sqlmodel import col, select
+
+from domain.entitlements import is_token_pack_product_id, token_pack_size
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from services.wallet import grant_purchase_credit
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from models.user import User
+
+__all__ = ["claim_token_pack_sales", "credit_token_pack_sale"]
+
+
+async def _take_credit_claim(session: AsyncSession, sale_id: str, user_id: int) -> bool:
+    """Stamp the sale's claim columns, returning whether this caller won.
+
+    Under READ COMMITTED two transactions issuing this UPDATE serialize on
+    the row lock. The loser re-evaluates its WHERE against the new row
+    version, sees ``token_pack_credited_at IS NOT NULL``, gets ``rowcount``
+    0, and credits nothing. If the winner rolls back, the loser instead sees
+    the pre-image and credits — so the credit can be delayed by a race but
+    never lost, and never doubled. ``gumroad_sale_id`` is UNIQUE, so the
+    predicate targets exactly one row.
+
+    ``synchronize_session=False`` is load-bearing, not decoration: the sale
+    may already sit in the session's identity map, and SQLAlchemy's
+    Python-side WHERE evaluator would then compare a timezone-naive stored
+    value against an aware one and raise on SQLite. Issuing the UPDATE
+    through SQL alone is exactly what the guard already guarantees.
+    """
+    result = await session.execute(
+        update(GumroadSale)
+        .where(
+            col(GumroadSale.gumroad_sale_id) == sale_id,
+            col(GumroadSale.token_pack_credited_at).is_(None),
+        )
+        .values(
+            token_pack_credited_at=datetime.now(UTC),
+            token_pack_credited_user_id=user_id,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    return bool(cast("CursorResult[Any]", result).rowcount)
+
+
+async def credit_token_pack_sale(
+    session: AsyncSession,
+    *,
+    sale_id: str,
+    user_id: int,
+    amount: int,
+) -> int | None:
+    """Credit ``amount`` for ``sale_id`` exactly once; return the new balance.
+
+    Returns ``None`` without touching the wallet when the claim cannot be
+    taken — the sale was already credited, or no such sale is stored.
+
+    A vanished buyer (the grant returns ``None``) rolls the claim back rather
+    than leaving a sale marked as credited to nobody, so a later replay or
+    signup sweep can still deliver the credits the buyer paid for.
+
+    Commits on success: the claim, the balance, and the audit row are one
+    transaction, so no crash can leave the sale claimed but unpaid.
+    """
+    if not await _take_credit_claim(session, sale_id, user_id):
+        return None
+    new_balance = await grant_purchase_credit(session, user_id, amount)
+    if new_balance is None:
+        await session.rollback()
+        return None
+    await session.commit()
+    return new_balance
+
+
+async def _unclaimed_token_pack_sales(
+    session: AsyncSession,
+    email: str,
+) -> list[tuple[str, str]]:
+    """Return ``(sale_id, product_id)`` for every sale still awaiting a credit.
+
+    Filters in SQL to the rows a credit could ever apply to: purchase events
+    only, not refunded, not already claimed, and belonging to ``email``
+    case-insensitively (Gumroad reports the buyer's address as they typed
+    it). Product classification stays in Python because both allowlists are
+    environment configuration, not columns.
+
+    Returns plain tuples rather than ORM rows on purpose: the caller commits
+    between iterations, which would expire attached instances and turn the
+    next attribute read into a lazy load outside the async context.
+    """
+    result = await session.execute(
+        select(GumroadSale.gumroad_sale_id, GumroadSale.product_id).where(
+            func.lower(GumroadSale.email) == email,
+            col(GumroadSale.token_pack_credited_at).is_(None),
+            col(GumroadSale.refunded).is_(False),
+            col(GumroadSale.resource_name) == SALE_RESOURCE_NAME,
+        )
+    )
+    return [(row.gumroad_sale_id, row.product_id) for row in result.all()]
+
+
+async def claim_token_pack_sales(session: AsyncSession, user: User) -> None:
+    """Sweep every token pack bought before ``user`` had an account into their wallet.
+
+    Called once at signup. Each waiting sale is credited through the same
+    exactly-once claim the webhook uses, so a pack that the webhook already
+    credited (the buyer registered first) is skipped, and a pack swept here
+    is skipped by any later webhook replay.
+
+    ``user.id`` and ``user.email`` are snapshotted before the first credit
+    because crediting commits this session, which expires the passed
+    instance; re-reading an attribute afterwards would trigger a lazy load
+    outside the greenlet rather than a fresh value.
+    """
+    user_id = user.id
+    email = user.email.strip().lower()
+    if user_id is None:
+        return
+    for sale_id, product_id in await _unclaimed_token_pack_sales(session, email):
+        # An allowlisted product with no configured size credits nothing:
+        # there is no safe default amount for real money.
+        amount = token_pack_size(product_id) if is_token_pack_product_id(product_id) else None
+        if amount is not None:
+            await credit_token_pack_sale(session, sale_id=sale_id, user_id=user_id, amount=amount)

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -40,6 +40,7 @@ from models.wallet_audit import (
     BUCKET_MONTHLY,
     BUCKET_OFFERING,
     REASON_ADMIN_GRANT,
+    REASON_GUMROAD_PURCHASE,
     REASON_MONTHLY_RESET,
     REASON_SELF_GRANT,
     REASON_SPEND_MONTHLY,
@@ -316,6 +317,54 @@ async def preflight_deduction(session: AsyncSession, user_id: int) -> SpendResul
     raise payment_required("insufficient_offerings")
 
 
+async def _credit_offering(
+    session: AsyncSession,
+    user_id: int,
+    amount: int,
+    *,
+    reason: str,
+    actor_user_id: int,
+) -> int | None:
+    """Add ``amount`` to ``offering_balance`` and stage the matching audit row.
+
+    The shared atomic body behind every offering-bucket credit: one
+    ``UPDATE ... RETURNING`` (no lost-update window between read and
+    write) plus one staged ``WalletAudit``.  Deliberately does NOT
+    commit — the caller owns the transaction boundary, which is what
+    lets a credit land atomically alongside whatever else it guards.
+
+    Returns the post-credit balance, or ``None`` when no row matched
+    ``user_id`` (in which case nothing is staged).
+    """
+    result = await session.execute(
+        update(User)
+        .where(col(User.id) == user_id)
+        .values(offering_balance=col(User.offering_balance) + amount)
+        .returning(col(User.offering_balance))
+    )
+    new_balance = result.scalar()
+    if new_balance is None:
+        return None
+    new_balance_int = int(new_balance)
+    _stage_audit(
+        session,
+        _AuditEntry(
+            user_id=user_id,
+            actor_user_id=actor_user_id,
+            bucket=BUCKET_OFFERING,
+            reason=reason,
+            # ``balance_before`` is derived from the post-update value
+            # (``new_balance_int - amount``).  This relies on the
+            # ``UPDATE`` having applied the full ``amount`` -- which it
+            # does, because there is no clamping in the SQL.
+            delta=Decimal(amount),
+            balance_before=Decimal(new_balance_int - amount),
+            balance_after=Decimal(new_balance_int),
+        ),
+    )
+    return new_balance_int
+
+
 async def add_balance(
     session: AsyncSession,
     user_id: int,
@@ -338,16 +387,6 @@ async def add_balance(
     future cross-user grant path (e.g. a Stripe webhook or referral
     credit); no such caller exists yet.
     """
-    result = await session.execute(
-        update(User)
-        .where(col(User.id) == user_id)
-        .values(offering_balance=col(User.offering_balance) + amount)
-        .returning(col(User.offering_balance))
-    )
-    new_balance = result.scalar()
-    if new_balance is None:
-        return None
-    new_balance_int = int(new_balance)
     # ``actor`` defaults to ``user_id`` so a self-grant (legacy or future
     # non-admin caller) does not look like an admin-initiated mutation
     # in the audit log.  Picking ``admin_grant`` only when the actor is
@@ -355,20 +394,27 @@ async def add_balance(
     # honest if a Stripe webhook or referral-credit path ever calls in.
     actor = actor_user_id if actor_user_id is not None else user_id
     reason = REASON_ADMIN_GRANT if actor != user_id else REASON_SELF_GRANT
-    _stage_audit(
+    return await _credit_offering(session, user_id, amount, reason=reason, actor_user_id=actor)
+
+
+async def grant_purchase_credit(session: AsyncSession, user_id: int, amount: int) -> int | None:
+    """Credit ``amount`` bought credits to ``user_id`` and return the new total.
+
+    The wallet half of a Gumroad token-pack purchase.  The buyer is their
+    own actor -- nobody granted these credits, they paid for them -- so
+    the audit row records ``actor_user_id == user_id`` with reason
+    ``gumroad_purchase``, keeping revenue-backed credits distinguishable
+    from courtesy top-ups.
+
+    Returns ``None`` (staging no audit row) when the user has vanished, so
+    the caller can abandon the surrounding claim rather than record a
+    credit nobody received.  Does not commit: the caller owns the
+    transaction so the credit and its exactly-once guard land together.
+    """
+    return await _credit_offering(
         session,
-        _AuditEntry(
-            user_id=user_id,
-            actor_user_id=actor,
-            bucket=BUCKET_OFFERING,
-            reason=reason,
-            # ``balance_before`` is derived from the post-update value
-            # (``new_balance_int - amount``).  This relies on the
-            # ``UPDATE`` having applied the full ``amount`` -- which it
-            # does, because there is no clamping in the SQL.
-            delta=Decimal(amount),
-            balance_before=Decimal(new_balance_int - amount),
-            balance_after=Decimal(new_balance_int),
-        ),
+        user_id,
+        amount,
+        reason=REASON_GUMROAD_PURCHASE,
+        actor_user_id=user_id,
     )
-    return new_balance_int

--- a/backend/tests/domain/test_entitlements.py
+++ b/backend/tests/domain/test_entitlements.py
@@ -20,10 +20,15 @@ from sqlmodel import SQLModel, col, select
 
 from domain.entitlements import (
     PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_SIZES_ENV_VAR,
     grant_course_access,
     has_course_access,
     is_aptitude_product_id,
+    is_token_pack_product_id,
     revoke_course_access,
+    token_pack_product_ids,
+    token_pack_size,
 )
 from models.entitlement import Entitlement, EntitlementKind
 from models.gumroad_sale import GumroadSale
@@ -39,6 +44,15 @@ SALE_ID = "S-500"
 GRANT_REASON_DEFAULT = "signup_redemption"
 REVOKE_REASON = "refund"
 STUB_USER_ID = 1
+TOKEN_PACK_PRODUCT_ID = "prod_pack_small"
+SECOND_TOKEN_PACK_PRODUCT_ID = "prod_pack_large"
+MALFORMED_PACK_PRODUCT_ID = "prod_pack_malformed"
+TOKEN_PACK_SIZE = 100
+SECOND_TOKEN_PACK_SIZE = 250
+REVISED_TOKEN_PACK_SIZE = 500
+# A full-width Unicode digit sequence, written as escapes so the source stays
+# pure ASCII: ``str.isdigit()`` accepts it but ``str.isascii()`` does not.
+NON_ASCII_DIGIT_SIZE = "\uff11\uff10\uff10"
 
 
 def _log_carries_reason(caplog: pytest.LogCaptureFixture, reason: str) -> bool:
@@ -277,3 +291,139 @@ async def test_distinct_users_hold_active_entitlements_simultaneously(
 
     assert await _count_entitlements(db_session, first_id) == 1
     assert await _count_entitlements(db_session, second_id) == 1
+
+
+def test_is_token_pack_product_id_is_false_when_allowlist_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset token-pack allowlist fails closed for every product id."""
+    monkeypatch.delenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, raising=False)
+    assert is_token_pack_product_id(TOKEN_PACK_PRODUCT_ID) is False
+
+
+def test_is_token_pack_product_id_matches_only_allowlisted_products(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exact allowlist entry matches; an unlisted product does not."""
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f"{TOKEN_PACK_PRODUCT_ID},{SECOND_TOKEN_PACK_PRODUCT_ID}",
+    )
+    assert is_token_pack_product_id(TOKEN_PACK_PRODUCT_ID) is True
+    assert is_token_pack_product_id(SECOND_TOKEN_PACK_PRODUCT_ID) is True
+    assert is_token_pack_product_id(PRODUCT_ID) is False
+
+
+def test_is_token_pack_product_id_skips_blank_and_whitespace_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Padding, blank entries, and a trailing comma are all harmless."""
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f" {TOKEN_PACK_PRODUCT_ID} , ,,{SECOND_TOKEN_PACK_PRODUCT_ID},",
+    )
+    assert is_token_pack_product_id(TOKEN_PACK_PRODUCT_ID) is True
+    assert is_token_pack_product_id(SECOND_TOKEN_PACK_PRODUCT_ID) is True
+    assert is_token_pack_product_id("") is False
+    assert is_token_pack_product_id("   ") is False
+    assert is_token_pack_product_id(None) is False
+
+
+def test_token_pack_product_ids_returns_the_parsed_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parsed allowlist is the stripped, blank-free list of configured ids."""
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f" {TOKEN_PACK_PRODUCT_ID} ,, {SECOND_TOKEN_PACK_PRODUCT_ID},",
+    )
+    assert token_pack_product_ids() == [TOKEN_PACK_PRODUCT_ID, SECOND_TOKEN_PACK_PRODUCT_ID]
+
+
+def test_token_pack_product_ids_is_empty_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset allowlist parses to the empty list, not to a default product."""
+    monkeypatch.delenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, raising=False)
+    assert token_pack_product_ids() == []
+
+
+def test_token_pack_size_parses_every_configured_pack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each ``product_id:count`` entry maps its id to the configured integer size."""
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR,
+        f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}, "
+        f"{SECOND_TOKEN_PACK_PRODUCT_ID}:{SECOND_TOKEN_PACK_SIZE}",
+    )
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) == TOKEN_PACK_SIZE
+    assert token_pack_size(SECOND_TOKEN_PACK_PRODUCT_ID) == SECOND_TOKEN_PACK_SIZE
+
+
+def test_token_pack_size_is_none_for_unconfigured_and_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset size map, and an id missing from a set map, both yield None."""
+    monkeypatch.delenv(TOKEN_PACK_SIZES_ENV_VAR, raising=False)
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) is None
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}")
+    assert token_pack_size(SECOND_TOKEN_PACK_PRODUCT_ID) is None
+    assert token_pack_size(None) is None
+
+
+def test_token_pack_size_last_duplicate_entry_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A repeated product id resolves to the right-most configured size."""
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR,
+        f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE},"
+        f"{TOKEN_PACK_PRODUCT_ID}:{REVISED_TOKEN_PACK_SIZE}",
+    )
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) == REVISED_TOKEN_PACK_SIZE
+
+
+@pytest.mark.parametrize(
+    "malformed_entry",
+    [
+        MALFORMED_PACK_PRODUCT_ID,
+        f"{MALFORMED_PACK_PRODUCT_ID}:",
+        f"{MALFORMED_PACK_PRODUCT_ID}:x",
+        f"{MALFORMED_PACK_PRODUCT_ID}:0",
+        f"{MALFORMED_PACK_PRODUCT_ID}:-5",
+        f"{MALFORMED_PACK_PRODUCT_ID}:1.5",
+        f"{MALFORMED_PACK_PRODUCT_ID}:{NON_ASCII_DIGIT_SIZE}",
+        f":{TOKEN_PACK_SIZE}",
+    ],
+)
+def test_token_pack_size_drops_malformed_entries_without_defaulting(
+    monkeypatch: pytest.MonkeyPatch,
+    malformed_entry: str,
+) -> None:
+    """A malformed entry yields None for its id and never poisons its neighbour."""
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR,
+        f"{malformed_entry},{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}",
+    )
+    assert token_pack_size(MALFORMED_PACK_PRODUCT_ID) is None
+    assert token_pack_size("") is None
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) == TOKEN_PACK_SIZE
+
+
+def test_token_pack_size_reads_the_environment_at_call_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-pointing the env var changes the answer without a module reload."""
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}")
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) == TOKEN_PACK_SIZE
+
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{REVISED_TOKEN_PACK_SIZE}"
+    )
+    assert token_pack_size(TOKEN_PACK_PRODUCT_ID) == REVISED_TOKEN_PACK_SIZE
+
+
+def test_is_token_pack_product_id_reads_the_environment_at_call_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotating the allowlist takes effect on the next call, with no restart."""
+    monkeypatch.setenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_PRODUCT_ID)
+    assert is_token_pack_product_id(TOKEN_PACK_PRODUCT_ID) is True
+
+    monkeypatch.setenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, SECOND_TOKEN_PACK_PRODUCT_ID)
+    assert is_token_pack_product_id(TOKEN_PACK_PRODUCT_ID) is False

--- a/backend/tests/routers/test_gumroad_sale_dispatch.py
+++ b/backend/tests/routers/test_gumroad_sale_dispatch.py
@@ -6,6 +6,11 @@ course_access entitlement when a user with the buyer's email already exists
 with no matching user only the sale row is persisted; a later license-gated
 signup for that email converges by linking its entitlement to the stored
 sale; non-sale events never grant.
+
+The token-pack branch is exercised alongside it: a sale of an allowlisted
+token-pack product credits the buyer's offering wallet exactly once, by the
+configured pack size only, and never grants course access - the two product
+allowlists dispatch to disjoint side effects.
 """
 
 from __future__ import annotations
@@ -20,9 +25,11 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from domain.entitlements import TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_SIZES_ENV_VAR
 from models.entitlement import Entitlement
 from models.gumroad_sale import GumroadSale
 from models.user import User
+from models.wallet_audit import REASON_GUMROAD_PURCHASE, WalletAudit
 from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
 
 pytestmark = pytest.mark.real_license_gate
@@ -43,6 +50,19 @@ SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
 COURSE_ACCESS_KIND = "course_access"
 LICENSE_USES = 1
 WEBHOOK_SALE_MARKER = "webhook_sale"
+TOKEN_PACK_PRODUCT_ID = "prod_pack_small"
+UNSIZED_TOKEN_PACK_PRODUCT_ID = "prod_pack_unsized"
+UNKNOWN_PRODUCT_ID = "prod_not_sold_here"
+TOKEN_PACK_SIZE = 100
+TOKEN_PACK_SALE_ID = "S-200"
+UNKNOWN_PRODUCT_MARKER = "unknown_product"
+REFUNDED_SALE_MARKER = "refunded_sale"
+UNCONFIGURED_SIZE_MARKER = "token_pack_size_unconfigured"
+WRONG_WEBHOOK_SECRET = "not-the-shared-secret"  # pragma: allowlist secret
+# A payload field a naive implementation might trust; the credit must come
+# from the configured pack size alone.
+PAYLOAD_QUANTITY_FIELD = "quantity"
+PAYLOAD_QUANTITY_VALUE = "9999"
 
 
 @pytest.fixture
@@ -297,3 +317,297 @@ async def test_webhook_first_then_signup_links_entitlement_to_stored_sale(
     assert entitlement.user_id == signup.json()["user_id"]
     assert entitlement.kind == COURSE_ACCESS_KIND
     assert entitlement.revoked_at is None
+
+
+# -- Token-pack credit branch ------------------------------------------------
+
+
+@pytest.fixture
+def token_pack_config(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Allowlist the token-pack products and size only the sellable one.
+
+    ``UNSIZED_TOKEN_PACK_PRODUCT_ID`` is deliberately allowlisted without a
+    size so the unconfigured-size branch has a product to exercise.
+    """
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f"{TOKEN_PACK_PRODUCT_ID},{UNSIZED_TOKEN_PACK_PRODUCT_ID}",
+    )
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}")
+    return TOKEN_PACK_PRODUCT_ID
+
+
+def _token_pack_payload(**overrides: str) -> dict[str, str]:
+    """Build a ping payload for a token-pack sale, with optional overrides."""
+    pack_defaults = {"sale_id": TOKEN_PACK_SALE_ID, "product_id": TOKEN_PACK_PRODUCT_ID}
+    return _sale_payload(**{**pack_defaults, **overrides})
+
+
+async def _offering_balance(db_session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted offering balance, read fresh."""
+    result = await db_session.execute(
+        select(User).where(User.id == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _count_purchase_audits(db_session: AsyncSession) -> int:
+    """Count only ``gumroad_purchase`` audit rows so other reasons cannot skew."""
+    result = await db_session.execute(
+        select(func.count())
+        .select_from(WalletAudit)
+        .where(WalletAudit.reason == REASON_GUMROAD_PURCHASE)
+    )
+    return int(result.scalar_one())
+
+
+async def _reload_sale(db_session: AsyncSession, sale_id: str) -> GumroadSale:
+    """Re-read one sale row from the database, bypassing the identity map."""
+    result = await db_session.execute(
+        select(GumroadSale)
+        .where(GumroadSale.gumroad_sale_id == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_token_pack_ping_credits_registered_buyer(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A token-pack sale credits exactly the configured pack size and claims the sale."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(**{PAYLOAD_QUANTITY_FIELD: PAYLOAD_QUANTITY_VALUE}),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1
+    sale = await _reload_sale(db_session, TOKEN_PACK_SALE_ID)
+    assert sale.token_pack_credited_at is not None
+    assert sale.token_pack_credited_user_id == user_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_replayed_token_pack_ping_credits_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A duplicate delivery of the same ping stays 200 and never double-credits."""
+    _user, user_id = await _persist_user(db_session)
+    payload = _token_pack_payload()
+
+    first = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+    second = await async_client.post(WEBHOOK_PATH, params={"secret": webhook_secret}, data=payload)
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_token_pack_ping_without_user_leaves_sale_unclaimed(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """With no account yet the sale is stored unclaimed, awaiting the signup sweep."""
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_token_pack_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    sale = await _reload_sale(db_session, TOKEN_PACK_SALE_ID)
+    assert sale.token_pack_credited_at is None
+    assert sale.token_pack_credited_user_id is None
+    assert await _count_purchase_audits(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_aptitude_sale_leaves_offering_balance_untouched(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A course sale grants access without minting a single wallet credit."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_sale_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_entitlements(db_session) == 1
+    assert await _offering_balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_token_pack_sale_grants_no_entitlement(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """Buying credits must never hand out course access."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH, params={"secret": webhook_secret}, data=_token_pack_payload()
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_refunded_token_pack_ping_credits_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refunded sale is persisted for the record but never credited."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(refunded="true"),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _offering_balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+    assert _log_carries_marker(caplog, REFUNDED_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_unsized_token_pack_product_credits_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An allowlisted pack with no configured size fails closed and says so."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(product_id=UNSIZED_TOKEN_PACK_PRODUCT_ID),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+    assert _log_carries_marker(caplog, UNCONFIGURED_SIZE_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_product_on_neither_allowlist_is_logged_and_inert(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognised product grants nothing, credits nothing, and is flagged."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(product_id=UNKNOWN_PRODUCT_ID),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+    assert _log_carries_marker(caplog, UNKNOWN_PRODUCT_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_non_sale_resource_with_token_pack_product_credits_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A refund event carrying a pack product must not credit the wallet."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(resource_name=NON_SALE_RESOURCE),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _count_sales(db_session) == 1
+    assert await _offering_balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config")
+async def test_token_pack_email_match_is_case_insensitive(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+) -> None:
+    """A mixed-case buyer email still credits the lowercase stored account."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        data=_token_pack_payload(email=MIXED_CASE_BUYER_EMAIL),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("token_pack_config", "webhook_secret")
+async def test_forged_token_pack_ping_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A ping with the wrong shared secret mints no credits and stores no rows."""
+    _user, user_id = await _persist_user(db_session)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": WRONG_WEBHOOK_SECRET},
+        data=_token_pack_payload(),
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert await _count_sales(db_session) == 0
+    assert await _count_purchase_audits(db_session) == 0
+    assert await _offering_balance(db_session, user_id) == 0

--- a/backend/tests/routers/test_gumroad_token_pack_concurrency.py
+++ b/backend/tests/routers/test_gumroad_token_pack_concurrency.py
@@ -1,0 +1,106 @@
+"""Concurrency test for the Gumroad token-pack credit path.
+
+Gumroad retries a ping it believes was not acknowledged, so five identical
+deliveries can land at once. The invariant asserted here is the outcome, not
+the mechanism: whatever guard the implementation uses, the buyer's wallet
+gains exactly one pack, exactly one ``gumroad_purchase`` audit row exists,
+and the single stored sale ends up claimed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from domain.entitlements import TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_SIZES_ENV_VAR
+from models.gumroad_sale import GumroadSale
+from models.user import User
+from models.wallet_audit import REASON_GUMROAD_PURCHASE, WalletAudit
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+WEBHOOK_SECRET = "gumroad-concurrency-shared-secret"  # pragma: allowlist secret
+WEBHOOK_SECRET_ENV_VAR = "GUMROAD_WEBHOOK_SECRET"  # pragma: allowlist secret
+BUYER_EMAIL = "concurrent-buyer@example.com"
+PACK_PRODUCT_ID = "prod_pack_concurrent"
+PACK_SIZE = 100
+SALE_ID = "S-CONCURRENT-1"
+CONCURRENT_PINGS = 5
+
+
+@pytest.fixture(autouse=True)
+def token_pack_webhook_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the shared secret and the single sized token-pack product."""
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV_VAR, WEBHOOK_SECRET)
+    monkeypatch.setenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, PACK_PRODUCT_ID)
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{PACK_PRODUCT_ID}:{PACK_SIZE}")
+
+
+def _ping_payload() -> dict[str, str]:
+    """Build the token-pack sale ping every concurrent delivery repeats."""
+    return {
+        "sale_id": SALE_ID,
+        "product_id": PACK_PRODUCT_ID,
+        "email": BUYER_EMAIL,
+        "resource_name": "sale",
+        "is_recurring_charge": "false",
+        "refunded": "false",
+    }
+
+
+async def _seed_buyer(factory: async_sessionmaker[AsyncSession]) -> int:
+    """Insert the buyer into the concurrency engine and return their id."""
+    async with factory() as session:
+        user = User(email=BUYER_EMAIL, password_hash="x")  # pragma: allowlist secret
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        if user.id is None:
+            msg = "user id missing after commit"
+            raise RuntimeError(msg)
+        return user.id
+
+
+@pytest.mark.asyncio
+async def test_concurrent_token_pack_pings_credit_exactly_one_pack(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Five simultaneous deliveries of one sale credit the wallet exactly once."""
+    user_id = await _seed_buyer(concurrent_session_factory)
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(
+                WEBHOOK_PATH, params={"secret": WEBHOOK_SECRET}, data=_ping_payload()
+            )
+            for _ in range(CONCURRENT_PINGS)
+        ]
+    )
+
+    assert [response.status_code for response in responses] == [HTTPStatus.OK] * CONCURRENT_PINGS
+
+    async with concurrent_session_factory() as session:
+        balance = (
+            await session.execute(select(User.offering_balance).where(User.id == user_id))
+        ).scalar_one()
+        assert int(balance) == PACK_SIZE
+
+        audit_count = (
+            await session.execute(
+                select(func.count())
+                .select_from(WalletAudit)
+                .where(WalletAudit.reason == REASON_GUMROAD_PURCHASE)
+            )
+        ).scalar_one()
+        assert int(audit_count) == 1
+
+        sale = (await session.execute(select(GumroadSale))).scalars().one()
+        assert sale.gumroad_sale_id == SALE_ID
+        assert sale.token_pack_credited_at is not None
+        assert sale.token_pack_credited_user_id == user_id

--- a/backend/tests/routers/test_signup_token_pack_claim.py
+++ b/backend/tests/routers/test_signup_token_pack_claim.py
@@ -1,0 +1,242 @@
+"""Signup-time claim of token packs bought before the buyer had an account.
+
+Contract: a token-pack sale that arrives while nobody owns the email waits
+unclaimed on the ``GumroadSale`` row; the first signup for that email sweeps
+every waiting pack into ``offering_balance`` exactly once, matching the buyer
+email case-insensitively and skipping refunded or already-claimed rows. A
+signup with nothing waiting is an ordinary signup with a zero balance.
+
+This module deliberately rides the default stub-open license gate, so signup
+succeeds without a live Gumroad verify call.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from domain.entitlements import TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_SIZES_ENV_VAR
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from models.wallet_audit import REASON_GUMROAD_PURCHASE, WalletAudit
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+SIGNUP_PATH = "/auth/signup"
+WEBHOOK_SECRET = "signup-claim-shared-secret"  # pragma: allowlist secret
+WEBHOOK_SECRET_ENV_VAR = "GUMROAD_WEBHOOK_SECRET"  # pragma: allowlist secret
+BUYER_EMAIL = "late-buyer@example.com"
+MIXED_CASE_BUYER_EMAIL = "Late-Buyer@Example.COM"
+SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
+LICENSE_KEY = "SIGNUP-CLAIM-TEST-KEY"  # pragma: allowlist secret
+PACK_PRODUCT_ID = "prod_pack_small"
+SECOND_PACK_PRODUCT_ID = "prod_pack_large"
+PACK_SIZE = 100
+SECOND_PACK_SIZE = 250
+SALE_ID = "S-700"
+SECOND_SALE_ID = "S-701"
+
+
+@pytest.fixture(autouse=True)
+def token_pack_webhook_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the shared secret and both sized token-pack products."""
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV_VAR, WEBHOOK_SECRET)
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f"{PACK_PRODUCT_ID},{SECOND_PACK_PRODUCT_ID}",
+    )
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR,
+        f"{PACK_PRODUCT_ID}:{PACK_SIZE},{SECOND_PACK_PRODUCT_ID}:{SECOND_PACK_SIZE}",
+    )
+
+
+def _pack_payload(
+    *,
+    sale_id: str = SALE_ID,
+    product_id: str = PACK_PRODUCT_ID,
+    email: str = BUYER_EMAIL,
+    refunded: str = "false",
+) -> dict[str, str]:
+    """Build a token-pack sale ping payload."""
+    return {
+        "sale_id": sale_id,
+        "product_id": product_id,
+        "email": email,
+        "resource_name": SALE_RESOURCE_NAME,
+        "is_recurring_charge": "false",
+        "refunded": refunded,
+    }
+
+
+async def _post_ping(client: AsyncClient, payload: dict[str, str]) -> None:
+    """Deliver one authenticated ping and assert it was accepted."""
+    response = await client.post(WEBHOOK_PATH, params={"secret": WEBHOOK_SECRET}, data=payload)
+    assert response.status_code == HTTPStatus.OK
+
+
+async def _signup(client: AsyncClient, email: str = BUYER_EMAIL) -> int:
+    """Sign up ``email`` and return the created user id."""
+    response = await client.post(
+        SIGNUP_PATH,
+        json={"email": email, "password": SIGNUP_PASSWORD, "license_key": LICENSE_KEY},
+    )
+    assert response.status_code == HTTPStatus.OK
+    return int(response.json()["user_id"])
+
+
+async def _balance(db_session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted offering balance, read fresh."""
+    result = await db_session.execute(
+        select(User).where(User.id == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _count_purchase_audits(db_session: AsyncSession) -> int:
+    """Count only ``gumroad_purchase`` audit rows so other reasons cannot skew."""
+    result = await db_session.execute(
+        select(func.count())
+        .select_from(WalletAudit)
+        .where(WalletAudit.reason == REASON_GUMROAD_PURCHASE)
+    )
+    return int(result.scalar_one())
+
+
+async def _reload_sale(db_session: AsyncSession, sale_id: str) -> GumroadSale:
+    """Re-read one sale row from the database, bypassing the identity map."""
+    result = await db_session.execute(
+        select(GumroadSale)
+        .where(GumroadSale.gumroad_sale_id == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+async def _seed_claimed_sale(db_session: AsyncSession) -> None:
+    """Persist a token-pack sale that some earlier pass already credited."""
+    sale = GumroadSale(
+        gumroad_sale_id=SALE_ID,
+        product_id=PACK_PRODUCT_ID,
+        email=BUYER_EMAIL,
+        resource_name=SALE_RESOURCE_NAME,
+        raw_payload={"sale_id": SALE_ID},
+        token_pack_credited_at=datetime.now(UTC),
+    )
+    db_session.add(sale)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_signup_claims_pack_bought_before_the_account_existed(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The first signup for the buyer's email sweeps the waiting pack in."""
+    await _post_ping(async_client, _pack_payload())
+
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.token_pack_credited_user_id == user_id
+    assert sale.token_pack_credited_at is not None
+
+
+@pytest.mark.asyncio
+async def test_signup_claims_pack_bought_under_a_mixed_case_email(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Gumroad's mixed-case buyer email still matches the normalized account."""
+    await _post_ping(async_client, _pack_payload(email=MIXED_CASE_BUYER_EMAIL))
+
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_signup_claims_every_waiting_pack(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Two waiting packs sum into the opening balance and both get claimed."""
+    await _post_ping(async_client, _pack_payload())
+    await _post_ping(
+        async_client,
+        _pack_payload(sale_id=SECOND_SALE_ID, product_id=SECOND_PACK_PRODUCT_ID),
+    )
+
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == PACK_SIZE + SECOND_PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 2
+    for sale_id in (SALE_ID, SECOND_SALE_ID):
+        sale = await _reload_sale(db_session, sale_id)
+        assert sale.token_pack_credited_user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_signup_does_not_claim_a_refunded_pack(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A refunded purchase must not fund the account it was refunded from."""
+    await _post_ping(async_client, _pack_payload(refunded="true"))
+
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.token_pack_credited_at is None
+
+
+@pytest.mark.asyncio
+async def test_signup_does_not_recredit_an_already_claimed_pack(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A sale stamped as credited is never swept a second time."""
+    await _seed_claimed_sale(db_session)
+
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_signup_with_no_waiting_packs_starts_at_zero_balance(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The empty sweep path must not break an otherwise ordinary signup."""
+    user_id = await _signup(async_client)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _count_purchase_audits(db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_signup_then_webhook_credits_once_across_a_replay(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """When the account exists first the webhook credits it, and a replay does not."""
+    user_id = await _signup(async_client)
+    assert await _balance(db_session, user_id) == 0
+
+    await _post_ping(async_client, _pack_payload())
+    await _post_ping(async_client, _pack_payload())
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _count_purchase_audits(db_session) == 1

--- a/backend/tests/services/test_token_packs.py
+++ b/backend/tests/services/test_token_packs.py
@@ -1,0 +1,322 @@
+"""Unit tests for :mod:`services.token_packs` - exactly-once token-pack credit.
+
+Contract: taking a sale's claim and crediting the buyer's ``offering_balance``
+happen in one transaction guarded by ``token_pack_credited_at``. A second
+attempt on the same sale credits nothing; a grant against a vanished user
+rolls the claim back so the sale stays available for a later retry. The
+signup-time sweep claims every unclaimed, non-refunded, allowlisted, sized
+sale ping matching the account's email case-insensitively.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.entitlements import TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_SIZES_ENV_VAR
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from models.wallet_audit import REASON_GUMROAD_PURCHASE, WalletAudit
+from services.token_packs import claim_token_pack_sales, credit_token_pack_sale
+
+BUYER_EMAIL = "buyer@example.com"
+MIXED_CASE_BUYER_EMAIL = "Buyer@Example.COM"
+OTHER_EMAIL = "someone-else@example.com"
+PACK_PRODUCT_ID = "prod_pack_small"
+SECOND_PACK_PRODUCT_ID = "prod_pack_large"
+UNSIZED_PACK_PRODUCT_ID = "prod_pack_unsized"
+OFF_ALLOWLIST_PRODUCT_ID = "prod_course"
+PACK_SIZE = 100
+SECOND_PACK_SIZE = 250
+SALE_ID = "S-900"
+SECOND_SALE_ID = "S-901"
+REFUND_RESOURCE_NAME = "refund"
+MISSING_USER_ID = 999
+PREEXISTING_BALANCE = 7
+ALREADY_CLAIMED_AT = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture(autouse=True)
+def token_pack_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure both token-pack env vars for every test in this module."""
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+        f"{PACK_PRODUCT_ID},{SECOND_PACK_PRODUCT_ID},{UNSIZED_PACK_PRODUCT_ID}",
+    )
+    monkeypatch.setenv(
+        TOKEN_PACK_SIZES_ENV_VAR,
+        f"{PACK_PRODUCT_ID}:{PACK_SIZE},{SECOND_PACK_PRODUCT_ID}:{SECOND_PACK_SIZE}",
+    )
+
+
+async def _make_user(
+    session: AsyncSession,
+    *,
+    email: str = BUYER_EMAIL,
+    offering_balance: int = 0,
+) -> tuple[User, int]:
+    """Create and commit a buyer; return the row plus its non-null id.
+
+    The id is returned separately because the services under test commit and
+    roll back the same session, which expires the ORM instance -- reading
+    ``user_id`` afterwards would trigger a lazy load outside the async
+    context rather than an assertion failure.
+    """
+    user = User(
+        email=email,
+        password_hash="x",  # pragma: allowlist secret
+        offering_balance=offering_balance,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user, user.id
+
+
+@dataclass(frozen=True)
+class _SaleShape:
+    """The variable fields of one seeded Gumroad ping row.
+
+    Bundling them keeps the seeding helper under ruff's argument-count cap
+    and lets the ineligible-row cases be parametrized as whole records.
+    """
+
+    sale_id: str = SALE_ID
+    product_id: str = PACK_PRODUCT_ID
+    email: str = BUYER_EMAIL
+    resource_name: str = SALE_RESOURCE_NAME
+    refunded: bool = False
+    claimed: bool = False
+
+
+_ELIGIBLE_SALE = _SaleShape()
+
+
+async def _make_sale(session: AsyncSession, shape: _SaleShape = _ELIGIBLE_SALE) -> GumroadSale:
+    """Create and commit one Gumroad ping row, optionally pre-claimed."""
+    sale = GumroadSale(
+        gumroad_sale_id=shape.sale_id,
+        product_id=shape.product_id,
+        email=shape.email,
+        resource_name=shape.resource_name,
+        refunded=shape.refunded,
+        raw_payload={"sale_id": shape.sale_id},
+    )
+    if shape.claimed:
+        sale.token_pack_credited_at = datetime.fromisoformat(ALREADY_CLAIMED_AT)
+    session.add(sale)
+    await session.commit()
+    await session.refresh(sale)
+    return sale
+
+
+async def _reload_sale(session: AsyncSession, sale_id: str) -> GumroadSale:
+    """Re-read a sale row from the database, bypassing the identity map."""
+    result = await session.execute(
+        select(GumroadSale)
+        .where(GumroadSale.gumroad_sale_id == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+async def _balance(session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted ``offering_balance``, read fresh."""
+    result = await session.execute(
+        select(User).where(User.id == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _purchase_audits(session: AsyncSession, user_id: int) -> list[WalletAudit]:
+    """Return only the ``gumroad_purchase`` audit rows for ``user_id``."""
+    result = await session.execute(
+        select(WalletAudit)
+        .where(
+            col(WalletAudit.user_id) == user_id,
+            col(WalletAudit.reason) == REASON_GUMROAD_PURCHASE,
+        )
+        .order_by(col(WalletAudit.id))
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_credit_token_pack_sale_credits_and_stamps_the_claim(
+    db_session: AsyncSession,
+) -> None:
+    """A first credit adds the pack, stamps both claim columns, and audits once."""
+    _user, user_id = await _make_user(db_session, offering_balance=PREEXISTING_BALANCE)
+    await _make_sale(db_session)
+
+    new_balance = await credit_token_pack_sale(
+        db_session, sale_id=SALE_ID, user_id=user_id, amount=PACK_SIZE
+    )
+
+    assert new_balance == PREEXISTING_BALANCE + PACK_SIZE
+    assert await _balance(db_session, user_id) == PREEXISTING_BALANCE + PACK_SIZE
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.token_pack_credited_at is not None
+    assert sale.token_pack_credited_user_id == user_id
+    assert len(await _purchase_audits(db_session, user_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_credit_token_pack_sale_is_exactly_once_per_sale(
+    db_session: AsyncSession,
+) -> None:
+    """A second credit for the same sale returns None and moves no credits."""
+    _user, user_id = await _make_user(db_session)
+    await _make_sale(db_session)
+
+    first = await credit_token_pack_sale(
+        db_session, sale_id=SALE_ID, user_id=user_id, amount=PACK_SIZE
+    )
+    second = await credit_token_pack_sale(
+        db_session, sale_id=SALE_ID, user_id=user_id, amount=PACK_SIZE
+    )
+
+    assert first == PACK_SIZE
+    assert second is None
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert len(await _purchase_audits(db_session, user_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_credit_token_pack_sale_missing_user_leaves_sale_unclaimed(
+    db_session: AsyncSession,
+) -> None:
+    """A vanished buyer rolls the claim back so the sale stays creditable later."""
+    await _make_sale(db_session)
+
+    result = await credit_token_pack_sale(
+        db_session, sale_id=SALE_ID, user_id=MISSING_USER_ID, amount=PACK_SIZE
+    )
+
+    assert result is None
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.token_pack_credited_at is None
+    assert sale.token_pack_credited_user_id is None
+    assert await _purchase_audits(db_session, MISSING_USER_ID) == []
+
+
+@pytest.mark.asyncio
+async def test_credit_token_pack_sale_unknown_sale_id_credits_nothing(
+    db_session: AsyncSession,
+) -> None:
+    """A sale_id with no stored row cannot be claimed, so no wallet moves."""
+    _user, user_id = await _make_user(db_session)
+
+    result = await credit_token_pack_sale(
+        db_session, sale_id=SALE_ID, user_id=user_id, amount=PACK_SIZE
+    )
+
+    assert result is None
+    assert await _balance(db_session, user_id) == 0
+    assert await _purchase_audits(db_session, user_id) == []
+
+
+@pytest.mark.asyncio
+async def test_claim_token_pack_sales_credits_every_unclaimed_pack(
+    db_session: AsyncSession,
+) -> None:
+    """Two waiting packs sum into the balance and each stamps its own claim."""
+    user, user_id = await _make_user(db_session)
+    await _make_sale(db_session, _SaleShape(sale_id=SALE_ID, product_id=PACK_PRODUCT_ID))
+    await _make_sale(
+        db_session, _SaleShape(sale_id=SECOND_SALE_ID, product_id=SECOND_PACK_PRODUCT_ID)
+    )
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == PACK_SIZE + SECOND_PACK_SIZE
+    assert len(await _purchase_audits(db_session, user_id)) == 2
+    for sale_id in (SALE_ID, SECOND_SALE_ID):
+        sale = await _reload_sale(db_session, sale_id)
+        assert sale.token_pack_credited_at is not None
+        assert sale.token_pack_credited_user_id == user_id
+
+
+@pytest.mark.asyncio
+async def test_claim_token_pack_sales_matches_email_case_insensitively(
+    db_session: AsyncSession,
+) -> None:
+    """A pack bought under a mixed-case email still reaches the lowercase account."""
+    user, user_id = await _make_user(db_session)
+    await _make_sale(db_session, _SaleShape(email=MIXED_CASE_BUYER_EMAIL))
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert len(await _purchase_audits(db_session, user_id)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "shape",
+    [
+        _SaleShape(refunded=True),
+        _SaleShape(resource_name=REFUND_RESOURCE_NAME),
+        _SaleShape(product_id=OFF_ALLOWLIST_PRODUCT_ID),
+        _SaleShape(product_id=UNSIZED_PACK_PRODUCT_ID),
+        _SaleShape(claimed=True),
+        _SaleShape(email=OTHER_EMAIL),
+    ],
+    ids=[
+        "refunded",
+        "non_sale_resource",
+        "off_allowlist",
+        "unsized_product",
+        "already_claimed",
+        "other_buyer",
+    ],
+)
+async def test_claim_token_pack_sales_skips_ineligible_rows(
+    db_session: AsyncSession,
+    shape: _SaleShape,
+) -> None:
+    """Every ineligible sale shape leaves the wallet at zero with no audit row."""
+    user, user_id = await _make_user(db_session)
+    await _make_sale(db_session, shape)
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _purchase_audits(db_session, user_id) == []
+
+
+@pytest.mark.asyncio
+async def test_claim_token_pack_sales_with_empty_allowlist_is_a_no_op(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unconfigured allowlist fails closed: a waiting pack credits nothing."""
+    monkeypatch.delenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, raising=False)
+    user, user_id = await _make_user(db_session)
+    await _make_sale(db_session)
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == 0
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.token_pack_credited_at is None
+
+
+@pytest.mark.asyncio
+async def test_claim_token_pack_sales_without_any_sale_is_a_no_op(
+    db_session: AsyncSession,
+) -> None:
+    """A buyer with no waiting packs finishes the sweep with an untouched wallet."""
+    user, user_id = await _make_user(db_session)
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _purchase_audits(db_session, user_id) == []

--- a/backend/tests/services/test_wallet.py
+++ b/backend/tests/services/test_wallet.py
@@ -22,6 +22,7 @@ from models.wallet_audit import (
     BUCKET_MONTHLY,
     BUCKET_OFFERING,
     REASON_ADMIN_GRANT,
+    REASON_GUMROAD_PURCHASE,
     REASON_MONTHLY_RESET,
     REASON_SELF_GRANT,
     REASON_SPEND_MONTHLY,
@@ -32,6 +33,7 @@ from services.wallet import (
     SpendResult,
     add_balance,
     get_user_fresh,
+    grant_purchase_credit,
     preflight_deduction,
     require_user_fresh,
     reset_monthly_usage_if_due,
@@ -497,3 +499,65 @@ async def test_reset_audit_balance_before_under_racing_spend_is_within_one(
     refreshed = await real_get_user_fresh(db_session, user_id)
     assert refreshed is not None
     assert refreshed.monthly_messages_used == 0
+
+
+# -- Gumroad token-pack purchase credit --------------------------------------
+
+# Seeded starting balance plus the pack size the purchase credits.
+_SEEDED_PURCHASE_BALANCE = 4
+_PURCHASE_PACK_SIZE = 100
+_MISSING_USER_ID = 999
+
+
+@pytest.mark.asyncio
+async def test_grant_purchase_credit_adds_amount_and_returns_new_total(
+    db_session: AsyncSession,
+) -> None:
+    """A purchase credit adds exactly ``amount`` and reports the post-credit total."""
+    user = await _make_user(db_session, offering_balance=_SEEDED_PURCHASE_BALANCE)
+    assert user.id is not None
+
+    new_total = await grant_purchase_credit(db_session, user.id, _PURCHASE_PACK_SIZE)
+    await db_session.commit()
+
+    expected = _SEEDED_PURCHASE_BALANCE + _PURCHASE_PACK_SIZE
+    assert new_total == expected
+    refreshed = await get_user_fresh(db_session, user.id)
+    assert refreshed is not None
+    assert refreshed.offering_balance == expected
+
+
+@pytest.mark.asyncio
+async def test_grant_purchase_credit_writes_one_gumroad_purchase_audit_row(
+    db_session: AsyncSession,
+) -> None:
+    """The credit stages exactly one offering-bucket row tagged ``gumroad_purchase``."""
+    user = await _make_user(db_session, offering_balance=_SEEDED_PURCHASE_BALANCE)
+    assert user.id is not None
+
+    await grant_purchase_credit(db_session, user.id, _PURCHASE_PACK_SIZE)
+    await db_session.commit()
+
+    rows = await _audit_rows(db_session, user.id)
+    assert len(rows) == 1
+    audit = rows[0]
+    assert audit.user_id == user.id
+    # The buyer is their own actor: nobody else initiated this credit.
+    assert audit.actor_user_id == user.id
+    assert audit.bucket == BUCKET_OFFERING
+    assert audit.reason == REASON_GUMROAD_PURCHASE
+    assert audit.delta == Decimal(_PURCHASE_PACK_SIZE)
+    assert audit.balance_before == Decimal(_SEEDED_PURCHASE_BALANCE)
+    assert audit.balance_after == Decimal(_SEEDED_PURCHASE_BALANCE + _PURCHASE_PACK_SIZE)
+
+
+@pytest.mark.asyncio
+async def test_grant_purchase_credit_missing_user_returns_none_without_audit(
+    db_session: AsyncSession,
+) -> None:
+    """An unknown buyer yields None and must not leave an orphan audit row."""
+    result = await grant_purchase_credit(db_session, _MISSING_USER_ID, _PURCHASE_PACK_SIZE)
+    await db_session.commit()
+
+    assert result is None
+    assert await _audit_rows(db_session, _MISSING_USER_ID) == []


### PR DESCRIPTION
## Summary

- **Token-pack sales credit the wallet.** A Gumroad `sale` ping whose `product_id` is on
  `GUMROAD_TOKEN_PACK_PRODUCT_IDS` now credits the buyer's BotMason `offering_balance` by
  the amount configured in the new `GUMROAD_TOKEN_PACK_SIZES` (`product_id:count,…`) map,
  writing a `WalletAudit` row under the new `gumroad_purchase` reason. The amount comes
  **only** from that operator-set map — never from `price`, `quantity`, or any other field
  a forged ping would control.
- **Exactly once per sale, not per delivery.** New `services/token_packs.py` takes a claim
  on the persisted `GumroadSale` row with a single conditional
  `UPDATE … WHERE token_pack_credited_at IS NULL`; only the writer whose `rowcount` is 1
  moves money, and the claim, the atomic balance `UPDATE … RETURNING`, and the audit row
  commit as one transaction. Replays and concurrent redeliveries credit the pack once. A
  vanished buyer rolls the claim back rather than marking a sale credited to nobody, so a
  credit can be delayed by a race but never lost and never doubled.
- **Buy-before-signup converges.** With no account for the buyer's email the sale simply
  waits unclaimed; signup sweeps every waiting, non-refunded, allowlisted, sized pack for
  that email (matched case-insensitively) into the new wallet through the same claim. So
  whichever of webhook-first or signup-first happens, the buyer is credited exactly once.
- **Disjoint allowlists, failing closed.** `domain/entitlements.py` now owns both halves of
  Gumroad product classification, so an APTITUDE sale can never mint credits and a pack can
  never grant course access. The pack allowlist (is this a pack?) and the size map (how
  much?) are separate on purpose: an allowlisted-but-unpriced product credits **nothing**
  and logs `token_pack_size_unconfigured` rather than guessing an amount. Products on
  neither allowlist log `unknown_product` and still return 200.
- **Wallet refactor, no behavior change.** `services/wallet.py` factors the atomic
  offering-bucket credit out of `add_balance` into a shared `_credit_offering` and adds
  `grant_purchase_credit` on top of it; `add_balance`'s self/admin reason selection is
  unchanged.
- **Migration `b8c9d0e1f2a3`** is purely additive: the two claim columns, the actor FK
  (`ON DELETE SET NULL`, mirroring `walletaudit.actor_user_id` so the financial trail
  outlives the account), and a `lower(email)` index backing the signup sweep. Every
  pre-existing row lands unclaimed, which is correct — this change is the first consumer of
  the token-pack allowlist.

Scope is crediting only: no refund claw-back (the next sub-issue) and no admin surface.

`backend/.env.example` also gains an accurate description of all three Gumroad allowlist
variables, replacing the block that called them "unused by the webhook … today" — the prose
half of #1971. That issue additionally asks for a documentation drift-guard test, which is
deliberately left to it.

## Test plan

- `./scripts/backend/check-all.sh` → exit 0, 7/7 (ruff, ruff-format, mypy strict, bandit,
  complexity, pytest, coverage). Run twice: before merging `origin/main` and again after.
- `3124 passed, 2 skipped`; total coverage **96.90%** (gate 90%). `services/token_packs.py`
  90%, `services/wallet.py` 100%.
- Not covered by `check-all.sh`, so run explicitly against `src/`:
  `xenon --max-absolute A --max-modules A --max-average A` (clean),
  `radon mi -n B -s` (clean), `interrogate -c pyproject.toml` → **96.4%** (gate 85%).
- Migration verified as a single head: `b8c9d0e1f2a3` is the only revision whose
  `down_revision` is `a6b7c8d9e0f1`, and no revision id is duplicated.
- New tests:
  - `tests/services/test_token_packs.py` — a first credit stamps both claim columns and
    audits once; a second credit for the same sale returns `None` and moves nothing; a
    vanished buyer leaves the sale unclaimed and still creditable; an unknown `sale_id`
    credits nothing; the signup sweep credits every waiting pack and folds email case; six
    parametrized ineligible shapes (refunded, non-`sale` resource, off-allowlist, unsized,
    already claimed, other buyer) each leave the wallet at zero; an unset allowlist is a
    no-op.
  - `tests/routers/test_gumroad_token_pack_concurrency.py` — five simultaneous deliveries of
    one sale, against the real concurrent-engine fixture, leave exactly one pack in the
    balance, exactly one `gumroad_purchase` audit row, and one claimed sale.
  - `tests/routers/test_signup_token_pack_claim.py` — buy-before-signup end to end over
    HTTP: mixed-case buyer email, two waiting packs, a refunded pack that must not fund the
    account, an already-claimed pack, an ordinary signup with nothing waiting, and
    signup-first followed by a webhook replay.
  - `tests/domain/test_entitlements.py` — allowlist and size-map parsing: call-time reads
    (rotation without restart), blank/padded/trailing entries, duplicate-key resolution, and
    eight malformed size entries (missing colon, empty count, `x`, `0`, `-5`, `1.5`,
    full-width Unicode digits, empty id) each dropped without defaulting and without
    poisoning a neighbouring well-formed entry.
  - `tests/services/test_wallet.py` — `grant_purchase_credit` adds the amount, writes one
    offering-bucket `gumroad_purchase` row with buyer-as-actor and correct before/after
    balances, and returns `None` with no orphan audit row for a missing user.

Closes #1944
Refs #1938
Refs #1971
