### PR TITLE
feat(backend): AuthIdentity model + POST /auth/oauth/google

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,6 +76,12 @@ GUMROAD_APTITUDE_PRODUCT_IDS=  # APTITUDE course product IDs, e.g. abc123,def456
 GUMROAD_TOKEN_PACK_PRODUCT_IDS=  # Token-pack product IDs, e.g. ghi789,jkl012
 GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 
+# Comma-separated Google OAuth client IDs (iOS / Android / web) accepted as the
+# ``aud`` claim of a submitted id_token. Read at request time, so rotating or
+# adding a platform needs no restart. Fails closed: unset means Google sign-in
+# rejects every token.
+GOOGLE_OAUTH_CLIENT_IDS=  # e.g. 1234-ios.apps.googleusercontent.com,1234-web.apps.googleusercontent.com
+
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production
 # RAILWAY_PUBLIC_DOMAIN=your-app.up.railway.app

--- a/backend/migrations/versions/e6f7a8b9c0d1_auth_identity_table.py
+++ b/backend/migrations/versions/e6f7a8b9c0d1_auth_identity_table.py
@@ -1,0 +1,64 @@
+"""Add the authidentity table for social sign-in account links.
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-07-28 00:00:00.000000
+
+Issue #1948: Google sign-in is a second authentication path into an account,
+so the link between a provider subject and an Adepthood user needs its own
+table with its own integrity rules.
+
+Purely additive: creates ``authidentity`` — one row per
+``(provider, subject)`` pair, cascade-deleted with its owning user, carrying
+the provider address that authorised the link. The unique constraint on
+``(provider, subject)`` is the load-bearing one: without it a race could fork
+a single Google account across two Adepthood accounts. The CHECK mirrors
+``models.auth_identity.AuthProvider`` so the accepted provider set cannot
+drift from the enum. ``downgrade`` drops the index then the table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e6f7a8b9c0d1"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "d5e6f7a8b9c0"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "authidentity"
+_USER_ID_INDEX = "ix_authidentity_user_id"
+
+# Mirror ``models.auth_identity``'s column bounds.
+_PROVIDER_MAX = 16
+_SUBJECT_MAX = 255
+_EMAIL_MAX = 254
+
+
+def upgrade() -> None:
+    """Create the authidentity table, its provider CHECK, and the user index."""
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("provider", sa.String(length=_PROVIDER_MAX), nullable=False),
+        sa.Column("subject", sa.String(length=_SUBJECT_MAX), nullable=False),
+        sa.Column("email_at_link_time", sa.String(length=_EMAIL_MAX), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "provider IN ('google', 'apple')",
+            name="ck_authidentity_provider_valid",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider", "subject", name="uq_authidentity_provider_subject"),
+    )
+    op.create_index(op.f(_USER_ID_INDEX), _TABLE, ["user_id"])
+
+
+def downgrade() -> None:
+    """Drop the authidentity index then the table."""
+    op.drop_index(op.f(_USER_ID_INDEX), table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,5 +1,6 @@
 """Database models package."""
 
+from .auth_identity import AuthIdentity
 from .completion_suggestion import CompletionSuggestion
 from .content_completion import ContentCompletion
 from .course_stage import CourseStage
@@ -37,6 +38,7 @@ from .user_ui_flags import UserUiFlags
 from .wallet_audit import WalletAudit
 
 __all__ = [
+    "AuthIdentity",
     "CompletionSuggestion",
     "ContentCompletion",
     "CourseStage",

--- a/backend/src/models/auth_identity.py
+++ b/backend/src/models/auth_identity.py
@@ -1,0 +1,88 @@
+"""Social sign-in identities — the "this provider account is that user" link.
+
+One row per (provider, provider-subject) pair, pointing at the Adepthood
+account it unlocks. A dedicated table rather than columns on ``User`` because a
+single account may eventually carry several links (Google today, Apple next)
+and because the link's own provenance — which mailbox proved ownership, and
+when — is audit data that does not belong in the account row.
+
+Two constraints carry the security of the table:
+
+* ``uq_authidentity_provider_subject`` — no two rows may claim the same
+  provider subject. Without it a race could fork one Google account across two
+  Adepthood accounts, and thereafter which one a sign-in reached would be
+  decided by row order.
+* ``ck_authidentity_provider_valid`` — the accepted provider set is derived
+  from :class:`AuthProvider` so the database set cannot drift from the Python
+  enum.
+
+The unique constraint is a plain ``UniqueConstraint`` rather than a partial
+index on purpose: it renders identically through ``metadata.create_all`` on the
+SQLite test database and through the migration on PostgreSQL, so the
+integrity contract is exercised by the same DDL everywhere.
+"""
+
+import enum
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+# Generous ceiling for the provider discriminator; the longest member
+# ("google") is six characters.
+_PROVIDER_MAX = 16
+
+# Provider subject identifiers are opaque strings. Google's are ~21 digits and
+# Apple's ~44 characters; 255 leaves room without accepting unbounded input.
+_SUBJECT_MAX = 255
+
+# Matches ``User.email``'s ceiling so a link can always record the address it
+# was made against.
+_EMAIL_MAX = 254
+
+
+class AuthProvider(enum.StrEnum):
+    """The identity providers Adepthood accepts a sign-in from.
+
+    Values are the wire spellings the providers themselves use, so the stored
+    discriminator reads the same in the database as in a provider's docs.
+    """
+
+    GOOGLE = "google"
+    APPLE = "apple"
+
+
+def _provider_check() -> CheckConstraint:
+    """CHECK derived from ``AuthProvider`` so the DB set can't drift."""
+    quoted = ", ".join(f"'{provider.value}'" for provider in AuthProvider)
+    return CheckConstraint(f"provider IN ({quoted})", name="ck_authidentity_provider_valid")
+
+
+class AuthIdentity(SQLModel, table=True):
+    """One provider account, linked to the Adepthood account it signs into.
+
+    ``subject`` is the provider's stable per-application user id and is the
+    only field a sign-in may be keyed on: a provider can reassign an email
+    address, but never a subject.
+
+    ``email_at_link_time`` is NOT NULL by design. A link is only ever created
+    against an address the provider has verified, so recording that address is
+    an invariant, not an option — it is the audit answer to "which mailbox
+    authorised this link?". It is a snapshot, never a lookup key: the account's
+    current address lives on ``User.email`` and may since have changed.
+    """
+
+    __table_args__ = (
+        _provider_check(),
+        UniqueConstraint("provider", "subject", name="uq_authidentity_provider_subject"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", ondelete="CASCADE", index=True)
+    provider: str = Field(max_length=_PROVIDER_MAX)
+    subject: str = Field(max_length=_SUBJECT_MAX)
+    email_at_link_time: str = Field(max_length=_EMAIL_MAX)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -1621,6 +1621,7 @@ _REASON_OAUTH_LINKED = "oauth_linked"
 _REASON_OAUTH_SIGNUP = "oauth_signup"
 _REASON_OAUTH_NEEDS_LICENSE = "oauth_needs_license"
 _REASON_OAUTH_ACCOUNT_GATED = "oauth_account_gated"
+_REASON_OAUTH_LINK_CONFLICT = "oauth_link_conflict"
 
 # Single log event name so an operator greps one string and filters by
 # ``reason_code``.
@@ -1682,7 +1683,15 @@ async def _needs_license_conflict(email: str | None) -> HTTPException:
     nothing is ever interpolated into it.
 
     The dummy bcrypt verify matches the cost of the account-creating path, so
-    the refusals cannot be told apart by response time either.
+    the dominant CPU cost is the same whichever refusal fired.  That parity is
+    deliberately not claimed for wall-clock time: a refusal that reached the
+    license check has paid an outbound Gumroad round trip that a refusal
+    resolved from the database alone has not.  Closing that gap would mean
+    calling Gumroad on every sign-in, including the ordinary logins that need
+    no license at all, and the residual it leaves is narrow -- only the holder
+    of a provider-verified token for an address can reach those rungs, so the
+    most the timing distinguishes is the state of an account whose mailbox the
+    caller already controls.
 
     Returned rather than raised so every call site reads ``raise await
     _needs_license_conflict(...)`` -- the ``raise`` stays visible at the point
@@ -1974,7 +1983,12 @@ async def _create_oauth_account(
     await _grant_signup_entitlement(session, user, purchase)
     await claim_token_pack_sales(session, user)
     response = _auth_response_for(user)
-    await _insert_identity(session, response.user_id, claims.subject, email)
+    if not await _insert_identity(session, response.user_id, claims.subject, email):
+        # Expected only when a racer linked this subject to the account we just
+        # created, which leaves the caller signed in to the right account
+        # anyway.  Logged rather than ignored so that an integrity failure with
+        # some other cause is visible instead of silently looking like a login.
+        _log_oauth(_REASON_OAUTH_LINK_CONFLICT, email)
     _log_oauth(_REASON_OAUTH_SIGNUP, email)
     return response
 
@@ -2001,8 +2015,9 @@ async def google_oauth_signin(
 
     Everything else -- no license, a bad license, an unverified address, a
     token with no email, a disabled or deleted account -- is one 409 with
-    identical bytes and matched timing, so the endpoint answers no questions
-    about which accounts exist or which are gated.
+    identical bytes, so the endpoint answers no questions about which accounts
+    exist or which are gated.  See :func:`_needs_license_conflict` for the one
+    dimension along which that parity is bounded rather than absolute.
     """
     claims = await _verify_oauth_identity(payload.id_token)
     resolved = await _resolve_existing_account(session, claims)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -17,7 +17,7 @@ import jwt
 from cachetools import TTLCache
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, Field, field_validator
-from sqlalchemy import text
+from sqlalchemy import func, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
@@ -34,7 +34,8 @@ from domain.entitlements import (
     verify_aptitude_license,
 )
 from domain.timezone import normalize_timezone
-from errors import bad_request, service_unavailable
+from errors import bad_request, conflict, service_unavailable
+from models.auth_identity import AuthIdentity, AuthProvider
 from models.gumroad_sale import GumroadSale
 from models.login_attempt import LoginAttempt
 from models.password_reset_token import PasswordResetToken
@@ -53,6 +54,8 @@ from services.email import (
     EmailSender,
     get_email_sender,
 )
+from services.oauth_google import verify_google_id_token
+from services.oidc import OIDCIdentity, OIDCTokenError
 from services.token_packs import claim_token_pack_sales
 from services.users import get_user_timezone
 
@@ -1584,3 +1587,428 @@ async def cancel_password_reset(
     cancelled_email = user.email if user is not None else ""
     await session.commit()
     _log_reset_event("cancelled", cancelled_email, request)
+
+
+# ---------------------------------------------------------------------------
+# Social sign-in (Google OAuth / OIDC)
+# ---------------------------------------------------------------------------
+
+# Ceiling on the submitted ``id_token``.  Real Google id_tokens run well under
+# 2 KB; the cap exists so an over-length body is rejected by Pydantic *before*
+# any JWKS lookup is attempted, denying an attacker a free way to drive
+# outbound key fetches (and CPU) with garbage.
+_MAX_ID_TOKEN_LENGTH = 4096
+
+# Entropy for the unusable password minted behind a social account.  32 bytes
+# encodes to a 43-character URL-safe string (256 bits) -- comfortably inside
+# bcrypt's 72-byte input window and never shown to anyone, so no password can
+# ever authenticate the row.
+_SOCIAL_PASSWORD_BYTES = 32
+
+# The two client-visible details of the OAuth ladder.  401 is spent *only* on
+# "this token failed cryptographic verification"; every other refusal collapses
+# onto the single 409 below.  Keep both immutable and never interpolate:
+# byte-identical rejections are what stop the endpoint being an oracle for
+# which accounts exist, which are banned, and which license keys are real.
+_DETAIL_INVALID_OAUTH_TOKEN = "invalid_oauth_token"  # noqa: S105  # nosec B105  # pragma: allowlist secret
+_DETAIL_NEEDS_LICENSE = "needs_license"
+
+# Server-side-only reason codes for the OAuth audit trail.  These carry the
+# distinctions the wire response deliberately refuses to make.
+_REASON_OAUTH_INVALID_TOKEN = "oauth_invalid_token"  # noqa: S105  # nosec B105  # pragma: allowlist secret
+_REASON_OAUTH_LOGIN = "oauth_login"
+_REASON_OAUTH_LINKED = "oauth_linked"
+_REASON_OAUTH_SIGNUP = "oauth_signup"
+_REASON_OAUTH_NEEDS_LICENSE = "oauth_needs_license"
+_REASON_OAUTH_ACCOUNT_GATED = "oauth_account_gated"
+
+# Single log event name so an operator greps one string and filters by
+# ``reason_code``.
+_OAUTH_LOG_EVENT = "oauth_signin"
+
+
+class GoogleOAuthRequest(BaseModel):
+    """Google sign-in payload -- an ``id_token``, plus first-run extras.
+
+    ``id_token`` carries an explicit ``_MAX_ID_TOKEN_LENGTH`` bound for the
+    same reason ``AuthRequest.password`` carries one: without it an unbounded
+    string reaches the verifier, and each attempt can cost a signing-key
+    lookup.  The bound rejects abuse at the schema layer, before any of that
+    work happens.
+
+    ``license_key`` is optional because most sign-ins are logins or links to an
+    already-paid account; it is only consulted on the rung that would create a
+    brand-new account, which stays license-gated exactly like ``/auth/signup``.
+
+    ``timezone`` mirrors :class:`SignupRequest`: validated at the trust
+    boundary so a malformed IANA string is a 422 rather than a permanently
+    stored bad value, and omitting it keeps the column at ``"UTC"``.
+    """
+
+    id_token: str = Field(min_length=1, max_length=_MAX_ID_TOKEN_LENGTH)
+    license_key: str | None = Field(default=None, max_length=_MAX_LICENSE_KEY_LENGTH)
+    timezone: str = DEFAULT_USER_TIMEZONE
+
+    @field_validator("timezone", mode="before")
+    @classmethod
+    def _validate_timezone(cls, value: object) -> str:
+        """Reject malformed IANA strings before they reach the DB."""
+        return normalize_timezone(value, DEFAULT_USER_TIMEZONE)
+
+
+def _log_oauth(reason_code: str, email: str | None = None) -> None:
+    """Emit one OAuth audit line, carrying no user-supplied material.
+
+    The email is reduced to the same non-reversible fingerprint every other
+    auth log line uses, and the ``id_token`` is never passed in at all -- it is
+    a replayable credential, so a single leaked log line would be a working
+    session for whoever reads the log.
+    """
+    extra: dict[str, object] = {"reason_code": reason_code}
+    if email:
+        extra["email_fingerprint"] = _email_log_fingerprint(email)
+    logger.info(_OAUTH_LOG_EVENT, extra=extra)
+
+
+async def _needs_license_conflict(email: str | None) -> HTTPException:
+    """Build the one refusal every OAuth path that is not a bad token shares.
+
+    A brand-new email without a license, an invalid license under the hourly
+    cap, an unverified address colliding with an existing account, a token with
+    no email at all, and an account an operator has disabled or deleted all
+    end here and receive the *same bytes*: same status, same body, same
+    length.  Any variation between them would tell an unauthenticated caller
+    which accounts exist and which are banned, so the detail is a constant and
+    nothing is ever interpolated into it.
+
+    The dummy bcrypt verify matches the cost of the account-creating path, so
+    the refusals cannot be told apart by response time either.
+
+    Returned rather than raised so every call site reads ``raise await
+    _needs_license_conflict(...)`` -- the ``raise`` stays visible at the point
+    of refusal instead of hiding inside a helper.
+    """
+    await _consume_dummy_password_verify()
+    _log_oauth(_REASON_OAUTH_NEEDS_LICENSE, email)
+    return conflict(_DETAIL_NEEDS_LICENSE)
+
+
+async def _gated_account_conflict(email: str | None) -> HTTPException:
+    """Record that the refusal was a gated account, then build the generic 409.
+
+    The distinction exists only in the log: an operator investigating a
+    disabled account needs to see ``oauth_account_gated``, while the caller
+    must not be able to tell it apart from "we have never heard of you".
+    """
+    _log_oauth(_REASON_OAUTH_ACCOUNT_GATED, email)
+    return await _needs_license_conflict(email)
+
+
+async def _verify_oauth_identity(id_token: str) -> OIDCIdentity:
+    """Verify the submitted ``id_token``, or raise the only 401 this route uses.
+
+    401 is reserved *exclusively* for "the token itself did not verify", which
+    is a statement about the token and reveals nothing about any account.
+    ``from None`` severs the chain so the raw token inside the verifier's error
+    context cannot surface in a traceback or a 500 body.
+    """
+    try:
+        return await verify_google_id_token(id_token)
+    except OIDCTokenError:
+        _log_oauth(_REASON_OAUTH_INVALID_TOKEN)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=_DETAIL_INVALID_OAUTH_TOKEN,
+        ) from None
+
+
+def _require_user_id(user: User) -> int:
+    """Return a committed user's primary key, refusing to continue without one."""
+    if user.id is None:
+        msg = "User ID unexpectedly None after database commit"
+        raise RuntimeError(msg)
+    return user.id
+
+
+def _auth_response_for(user: User) -> AuthResponse:
+    """Mint a session token for ``user`` in the standard auth-response shape."""
+    user_id = _require_user_id(user)
+    token, _ = _create_token(user_id)
+    return AuthResponse(token=token, user_id=user_id, timezone=user.timezone)
+
+
+def _linkable_email(claims: OIDCIdentity) -> str | None:
+    """Return the normalized address an identity may link or create with.
+
+    Only a provider-verified email qualifies.  An unverified address is the
+    account-takeover vector this endpoint exists to close -- anyone can put
+    someone else's address on an account at most providers -- so it neither
+    links to an existing account nor creates a new one, no matter what else
+    the request carries.
+    """
+    if not claims.email_verified or claims.email is None:
+        return None
+    return claims.email.strip().lower()
+
+
+async def _find_identity(session: AsyncSession, subject: str) -> AuthIdentity | None:
+    """Return the stored Google link for ``subject``, or ``None``.
+
+    Keyed on the provider subject rather than the email because a subject is
+    the only identifier a provider promises never to reassign.
+    """
+    result = await session.execute(
+        select(AuthIdentity).where(
+            AuthIdentity.provider == AuthProvider.GOOGLE,
+            AuthIdentity.subject == subject,
+        )
+    )
+    return result.scalars().first()
+
+
+async def _find_user_by_email(session: AsyncSession, email: str) -> User | None:
+    """Case-insensitively find the account owning ``email``.
+
+    Compares on ``lower(email)`` rather than trusting stored casing so a legacy
+    row written before the normalizing boundary landed still matches.
+    """
+    result = await session.execute(select(User).where(func.lower(col(User.email)) == email))
+    return result.scalars().first()
+
+
+async def _insert_identity(
+    session: AsyncSession,
+    user_id: int,
+    subject: str,
+    email: str,
+) -> bool:
+    """Persist the provider link; ``False`` when a concurrent caller won it.
+
+    The ``(provider, subject)`` unique constraint is what makes the race safe:
+    the loser rolls back and re-resolves against the row the winner wrote, and
+    because both were resolving the same subject they converge on the same
+    account.
+
+    ``email_at_link_time`` records the verified address that authorised the
+    link.  ``User.email_verified`` is deliberately left alone -- that column
+    belongs to the (unbuilt) email-verification flow, and setting it from a
+    provider claim would silently satisfy a gate it was never meant to satisfy.
+    """
+    session.add(
+        AuthIdentity(
+            user_id=user_id,
+            provider=AuthProvider.GOOGLE,
+            subject=subject,
+            email_at_link_time=email,
+        )
+    )
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return False
+    return True
+
+
+async def _login_via_identity(
+    session: AsyncSession,
+    identity: AuthIdentity,
+    email: str | None,
+) -> AuthResponse:
+    """Mint a token for an already-linked identity, or take the generic exit.
+
+    A link whose account has been soft-disabled, soft-deleted, or hard-deleted
+    is refused with the same 409 an unknown caller gets.  Spending the 401 here
+    would confirm to any holder of a valid Google token that the identity it
+    names is attached to a banned Adepthood account.
+    """
+    user = await session.get(User, identity.user_id)
+    if user is None or _user_state_reject_reason(user) is not None:
+        raise await _gated_account_conflict(email)
+    _log_oauth(_REASON_OAUTH_LOGIN, email)
+    return _auth_response_for(user)
+
+
+async def _link_or_relogin(
+    session: AsyncSession,
+    user: User,
+    claims: OIDCIdentity,
+    email: str,
+) -> AuthResponse:
+    """Attach a first Google link to ``user``, re-resolving once if a racer won."""
+    if await _insert_identity(session, _require_user_id(user), claims.subject, email):
+        _log_oauth(_REASON_OAUTH_LINKED, email)
+        return _auth_response_for(user)
+    identity = await _find_identity(session, claims.subject)
+    if identity is None:
+        raise await _needs_license_conflict(email)
+    return await _login_via_identity(session, identity, email)
+
+
+async def _resolve_existing_account(
+    session: AsyncSession,
+    claims: OIDCIdentity,
+) -> AuthResponse | None:
+    """Walk the two rungs that need no license: stored link, then verified email.
+
+    Returns ``None`` when neither rung matched, which hands the caller down to
+    the license-gated creation rung.  Anything that matched but must not
+    proceed (a disabled or deleted account) never returns at all -- it raises
+    the generic refusal from inside.
+    """
+    identity = await _find_identity(session, claims.subject)
+    if identity is not None:
+        return await _login_via_identity(session, identity, claims.email)
+    email = _linkable_email(claims)
+    if email is None:
+        return None
+    user = await _find_user_by_email(session, email)
+    if user is None:
+        return None
+    if _user_state_reject_reason(user) is not None:
+        raise await _gated_account_conflict(email)
+    return await _link_or_relogin(session, user, claims, email)
+
+
+async def _count_invalid_license_attempt(request: Request, license_key: str | None) -> None:
+    """Charge a failed non-blank key against the per-IP hourly cap.
+
+    Without this the OAuth route would be a free bypass of the brute-force
+    throttle ``/auth/signup`` enforces: an attacker could grind license keys
+    here at the per-minute rate forever.  A blank key never reached Gumroad and
+    is not a guess, so it is not counted.
+    """
+    if not (license_key or "").strip():
+        return
+    if record_invalid_license_attempt(_get_client_ip(request)):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=_DETAIL_TOO_MANY_LICENSE_ATTEMPTS,
+    )
+
+
+async def _verify_oauth_license(
+    request: Request,
+    email: str,
+    license_key: str | None,
+) -> GumroadPurchase:
+    """Verify the APTITUDE license backing a brand-new social account.
+
+    Anything short of VERIFIED lands on the generic 409 -- a missing key, a
+    wrong key, and a key bought under a different address are indistinguishable
+    on the wire.  A Gumroad outage fails closed with 503 before any row is
+    written; ``from None`` severs the chain so the caught error's request body
+    (which carries the license key) is unreachable via ``__cause__``.
+    """
+    try:
+        check = await verify_aptitude_license(email, license_key)
+    except GumroadUnavailableError:
+        raise service_unavailable(_DETAIL_LICENSE_UNAVAILABLE) from None
+    if check.outcome is LicenseOutcome.VERIFIED and check.purchase is not None:
+        return check.purchase
+    await _count_invalid_license_attempt(request, license_key)
+    raise await _needs_license_conflict(email)
+
+
+async def _insert_social_user(session: AsyncSession, email: str, timezone: str) -> User | None:
+    """Create the account behind a social sign-in; ``None`` when a racer won.
+
+    The stored hash is a fresh 256-bit random run through the same bcrypt cost
+    the password flow uses.  That satisfies the NOT NULL hash contract while
+    guaranteeing no password can ever authenticate the row, and it keeps the
+    creation path's timing indistinguishable from an ordinary signup.
+    """
+    password_hash = await _hash_password(secrets.token_urlsafe(_SOCIAL_PASSWORD_BYTES))
+    user = User(email=email, password_hash=password_hash, timezone=timezone)
+    session.add(user)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        return None
+    await session.refresh(user)
+    return user
+
+
+async def _reresolve_after_create_race(
+    session: AsyncSession,
+    claims: OIDCIdentity,
+) -> AuthResponse:
+    """Re-walk the login / link rungs once after losing the account-create race.
+
+    The winner has now committed the account this request was about to create,
+    so the same two rungs that ran a moment ago resolve to it.  Bounded to one
+    retry: a second miss means something other than a race, and the generic
+    refusal is the honest answer.
+    """
+    resolved = await _resolve_existing_account(session, claims)
+    if resolved is None:
+        raise await _needs_license_conflict(claims.email)
+    return resolved
+
+
+async def _create_oauth_account(
+    request: Request,
+    session: AsyncSession,
+    payload: GoogleOAuthRequest,
+    claims: OIDCIdentity,
+    email: str,
+) -> AuthResponse:
+    """Create the license-verified account, grant the course, and link the identity.
+
+    The license is verified before any row is written (verify-then-create), and
+    any token pack bought under the same address before this sign-in is swept
+    into the new wallet, exactly as ``/auth/signup`` does.
+
+    The identity link is written last, and the response is built before it, so
+    that losing the link race (a concurrent caller resolved the same subject
+    against the account we just created) rolls back only that insert.  Reading
+    an ORM attribute after that rollback would be a lazy load outside the
+    greenlet; the racer's row points at the same account anyway.
+    """
+    purchase = await _verify_oauth_license(request, email, payload.license_key)
+    user = await _insert_social_user(session, email, payload.timezone)
+    if user is None:
+        return await _reresolve_after_create_race(session, claims)
+    await _grant_signup_entitlement(session, user, purchase)
+    await claim_token_pack_sales(session, user)
+    response = _auth_response_for(user)
+    await _insert_identity(session, response.user_id, claims.subject, email)
+    _log_oauth(_REASON_OAUTH_SIGNUP, email)
+    return response
+
+
+@router.post("/oauth/google", response_model=AuthResponse)
+@limiter.limit("5/minute")
+async def google_oauth_signin(
+    request: Request,
+    payload: GoogleOAuthRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AuthResponse:
+    """Sign in (or, with a license, sign up) with a Google ``id_token``.
+
+    Four rungs, tried in order, and exactly two possible refusals:
+
+    1. The token is verified against Google's published keys.  Failure is the
+       only 401 this route emits, and it writes nothing.
+    2. A stored ``(google, subject)`` link logs its account straight in.
+    3. Otherwise a *verified* provider email links onto the account that
+       already owns it.  An unverified email never links -- that is the
+       account-takeover vector.
+    4. Otherwise a verified email plus a valid APTITUDE license creates the
+       account, exactly as ``/auth/signup`` would.
+
+    Everything else -- no license, a bad license, an unverified address, a
+    token with no email, a disabled or deleted account -- is one 409 with
+    identical bytes and matched timing, so the endpoint answers no questions
+    about which accounts exist or which are gated.
+    """
+    claims = await _verify_oauth_identity(payload.id_token)
+    resolved = await _resolve_existing_account(session, claims)
+    if resolved is not None:
+        return resolved
+    email = _linkable_email(claims)
+    if email is None:
+        raise await _needs_license_conflict(claims.email)
+    return await _create_oauth_account(request, session, payload, claims, email)

--- a/backend/src/services/oauth_google.py
+++ b/backend/src/services/oauth_google.py
@@ -27,6 +27,8 @@ __all__ = [
     "GOOGLE_ISSUERS",
     "GOOGLE_JWKS_URL",
     "GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR",
+    "JWKS_TIMEOUT_SECONDS",
+    "build_jwk_client",
     "verify_google_id_token",
 ]
 
@@ -53,6 +55,17 @@ _JWKS_CACHE_SECONDS = 3600.0
 # time; the bound keeps a malformed ``kid`` stream from growing the cache.
 _MAX_CACHED_KEYS = 16
 
+# Wall-clock budget for a JWKS fetch. PyJWT's own default is 30 seconds, which
+# is far too generous here: a token naming a ``kid`` outside the cached set
+# makes the client refetch immediately (bypassing ``lifespan``), and that fetch
+# runs in the shared default thread pool -- the same pool bcrypt uses. An
+# unauthenticated caller sending random ``kid`` values could therefore park
+# workers that logins and signups need. Five seconds mirrors
+# ``GUMROAD_TIMEOUT_SECONDS`` and the reasoning behind it: verification sits on
+# an interactive path, so a wedged endpoint must fail fast rather than hold a
+# request -- and a thread -- open.
+JWKS_TIMEOUT_SECONDS: float = 5.0
+
 # Google's claim names, spelled once so a typo cannot silently disable a check.
 _SUBJECT_CLAIM = "sub"
 _EMAIL_CLAIM = "email"
@@ -72,6 +85,27 @@ def _google_client_ids() -> list[str]:
     return [client_id.strip() for client_id in raw.split(_CLIENT_ID_SEPARATOR) if client_id.strip()]
 
 
+def build_jwk_client() -> PyJWKClient:
+    """Construct the Google JWKS client, timeout and caches explicitly bounded.
+
+    Split out from the cached accessor so the bounds can be asserted without
+    reaching through an ``lru_cache`` (and without the network: constructing a
+    client fetches nothing).
+
+    Every argument here is a limit rather than a default. ``timeout`` in
+    particular is not optional: PyJWT's 30-second default, combined with the
+    forced refetch an unrecognised ``kid`` triggers, is how a stream of junk
+    tokens turns into parked threads in the pool bcrypt shares.
+    """
+    return PyJWKClient(
+        GOOGLE_JWKS_URL,
+        cache_keys=True,
+        max_cached_keys=_MAX_CACHED_KEYS,
+        lifespan=_JWKS_CACHE_SECONDS,
+        timeout=JWKS_TIMEOUT_SECONDS,
+    )
+
+
 @lru_cache(maxsize=1)
 def _get_jwk_client() -> PyJWKClient:
     """Return the process-wide, key-caching JWKS client for Google.
@@ -85,12 +119,7 @@ def _get_jwk_client() -> PyJWKClient:
     :func:`verify_google_id_token` resolves it per call rather than binding a
     client at import time: tests replace it wholesale to stay offline.
     """
-    return PyJWKClient(
-        GOOGLE_JWKS_URL,
-        cache_keys=True,
-        max_cached_keys=_MAX_CACHED_KEYS,
-        lifespan=_JWKS_CACHE_SECONDS,
-    )
+    return build_jwk_client()
 
 
 def _claim_str(claims: dict[str, Any], name: str) -> str | None:

--- a/backend/src/services/oauth_google.py
+++ b/backend/src/services/oauth_google.py
@@ -1,0 +1,145 @@
+"""Google's adapter over the provider-neutral OIDC verifier.
+
+Everything Google-specific lives here and nowhere else: the published JWKS
+endpoint, the two interchangeable spellings of Google's issuer, the accepted
+``aud`` allowlist, and the projection of Google's claim names onto
+:class:`services.oidc.OIDCIdentity`. The verification itself — algorithm
+pinning, required claims, the single collapsed failure mode — belongs to
+:mod:`services.oidc`, so an Apple adapter can be added beside this one without
+re-deriving (or subtly weakening) any of it.
+
+The client-id allowlist is read from the environment at call time, so rotating
+or adding a platform's OAuth client needs no restart. It fails closed: unset or
+blank means Google sign-in rejects every token rather than accepting any.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+from jwt import PyJWKClient
+
+from services.oidc import OIDCIdentity, verify_oidc_id_token
+
+__all__ = [
+    "GOOGLE_ISSUERS",
+    "GOOGLE_JWKS_URL",
+    "GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR",
+    "verify_google_id_token",
+]
+
+# Comma-separated OAuth client ids (iOS / Android / web) accepted as the
+# ``aud`` claim. One variable rather than one per platform because the check is
+# pure membership and a single list is what an operator can read back.
+GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR = "GOOGLE_OAUTH_CLIENT_IDS"
+_CLIENT_ID_SEPARATOR = ","
+
+# Google's published JWKS endpoint. HTTPS on a Google host is not decoration:
+# the keys fetched from here are the entire basis for trusting a token.
+GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+
+# Google mints ``iss`` as either spelling depending on the client library that
+# requested the token, and both are legitimate, so both must verify.
+GOOGLE_ISSUERS = frozenset({"https://accounts.google.com", "accounts.google.com"})
+
+# How long a cached JWKS set may be reused before it is refetched. An hour is
+# far shorter than Google's key-rotation cadence (days), so a rotated key is
+# picked up automatically, while ordinary sign-ins pay no network round trip.
+_JWKS_CACHE_SECONDS = 3600.0
+
+# Ceiling on individually cached signing keys. Google publishes a handful at a
+# time; the bound keeps a malformed ``kid`` stream from growing the cache.
+_MAX_CACHED_KEYS = 16
+
+# Google's claim names, spelled once so a typo cannot silently disable a check.
+_SUBJECT_CLAIM = "sub"
+_EMAIL_CLAIM = "email"
+_EMAIL_VERIFIED_CLAIM = "email_verified"
+_NAME_CLAIM = "name"
+
+
+def _google_client_ids() -> list[str]:
+    """Read the accepted ``aud`` allowlist from the environment at call time.
+
+    Tolerant in exactly the way the Gumroad product allowlists are: padding,
+    empty entries, and a trailing separator in the deployment config are all
+    harmless. An unset or blank variable yields an empty list, which makes the
+    verifier reject every token — the fail-closed direction.
+    """
+    raw = os.getenv(GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR, "")
+    return [client_id.strip() for client_id in raw.split(_CLIENT_ID_SEPARATOR) if client_id.strip()]
+
+
+@lru_cache(maxsize=1)
+def _get_jwk_client() -> PyJWKClient:
+    """Return the process-wide, key-caching JWKS client for Google.
+
+    Cached because refetching Google's key set on every sign-in would put a
+    network round trip on the login path and hammer an endpoint whose contents
+    change on the order of days; ``lifespan`` bounds how stale that cache may
+    get so a rotation still lands without a restart.
+
+    This function is also the module's only outbound-network seam, which is why
+    :func:`verify_google_id_token` resolves it per call rather than binding a
+    client at import time: tests replace it wholesale to stay offline.
+    """
+    return PyJWKClient(
+        GOOGLE_JWKS_URL,
+        cache_keys=True,
+        max_cached_keys=_MAX_CACHED_KEYS,
+        lifespan=_JWKS_CACHE_SECONDS,
+    )
+
+
+def _claim_str(claims: dict[str, Any], name: str) -> str | None:
+    """Return a non-blank string claim, or ``None`` when absent or malformed."""
+    value = claims.get(name)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
+
+
+def _identity_from_claims(claims: dict[str, Any]) -> OIDCIdentity:
+    """Project Google's verified claim set onto the neutral identity shape.
+
+    ``email_verified`` is honoured only for a real JSON ``true``. Google sends
+    a boolean; the string ``"true"`` some other providers send is deliberately
+    not coerced, and the coercion is not pushed down into the shared core
+    either — a truthy-string rule applied everywhere is precisely how an
+    unverified address ends up linking to somebody else's account. A token with
+    no usable ``email`` reports ``email_verified=False``, because an address
+    that is not there cannot have been verified.
+    """
+    email = _claim_str(claims, _EMAIL_CLAIM)
+    return OIDCIdentity(
+        subject=str(claims[_SUBJECT_CLAIM]),
+        email=email,
+        email_verified=email is not None and claims.get(_EMAIL_VERIFIED_CLAIM) is True,
+        name=_claim_str(claims, _NAME_CLAIM),
+    )
+
+
+async def verify_google_id_token(token: str) -> OIDCIdentity:
+    """Verify a Google-issued ``id_token`` and return the identity it names.
+
+    Args:
+        token: The compact-serialized ``id_token`` the client received from
+            Google's sign-in SDK.
+
+    Returns:
+        The verified identity — subject, optional email, and whether Google
+        vouches for that email.
+
+    Raises:
+        OIDCTokenError: For every verification failure, with a static message
+            that never embeds the token.
+    """
+    claims = await verify_oidc_id_token(
+        token,
+        key_provider=_get_jwk_client(),
+        issuers=GOOGLE_ISSUERS,
+        audiences=_google_client_ids(),
+    )
+    return _identity_from_claims(claims)

--- a/backend/src/services/oidc.py
+++ b/backend/src/services/oidc.py
@@ -1,0 +1,181 @@
+"""Provider-neutral OpenID Connect ``id_token`` verification.
+
+One verifier, one failure mode. Every way a token can fail — a signature that
+does not check out, an audience belonging to another client, an issuer nobody
+recognises, an expired or claim-less payload, a JWKS lookup that cannot
+resolve the ``kid`` — collapses into a single :class:`OIDCTokenError` carrying
+a static message. Callers therefore cannot accidentally build an oracle out of
+the exception, and the raw token (a replayable credential) never travels
+inside an exception, a log record, or a response body.
+
+Two properties carry the security of the whole module:
+
+* ``algorithms`` is supplied by the caller and never read from the token's own
+  header. That single decision closes both the ``alg: none`` forgery and the
+  RS256-to-HS256 confusion attack, where a verifier that trusts the header
+  treats the public key as a shared HMAC secret and lets anyone who can read
+  the published JWKS mint tokens for any account.
+* An empty ``audiences`` fails closed. A deployment that has not configured
+  its client ids rejects every token rather than accepting all of them.
+
+The module is provider-neutral on purpose: Google's adapter lives in
+:mod:`services.oauth_google`, and a future Apple adapter reuses this core by
+supplying its own issuers, audiences, and key provider. Claim-shape quirks
+(Apple's string-valued ``email_verified``, for instance) belong in the
+adapters — coercing them here is how an unverified address would end up
+trusted by every provider at once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+import jwt
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+
+    from jwt import PyJWK
+    from jwt.algorithms import AllowedPublicKeys
+
+__all__ = [
+    "OIDCIdentity",
+    "OIDCKeyProvider",
+    "OIDCSigningKey",
+    "OIDCTokenError",
+    "verify_oidc_id_token",
+]
+
+# Signature algorithms accepted unless a caller narrows or widens the set.
+# RS256 is what Google and Apple both publish; asymmetric-only is the point.
+DEFAULT_OIDC_ALGORITHMS: tuple[str, ...] = ("RS256",)
+
+# Claims a token must actually carry. Without ``require`` PyJWT silently skips
+# validating a claim that is simply absent, so a token with no ``exp`` would
+# never expire and one with no ``sub`` would name no user.
+_REQUIRED_CLAIMS: tuple[str, ...] = ("exp", "iat", "aud", "iss", "sub")
+
+# The two messages this module ever raises with. Static by construction: any
+# interpolation of caller input here would be a channel for the token itself
+# to reach a log line or an error body.
+_INVALID_TOKEN_MESSAGE = "oidc id_token failed verification"  # noqa: S105  # nosec B105  # pragma: allowlist secret
+_UNCONFIGURED_AUDIENCE_MESSAGE = "no oidc audience configured"
+
+
+class OIDCTokenError(Exception):
+    """Every ``id_token`` verification failure, collapsed into one type.
+
+    Deliberately undifferentiated: a caller that could tell "expired" from
+    "wrong audience" from "unknown signing key" would be tempted to say so on
+    the wire, and that difference is an oracle for anyone probing the endpoint.
+    """
+
+
+@dataclass(frozen=True)
+class OIDCIdentity:
+    """The verified subset of an ``id_token`` the sign-in ladder consumes.
+
+    ``subject`` is the provider's stable, per-application user id and is the
+    only field safe to key an account link on — ``email`` can be reassigned by
+    the provider and ``name`` is free text. ``email_verified`` is the flag that
+    decides whether ``email`` may be trusted to match an existing account at
+    all; ``False`` means the address proves nothing.
+    """
+
+    subject: str
+    email: str | None
+    email_verified: bool
+    name: str | None
+
+
+class OIDCSigningKey(Protocol):
+    """What a JWKS client hands back for a token's ``kid``: a key carrier."""
+
+    @property
+    def key(self) -> AllowedPublicKeys | PyJWK | str | bytes:
+        """The material the signature is verified against."""
+
+
+class OIDCKeyProvider(Protocol):
+    """The one capability this module needs from a JWKS client.
+
+    Narrowed to a protocol rather than typed as ``PyJWKClient`` so tests can
+    substitute an offline stand-in without a network fetch, and so an adapter
+    is free to bring a differently-sourced key set.
+    """
+
+    def get_signing_key_from_jwt(self, token: str) -> OIDCSigningKey:
+        """Resolve the signing key named by ``token``'s ``kid`` header."""
+
+
+async def _decode_verified_claims(
+    token: str,
+    key_provider: OIDCKeyProvider,
+    audiences: list[str],
+    algorithms: Sequence[str],
+) -> dict[str, Any]:
+    """Resolve the signing key off-loop, then verify ``token`` against it.
+
+    ``PyJWKClient`` is synchronous urllib under the hood, so the lookup runs in
+    a worker thread; calling it inline would park the whole event loop behind a
+    network fetch on the login path.
+
+    ``from None`` is load-bearing rather than stylistic: it severs
+    ``__cause__`` so the raw token embedded in a PyJWT error's context can
+    never surface through an exception chain into a log or a 500 body.
+    """
+    try:
+        signing_key = await asyncio.to_thread(key_provider.get_signing_key_from_jwt, token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=list(algorithms),
+            audience=audiences,
+            options={"require": list(_REQUIRED_CLAIMS)},
+        )
+    except jwt.PyJWTError:
+        raise OIDCTokenError(_INVALID_TOKEN_MESSAGE) from None
+    return claims
+
+
+async def verify_oidc_id_token(
+    token: str,
+    *,
+    key_provider: OIDCKeyProvider,
+    issuers: Collection[str],
+    audiences: Collection[str],
+    algorithms: Sequence[str] = DEFAULT_OIDC_ALGORITHMS,
+) -> dict[str, Any]:
+    """Verify ``token`` and return its claim set, or raise :class:`OIDCTokenError`.
+
+    The audience check runs before anything else so an unconfigured deployment
+    costs no JWKS lookup and, more importantly, cannot accidentally accept a
+    token minted for some other application.
+
+    The issuer is checked here as an explicit membership test rather than
+    through PyJWT's ``issuer=`` argument, whose single-value semantics vary
+    across releases — and Google signs with two interchangeable spellings of
+    its own issuer, so both must pass under either release.
+
+    Args:
+        token: The compact-serialized ``id_token`` presented by the client.
+        key_provider: Resolves the signing key named by the token's ``kid``.
+        issuers: Every ``iss`` spelling this provider is allowed to use.
+        audiences: Accepted ``aud`` values; empty means "reject everything".
+        algorithms: Accepted signature algorithms — never read from the token.
+
+    Returns:
+        The verified claim set.
+
+    Raises:
+        OIDCTokenError: On any verification failure, with a static message.
+    """
+    accepted_audiences = list(audiences)
+    if not accepted_audiences:
+        raise OIDCTokenError(_UNCONFIGURED_AUDIENCE_MESSAGE)
+    claims = await _decode_verified_claims(token, key_provider, accepted_audiences, algorithms)
+    if claims.get("iss") not in issuers:
+        raise OIDCTokenError(_INVALID_TOKEN_MESSAGE)
+    return claims

--- a/backend/tests/routers/test_oauth_google.py
+++ b/backend/tests/routers/test_oauth_google.py
@@ -1,0 +1,1072 @@
+"""Google OAuth sign-in tests for POST /auth/oauth/google.
+
+This is the second authentication path into an account, so the contract is
+pinned end to end: an id_token that fails cryptographic verification is a 401
+that writes nothing; a known ``(provider, subject)`` pair logs in; a verified
+email links a Google identity onto an existing account; a brand-new verified
+email plus a valid APTITUDE license creates the account; and everything else
+is one byte-identical 409 that reveals nothing about which check failed.
+
+Every test runs offline — the Google JWKS client and the outbound Gumroad
+verify are both replaced with in-process stubs — and the raw id_token is
+never allowed to reach a log line or a response body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import SQLModel, select
+
+from domain.entitlements import PRODUCT_IDS_ENV_VAR
+from integrations.gumroad import GumroadUnavailableError
+from models.auth_identity import AuthIdentity, AuthProvider
+from models.entitlement import Entitlement
+from models.user import User
+from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
+from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
+from services.oauth_google import GOOGLE_JWKS_URL, GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR
+from services.oidc import OIDCIdentity
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Response
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+pytestmark = pytest.mark.real_license_gate
+
+OAUTH_PATH = "/auth/oauth/google"
+LOGIN_PATH = "/auth/login"
+
+# Test seams. The JWKS seam is the only thing standing between this suite and
+# a live network fetch of Google's signing keys, so every test replaces it.
+JWKS_SEAM = "services.oauth_google._get_jwk_client"
+VERIFY_SEAM = "domain.entitlements.verify_license"
+
+ALLOWED_PRODUCT_ALPHA = "prod_alpha"
+ALLOWED_PRODUCT_BETA = "prod_beta"
+ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
+
+TEST_CLIENT_ID = "1000000001-adepthood.apps.googleusercontent.com"  # pragma: allowlist secret
+OTHER_CLIENT_ID = "2000000002-attacker.apps.googleusercontent.com"  # pragma: allowlist secret
+TEST_KID = "adepthood-test-signing-key"
+GOOGLE_ISSUER_URL = "https://accounts.google.com"
+GOOGLE_ISSUER_BARE = "accounts.google.com"
+EVIL_ISSUER = "https://evil.example.com"
+GOOGLE_JWKS_HOSTS = ("www.googleapis.com", "accounts.google.com")
+
+RS256_ALGORITHM = "RS256"
+HS256_ALGORITHM = "HS256"
+NONE_ALGORITHM = "none"
+JWT_TYPE = "JWT"
+RSA_PUBLIC_EXPONENT = 65537
+RSA_KEY_SIZE = 2048
+
+TOKEN_LIFETIME = timedelta(minutes=5)
+EXPIRED_ISSUED_AGO = timedelta(hours=2)
+EXPIRED_EXPIRY_AGO = timedelta(hours=1)
+SOFT_DELETED_AT = datetime(2026, 1, 1, tzinfo=UTC)
+
+EXISTING_EMAIL = "seeker@example.com"
+EXISTING_EMAIL_MIXED_CASE = "SeeKeR@Example.COM"
+NEW_EMAIL = "newcomer@example.com"
+SECOND_NEW_EMAIL = "second-newcomer@example.com"
+UNCLAIMED_EMAIL = "stranger@example.com"
+UNVERIFIED_NEW_EMAIL = "unverified-newcomer@example.com"
+DISPLAY_NAME = "Seeker Example"
+
+KNOWN_SUBJECT = "google-sub-known-0001"
+FRESH_SUBJECT = "google-sub-fresh-0002"
+NEW_SUBJECT = "google-sub-new-0003"
+SECOND_NEW_SUBJECT = "google-sub-new-0004"
+RACING_SUBJECT = "google-sub-racing-0005"
+NO_KEY_SUBJECT = "google-sub-nokey-0006"
+BAD_KEY_SUBJECT = "google-sub-badkey-0007"
+COLLISION_SUBJECT = "google-sub-collision-0008"
+UNVERIFIED_SUBJECT = "google-sub-unverified-0009"
+THROTTLE_SUBJECT_PREFIX = "google-sub-throttle-"
+THROTTLE_EMAIL_PREFIX = "throttle-attempt-"
+
+VALID_LICENSE_KEY = "AAAA1111-BBBB-2222-OAUTH"  # pragma: allowlist secret
+SECOND_LICENSE_KEY = "CCCC3333-DDDD-4444-OAUTH"  # pragma: allowlist secret
+INVALID_LICENSE_KEY = "ZZZZ9999-YYYY-8888-OAUTH"  # pragma: allowlist secret
+SALE_ID = "S-OAUTH-1"
+LICENSE_USES = 1
+COURSE_ACCESS_KIND = "course_access"
+GUMROAD_DOWN_MESSAGE = "gumroad unavailable in test"
+
+SEEDED_PASSWORD_HASH = (
+    "$2b$12$seededplaceholderdigestforteststhatneveraccepts"  # pragma: allowlist secret
+)
+ARBITRARY_PASSWORD = "any-password-at-all"  # pragma: allowlist secret
+BCRYPT_PREFIX = "$2"
+
+SEEDED_TIMEZONE = "America/New_York"
+SIGNUP_TIMEZONE = "America/Los_Angeles"
+
+DETAIL_INVALID_TOKEN = "invalid_oauth_token"
+DETAIL_NEEDS_LICENSE = "needs_license"
+DETAIL_UNAVAILABLE = "license_verification_unavailable"
+DETAIL_THROTTLED = "too_many_license_attempts"
+DETAIL_INVALID_CREDENTIALS = "invalid_credentials"
+
+REASON_INVALID_TOKEN = "oauth_invalid_token"
+REASON_LOGIN = "oauth_login"
+REASON_LINKED = "oauth_linked"
+REASON_SIGNUP = "oauth_signup"
+REASON_NEEDS_LICENSE = "oauth_needs_license"
+REASON_ACCOUNT_GATED = "oauth_account_gated"
+
+JWT_SEGMENT_COUNT = 3
+MAX_ID_TOKEN_LENGTH = 4096
+OVER_LENGTH_ID_TOKEN = "a" * (MAX_ID_TOKEN_LENGTH + 1)
+GARBAGE_TOKEN = "not.a.jwt"
+OAUTH_RATE_LIMIT_PER_MINUTE = 5
+CONCURRENT_REQUESTS = 2
+SOCIAL_ACCOUNT_COUNT = 2
+BYTE_IDENTICAL_REJECTIONS = 4
+
+# One 2048-bit keypair per module: generation is expensive enough that doing it
+# per test would dominate the suite's runtime. The second, unrelated key exists
+# only to forge a well-formed token signed by the wrong hand.
+_SIGNING_KEY = rsa.generate_private_key(
+    public_exponent=RSA_PUBLIC_EXPONENT,
+    key_size=RSA_KEY_SIZE,
+)
+_FORGER_KEY = rsa.generate_private_key(
+    public_exponent=RSA_PUBLIC_EXPONENT,
+    key_size=RSA_KEY_SIZE,
+)
+_PUBLIC_KEY_PEM = _SIGNING_KEY.public_key().public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+
+
+def _epoch(offset: timedelta) -> int:
+    """Return the UNIX timestamp ``offset`` away from now."""
+    return int((datetime.now(UTC) + offset).timestamp())
+
+
+def _claims(**overrides: object) -> dict[str, object]:
+    """Build a Google-shaped id_token claim set with per-test overrides."""
+    base: dict[str, object] = {
+        "iss": GOOGLE_ISSUER_URL,
+        "aud": TEST_CLIENT_ID,
+        "sub": KNOWN_SUBJECT,
+        "email": EXISTING_EMAIL,
+        "email_verified": True,
+        "name": DISPLAY_NAME,
+        "iat": _epoch(-timedelta(seconds=1)),
+        "exp": _epoch(TOKEN_LIFETIME),
+    }
+    base.update(overrides)
+    return base
+
+
+def _sign_rs256(claims: dict[str, object], private_key: rsa.RSAPrivateKey) -> str:
+    """Sign ``claims`` as an RS256 JWT carrying the module's ``kid`` header."""
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm=RS256_ALGORITHM,
+        headers={"kid": TEST_KID},
+    )
+
+
+def _mint_token(**overrides: object) -> str:
+    """Mint a legitimately signed Google id_token."""
+    return _sign_rs256(_claims(**overrides), _SIGNING_KEY)
+
+
+def _mint_forged_token(**overrides: object) -> str:
+    """Mint a well-formed id_token signed by a key Google never published."""
+    return _sign_rs256(_claims(**overrides), _FORGER_KEY)
+
+
+def _mint_token_missing(claim: str, **overrides: object) -> str:
+    """Mint a legitimately signed token with ``claim`` removed entirely."""
+    claims = _claims(**overrides)
+    del claims[claim]
+    return _sign_rs256(claims, _SIGNING_KEY)
+
+
+def _b64url(raw: bytes) -> bytes:
+    """Base64url-encode ``raw`` without padding, as JWT compact serialization does."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+def _b64url_json(data: dict[str, object]) -> bytes:
+    """Base64url-encode ``data`` as compact JSON."""
+    return _b64url(json.dumps(data, separators=(",", ":")).encode("utf-8"))
+
+
+def _signing_input(algorithm: str, **overrides: object) -> bytes:
+    """Return the ``header.payload`` bytes a JWT signature is computed over."""
+    header: dict[str, object] = {"alg": algorithm, "kid": TEST_KID, "typ": JWT_TYPE}
+    return b".".join((_b64url_json(header), _b64url_json(_claims(**overrides))))
+
+
+def _mint_unsigned_token(**overrides: object) -> str:
+    """Mint an ``alg: none`` token: real claims, no signature at all."""
+    return _signing_input(NONE_ALGORITHM, **overrides).decode("ascii") + "."
+
+
+def _mint_algorithm_confusion_token(**overrides: object) -> str:
+    """Mint the RS256-to-HS256 downgrade: HMAC keyed by the RSA public key PEM.
+
+    A verifier that accepts the token's own ``alg`` header would treat the
+    public key as a shared secret, letting anyone who can read the JWKS mint
+    tokens for any account.
+    """
+    signing_input = _signing_input(HS256_ALGORITHM, **overrides)
+    signature = hmac.new(_PUBLIC_KEY_PEM, signing_input, hashlib.sha256).digest()
+    return b".".join((signing_input, _b64url(signature))).decode("ascii")
+
+
+def _oauth_payload(
+    id_token: str,
+    license_key: str | None = None,
+    timezone: str | None = None,
+) -> dict[str, str]:
+    """Build the request body; ``None`` arguments omit their field entirely."""
+    payload = {"id_token": id_token}
+    if license_key is not None:
+        payload["license_key"] = license_key
+    if timezone is not None:
+        payload["timezone"] = timezone
+    return payload
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+def _fingerprint(response: Response) -> tuple[int, str | None, bytes]:
+    """Return everything an unauthenticated observer can see about a rejection."""
+    return (response.status_code, response.headers.get("content-type"), response.content)
+
+
+async def _needs_license_reference(client: AsyncClient) -> tuple[int, str | None, bytes]:
+    """Fingerprint the canonical step-5 rejection every other refusal must match.
+
+    A brand-new verified email with no license key is the most ordinary way to
+    be turned away.  Any other refusal that differs from this by even one byte
+    is an oracle, so the gated-account tests compare against it directly rather
+    than restating the expected body.
+    """
+    return _fingerprint(
+        await client.post(
+            OAUTH_PATH,
+            json=_oauth_payload(_mint_token(sub=NO_KEY_SUBJECT, email=NEW_EMAIL)),
+        )
+    )
+
+
+def _license_result(email: str) -> GumroadLicenseResult:
+    """Build a live, unreversed Gumroad verify answer for ``email``."""
+    return GumroadLicenseResult(
+        success=True,
+        uses=LICENSE_USES,
+        purchase=GumroadPurchase(
+            email=email,
+            product_id=ALLOWED_PRODUCT_ALPHA,
+            sale_id=SALE_ID,
+            refunded=False,
+            chargebacked=False,
+            disputed=False,
+            dispute_won=False,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class _StubSigningKey:
+    """What a JWKS client hands back for a token's ``kid``: a key carrier."""
+
+    key: object
+
+
+class _StubJWKClient:
+    """Offline stand-in for ``PyJWKClient`` — answers from the module keypair."""
+
+    def __init__(self, key: object) -> None:
+        """Hold the public key every lookup resolves to."""
+        self._key = key
+        self.lookups: list[str] = []
+
+    def get_signing_key_from_jwt(self, token: str) -> _StubSigningKey:
+        """Record the lookup and return the module's public signing key."""
+        self.lookups.append(token)
+        return _StubSigningKey(self._key)
+
+
+class _LicenseVerifier:
+    """Network-free stand-in for the outbound Gumroad license verify."""
+
+    def __init__(self) -> None:
+        """Start with no grants recorded and Gumroad nominally healthy."""
+        self.calls: list[tuple[str, str]] = []
+        self.results: dict[str, GumroadLicenseResult] = {}
+        self.unavailable = False
+
+    def grant(self, license_key: str, email: str) -> None:
+        """Make ``license_key`` verify as a live purchase made by ``email``."""
+        self.results[license_key] = _license_result(email)
+
+    async def verify(
+        self,
+        product_id: str,
+        license_key: str,
+        **_kwargs: object,
+    ) -> GumroadLicenseResult | None:
+        """Answer for ``license_key``, or raise when Gumroad is stubbed down."""
+        self.calls.append((product_id, license_key))
+        if self.unavailable:
+            raise GumroadUnavailableError(GUMROAD_DOWN_MESSAGE)
+        return self.results.get(license_key)
+
+
+@pytest.fixture(autouse=True)
+def offline_jwks(monkeypatch: pytest.MonkeyPatch) -> _StubJWKClient:
+    """Replace Google's JWKS client so no test in this module hits the network."""
+    client = _StubJWKClient(_SIGNING_KEY.public_key())
+
+    def _factory() -> _StubJWKClient:
+        return client
+
+    monkeypatch.setattr(JWKS_SEAM, _factory)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def google_client_ids(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Configure the single accepted OAuth audience for the module."""
+    monkeypatch.setenv(GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR, TEST_CLIENT_ID)
+    return TEST_CLIENT_ID
+
+
+@pytest.fixture
+def allowlisted_products(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point the APTITUDE product allowlist at the two test product ids."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, ALLOWLIST)
+    return ALLOWLIST
+
+
+@pytest.fixture
+def license_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    allowlisted_products: str,  # noqa: ARG001 — side-effect: configures the allowlist
+) -> _LicenseVerifier:
+    """Stub the outbound Gumroad verify while leaving the real license gate in place."""
+    verifier = _LicenseVerifier()
+    monkeypatch.setattr(VERIFY_SEAM, verifier.verify)
+    return verifier
+
+
+def _user_id(user: User) -> int:
+    """Return a committed user's primary key, failing loudly when absent."""
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user.id
+
+
+async def _count_rows(session: AsyncSession, model: type[SQLModel]) -> int:
+    """Return the number of ``model`` rows visible to ``session``."""
+    result = await session.execute(select(func.count()).select_from(model))
+    return int(result.scalar_one())
+
+
+async def _count_rows_via(
+    factory: async_sessionmaker[AsyncSession],
+    model: type[SQLModel],
+) -> int:
+    """Return the number of ``model`` rows in the concurrency fixture's database."""
+    async with factory() as session:
+        return await _count_rows(session, model)
+
+
+async def _seed_user(
+    session: AsyncSession,
+    email: str = EXISTING_EMAIL,
+    *,
+    is_active: bool = True,
+    deleted_at: datetime | None = None,
+) -> User:
+    """Insert a password-authenticated user and return the committed row."""
+    user = User(
+        email=email,
+        password_hash=SEEDED_PASSWORD_HASH,
+        timezone=SEEDED_TIMEZONE,
+        is_active=is_active,
+        deleted_at=deleted_at,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def _seed_identity(
+    session: AsyncSession,
+    user_id: int,
+    subject: str,
+    email: str = EXISTING_EMAIL,
+) -> AuthIdentity:
+    """Insert a linked Google identity for ``user_id`` and return the committed row."""
+    identity = AuthIdentity(
+        user_id=user_id,
+        provider=AuthProvider.GOOGLE,
+        subject=subject,
+        email_at_link_time=email,
+    )
+    session.add(identity)
+    await session.commit()
+    await session.refresh(identity)
+    return identity
+
+
+async def _seed_user_via(
+    factory: async_sessionmaker[AsyncSession],
+    email: str = EXISTING_EMAIL,
+) -> int:
+    """Insert a user into the concurrency fixture's database and return its id."""
+    async with factory() as session:
+        return _user_id(await _seed_user(session, email))
+
+
+async def _only_identity(session: AsyncSession) -> AuthIdentity:
+    """Return the single AuthIdentity row, asserting there is exactly one."""
+    identities = (await session.execute(select(AuthIdentity))).scalars().all()
+    assert len(identities) == 1
+    return identities[0]
+
+
+# ---------------------------------------------------------------------------
+# Model contract
+# ---------------------------------------------------------------------------
+
+
+def test_auth_provider_enum_names_the_two_supported_providers() -> None:
+    """The provider discriminator stores the wire values Apple and Google use."""
+    assert AuthProvider.GOOGLE.value == "google"
+    assert AuthProvider.APPLE.value == "apple"
+
+
+def test_oidc_identity_exposes_the_claims_the_ladder_reads() -> None:
+    """The verifier's return value carries exactly the claims the ladder consumes."""
+    identity = OIDCIdentity(
+        subject=KNOWN_SUBJECT,
+        email=EXISTING_EMAIL,
+        email_verified=True,
+        name=DISPLAY_NAME,
+    )
+
+    assert identity.subject == KNOWN_SUBJECT
+    assert identity.email == EXISTING_EMAIL
+    assert identity.email_verified is True
+    assert identity.name == DISPLAY_NAME
+
+
+def test_google_jwks_url_is_https_on_a_google_host() -> None:
+    """Signing keys are fetched over TLS from Google, never plaintext or elsewhere."""
+    parsed = urlparse(GOOGLE_JWKS_URL)
+
+    assert parsed.scheme == "https"
+    assert parsed.hostname in GOOGLE_JWKS_HOSTS
+
+
+@pytest.mark.asyncio
+async def test_provider_subject_pair_is_unique(db_session: AsyncSession) -> None:
+    """Two rows may not claim the same Google subject — that would fork an account."""
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    duplicate = AuthIdentity(
+        user_id=_user_id(user),
+        provider=AuthProvider.GOOGLE,
+        subject=KNOWN_SUBJECT,
+        email_at_link_time=EXISTING_EMAIL,
+    )
+    db_session.add(duplicate)
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# A. Cryptographic verification
+# ---------------------------------------------------------------------------
+
+_UNVERIFIABLE_TOKENS = (
+    pytest.param(_mint_forged_token(), id="signed-by-an-unrelated-key"),
+    pytest.param(_mint_token(aud=OTHER_CLIENT_ID), id="audience-is-another-client"),
+    pytest.param(_mint_token(iss=EVIL_ISSUER), id="issuer-is-not-google"),
+    pytest.param(
+        _mint_token(iat=_epoch(-EXPIRED_ISSUED_AGO), exp=_epoch(-EXPIRED_EXPIRY_AGO)),
+        id="expired",
+    ),
+    pytest.param(_mint_unsigned_token(), id="alg-none-unsigned"),
+    pytest.param(_mint_algorithm_confusion_token(), id="rs256-to-hs256-confusion"),
+    pytest.param(GARBAGE_TOKEN, id="structurally-not-a-jwt"),
+    pytest.param(_mint_token_missing("sub"), id="valid-signature-no-subject"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("id_token", _UNVERIFIABLE_TOKENS)
+async def test_unverifiable_token_is_401_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    id_token: str,
+) -> None:
+    """Every failure of cryptographic verification is the same 401 with zero writes."""
+    caplog.set_level(logging.INFO)
+
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json()["detail"] == DETAIL_INVALID_TOKEN
+    assert "token" not in response.json()
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert await _count_rows(db_session, User) == 0
+    assert _log_carries_marker(caplog, REASON_INVALID_TOKEN)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_ids", [None, ""], ids=["unset", "blank"])
+async def test_unconfigured_client_ids_reject_even_a_perfect_token(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    client_ids: str | None,
+) -> None:
+    """With no configured audience the verifier fails closed rather than open."""
+    if client_ids is None:
+        monkeypatch.delenv(GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR, client_ids)
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(_mint_token()))
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json()["detail"] == DETAIL_INVALID_TOKEN
+    assert await _count_rows(db_session, AuthIdentity) == 1
+
+
+@pytest.mark.asyncio
+async def test_over_length_id_token_is_rejected_before_verification(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    offline_jwks: _StubJWKClient,
+) -> None:
+    """An id_token past the schema ceiling is a 422; no key lookup is attempted."""
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(OVER_LENGTH_ID_TOKEN))
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert offline_jwks.lookups == []
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+
+
+@pytest.mark.asyncio
+async def test_sixth_attempt_in_a_minute_is_rate_limited(async_client: AsyncClient) -> None:
+    """The endpoint carries the login-strength 5/minute per-IP cap."""
+    id_token = _mint_forged_token()
+
+    for _ in range(OAUTH_RATE_LIMIT_PER_MINUTE):
+        response = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    throttled = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+# ---------------------------------------------------------------------------
+# B. Step 2 — an already-linked identity logs in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_known_identity_logs_in_without_creating_a_row(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stored (google, sub) pair mints a JWT for its user and links nothing new."""
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=KNOWN_SUBJECT)),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["user_id"] == _user_id(user)
+    assert body["timezone"] == SEEDED_TIMEZONE
+    assert len(body["token"].split(".")) == JWT_SEGMENT_COUNT
+    assert await _count_rows(db_session, AuthIdentity) == 1
+    assert await _count_rows(db_session, User) == 1
+    assert _log_carries_marker(caplog, REASON_LOGIN)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "issuer",
+    [GOOGLE_ISSUER_URL, GOOGLE_ISSUER_BARE],
+    ids=["https-issuer", "bare-issuer"],
+)
+async def test_both_google_issuer_spellings_are_accepted(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    issuer: str,
+) -> None:
+    """Google mints both ``accounts.google.com`` spellings; both must verify."""
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=KNOWN_SUBJECT, iss=issuer)),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("is_active", "deleted_at"),
+    [(False, None), (True, SOFT_DELETED_AT)],
+    ids=["soft-disabled", "soft-deleted"],
+)
+async def test_linked_identity_on_a_gated_account_issues_no_token(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    is_active: bool,
+    deleted_at: datetime | None,
+) -> None:
+    """A gated account is refused with the generic 409, never a telltale 401.
+
+    401 is reserved for "this token did not verify".  Spending it here would
+    tell any holder of a valid Google token whether the identity it names is
+    attached to a banned Adepthood account, so the refusal collapses onto the
+    same body an unknown account gets.
+    """
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session, is_active=is_active, deleted_at=deleted_at)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=KNOWN_SUBJECT)),
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+    assert "token" not in response.json()
+    assert _fingerprint(response) == await _needs_license_reference(async_client)
+    assert _log_carries_marker(caplog, REASON_ACCOUNT_GATED)
+
+
+# ---------------------------------------------------------------------------
+# C. Step 3 — link by verified email
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verified_email_links_onto_the_existing_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A verified provider email matches case-insensitively and links exactly one row."""
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=FRESH_SUBJECT, email=EXISTING_EMAIL_MIXED_CASE, email_verified=True)
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+    assert await _count_rows(db_session, User) == 1
+
+    identity = await _only_identity(db_session)
+    assert identity.provider == AuthProvider.GOOGLE
+    assert identity.subject == FRESH_SUBJECT
+    assert identity.user_id == _user_id(user)
+    assert identity.email_at_link_time.lower() == EXISTING_EMAIL
+    assert _log_carries_marker(caplog, REASON_LINKED)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("license_verifier")
+async def test_unverified_email_never_links_to_an_existing_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unverified provider email is the takeover vector; it must not link."""
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=FRESH_SUBJECT, email=EXISTING_EMAIL, email_verified=False)
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+    assert "token" not in response.json()
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert await _count_rows(db_session, User) == 1
+
+    await db_session.refresh(user)
+    assert user.email == EXISTING_EMAIL
+    assert user.is_active is True
+    assert _log_carries_marker(caplog, REASON_NEEDS_LICENSE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("is_active", "deleted_at"),
+    [(False, None), (True, SOFT_DELETED_AT)],
+    ids=["soft-disabled", "soft-deleted"],
+)
+async def test_verified_email_never_links_onto_a_gated_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    is_active: bool,
+    deleted_at: datetime | None,
+) -> None:
+    """Probing a banned account with a verified provider email reveals nothing.
+
+    Linking here would hand a fresh session to an account an operator has
+    already shut, and answering differently from an unknown email would let an
+    attacker who controls the address confirm the ban exists.  Both are closed
+    by the same generic 409.
+    """
+    caplog.set_level(logging.INFO)
+    await _seed_user(db_session, is_active=is_active, deleted_at=deleted_at)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=FRESH_SUBJECT, email=EXISTING_EMAIL, email_verified=True)
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+    assert _fingerprint(response) == await _needs_license_reference(async_client)
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert await _count_rows(db_session, User) == 1
+    assert _log_carries_marker(caplog, REASON_ACCOUNT_GATED)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_links_create_exactly_one_identity(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Two simultaneous first-links for one subject converge on a single row."""
+    user_id = await _seed_user_via(concurrent_session_factory)
+    payload = _oauth_payload(_mint_token(sub=RACING_SUBJECT, email=EXISTING_EMAIL))
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(OAUTH_PATH, json=payload)
+            for _ in range(CONCURRENT_REQUESTS)
+        ]
+    )
+
+    assert [response.status_code for response in responses] == [HTTPStatus.OK] * CONCURRENT_REQUESTS
+    assert {response.json()["user_id"] for response in responses} == {user_id}
+    assert await _count_rows_via(concurrent_session_factory, AuthIdentity) == 1
+    assert await _count_rows_via(concurrent_session_factory, User) == 1
+
+
+# ---------------------------------------------------------------------------
+# D. Step 4 — license-gated account creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_email_with_valid_license_creates_the_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A verified stranger holding a license gets a user, an entitlement, and a link."""
+    caplog.set_level(logging.INFO)
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL),
+            license_key=VALID_LICENSE_KEY,
+            timezone=SIGNUP_TIMEZONE,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["timezone"] == SIGNUP_TIMEZONE
+    assert len(body["token"].split(".")) == JWT_SEGMENT_COUNT
+
+    users = (await db_session.execute(select(User))).scalars().all()
+    assert len(users) == 1
+    assert users[0].email == NEW_EMAIL
+    assert users[0].timezone == SIGNUP_TIMEZONE
+    assert users[0].id == body["user_id"]
+    assert users[0].password_hash.startswith(BCRYPT_PREFIX)
+
+    entitlements = (await db_session.execute(select(Entitlement))).scalars().all()
+    assert len(entitlements) == 1
+    assert entitlements[0].kind == COURSE_ACCESS_KIND
+    assert entitlements[0].user_id == body["user_id"]
+    assert entitlements[0].revoked_at is None
+
+    identity = await _only_identity(db_session)
+    assert identity.subject == NEW_SUBJECT
+    assert identity.user_id == body["user_id"]
+    assert _log_carries_marker(caplog, REASON_SIGNUP)
+
+
+@pytest.mark.asyncio
+async def test_social_accounts_get_distinct_unusable_passwords(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """A social-only account cannot be logged into with a password, and its secret is unique."""
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+    license_verifier.grant(SECOND_LICENSE_KEY, SECOND_NEW_EMAIL)
+
+    first = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL), license_key=VALID_LICENSE_KEY
+        ),
+    )
+    second = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=SECOND_NEW_SUBJECT, email=SECOND_NEW_EMAIL),
+            license_key=SECOND_LICENSE_KEY,
+        ),
+    )
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+
+    hashes = (await db_session.execute(select(User.password_hash))).scalars().all()
+    assert len(hashes) == SOCIAL_ACCOUNT_COUNT
+    assert all(digest.startswith(BCRYPT_PREFIX) for digest in hashes)
+    assert len(set(hashes)) == SOCIAL_ACCOUNT_COUNT
+
+    login = await async_client.post(
+        LOGIN_PATH,
+        json={"email": NEW_EMAIL, "password": ARBITRARY_PASSWORD},
+    )
+
+    assert login.status_code == HTTPStatus.UNAUTHORIZED
+    assert login.json()["detail"] == DETAIL_INVALID_CREDENTIALS
+    assert "token" not in login.json()
+
+
+@pytest.mark.asyncio
+async def test_gumroad_outage_fails_closed_with_503(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """An unreachable Gumroad answers 503 and creates nothing."""
+    license_verifier.unavailable = True
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL), license_key=VALID_LICENSE_KEY
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json()["detail"] == DETAIL_UNAVAILABLE
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, Entitlement) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_logins_create_exactly_one_account(
+    concurrent_async_client: AsyncClient,
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """Two simultaneous licensed first-logins yield one user and one identity."""
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+    payload = _oauth_payload(
+        _mint_token(sub=RACING_SUBJECT, email=NEW_EMAIL),
+        license_key=VALID_LICENSE_KEY,
+    )
+
+    responses = await asyncio.gather(
+        *[
+            concurrent_async_client.post(OAUTH_PATH, json=payload)
+            for _ in range(CONCURRENT_REQUESTS)
+        ]
+    )
+
+    assert all(response.status_code != HTTPStatus.INTERNAL_SERVER_ERROR for response in responses)
+    assert await _count_rows_via(concurrent_session_factory, User) == 1
+    assert await _count_rows_via(concurrent_session_factory, AuthIdentity) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_invalid_license_attempts_share_the_hourly_cap(
+    async_client: AsyncClient,
+    license_verifier: _LicenseVerifier,  # noqa: ARG001 — no key ever verifies
+) -> None:
+    """The OAuth path is not a bypass of signup's invalid-license throttle."""
+    for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
+        id_token = _mint_token(
+            sub=f"{THROTTLE_SUBJECT_PREFIX}{attempt}",
+            email=f"{THROTTLE_EMAIL_PREFIX}{attempt}@example.com",
+        )
+        response = await async_client.post(
+            OAUTH_PATH,
+            json=_oauth_payload(id_token, license_key=INVALID_LICENSE_KEY),
+        )
+        assert response.status_code == HTTPStatus.CONFLICT
+        assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+
+    final_token = _mint_token(sub=f"{THROTTLE_SUBJECT_PREFIX}final", email=UNCLAIMED_EMAIL)
+    throttled = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(final_token, license_key=INVALID_LICENSE_KEY),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+# ---------------------------------------------------------------------------
+# E. Step 5 — anti-enumeration and secret hygiene
+# ---------------------------------------------------------------------------
+
+
+def _needs_license_payloads() -> tuple[dict[str, str], ...]:
+    """The four distinct ways to land on step 5, which must be indistinguishable."""
+    return (
+        _oauth_payload(_mint_token(sub=NO_KEY_SUBJECT, email=NEW_EMAIL)),
+        _oauth_payload(
+            _mint_token(sub=BAD_KEY_SUBJECT, email=SECOND_NEW_EMAIL),
+            license_key=INVALID_LICENSE_KEY,
+        ),
+        _oauth_payload(
+            _mint_token(sub=COLLISION_SUBJECT, email=EXISTING_EMAIL, email_verified=False)
+        ),
+        _oauth_payload(
+            _mint_token(sub=UNVERIFIED_SUBJECT, email=UNVERIFIED_NEW_EMAIL, email_verified=False),
+            license_key=VALID_LICENSE_KEY,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_every_needs_license_rejection_is_byte_identical(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """No 409 reveals whether the email exists, whether it is verified, or key validity."""
+    await _seed_user(db_session)
+    license_verifier.grant(VALID_LICENSE_KEY, UNVERIFIED_NEW_EMAIL)
+
+    fingerprints = [
+        _fingerprint(await async_client.post(OAUTH_PATH, json=payload))
+        for payload in _needs_license_payloads()
+    ]
+
+    assert len(fingerprints) == BYTE_IDENTICAL_REJECTIONS
+    assert all(status == HTTPStatus.CONFLICT for status, _, _ in fingerprints)
+    assert all(DETAIL_NEEDS_LICENSE.encode() in body for _, _, body in fingerprints)
+    assert len(set(fingerprints)) == 1
+    assert await _count_rows(db_session, User) == 1
+    assert await _count_rows(db_session, Entitlement) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+
+
+@pytest.mark.asyncio
+async def test_raw_id_token_never_reaches_a_log_or_a_response(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,  # noqa: ARG001 — keeps the gate network-free
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A leaked id_token is a replayable credential; no ladder path may echo one."""
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+    tokens = (
+        _mint_forged_token(sub=KNOWN_SUBJECT),
+        _mint_token(sub=KNOWN_SUBJECT),
+        _mint_token(sub=FRESH_SUBJECT, email=UNCLAIMED_EMAIL),
+    )
+
+    caplog.set_level(logging.INFO)
+    responses = [
+        await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token)) for id_token in tokens
+    ]
+
+    # Pin that all three ladder rungs were actually walked, so the absence
+    # assertions below cannot pass vacuously against an unrouted endpoint.
+    assert [response.status_code for response in responses] == [
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.OK,
+        HTTPStatus.CONFLICT,
+    ]
+
+    haystack = caplog.text + "".join(response.text for response in responses)
+    for id_token in tokens:
+        assert id_token not in haystack
+        for segment in id_token.split("."):
+            assert segment not in haystack

--- a/backend/tests/routers/test_oauth_google.py
+++ b/backend/tests/routers/test_oauth_google.py
@@ -41,7 +41,12 @@ from models.entitlement import Entitlement
 from models.user import User
 from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
 from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
-from services.oauth_google import GOOGLE_JWKS_URL, GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR
+from services.oauth_google import (
+    GOOGLE_JWKS_URL,
+    GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR,
+    JWKS_TIMEOUT_SECONDS,
+    build_jwk_client,
+)
 from services.oidc import OIDCIdentity
 
 if TYPE_CHECKING:
@@ -133,6 +138,9 @@ REASON_NEEDS_LICENSE = "oauth_needs_license"
 REASON_ACCOUNT_GATED = "oauth_account_gated"
 
 JWT_SEGMENT_COUNT = 3
+# Upper bound the JWKS fetch timeout must stay under. Anything longer holds a
+# shared thread-pool worker for longer than an interactive request should.
+MAX_ACCEPTABLE_JWKS_TIMEOUT = 10.0
 MAX_ID_TOKEN_LENGTH = 4096
 OVER_LENGTH_ID_TOKEN = "a" * (MAX_ID_TOKEN_LENGTH + 1)
 GARBAGE_TOKEN = "not.a.jwt"
@@ -530,6 +538,10 @@ _UNVERIFIABLE_TOKENS = (
     pytest.param(_mint_algorithm_confusion_token(), id="rs256-to-hs256-confusion"),
     pytest.param(GARBAGE_TOKEN, id="structurally-not-a-jwt"),
     pytest.param(_mint_token_missing("sub"), id="valid-signature-no-subject"),
+    # A token carrying no ``exp`` never expires, so absence has to be rejected
+    # outright rather than skipped the way an unasserted claim would be.
+    pytest.param(_mint_token_missing("exp"), id="valid-signature-no-expiry"),
+    pytest.param(_mint_token_missing("iat"), id="valid-signature-no-issued-at"),
 )
 
 
@@ -759,6 +771,55 @@ async def test_unverified_email_never_links_to_an_existing_account(
     assert user.email == EXISTING_EMAIL
     assert user.is_active is True
     assert _log_carries_marker(caplog, REASON_NEEDS_LICENSE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("license_verifier")
+@pytest.mark.parametrize(
+    "email_verified",
+    ["true", "True", 1],
+    ids=["string-true", "string-True", "integer-one"],
+)
+async def test_only_a_real_boolean_true_counts_as_a_verified_email(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    email_verified: object,
+) -> None:
+    """A truthy non-boolean ``email_verified`` must not be read as verified.
+
+    Google sends a JSON boolean, but other providers send the string ``"true"``
+    -- and a verifier that accepts anything truthy is exactly how an address
+    nobody proved ends up linked to somebody else's account.  Pinned because
+    the guard is a single ``is True`` that a well-meaning "be tolerant"
+    refactor would quietly widen.
+    """
+    await _seed_user(db_session)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=FRESH_SUBJECT, email=EXISTING_EMAIL, email_verified=email_verified)
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert await _count_rows(db_session, User) == 1
+
+
+def test_jwks_client_bounds_its_fetch_timeout() -> None:
+    """The JWKS fetch must not inherit PyJWT's 30-second default.
+
+    An unrecognised ``kid`` makes the client refetch immediately, bypassing the
+    key-set cache, and that fetch occupies a worker in the same default thread
+    pool bcrypt runs in.  An unbounded timeout therefore lets unauthenticated
+    junk tokens park threads that logins and signups need.
+    """
+    client = build_jwk_client()
+
+    assert client.timeout == JWKS_TIMEOUT_SECONDS
+    assert 0 < JWKS_TIMEOUT_SECONDS <= MAX_ACCEPTABLE_JWKS_TIMEOUT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `POST /auth/oauth/google`, a second authentication path that verifies a Google-issued `id_token` against Google's published JWKS and resolves it to an ordinary Adepthood JWT. Social sign-in changes how you prove who you are, never who is allowed in: a brand-new account still requires a verified Gumroad APTITUDE license, so `409 needs_license` is a normal outcome and the frontend already routes on it.
- Verification splits into a provider-neutral core (`services/oidc.py`) and a thin Google adapter (`services/oauth_google.py`), so the Apple endpoint can reuse the core with a different issuer, audience, and JWKS URL rather than re-deriving — or subtly weakening — any of it.
- New `AuthIdentity` table (`provider`, `subject`, unique together; many identities per user) plus migration `e6f7a8b9c0d1` on head `d5e6f7a8b9c0`.

### The ladder

Four rungs, tried in order: a stored `(google, subject)` link logs straight in; otherwise a provider-**verified** email links onto the account that already owns it; otherwise a verified email plus a valid license creates the `User`, `Entitlement`, and link. An unverified email never links and never creates — that is the takeover vector, since most providers will carry an address nobody proved.

### Security properties, each pinned by a test

- **Algorithm pinning.** The accepted algorithms are supplied by the caller and never read from the token header, which closes both `alg: none` and the RS256→HS256 confusion attack where the published public key is used as a shared HMAC secret.
- **Required claims are asserted, not skipped.** A token with no `exp` would otherwise never expire.
- **Fail-closed config.** Unset or blank `GOOGLE_OAUTH_CLIENT_IDS` yields an empty audience list, and every token is rejected.
- **Exactly two refusals.** `401` is spent only on "this token failed verification" — a statement about the token that reveals nothing about any account. Everything else (no license, bad license, unverified address colliding with a real account, token with no email, an account an operator disabled or deleted) returns one `409` with byte-identical bytes and a matched bcrypt spend. A test compares the raw `response.content` of six different routes against a live reference and asserts a single distinct value.
- **No license brute-force bypass.** Failed keys are charged against the same per-IP hourly cap `/auth/signup` enforces.
- **The raw `id_token` never reaches a log, a response, or an exception chain** (`raise ... from None`); emails are logged only as the existing non-reversible fingerprint.
- **Races are arbitrated by the database**, matching the existing signup path: the `(provider, subject)` unique constraint and the `user.email` index turn a concurrent first sign-in into an `IntegrityError`, and the loser re-resolves once onto the row the winner wrote.
- **Social accounts hold a per-account 256-bit random** at the standard bcrypt cost, so password login against them fails indistinguishably from a wrong password.

Self-review caught and fixed one real issue before push: `PyJWKClient` was inheriting PyJWT's 30-second default timeout, and because an unrecognised `kid` forces an immediate refetch on the same thread pool bcrypt uses, unauthenticated junk tokens could park workers that login and signup need. Bounded to 5s, matching `GUMROAD_TIMEOUT_SECONDS`.

## Test plan

- `backend/tests/routers/test_oauth_google.py` — 39 tests, offline throughout (module-scoped RSA keypair, stubbed JWKS; never touches Google). Covers all four ladder outcomes; forged signature, wrong `aud`, wrong `iss`, expired, missing `exp`/`iat`/`sub`, `alg: none`, HS256-with-the-public-key, and unconfigured client IDs all → 401 with zero rows; unverified-email non-linking including truthy-but-not-boolean `email_verified`; gated accounts refused without an enumeration oracle; byte-identical 409s; concurrent link and concurrent first-login each converging on one row; password login on a social-only account; the license throttle; and an assertion that the raw token appears in no log or body.
- Full backend suite: **3212 passed, 2 skipped**, total coverage **96.93%** (gate 90%).
- `./scripts/backend/check-all.sh` green; additionally `ruff` clean, `mypy --strict` clean across 184 files, `xenon --max-absolute A --max-modules A --max-average A src` exit 0, `radon mi -nb src` clean, `interrogate` 96.5% (gate 85%), `detect-secrets` pass, and `alembic heads` reports the single head `e6f7a8b9c0d1`.
- Backend only; no frontend and no dependency changes (`PyJWT` and `cryptography` were already pinned).

Closes #1948
Refs #1947
