### PR TITLE
feat(backend): POST /auth/oauth/apple with relay-email and first-auth-name handling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -82,6 +82,12 @@ GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 # rejects every token.
 GOOGLE_OAUTH_CLIENT_IDS=  # e.g. 1234-ios.apps.googleusercontent.com,1234-web.apps.googleusercontent.com
 
+# Comma-separated Apple client IDs accepted as the ``aud`` claim of a submitted
+# id_token: the iOS bundle ID, plus the Services ID if the web flow is enabled.
+# Read at request time, so rotating or adding one needs no restart. Fails
+# closed: unset means Sign in with Apple rejects every token.
+APPLE_OAUTH_CLIENT_IDS=  # e.g. com.adepthood.app,com.adepthood.web
+
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production
 # RAILWAY_PUBLIC_DOMAIN=your-app.up.railway.app

--- a/backend/migrations/versions/b0c1d2e3f4a5_add_user_display_name.py
+++ b/backend/migrations/versions/b0c1d2e3f4a5_add_user_display_name.py
@@ -1,0 +1,54 @@
+"""Add user.display_name for the name a social sign-in supplies.
+
+Revision ID: b0c1d2e3f4a5
+Revises: e6f7a8b9c0d1
+Create Date: 2026-07-28 00:00:00.000000
+
+Issue #1949: Sign in with Apple sends the user's name exactly once, in the
+body of the very first authorization, and never again -- so it has to be
+persisted at account creation or it is gone for good. Google sends the same
+thing as a verified ``name`` claim. Both land in one column.
+
+Purely additive and nullable: existing rows keep the ``NULL`` that means "no
+name supplied", which is the steady state for every password signup, so no
+backfill is needed and every reader already carries a fallback. There is no
+server default -- the model owns the ``None`` default, which keeps
+``alembic check`` drift-free. ``downgrade`` drops the column.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b0c1d2e3f4a5"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "e6f7a8b9c0d1"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "user"
+_COLUMN = "display_name"
+
+# Mirrors ``models.user.DISPLAY_NAME_MAX_LENGTH``.
+_DISPLAY_NAME_MAX = 120
+
+
+def upgrade() -> None:
+    """Add the nullable ``display_name`` column."""
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sqlmodel.sql.sqltypes.AutoString(length=_DISPLAY_NAME_MAX),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``display_name`` column."""
+    # Batch mode keeps the DROP COLUMN SQLite-compatible for the round-trip test.
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column(_COLUMN)

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -25,6 +25,13 @@ def _default_reset_date() -> datetime:
 # timezone column existed (legacy rows backfilled to ``"UTC"``).
 DEFAULT_USER_TIMEZONE = "UTC"
 
+# Ceiling on the human-readable name shown beside a user's shared content.
+# Generous enough for a full legal name in any script, short enough that the
+# value stays renderable in a single line of UI — and, because it is enforced
+# at the request boundary too, an over-long name is refused rather than
+# silently truncated into a name its owner never chose.
+DISPLAY_NAME_MAX_LENGTH = 120
+
 
 class User(SQLModel, table=True):
     """Represents a user account.
@@ -66,6 +73,14 @@ class User(SQLModel, table=True):
     # the default so SQLModel forces every caller to supply a hash and a
     # blank-password account becomes impossible at the schema level.
     password_hash: str = Field(min_length=1)
+    # The name the user goes by, when they have supplied one.  Written once, at
+    # account creation, from whatever the sign-in path knew: a social provider's
+    # verified ``name`` claim, or (for Sign in with Apple, which never puts the
+    # name in the token) the name the client forwarded on the first
+    # authorization.  ``None`` is the ordinary steady state -- password signups
+    # supply no name -- so every reader must carry a fallback.  Nullable with no
+    # server default so existing rows need no backfill.
+    display_name: str | None = Field(default=None, max_length=DISPLAY_NAME_MAX_LENGTH)
     timezone: str = Field(
         default=DEFAULT_USER_TIMEZONE,
         sa_column=Column(

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -7,8 +7,9 @@ import hashlib
 import logging
 import os
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Annotated, NoReturn
 
@@ -40,7 +41,7 @@ from models.gumroad_sale import GumroadSale
 from models.login_attempt import LoginAttempt
 from models.password_reset_token import PasswordResetToken
 from models.revoked_token import RevokedToken
-from models.user import DEFAULT_USER_TIMEZONE, User
+from models.user import DEFAULT_USER_TIMEZONE, DISPLAY_NAME_MAX_LENGTH, User
 from rate_limit import limiter, record_invalid_license_attempt
 from schemas.password_reset import (
     PasswordResetAccepted,
@@ -54,6 +55,7 @@ from services.email import (
     EmailSender,
     get_email_sender,
 )
+from services.oauth_apple import verify_apple_id_token
 from services.oauth_google import verify_google_id_token
 from services.oidc import OIDCIdentity, OIDCTokenError
 from services.token_packs import claim_token_pack_sales
@@ -1590,10 +1592,10 @@ async def cancel_password_reset(
 
 
 # ---------------------------------------------------------------------------
-# Social sign-in (Google OAuth / OIDC)
+# Social sign-in (Google / Apple OIDC)
 # ---------------------------------------------------------------------------
 
-# Ceiling on the submitted ``id_token``.  Real Google id_tokens run well under
+# Ceiling on the submitted ``id_token``.  Real provider id_tokens run well under
 # 2 KB; the cap exists so an over-length body is rejected by Pydantic *before*
 # any JWKS lookup is attempted, denying an attacker a free way to drive
 # outbound key fetches (and CPU) with garbage.
@@ -1627,9 +1629,33 @@ _REASON_OAUTH_LINK_CONFLICT = "oauth_link_conflict"
 # ``reason_code``.
 _OAUTH_LOG_EVENT = "oauth_signin"
 
+# What a provider adapter contributes to the ladder: turn a raw ``id_token``
+# into verified claims, or raise ``OIDCTokenError``.  Narrowing the seam to one
+# callable is what keeps "one resolution ladder, two thin adapters" true.
+_OIDCVerifier = Callable[[str], Awaitable[OIDCIdentity]]
 
-class GoogleOAuthRequest(BaseModel):
-    """Google sign-in payload -- an ``id_token``, plus first-run extras.
+
+@dataclass(frozen=True)
+class _OAuthAttempt:
+    """One social sign-in in flight: who vouched, for whom, under what name.
+
+    Bundled rather than passed as three more arguments down every rung so the
+    ladder stays provider-agnostic without any rung growing an argument list
+    nobody can read.
+
+    ``display_name`` is the *proposed* name, and only the rung that creates a
+    brand-new row ever reads it.  Google supplies it from the verified ``name``
+    claim, Apple from the request body -- and for both the write is once-only,
+    so no later sign-in can rename an account that already exists.
+    """
+
+    provider: AuthProvider
+    claims: OIDCIdentity
+    display_name: str | None
+
+
+class OAuthSignInRequest(BaseModel):
+    """What every social sign-in carries -- an ``id_token``, plus first-run extras.
 
     ``id_token`` carries an explicit ``_MAX_ID_TOKEN_LENGTH`` bound for the
     same reason ``AuthRequest.password`` carries one: without it an unbounded
@@ -1644,6 +1670,9 @@ class GoogleOAuthRequest(BaseModel):
     ``timezone`` mirrors :class:`SignupRequest`: validated at the trust
     boundary so a malformed IANA string is a 422 rather than a permanently
     stored bad value, and omitting it keeps the column at ``"UTC"``.
+
+    Shared as a base class rather than copied per provider so a bound added
+    here can never be added to one provider's route and forgotten on another's.
     """
 
     id_token: str = Field(min_length=1, max_length=_MAX_ID_TOKEN_LENGTH)
@@ -1655,6 +1684,42 @@ class GoogleOAuthRequest(BaseModel):
     def _validate_timezone(cls, value: object) -> str:
         """Reject malformed IANA strings before they reach the DB."""
         return normalize_timezone(value, DEFAULT_USER_TIMEZONE)
+
+
+class GoogleOAuthRequest(OAuthSignInRequest):
+    """Google sign-in payload -- the shared shape, unchanged.
+
+    Google puts the user's name in the ``id_token`` itself, so there is nothing
+    for the client to add: everything the create rung needs arrives inside the
+    verified claims.
+    """
+
+
+class AppleOAuthRequest(OAuthSignInRequest):
+    """Apple sign-in payload -- the shared shape plus the one-shot ``full_name``.
+
+    Apple never puts the name in the token.  It is handed to the client once,
+    during the very first authorization, and never sent again -- so the client
+    forwards it here or it is lost.  That also makes it the one field on this
+    route the provider has *not* vouched for, which is why the ladder consults
+    it only when creating a brand-new row: a later request carrying a different
+    name can never relabel an account that already exists.
+
+    Blank (or whitespace-only) means "no name", not an empty name, so the
+    column stays ``NULL`` and every reader's fallback keeps working.  The
+    length bound matches the column's, so an over-long name is a 422 here
+    rather than a truncating write or a 500 from mid-transaction.
+    """
+
+    full_name: str | None = Field(default=None, max_length=DISPLAY_NAME_MAX_LENGTH)
+
+    @field_validator("full_name")
+    @classmethod
+    def _normalize_full_name(cls, value: str | None) -> str | None:
+        """Trim surrounding whitespace and treat a blank result as absent."""
+        if value is None:
+            return None
+        return value.strip() or None
 
 
 def _log_oauth(reason_code: str, email: str | None = None) -> None:
@@ -1713,16 +1778,20 @@ async def _gated_account_conflict(email: str | None) -> HTTPException:
     return await _needs_license_conflict(email)
 
 
-async def _verify_oauth_identity(id_token: str) -> OIDCIdentity:
+async def _verify_oauth_identity(id_token: str, verifier: _OIDCVerifier) -> OIDCIdentity:
     """Verify the submitted ``id_token``, or raise the only 401 this route uses.
 
     401 is reserved *exclusively* for "the token itself did not verify", which
     is a statement about the token and reveals nothing about any account.
     ``from None`` severs the chain so the raw token inside the verifier's error
     context cannot surface in a traceback or a 500 body.
+
+    The provider's verifier is injected rather than chosen here so every
+    provider inherits this exact refusal -- same status, same detail, same log
+    line -- instead of each route growing its own near-copy of it.
     """
     try:
-        return await verify_google_id_token(id_token)
+        return await verifier(id_token)
     except OIDCTokenError:
         _log_oauth(_REASON_OAUTH_INVALID_TOKEN)
         raise HTTPException(
@@ -1760,15 +1829,21 @@ def _linkable_email(claims: OIDCIdentity) -> str | None:
     return claims.email.strip().lower()
 
 
-async def _find_identity(session: AsyncSession, subject: str) -> AuthIdentity | None:
-    """Return the stored Google link for ``subject``, or ``None``.
+async def _find_identity(
+    session: AsyncSession,
+    provider: AuthProvider,
+    subject: str,
+) -> AuthIdentity | None:
+    """Return the stored ``provider`` link for ``subject``, or ``None``.
 
     Keyed on the provider subject rather than the email because a subject is
-    the only identifier a provider promises never to reassign.
+    the only identifier a provider promises never to reassign -- and scoped by
+    provider because subjects are only unique within one, so an unscoped lookup
+    would let a collision across providers resolve to the wrong account.
     """
     result = await session.execute(
         select(AuthIdentity).where(
-            AuthIdentity.provider == AuthProvider.GOOGLE,
+            AuthIdentity.provider == provider,
             AuthIdentity.subject == subject,
         )
     )
@@ -1787,6 +1862,7 @@ async def _find_user_by_email(session: AsyncSession, email: str) -> User | None:
 
 async def _insert_identity(
     session: AsyncSession,
+    provider: AuthProvider,
     user_id: int,
     subject: str,
     email: str,
@@ -1806,7 +1882,7 @@ async def _insert_identity(
     session.add(
         AuthIdentity(
             user_id=user_id,
-            provider=AuthProvider.GOOGLE,
+            provider=provider,
             subject=subject,
             email_at_link_time=email,
         )
@@ -1828,7 +1904,7 @@ async def _login_via_identity(
 
     A link whose account has been soft-disabled, soft-deleted, or hard-deleted
     is refused with the same 409 an unknown caller gets.  Spending the 401 here
-    would confirm to any holder of a valid Google token that the identity it
+    would confirm to any holder of a valid provider token that the identity it
     names is attached to a banned Adepthood account.
     """
     user = await session.get(User, identity.user_id)
@@ -1840,15 +1916,22 @@ async def _login_via_identity(
 
 async def _link_or_relogin(
     session: AsyncSession,
+    attempt: _OAuthAttempt,
     user: User,
-    claims: OIDCIdentity,
     email: str,
 ) -> AuthResponse:
-    """Attach a first Google link to ``user``, re-resolving once if a racer won."""
-    if await _insert_identity(session, _require_user_id(user), claims.subject, email):
+    """Attach a first provider link to ``user``, re-resolving once if a racer won.
+
+    The account already exists, so ``attempt.display_name`` is deliberately not
+    consulted: the name on that row (or its deliberate absence) belongs to its
+    owner, and letting a sign-in overwrite it would make this route a rename
+    endpoint for anyone holding a valid token.
+    """
+    subject = attempt.claims.subject
+    if await _insert_identity(session, attempt.provider, _require_user_id(user), subject, email):
         _log_oauth(_REASON_OAUTH_LINKED, email)
         return _auth_response_for(user)
-    identity = await _find_identity(session, claims.subject)
+    identity = await _find_identity(session, attempt.provider, subject)
     if identity is None:
         raise await _needs_license_conflict(email)
     return await _login_via_identity(session, identity, email)
@@ -1856,7 +1939,7 @@ async def _link_or_relogin(
 
 async def _resolve_existing_account(
     session: AsyncSession,
-    claims: OIDCIdentity,
+    attempt: _OAuthAttempt,
 ) -> AuthResponse | None:
     """Walk the two rungs that need no license: stored link, then verified email.
 
@@ -1865,7 +1948,8 @@ async def _resolve_existing_account(
     proceed (a disabled or deleted account) never returns at all -- it raises
     the generic refusal from inside.
     """
-    identity = await _find_identity(session, claims.subject)
+    claims = attempt.claims
+    identity = await _find_identity(session, attempt.provider, claims.subject)
     if identity is not None:
         return await _login_via_identity(session, identity, claims.email)
     email = _linkable_email(claims)
@@ -1876,7 +1960,7 @@ async def _resolve_existing_account(
         return None
     if _user_state_reject_reason(user) is not None:
         raise await _gated_account_conflict(email)
-    return await _link_or_relogin(session, user, claims, email)
+    return await _link_or_relogin(session, attempt, user, email)
 
 
 async def _count_invalid_license_attempt(request: Request, license_key: str | None) -> None:
@@ -1920,16 +2004,30 @@ async def _verify_oauth_license(
     raise await _needs_license_conflict(email)
 
 
-async def _insert_social_user(session: AsyncSession, email: str, timezone: str) -> User | None:
+async def _insert_social_user(
+    session: AsyncSession,
+    email: str,
+    timezone: str,
+    display_name: str | None,
+) -> User | None:
     """Create the account behind a social sign-in; ``None`` when a racer won.
 
     The stored hash is a fresh 256-bit random run through the same bcrypt cost
     the password flow uses.  That satisfies the NOT NULL hash contract while
     guaranteeing no password can ever authenticate the row, and it keeps the
     creation path's timing indistinguishable from an ordinary signup.
+
+    ``display_name`` is written here and only here.  Apple hands the name over
+    exactly once, on the first authorization, so this insert is the sole
+    opportunity to keep it.
     """
     password_hash = await _hash_password(secrets.token_urlsafe(_SOCIAL_PASSWORD_BYTES))
-    user = User(email=email, password_hash=password_hash, timezone=timezone)
+    user = User(
+        email=email,
+        password_hash=password_hash,
+        timezone=timezone,
+        display_name=display_name,
+    )
     session.add(user)
     try:
         await session.commit()
@@ -1942,7 +2040,7 @@ async def _insert_social_user(session: AsyncSession, email: str, timezone: str) 
 
 async def _reresolve_after_create_race(
     session: AsyncSession,
-    claims: OIDCIdentity,
+    attempt: _OAuthAttempt,
 ) -> AuthResponse:
     """Re-walk the login / link rungs once after losing the account-create race.
 
@@ -1951,17 +2049,17 @@ async def _reresolve_after_create_race(
     retry: a second miss means something other than a race, and the generic
     refusal is the honest answer.
     """
-    resolved = await _resolve_existing_account(session, claims)
+    resolved = await _resolve_existing_account(session, attempt)
     if resolved is None:
-        raise await _needs_license_conflict(claims.email)
+        raise await _needs_license_conflict(attempt.claims.email)
     return resolved
 
 
 async def _create_oauth_account(
     request: Request,
     session: AsyncSession,
-    payload: GoogleOAuthRequest,
-    claims: OIDCIdentity,
+    payload: OAuthSignInRequest,
+    attempt: _OAuthAttempt,
     email: str,
 ) -> AuthResponse:
     """Create the license-verified account, grant the course, and link the identity.
@@ -1977,13 +2075,15 @@ async def _create_oauth_account(
     greenlet; the racer's row points at the same account anyway.
     """
     purchase = await _verify_oauth_license(request, email, payload.license_key)
-    user = await _insert_social_user(session, email, payload.timezone)
+    user = await _insert_social_user(session, email, payload.timezone, attempt.display_name)
     if user is None:
-        return await _reresolve_after_create_race(session, claims)
+        return await _reresolve_after_create_race(session, attempt)
     await _grant_signup_entitlement(session, user, purchase)
     await claim_token_pack_sales(session, user)
     response = _auth_response_for(user)
-    if not await _insert_identity(session, response.user_id, claims.subject, email):
+    if not await _insert_identity(
+        session, attempt.provider, response.user_id, attempt.claims.subject, email
+    ):
         # Expected only when a racer linked this subject to the account we just
         # created, which leaves the caller signed in to the right account
         # anyway.  Logged rather than ignored so that an integrity failure with
@@ -1991,6 +2091,28 @@ async def _create_oauth_account(
         _log_oauth(_REASON_OAUTH_LINK_CONFLICT, email)
     _log_oauth(_REASON_OAUTH_SIGNUP, email)
     return response
+
+
+async def _resolve_oauth_user(
+    request: Request,
+    session: AsyncSession,
+    payload: OAuthSignInRequest,
+    attempt: _OAuthAttempt,
+) -> AuthResponse:
+    """Walk the three rungs below verification: log in, link, or create.
+
+    Every provider shares this ladder verbatim.  That is the security property,
+    not just a tidiness one: the moment a provider gets its own copy, the two
+    drift, and a divergence in which refusals collapse onto the single 409
+    reopens the account-enumeration oracle on whichever route drifted.
+    """
+    resolved = await _resolve_existing_account(session, attempt)
+    if resolved is not None:
+        return resolved
+    email = _linkable_email(attempt.claims)
+    if email is None:
+        raise await _needs_license_conflict(attempt.claims.email)
+    return await _create_oauth_account(request, session, payload, attempt, email)
 
 
 @router.post("/oauth/google", response_model=AuthResponse)
@@ -2018,12 +2140,44 @@ async def google_oauth_signin(
     identical bytes, so the endpoint answers no questions about which accounts
     exist or which are gated.  See :func:`_needs_license_conflict` for the one
     dimension along which that parity is bounded rather than absolute.
+
+    Google puts the display name in the token, so the name a new account is
+    created under comes from the verified claims rather than from anything the
+    client chose to send.
     """
-    claims = await _verify_oauth_identity(payload.id_token)
-    resolved = await _resolve_existing_account(session, claims)
-    if resolved is not None:
-        return resolved
-    email = _linkable_email(claims)
-    if email is None:
-        raise await _needs_license_conflict(claims.email)
-    return await _create_oauth_account(request, session, payload, claims, email)
+    claims = await _verify_oauth_identity(payload.id_token, verify_google_id_token)
+    attempt = _OAuthAttempt(
+        provider=AuthProvider.GOOGLE,
+        claims=claims,
+        display_name=claims.name,
+    )
+    return await _resolve_oauth_user(request, session, payload, attempt)
+
+
+@router.post("/oauth/apple", response_model=AuthResponse)
+@limiter.limit("5/minute")
+async def apple_oauth_signin(
+    request: Request,
+    payload: AppleOAuthRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AuthResponse:
+    """Sign in (or, with a license, sign up) with an Apple ``id_token``.
+
+    The same four rungs as :func:`google_oauth_signin`, on the same shared
+    ladder, with the same two possible refusals -- deliberately, so neither
+    route can become an enumeration oracle the other is not.
+
+    Two things are Apple-shaped, and both are handled outside this function:
+    ``email`` arrives only on the very first authorization (so rung 2 keys on
+    the stored subject, which every later token still carries), and the user's
+    name is never in the token at all.  ``full_name`` from the request body
+    fills that gap, and because it is the one unvouched-for field on the route
+    it is read only by the rung that creates a brand-new row.
+    """
+    claims = await _verify_oauth_identity(payload.id_token, verify_apple_id_token)
+    attempt = _OAuthAttempt(
+        provider=AuthProvider.APPLE,
+        claims=claims,
+        display_name=payload.full_name,
+    )
+    return await _resolve_oauth_user(request, session, payload, attempt)

--- a/backend/src/routers/practice_share.py
+++ b/backend/src/routers/practice_share.py
@@ -315,7 +315,11 @@ async def preview_share_link(
     if link.created_by_user_id is not None:
         owner = await session.get(User, link.created_by_user_id)
         if owner is not None:
-            display_name = _display_name_from_email(owner.email)
+            # A name the owner actually supplied beats one derived from their
+            # address: the derivation is a fallback for accounts that have no
+            # name, and leaking the local-part of an email when a real name is
+            # on file is both wrong and needlessly revealing.
+            display_name = owner.display_name or _display_name_from_email(owner.email)
 
     return ShareLinkPreviewResponse(
         practice_id=cast("int", practice.id),

--- a/backend/src/services/oauth_apple.py
+++ b/backend/src/services/oauth_apple.py
@@ -1,0 +1,192 @@
+"""Apple's adapter over the provider-neutral OIDC verifier.
+
+Everything Apple-specific lives here and nowhere else: the published JWKS
+endpoint, the single legitimate issuer, the accepted ``aud`` allowlist, and the
+projection of Apple's claim names onto :class:`services.oidc.OIDCIdentity`.
+Verification itself — algorithm pinning, required claims, the single collapsed
+failure mode — belongs to :mod:`services.oidc` and is shared byte-for-byte with
+:mod:`services.oauth_google`.
+
+Four things about Apple are worth stating outright, because each one is a place
+a well-meaning special case would open a hole:
+
+**Private-relay addresses are safe to link on.** A Hide My Email address is
+minted by Apple per (Apple user, application) and routes only to that Apple
+user's real mailbox. It is provider-verified like any other Apple address, it
+is unique to this app, and it can never collide with some third party's real
+address — so an existing Adepthood account already bearing that address can
+only have been created by the same Apple user, coming back. Refusing to link on
+it would strand exactly the users who chose the most private option.
+
+**``is_private_email`` is deliberately never read.** It describes the shape of
+the address, not whether Apple vouches for it, so branching on it would be
+special-casing a class of user for no security gain — precisely the divergence
+the shared ladder exists to prevent. Only ``email_verified`` decides trust.
+
+**There is no client-secret round trip.** The app posts the ``id_token`` it
+already holds and JWKS verification is the whole proof; no authorization-code
+exchange happens, so no client secret is needed. That matters because Apple's
+"client secret" is not a static string at all but a short-lived ES256 JWT the
+server would have to mint and rotate from a downloaded private key — an entire
+key-custody problem this flow simply never acquires.
+
+**The APTITUDE license gate applies unchanged.** Creating an account still
+requires a license whose Gumroad purchase email matches the address the token
+carries. For a Hide My Email user whose purchase was made under their real
+address those two differ, so the create rung refuses — as the generic 409 that
+every other refusal also returns, which is the point: the response says nothing
+about why. That is a known, accepted consequence of keeping one ladder with no
+provider-shaped exceptions in it.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any
+
+from jwt import PyJWKClient
+
+from services.oidc import (
+    OIDCIdentity,
+    build_bounded_jwk_client,
+    claim_str,
+    verify_oidc_id_token,
+)
+
+__all__ = [
+    "APPLE_ISSUERS",
+    "APPLE_JWKS_URL",
+    "APPLE_OAUTH_CLIENT_IDS_ENV_VAR",
+    "build_jwk_client",
+    "verify_apple_id_token",
+]
+
+# Comma-separated Apple client ids accepted as the ``aud`` claim: the iOS
+# bundle id the native app signs in with, plus the Services id the web flow
+# uses. One variable rather than one per platform because the check is pure
+# membership and a single list is what an operator can read back.
+APPLE_OAUTH_CLIENT_IDS_ENV_VAR = "APPLE_OAUTH_CLIENT_IDS"
+_CLIENT_ID_SEPARATOR = ","
+
+# Apple's published JWKS endpoint. HTTPS on an Apple host is not decoration:
+# the keys fetched from here are the entire basis for trusting a token.
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+
+# Apple signs with exactly one issuer spelling — unlike Google, which mints two
+# interchangeable ones. Keeping this set at one element means a token claiming
+# any other issuer, including a bare-hostname lookalike, fails verification.
+APPLE_ISSUERS = frozenset({"https://appleid.apple.com"})
+
+# Apple's claim names, spelled once so a typo cannot silently disable a check.
+_SUBJECT_CLAIM = "sub"
+_EMAIL_CLAIM = "email"
+_EMAIL_VERIFIED_CLAIM = "email_verified"
+
+# The one string Apple may spell a true ``email_verified`` with. Compared
+# exactly, never coerced: ``bool("false")`` is ``True``, so a truthy test here
+# would read Apple's explicit refusal to vouch for an address as proof of it.
+_VERIFIED_TRUE_STRING = "true"
+
+
+def _apple_client_ids() -> list[str]:
+    """Read the accepted ``aud`` allowlist from the environment at call time.
+
+    Read per request rather than at import so rotating or adding a platform's
+    client id needs no restart, and tolerant of padding, empty entries, and a
+    trailing separator in the deployment config. An unset or blank variable
+    yields an empty list, which makes the verifier reject every token — the
+    fail-closed direction.
+    """
+    raw = os.getenv(APPLE_OAUTH_CLIENT_IDS_ENV_VAR, "")
+    return [client_id.strip() for client_id in raw.split(_CLIENT_ID_SEPARATOR) if client_id.strip()]
+
+
+def build_jwk_client() -> PyJWKClient:
+    """Construct the Apple JWKS client, timeout and caches explicitly bounded.
+
+    The bounds live in :func:`services.oidc.build_bounded_jwk_client` so Apple
+    and Google cannot drift apart on them; all this adapter contributes is the
+    endpoint.
+    """
+    return build_bounded_jwk_client(APPLE_JWKS_URL)
+
+
+@lru_cache(maxsize=1)
+def _get_jwk_client() -> PyJWKClient:
+    """Return the process-wide, key-caching JWKS client for Apple.
+
+    Cached because refetching Apple's key set on every sign-in would put a
+    network round trip on the login path and hammer an endpoint whose contents
+    change on the order of days; the client's ``lifespan`` bounds how stale that
+    cache may get so a rotation still lands without a restart.
+
+    This function is also the module's only outbound-network seam, which is why
+    :func:`verify_apple_id_token` resolves it per call rather than binding a
+    client at import time: tests replace it wholesale to stay offline.
+    """
+    return build_jwk_client()
+
+
+def _apple_email_verified(claims: dict[str, Any]) -> bool:
+    """Return whether Apple vouches for the token's email address.
+
+    Apple sends ``email_verified`` as the *string* ``"true"`` or ``"false"``
+    from some flows and as a real JSON boolean from others, so both spellings of
+    true have to be honoured. Everything else — the string ``"false"``, boolean
+    ``False``, an absent claim, or anything unrecognised — is not a vouch.
+
+    The exact comparison is the whole point. ``bool("false")`` is ``True``, so a
+    truthy coercion would turn Apple's explicit "we have not verified this
+    address" into proof of ownership and hand the account it names to whoever
+    asked. The rule stays in this adapter rather than in
+    :mod:`services.oidc` because applying it to every provider at once is the
+    same mistake with a wider blast radius.
+    """
+    value = claims.get(_EMAIL_VERIFIED_CLAIM)
+    return value is True or value == _VERIFIED_TRUE_STRING
+
+
+def _identity_from_claims(claims: dict[str, Any]) -> OIDCIdentity:
+    """Project Apple's verified claim set onto the neutral identity shape.
+
+    ``name`` is always ``None``: Apple never puts the user's name in the token.
+    It arrives once, in the sign-in request body, and the router — not this
+    adapter — decides what to do with it.
+
+    ``email`` is absent from every sign-in after the first, which is why the
+    ladder keys on ``subject``. A token with no usable ``email`` reports
+    ``email_verified=False``, because an address that is not there cannot have
+    been verified.
+    """
+    email = claim_str(claims, _EMAIL_CLAIM)
+    return OIDCIdentity(
+        subject=str(claims[_SUBJECT_CLAIM]),
+        email=email,
+        email_verified=email is not None and _apple_email_verified(claims),
+        name=None,
+    )
+
+
+async def verify_apple_id_token(token: str) -> OIDCIdentity:
+    """Verify an Apple-issued ``id_token`` and return the identity it names.
+
+    Args:
+        token: The compact-serialized ``id_token`` the client received from
+            Sign in with Apple.
+
+    Returns:
+        The verified identity — subject, optional email, and whether Apple
+        vouches for that email.
+
+    Raises:
+        OIDCTokenError: For every verification failure, with a static message
+            that never embeds the token.
+    """
+    claims = await verify_oidc_id_token(
+        token,
+        key_provider=_get_jwk_client(),
+        issuers=APPLE_ISSUERS,
+        audiences=_apple_client_ids(),
+    )
+    return _identity_from_claims(claims)

--- a/backend/src/services/oauth_google.py
+++ b/backend/src/services/oauth_google.py
@@ -5,8 +5,8 @@ endpoint, the two interchangeable spellings of Google's issuer, the accepted
 ``aud`` allowlist, and the projection of Google's claim names onto
 :class:`services.oidc.OIDCIdentity`. The verification itself — algorithm
 pinning, required claims, the single collapsed failure mode — belongs to
-:mod:`services.oidc`, so an Apple adapter can be added beside this one without
-re-deriving (or subtly weakening) any of it.
+:mod:`services.oidc`, so :mod:`services.oauth_apple` sits beside this one
+without re-deriving (or subtly weakening) any of it.
 
 The client-id allowlist is read from the environment at call time, so rotating
 or adding a platform's OAuth client needs no restart. It fails closed: unset or
@@ -21,7 +21,13 @@ from typing import Any
 
 from jwt import PyJWKClient
 
-from services.oidc import OIDCIdentity, verify_oidc_id_token
+from services.oidc import (
+    JWKS_TIMEOUT_SECONDS,
+    OIDCIdentity,
+    build_bounded_jwk_client,
+    claim_str,
+    verify_oidc_id_token,
+)
 
 __all__ = [
     "GOOGLE_ISSUERS",
@@ -46,26 +52,6 @@ GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
 # requested the token, and both are legitimate, so both must verify.
 GOOGLE_ISSUERS = frozenset({"https://accounts.google.com", "accounts.google.com"})
 
-# How long a cached JWKS set may be reused before it is refetched. An hour is
-# far shorter than Google's key-rotation cadence (days), so a rotated key is
-# picked up automatically, while ordinary sign-ins pay no network round trip.
-_JWKS_CACHE_SECONDS = 3600.0
-
-# Ceiling on individually cached signing keys. Google publishes a handful at a
-# time; the bound keeps a malformed ``kid`` stream from growing the cache.
-_MAX_CACHED_KEYS = 16
-
-# Wall-clock budget for a JWKS fetch. PyJWT's own default is 30 seconds, which
-# is far too generous here: a token naming a ``kid`` outside the cached set
-# makes the client refetch immediately (bypassing ``lifespan``), and that fetch
-# runs in the shared default thread pool -- the same pool bcrypt uses. An
-# unauthenticated caller sending random ``kid`` values could therefore park
-# workers that logins and signups need. Five seconds mirrors
-# ``GUMROAD_TIMEOUT_SECONDS`` and the reasoning behind it: verification sits on
-# an interactive path, so a wedged endpoint must fail fast rather than hold a
-# request -- and a thread -- open.
-JWKS_TIMEOUT_SECONDS: float = 5.0
-
 # Google's claim names, spelled once so a typo cannot silently disable a check.
 _SUBJECT_CLAIM = "sub"
 _EMAIL_CLAIM = "email"
@@ -88,22 +74,12 @@ def _google_client_ids() -> list[str]:
 def build_jwk_client() -> PyJWKClient:
     """Construct the Google JWKS client, timeout and caches explicitly bounded.
 
-    Split out from the cached accessor so the bounds can be asserted without
-    reaching through an ``lru_cache`` (and without the network: constructing a
-    client fetches nothing).
-
-    Every argument here is a limit rather than a default. ``timeout`` in
-    particular is not optional: PyJWT's 30-second default, combined with the
-    forced refetch an unrecognised ``kid`` triggers, is how a stream of junk
-    tokens turns into parked threads in the pool bcrypt shares.
+    The bounds themselves live in :func:`services.oidc.build_bounded_jwk_client`
+    so Google and Apple cannot drift apart on the one setting -- ``timeout`` --
+    whose absence turns junk tokens into parked threads in the pool bcrypt
+    shares. All this adapter contributes is the endpoint.
     """
-    return PyJWKClient(
-        GOOGLE_JWKS_URL,
-        cache_keys=True,
-        max_cached_keys=_MAX_CACHED_KEYS,
-        lifespan=_JWKS_CACHE_SECONDS,
-        timeout=JWKS_TIMEOUT_SECONDS,
-    )
+    return build_bounded_jwk_client(GOOGLE_JWKS_URL)
 
 
 @lru_cache(maxsize=1)
@@ -122,14 +98,6 @@ def _get_jwk_client() -> PyJWKClient:
     return build_jwk_client()
 
 
-def _claim_str(claims: dict[str, Any], name: str) -> str | None:
-    """Return a non-blank string claim, or ``None`` when absent or malformed."""
-    value = claims.get(name)
-    if not isinstance(value, str) or not value.strip():
-        return None
-    return value
-
-
 def _identity_from_claims(claims: dict[str, Any]) -> OIDCIdentity:
     """Project Google's verified claim set onto the neutral identity shape.
 
@@ -141,12 +109,12 @@ def _identity_from_claims(claims: dict[str, Any]) -> OIDCIdentity:
     no usable ``email`` reports ``email_verified=False``, because an address
     that is not there cannot have been verified.
     """
-    email = _claim_str(claims, _EMAIL_CLAIM)
+    email = claim_str(claims, _EMAIL_CLAIM)
     return OIDCIdentity(
         subject=str(claims[_SUBJECT_CLAIM]),
         email=email,
         email_verified=email is not None and claims.get(_EMAIL_VERIFIED_CLAIM) is True,
-        name=_claim_str(claims, _NAME_CLAIM),
+        name=claim_str(claims, _NAME_CLAIM),
     )
 
 

--- a/backend/src/services/oidc.py
+++ b/backend/src/services/oidc.py
@@ -19,11 +19,11 @@ Two properties carry the security of the whole module:
   its client ids rejects every token rather than accepting all of them.
 
 The module is provider-neutral on purpose: Google's adapter lives in
-:mod:`services.oauth_google`, and a future Apple adapter reuses this core by
-supplying its own issuers, audiences, and key provider. Claim-shape quirks
-(Apple's string-valued ``email_verified``, for instance) belong in the
-adapters — coercing them here is how an unverified address would end up
-trusted by every provider at once.
+:mod:`services.oauth_google` and Apple's in :mod:`services.oauth_apple`, each
+reusing this core by supplying its own issuers, audiences, and key provider.
+Claim-shape quirks (Apple's string-valued ``email_verified``, for instance)
+belong in the adapters — coercing them here is how an unverified address would
+end up trusted by every provider at once.
 """
 
 from __future__ import annotations
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
 import jwt
+from jwt import PyJWKClient
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
@@ -41,10 +42,13 @@ if TYPE_CHECKING:
     from jwt.algorithms import AllowedPublicKeys
 
 __all__ = [
+    "JWKS_TIMEOUT_SECONDS",
     "OIDCIdentity",
     "OIDCKeyProvider",
     "OIDCSigningKey",
     "OIDCTokenError",
+    "build_bounded_jwk_client",
+    "claim_str",
     "verify_oidc_id_token",
 ]
 
@@ -62,6 +66,26 @@ _REQUIRED_CLAIMS: tuple[str, ...] = ("exp", "iat", "aud", "iss", "sub")
 # to reach a log line or an error body.
 _INVALID_TOKEN_MESSAGE = "oidc id_token failed verification"  # noqa: S105  # nosec B105  # pragma: allowlist secret
 _UNCONFIGURED_AUDIENCE_MESSAGE = "no oidc audience configured"
+
+# How long a cached JWKS set may be reused before it is refetched. An hour is
+# far shorter than any provider's key-rotation cadence (days), so a rotated key
+# is picked up automatically, while ordinary sign-ins pay no network round trip.
+_JWKS_CACHE_SECONDS = 3600.0
+
+# Ceiling on individually cached signing keys. Providers publish a handful at a
+# time; the bound keeps a malformed ``kid`` stream from growing the cache.
+_MAX_CACHED_KEYS = 16
+
+# Wall-clock budget for a JWKS fetch. PyJWT's own default is 30 seconds, which
+# is far too generous here: a token naming a ``kid`` outside the cached set
+# makes the client refetch immediately (bypassing ``lifespan``), and that fetch
+# runs in the shared default thread pool -- the same pool bcrypt uses. An
+# unauthenticated caller sending random ``kid`` values could therefore park
+# workers that logins and signups need. Five seconds mirrors
+# ``GUMROAD_TIMEOUT_SECONDS`` and the reasoning behind it: verification sits on
+# an interactive path, so a wedged endpoint must fail fast rather than hold a
+# request -- and a thread -- open.
+JWKS_TIMEOUT_SECONDS: float = 5.0
 
 
 class OIDCTokenError(Exception):
@@ -108,6 +132,49 @@ class OIDCKeyProvider(Protocol):
 
     def get_signing_key_from_jwt(self, token: str) -> OIDCSigningKey:
         """Resolve the signing key named by ``token``'s ``kid`` header."""
+
+
+def build_bounded_jwk_client(jwks_url: str) -> PyJWKClient:
+    """Construct a JWKS client for ``jwks_url`` with every cache and timeout bounded.
+
+    Shared by every provider adapter so the bounds are derived once rather than
+    re-typed (and eventually mistyped) per provider. Split out from each
+    adapter's cached accessor so the bounds can be asserted without reaching
+    through an ``lru_cache`` — and without the network, since constructing a
+    client fetches nothing.
+
+    Every argument here is a limit rather than a default. ``timeout`` in
+    particular is not optional: PyJWT's 30-second default, combined with the
+    forced refetch an unrecognised ``kid`` triggers, is how a stream of junk
+    tokens turns into parked threads in the pool bcrypt shares.
+
+    Args:
+        jwks_url: The provider's published JWKS endpoint.
+
+    Returns:
+        A key-caching client bound to that endpoint.
+    """
+    return PyJWKClient(
+        jwks_url,
+        cache_keys=True,
+        max_cached_keys=_MAX_CACHED_KEYS,
+        lifespan=_JWKS_CACHE_SECONDS,
+        timeout=JWKS_TIMEOUT_SECONDS,
+    )
+
+
+def claim_str(claims: dict[str, Any], name: str) -> str | None:
+    """Return a non-blank string claim, or ``None`` when absent or malformed.
+
+    Shared by the adapters because "is this claim a usable string?" is a
+    question about JSON, not about any one provider — the provider-specific
+    judgement is which claims get read and what they mean, and that stays in
+    the adapters.
+    """
+    value = claims.get(name)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
 
 
 async def _decode_verified_claims(

--- a/backend/tests/routers/test_oauth_apple.py
+++ b/backend/tests/routers/test_oauth_apple.py
@@ -1,0 +1,1053 @@
+"""Sign in with Apple tests for POST /auth/oauth/apple.
+
+Apple's ``id_token`` is the same OIDC shape Google's is, with three quirks that
+each become an account-takeover or data-loss bug if they are mishandled:
+
+* ``email_verified`` (and ``is_private_email``) arrive as the *strings*
+  ``"true"`` / ``"false"`` rather than JSON booleans, and Apple sometimes sends
+  a real boolean instead. Both spellings have to mean the same thing, and the
+  false spellings must stay false.
+* ``email`` is present only on the very first authorization. Every later
+  sign-in carries a ``sub`` and nothing else, so a lookup keyed on email would
+  strand the account after its first login.
+* the user's name is never in the token at all. It arrives once, in the
+  request body's ``full_name``, and is never sent again -- so it is written at
+  account creation and no later request may ever overwrite it.
+
+Everything here runs offline: Apple's JWKS client and the outbound Gumroad
+verify are both replaced with in-process stubs, and the raw ``id_token`` -- a
+replayable credential -- is never allowed to reach a log line or a response
+body.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sqlalchemy import func
+from sqlmodel import SQLModel, select
+
+from domain.entitlements import PRODUCT_IDS_ENV_VAR
+from models.auth_identity import AuthIdentity, AuthProvider
+from models.entitlement import Entitlement
+from models.user import User
+from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
+from services.oauth_apple import (
+    APPLE_ISSUERS,
+    APPLE_JWKS_URL,
+    APPLE_OAUTH_CLIENT_IDS_ENV_VAR,
+    build_jwk_client,
+)
+from services.oauth_google import GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR
+from services.oidc import JWKS_TIMEOUT_SECONDS
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Response
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.real_license_gate
+
+OAUTH_PATH = "/auth/oauth/apple"
+GOOGLE_OAUTH_PATH = "/auth/oauth/google"
+
+# Test seams. The JWKS seam is the only thing standing between this suite and a
+# live network fetch of Apple's signing keys, so every test replaces it.
+JWKS_SEAM = "services.oauth_apple._get_jwk_client"
+GOOGLE_JWKS_SEAM = "services.oauth_google._get_jwk_client"
+VERIFY_SEAM = "domain.entitlements.verify_license"
+
+ALLOWED_PRODUCT = "prod_alpha"
+ALLOWLIST = ALLOWED_PRODUCT
+
+# Apple audiences: the iOS bundle id plus the Services id used by the web flow.
+BUNDLE_ID = "com.adepthood.app"
+SERVICES_ID = "com.adepthood.web"
+CONFIGURED_CLIENT_IDS = f"{BUNDLE_ID},{SERVICES_ID}"
+OTHER_CLIENT_ID = "com.attacker.app"
+
+GOOGLE_CLIENT_ID = "1000000001-adepthood.apps.googleusercontent.com"  # pragma: allowlist secret
+GOOGLE_ISSUER = "https://accounts.google.com"
+
+TEST_KID = "adepthood-apple-test-signing-key"
+APPLE_ISSUER = "https://appleid.apple.com"
+APPLE_HOST = "appleid.apple.com"
+EVIL_ISSUER = "https://evil.example.com"
+
+RS256_ALGORITHM = "RS256"
+RSA_PUBLIC_EXPONENT = 65537
+RSA_KEY_SIZE = 2048
+
+TOKEN_LIFETIME = timedelta(minutes=5)
+JUST_ISSUED = timedelta(seconds=1)
+EXPIRED_ISSUED_AGO = timedelta(hours=2)
+EXPIRED_EXPIRY_AGO = timedelta(hours=1)
+
+EXISTING_EMAIL = "seeker@example.com"
+NEW_EMAIL = "newcomer@example.com"
+SECOND_NEW_EMAIL = "second-newcomer@example.com"
+RELAY_EMAIL = "a1b2c3d4e5@privaterelay.appleid.com"
+
+# Apple subjects are opaque ~44 character strings, not digits like Google's.
+KNOWN_SUBJECT = "000123.4c8f1a2b3d4e5f60718293a4b5c6d7e8.0001"
+FRESH_SUBJECT = "000124.5d9e2b3c4f506172839405a6b7c8d9e0.0002"
+NEW_SUBJECT = "000125.6ea3c4d5e6f70819202a3b4c5d6e7f80.0003"
+RELAY_SUBJECT = "000126.7fb4d5e6f708192a3b4c5d6e7f809012.0004"
+UNVERIFIED_SUBJECT = "000127.80c5e6f7089a1b2c3d4e5f60718293a4.0005"
+NO_LICENSE_SUBJECT = "000128.91d6f708192a3b4c5d6e7f8091a2b3c4.0006"
+LINKED_SUBJECT = "000129.a2e708192a3b4c5d6e7f8091a2b3c4d5.0007"
+GOOGLE_SUBJECT = "109876543210987654321"
+
+VALID_LICENSE_KEY = "AAAA1111-BBBB-2222-APPLE"  # pragma: allowlist secret
+RELAY_LICENSE_KEY = "CCCC3333-DDDD-4444-APPLE"  # pragma: allowlist secret
+SALE_ID = "S-APPLE-1"
+LICENSE_USES = 1
+COURSE_ACCESS_KIND = "course_access"
+
+SEEDED_PASSWORD_HASH = (
+    "$2b$12$seededplaceholderdigestforteststhatneveraccepts"  # pragma: allowlist secret
+)
+SEEDED_TIMEZONE = "America/New_York"
+SIGNUP_TIMEZONE = "America/Los_Angeles"
+
+FULL_NAME = "Ada Lovelace"
+PADDED_FULL_NAME = "  Ada Lovelace  "
+# The stored display name's ceiling. One character past it must be refused at
+# the schema boundary, so no over-long name can reach a column that would
+# silently truncate it into a name its owner never chose.
+DISPLAY_NAME_CEILING = 120
+OVERLONG_FULL_NAME = "A" * (DISPLAY_NAME_CEILING + 1)
+IMPOSTOR_NAME = "Someone Else Entirely"
+SEEDED_DISPLAY_NAME = "Seeker Of Old"
+
+VERIFIED_TRUE_STRING = "true"
+VERIFIED_FALSE_STRING = "false"
+
+DETAIL_INVALID_TOKEN = "invalid_oauth_token"
+DETAIL_NEEDS_LICENSE = "needs_license"
+
+REASON_INVALID_TOKEN = "oauth_invalid_token"
+REASON_LOGIN = "oauth_login"
+REASON_LINKED = "oauth_linked"
+REASON_SIGNUP = "oauth_signup"
+
+JWT_SEGMENT_COUNT = 3
+SOLE_APPLE_ISSUER_COUNT = 1
+OAUTH_RATE_LIMIT_PER_MINUTE = 5
+BYTE_IDENTICAL_REJECTIONS = 2
+DUAL_IDENTITY_COUNT = 2
+
+# Upper bounds the JWKS client must stay inside. An unbounded fetch timeout
+# parks a worker in the same default thread pool bcrypt runs in, an unbounded
+# key cache grows on a stream of junk ``kid`` values, and an unbounded key-set
+# lifespan means a rotated Apple key needs a restart to be picked up.
+MAX_ACCEPTABLE_JWKS_TIMEOUT = 10.0
+MAX_ACCEPTABLE_CACHED_KEYS = 128
+MAX_ACCEPTABLE_JWKS_LIFESPAN = 86400.0
+
+# One 2048-bit keypair per module: generation is expensive enough that doing it
+# per test would dominate the suite's runtime. The second, unrelated key exists
+# only to forge a well-formed token signed by a hand Apple never published.
+_SIGNING_KEY = rsa.generate_private_key(
+    public_exponent=RSA_PUBLIC_EXPONENT,
+    key_size=RSA_KEY_SIZE,
+)
+_FORGER_KEY = rsa.generate_private_key(
+    public_exponent=RSA_PUBLIC_EXPONENT,
+    key_size=RSA_KEY_SIZE,
+)
+
+
+def _epoch(offset: timedelta) -> int:
+    """Return the UNIX timestamp ``offset`` away from now."""
+    return int((datetime.now(UTC) + offset).timestamp())
+
+
+def _claims(**overrides: object) -> dict[str, object]:
+    """Build an Apple-shaped id_token claim set with per-test overrides.
+
+    The string-valued ``email_verified`` and ``is_private_email`` are the
+    defaults because that is what Apple actually sends; the boolean spellings
+    are exercised by explicit overrides.
+    """
+    base: dict[str, object] = {
+        "iss": APPLE_ISSUER,
+        "aud": BUNDLE_ID,
+        "sub": KNOWN_SUBJECT,
+        "email": EXISTING_EMAIL,
+        "email_verified": VERIFIED_TRUE_STRING,
+        "is_private_email": VERIFIED_FALSE_STRING,
+        "iat": _epoch(-JUST_ISSUED),
+        "exp": _epoch(TOKEN_LIFETIME),
+    }
+    base.update(overrides)
+    return base
+
+
+def _sign_rs256(claims: dict[str, object], private_key: rsa.RSAPrivateKey) -> str:
+    """Sign ``claims`` as an RS256 JWT carrying the module's ``kid`` header."""
+    return jwt.encode(
+        claims,
+        private_key,
+        algorithm=RS256_ALGORITHM,
+        headers={"kid": TEST_KID},
+    )
+
+
+def _mint_token(**overrides: object) -> str:
+    """Mint a legitimately signed Apple id_token."""
+    return _sign_rs256(_claims(**overrides), _SIGNING_KEY)
+
+
+def _mint_forged_token(**overrides: object) -> str:
+    """Mint a well-formed id_token signed by a key Apple never published."""
+    return _sign_rs256(_claims(**overrides), _FORGER_KEY)
+
+
+def _mint_token_without(*dropped: str, **overrides: object) -> str:
+    """Mint a legitimately signed token with ``dropped`` claims removed entirely."""
+    claims = _claims(**overrides)
+    for claim in dropped:
+        claims.pop(claim, None)
+    return _sign_rs256(claims, _SIGNING_KEY)
+
+
+def _mint_google_token(**overrides: object) -> str:
+    """Mint a Google-shaped id_token for the cross-provider linking test."""
+    claims: dict[str, object] = {
+        "iss": GOOGLE_ISSUER,
+        "aud": GOOGLE_CLIENT_ID,
+        "sub": GOOGLE_SUBJECT,
+        "email": EXISTING_EMAIL,
+        "email_verified": True,
+        "iat": _epoch(-JUST_ISSUED),
+        "exp": _epoch(TOKEN_LIFETIME),
+    }
+    claims.update(overrides)
+    return _sign_rs256(claims, _SIGNING_KEY)
+
+
+def _oauth_payload(
+    id_token: str,
+    license_key: str | None = None,
+    full_name: str | None = None,
+    timezone: str | None = None,
+) -> dict[str, str]:
+    """Build the request body; ``None`` arguments omit their field entirely."""
+    payload = {"id_token": id_token}
+    if license_key is not None:
+        payload["license_key"] = license_key
+    if full_name is not None:
+        payload["full_name"] = full_name
+    if timezone is not None:
+        payload["timezone"] = timezone
+    return payload
+
+
+def _log_carries_marker(caplog: pytest.LogCaptureFixture, marker: str) -> bool:
+    """Return True when ``marker`` appears in captured text or as a reason_code."""
+    if marker in caplog.text:
+        return True
+    return any(getattr(record, "reason_code", None) == marker for record in caplog.records)
+
+
+def _log_haystack(caplog: pytest.LogCaptureFixture) -> str:
+    """Return every captured record's text, including the formatted extras."""
+    return caplog.text + "".join(str(record.__dict__) for record in caplog.records)
+
+
+def _fingerprint(response: Response) -> tuple[int, str | None, bytes]:
+    """Return everything an unauthenticated observer can see about a rejection."""
+    return (response.status_code, response.headers.get("content-type"), response.content)
+
+
+def _license_result(email: str) -> GumroadLicenseResult:
+    """Build a live, unreversed Gumroad verify answer for ``email``."""
+    return GumroadLicenseResult(
+        success=True,
+        uses=LICENSE_USES,
+        purchase=GumroadPurchase(
+            email=email,
+            product_id=ALLOWED_PRODUCT,
+            sale_id=SALE_ID,
+            refunded=False,
+            chargebacked=False,
+            disputed=False,
+            dispute_won=False,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class _StubSigningKey:
+    """What a JWKS client hands back for a token's ``kid``: a key carrier."""
+
+    key: object
+
+
+class _StubJWKClient:
+    """Offline stand-in for ``PyJWKClient`` -- answers from the module keypair."""
+
+    def __init__(self, key: object) -> None:
+        """Hold the public key every lookup resolves to."""
+        self._key = key
+        self.lookups: list[str] = []
+
+    def get_signing_key_from_jwt(self, token: str) -> _StubSigningKey:
+        """Record the lookup and return the module's public signing key."""
+        self.lookups.append(token)
+        return _StubSigningKey(self._key)
+
+
+class _LicenseVerifier:
+    """Network-free stand-in for the outbound Gumroad license verify."""
+
+    def __init__(self) -> None:
+        """Start with no grants recorded."""
+        self.calls: list[tuple[str, str]] = []
+        self.results: dict[str, GumroadLicenseResult] = {}
+
+    def grant(self, license_key: str, email: str) -> None:
+        """Make ``license_key`` verify as a live purchase made by ``email``."""
+        self.results[license_key] = _license_result(email)
+
+    async def verify(
+        self,
+        product_id: str,
+        license_key: str,
+        **_kwargs: object,
+    ) -> GumroadLicenseResult | None:
+        """Answer for ``license_key``, or ``None`` when it was never granted."""
+        self.calls.append((product_id, license_key))
+        return self.results.get(license_key)
+
+
+@pytest.fixture(autouse=True)
+def offline_jwks(monkeypatch: pytest.MonkeyPatch) -> _StubJWKClient:
+    """Replace Apple's JWKS client so no test in this module hits the network."""
+    client = _StubJWKClient(_SIGNING_KEY.public_key())
+
+    def _factory() -> _StubJWKClient:
+        return client
+
+    monkeypatch.setattr(JWKS_SEAM, _factory)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def apple_client_ids(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Configure the accepted Apple audiences for the module."""
+    monkeypatch.setenv(APPLE_OAUTH_CLIENT_IDS_ENV_VAR, CONFIGURED_CLIENT_IDS)
+    return CONFIGURED_CLIENT_IDS
+
+
+@pytest.fixture
+def offline_google(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure and stub the Google adapter for the cross-provider test."""
+    client = _StubJWKClient(_SIGNING_KEY.public_key())
+
+    def _factory() -> _StubJWKClient:
+        return client
+
+    monkeypatch.setattr(GOOGLE_JWKS_SEAM, _factory)
+    monkeypatch.setenv(GOOGLE_OAUTH_CLIENT_IDS_ENV_VAR, GOOGLE_CLIENT_ID)
+
+
+@pytest.fixture
+def allowlisted_products(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point the APTITUDE product allowlist at the test product id."""
+    monkeypatch.setenv(PRODUCT_IDS_ENV_VAR, ALLOWLIST)
+    return ALLOWLIST
+
+
+@pytest.fixture
+def license_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+    allowlisted_products: str,  # noqa: ARG001 - side-effect: configures the allowlist
+) -> _LicenseVerifier:
+    """Stub the outbound Gumroad verify while leaving the real license gate in place."""
+    verifier = _LicenseVerifier()
+    monkeypatch.setattr(VERIFY_SEAM, verifier.verify)
+    return verifier
+
+
+def _user_id(user: User) -> int:
+    """Return a committed user's primary key, failing loudly when absent."""
+    if user.id is None:
+        msg = "user id missing after commit"
+        raise RuntimeError(msg)
+    return user.id
+
+
+async def _count_rows(session: AsyncSession, model: type[SQLModel]) -> int:
+    """Return the number of ``model`` rows visible to ``session``."""
+    result = await session.execute(select(func.count()).select_from(model))
+    return int(result.scalar_one())
+
+
+async def _seed_user(
+    session: AsyncSession,
+    email: str = EXISTING_EMAIL,
+    display_name: str | None = None,
+) -> User:
+    """Insert a password-authenticated user and return the committed row."""
+    user = User(
+        email=email,
+        password_hash=SEEDED_PASSWORD_HASH,
+        timezone=SEEDED_TIMEZONE,
+        display_name=display_name,
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+async def _seed_identity(
+    session: AsyncSession,
+    user_id: int,
+    subject: str,
+    provider: AuthProvider = AuthProvider.APPLE,
+    email: str = EXISTING_EMAIL,
+) -> AuthIdentity:
+    """Insert a linked provider identity for ``user_id`` and return the committed row."""
+    identity = AuthIdentity(
+        user_id=user_id,
+        provider=provider,
+        subject=subject,
+        email_at_link_time=email,
+    )
+    session.add(identity)
+    await session.commit()
+    await session.refresh(identity)
+    return identity
+
+
+async def _only_identity(session: AsyncSession) -> AuthIdentity:
+    """Return the single AuthIdentity row, asserting there is exactly one."""
+    identities = (await session.execute(select(AuthIdentity))).scalars().all()
+    assert len(identities) == 1
+    return identities[0]
+
+
+async def _reload_user(session: AsyncSession, user_id: int) -> User:
+    """Re-read ``user_id`` from the database, defeating any stale identity map."""
+    user = await session.get(User, user_id)
+    assert user is not None
+    await session.refresh(user)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# A. Provider configuration
+# ---------------------------------------------------------------------------
+
+
+def test_apple_issuers_is_exactly_apples_identity_service() -> None:
+    """Only Apple's own issuer may sign a token this route accepts."""
+    assert APPLE_ISSUER in APPLE_ISSUERS
+    assert len(APPLE_ISSUERS) == SOLE_APPLE_ISSUER_COUNT
+
+
+def test_jwks_client_is_bounded_and_points_at_apple() -> None:
+    """The JWKS client is Apple's, over TLS, with every cache and timeout bounded.
+
+    PyJWT's 30-second default timeout is the dangerous one: a token naming a
+    ``kid`` outside the cached set forces an immediate refetch, and that fetch
+    occupies a worker in the same default thread pool bcrypt runs in, so
+    unauthenticated junk tokens could park threads that logins need.
+    """
+    client = build_jwk_client()
+    parsed = urlparse(client.uri)
+
+    assert client.uri == APPLE_JWKS_URL
+    assert parsed.scheme == "https"
+    assert parsed.hostname == APPLE_HOST
+    assert client.timeout == JWKS_TIMEOUT_SECONDS
+    assert 0 < JWKS_TIMEOUT_SECONDS <= MAX_ACCEPTABLE_JWKS_TIMEOUT
+
+    key_cache = getattr(client.get_signing_key, "cache_info", None)
+    assert key_cache is not None
+    assert 0 < key_cache().maxsize <= MAX_ACCEPTABLE_CACHED_KEYS
+
+    assert client.jwk_set_cache is not None
+    assert 0 < client.jwk_set_cache.lifespan <= MAX_ACCEPTABLE_JWKS_LIFESPAN
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_ids", [None, ""], ids=["unset", "blank"])
+async def test_unconfigured_client_ids_reject_even_a_perfect_token(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    client_ids: str | None,
+) -> None:
+    """With no configured audience the verifier fails closed rather than open."""
+    if client_ids is None:
+        monkeypatch.delenv(APPLE_OAUTH_CLIENT_IDS_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(APPLE_OAUTH_CLIENT_IDS_ENV_VAR, client_ids)
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(_mint_token()))
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json()["detail"] == DETAIL_INVALID_TOKEN
+    assert await _count_rows(db_session, AuthIdentity) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "audience",
+    [BUNDLE_ID, SERVICES_ID],
+    ids=["ios-bundle-id", "services-id"],
+)
+async def test_either_configured_audience_is_accepted(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    audience: str,
+) -> None:
+    """The native app and the web Services id are both legitimate audiences."""
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(aud=audience)),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+
+
+# ---------------------------------------------------------------------------
+# B. Cryptographic verification
+# ---------------------------------------------------------------------------
+
+_UNVERIFIABLE_TOKENS = (
+    pytest.param(_mint_forged_token(), id="signed-by-an-unrelated-key"),
+    pytest.param(_mint_token(aud=OTHER_CLIENT_ID), id="audience-is-another-client"),
+    pytest.param(_mint_token(iss=EVIL_ISSUER), id="issuer-is-not-apple"),
+    pytest.param(
+        _mint_token(iat=_epoch(-EXPIRED_ISSUED_AGO), exp=_epoch(-EXPIRED_EXPIRY_AGO)),
+        id="expired",
+    ),
+    # A token carrying no ``exp`` never expires, so absence has to be rejected
+    # outright rather than skipped the way an unasserted claim would be.
+    pytest.param(_mint_token_without("exp"), id="valid-signature-no-expiry"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("id_token", _UNVERIFIABLE_TOKENS)
+async def test_unverifiable_token_is_401_and_leaks_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    id_token: str,
+) -> None:
+    """Every verification failure is the same 401, writes nothing, and logs no token."""
+    caplog.set_level(logging.INFO)
+
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    assert response.json()["detail"] == DETAIL_INVALID_TOKEN
+    assert "token" not in response.json()
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert _log_carries_marker(caplog, REASON_INVALID_TOKEN)
+
+    haystack = _log_haystack(caplog) + response.text
+    assert id_token not in haystack
+    for segment in id_token.split("."):
+        assert segment not in haystack
+
+
+@pytest.mark.asyncio
+async def test_sixth_attempt_in_a_minute_is_rate_limited(async_client: AsyncClient) -> None:
+    """The endpoint carries the login-strength 5/minute per-IP cap."""
+    id_token = _mint_forged_token()
+
+    for _ in range(OAUTH_RATE_LIMIT_PER_MINUTE):
+        response = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    throttled = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+# ---------------------------------------------------------------------------
+# C. Sign-in by stored subject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_known_apple_identity_logs_in_without_creating_a_row(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stored (apple, sub) pair mints a JWT for its user and links nothing new."""
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=KNOWN_SUBJECT)),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["user_id"] == _user_id(user)
+    assert body["timezone"] == SEEDED_TIMEZONE
+    assert len(body["token"].split(".")) == JWT_SEGMENT_COUNT
+    assert await _count_rows(db_session, AuthIdentity) == 1
+    assert await _count_rows(db_session, User) == 1
+    assert _log_carries_marker(caplog, REASON_LOGIN)
+
+
+@pytest.mark.asyncio
+async def test_repeat_signin_without_any_email_claim_resolves_by_subject(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Apple sends ``email`` only on the first authorization; later tokens have none.
+
+    Keying the lookup on email rather than ``sub`` would work exactly once and
+    then lock every returning user out of their own account.
+    """
+    user = await _seed_user(db_session)
+    await _seed_identity(db_session, _user_id(user), KNOWN_SUBJECT)
+    id_token = _mint_token_without("email", "email_verified", "is_private_email")
+
+    response = await async_client.post(OAUTH_PATH, json=_oauth_payload(id_token))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+    assert await _count_rows(db_session, AuthIdentity) == 1
+
+
+# ---------------------------------------------------------------------------
+# D. Apple's string-valued booleans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "email_verified",
+    [VERIFIED_TRUE_STRING, True],
+    ids=["string-true", "boolean-true"],
+)
+@pytest.mark.parametrize(
+    "is_private_email",
+    [VERIFIED_TRUE_STRING, VERIFIED_FALSE_STRING],
+    ids=["private-relay-flag-true", "private-relay-flag-false"],
+)
+async def test_string_true_email_verified_is_honoured(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    email_verified: object,
+    is_private_email: str,
+) -> None:
+    """Apple's string ``"true"`` verifies the email exactly as a boolean would.
+
+    ``is_private_email`` is orthogonal: it describes the address, not whether
+    Apple vouches for it, so it must not change the outcome either way.
+    """
+    caplog.set_level(logging.INFO)
+    user = await _seed_user(db_session)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(
+                sub=FRESH_SUBJECT,
+                email=EXISTING_EMAIL,
+                email_verified=email_verified,
+                is_private_email=is_private_email,
+            )
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+    assert await _count_rows(db_session, User) == 1
+
+    identity = await _only_identity(db_session)
+    assert identity.provider == AuthProvider.APPLE
+    assert identity.subject == FRESH_SUBJECT
+    assert identity.user_id == _user_id(user)
+    assert _log_carries_marker(caplog, REASON_LINKED)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "email_verified",
+    [VERIFIED_FALSE_STRING, False],
+    ids=["string-false", "boolean-false"],
+)
+async def test_unverified_email_never_creates_an_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    email_verified: object,
+) -> None:
+    """A false ``email_verified`` blocks creation even with a valid license in hand.
+
+    The string ``"false"`` is the trap: it is truthy in Python, so a verifier
+    that coerces with ``bool(...)`` would treat an address Apple explicitly
+    refuses to vouch for as proven.
+    """
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=UNVERIFIED_SUBJECT, email=NEW_EMAIL, email_verified=email_verified),
+            license_key=VALID_LICENSE_KEY,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.CONFLICT
+    assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
+    assert "token" not in response.json()
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+    assert await _count_rows(db_session, Entitlement) == 0
+
+
+# ---------------------------------------------------------------------------
+# E. Account creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_private_relay_email_with_a_license_creates_the_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``privaterelay.appleid.com`` address is a first-class account address.
+
+    Apple's Hide My Email users never present anything else, so the relay
+    address is stored verbatim and is the address the license must match.
+    """
+    caplog.set_level(logging.INFO)
+    license_verifier.grant(RELAY_LICENSE_KEY, RELAY_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(
+                sub=RELAY_SUBJECT,
+                email=RELAY_EMAIL,
+                is_private_email=VERIFIED_TRUE_STRING,
+            ),
+            license_key=RELAY_LICENSE_KEY,
+            timezone=SIGNUP_TIMEZONE,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["timezone"] == SIGNUP_TIMEZONE
+    assert len(body["token"].split(".")) == JWT_SEGMENT_COUNT
+
+    users = (await db_session.execute(select(User))).scalars().all()
+    assert len(users) == 1
+    assert users[0].email == RELAY_EMAIL
+    assert users[0].id == body["user_id"]
+
+    entitlements = (await db_session.execute(select(Entitlement))).scalars().all()
+    assert len(entitlements) == 1
+    assert entitlements[0].kind == COURSE_ACCESS_KIND
+    assert entitlements[0].user_id == body["user_id"]
+    assert entitlements[0].revoked_at is None
+
+    identity = await _only_identity(db_session)
+    assert identity.provider == AuthProvider.APPLE
+    assert identity.subject == RELAY_SUBJECT
+    assert identity.user_id == body["user_id"]
+    assert identity.email_at_link_time == RELAY_EMAIL
+    assert _log_carries_marker(caplog, REASON_SIGNUP)
+
+
+# ---------------------------------------------------------------------------
+# F. The display name, which only ever arrives once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("submitted", "stored"),
+    [(FULL_NAME, FULL_NAME), (PADDED_FULL_NAME, FULL_NAME)],
+    ids=["exact", "padded"],
+)
+async def test_full_name_becomes_the_display_name_at_creation(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    submitted: str,
+    stored: str,
+) -> None:
+    """Apple never puts a name in the token, so the body's ``full_name`` is it."""
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL),
+            license_key=VALID_LICENSE_KEY,
+            full_name=submitted,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    user = await _reload_user(db_session, response.json()["user_id"])
+    assert user.display_name == stored
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("full_name", ["", "   ", "\t\n"], ids=["empty", "spaces", "whitespace"])
+async def test_blank_full_name_stores_no_display_name(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    full_name: str,
+) -> None:
+    """A blank name is an absent name, not a blank string rendered in the UI."""
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL),
+            license_key=VALID_LICENSE_KEY,
+            full_name=full_name,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    user = await _reload_user(db_session, response.json()["user_id"])
+    assert user.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_full_name_past_the_stored_ceiling_is_refused_by_the_schema(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """An over-long name is a 422 at the boundary, never a truncated column write.
+
+    The bound has to live on the request model rather than only on the column:
+    a database left to enforce it either raises a 500 mid-transaction or, on a
+    backend that truncates silently, stores a name the user never chose.
+    """
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL),
+            license_key=VALID_LICENSE_KEY,
+            full_name=OVERLONG_FULL_NAME,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_later_signin_can_never_rename_the_account(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """The name is write-once: Apple only ever sends it on the first authorization.
+
+    A later request carrying a different ``full_name`` is either a stale client
+    or an attacker with a valid token; either way the stored name stands, so
+    the sign-in route can never be used to rename somebody's account.
+    """
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+    created = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL),
+            license_key=VALID_LICENSE_KEY,
+            full_name=FULL_NAME,
+        ),
+    )
+    assert created.status_code == HTTPStatus.OK
+    user_id = created.json()["user_id"]
+
+    silent = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token_without("email", "email_verified", sub=NEW_SUBJECT)),
+    )
+
+    assert silent.status_code == HTTPStatus.OK
+    assert silent.json()["user_id"] == user_id
+    assert (await _reload_user(db_session, user_id)).display_name == FULL_NAME
+
+    renaming = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token_without("email", "email_verified", sub=NEW_SUBJECT),
+            full_name=IMPOSTOR_NAME,
+        ),
+    )
+
+    assert renaming.status_code == HTTPStatus.OK
+    assert renaming.json()["user_id"] == user_id
+    assert (await _reload_user(db_session, user_id)).display_name == FULL_NAME
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "seeded_name",
+    [None, SEEDED_DISPLAY_NAME],
+    ids=["no-stored-name", "stored-name"],
+)
+async def test_full_name_is_ignored_on_the_email_link_rung(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    seeded_name: str | None,
+) -> None:
+    """Linking Apple onto an existing account may not relabel that account.
+
+    The account already exists and its name (or deliberate lack of one) belongs
+    to its owner; ``full_name`` is only ever consulted by the rung that creates
+    the row.
+    """
+    user = await _seed_user(db_session, display_name=seeded_name)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=FRESH_SUBJECT, email=EXISTING_EMAIL),
+            full_name=IMPOSTOR_NAME,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["user_id"] == _user_id(user)
+    assert (await _only_identity(db_session)).subject == FRESH_SUBJECT
+    assert (await _reload_user(db_session, _user_id(user))).display_name == seeded_name
+
+
+# ---------------------------------------------------------------------------
+# G. Anti-enumeration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_license_refusals_are_byte_identical(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """A brand-new email with no license and an unverified one look the same.
+
+    Any difference between the two -- one byte of body, one header, one status
+    -- would tell an unauthenticated caller which addresses Apple has verified
+    and which accounts already exist.
+    """
+    license_verifier.grant(VALID_LICENSE_KEY, SECOND_NEW_EMAIL)
+
+    no_license = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=NO_LICENSE_SUBJECT, email=NEW_EMAIL)),
+    )
+    unverified = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(
+                sub=UNVERIFIED_SUBJECT,
+                email=SECOND_NEW_EMAIL,
+                email_verified=VERIFIED_FALSE_STRING,
+            ),
+            license_key=VALID_LICENSE_KEY,
+        ),
+    )
+
+    fingerprints = [_fingerprint(no_license), _fingerprint(unverified)]
+    assert len(fingerprints) == BYTE_IDENTICAL_REJECTIONS
+    assert all(status == HTTPStatus.CONFLICT for status, _, _ in fingerprints)
+    assert all(DETAIL_NEEDS_LICENSE.encode() in body for _, _, body in fingerprints)
+    assert len(set(fingerprints)) == 1
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
+
+
+# ---------------------------------------------------------------------------
+# H. Two providers, one account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("offline_google")
+async def test_apple_links_alongside_an_existing_google_identity(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """One account may carry both links, and either one signs into it.
+
+    The unique constraint is on ``(provider, subject)``, not on ``user_id``, so
+    a second provider is a second row -- never a second account.
+    """
+    user = await _seed_user(db_session)
+    await _seed_identity(
+        db_session,
+        _user_id(user),
+        GOOGLE_SUBJECT,
+        provider=AuthProvider.GOOGLE,
+    )
+
+    linked = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token(sub=LINKED_SUBJECT, email=EXISTING_EMAIL)),
+    )
+
+    assert linked.status_code == HTTPStatus.OK
+    assert linked.json()["user_id"] == _user_id(user)
+
+    identities = (await db_session.execute(select(AuthIdentity))).scalars().all()
+    assert len(identities) == DUAL_IDENTITY_COUNT
+    assert {identity.provider for identity in identities} == {
+        AuthProvider.GOOGLE,
+        AuthProvider.APPLE,
+    }
+    assert {identity.user_id for identity in identities} == {_user_id(user)}
+    assert await _count_rows(db_session, User) == 1
+
+    via_google = await async_client.post(
+        GOOGLE_OAUTH_PATH,
+        json=_oauth_payload(_mint_google_token()),
+    )
+    via_apple = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(_mint_token_without("email", "email_verified", sub=LINKED_SUBJECT)),
+    )
+
+    assert via_google.status_code == HTTPStatus.OK
+    assert via_apple.status_code == HTTPStatus.OK
+    assert via_google.json()["user_id"] == _user_id(user)
+    assert via_apple.json()["user_id"] == _user_id(user)
+    assert await _count_rows(db_session, AuthIdentity) == DUAL_IDENTITY_COUNT

--- a/backend/tests/routers/test_oauth_google.py
+++ b/backend/tests/routers/test_oauth_google.py
@@ -932,6 +932,35 @@ async def test_new_email_with_valid_license_creates_the_account(
 
 
 @pytest.mark.asyncio
+async def test_created_account_takes_its_display_name_from_the_name_claim(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """Google's verified ``name`` claim seeds the account's stored display name.
+
+    Google, unlike Apple, puts the name in the token itself, so the create rung
+    reads it from the verified claims rather than from anything the client sent
+    alongside them.
+    """
+    license_verifier.grant(VALID_LICENSE_KEY, NEW_EMAIL)
+
+    response = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(
+            _mint_token(sub=NEW_SUBJECT, email=NEW_EMAIL, name=DISPLAY_NAME),
+            license_key=VALID_LICENSE_KEY,
+        ),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    user = await db_session.get(User, response.json()["user_id"])
+    assert user is not None
+    await db_session.refresh(user)
+    assert user.display_name == DISPLAY_NAME
+
+
+@pytest.mark.asyncio
 async def test_social_accounts_get_distinct_unusable_passwords(
     async_client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_practice_share.py
+++ b/backend/tests/test_practice_share.py
@@ -14,6 +14,11 @@ from sqlmodel import select
 
 from models.practice import Practice
 from models.practice_share_link import PracticeShareLink
+from models.user import User
+
+# A display name that shares no substring with the owner's email local-part, so
+# the assertion cannot pass on the derived fallback by accident.
+_STORED_DISPLAY_NAME = "Willow of the Fen"
 
 
 def _timer_cfg(duration_minutes: float) -> dict[str, object]:
@@ -204,6 +209,37 @@ async def test_preview_returns_practice_and_owner_display_name(
     # Issue #348 constraint: do not expose the original owner's user id.
     assert "submitted_by_user_id" not in data
     assert "created_by_user_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_preview_prefers_a_stored_display_name_over_the_email_derivation(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A name the owner actually has beats the local-part of their address.
+
+    The email-derived fallback exists only for accounts that never supplied a
+    name; once one is stored, leaking ``carol`` from ``carol@example.com``
+    would be both wrong and needlessly revealing about the address.
+    """
+    owner_headers, owner_id = await _signup(async_client, "carol")
+    practice_id = await _create_custom_practice(async_client, owner_headers)
+    link = await _mint_link(async_client, owner_headers, practice_id)
+
+    owner = await db_session.get(User, owner_id)
+    assert owner is not None
+    owner.display_name = _STORED_DISPLAY_NAME
+    db_session.add(owner)
+    await db_session.commit()
+
+    recipient_headers, _ = await _signup(async_client, "dave")
+    resp = await async_client.get(
+        f"/practices/share/{cast('str', link['token'])}",
+        headers=recipient_headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["created_by_display_name"] == _STORED_DISPLAY_NAME
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `POST /auth/oauth/apple`. Apple is a second OIDC provider, not a second implementation: `services/oidc.py` already carried the verification core (algorithm pinning, required claims, collapsed failure mode, fail-closed audience), so the new `services/oauth_apple.py` adds only Apple's single issuer spelling, its JWKS endpoint, and the `APPLE_OAUTH_CLIENT_IDS` allowlist. The resolution ladder in `routers/auth.py` is now parameterized by provider and shared through one `_resolve_oauth_user`, which both endpoints call — no copy-pasted handler logic. No new table; `AuthIdentity` and `AuthProvider.APPLE` already existed.
- Handles Apple's two disappearing claims. The user's **name** arrives once, in the body of the first authorization, and never again, so it is persisted at account creation into a new nullable `user.display_name` and is never read on the login or link rungs — a client presenting a different `full_name` later cannot rename an account. The **email** claim disappears the same way, present on the first authorization and absent afterwards, so every lookup keys on the provider `sub`. A ladder keyed on email would have passed testing and broken on each user's second login.
- Treats private relay addresses as ordinary verified emails with no branch on `is_private_email` at all. A relay address is minted per Apple user per app and routes only to that user's mailbox, so an existing account bearing one can only have been created by the same person — it cannot collide with a third party's real address, which makes it no more dangerous to link on than a verified Gmail address.

## Carried forward from the Google sibling (#1985)

The point of a second auth route is that it must not reopen anything the first one closed:

- **`401` still means token-verification failure and nothing else.** No license, an invalid license, an unverified address, a token with no email, and an account an operator gated all return the one byte-identical `409 needs_license`, with the real cause only on a server-side `reason_code`. A test fingerprints `(status, content-type, body)` across two independently-triggered refusals and asserts equality, so the account-enumeration oracle stays shut on the new route.
- **`email_verified` truthy-string coercion is confined to the Apple adapter.** Apple sends the string `"true"` as often as a boolean; Google's adapter still accepts only a real boolean, and the shared core still has no `email_verified` handling. A truthy-string rule applied to every provider at once is precisely how an address nobody proved starts linking to someone else's account.
- **JWKS fetches stay timeout-bounded (5s), key-cached, and resolved off the event loop.** The bound moved into `services/oidc.py` as `build_bounded_jwk_client` so both adapters inherit it rather than re-deriving it. An unbounded fetch on an attacker-chosen `kid` parks threads that login and signup share.
- **A token with no `exp` is still rejected** — PyJWT skips validating an absent claim without `require`, so a claim-less token would otherwise never expire. Pinned by a test that mints a token with the claim removed.
- **The Gumroad APTITUDE license gate still gates account creation**, unweakened and un-special-cased, and the per-IP invalid-license hourly cap is charged on this route too so Apple is not a free lane for grinding license keys.
- **The raw identity token never reaches a log, an exception chain, a response body, or the database**, and every `from None` that severs `__cause__` is intact.

There is no Apple client-secret or token-exchange round trip: the app posts the identity token and JWKS verification suffices. Apple's client secret is a signed JWT rather than a static string, so modelling it as a configured constant would have been wrong as well as unnecessary.

## Known gap, filed rather than papered over

`verify_aptitude_license` requires the Gumroad purchase email to match the sign-in email. A relay address essentially never matches a real purchase, so a Hide-My-Email user with a valid license and no existing account lands on the generic 409 at the creation rung. Special-casing relay addresses in the license check would turn a leaked key into an account-creation primitive, so the gate was left alone and the missing product flow is filed as #1987. Apple users who share their real email, and Hide-My-Email users who already have an account, are both unaffected.

## Test plan

- New `backend/tests/routers/test_oauth_apple.py` (1053 lines, 31 cases), fully offline — the JWKS client and the outbound Gumroad verify are both stubbed. Covers: login via a stored `(apple, sub)` link; **repeat sign-in with no `email` claim at all**, resolving by subject; relay email + valid license creating the account, entitlement, and link; string `"true"` honoured and `"false"`/boolean `False` refused; `full_name` persisted at creation only, blank stripped to `None`, not overwritten by a later sign-in, ignored on the link rung and past its 120-char ceiling as a 422; wrong `aud` / expired / **absent `exp`** / wrong `iss` / unpublished signing key each 401 with the raw token absent from logs and body; no license as a 409 byte-identical to the others; **one user holding both a Google and an Apple identity**; unset `APPLE_OAUTH_CLIENT_IDS` failing closed; JWKS client bounds asserted without network; `5/minute` rate limit.
- One additive test each in `test_oauth_google.py` (Google create rung sets `display_name` from the verified `name` claim) and `test_practice_share.py` (a stored `display_name` beats the email derivation).
- The pre-existing Google suite passes **unchanged** — that is the regression guard on the provider-parameterization refactor, including its assertion that Google still rejects the string `"true"`.
- `./scripts/backend/check-all.sh` exit 0 (7/7). Full backend suite: 3247 passed, 2 skipped, 96.88% total coverage. `xenon --max-absolute A --max-modules A --max-average A src` and `radon mi src -nb` both clean (check-all omits these). `interrogate` 96.6%. `alembic heads` shows exactly one head. Every changed file parses under Python 3.11 for the compat job.

Closes #1949
Refs #1947
Refs #1987
