### PR TITLE
feat(backend): revoke access and claw back credits on Gumroad reversals

### DIFF
--- a/backend/migrations/versions/d5e6f7a8b9c0_gumroad_sale_revocation_claim.py
+++ b/backend/migrations/versions/d5e6f7a8b9c0_gumroad_sale_revocation_claim.py
@@ -1,0 +1,48 @@
+"""Add the shared revocation claim column to gumroadsale.
+
+Revision ID: d5e6f7a8b9c0
+Revises: b8c9d0e1f2a3
+Create Date: 2026-07-24 00:00:00.000000
+
+Issue #1945: a Gumroad refund, dispute, cancellation, or subscription-ended
+ping unwinds the original sale exactly once. ``revocation_processed_at`` is
+the single claim guard every one of those events competes for, taken with a
+guarded ``UPDATE ... WHERE revocation_processed_at IS NULL``. One column
+rather than one per event kind is deliberate: a cancelled subscription that
+is later refunded has nothing left to revoke, and the loser of the race must
+see that in the data.
+
+Purely additive. Every pre-existing row lands ``NULL``, i.e. unreversed —
+which is correct: no reversal has ever been processed, because this change is
+the first handler for those event types.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d5e6f7a8b9c0"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "b8c9d0e1f2a3"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "gumroadsale"
+_REVOCATION_COLUMN = "revocation_processed_at"
+
+
+def upgrade() -> None:
+    """Add the nullable, timezone-aware revocation claim column."""
+    # Batch mode keeps this SQLite-safe (table rebuild) while emitting a plain
+    # ALTER on Postgres, which is what production runs.
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(
+            sa.Column(_REVOCATION_COLUMN, sa.DateTime(timezone=True), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Drop the revocation claim column."""
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column(_REVOCATION_COLUMN)

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 __all__ = [
     "PRODUCT_IDS_ENV_VAR",
     "REASON_ADMIN_OVERRIDE",
+    "REASON_CANCELLATION",
     "REASON_DUPLICATE_SIGNUP",
     "REASON_EMAIL_MISMATCH",
     "REASON_REFUND",
@@ -74,9 +75,12 @@ logger = logging.getLogger(__name__)
 # per code so grep-by-reason in log aggregation has a single spelling.
 REASON_SIGNUP_REDEMPTION = "signup_redemption"
 REASON_WEBHOOK_SALE = "webhook_sale"
-# Forward-reserved for the post-grant revocation paths (refund-driven and
-# manual admin override); exported now so those code paths share this spelling.
+# The two webhook-driven revocations. Kept apart so an operator reading the
+# log can tell "the buyer got their money back" from "the subscription simply
+# lapsed" — the entitlement outcome is identical, the accounting is not.
 REASON_REFUND = "refund"
+REASON_CANCELLATION = "cancellation"
+# Still forward-reserved: no manual admin-override revocation path exists yet.
 REASON_ADMIN_OVERRIDE = "admin_override"
 REASON_DUPLICATE_SIGNUP = "duplicate_signup"
 REASON_EMAIL_MISMATCH = "email_mismatch"

--- a/backend/src/models/gumroad_sale.py
+++ b/backend/src/models/gumroad_sale.py
@@ -9,6 +9,11 @@ Gumroad to resend history.
 The row also carries the token-pack credit claim: ``token_pack_credited_at``
 is the exactly-once guard a wallet credit takes before moving any money, and
 ``token_pack_credited_user_id`` records which account received it.
+
+``revocation_processed_at`` is the mirror-image guard for reversals — the one
+claim every refund, dispute, cancellation, and subscription-ended event
+competes for, so a purchase is unwound exactly once no matter how many
+reversal pings Gumroad delivers.
 """
 
 from datetime import UTC, datetime
@@ -61,4 +66,13 @@ class GumroadSale(SQLModel, table=True):
         ondelete="SET NULL",
         index=True,
         nullable=True,
+    )
+    # The reversal claim guard, shared by every event that unwinds a purchase.
+    # NULL means "nothing has reversed this sale yet"; a guarded UPDATE stamps
+    # it, so the refund and the cancellation of the same subscription cannot
+    # both revoke. Sharing one column rather than one per event kind is the
+    # point: the second event to arrive has genuinely nothing left to undo.
+    revocation_processed_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
     )

--- a/backend/src/models/wallet_audit.py
+++ b/backend/src/models/wallet_audit.py
@@ -56,6 +56,16 @@ REASON_MONTHLY_RESET = "monthly_reset"
 # apart from courtesy top-ups, and so a later refund claw-back can find
 # exactly the rows it must reverse.
 REASON_GUMROAD_PURCHASE = "gumroad_purchase"
+# ``gumroad_refund`` — the reversal of the row above, written when a refund
+# or chargeback ping claws the pack back out of ``BUCKET_OFFERING``.  The
+# ``delta`` is the negative of the original purchase, so
+# ``SUM(delta WHERE bucket='offering')`` still equals the live balance and a
+# refunded pack nets to zero across the pair.  Like the purchase it is
+# system-initiated with ``actor_user_id == user_id``: the buyer's own
+# chargeback moved their wallet, nobody granted or took anything by hand.
+# The claw-back is deliberately unclamped, so this row can carry the balance
+# below zero — spending the credits first must not make the refund cheaper.
+REASON_GUMROAD_REFUND = "gumroad_refund"
 
 # Bucket tokens — which side of the wallet was changed.  ``monthly`` is
 # the free per-calendar-month allocation; ``offering`` is the durable

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -6,12 +6,21 @@ body is read, so an unauthenticated caller can never drive the parser. Valid
 pings are persisted verbatim into :class:`~models.gumroad_sale.GumroadSale`,
 idempotently keyed by ``sale_id``.
 
-A ``sale`` event additionally dispatches two side effects guarded by disjoint
-product allowlists, so at most one fires: the buyer's ``course_access``
-entitlement for an APTITUDE product, and a BotMason wallet credit for a token
-pack. Both are idempotent, so replays stay safe. The credited amount comes
-solely from the operator-configured pack-size map — never from a payload
-field, which a forged ping would control.
+Each event type this router understands is routed through ``_EVENT_HANDLERS``,
+the single table that also defines what counts as a known event.
+
+A ``sale`` event dispatches two side effects guarded by disjoint product
+allowlists, so at most one fires: the buyer's ``course_access`` entitlement
+for an APTITUDE product, and a BotMason wallet credit for a token pack. Both
+are idempotent, so replays stay safe. The credited amount comes solely from
+the operator-configured pack-size map — never from a payload field, which a
+forged ping would control.
+
+The reversal events unwind that delivery. ``refund`` and ``dispute`` return
+the money; ``cancellation`` and ``subscription_ended`` only stop the
+renewals. All four compete for one exactly-once claim on the stored sale (see
+:mod:`services.gumroad_revocation`), and all four read every fact they act on
+off that stored row rather than off the ping.
 
 Secrets discipline: the webhook secret, buyer email, and raw payload never
 appear in log text — only static markers and non-PII metadata do.
@@ -22,6 +31,7 @@ from __future__ import annotations
 import hmac
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -41,18 +51,12 @@ from domain.entitlements import (
 from errors import bad_request
 from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
 from models.user import User
+from services.gumroad_revocation import process_cancellation, process_refund
 from services.token_packs import credit_token_pack_sale
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhooks/gumroad", tags=["gumroad"])
-
-# resource_name values Gumroad documents for ping webhooks. Anything else is
-# still persisted (verbatim capture) but flagged with
-# ``reason_code=unhandled_event`` so operators notice new event types.
-KNOWN_RESOURCE_NAMES = frozenset(
-    {SALE_RESOURCE_NAME, "refund", "dispute", "cancellation", "subscription_ended"}
-)
 
 # Gumroad posts booleans as the form strings "true"/"false".
 _TRUE_FORM_VALUE = "true"
@@ -246,6 +250,26 @@ async def _dispatch_sale(session: AsyncSession, payload: dict[str, str]) -> None
     await _credit_token_pack_for_sale(session, payload)
 
 
+# Every ping event type this webhook acts on, and the coroutine that owns it.
+# A refund and a dispute are the same reversal (the money went back); a
+# cancellation and a subscription ending are the same lapse. One table means
+# the routing and the "do we recognise this event?" question can never drift
+# apart.
+_EVENT_HANDLERS: dict[str, Callable[[AsyncSession, dict[str, str]], Awaitable[None]]] = {
+    SALE_RESOURCE_NAME: _dispatch_sale,
+    "refund": process_refund,
+    "dispute": process_refund,
+    "cancellation": process_cancellation,
+    "subscription_ended": process_cancellation,
+}
+
+# resource_name values Gumroad documents for ping webhooks — derived from the
+# handler table so adding an event registers it in both senses at once.
+# Anything else is still persisted (verbatim capture) but flagged with
+# ``reason_code=unhandled_event`` so operators notice new event types.
+KNOWN_RESOURCE_NAMES = frozenset(_EVENT_HANDLERS)
+
+
 @router.post("/ping")
 async def receive_ping(
     request: Request,
@@ -256,8 +280,12 @@ async def receive_ping(
 
     Always answers 200 on an authenticated, well-formed ping — including
     replays and unknown event types — so Gumroad never re-queues an event we
-    have already captured. A ``sale`` event additionally dispatches its
-    (idempotent) entitlement grant and token-pack credit.
+    have already captured. Recognised events then run their handler from
+    ``_EVENT_HANDLERS``: a sale dispatches its (idempotent) entitlement grant
+    and token-pack credit, a reversal unwinds them exactly once.
+
+    The row is persisted before the handler runs, so an orphan reversal ping
+    is captured even though it reverses nothing.
     """
     _require_valid_secret(secret)
     payload = await _read_ping_payload(request)
@@ -267,8 +295,9 @@ async def receive_ping(
         logger.info("gumroad_webhook_event reason_code=unhandled_event")
     if not await _sale_already_recorded(session, payload["sale_id"]):
         await _persist_sale(session, payload)
-    if resource_name == SALE_RESOURCE_NAME:
-        await _dispatch_sale(session, payload)
+    handler = _EVENT_HANDLERS.get(resource_name)
+    if handler is not None:
+        await handler(session, payload)
     logger.info(
         "gumroad_webhook_accepted",
         extra={"reason_code": "accepted", "resource_name": resource_name},

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -71,6 +71,7 @@ _REFUNDED_FIELD = "refunded"
 # stored but deliberately moved nothing.
 _REASON_UNKNOWN_PRODUCT = "unknown_product"
 _REASON_REFUNDED_SALE = "refunded_sale"
+_REASON_PREVIOUSLY_REVERSED = "sale_previously_reversed"
 _REASON_SIZE_UNCONFIGURED = "token_pack_size_unconfigured"
 _REASON_PACK_CREDITED = "token_pack_credited"
 
@@ -163,6 +164,9 @@ async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> Non
     sale row alone is the outcome (the buyer's later license-gated signup
     converges by linking to it). The grant is idempotent, so webhook replays
     never duplicate an entitlement.
+
+    Requires the stored sale to be unreversed: a sale whose reversal claim is
+    already spent grants nothing, however many times Gumroad redelivers it.
     """
     if not is_aptitude_product_id(payload.get(_PRODUCT_ID_FIELD)):
         return
@@ -170,9 +174,24 @@ async def _grant_for_sale(session: AsyncSession, payload: dict[str, str]) -> Non
     if user is None:
         return
     sale_result = await session.execute(
-        select(GumroadSale).where(GumroadSale.gumroad_sale_id == payload["sale_id"])
+        select(GumroadSale)
+        .where(GumroadSale.gumroad_sale_id == payload["sale_id"])
+        # A reversal writes the claim through SQL alone, so an instance this
+        # session already holds would still read as unreversed; the guard
+        # below has to see the row as the database has it.
+        .execution_options(populate_existing=True)
     )
     sale = sale_result.scalars().first()
+    if sale is not None and sale.revocation_processed_at is not None:
+        # A reversal is permanent for the sale that funded the access, and it
+        # deliberately leaves the buyer with no active entitlement. Since the
+        # grant is only idempotent against a live one, a stale redelivery of
+        # the original purchase would mint a fresh grant and hand a refunded
+        # buyer back the access they were charged back for. The token-pack
+        # side needs no twin of this guard: ``token_pack_credited_at`` is a
+        # permanent one-way gate that no reversal ever clears.
+        logger.info("gumroad_webhook_event", extra={"reason_code": _REASON_PREVIOUSLY_REVERSED})
+        return
     await grant_course_access(session, user, sale=sale, reason_code=REASON_WEBHOOK_SALE)
 
 

--- a/backend/src/services/gumroad_revocation.py
+++ b/backend/src/services/gumroad_revocation.py
@@ -1,0 +1,361 @@
+"""Exactly-once reversal of a Gumroad purchase.
+
+Gumroad reports every way a sale can come undone as its own ping: ``refund``
+and ``dispute`` return the money, ``cancellation`` and ``subscription_ended``
+merely stop the renewals. All four are re-delivered until acknowledged, and
+the same purchase can legitimately attract more than one of them, so the
+reversal has to be idempotent per *sale* rather than per delivery.
+
+The guard is ``GumroadSale.revocation_processed_at``, taken with a single
+conditional ``UPDATE ... WHERE revocation_processed_at IS NULL``. Only the
+writer whose ``rowcount`` comes back 1 reverses anything; every later event
+finds the claim spent and does nothing. One shared column across all four
+event types is deliberate — a subscription that is cancelled and then
+refunded must lose its access once, not twice.
+
+Two rules keep the reversal honest:
+
+* **Nothing but the idempotency key comes from the payload.** The product,
+  the buyer, the pack size, and the account that actually received the
+  credits are all read off the stored purchase row, so a forged ping cannot
+  redirect a claw-back or aim a revocation at somebody else's account.
+* **The purchase is resolved as a purchase.** An orphan reversal ping is
+  itself persisted verbatim by the webhook, so the lookup requires
+  ``resource_name == "sale"`` or a redelivery would find the row it just
+  created and "reverse" it.
+
+The two handlers are asymmetric about product class on purpose.
+``process_refund`` reverses whatever the sale delivered and claims every sale
+it resolves. ``process_cancellation`` acts only on an APTITUDE sale — a
+one-time token pack is not a subscription — and is otherwise wholly inert,
+taking no claim, because consuming the shared guard there would permanently
+disarm the refund that may follow and hand the buyer both their money and
+their credits.
+
+Lives in ``services`` rather than ``domain`` because it owns the transaction
+boundary: it commits.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlalchemy import CursorResult, func, update
+from sqlmodel import col, select
+
+from domain.entitlements import (
+    REASON_CANCELLATION,
+    REASON_REFUND,
+    is_aptitude_product_id,
+    is_token_pack_product_id,
+    revoke_course_access,
+    token_pack_size,
+)
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from services.wallet import claw_back_purchase_credit
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["process_cancellation", "process_refund"]
+
+logger = logging.getLogger(__name__)
+
+# Structured-log reason codes for the outcomes an operator needs to grep for.
+# Every one of them marks a reversal ping that was accepted and answered 200
+# but deliberately moved less than a naive reading would expect.
+_REASON_UNKNOWN_SALE = "unknown_sale"
+_REASON_UNKNOWN_PRODUCT = "unknown_product"
+_REASON_COVERED = "covered_by_other_sale"
+_REASON_NOT_APPLICABLE = "cancellation_not_applicable"
+_REASON_BUYER_NOT_REGISTERED = "buyer_not_registered"
+_REASON_NEVER_CREDITED = "token_pack_never_credited"
+_REASON_CREDITED_USER_MISSING = "credited_user_missing"
+# Same spelling the sale-dispatch path already uses for a priced-out pack, so
+# both halves of the money story group under one reason code.
+_REASON_SIZE_UNCONFIGURED = "token_pack_size_unconfigured"
+_REASON_CLAWED_BACK = "token_pack_clawed_back"
+
+# One event name for every declined reversal so a log query can start from
+# the marker and narrow by reason_code, matching the router's convention.
+_SKIPPED_EVENT = "gumroad_reversal_skipped"
+
+
+@dataclass(frozen=True)
+class _StoredSale:
+    """The stored purchase facts a reversal is allowed to act on.
+
+    Snapshotted into a plain record the moment the sale is resolved, before
+    anything commits. Reading these off an attached ORM instance instead
+    would turn every post-commit access into a lazy load outside the async
+    context, and would invite the payload's own fields to creep back in.
+    """
+
+    sale_id: str
+    product_id: str
+    email: str
+    token_pack_credited_at: datetime | None
+    token_pack_credited_user_id: int | None
+
+
+async def _resolve_stored_sale(
+    session: AsyncSession, payload: dict[str, str]
+) -> _StoredSale | None:
+    """Resolve the original purchase this reversal names, or ``None``.
+
+    The ``resource_name == "sale"`` filter is load-bearing rather than
+    cosmetic: an unrecognised ``sale_id`` makes the webhook persist the
+    reversal ping itself as a row under the same key, and without the filter
+    a redelivery of that ping would resolve the row it just created.
+    """
+    sale_id = payload["sale_id"]
+    result = await session.execute(
+        select(
+            GumroadSale.product_id,
+            GumroadSale.email,
+            GumroadSale.token_pack_credited_at,
+            GumroadSale.token_pack_credited_user_id,
+        ).where(
+            col(GumroadSale.gumroad_sale_id) == sale_id,
+            col(GumroadSale.resource_name) == SALE_RESOURCE_NAME,
+        )
+    )
+    row = result.first()
+    if row is None:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_UNKNOWN_SALE})
+        return None
+    return _StoredSale(
+        sale_id=sale_id,
+        product_id=row.product_id,
+        email=row.email,
+        token_pack_credited_at=row.token_pack_credited_at,
+        token_pack_credited_user_id=row.token_pack_credited_user_id,
+    )
+
+
+async def _take_revocation_claim(
+    session: AsyncSession,
+    sale_id: str,
+    *,
+    mark_refunded: bool,
+) -> bool:
+    """Stamp the sale's reversal claim, returning whether this caller won.
+
+    Under READ COMMITTED two transactions issuing this UPDATE serialize on
+    the row lock. The loser re-evaluates its WHERE against the new row
+    version, sees ``revocation_processed_at IS NOT NULL``, gets ``rowcount``
+    0, and reverses nothing. ``gumroad_sale_id`` is UNIQUE and the
+    ``resource_name`` predicate is the same one that resolved the row, so
+    the statement targets exactly the purchase being reversed.
+
+    ``mark_refunded`` folds the money question into the same statement: a
+    refund flips ``refunded`` alongside the claim (which is also what stops
+    the signup sweep paying the pack out later), while a cancellation leaves
+    it alone because the seller kept the payment.
+
+    ``synchronize_session=False`` is load-bearing, not decoration: the sale
+    may already sit in the session's identity map, and SQLAlchemy's
+    Python-side WHERE evaluator would then compare a timezone-naive stored
+    value against an aware one and raise on SQLite. Issuing the UPDATE
+    through SQL alone is exactly what the guard already guarantees.
+    """
+    values: dict[str, Any] = {"revocation_processed_at": datetime.now(UTC)}
+    if mark_refunded:
+        values["refunded"] = True
+    result = await session.execute(
+        update(GumroadSale)
+        .where(
+            col(GumroadSale.gumroad_sale_id) == sale_id,
+            col(GumroadSale.resource_name) == SALE_RESOURCE_NAME,
+            col(GumroadSale.revocation_processed_at).is_(None),
+        )
+        .values(**values)
+        .execution_options(synchronize_session=False)
+    )
+    return bool(cast("CursorResult[Any]", result).rowcount)
+
+
+async def _is_covered_by_another_sale(session: AsyncSession, stored: _StoredSale) -> bool:
+    """Return True when another live APTITUDE purchase still earns this access.
+
+    A buyer who owns the course twice and reverses one copy keeps their
+    access — the entitlement belongs to the person, not to the receipt. A
+    sale stops covering the moment it is itself refunded *or* claimed by any
+    reversal, which is why the predicate cannot lean on ``refunded`` alone: a
+    cancellation stamps only the claim.
+
+    Filters in SQL down to the rows a cover could ever come from and
+    classifies the product in Python, the same split
+    :func:`services.token_packs._unclaimed_token_pack_sales` uses, because
+    both allowlists are environment configuration rather than columns. The
+    email predicate folds case to ride ``ix_gumroadsale_lower_email``.
+    """
+    result = await session.execute(
+        select(GumroadSale.product_id).where(
+            col(GumroadSale.resource_name) == SALE_RESOURCE_NAME,
+            col(GumroadSale.gumroad_sale_id) != stored.sale_id,
+            func.lower(GumroadSale.email) == stored.email.strip().lower(),
+            col(GumroadSale.refunded).is_(False),
+            col(GumroadSale.revocation_processed_at).is_(None),
+        )
+    )
+    return any(is_aptitude_product_id(row.product_id) for row in result.all())
+
+
+async def _find_user_id_by_email(session: AsyncSession, email: str) -> int | None:
+    """Return the id of the account registered under ``email``, or ``None``.
+
+    Folds case exactly as the webhook's own lookup does: Gumroad reports the
+    buyer's address as they typed it while accounts are stored normalized.
+    Resolving the buyer here rather than in the router keeps the dependency
+    pointing one way — routers import services, never the reverse.
+    """
+    normalized = email.strip().lower()
+    if not normalized:
+        return None
+    result = await session.execute(select(User.id).where(func.lower(User.email) == normalized))
+    return result.scalars().first()
+
+
+async def _revoke_course_access_for(
+    session: AsyncSession,
+    stored: _StoredSale,
+    reason: str,
+) -> None:
+    """Revoke the buyer's course access unless another purchase still covers it.
+
+    A buyer who never registered is a clean no-op: the sale granted nothing
+    at purchase time, so there is nothing to take back. The claim is still
+    spent by the caller either way, which closes the sale out rather than
+    leaving it armed for a redelivery to reverse an account that appears
+    later.
+    """
+    if await _is_covered_by_another_sale(session, stored):
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_COVERED})
+        return
+    user_id = await _find_user_id_by_email(session, stored.email)
+    if user_id is None:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_BUYER_NOT_REGISTERED})
+        return
+    await revoke_course_access(session, user_id, reason)
+
+
+def _claw_back_amount(stored: _StoredSale) -> int | None:
+    """Return how many credits this refund must reclaim, or ``None`` for none.
+
+    Two gates, each failing closed and each logged. A pack nobody ever
+    claimed has no credits to take back (the buyer refunded before
+    registering; stamping ``refunded`` is what stops the signup sweep paying
+    it out). An allowlisted pack whose configured size has gone missing is
+    reconciled by hand rather than guessed at — there is no safe default
+    claw-back for real money.
+    """
+    if stored.token_pack_credited_at is None:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_NEVER_CREDITED})
+        return None
+    amount = token_pack_size(stored.product_id)
+    if amount is None:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_SIZE_UNCONFIGURED})
+    return amount
+
+
+async def _debit_credited_account(
+    session: AsyncSession,
+    stored: _StoredSale,
+    amount: int,
+) -> None:
+    """Take ``amount`` back out of the account that actually received the pack.
+
+    ``token_pack_credited_user_id`` is ``SET NULL`` on account deletion, so a
+    claimed sale can outlive the wallet it paid into; that case is recorded
+    rather than redirected, because the alternative is inventing a victim
+    from the payload's email.
+    """
+    user_id = stored.token_pack_credited_user_id
+    new_balance = (
+        None if user_id is None else await claw_back_purchase_credit(session, user_id, amount)
+    )
+    if new_balance is None:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_CREDITED_USER_MISSING})
+        return
+    logger.info(
+        "gumroad_token_pack_clawed_back",
+        extra={"reason_code": _REASON_CLAWED_BACK, "user_id": user_id, "amount": amount},
+    )
+
+
+async def _reverse_delivered_value(session: AsyncSession, stored: _StoredSale) -> None:
+    """Undo whatever the stored sale delivered, per its product class.
+
+    The two branches are disjoint because the allowlists are: a course
+    refund writes no wallet audit row and a pack refund touches no
+    entitlement. A product on neither allowlist reverses nothing — it
+    delivered nothing either — but is flagged, since a sale that granted
+    silently and now un-grants silently is exactly the drift an operator
+    needs to see.
+    """
+    if is_aptitude_product_id(stored.product_id):
+        await _revoke_course_access_for(session, stored, REASON_REFUND)
+    elif is_token_pack_product_id(stored.product_id):
+        amount = _claw_back_amount(stored)
+        if amount is not None:
+            await _debit_credited_account(session, stored, amount)
+    else:
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_UNKNOWN_PRODUCT})
+
+
+async def process_refund(session: AsyncSession, payload: dict[str, str]) -> None:
+    """Reverse the purchase a ``refund`` or ``dispute`` ping names.
+
+    The money went back, so the claim is taken with ``refunded=True`` and
+    whatever the stored sale delivered is undone: course access for an
+    APTITUDE product, the full configured pack for a token pack, nothing at
+    all for anything else. Every resolved sale is claimed even when there is
+    nothing to reverse — an edge case that left the claim open would be a
+    stale-redelivery trap, waiting to re-run against a wallet or an account
+    that has since changed.
+
+    Commits, so the claim lands with the reversal it authorised. A ping
+    naming no stored purchase, or one that loses the claim race, returns
+    having written nothing.
+    """
+    stored = await _resolve_stored_sale(session, payload)
+    if stored is None:
+        return
+    if not await _take_revocation_claim(session, stored.sale_id, mark_refunded=True):
+        return
+    await _reverse_delivered_value(session, stored)
+    await session.commit()
+
+
+async def process_cancellation(session: AsyncSession, payload: dict[str, str]) -> None:
+    """End future access for a ``cancellation`` or ``subscription_ended`` ping.
+
+    Applies only to an APTITUDE sale: a subscription is the only thing there
+    is to cancel. ``refunded`` stays False because the seller kept the
+    payment, and the wallet is never touched.
+
+    For anything else the handler is wholly inert — it takes no claim. That
+    restraint is what protects the money: a one-time token pack cannot be
+    cancelled, and letting a stray cancellation consume the shared guard
+    would silently disarm the refund that may follow, leaving a refunded
+    buyer holding every credit.
+
+    Commits when it acts. A ping naming no stored purchase, or one that
+    loses the claim race to an earlier reversal, returns having written
+    nothing.
+    """
+    stored = await _resolve_stored_sale(session, payload)
+    if stored is None:
+        return
+    if not is_aptitude_product_id(stored.product_id):
+        logger.info(_SKIPPED_EVENT, extra={"reason_code": _REASON_NOT_APPLICABLE})
+        return
+    if not await _take_revocation_claim(session, stored.sale_id, mark_refunded=False):
+        return
+    await _revoke_course_access_for(session, stored, REASON_CANCELLATION)
+    await session.commit()

--- a/backend/src/services/wallet.py
+++ b/backend/src/services/wallet.py
@@ -41,6 +41,7 @@ from models.wallet_audit import (
     BUCKET_OFFERING,
     REASON_ADMIN_GRANT,
     REASON_GUMROAD_PURCHASE,
+    REASON_GUMROAD_REFUND,
     REASON_MONTHLY_RESET,
     REASON_SELF_GRANT,
     REASON_SPEND_MONTHLY,
@@ -416,5 +417,43 @@ async def grant_purchase_credit(session: AsyncSession, user_id: int, amount: int
         user_id,
         amount,
         reason=REASON_GUMROAD_PURCHASE,
+        actor_user_id=user_id,
+    )
+
+
+async def claw_back_purchase_credit(
+    session: AsyncSession,
+    user_id: int,
+    amount: int,
+) -> int | None:
+    """Debit a refunded Gumroad purchase's ``amount`` and return the new total.
+
+    The exact inverse of :func:`grant_purchase_credit`: ``amount`` is passed
+    in positive and applied as ``-amount``, so the audit pair for a refunded
+    pack sums to zero.  The buyer is their own actor again -- their
+    chargeback moved the wallet, nobody granted or confiscated anything by
+    hand.
+
+    **The resulting balance may be negative, and that is the point.**
+    ``_credit_offering`` does no clamping, so a buyer who spent half a pack
+    before disputing the charge is left overdrawn rather than keeping the
+    messages they spent.  Clamping at zero would make spending first a way to
+    get the credits for free.  A negative balance is still unspendable:
+    :func:`spend_one_message` guards its offering branch with
+    ``WHERE offering_balance > 0``, so the buyer simply has no paid capacity
+    until the shortfall is made good.  The audit arithmetic needs no special
+    case either -- ``balance_before = new_balance - amount`` is already
+    correct for a negative ``amount``.
+
+    Returns ``None`` (staging no audit row) when the user has vanished, so
+    the caller can log the orphaned reversal rather than record a debit
+    against nobody.  Does not commit: the caller owns the transaction so the
+    debit lands with whatever claim guards it.
+    """
+    return await _credit_offering(
+        session,
+        user_id,
+        -amount,
+        reason=REASON_GUMROAD_REFUND,
         actor_user_id=user_id,
     )

--- a/backend/tests/routers/test_gumroad_cancellation.py
+++ b/backend/tests/routers/test_gumroad_cancellation.py
@@ -1,0 +1,426 @@
+"""Cancellation / subscription-ended handling for POST /webhooks/gumroad/ping.
+
+Contract: a ``cancellation`` or ``subscription_ended`` ping ends future access
+without reversing money. It applies ONLY to an APTITUDE sale — a subscription
+is the only thing there is to cancel. The buyer's ``course_access`` is revoked
+(unless another live APTITUDE purchase still covers it), the original sale
+keeps ``refunded`` False because the seller kept the payment, and the wallet is
+never touched.
+
+A cancellation naming a token-pack sale (or any product on neither allowlist)
+is wholly inert: one-time purchases cannot be cancelled, so the handler takes
+no claim, writes nothing, and logs ``cancellation_not_applicable``. Staying
+inert is what protects the money — the pack sale keeps its unspent
+``revocation_processed_at`` claim, so a genuine later refund still claws the
+credits back in full.
+
+On the APTITUDE side, cancellation and refund do share that single
+exactly-once claim, so whichever lands first wins and the other becomes a
+no-op rather than revoking twice.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.entitlements import (
+    PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_SIZES_ENV_VAR,
+)
+from models.entitlement import Entitlement
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from models.wallet_audit import REASON_GUMROAD_REFUND, WalletAudit
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+WEBHOOK_SECRET = "gumroad-cancellation-shared-secret-test-only"  # pragma: allowlist secret
+WRONG_WEBHOOK_SECRET = "not-the-shared-secret"  # pragma: allowlist secret
+WEBHOOK_SECRET_ENV_VAR = "GUMROAD_WEBHOOK_SECRET"  # pragma: allowlist secret
+
+APTITUDE_PRODUCT_ID = "prod_course_abc"
+SECOND_APTITUDE_PRODUCT_ID = "prod_course_xyz"
+TOKEN_PACK_PRODUCT_ID = "prod_pack_small"
+TOKEN_PACK_SIZE = 100
+
+BUYER_EMAIL = "buyer@example.com"
+MIXED_CASE_BUYER_EMAIL = "Buyer@Example.COM"
+
+SALE_ID = "S-100"
+SECOND_SALE_ID = "S-101"
+PACK_SALE_ID = "S-200"
+UNKNOWN_SALE_ID = "S-999"
+
+CANCELLATION_RESOURCE = "cancellation"
+SUBSCRIPTION_ENDED_RESOURCE = "subscription_ended"
+REFUND_RESOURCE = "refund"
+
+UNKNOWN_SALE_MARKER = "unknown_sale"
+COVERED_MARKER = "covered_by_other_sale"
+NOT_APPLICABLE_MARKER = "cancellation_not_applicable"
+
+EXPECTED_SALES_AFTER_ORPHAN_CANCELLATION = 2
+
+
+@pytest.fixture(autouse=True)
+def gumroad_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the shared secret and both product allowlists for every test."""
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV_VAR, WEBHOOK_SECRET)
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, f"{APTITUDE_PRODUCT_ID},{SECOND_APTITUDE_PRODUCT_ID}")
+    monkeypatch.setenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_PRODUCT_ID)
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}")
+
+
+def _sale_payload(**overrides: str) -> dict[str, str]:
+    """Build a form-encoded APTITUDE sale ping, with optional overrides."""
+    payload = {
+        "sale_id": SALE_ID,
+        "product_id": APTITUDE_PRODUCT_ID,
+        "email": BUYER_EMAIL,
+        "resource_name": SALE_RESOURCE_NAME,
+        "is_recurring_charge": "false",
+        "refunded": "false",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _pack_payload(**overrides: str) -> dict[str, str]:
+    """Build a token-pack sale ping, with optional overrides."""
+    defaults = {"sale_id": PACK_SALE_ID, "product_id": TOKEN_PACK_PRODUCT_ID}
+    return _sale_payload(**{**defaults, **overrides})
+
+
+def _cancellation_payload(**overrides: str) -> dict[str, str]:
+    """Build a cancellation ping for the default APTITUDE sale."""
+    return _sale_payload(**{"resource_name": CANCELLATION_RESOURCE, **overrides})
+
+
+async def _ping(
+    client: AsyncClient,
+    payload: dict[str, str],
+    secret: str = WEBHOOK_SECRET,
+) -> Response:
+    """POST one form-encoded ping with the given shared secret."""
+    return await client.post(WEBHOOK_PATH, params={"secret": secret}, data=payload)
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+async def _persist_user(db_session: AsyncSession, email: str = BUYER_EMAIL) -> int:
+    """Create and commit a user; return their non-null id."""
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user.id
+
+
+async def _offering_balance(db_session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted offering balance, read fresh."""
+    result = await db_session.execute(
+        select(User).where(col(User.id) == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _reload_sale(db_session: AsyncSession, sale_id: str) -> GumroadSale:
+    """Re-read one sale row from the database, bypassing the identity map."""
+    result = await db_session.execute(
+        select(GumroadSale)
+        .where(col(GumroadSale.gumroad_sale_id) == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+async def _entitlements(db_session: AsyncSession) -> list[Entitlement]:
+    """Return every entitlement row, read fresh and ordered by insertion."""
+    result = await db_session.execute(
+        select(Entitlement).order_by(col(Entitlement.id)).execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+async def _sole_entitlement(db_session: AsyncSession) -> Entitlement:
+    """Return the single entitlement row, failing loudly if there is not exactly one."""
+    entitlements = await _entitlements(db_session)
+    assert len(entitlements) == 1
+    return entitlements[0]
+
+
+async def _refund_audits(db_session: AsyncSession) -> list[WalletAudit]:
+    """Return only the ``gumroad_refund`` audit rows, oldest first."""
+    result = await db_session.execute(
+        select(WalletAudit)
+        .where(col(WalletAudit.reason) == REASON_GUMROAD_REFUND)
+        .order_by(col(WalletAudit.id))
+        .execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+async def _count_sales(db_session: AsyncSession) -> int:
+    """Return the number of GumroadSale rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(GumroadSale))
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", [CANCELLATION_RESOURCE, SUBSCRIPTION_ENDED_RESOURCE])
+async def test_ending_event_revokes_course_access_without_a_refund(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    resource_name: str,
+) -> None:
+    """Cancelling ends access but leaves the sale unrefunded — the money was kept."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _cancellation_payload(resource_name=resource_name))
+
+    assert response.status_code == HTTPStatus.OK
+    entitlement = await _sole_entitlement(db_session)
+    assert entitlement.user_id == user_id
+    assert entitlement.revoked_at is not None
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is not None
+    assert await _refund_audits(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_replayed_cancellation_revokes_exactly_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A redelivered cancellation keeps one revoked entitlement, timestamp unchanged."""
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    first = await _ping(async_client, _cancellation_payload())
+    revoked_at = (await _sole_entitlement(db_session)).revoked_at
+    claimed_at = (await _reload_sale(db_session, SALE_ID)).revocation_processed_at
+    second = await _ping(async_client, _cancellation_payload())
+
+    assert [first.status_code, second.status_code] == [HTTPStatus.OK, HTTPStatus.OK]
+    assert revoked_at is not None
+    assert (await _sole_entitlement(db_session)).revoked_at == revoked_at
+    assert (await _reload_sale(db_session, SALE_ID)).revocation_processed_at == claimed_at
+
+
+@pytest.mark.asyncio
+async def test_cancellation_for_an_unknown_sale_changes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cancellation naming a sale_id we never stored is logged and moves nothing."""
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _cancellation_payload(sale_id=UNKNOWN_SALE_ID))
+
+    assert response.status_code == HTTPStatus.OK
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    original = await _reload_sale(db_session, SALE_ID)
+    assert original.revocation_processed_at is None
+    assert await _count_sales(db_session) == EXPECTED_SALES_AFTER_ORPHAN_CANCELLATION
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_a_cancellation_ping_row_never_satisfies_its_own_sale_lookup(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The row a cancellation ping creates for itself must not read as an original sale.
+
+    An unseen sale_id makes the webhook persist the cancellation verbatim with
+    ``resource_name="cancellation"``. A redelivery would then meet the row it
+    just created, so a lookup that forgets ``resource_name == "sale"`` would
+    revoke the buyer's unrelated live access.
+    """
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    orphan = _cancellation_payload(sale_id=UNKNOWN_SALE_ID)
+
+    first = await _ping(async_client, orphan)
+    second = await _ping(async_client, orphan)
+
+    assert [first.status_code, second.status_code] == [HTTPStatus.OK, HTTPStatus.OK]
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    stored = await _reload_sale(db_session, UNKNOWN_SALE_ID)
+    assert stored.resource_name == CANCELLATION_RESOURCE
+    assert stored.revocation_processed_at is None
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_of_a_covered_purchase_keeps_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second live APTITUDE purchase survives one of them being cancelled."""
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(
+        async_client,
+        _sale_payload(
+            sale_id=SECOND_SALE_ID,
+            product_id=SECOND_APTITUDE_PRODUCT_ID,
+            email=MIXED_CASE_BUYER_EMAIL,
+        ),
+    )
+
+    response = await _ping(async_client, _cancellation_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    cancelled_sale = await _reload_sale(db_session, SALE_ID)
+    assert cancelled_sale.refunded is False
+    assert cancelled_sale.revocation_processed_at is not None
+    assert _log_carries_marker(caplog, COVERED_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_of_a_token_pack_sale_keeps_the_credits(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A pack cancellation is wholly inert, right down to leaving the claim unspent.
+
+    Credits obviously survive an event that reversed no money, but the
+    load-bearing assertion is ``revocation_processed_at is None``: consuming
+    the shared claim here would disarm the refund that may follow.
+    """
+    caplog.set_level(logging.DEBUG)
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+
+    response = await _ping(async_client, _pack_payload(resource_name=CANCELLATION_RESOURCE))
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _refund_audits(db_session) == []
+    sale = await _reload_sale(db_session, PACK_SALE_ID)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is None
+    assert _log_carries_marker(caplog, NOT_APPLICABLE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_refund_after_an_inert_pack_cancellation_still_claws_back(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A stray cancellation cannot shield a pack from a genuine later refund.
+
+    Cancellations do not apply to one-time purchases, so the earlier ping
+    consumed nothing. The refund therefore finds the claim untaken and
+    reverses the whole pack — otherwise this ordering would hand the buyer
+    their money back and let them keep every credit.
+    """
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+    await _ping(async_client, _pack_payload(resource_name=CANCELLATION_RESOURCE))
+
+    response = await _ping(async_client, _pack_payload(resource_name=REFUND_RESOURCE))
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    audits = await _refund_audits(db_session)
+    assert len(audits) == 1
+    assert audits[0].user_id == user_id
+    assert audits[0].delta == Decimal(-TOKEN_PACK_SIZE)
+    sale = await _reload_sale(db_session, PACK_SALE_ID)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_refund_after_an_aptitude_cancellation_revokes_only_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """On the side the shared claim was built for, the second event is a no-op.
+
+    A cancelled subscription that is later refunded must not produce a second
+    revoke transition, and the late refund must not re-stamp the claim or flip
+    ``refunded`` — the cancellation already spent it.
+    """
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(async_client, _cancellation_payload())
+    revoked_at = (await _sole_entitlement(db_session)).revoked_at
+    claimed_at = (await _reload_sale(db_session, SALE_ID)).revocation_processed_at
+
+    response = await _ping(async_client, _sale_payload(resource_name=REFUND_RESOURCE))
+
+    assert response.status_code == HTTPStatus.OK
+    assert revoked_at is not None
+    assert claimed_at is not None
+    assert (await _sole_entitlement(db_session)).revoked_at == revoked_at
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.revocation_processed_at == claimed_at
+    assert sale.refunded is False
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_refund_claws_back_nothing_further(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A cancellation trailing a refund leaves the single claw-back untouched."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+    await _ping(async_client, _pack_payload(resource_name=REFUND_RESOURCE))
+    claimed_at = (await _reload_sale(db_session, PACK_SALE_ID)).revocation_processed_at
+
+    response = await _ping(async_client, _pack_payload(resource_name=CANCELLATION_RESOURCE))
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    assert len(await _refund_audits(db_session)) == 1
+    sale = await _reload_sale(db_session, PACK_SALE_ID)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at == claimed_at
+
+
+@pytest.mark.asyncio
+async def test_forged_cancellation_is_rejected_and_changes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An unauthenticated cancellation is a 401 that leaves access alive."""
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _cancellation_payload(), secret=WRONG_WEBHOOK_SECRET)
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.revocation_processed_at is None

--- a/backend/tests/routers/test_gumroad_cancellation.py
+++ b/backend/tests/routers/test_gumroad_cancellation.py
@@ -35,6 +35,7 @@ from domain.entitlements import (
     PRODUCT_IDS_ENV_VAR,
     TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
     TOKEN_PACK_SIZES_ENV_VAR,
+    has_course_access,
 )
 from models.entitlement import Entitlement
 from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
@@ -66,6 +67,7 @@ REFUND_RESOURCE = "refund"
 UNKNOWN_SALE_MARKER = "unknown_sale"
 COVERED_MARKER = "covered_by_other_sale"
 NOT_APPLICABLE_MARKER = "cancellation_not_applicable"
+PREVIOUSLY_REVERSED_MARKER = "sale_previously_reversed"
 
 EXPECTED_SALES_AFTER_ORPHAN_CANCELLATION = 2
 
@@ -174,6 +176,11 @@ async def _refund_audits(db_session: AsyncSession) -> list[WalletAudit]:
         .execution_options(populate_existing=True)
     )
     return list(result.scalars().all())
+
+
+async def _active_entitlements(db_session: AsyncSession) -> list[Entitlement]:
+    """Return only the entitlement rows that are still live (``revoked_at`` unset)."""
+    return [row for row in await _entitlements(db_session) if row.revoked_at is None]
 
 
 async def _count_sales(db_session: AsyncSession) -> int:
@@ -407,6 +414,39 @@ async def test_cancellation_after_refund_claws_back_nothing_further(
     sale = await _reload_sale(db_session, PACK_SALE_ID)
     assert sale.refunded is True
     assert sale.revocation_processed_at == claimed_at
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_sale_ping_does_not_reinstate_cancelled_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A redelivered original sale ping must never undo a completed cancellation.
+
+    Cancellation leaves the same shape a refund does — the entitlement row is
+    stamped ``revoked_at`` and the sale carries a spent claim — so the sale
+    ping Gumroad re-delivers afterwards finds no active grant and would mint a
+    fresh one, silently resurrecting the subscription the buyer ended.
+    """
+    caplog.set_level(logging.DEBUG)
+    user_id = await _persist_user(db_session)
+    original_sale = _sale_payload()
+    await _ping(async_client, original_sale)
+    await _ping(async_client, _cancellation_payload())
+    claimed_at = (await _reload_sale(db_session, SALE_ID)).revocation_processed_at
+
+    response = await _ping(async_client, original_sale)
+
+    assert await _active_entitlements(db_session) == []
+    assert await has_course_access(db_session, user_id) is False
+    assert len(await _entitlements(db_session)) == 1
+    assert response.status_code == HTTPStatus.OK
+    assert claimed_at is not None
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.revocation_processed_at == claimed_at
+    assert sale.refunded is False
+    assert _log_carries_marker(caplog, PREVIOUSLY_REVERSED_MARKER)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_gumroad_refund.py
+++ b/backend/tests/routers/test_gumroad_refund.py
@@ -31,11 +31,17 @@ from domain.entitlements import (
     PRODUCT_IDS_ENV_VAR,
     TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
     TOKEN_PACK_SIZES_ENV_VAR,
+    has_course_access,
 )
 from models.entitlement import Entitlement
 from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
 from models.user import User
-from models.wallet_audit import BUCKET_OFFERING, REASON_GUMROAD_REFUND, WalletAudit
+from models.wallet_audit import (
+    BUCKET_OFFERING,
+    REASON_GUMROAD_PURCHASE,
+    REASON_GUMROAD_REFUND,
+    WalletAudit,
+)
 
 WEBHOOK_PATH = "/webhooks/gumroad/ping"
 WEBHOOK_SECRET = "gumroad-refund-shared-secret-test-only"  # pragma: allowlist secret
@@ -63,6 +69,7 @@ CANCELLATION_RESOURCE = "cancellation"
 
 UNKNOWN_SALE_MARKER = "unknown_sale"
 COVERED_MARKER = "covered_by_other_sale"
+PREVIOUSLY_REVERSED_MARKER = "sale_previously_reversed"
 
 # The buyer spent part of the pack before charging back, so the full-size
 # claw-back has to take the balance below zero.
@@ -201,6 +208,22 @@ async def _refund_audits(db_session: AsyncSession) -> list[WalletAudit]:
         .execution_options(populate_existing=True)
     )
     return list(result.scalars().all())
+
+
+async def _purchase_audits(db_session: AsyncSession) -> list[WalletAudit]:
+    """Return only the ``gumroad_purchase`` audit rows, oldest first."""
+    result = await db_session.execute(
+        select(WalletAudit)
+        .where(col(WalletAudit.reason) == REASON_GUMROAD_PURCHASE)
+        .order_by(col(WalletAudit.id))
+        .execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+async def _active_entitlements(db_session: AsyncSession) -> list[Entitlement]:
+    """Return only the entitlement rows that are still live (``revoked_at`` unset)."""
+    return [row for row in await _entitlements(db_session) if row.revoked_at is None]
 
 
 async def _count_sales(db_session: AsyncSession) -> int:
@@ -574,6 +597,65 @@ async def test_token_pack_refund_leaves_course_access_intact(
 
     assert (await _sole_entitlement(db_session)).revoked_at is None
     assert await _offering_balance(db_session, user_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_sale_ping_does_not_reinstate_refunded_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A redelivered original sale ping must never undo a completed refund.
+
+    Gumroad re-delivers any ping it believes went unacknowledged, so the
+    original purchase event can land again long after the money went back.
+    The grant is only idempotent against an *active* entitlement, and the
+    refund deliberately freed that slot, so re-dispatching the sale mints a
+    brand-new live row and hands a refunded buyer both their money and their
+    course access.
+    """
+    caplog.set_level(logging.DEBUG)
+    user_id = await _persist_user(db_session)
+    original_sale = _sale_payload()
+    await _ping(async_client, original_sale)
+    await _ping(async_client, _refund_payload())
+    claimed_at = (await _reload_sale(db_session, SALE_ID)).revocation_processed_at
+
+    response = await _ping(async_client, original_sale)
+
+    assert await _active_entitlements(db_session) == []
+    assert await has_course_access(db_session, user_id) is False
+    assert len(await _entitlements(db_session)) == 1
+    assert response.status_code == HTTPStatus.OK
+    assert claimed_at is not None
+    assert (await _reload_sale(db_session, SALE_ID)).revocation_processed_at == claimed_at
+    assert _log_carries_marker(caplog, PREVIOUSLY_REVERSED_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_pack_sale_after_a_refund_credits_nothing_further(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The wallet's one-way credit gate survives a replayed, already-refunded pack sale.
+
+    ``token_pack_credited_at`` is stamped permanently and no reversal clears
+    it, so the money side is already immune to the redelivery that reinstates
+    course access. Pinned here so narrowing the course grant cannot loosen
+    this gate on the way past.
+    """
+    user_id = await _persist_user(db_session)
+    original_pack_sale = _pack_payload()
+    await _ping(async_client, original_pack_sale)
+    await _ping(async_client, _pack_refund_payload())
+
+    response = await _ping(async_client, original_pack_sale)
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    assert len(await _purchase_audits(db_session)) == 1
+    assert len(await _refund_audits(db_session)) == 1
+    assert await _entitlements(db_session) == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/routers/test_gumroad_refund.py
+++ b/backend/tests/routers/test_gumroad_refund.py
@@ -1,0 +1,601 @@
+"""Refund / dispute handling for POST /webhooks/gumroad/ping.
+
+Contract: a ``refund`` or ``dispute`` ping resolves the ORIGINAL stored sale
+row (``resource_name == "sale"``, same ``sale_id``) and reverses exactly what
+that sale delivered. An APTITUDE sale loses ``course_access`` unless another
+live APTITUDE purchase by the same buyer still covers it; a token-pack sale
+has the full configured pack size clawed back from the account that actually
+received the credits, even when that drives the balance negative. The two
+reversals are disjoint: a course refund writes no wallet audit, a pack refund
+touches no entitlement.
+
+Every reversal is claimed exactly once via ``revocation_processed_at``, so a
+replayed delivery moves nothing. Nothing in the refund payload steers the
+outcome: the product, the amount, and the recipient all come from the stored
+sale, so a forged override cannot redirect or inflate the claw-back.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient, Response
+from sqlalchemy import func, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.entitlements import (
+    PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_SIZES_ENV_VAR,
+)
+from models.entitlement import Entitlement
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from models.wallet_audit import BUCKET_OFFERING, REASON_GUMROAD_REFUND, WalletAudit
+
+WEBHOOK_PATH = "/webhooks/gumroad/ping"
+WEBHOOK_SECRET = "gumroad-refund-shared-secret-test-only"  # pragma: allowlist secret
+WRONG_WEBHOOK_SECRET = "not-the-shared-secret"  # pragma: allowlist secret
+BLANK_SECRET = ""
+WEBHOOK_SECRET_ENV_VAR = "GUMROAD_WEBHOOK_SECRET"  # pragma: allowlist secret
+
+APTITUDE_PRODUCT_ID = "prod_course_abc"
+SECOND_APTITUDE_PRODUCT_ID = "prod_course_xyz"
+TOKEN_PACK_PRODUCT_ID = "prod_pack_small"
+TOKEN_PACK_SIZE = 100
+
+BUYER_EMAIL = "buyer@example.com"
+MIXED_CASE_BUYER_EMAIL = "Buyer@Example.COM"
+OTHER_EMAIL = "other-buyer@example.com"
+
+SALE_ID = "S-100"
+SECOND_SALE_ID = "S-101"
+PACK_SALE_ID = "S-200"
+UNKNOWN_SALE_ID = "S-999"
+
+REFUND_RESOURCE = "refund"
+DISPUTE_RESOURCE = "dispute"
+CANCELLATION_RESOURCE = "cancellation"
+
+UNKNOWN_SALE_MARKER = "unknown_sale"
+COVERED_MARKER = "covered_by_other_sale"
+
+# The buyer spent part of the pack before charging back, so the full-size
+# claw-back has to take the balance below zero.
+SPENT_DOWN_BALANCE = 40
+NEGATIVE_BALANCE = SPENT_DOWN_BALANCE - TOKEN_PACK_SIZE
+
+# Payload fields a naive implementation might trust over the stored sale.
+HOSTILE_QUANTITY = "9999"
+HOSTILE_PRICE = "9999"
+
+EXPECTED_SALES_AFTER_ORPHAN_REFUND = 2
+
+
+@pytest.fixture(autouse=True)
+def gumroad_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the shared secret and both product allowlists for every test."""
+    monkeypatch.setenv(WEBHOOK_SECRET_ENV_VAR, WEBHOOK_SECRET)
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, f"{APTITUDE_PRODUCT_ID},{SECOND_APTITUDE_PRODUCT_ID}")
+    monkeypatch.setenv(TOKEN_PACK_PRODUCT_IDS_ENV_VAR, TOKEN_PACK_PRODUCT_ID)
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{TOKEN_PACK_PRODUCT_ID}:{TOKEN_PACK_SIZE}")
+
+
+def _sale_payload(**overrides: str) -> dict[str, str]:
+    """Build a form-encoded APTITUDE sale ping, with optional overrides."""
+    payload = {
+        "sale_id": SALE_ID,
+        "product_id": APTITUDE_PRODUCT_ID,
+        "email": BUYER_EMAIL,
+        "resource_name": SALE_RESOURCE_NAME,
+        "is_recurring_charge": "false",
+        "refunded": "false",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _pack_payload(**overrides: str) -> dict[str, str]:
+    """Build a token-pack sale ping, with optional overrides."""
+    defaults = {"sale_id": PACK_SALE_ID, "product_id": TOKEN_PACK_PRODUCT_ID}
+    return _sale_payload(**{**defaults, **overrides})
+
+
+def _refund_payload(**overrides: str) -> dict[str, str]:
+    """Build a refund ping for the default APTITUDE sale."""
+    return _sale_payload(**{"resource_name": REFUND_RESOURCE, **overrides})
+
+
+def _pack_refund_payload(**overrides: str) -> dict[str, str]:
+    """Build a refund ping for the default token-pack sale."""
+    return _pack_payload(**{"resource_name": REFUND_RESOURCE, **overrides})
+
+
+async def _ping(
+    client: AsyncClient,
+    payload: dict[str, str],
+    secret: str = WEBHOOK_SECRET,
+) -> Response:
+    """POST one form-encoded ping with the given shared secret."""
+    return await client.post(WEBHOOK_PATH, params={"secret": secret}, data=payload)
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+async def _persist_user(db_session: AsyncSession, email: str = BUYER_EMAIL) -> int:
+    """Create and commit a user; return their non-null id.
+
+    Only the id is returned because the handlers under test commit the same
+    session, and reading an attribute off a stale instance afterwards would
+    lazy-load outside the async context instead of failing an assertion.
+    """
+    user = User(email=email, password_hash="x")  # pragma: allowlist secret
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user.id
+
+
+async def _set_offering_balance(db_session: AsyncSession, user_id: int, balance: int) -> None:
+    """Overwrite a user's ``offering_balance`` to simulate prior spending."""
+    await db_session.execute(
+        update(User)
+        .where(col(User.id) == user_id)
+        .values(offering_balance=balance)
+        .execution_options(synchronize_session=False)
+    )
+    await db_session.commit()
+
+
+async def _offering_balance(db_session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted offering balance, read fresh."""
+    result = await db_session.execute(
+        select(User).where(col(User.id) == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _reload_sale(db_session: AsyncSession, sale_id: str) -> GumroadSale:
+    """Re-read one sale row from the database, bypassing the identity map."""
+    result = await db_session.execute(
+        select(GumroadSale)
+        .where(col(GumroadSale.gumroad_sale_id) == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+async def _entitlements(db_session: AsyncSession) -> list[Entitlement]:
+    """Return every entitlement row, read fresh and ordered by insertion."""
+    result = await db_session.execute(
+        select(Entitlement).order_by(col(Entitlement.id)).execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+async def _sole_entitlement(db_session: AsyncSession) -> Entitlement:
+    """Return the single entitlement row, failing loudly if there is not exactly one."""
+    entitlements = await _entitlements(db_session)
+    assert len(entitlements) == 1
+    return entitlements[0]
+
+
+async def _refund_audits(db_session: AsyncSession) -> list[WalletAudit]:
+    """Return only the ``gumroad_refund`` audit rows, oldest first."""
+    result = await db_session.execute(
+        select(WalletAudit)
+        .where(col(WalletAudit.reason) == REASON_GUMROAD_REFUND)
+        .order_by(col(WalletAudit.id))
+        .execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+async def _count_sales(db_session: AsyncSession) -> int:
+    """Return the number of GumroadSale rows in the test database."""
+    result = await db_session.execute(select(func.count()).select_from(GumroadSale))
+    return int(result.scalar_one())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", [REFUND_RESOURCE, DISPUTE_RESOURCE])
+async def test_reversal_event_revokes_course_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    resource_name: str,
+) -> None:
+    """A refund or a dispute revokes the buyer's course access and marks the sale."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _refund_payload(resource_name=resource_name))
+
+    assert response.status_code == HTTPStatus.OK
+    entitlement = await _sole_entitlement(db_session)
+    assert entitlement.user_id == user_id
+    assert entitlement.revoked_at is not None
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+    assert await _refund_audits(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_replayed_refund_revokes_exactly_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A redelivered refund keeps one revoked entitlement with an unchanged timestamp."""
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    first = await _ping(async_client, _refund_payload())
+    revoked_at = (await _sole_entitlement(db_session)).revoked_at
+    claimed_at = (await _reload_sale(db_session, SALE_ID)).revocation_processed_at
+    second = await _ping(async_client, _refund_payload())
+
+    assert [first.status_code, second.status_code] == [HTTPStatus.OK, HTTPStatus.OK]
+    assert revoked_at is not None
+    assert (await _sole_entitlement(db_session)).revoked_at == revoked_at
+    assert (await _reload_sale(db_session, SALE_ID)).revocation_processed_at == claimed_at
+
+
+@pytest.mark.asyncio
+async def test_refund_for_an_unknown_sale_changes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refund naming a sale_id we never stored is logged and moves nothing."""
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _refund_payload(sale_id=UNKNOWN_SALE_ID))
+
+    assert response.status_code == HTTPStatus.OK
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    original = await _reload_sale(db_session, SALE_ID)
+    assert original.refunded is False
+    assert original.revocation_processed_at is None
+    assert await _count_sales(db_session) == EXPECTED_SALES_AFTER_ORPHAN_REFUND
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_a_refund_ping_row_never_satisfies_its_own_sale_lookup(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The row a refund ping creates for itself must not read as an original sale.
+
+    An unseen sale_id makes the webhook persist the refund ping verbatim with
+    ``resource_name="refund"``. A redelivery of that same ping would then find
+    the row it just created, so a lookup that forgets to require
+    ``resource_name == "sale"`` would revoke the buyer's unrelated live access.
+    """
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    orphan = _refund_payload(sale_id=UNKNOWN_SALE_ID)
+
+    first = await _ping(async_client, orphan)
+    second = await _ping(async_client, orphan)
+
+    assert [first.status_code, second.status_code] == [HTTPStatus.OK, HTTPStatus.OK]
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    stored = await _reload_sale(db_session, UNKNOWN_SALE_ID)
+    assert stored.resource_name == REFUND_RESOURCE
+    assert stored.refunded is False
+    assert stored.revocation_processed_at is None
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_refund_of_a_covered_purchase_keeps_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A second live APTITUDE purchase keeps access alive through the refund.
+
+    The covering sale is recorded under a mixed-case spelling of the same
+    address, so coverage has to fold email case the way every other Gumroad
+    lookup does.
+    """
+    caplog.set_level(logging.DEBUG)
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(
+        async_client,
+        _sale_payload(
+            sale_id=SECOND_SALE_ID,
+            product_id=SECOND_APTITUDE_PRODUCT_ID,
+            email=MIXED_CASE_BUYER_EMAIL,
+        ),
+    )
+
+    response = await _ping(async_client, _refund_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    refunded_sale = await _reload_sale(db_session, SALE_ID)
+    assert refunded_sale.refunded is True
+    assert refunded_sale.revocation_processed_at is not None
+    assert _log_carries_marker(caplog, COVERED_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_refunding_every_purchase_finally_revokes_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """An already-refunded sale stops covering, so the last refund revokes."""
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    second_sale = _sale_payload(sale_id=SECOND_SALE_ID, product_id=SECOND_APTITUDE_PRODUCT_ID)
+    await _ping(async_client, second_sale)
+
+    await _ping(async_client, _refund_payload())
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    await _ping(async_client, {**second_sale, "resource_name": REFUND_RESOURCE})
+
+    assert (await _sole_entitlement(db_session)).revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_sale_no_longer_covers_a_later_refund(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A cancelled purchase keeps ``refunded`` False yet must stop covering.
+
+    Cancellation stamps only the shared claim, so coverage cannot lean on
+    ``refunded`` alone — it has to exclude any sale whose revocation was
+    already processed.
+    """
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    second_sale = _sale_payload(sale_id=SECOND_SALE_ID, product_id=SECOND_APTITUDE_PRODUCT_ID)
+    await _ping(async_client, second_sale)
+
+    await _ping(async_client, {**second_sale, "resource_name": CANCELLATION_RESOURCE})
+    assert (await _reload_sale(db_session, SECOND_SALE_ID)).refunded is False
+    await _ping(async_client, _refund_payload())
+
+    assert (await _sole_entitlement(db_session)).revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_another_buyers_purchase_does_not_cover_a_refund(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A live APTITUDE sale belonging to someone else never keeps access alive."""
+    await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(
+        async_client,
+        _sale_payload(
+            sale_id=SECOND_SALE_ID,
+            product_id=SECOND_APTITUDE_PRODUCT_ID,
+            email=OTHER_EMAIL,
+        ),
+    )
+
+    await _ping(async_client, _refund_payload())
+
+    assert (await _sole_entitlement(db_session)).revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_refund_for_a_buyer_who_never_signed_up_is_a_clean_no_op(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A refund can land before the buyer ever registers, and must not blow up.
+
+    A sale for an unknown address grants nothing at purchase time, so the
+    refund has no entitlement to revoke. It still has to answer 200 and still
+    has to take the claim, so the sale is closed out rather than left waiting
+    for a redelivery to reverse an account that may appear later.
+    """
+    await _ping(async_client, _sale_payload())
+
+    response = await _ping(async_client, _refund_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _entitlements(db_session) == []
+    assert await _refund_audits(db_session) == []
+    sale = await _reload_sale(db_session, SALE_ID)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_token_pack_purchase_does_not_cover_a_refunded_course_sale(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Buying credits is not buying the course, so it cannot preserve access.
+
+    Doubles as the course-side disjointness check: revoking access writes no
+    wallet audit row and leaves the buyer's purchased credits alone.
+    """
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(async_client, _pack_payload())
+
+    await _ping(async_client, _refund_payload())
+
+    assert (await _sole_entitlement(db_session)).revoked_at is not None
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _refund_audits(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_token_pack_refund_claws_back_the_full_pack(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A pack refund debits the configured size once, with a reconciling audit row."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+
+    response = await _ping(async_client, _pack_refund_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    audits = await _refund_audits(db_session)
+    assert len(audits) == 1
+    assert audits[0].user_id == user_id
+    assert audits[0].bucket == BUCKET_OFFERING
+    assert audits[0].delta == Decimal(-TOKEN_PACK_SIZE)
+    assert audits[0].balance_before == Decimal(TOKEN_PACK_SIZE)
+    assert audits[0].balance_after == Decimal(0)
+    sale = await _reload_sale(db_session, PACK_SALE_ID)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_token_pack_refund_may_drive_the_balance_negative(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Credits already spent still come back in full, overdrawing the wallet.
+
+    A chargeback reverses the whole purchase; clamping at zero would let a
+    buyer keep the messages they spent before disputing the charge.
+    """
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+    await _set_offering_balance(db_session, user_id, SPENT_DOWN_BALANCE)
+
+    response = await _ping(async_client, _pack_refund_payload())
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == NEGATIVE_BALANCE
+    audits = await _refund_audits(db_session)
+    assert len(audits) == 1
+    assert audits[0].delta == Decimal(-TOKEN_PACK_SIZE)
+    assert audits[0].balance_before == Decimal(SPENT_DOWN_BALANCE)
+    assert audits[0].balance_after == Decimal(NEGATIVE_BALANCE)
+
+
+@pytest.mark.asyncio
+async def test_replayed_token_pack_refund_claws_back_exactly_once(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A redelivered pack refund writes no second audit row and moves no credits."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+
+    first = await _ping(async_client, _pack_refund_payload())
+    second = await _ping(async_client, _pack_refund_payload())
+
+    assert [first.status_code, second.status_code] == [HTTPStatus.OK, HTTPStatus.OK]
+    assert await _offering_balance(db_session, user_id) == 0
+    assert len(await _refund_audits(db_session)) == 1
+
+
+@pytest.mark.asyncio
+async def test_refund_claws_back_from_the_account_that_received_the_credits(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The debit follows the stored credit recipient, not the refund's email field."""
+    buyer_id = await _persist_user(db_session)
+    other_id = await _persist_user(db_session, OTHER_EMAIL)
+    await _ping(async_client, _pack_payload())
+    await _set_offering_balance(db_session, other_id, SPENT_DOWN_BALANCE)
+
+    await _ping(async_client, _pack_refund_payload(email=OTHER_EMAIL))
+
+    assert await _offering_balance(db_session, buyer_id) == 0
+    assert await _offering_balance(db_session, other_id) == SPENT_DOWN_BALANCE
+    audits = await _refund_audits(db_session)
+    assert len(audits) == 1
+    assert audits[0].user_id == buyer_id
+
+
+@pytest.mark.asyncio
+async def test_refund_payload_overrides_cannot_change_the_claw_back(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A forged product, quantity, and price are ignored in favour of the stored sale."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _pack_payload())
+
+    response = await _ping(
+        async_client,
+        _pack_refund_payload(
+            product_id=APTITUDE_PRODUCT_ID,
+            quantity=HOSTILE_QUANTITY,
+            price=HOSTILE_PRICE,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert await _offering_balance(db_session, user_id) == 0
+    audits = await _refund_audits(db_session)
+    assert len(audits) == 1
+    assert audits[0].delta == Decimal(-TOKEN_PACK_SIZE)
+    assert await _entitlements(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_token_pack_refund_leaves_course_access_intact(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Reversing a credit purchase never disturbs the buyer's course entitlement."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(async_client, _pack_payload())
+
+    await _ping(async_client, _pack_refund_payload())
+
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    assert await _offering_balance(db_session, user_id) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "secret", [WRONG_WEBHOOK_SECRET, BLANK_SECRET], ids=["wrong_secret", "blank_secret"]
+)
+async def test_forged_refund_is_rejected_and_changes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    secret: str,
+) -> None:
+    """An unauthenticated refund is a 401 that reverses neither access nor credits."""
+    user_id = await _persist_user(db_session)
+    await _ping(async_client, _sale_payload())
+    await _ping(async_client, _pack_payload())
+
+    response = await _ping(async_client, _pack_refund_payload(), secret=secret)
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert (await _sole_entitlement(db_session)).revoked_at is None
+    assert await _offering_balance(db_session, user_id) == TOKEN_PACK_SIZE
+    assert await _refund_audits(db_session) == []
+    sale = await _reload_sale(db_session, PACK_SALE_ID)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is None

--- a/backend/tests/services/test_gumroad_revocation.py
+++ b/backend/tests/services/test_gumroad_revocation.py
@@ -1,0 +1,434 @@
+"""Unit tests for :mod:`services.gumroad_revocation` — the reversal edge branches.
+
+Driven directly against a session so the states the webhook cannot easily
+stage are reachable: a pack refunded before anyone claimed it, a pack whose
+product lost its configured size, and a claimed pack whose crediting account
+has since been deleted. Each of those must still stamp the shared
+``revocation_processed_at`` claim, write nothing to the wallet, and say why in
+a structured log line.
+
+Also pins the lookup contract both handlers share: the sale is resolved from
+the STORED purchase row (``resource_name == "sale"``), so the row the webhook
+persists for an orphan refund or cancellation ping can never stand in for the
+purchase it claims to reverse.
+
+The two handlers are deliberately asymmetric about product class.
+``process_refund`` reverses whatever the stored sale delivered and claims
+every sale it resolves. ``process_cancellation`` acts only on an APTITUDE
+product — nothing else is a subscription — and is inert for anything else,
+taking no claim so the refund path stays armed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from domain.entitlements import (
+    PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_PRODUCT_IDS_ENV_VAR,
+    TOKEN_PACK_SIZES_ENV_VAR,
+)
+from models.gumroad_sale import SALE_RESOURCE_NAME, GumroadSale
+from models.user import User
+from models.wallet_audit import REASON_GUMROAD_PURCHASE, REASON_GUMROAD_REFUND, WalletAudit
+from services.gumroad_revocation import process_cancellation, process_refund
+from services.token_packs import claim_token_pack_sales
+
+APTITUDE_PRODUCT_ID = "prod_course_abc"
+PACK_PRODUCT_ID = "prod_pack_small"
+UNSIZED_PACK_PRODUCT_ID = "prod_pack_unsized"
+UNKNOWN_PRODUCT_ID = "prod_not_sold_here"
+PACK_SIZE = 100
+
+BUYER_EMAIL = "buyer@example.com"
+SALE_ID = "S-900"
+SEEDED_BALANCE = 42
+CREDITED_AT = "2026-01-01T00:00:00+00:00"
+
+REFUND_RESOURCE = "refund"
+CANCELLATION_RESOURCE = "cancellation"
+
+UNKNOWN_SALE_MARKER = "unknown_sale"
+UNCONFIGURED_SIZE_MARKER = "token_pack_size_unconfigured"
+CREDITED_USER_MISSING_MARKER = "credited_user_missing"
+NOT_APPLICABLE_MARKER = "cancellation_not_applicable"
+
+
+@pytest.fixture(autouse=True)
+def gumroad_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allowlist both product families and size only the sellable pack."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, APTITUDE_PRODUCT_ID)
+    monkeypatch.setenv(
+        TOKEN_PACK_PRODUCT_IDS_ENV_VAR, f"{PACK_PRODUCT_ID},{UNSIZED_PACK_PRODUCT_ID}"
+    )
+    monkeypatch.setenv(TOKEN_PACK_SIZES_ENV_VAR, f"{PACK_PRODUCT_ID}:{PACK_SIZE}")
+
+
+def _payload(sale_id: str = SALE_ID) -> dict[str, str]:
+    """Build the minimal ping payload a revocation handler consumes.
+
+    Deliberately carries nothing but the idempotency key: every other fact
+    the handlers act on has to come from the stored sale row.
+    """
+    return {"sale_id": sale_id}
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+async def _make_user(
+    session: AsyncSession,
+    *,
+    email: str = BUYER_EMAIL,
+    offering_balance: int = 0,
+) -> tuple[User, int]:
+    """Create and commit a buyer; return the row plus its non-null id.
+
+    The id comes back separately because the services under test commit the
+    same session, so a later attribute read off the instance would lazy-load
+    outside the async context rather than fail an assertion.
+    """
+    user = User(
+        email=email,
+        password_hash="x",  # pragma: allowlist secret
+        offering_balance=offering_balance,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user, user.id
+
+
+@dataclass(frozen=True)
+class _SaleShape:
+    """The variable fields of one seeded Gumroad ping row.
+
+    Bundling them keeps the seeding helper under ruff's argument-count cap
+    and lets each edge state be expressed as a whole record.
+    """
+
+    sale_id: str = SALE_ID
+    product_id: str = PACK_PRODUCT_ID
+    email: str = BUYER_EMAIL
+    resource_name: str = SALE_RESOURCE_NAME
+    refunded: bool = False
+    credited: bool = False
+    credited_user_id: int | None = None
+
+
+async def _make_sale(session: AsyncSession, shape: _SaleShape) -> None:
+    """Create and commit one Gumroad ping row in the requested state."""
+    sale = GumroadSale(
+        gumroad_sale_id=shape.sale_id,
+        product_id=shape.product_id,
+        email=shape.email,
+        resource_name=shape.resource_name,
+        refunded=shape.refunded,
+        raw_payload={"sale_id": shape.sale_id},
+    )
+    if shape.credited:
+        sale.token_pack_credited_at = datetime.fromisoformat(CREDITED_AT)
+        sale.token_pack_credited_user_id = shape.credited_user_id
+    session.add(sale)
+    await session.commit()
+
+
+async def _reload_sale(session: AsyncSession, sale_id: str = SALE_ID) -> GumroadSale:
+    """Re-read one sale row from the database, bypassing the identity map."""
+    result = await session.execute(
+        select(GumroadSale)
+        .where(col(GumroadSale.gumroad_sale_id) == sale_id)
+        .execution_options(populate_existing=True)
+    )
+    return result.scalars().one()
+
+
+async def _balance(session: AsyncSession, user_id: int) -> int:
+    """Return the user's persisted offering balance, read fresh."""
+    result = await session.execute(
+        select(User).where(col(User.id) == user_id).execution_options(populate_existing=True)
+    )
+    return int(result.scalars().one().offering_balance)
+
+
+async def _audits(session: AsyncSession, reason: str) -> list[WalletAudit]:
+    """Return every wallet-audit row carrying ``reason``, oldest first."""
+    result = await session.execute(
+        select(WalletAudit)
+        .where(col(WalletAudit.reason) == reason)
+        .order_by(col(WalletAudit.id))
+        .execution_options(populate_existing=True)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_refund_of_an_uncredited_pack_stamps_the_claim_only(
+    db_session: AsyncSession,
+) -> None:
+    """A pack refunded before anyone claimed it marks the sale and moves no money."""
+    _user, user_id = await _make_user(db_session)
+    await _make_sale(db_session, _SaleShape())
+
+    await process_refund(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_refunded_uncredited_pack_is_skipped_by_the_signup_sweep(
+    db_session: AsyncSession,
+) -> None:
+    """Stamping ``refunded`` is what stops the signup sweep paying out later.
+
+    The buyer refunds before registering, then signs up: the sweep filters on
+    ``refunded IS False``, so the pack they no longer paid for must not land
+    in the new account's wallet.
+    """
+    user, user_id = await _make_user(db_session)
+    await _make_sale(db_session, _SaleShape())
+    await process_refund(db_session, _payload())
+
+    await claim_token_pack_sales(db_session, user)
+
+    assert await _balance(db_session, user_id) == 0
+    assert await _audits(db_session, REASON_GUMROAD_PURCHASE) == []
+    assert (await _reload_sale(db_session)).token_pack_credited_at is None
+
+
+@pytest.mark.asyncio
+async def test_refund_of_a_pack_with_no_configured_size_stamps_the_claim_only(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An allowlisted pack that lost its price fails closed instead of guessing.
+
+    There is no safe default claw-back amount for real money, so the claim is
+    taken (nothing will retry it blindly) and the reason is logged for an
+    operator to reconcile by hand.
+    """
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=SEEDED_BALANCE)
+    await _make_sale(
+        db_session,
+        _SaleShape(product_id=UNSIZED_PACK_PRODUCT_ID, credited=True, credited_user_id=user_id),
+    )
+
+    await process_refund(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == SEEDED_BALANCE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+    assert _log_carries_marker(caplog, UNCONFIGURED_SIZE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_refund_of_a_pack_whose_credited_account_vanished_stamps_the_claim_only(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A credited sale with no recipient left cannot be debited, only recorded.
+
+    ``token_pack_credited_user_id`` is ``SET NULL`` on account deletion, so a
+    claimed sale can outlive the wallet it paid into. The refund must not
+    crash and must not invent a victim.
+    """
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=SEEDED_BALANCE)
+    await _make_sale(db_session, _SaleShape(credited=True))
+
+    await process_refund(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == SEEDED_BALANCE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is True
+    assert sale.revocation_processed_at is not None
+    assert _log_carries_marker(caplog, CREDITED_USER_MISSING_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_refund_of_a_sale_on_neither_allowlist_stamps_the_claim_only(
+    db_session: AsyncSession,
+) -> None:
+    """An unrecognised product reverses nothing, but is still claimed once."""
+    _user, user_id = await _make_user(db_session, offering_balance=SEEDED_BALANCE)
+    await _make_sale(
+        db_session,
+        _SaleShape(product_id=UNKNOWN_PRODUCT_ID, credited=True, credited_user_id=user_id),
+    )
+
+    await process_refund(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == SEEDED_BALANCE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    assert (await _reload_sale(db_session)).revocation_processed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cancellation_of_a_credited_pack_keeps_the_credits(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A one-time purchase cannot be cancelled, so the handler declines it outright.
+
+    Declining has to mean taking no claim, not merely moving no money: a
+    stamped ``revocation_processed_at`` here would silently disarm the refund
+    handler and let a refunded buyer keep the pack.
+    """
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=PACK_SIZE)
+    await _make_sale(db_session, _SaleShape(credited=True, credited_user_id=user_id))
+
+    await process_cancellation(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is None
+    assert _log_carries_marker(caplog, NOT_APPLICABLE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_of_a_sale_on_neither_allowlist_is_inert(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognised product is not a subscription either, so nothing is claimed.
+
+    The refund twin of this case still stamps the claim; only cancellation
+    narrows to APTITUDE, and it must fail closed for products it does not
+    recognise rather than defaulting to "cancel it".
+    """
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=SEEDED_BALANCE)
+    await _make_sale(
+        db_session,
+        _SaleShape(product_id=UNKNOWN_PRODUCT_ID, credited=True, credited_user_id=user_id),
+    )
+
+    await process_cancellation(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == SEEDED_BALANCE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is None
+    assert _log_carries_marker(caplog, NOT_APPLICABLE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_a_pack_refund_takes_no_second_claim(
+    db_session: AsyncSession,
+) -> None:
+    """A trailing cancellation leaves a refunded pack exactly as the refund left it.
+
+    Two reasons converge here and both must hold: the refund already spent the
+    shared claim, and a pack is not cancellable in the first place. Either way
+    the timestamp, the balance, and the audit count are frozen.
+    """
+    _user, user_id = await _make_user(db_session, offering_balance=PACK_SIZE)
+    await _make_sale(db_session, _SaleShape(credited=True, credited_user_id=user_id))
+
+    await process_refund(db_session, _payload())
+    claimed_at = (await _reload_sale(db_session)).revocation_processed_at
+    await process_cancellation(db_session, _payload())
+
+    assert claimed_at is not None
+    assert (await _reload_sale(db_session)).revocation_processed_at == claimed_at
+    assert await _balance(db_session, user_id) == 0
+    assert len(await _audits(db_session, REASON_GUMROAD_REFUND)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", [REFUND_RESOURCE, CANCELLATION_RESOURCE])
+async def test_process_refund_ignores_a_row_that_is_not_a_purchase(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    resource_name: str,
+) -> None:
+    """Only a ``sale`` row can be reversed; a stored event row is not a purchase."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=PACK_SIZE)
+    await _make_sale(
+        db_session,
+        _SaleShape(resource_name=resource_name, credited=True, credited_user_id=user_id),
+    )
+
+    await process_refund(db_session, _payload())
+
+    sale = await _reload_sale(db_session)
+    assert sale.refunded is False
+    assert sale.revocation_processed_at is None
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", [REFUND_RESOURCE, CANCELLATION_RESOURCE])
+async def test_process_cancellation_ignores_a_row_that_is_not_a_purchase(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    resource_name: str,
+) -> None:
+    """The cancellation handler shares the purchase-only lookup with the refund one."""
+    caplog.set_level(logging.DEBUG)
+    await _make_sale(db_session, _SaleShape(resource_name=resource_name))
+
+    await process_cancellation(db_session, _payload())
+
+    assert (await _reload_sale(db_session)).revocation_processed_at is None
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_process_refund_with_no_stored_sale_is_a_no_op(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refund for a sale_id that was never stored writes nothing at all."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=PACK_SIZE)
+
+    await process_refund(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)
+
+
+@pytest.mark.asyncio
+async def test_process_cancellation_with_no_stored_sale_is_a_no_op(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cancellation for a sale_id that was never stored writes nothing at all."""
+    caplog.set_level(logging.DEBUG)
+    _user, user_id = await _make_user(db_session, offering_balance=PACK_SIZE)
+
+    await process_cancellation(db_session, _payload())
+
+    assert await _balance(db_session, user_id) == PACK_SIZE
+    assert await _audits(db_session, REASON_GUMROAD_REFUND) == []
+    assert _log_carries_marker(caplog, UNKNOWN_SALE_MARKER)


### PR DESCRIPTION
## Summary

- Closes the Gumroad entitlement loop: `refund`, `dispute`, `cancellation`, and `subscription_ended` pings now unwind the sale they name, exactly once, within one webhook delivery. The router gains a single `_EVENT_HANDLERS` table that both routes an event and *defines* what counts as a known one, so routing and the `unhandled_event` log path can never drift apart.
- New `services/gumroad_revocation.py` owns the reversal transaction, guarded by a new `gumroadsale.revocation_processed_at` claim taken with one conditional `UPDATE ... WHERE revocation_processed_at IS NULL` — the same exactly-once shape the token-pack credit already uses. A refund reverses whatever the sale delivered: course access for an APTITUDE product (via `revoke_course_access`), the full configured pack size for a token pack (via a new `claw_back_purchase_credit`, recorded as a `REASON_GUMROAD_REFUND` wallet audit row). The two branches are disjoint because the allowlists are.
- Every fact a reversal acts on is read off the **stored sale row**, never the ping: a forged payload cannot redirect a claw-back or aim a revocation at another account. The purchase lookup requires `resource_name = "sale"`, so an orphan reversal ping can never resolve the row the webhook just created for it.

## Decisions worth reviewing

**The claw-back is unclamped and `offering_balance` may go negative.** This is the issue's specified chargeback semantics: tokens already spent stay spent, and future BotMason spends fail until the balance is credited. The issue asked me to fall back to floor-at-zero if this conflicted with a DB constraint or `prompts/security/sec-17-offering-balance-race-condition.md` — **it does not**, so no fallback was needed. There is no CHECK constraint on the column, and sec-17's "never negative" governs the *spend* path, whose `WHERE offering_balance > 0` guard in `spend_one_message` still correctly makes a negative balance unspendable.

**A cancellation applies only to an APTITUDE sale; for anything else it is wholly inert and takes no claim.** All four reversal events share one claim column, so a cancelled-then-refunded subscription loses access once, not twice. But letting a stray cancellation consume that shared guard on a one-time token pack would permanently disarm the refund that may follow, handing a refunded buyer both their money and their credits. Cancellation is a subscription concept; a pack cannot be cancelled.

**A pack whose configured size has gone missing stamps the claim and defers to a manual operator adjustment** (`reason_code=token_pack_size_unconfigured`) rather than leaving the claim open. An open claim plus a later env-var restore and a stale Gumroad redelivery would silently debit a user months afterwards; a loud log line is the safer failure. Same reasoning for the uncredited-pack and deleted-account edges.

**"Covered by another sale" is evaluated over `GumroadSale`, not `Entitlement`,** because the model permits at most one active `course_access` row per user — a buyer who owns both tiers cannot have a second entitlement row, and `source_sale_id` alone would mis-fire (a re-grant overwrites it with the newest sale).

## Self-review caught a real hole

The first pass shipped the reversal but left the door open behind it: `receive_ping` skips re-persisting an already-stored sale yet still dispatches it, and `grant_course_access` is only idempotent against a *live* entitlement — it mints a fresh one whenever none is active, which is exactly the state a reversal leaves behind. So `sale` -> `refund` -> redelivered original `sale` ping handed a refunded buyer their access back. Fixed in 77f8ed8a: `_grant_for_sale` now reads the stored sale's reversal claim and declines (`reason_code=sale_previously_reversed`). The lookup gained `populate_existing=True` because the claim is written through raw SQL, so an instance already in the session's identity map would still read as unreversed. The token-pack side needs no twin guard — `token_pack_credited_at` is a one-way gate no reversal clears.

## Test plan

- **47 new tests** across `tests/routers/test_gumroad_refund.py`, `tests/routers/test_gumroad_cancellation.py`, and `tests/services/test_gumroad_revocation.py`, all written failing first and confirmed RED for the right reason before implementation.
- Pinned properties: idempotent replayed refund (no double-revoke, no second audit row); claw-back driving the balance to `-60` from a spent-down pack; refund/dispute equivalence and cancellation/`subscription_ended` equivalence; disjointness in both directions (a pack refund touches no entitlement, a course refund writes no wallet audit); unknown sale -> 200 + `unknown_sale`; an orphan reversal row never satisfying its own lookup; the both-tiers case preserving access; coverage lapsing when the covering sale is itself refunded *or* claimed; claw-back following `token_pack_credited_user_id` and ignoring hostile `product_id`/`quantity`/`price`/`email` payload overrides; a forged or unauthenticated ping (401) changing nothing; and the two replay-after-reversal regressions above.
- `./scripts/backend/check-all.sh` exit 0 — 3172 passed, 2 skipped, 96.96% line coverage.
- Explicitly beyond check-all (these are CI-only gates): `xenon --max-absolute A --max-modules A --max-average A` exit 0, `radon mi src/ -n B -s` exit 0, `interrogate` PASSED at 96.5%, `alembic heads` -> single head `d5e6f7a8b9c0`.

Migration `d5e6f7a8b9c0` is purely additive (one nullable timestamptz), chains off `b8c9d0e1f2a3`, uses batch mode for SQLite safety, and has a real downgrade. No new environment variables.

Closes #1945
Refs #1938
