### PR TITLE
feat(frontend): Continue with Apple (iOS) — expo-apple-authentication button in the social auth row

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,5 +35,11 @@ platform: with no ID for the platform the app is running on (whitespace counts
 as no ID), the Google button is not rendered at all and email sign-in is the
 only path. Set them one platform at a time to roll the flow out gradually.
 
+Sign in with Apple has no `EXPO_PUBLIC_*` switch of its own. The button appears
+only where `AppleAuthentication.isAvailableAsync()` reports that the platform
+supports it (iOS 13 and later), so there is nothing to set per environment —
+what makes it work is `ios.usesAppleSignIn: true` in `app.json`, which is what
+lands the entitlement in a build.
+
 For deploy steps and where to set these in Railway, see
 [`../DEPLOYMENT.md`](../DEPLOYMENT.md).

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -8,7 +8,8 @@
     },
     "icon": "./assets/icon.png",
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "usesAppleSignIn": true
     },
     "name": "frontend",
     "newArchEnabled": true,

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@react-native-async-storage/async-storage$': '<rootDir>/src/__mocks__/async-storage.js',
     '^expo-secure-store$': '<rootDir>/src/__mocks__/expo-secure-store.js',
+    '^expo-apple-authentication$': '<rootDir>/src/__mocks__/expo-apple-authentication.js',
     '^expo-auth-session/providers/google$': '<rootDir>/src/__mocks__/expo-auth-session-google.js',
     '^expo-web-browser$': '<rootDir>/src/__mocks__/expo-web-browser.js',
     '^expo-av$': '<rootDir>/src/__mocks__/expo-av.js',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/native-stack": "^7.18.2",
         "expo": "~52.0.43",
+        "expo-apple-authentication": "~7.1.3",
         "expo-auth-session": "~6.0.3",
         "expo-av": "~15.1.7",
         "expo-file-system": "~18.0.12",
@@ -9893,6 +9894,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-7.1.3.tgz",
+      "integrity": "sha512-TRaF513oDGjGx3hRiAwkMiSnKLN8BIR9Se5Gi3ttz2UUgP9y+tNHV6Ji6/oztJo9ON7zerHg2mn5Y+3B8c2vTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/native-stack": "^7.18.2",
     "expo": "~52.0.43",
+    "expo-apple-authentication": "~7.1.3",
     "expo-auth-session": "~6.0.3",
     "expo-av": "~15.1.7",
     "expo-file-system": "~18.0.12",

--- a/frontend/src/__mocks__/expo-apple-authentication.js
+++ b/frontend/src/__mocks__/expo-apple-authentication.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+/* global jest */
+// ``expo-apple-authentication`` ships untranspiled ESM and is not covered by
+// the preset's transformIgnorePatterns allowlist, so Jest cannot parse the real
+// module. Tests that care about the flow override the async members with
+// jest.mock; component tests render against the button stub below.
+const React = require('react');
+const { Pressable } = require('react-native');
+
+// The real button is a native view whose text and colour scheme are chosen by
+// UIKit from these props. Keeping them readable on the rendered node is the
+// only way a test can assert which variant was asked for.
+const AppleAuthenticationButton = (props) =>
+  React.createElement(Pressable, {
+    accessibilityLabel: props.accessibilityLabel,
+    accessibilityRole: 'button',
+    buttonStyle: props.buttonStyle,
+    buttonType: props.buttonType,
+    cornerRadius: props.cornerRadius,
+    onPress: props.onPress,
+    style: props.style,
+    testID: props.testID,
+  });
+
+module.exports = {
+  isAvailableAsync: jest.fn(() => Promise.resolve(false)),
+  signInAsync: jest.fn(),
+  AppleAuthenticationButton,
+  AppleAuthenticationScope: Object.freeze({ FULL_NAME: 0, EMAIL: 1 }),
+  AppleAuthenticationButtonType: Object.freeze({ SIGN_IN: 0, CONTINUE: 1, SIGN_UP: 2 }),
+  AppleAuthenticationButtonStyle: Object.freeze({ WHITE: 0, WHITE_OUTLINE: 1, BLACK: 2 }),
+  AppleAuthenticationUserDetectionStatus: Object.freeze({
+    UNSUPPORTED: 0,
+    UNKNOWN: 1,
+    LIKELY_REAL: 2,
+  }),
+};

--- a/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
+++ b/frontend/src/__tests__/navigation/authStatusNavigator.test.tsx
@@ -102,6 +102,7 @@ type MockAuth = {
   login: jest.Mock;
   signup: jest.Mock;
   loginWithGoogle: jest.Mock;
+  loginWithApple: jest.Mock;
   logout: jest.Mock;
   onUnauthorized: jest.Mock;
   dismissReauth: jest.Mock;
@@ -117,6 +118,7 @@ function buildAuth(overrides: Partial<MockAuth> = {}): MockAuth {
     login: jest.fn(() => Promise.resolve()),
     signup: jest.fn(() => Promise.resolve()),
     loginWithGoogle: jest.fn(() => Promise.resolve({ kind: 'success' })),
+    loginWithApple: jest.fn(() => Promise.resolve({ kind: 'success' })),
     logout: jest.fn(() => Promise.resolve()),
     onUnauthorized: jest.fn(),
     dismissReauth: jest.fn(() => Promise.resolve()),

--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -194,6 +194,22 @@ describe('google oauth codes', () => {
   });
 });
 
+// ``invalid_oauth_token`` is the single 401 detail behind BOTH oauth routes
+// (Google and Apple), so copy that names one provider misattributes half the
+// failures — a user who tapped Apple must not be told Google failed.
+describe('oauth credential copy is provider-neutral', () => {
+  it.each([[/google/i], [/apple/i]])('never names %p as the provider', (provider) => {
+    expect(USER_FACING_ERROR_MESSAGES.invalid_oauth_token).not.toMatch(provider);
+  });
+
+  it('still says a sign-in failed verification and invites a retry', () => {
+    const copy = USER_FACING_ERROR_MESSAGES.invalid_oauth_token;
+
+    expect(copy).toMatch(/sign-in/i);
+    expect(copy).toMatch(/try again/i);
+  });
+});
+
 describe('messageForCode', () => {
   it('returns the mapped copy for a known code', () => {
     expect(messageForCode('invalid_credentials')).toContain('email and password');

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -29,7 +29,7 @@ const NO_ACCESS = "You don't have access to this.";
 // silently truncate. Naming the ceiling turns "try again" into a fix. // pragma: allowlist secret
 const PASSWORD_TOO_LONG =
   'That password is longer than we can store. Shorten it to 64 characters or fewer.';
-// Shared by the signup form's ``license_required`` and the Google exchange's
+// Shared by the signup form's ``license_required`` and the social exchanges'
 // ``needs_license`` so the two roads to "we need your key" read identically.
 const ADD_LICENSE_KEY = 'Add the license key from your Gumroad receipt to continue.';
 
@@ -69,17 +69,19 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
   license_verification_unavailable:
     "We can't reach Gumroad to check your key right now. Nothing is lost — give it a few minutes and try again.",
 
-  // --- Google sign-in exchange -----------------------------------------
+  // --- Social sign-in exchange (Google, Apple) --------------------------
   // The backend collapses every non-cryptographic refusal — no license, a bad
   // license, an unverified or absent email, a disabled account — into one
   // byte-identical 409 so the endpoint cannot be used to enumerate accounts.
   // This copy must not reconstruct the distinction the wire format destroyed:
   // it names the only step the user can actually take and nothing else.
   needs_license: ADD_LICENSE_KEY,
-  // 401 means the Google credential itself failed verification (expired,
+  // 401 means the OAuth credential itself failed verification (expired,
   // replayed, wrong audience) — nothing about the user's account or purchase,
-  // so the remedy is simply another sign-in attempt.
-  invalid_oauth_token: 'That Google sign-in could not be verified. Try again in a moment.',
+  // so the remedy is simply another sign-in attempt. Both providers' routes
+  // return this one detail, so the copy must not name either of them: telling
+  // an Apple user that Google failed misattributes half of these failures.
+  invalid_oauth_token: 'That sign-in could not be verified. Try again in a moment.',
 
   // --- Admin -----------------------------------------------------------
   admin_required: 'Admin privileges are required for this action.',

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -2671,6 +2671,24 @@ export interface OAuthGoogleRequest {
   timezone?: string;
 }
 
+/**
+ * Payload for ``POST /auth/oauth/apple`` — mirrors ``AppleOAuthRequest`` in
+ * ``backend/src/routers/auth.py``.
+ *
+ * Same shape as the Google exchange plus ``full_name``, which is Apple's
+ * one-shot gift: the name is never in the token, and Apple hands it to the
+ * client only on the very first authorization. The client forwards it here or
+ * it is lost forever — which is also why the backend reads it only on the rung
+ * that creates a brand-new row, never to relabel an account that already
+ * exists.
+ */
+export interface OAuthAppleRequest {
+  id_token: string;
+  full_name?: string;
+  license_key?: string;
+  timezone?: string;
+}
+
 export interface AuthResponse {
   token: string;
   user_id: number;
@@ -2732,6 +2750,21 @@ export const auth = {
    */
   oauthGoogle(payload: OAuthGoogleRequest): Promise<AuthResponse> {
     return request<AuthResponse>('/auth/oauth/google', {
+      method: 'POST',
+      body: payload,
+      schema: loginAuthResponseSchema,
+    });
+  },
+  /**
+   * Trade an Apple ID token for an Adepthood session.
+   *
+   * Anonymous by design, exactly like the Google exchange, and validated with
+   * ``loginAuthResponseSchema`` for the same reason: the ``user_id == 0``
+   * sentinel belongs to ``/auth/signup`` alone, so a zero here would be a
+   * zombie session.
+   */
+  oauthApple(payload: OAuthAppleRequest): Promise<AuthResponse> {
+    return request<AuthResponse>('/auth/oauth/apple', {
       method: 'POST',
       body: payload,
       schema: loginAuthResponseSchema,

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -73,9 +73,6 @@ type ConfirmReset = (_token: string, _newPassword: string) => Promise<void>;
 export type SocialSignInResult =
   { kind: 'success' } | { kind: 'needs_license' } | { kind: 'error'; error: unknown };
 
-/** The Google flow's name for the shared outcome, kept for its call sites. */
-export type GoogleSignInResult = SocialSignInResult;
-
 /**
  * Exchange a Google ID token — plus, on the retry leg, the buyer's license key
  * — for a session. Total: it never throws.

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -65,19 +65,34 @@ export type AuthStatus = 'loading' | 'authenticated' | 'reauth-required' | 'anon
 type ConfirmReset = (_token: string, _newPassword: string) => Promise<void>;
 
 /**
- * Outcome of a Google ID-token exchange, returned as a value rather than
+ * Outcome of a social ID-token exchange, returned as a value rather than
  * signalled by a throw: ``needs_license`` is a normal branch of the flow (it
  * opens the inline license step), and a caller's ``catch`` would flatten it
  * into the generic error path and lose that step.
  */
-export type GoogleSignInResult =
+export type SocialSignInResult =
   { kind: 'success' } | { kind: 'needs_license' } | { kind: 'error'; error: unknown };
+
+/** The Google flow's name for the shared outcome, kept for its call sites. */
+export type GoogleSignInResult = SocialSignInResult;
 
 /**
  * Exchange a Google ID token — plus, on the retry leg, the buyer's license key
  * — for a session. Total: it never throws.
  */
-type LoginWithGoogle = (_idToken: string, _licenseKey?: string) => Promise<GoogleSignInResult>;
+type LoginWithGoogle = (_idToken: string, _licenseKey?: string) => Promise<SocialSignInResult>;
+
+/**
+ * Exchange an Apple ID token for a session. ``fullName`` is Apple's one-shot
+ * gift — offered only on the very first authorization — so it rides along on
+ * every leg of the flow, including the license retry that actually creates the
+ * account. Total: it never throws.
+ */
+type LoginWithApple = (
+  _idToken: string,
+  _fullName?: string,
+  _licenseKey?: string,
+) => Promise<SocialSignInResult>;
 
 interface AuthContextValue {
   token: string | null;
@@ -106,6 +121,12 @@ interface AuthContextValue {
    * never retained by the context — the caller owns its lifetime.
    */
   loginWithGoogle: LoginWithGoogle;
+  /**
+   * Sign in with an Apple ID token, optionally carrying the name Apple handed
+   * over on first authorization. Both the token and the name are per-call
+   * arguments the context never retains — the caller owns their lifetime.
+   */
+  loginWithApple: LoginWithApple;
   logout: () => Promise<void>;
   onUnauthorized: () => void;
   /** User dismissed the re-auth sheet: treat as an explicit logout. */
@@ -378,10 +399,15 @@ function useLoadStoredToken(mutators: AuthMutators): void {
   }, [mutators]);
 }
 
-interface AuthActions {
+/** The provider-specific sign-in actions, memoized together by {@link useSocialLogins}. */
+interface SocialLogins {
+  loginWithGoogle: LoginWithGoogle;
+  loginWithApple: LoginWithApple;
+}
+
+interface AuthActions extends SocialLogins {
   login: Login;
   signup: Signup;
-  loginWithGoogle: LoginWithGoogle;
   logout: () => Promise<void>;
   onUnauthorized: () => void;
   dismissReauth: () => Promise<void>;
@@ -448,7 +474,7 @@ async function signupWithDeviceTimezone(
   return response;
 }
 
-/** The one 409 the Google exchange uses for every non-cryptographic refusal. */
+/** The one 409 both social exchanges use for every non-cryptographic refusal. */
 const NEEDS_LICENSE_STATUS = 409;
 const NEEDS_LICENSE_DETAIL = 'needs_license';
 
@@ -466,8 +492,18 @@ function isNeedsLicenseRefusal(err: unknown): boolean {
 }
 
 /**
+ * Map an exchange rejection onto the non-success half of a
+ * {@link SocialSignInResult}: only the collapsed 409 opens the license step,
+ * everything else is a plain error the caller renders as copy.
+ */
+function refusalResult(err: unknown): SocialSignInResult {
+  if (isNeedsLicenseRefusal(err)) return { kind: 'needs_license' };
+  return { kind: 'error', error: err };
+}
+
+/**
  * POST /auth/oauth/google with the device's IANA timezone attached, mapping
- * every outcome to a {@link GoogleSignInResult}.
+ * every outcome to a {@link SocialSignInResult}.
  *
  * Lives at module scope for the same reason ``signupWithDeviceTimezone`` does:
  * it keeps ``useAuthActions`` a list of one-line delegations. ``license_key`` is
@@ -481,7 +517,7 @@ async function exchangeGoogleIdToken(
   idToken: string,
   licenseKey: string | undefined,
   mutators: AuthMutators,
-): Promise<GoogleSignInResult> {
+): Promise<SocialSignInResult> {
   try {
     const response = await authApi.oauthGoogle({
       id_token: idToken,
@@ -491,9 +527,57 @@ async function exchangeGoogleIdToken(
     await applyAuthResponse(response, mutators);
     return { kind: 'success' };
   } catch (err: unknown) {
-    if (isNeedsLicenseRefusal(err)) return { kind: 'needs_license' };
-    return { kind: 'error', error: err };
+    return refusalResult(err);
   }
+}
+
+/**
+ * POST /auth/oauth/apple — the Google exchange's twin, plus Apple's one-shot
+ * name.
+ *
+ * ``full_name`` and ``license_key`` are each omitted as *keys* rather than sent
+ * as ``undefined``: the wire payload should carry nothing the user has not
+ * supplied. The name rides along on the license retry too, because that retry
+ * is the request that creates the account — and Apple will never offer the name
+ * again.
+ */
+async function exchangeAppleIdToken(
+  idToken: string,
+  fullName: string | undefined,
+  licenseKey: string | undefined,
+  mutators: AuthMutators,
+): Promise<SocialSignInResult> {
+  try {
+    const response = await authApi.oauthApple({
+      id_token: idToken,
+      ...(fullName === undefined ? {} : { full_name: fullName }),
+      ...(licenseKey === undefined ? {} : { license_key: licenseKey }),
+      timezone: detectDeviceTimezone(),
+    });
+    await applyAuthResponse(response, mutators);
+    return { kind: 'success' };
+  } catch (err: unknown) {
+    return refusalResult(err);
+  }
+}
+
+/**
+ * The social sign-in actions, bundled into one memoized object so
+ * ``useAuthActions`` stays a short list of delegations under the max-lines cap.
+ */
+function useSocialLogins(mutators: AuthMutators): SocialLogins {
+  const loginWithGoogle = useCallback<LoginWithGoogle>(
+    (idToken, licenseKey) => exchangeGoogleIdToken(idToken, licenseKey, mutators),
+    [mutators],
+  );
+
+  const loginWithApple = useCallback<LoginWithApple>(
+    (idToken, fullName, licenseKey) =>
+      exchangeAppleIdToken(idToken, fullName, licenseKey, mutators),
+    [mutators],
+  );
+
+  return useMemo(() => ({ loginWithGoogle, loginWithApple }), [loginWithGoogle, loginWithApple]);
 }
 
 /**
@@ -531,10 +615,7 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
     [mutators],
   );
 
-  const loginWithGoogle = useCallback<LoginWithGoogle>(
-    (idToken, licenseKey) => exchangeGoogleIdToken(idToken, licenseKey, mutators),
-    [mutators],
-  );
+  const socialLogins = useSocialLogins(mutators);
 
   const logout = useCallback(() => tearDownSession(mutators, 'logout'), [mutators]);
 
@@ -567,13 +648,13 @@ function useAuthActions(mutators: AuthMutators): AuthActions {
     () => ({
       login,
       signup,
-      loginWithGoogle,
+      ...socialLogins,
       logout,
       onUnauthorized,
       dismissReauth,
       confirmPasswordReset,
     }),
-    [login, signup, loginWithGoogle, logout, onUnauthorized, dismissReauth, confirmPasswordReset],
+    [login, signup, socialLogins, logout, onUnauthorized, dismissReauth, confirmPasswordReset],
   );
 }
 

--- a/frontend/src/features/Auth/SocialAuthButtons.tsx
+++ b/frontend/src/features/Auth/SocialAuthButtons.tsx
@@ -1,3 +1,8 @@
+import {
+  AppleAuthenticationButton,
+  AppleAuthenticationButtonStyle,
+  AppleAuthenticationButtonType,
+} from 'expo-apple-authentication';
 import React, { useState } from 'react';
 import { Text, View } from 'react-native';
 
@@ -5,13 +10,18 @@ import { authStyles as styles } from './auth.styles';
 import { LicenseKeyField } from './components/LicenseKeyField';
 import { validateLicenseKey } from './licenseKeyValidation';
 import { isGoogleAuthConfigured } from './oauthConfig';
+import type { SocialAuthView } from './socialFlow';
+import { useAppleAuth, useAppleSignInAvailable } from './useAppleAuth';
 import { useGoogleAuth } from './useGoogleAuth';
 
 import { Button } from '@/components/Button';
 import { GUMROAD_HELP_URL } from '@/config';
+import { useTheme } from '@/design/ThemeContext';
+import { BORDER_RADIUS } from '@/design/tokens';
 import { openExternalUrl } from '@/utils/openExternalUrl';
 
 const GOOGLE_LABEL = 'Continue with Google';
+const APPLE_LABEL = 'Continue with Apple';
 
 /** The help page is static config — appending the typed key would leak it into browser history. */
 function openLicenseHelp(): void {
@@ -32,18 +42,21 @@ function AuthDivider(): React.JSX.Element {
 interface LicenseStepProps {
   value: string;
   submitting: boolean;
+  submitTestID: string;
   onChangeText: (_value: string) => void;
   onSubmit: () => void;
 }
 
 /**
- * The license key, asked for in place. The Google prompt already ran and its
- * token is still held by the hook, so finishing here costs the user one field —
- * never a second trip through Google, and never a different screen.
+ * The license key, asked for in place. The provider's prompt already ran and
+ * its credential is still held by the hook, so finishing here costs the user
+ * one field — never a second trip through the provider, and never a different
+ * screen.
  */
 function LicenseStep({
   value,
   submitting,
+  submitTestID,
   onChangeText,
   onSubmit,
 }: LicenseStepProps): React.JSX.Element {
@@ -59,18 +72,31 @@ function LicenseStep({
         disabled={submitting}
         label={submitting ? 'Checking...' : 'Continue'}
         onPress={onSubmit}
-        testID="social-auth-license-submit"
+        testID={submitTestID}
       />
     </View>
   );
 }
 
+interface ProviderFlowProps {
+  state: SocialAuthView & { submitLicenseKey: (_key: string) => void };
+  /** The provider's own button — Google's is ours to draw, Apple's is Apple's. */
+  button: React.ReactNode;
+  errorTestID: string;
+  licenseSubmitTestID: string;
+}
+
 /**
- * The configured half of {@link SocialAuthButtons} — split out so the auth hook
- * only ever runs in a build that can actually complete the flow.
+ * One provider's column: its button, its single error slot, and its inline
+ * license step. Shared by both providers so the two flows cannot drift apart in
+ * behaviour or in what a screen reader hears.
  */
-function GoogleSignIn(): React.JSX.Element {
-  const { status, error, submitting, signIn, submitLicenseKey } = useGoogleAuth();
+function ProviderFlow({
+  state,
+  button,
+  errorTestID,
+  licenseSubmitTestID,
+}: ProviderFlowProps): React.JSX.Element {
   const [licenseKey, setLicenseKey] = useState('');
   const [invalidKey, setInvalidKey] = useState<string | null>(null);
 
@@ -82,25 +108,17 @@ function GoogleSignIn(): React.JSX.Element {
   const handleSubmitKey = (): void => {
     const invalid = validateLicenseKey(licenseKey);
     setInvalidKey(invalid);
-    if (invalid === null) submitLicenseKey(licenseKey);
+    if (invalid === null) state.submitLicenseKey(licenseKey);
   };
 
-  // One error slot, so a screen reader is never handed two competing alerts.
-  // The local complaint wins: it is about what the user just typed.
-  const message = invalidKey ?? error;
+  // One error slot per provider, so a screen reader is never handed two
+  // competing alerts. The local complaint wins: it is about what the user just
+  // typed.
+  const message = invalidKey ?? state.error;
 
   return (
-    <View style={styles.socialSection}>
-      <AuthDivider />
-      <Button
-        accessibilityLabel={GOOGLE_LABEL}
-        busy={submitting}
-        disabled={submitting}
-        label={submitting ? 'Connecting...' : GOOGLE_LABEL}
-        onPress={signIn}
-        testID="social-auth-google"
-        variant="secondary"
-      />
+    <>
+      {button}
       {message === null ? null : (
         <Text
           // Appears in place with no mount cue, so pair the role with a live
@@ -108,32 +126,110 @@ function GoogleSignIn(): React.JSX.Element {
           accessibilityRole="alert"
           accessibilityLiveRegion="polite"
           style={styles.error}
-          testID="social-auth-error"
+          testID={errorTestID}
         >
           {message}
         </Text>
       )}
-      {status === 'needsLicense' ? (
+      {state.status === 'needsLicense' ? (
         <LicenseStep
           value={licenseKey}
-          submitting={submitting}
+          submitting={state.submitting}
+          submitTestID={licenseSubmitTestID}
           onChangeText={handleChangeKey}
           onSubmit={handleSubmitKey}
         />
       ) : null}
-    </View>
+    </>
   );
 }
 
 /**
- * "Continue with Google", offered beside — never above — the email form.
+ * The configured half of the Google option — split into its own component so
+ * the auth hook only ever runs in a build that can actually complete the flow.
+ */
+function GoogleSignIn(): React.JSX.Element {
+  const state = useGoogleAuth();
+  return (
+    <ProviderFlow
+      state={state}
+      errorTestID="social-auth-error"
+      licenseSubmitTestID="social-auth-license-submit"
+      button={
+        <Button
+          accessibilityLabel={GOOGLE_LABEL}
+          busy={state.submitting}
+          disabled={state.submitting}
+          label={state.submitting ? 'Connecting...' : GOOGLE_LABEL}
+          onPress={state.signIn}
+          testID="social-auth-google"
+          variant="secondary"
+        />
+      }
+    />
+  );
+}
+
+/**
+ * The Apple option, mounted only where the platform supports it.
  *
- * Renders nothing at all when this platform has no Google client ID: an
- * unconfigured build hides the option rather than shipping a control that
- * fails on tap, which doubles as the rollout switch. The config check happens
- * here, before any hook, so an unconfigured build never reaches the provider.
+ * The mark is Apple's own component, as their HIG and the App Store guidelines
+ * require — never a facsimile — which also means we do not get a ``disabled``
+ * prop, so the in-flight guard lives in the press handler instead. The style
+ * flips with the theme so the mark always contrasts with the canvas behind it.
+ */
+function AppleSignIn(): React.JSX.Element {
+  const state = useAppleAuth();
+  const { mode } = useTheme();
+
+  const handlePress = (): void => {
+    if (!state.submitting) state.signIn();
+  };
+
+  return (
+    <ProviderFlow
+      state={state}
+      errorTestID="social-auth-apple-error"
+      licenseSubmitTestID="social-auth-apple-license-submit"
+      button={
+        <AppleAuthenticationButton
+          accessibilityLabel={APPLE_LABEL}
+          buttonType={AppleAuthenticationButtonType.CONTINUE}
+          buttonStyle={
+            mode === 'dark'
+              ? AppleAuthenticationButtonStyle.WHITE
+              : AppleAuthenticationButtonStyle.BLACK
+          }
+          cornerRadius={BORDER_RADIUS.lg}
+          onPress={handlePress}
+          style={styles.appleButton}
+          testID="social-auth-apple"
+        />
+      }
+    />
+  );
+}
+
+/**
+ * The social sign-in options, offered beside — never above — the email form.
+ *
+ * Each provider draws only where it can actually finish: Google needs a client
+ * ID for this platform (which doubles as its rollout switch), Apple needs a
+ * platform that supports Sign in with Apple. An absent provider leaves no gap
+ * and no dead control, and with neither available the whole aside disappears
+ * and email is the only path. Both gates are read before any provider hook
+ * mounts, so an unconfigured build never reaches the provider SDK.
  */
 export function SocialAuthButtons(): React.JSX.Element | null {
-  if (!isGoogleAuthConfigured()) return null;
-  return <GoogleSignIn />;
+  const appleAvailable = useAppleSignInAvailable();
+  const googleConfigured = isGoogleAuthConfigured();
+  if (!googleConfigured && !appleAvailable) return null;
+
+  return (
+    <View style={styles.socialSection}>
+      <AuthDivider />
+      {googleConfigured ? <GoogleSignIn /> : null}
+      {appleAvailable ? <AppleSignIn /> : null}
+    </View>
+  );
 }

--- a/frontend/src/features/Auth/SocialAuthButtons.tsx
+++ b/frontend/src/features/Auth/SocialAuthButtons.tsx
@@ -39,10 +39,55 @@ function AuthDivider(): React.JSX.Element {
   );
 }
 
+/**
+ * How one provider's license step names itself. Nothing disables the other
+ * provider's button, so both steps can be on screen at once: every name and
+ * every testID here has to say which provider it belongs to, or voice control
+ * and a screen reader are both handed an ambiguity.
+ */
+interface LicenseStepIds {
+  fieldLabel: string;
+  helpLabel: string;
+  submitLabel: string;
+  helpTestID: string;
+  errorTestID: string;
+  submitTestID: string;
+}
+
+/** Scope one provider's license step: shared copy, suffixed with whose step it is. */
+function licenseIdsFor(
+  provider: string,
+  testIdPrefix: string,
+  submitTestID: string,
+): LicenseStepIds {
+  const suffix = `for ${provider} sign-in`;
+  return {
+    fieldLabel: `Gumroad license key ${suffix}`,
+    helpLabel: `Find your license key ${suffix}`,
+    submitLabel: `Submit license key ${suffix}`,
+    helpTestID: `${testIdPrefix}-license-help`,
+    errorTestID: `${testIdPrefix}-license-error`,
+    submitTestID,
+  };
+}
+
+// Google's submit keeps its original, unprefixed testID: it shipped first and
+// nothing else answers to it.
+const GOOGLE_LICENSE_IDS = licenseIdsFor(
+  'Google',
+  'social-auth-google',
+  'social-auth-license-submit',
+);
+const APPLE_LICENSE_IDS = licenseIdsFor(
+  'Apple',
+  'social-auth-apple',
+  'social-auth-apple-license-submit',
+);
+
 interface LicenseStepProps {
   value: string;
   submitting: boolean;
-  submitTestID: string;
+  ids: LicenseStepIds;
   onChangeText: (_value: string) => void;
   onSubmit: () => void;
 }
@@ -56,7 +101,7 @@ interface LicenseStepProps {
 function LicenseStep({
   value,
   submitting,
-  submitTestID,
+  ids,
   onChangeText,
   onSubmit,
 }: LicenseStepProps): React.JSX.Element {
@@ -65,14 +110,22 @@ function LicenseStep({
       <Text style={styles.licenseStepLead}>
         One more step: add the license key from your Gumroad receipt.
       </Text>
-      <LicenseKeyField value={value} onChangeText={onChangeText} onPressHelp={openLicenseHelp} />
+      <LicenseKeyField
+        value={value}
+        accessibilityLabel={ids.fieldLabel}
+        errorTestID={ids.errorTestID}
+        helpTestID={ids.helpTestID}
+        helpAccessibilityLabel={ids.helpLabel}
+        onChangeText={onChangeText}
+        onPressHelp={openLicenseHelp}
+      />
       <Button
-        accessibilityLabel="Submit license key"
+        accessibilityLabel={ids.submitLabel}
         busy={submitting}
         disabled={submitting}
         label={submitting ? 'Checking...' : 'Continue'}
         onPress={onSubmit}
-        testID={submitTestID}
+        testID={ids.submitTestID}
       />
     </View>
   );
@@ -83,7 +136,7 @@ interface ProviderFlowProps {
   /** The provider's own button — Google's is ours to draw, Apple's is Apple's. */
   button: React.ReactNode;
   errorTestID: string;
-  licenseSubmitTestID: string;
+  license: LicenseStepIds;
 }
 
 /**
@@ -95,7 +148,7 @@ function ProviderFlow({
   state,
   button,
   errorTestID,
-  licenseSubmitTestID,
+  license,
 }: ProviderFlowProps): React.JSX.Element {
   const [licenseKey, setLicenseKey] = useState('');
   const [invalidKey, setInvalidKey] = useState<string | null>(null);
@@ -135,7 +188,7 @@ function ProviderFlow({
         <LicenseStep
           value={licenseKey}
           submitting={state.submitting}
-          submitTestID={licenseSubmitTestID}
+          ids={license}
           onChangeText={handleChangeKey}
           onSubmit={handleSubmitKey}
         />
@@ -154,7 +207,7 @@ function GoogleSignIn(): React.JSX.Element {
     <ProviderFlow
       state={state}
       errorTestID="social-auth-error"
-      licenseSubmitTestID="social-auth-license-submit"
+      license={GOOGLE_LICENSE_IDS}
       button={
         <Button
           accessibilityLabel={GOOGLE_LABEL}
@@ -190,7 +243,7 @@ function AppleSignIn(): React.JSX.Element {
     <ProviderFlow
       state={state}
       errorTestID="social-auth-apple-error"
-      licenseSubmitTestID="social-auth-apple-license-submit"
+      license={APPLE_LICENSE_IDS}
       button={
         <AppleAuthenticationButton
           accessibilityLabel={APPLE_LABEL}

--- a/frontend/src/features/Auth/__tests__/SocialAuthButtons.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SocialAuthButtons.test.tsx
@@ -38,12 +38,31 @@ const mockUseAppleAuth = useAppleAuth as unknown as jest.Mock;
 const mockUseAppleAvailable = useAppleSignInAvailable as unknown as jest.Mock;
 
 const GOOGLE_LABEL = 'Continue with Google';
+/** The shared stem both providers' license fields extend — never an accessible name on its own. */
 const LICENSE_LABEL = 'Gumroad license key';
+const GOOGLE_LICENSE_LABEL = `${LICENSE_LABEL} for Google sign-in`;
+const APPLE_LICENSE_LABEL = `${LICENSE_LABEL} for Apple sign-in`;
+/** The help link's name is scoped the same way, and for the same reason. */
+const HELP_LABEL = 'Find your license key';
+const GOOGLE_HELP_LABEL = `${HELP_LABEL} for Google sign-in`;
+const APPLE_HELP_LABEL = `${HELP_LABEL} for Apple sign-in`;
+const SUBMIT_LABEL = 'Submit license key';
+const GOOGLE_SUBMIT_LABEL = `${SUBMIT_LABEL} for Google sign-in`;
+const APPLE_SUBMIT_LABEL = `${SUBMIT_LABEL} for Apple sign-in`;
 const LICENSE_SUBMIT_ID = 'social-auth-license-submit';
 const GOOGLE_BUTTON_ID = 'social-auth-google';
+const GOOGLE_ERROR_ID = 'social-auth-error';
+const GOOGLE_LICENSE_HELP_ID = 'social-auth-google-license-help';
 const APPLE_BUTTON_ID = 'social-auth-apple';
 const APPLE_ERROR_ID = 'social-auth-apple-error';
 const APPLE_LICENSE_SUBMIT_ID = 'social-auth-apple-license-submit';
+const APPLE_LICENSE_HELP_ID = 'social-auth-apple-license-help';
+/**
+ * The unscoped identifiers ``LicenseKeyField`` still defaults to for the signup
+ * form's single field. Two providers on one screen may not share them.
+ */
+const UNSCOPED_LICENSE_ERROR_ID = 'signup-license-error';
+const UNSCOPED_LICENSE_HELP_ID = 'signup-license-help';
 const VALID_LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
 const TOO_SHORT_KEY = 'abc'; // pragma: allowlist secret
 const TOO_SHORT_COPY = 'That key looks too short — a Gumroad key is at least 8 characters.';
@@ -84,17 +103,32 @@ interface RenderedNode {
   children?: unknown[] | null;
 }
 
+/** Every string value of one prop, in render order, across the whole tree. */
+function collectProp(node: unknown, key: string): string[] {
+  if (Array.isArray(node)) return node.flatMap((child) => collectProp(child, key));
+  if (node === null || typeof node !== 'object') return [];
+  const { props, children } = node as RenderedNode;
+  const value = props === undefined ? undefined : props[key];
+  const own = typeof value === 'string' ? [value] : [];
+  return [...own, ...collectProp(children ?? [], key)];
+}
+
 /**
  * Every testID in render order. Comparing these sequences pins layout: a
  * hidden placeholder for an absent provider would show up as an extra slot.
  */
 function testIdsOf(node: unknown): string[] {
-  if (Array.isArray(node)) return node.flatMap((child) => testIdsOf(child));
-  if (node === null || typeof node !== 'object') return [];
-  const { props, children } = node as RenderedNode;
-  const testId = props === undefined ? undefined : props.testID;
-  const own = typeof testId === 'string' ? [testId] : [];
-  return [...own, ...testIdsOf(children ?? [])];
+  return collectProp(node, 'testID');
+}
+
+/** Every accessible name in render order — what a screen reader would announce. */
+function labelsOf(node: unknown): string[] {
+  return collectProp(node, 'accessibilityLabel');
+}
+
+/** Only the names belonging to a license field, so unrelated controls cannot mask a clash. */
+function licenseLabelsOf(node: unknown): string[] {
+  return labelsOf(node).filter((label) => label.startsWith(LICENSE_LABEL));
 }
 
 beforeEach(() => {
@@ -149,15 +183,15 @@ describe('SocialAuthButtons — inline license step', () => {
 
     const { getByLabelText } = render(<SocialAuthButtons />);
 
-    expect(getByLabelText(LICENSE_LABEL)).toBeTruthy();
+    expect(getByLabelText(GOOGLE_LICENSE_LABEL)).toBeTruthy();
     expect(getByLabelText(GOOGLE_LABEL)).toBeTruthy();
     expect(signIn).not.toHaveBeenCalled();
   });
 
   it('hides the license field while idle', () => {
-    const { queryByLabelText } = render(<SocialAuthButtons />);
+    const { toJSON } = render(<SocialAuthButtons />);
 
-    expect(queryByLabelText(LICENSE_LABEL)).toBeNull();
+    expect(licenseLabelsOf(toJSON())).toEqual([]);
   });
 
   it('announces the refusal copy to screen readers', () => {
@@ -174,7 +208,7 @@ describe('SocialAuthButtons — inline license step', () => {
     setGoogleAuth({ status: 'needsLicense' });
     const { getByLabelText, getByTestId } = render(<SocialAuthButtons />);
 
-    fireEvent.changeText(getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+    fireEvent.changeText(getByLabelText(GOOGLE_LICENSE_LABEL), VALID_LICENSE_KEY);
     fireEvent.press(getByTestId(LICENSE_SUBMIT_ID));
 
     expect(submitLicenseKey).toHaveBeenCalledWith(VALID_LICENSE_KEY);
@@ -186,7 +220,7 @@ describe('SocialAuthButtons — client-side license validation', () => {
     setGoogleAuth({ status: 'needsLicense' });
     const { getByLabelText, getByTestId, getByRole } = render(<SocialAuthButtons />);
 
-    fireEvent.changeText(getByLabelText(LICENSE_LABEL), TOO_SHORT_KEY);
+    fireEvent.changeText(getByLabelText(GOOGLE_LICENSE_LABEL), TOO_SHORT_KEY);
     fireEvent.press(getByTestId(LICENSE_SUBMIT_ID));
 
     expect(submitLicenseKey).not.toHaveBeenCalled();
@@ -227,7 +261,7 @@ describe('SocialAuthButtons — busy state', () => {
     setGoogleAuth({ status: 'needsLicense', submitting: true });
 
     const { getByLabelText, getByTestId } = render(<SocialAuthButtons />);
-    fireEvent.changeText(getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+    fireEvent.changeText(getByLabelText(GOOGLE_LICENSE_LABEL), VALID_LICENSE_KEY);
     fireEvent.press(getByTestId(LICENSE_SUBMIT_ID));
 
     expect(submitLicenseKey).not.toHaveBeenCalled();
@@ -244,6 +278,9 @@ describe('SocialAuthButtons — Apple availability gate', () => {
 
     const { queryByTestId, toJSON } = render(<SocialAuthButtons />);
 
+    // Without this the baseline could be empty — an ``AppleSignIn`` that always
+    // returned null would satisfy the comparison below and prove nothing.
+    expect(withApple).toContain(APPLE_BUTTON_ID);
     expect(queryByTestId(APPLE_BUTTON_ID)).toBeNull();
     expect(testIdsOf(toJSON())).toEqual(withApple.filter((id) => !id.startsWith(APPLE_BUTTON_ID)));
   });
@@ -310,7 +347,7 @@ describe('SocialAuthButtons — Apple flow', () => {
     setAppleAuth({ status: 'needsLicense' });
     const { getByLabelText, getByTestId } = render(<SocialAuthButtons />);
 
-    fireEvent.changeText(getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+    fireEvent.changeText(getByLabelText(APPLE_LICENSE_LABEL), VALID_LICENSE_KEY);
     fireEvent.press(getByTestId(APPLE_LICENSE_SUBMIT_ID));
 
     expect(appleSubmitLicenseKey).toHaveBeenCalledWith(VALID_LICENSE_KEY);
@@ -348,5 +385,80 @@ describe('SocialAuthButtons — Apple button theming', () => {
     );
 
     expect(getByTestId(APPLE_BUTTON_ID).props.buttonStyle).toBe(expected);
+  });
+});
+
+// Nothing disables one provider's button while the other is mid-flow, so both
+// license steps can be on screen at once. Two fields announcing the same name,
+// or two nodes answering to the same testID, make the pair unusable by voice
+// control and ambiguous to a screen reader.
+describe('SocialAuthButtons — both providers at the license step', () => {
+  function renderBothLicenseSteps(error: string | null = null) {
+    mockUseAppleAvailable.mockReturnValue(true);
+    setGoogleAuth({ status: 'needsLicense', error });
+    setAppleAuth({ status: 'needsLicense', error });
+    return render(<SocialAuthButtons />);
+  }
+
+  it('gives each license field an accessible name naming its provider', () => {
+    const { queryAllByLabelText } = renderBothLicenseSteps();
+
+    expect(queryAllByLabelText(GOOGLE_LICENSE_LABEL)).toHaveLength(1);
+    expect(queryAllByLabelText(APPLE_LICENSE_LABEL)).toHaveLength(1);
+    expect(queryAllByLabelText(LICENSE_LABEL)).toHaveLength(0);
+  });
+
+  it('leaves no two license fields sharing an accessible name', () => {
+    const { toJSON } = renderBothLicenseSteps();
+    const names = licenseLabelsOf(toJSON());
+
+    expect(names).toEqual([GOOGLE_LICENSE_LABEL, APPLE_LICENSE_LABEL]);
+  });
+
+  it('scopes each help link to its own provider', () => {
+    const { getByTestId, queryAllByTestId } = renderBothLicenseSteps();
+
+    expect(getByTestId(GOOGLE_LICENSE_HELP_ID)).toBeTruthy();
+    expect(getByTestId(APPLE_LICENSE_HELP_ID)).toBeTruthy();
+    expect(queryAllByTestId(UNSCOPED_LICENSE_HELP_ID)).toHaveLength(0);
+    // A shared testID is only half the clash: two links reading out the same
+    // name are just as ambiguous to a screen reader and to voice control.
+    expect(getByTestId(GOOGLE_LICENSE_HELP_ID).props.accessibilityLabel).toBe(GOOGLE_HELP_LABEL);
+    expect(getByTestId(APPLE_LICENSE_HELP_ID).props.accessibilityLabel).toBe(APPLE_HELP_LABEL);
+    expect(GOOGLE_HELP_LABEL).not.toBe(APPLE_HELP_LABEL);
+  });
+
+  it('names each submit button for the provider it finishes', () => {
+    const { getByTestId, queryAllByLabelText } = renderBothLicenseSteps();
+
+    expect(getByTestId(LICENSE_SUBMIT_ID).props.accessibilityLabel).toBe(GOOGLE_SUBMIT_LABEL);
+    expect(getByTestId(APPLE_LICENSE_SUBMIT_ID).props.accessibilityLabel).toBe(APPLE_SUBMIT_LABEL);
+    expect(queryAllByLabelText(SUBMIT_LABEL)).toHaveLength(0);
+  });
+
+  it('keeps the two error slots on distinct testIDs', () => {
+    const { getByTestId, queryAllByTestId } = renderBothLicenseSteps(REFUSAL_COPY);
+
+    expect(getByTestId(GOOGLE_ERROR_ID)).toHaveTextContent(REFUSAL_COPY);
+    expect(getByTestId(APPLE_ERROR_ID)).toHaveTextContent(REFUSAL_COPY);
+    expect(queryAllByTestId(UNSCOPED_LICENSE_ERROR_ID)).toHaveLength(0);
+  });
+
+  it('answers every testID exactly once with both license steps open', () => {
+    const ids = testIdsOf(renderBothLicenseSteps(REFUSAL_COPY).toJSON());
+
+    expect(ids).toContain(GOOGLE_BUTTON_ID);
+    expect(ids).toContain(APPLE_BUTTON_ID);
+    expect([...new Set(ids)]).toEqual(ids);
+  });
+
+  it('still routes each submitted key to its own provider', () => {
+    const { getByLabelText, getByTestId } = renderBothLicenseSteps();
+
+    fireEvent.changeText(getByLabelText(APPLE_LICENSE_LABEL), VALID_LICENSE_KEY);
+    fireEvent.press(getByTestId(APPLE_LICENSE_SUBMIT_ID));
+
+    expect(appleSubmitLicenseKey).toHaveBeenCalledWith(VALID_LICENSE_KEY);
+    expect(submitLicenseKey).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/Auth/__tests__/SocialAuthButtons.test.tsx
+++ b/frontend/src/features/Auth/__tests__/SocialAuthButtons.test.tsx
@@ -1,9 +1,14 @@
 /* eslint-env jest */
 /* global describe, it, expect, beforeEach, jest */
 import { render, fireEvent } from '@testing-library/react-native';
+import { AppleAuthenticationButtonStyle } from 'expo-apple-authentication';
 import React from 'react';
 
 jest.mock('../useGoogleAuth', () => ({ useGoogleAuth: jest.fn() }));
+jest.mock('../useAppleAuth', () => ({
+  useAppleAuth: jest.fn(),
+  useAppleSignInAvailable: jest.fn(),
+}));
 jest.mock('../oauthConfig', () => ({
   isGoogleAuthConfigured: jest.fn(),
   googleClientIds: { ios: '', android: '', web: '' },
@@ -20,16 +25,25 @@ jest.mock('@/utils/openExternalUrl', () => ({
 
 import { isGoogleAuthConfigured } from '../oauthConfig';
 import { SocialAuthButtons } from '../SocialAuthButtons';
+import { useAppleAuth, useAppleSignInAvailable } from '../useAppleAuth';
 import { useGoogleAuth } from '../useGoogleAuth';
+
+import { ThemeProvider, type ThemeMode } from '@/design/ThemeContext';
 
 const mockIsConfigured = isGoogleAuthConfigured as jest.MockedFunction<
   typeof isGoogleAuthConfigured
 >;
 const mockUseGoogleAuth = useGoogleAuth as unknown as jest.Mock;
+const mockUseAppleAuth = useAppleAuth as unknown as jest.Mock;
+const mockUseAppleAvailable = useAppleSignInAvailable as unknown as jest.Mock;
 
 const GOOGLE_LABEL = 'Continue with Google';
 const LICENSE_LABEL = 'Gumroad license key';
 const LICENSE_SUBMIT_ID = 'social-auth-license-submit';
+const GOOGLE_BUTTON_ID = 'social-auth-google';
+const APPLE_BUTTON_ID = 'social-auth-apple';
+const APPLE_ERROR_ID = 'social-auth-apple-error';
+const APPLE_LICENSE_SUBMIT_ID = 'social-auth-apple-license-submit';
 const VALID_LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
 const TOO_SHORT_KEY = 'abc'; // pragma: allowlist secret
 const TOO_SHORT_COPY = 'That key looks too short — a Gumroad key is at least 8 characters.';
@@ -38,27 +52,57 @@ const REFUSAL_COPY = 'A license key is needed to finish connecting this sign-in.
 
 const signIn = jest.fn();
 const submitLicenseKey = jest.fn();
+const appleSignIn = jest.fn();
+const appleSubmitLicenseKey = jest.fn();
 
-interface GoogleAuthState {
+interface SocialAuthState {
   status: 'idle' | 'needsLicense';
   error: string | null;
   submitting: boolean;
 }
 
-function setGoogleAuth(state: Partial<GoogleAuthState> = {}): void {
-  mockUseGoogleAuth.mockReturnValue({
+function hookState(state: Partial<SocialAuthState>, onSignIn: jest.Mock, onSubmitKey: jest.Mock) {
+  return {
     status: state.status ?? 'idle',
     error: state.error ?? null,
     submitting: state.submitting ?? false,
-    signIn,
-    submitLicenseKey,
-  });
+    signIn: onSignIn,
+    submitLicenseKey: onSubmitKey,
+  };
+}
+
+function setGoogleAuth(state: Partial<SocialAuthState> = {}): void {
+  mockUseGoogleAuth.mockReturnValue(hookState(state, signIn, submitLicenseKey));
+}
+
+function setAppleAuth(state: Partial<SocialAuthState> = {}): void {
+  mockUseAppleAuth.mockReturnValue(hookState(state, appleSignIn, appleSubmitLicenseKey));
+}
+
+interface RenderedNode {
+  props?: Record<string, unknown>;
+  children?: unknown[] | null;
+}
+
+/**
+ * Every testID in render order. Comparing these sequences pins layout: a
+ * hidden placeholder for an absent provider would show up as an extra slot.
+ */
+function testIdsOf(node: unknown): string[] {
+  if (Array.isArray(node)) return node.flatMap((child) => testIdsOf(child));
+  if (node === null || typeof node !== 'object') return [];
+  const { props, children } = node as RenderedNode;
+  const testId = props === undefined ? undefined : props.testID;
+  const own = typeof testId === 'string' ? [testId] : [];
+  return [...own, ...testIdsOf(children ?? [])];
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockIsConfigured.mockReturnValue(true);
+  mockUseAppleAvailable.mockReturnValue(false);
   setGoogleAuth();
+  setAppleAuth();
 });
 
 describe('SocialAuthButtons — configuration gate', () => {
@@ -187,5 +231,122 @@ describe('SocialAuthButtons — busy state', () => {
     fireEvent.press(getByTestId(LICENSE_SUBMIT_ID));
 
     expect(submitLicenseKey).not.toHaveBeenCalled();
+  });
+});
+
+describe('SocialAuthButtons — Apple availability gate', () => {
+  // A device that cannot offer Apple sign-in must see the exact tree it saw
+  // before Apple existed — no reserved gap, no disabled control.
+  it('leaves no Apple slot and no placeholder when Apple sign-in is unavailable', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+    const withApple = testIdsOf(render(<SocialAuthButtons />).toJSON());
+    mockUseAppleAvailable.mockReturnValue(false);
+
+    const { queryByTestId, toJSON } = render(<SocialAuthButtons />);
+
+    expect(queryByTestId(APPLE_BUTTON_ID)).toBeNull();
+    expect(testIdsOf(toJSON())).toEqual(withApple.filter((id) => !id.startsWith(APPLE_BUTTON_ID)));
+  });
+
+  it('renders the Apple button below the Google button when available', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+
+    const { getByTestId, toJSON } = render(<SocialAuthButtons />);
+    const ids = testIdsOf(toJSON());
+
+    expect(getByTestId(APPLE_BUTTON_ID)).toBeTruthy();
+    expect(ids.indexOf(APPLE_BUTTON_ID)).toBeGreaterThan(ids.indexOf(GOOGLE_BUTTON_ID));
+  });
+
+  // Rules of hooks again, from the other side: an unconfigured Google build
+  // still has an Apple row to draw, and drawing it must not reach the Google
+  // provider.
+  it('still renders the row when Google is unconfigured but Apple is available', () => {
+    mockIsConfigured.mockReturnValue(false);
+    mockUseAppleAvailable.mockReturnValue(true);
+
+    const { getByTestId, getByText, queryByLabelText } = render(<SocialAuthButtons />);
+
+    expect(getByTestId(APPLE_BUTTON_ID)).toBeTruthy();
+    expect(getByText('or')).toBeTruthy();
+    expect(queryByLabelText(GOOGLE_LABEL)).toBeNull();
+    expect(mockUseGoogleAuth).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing when Google is unconfigured and Apple is unavailable', () => {
+    mockIsConfigured.mockReturnValue(false);
+    mockUseAppleAvailable.mockReturnValue(false);
+
+    const { queryByTestId, toJSON } = render(<SocialAuthButtons />);
+
+    expect(toJSON()).toBeNull();
+    expect(queryByTestId(APPLE_BUTTON_ID)).toBeNull();
+  });
+});
+
+describe('SocialAuthButtons — Apple flow', () => {
+  it('starts the Apple flow, and only the Apple flow, when its button is pressed', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+    const { getByTestId } = render(<SocialAuthButtons />);
+
+    fireEvent.press(getByTestId(APPLE_BUTTON_ID));
+
+    expect(appleSignIn).toHaveBeenCalledTimes(1);
+    expect(signIn).not.toHaveBeenCalled();
+  });
+
+  it('ignores an Apple press while the Apple exchange is in flight', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+    setAppleAuth({ submitting: true });
+    const { getByTestId } = render(<SocialAuthButtons />);
+
+    fireEvent.press(getByTestId(APPLE_BUTTON_ID));
+
+    expect(appleSignIn).not.toHaveBeenCalled();
+  });
+
+  it('forwards a well-formed key to the Apple hook verbatim', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+    setAppleAuth({ status: 'needsLicense' });
+    const { getByLabelText, getByTestId } = render(<SocialAuthButtons />);
+
+    fireEvent.changeText(getByLabelText(LICENSE_LABEL), VALID_LICENSE_KEY);
+    fireEvent.press(getByTestId(APPLE_LICENSE_SUBMIT_ID));
+
+    expect(appleSubmitLicenseKey).toHaveBeenCalledWith(VALID_LICENSE_KEY);
+    expect(submitLicenseKey).not.toHaveBeenCalled();
+  });
+
+  it('announces the Apple refusal in its own live region', () => {
+    mockUseAppleAvailable.mockReturnValue(true);
+    setAppleAuth({ status: 'needsLicense', error: REFUSAL_COPY });
+
+    const { getByTestId } = render(<SocialAuthButtons />);
+    const alert = getByTestId(APPLE_ERROR_ID);
+
+    expect(alert).toHaveTextContent(REFUSAL_COPY);
+    expect(alert.props.accessibilityRole).toBe('alert');
+    expect(alert.props.accessibilityLiveRegion).toBe('polite');
+  });
+});
+
+describe('SocialAuthButtons — Apple button theming', () => {
+  // Apple's HIG: the button contrasts with the surface behind it, so the dark
+  // canvas takes the white mark and the light canvas takes the black one.
+  const THEME_CASES: Array<[ThemeMode, AppleAuthenticationButtonStyle]> = [
+    ['dark', AppleAuthenticationButtonStyle.WHITE],
+    ['light', AppleAuthenticationButtonStyle.BLACK],
+  ];
+
+  it.each(THEME_CASES)('uses the contrasting mark in %s mode', (mode, expected) => {
+    mockUseAppleAvailable.mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <ThemeProvider initialMode={mode}>
+        <SocialAuthButtons />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId(APPLE_BUTTON_ID).props.buttonStyle).toBe(expected);
   });
 });

--- a/frontend/src/features/Auth/__tests__/useAppleAuth.test.tsx
+++ b/frontend/src/features/Auth/__tests__/useAppleAuth.test.tsx
@@ -67,6 +67,7 @@ import { useAppleAuth, useAppleSignInAvailable } from '../useAppleAuth';
 import { ApiError, auth } from '@/api';
 import { USER_FACING_ERROR_MESSAGES } from '@/api/errorMessages';
 import { AuthProvider, useAuth } from '@/context/AuthContext';
+import * as authStorage from '@/storage/authStorage';
 import { loadToken, saveToken } from '@/storage/authStorage';
 
 const DEVICE_TIMEZONE = 'America/Chicago';
@@ -82,6 +83,12 @@ const JOINED_NAME = 'Ada Lovelace';
 const APPLE_FALLBACK_COPY = "We couldn't finish that Apple sign-in. Try again in a moment.";
 /** The coded rejection ``expo-apple-authentication`` raises when the user backs out. */
 const CANCEL_CODE = 'ERR_REQUEST_CANCELED';
+/**
+ * Everything one Apple authorization yields that is the provider's to hold and
+ * ours to spend once. None of it may reach the device's disk: the session JWT
+ * is the only credential worth persisting.
+ */
+const APPLE_ONLY_SECRETS = [APPLE_ID_TOKEN, JOINED_NAME, GIVEN_NAME, FAMILY_NAME];
 
 const mockIsAvailableAsync = isAvailableAsync as unknown as jest.Mock;
 const mockSignInAsync = signInAsync as unknown as jest.Mock;
@@ -153,6 +160,22 @@ function cancelRejection(): Error {
 function payloadFor(index: number): Record<string, unknown> {
   const [payload] = mockOauthApple.mock.calls[index] as [Record<string, unknown>];
   return payload;
+}
+
+/**
+ * Every argument handed to every persistence entry point, as one searchable
+ * string — a leak through any of them, not just ``saveToken``, is a leak.
+ */
+function persistedArguments(): string {
+  const calls = Object.values(authStorage)
+    .map((entry) => (entry as unknown as { mock?: { calls: unknown[][] } }).mock?.calls)
+    .filter((entry) => entry !== undefined);
+  expect(calls).not.toHaveLength(0);
+  return JSON.stringify(calls);
+}
+
+function expectNoAppleSecrets(serialized: string): void {
+  for (const secret of APPLE_ONLY_SECRETS) expect(serialized).not.toContain(secret);
 }
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -257,6 +280,9 @@ describe('useAppleAuth — request payload', () => {
     [{ givenName: GIVEN_NAME, familyName: FAMILY_NAME }, JOINED_NAME],
     [{ givenName: GIVEN_NAME }, GIVEN_NAME],
     [{ familyName: FAMILY_NAME }, FAMILY_NAME],
+    // Each part is trimmed before the join, never after: joining first would
+    // leave the padding buried inside the name as ``Ada   Lovelace``.
+    [{ givenName: `  ${GIVEN_NAME}  `, familyName: FAMILY_NAME }, JOINED_NAME],
   ];
 
   it.each(NAME_CASES)('joins the name parts %o into full_name %p', async (parts, expected) => {
@@ -380,27 +406,41 @@ describe('useAppleAuth — cancellation', () => {
 });
 
 describe('useAppleAuth — unexpected failures', () => {
-  it('surfaces the fallback copy when the credential carries no identity token', async () => {
-    mockSignInAsync.mockResolvedValueOnce(appleCredential({ identityToken: null }));
-    const harness = await readyHarness();
+  // Both spellings mean the same thing — the sheet came back with nothing to
+  // exchange — and an empty token is no more sendable than an absent one.
+  const ABSENT_TOKEN_CASES: Array<[string, string | null]> = [
+    ['is null', null],
+    ['is an empty string', ''],
+  ];
 
-    await pressSignIn(harness);
+  it.each(ABSENT_TOKEN_CASES)(
+    'surfaces the fallback copy when the identity token %s',
+    async (_label, identityToken) => {
+      mockSignInAsync.mockResolvedValueOnce(appleCredential({ identityToken }));
+      const harness = await readyHarness();
 
-    expect(harness.result.current.apple.error).toBe(APPLE_FALLBACK_COPY);
-    expect(harness.result.current.apple.status).toBe('idle');
-    expect(harness.result.current.apple.submitting).toBe(false);
-    expect(mockOauthApple).not.toHaveBeenCalled();
-  });
+      await pressSignIn(harness);
 
-  it('releases the guard after a token-less credential so the user can retry', async () => {
-    mockSignInAsync.mockResolvedValueOnce(appleCredential({ identityToken: null }));
-    const harness = await readyHarness();
-    await pressSignIn(harness);
+      expect(harness.result.current.apple.error).toBe(APPLE_FALLBACK_COPY);
+      expect(harness.result.current.apple.status).toBe('idle');
+      expect(harness.result.current.apple.submitting).toBe(false);
+      expect(mockOauthApple).not.toHaveBeenCalled();
+    },
+  );
 
-    await pressSignIn(harness);
+  it.each(ABSENT_TOKEN_CASES)(
+    'releases the guard, with no exchange spent, when the identity token %s',
+    async (_label, identityToken) => {
+      mockSignInAsync.mockResolvedValue(appleCredential({ identityToken }));
+      const harness = await readyHarness();
+      await pressSignIn(harness);
 
-    expect(mockSignInAsync).toHaveBeenCalledTimes(2);
-  });
+      await pressSignIn(harness);
+
+      expect(mockSignInAsync).toHaveBeenCalledTimes(2);
+      expect(mockOauthApple).not.toHaveBeenCalled();
+    },
+  );
 
   // A cancel is silent; anything else is a real failure and must say so.
   it('surfaces the fallback copy when the Apple sheet fails for any other reason', async () => {
@@ -453,6 +493,33 @@ describe('useAppleAuth — token hygiene', () => {
     expect(serialized).not.toContain(GIVEN_NAME);
     expect(harness.result.current.apple.error).not.toContain(APPLE_ID_TOKEN);
     expect(harness.result.current.apple.error).not.toContain(GIVEN_NAME);
+  });
+
+  // Serializing the hook's return value only reaches its three plain fields, so
+  // the invariant that actually matters — nothing reaches the disk — has to be
+  // read off the persistence layer's own call records.
+  it('writes nothing to storage while the license step holds the credential', async () => {
+    const harness = await readyHarness();
+    await reachLicenseStep(harness, namedCredential());
+
+    expect(mockSaveToken).not.toHaveBeenCalled();
+    expectNoAppleSecrets(JSON.stringify(mockSaveToken.mock.calls));
+    expectNoAppleSecrets(persistedArguments());
+  });
+
+  it('persists the session token and nothing else once the exchange succeeds', async () => {
+    mockSignInAsync.mockResolvedValueOnce(namedCredential());
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(harness.result.current.auth.authStatus).toBe('authenticated'));
+    expect(mockSaveToken.mock.calls).toEqual([[SESSION_JWT]]);
+    expectNoAppleSecrets(JSON.stringify(mockSaveToken.mock.calls));
+    // The session JWT proves the sweep really reads the persistence layer, so
+    // the absences below are findings rather than an empty search.
+    expect(persistedArguments()).toContain(SESSION_JWT);
+    expectNoAppleSecrets(persistedArguments());
   });
 });
 

--- a/frontend/src/features/Auth/__tests__/useAppleAuth.test.tsx
+++ b/frontend/src/features/Auth/__tests__/useAppleAuth.test.tsx
@@ -1,0 +1,541 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, afterEach, jest */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import {
+  isAvailableAsync,
+  signInAsync,
+  AppleAuthenticationUserDetectionStatus,
+  type AppleAuthenticationCredential,
+  type AppleAuthenticationFullName,
+} from 'expo-apple-authentication';
+import React from 'react';
+import { Platform } from 'react-native';
+
+jest.mock('expo-apple-authentication', () => ({
+  isAvailableAsync: jest.fn(() => Promise.resolve(true)),
+  signInAsync: jest.fn(),
+  AppleAuthenticationScope: { FULL_NAME: 0, EMAIL: 1 },
+  AppleAuthenticationUserDetectionStatus: { UNSUPPORTED: 0, UNKNOWN: 1, LIKELY_REAL: 2 },
+}));
+
+jest.mock('@/api', () => {
+  const actual = jest.requireActual('@/api');
+  return {
+    ApiError: actual.ApiError,
+    ApiTimeoutError: actual.ApiTimeoutError,
+    ApiValidationError: actual.ApiValidationError,
+    auth: {
+      oauthApple: jest.fn(),
+      oauthGoogle: jest.fn(),
+      login: jest.fn(),
+      signup: jest.fn(),
+      refresh: jest.fn(),
+      requestPasswordReset: jest.fn(),
+      confirmPasswordReset: jest.fn(),
+      cancelPasswordReset: jest.fn(),
+    },
+    setTokenGetter: jest.fn(),
+    setOnUnauthorized: jest.fn(),
+    setOnTokenRefreshed: jest.fn(),
+    resetLlmApiKey: jest.fn(),
+  };
+});
+
+jest.mock('@/storage/authStorage', () => ({
+  saveToken: jest.fn(() => Promise.resolve()),
+  loadToken: jest.fn(() => Promise.resolve(null)),
+  clearToken: jest.fn(() => Promise.resolve()),
+  markLogoutPending: jest.fn(() => Promise.resolve()),
+  isLogoutPending: jest.fn(() => Promise.resolve(false)),
+  clearLogoutPending: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@/utils/token', () => ({
+  decodeJwtPayload: jest.fn(() => null),
+  isTokenExpired: jest.fn(() => false),
+  shouldRefreshToken: jest.fn(() => false),
+  REFRESH_BUFFER_SECONDS: 300,
+}));
+
+jest.mock('@/utils/dateUtils', () => ({
+  ...jest.requireActual('@/utils/dateUtils'),
+  detectDeviceTimezone: jest.fn(() => 'America/Chicago'),
+}));
+
+import { useAppleAuth, useAppleSignInAvailable } from '../useAppleAuth';
+
+import { ApiError, auth } from '@/api';
+import { USER_FACING_ERROR_MESSAGES } from '@/api/errorMessages';
+import { AuthProvider, useAuth } from '@/context/AuthContext';
+import { loadToken, saveToken } from '@/storage/authStorage';
+
+const DEVICE_TIMEZONE = 'America/Chicago';
+const APPLE_ID_TOKEN = 'apple-id-token-header.apple-id-token-payload.apple-id-token-signature';
+const APPLE_USER_ID = '001234.abcdef0123456789abcdef0123456789.0000';
+const AUTHORIZATION_CODE = 'apple-authorization-code';
+const SESSION_JWT = 'session.jwt.signature';
+const VALID_LICENSE_KEY = 'A1B2C3D4-E5F6A7B8-C9D0E1F2-A3B4C5D6'; // pragma: allowlist secret
+const GIVEN_NAME = 'Ada';
+const FAMILY_NAME = 'Lovelace';
+const JOINED_NAME = 'Ada Lovelace';
+/** Asserted by value: the hook keeps its fallback copy module-private on purpose. */
+const APPLE_FALLBACK_COPY = "We couldn't finish that Apple sign-in. Try again in a moment.";
+/** The coded rejection ``expo-apple-authentication`` raises when the user backs out. */
+const CANCEL_CODE = 'ERR_REQUEST_CANCELED';
+
+const mockIsAvailableAsync = isAvailableAsync as unknown as jest.Mock;
+const mockSignInAsync = signInAsync as unknown as jest.Mock;
+const mockOauthApple = auth.oauthApple as unknown as jest.Mock;
+const mockSaveToken = saveToken as jest.MockedFunction<typeof saveToken>;
+const mockLoadToken = loadToken as jest.MockedFunction<typeof loadToken>;
+
+interface SessionResponse {
+  token: string;
+  user_id: number;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (_value: T) => void;
+  reject: (_reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (_value: T) => void = () => undefined;
+  let reject: (_reason: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function appleFullName(parts: Partial<AppleAuthenticationFullName>): AppleAuthenticationFullName {
+  return {
+    namePrefix: null,
+    givenName: null,
+    middleName: null,
+    familyName: null,
+    nameSuffix: null,
+    nickname: null,
+    ...parts,
+  };
+}
+
+function appleCredential(
+  overrides: Partial<AppleAuthenticationCredential> = {},
+): AppleAuthenticationCredential {
+  return {
+    user: APPLE_USER_ID,
+    state: null,
+    fullName: null,
+    email: null,
+    realUserStatus: AppleAuthenticationUserDetectionStatus.LIKELY_REAL,
+    identityToken: APPLE_ID_TOKEN,
+    authorizationCode: AUTHORIZATION_CODE,
+    ...overrides,
+  };
+}
+
+function namedCredential(): AppleAuthenticationCredential {
+  return appleCredential({
+    fullName: appleFullName({ givenName: GIVEN_NAME, familyName: FAMILY_NAME }),
+  });
+}
+
+/** The rejection shape Apple uses for "the user closed the sheet". */
+function cancelRejection(): Error {
+  return Object.assign(new Error('The user canceled the authorization attempt'), {
+    code: CANCEL_CODE,
+  });
+}
+
+function payloadFor(index: number): Record<string, unknown> {
+  const [payload] = mockOauthApple.mock.calls[index] as [Record<string, unknown>];
+  return payload;
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+function renderAppleAuth() {
+  return renderHook(() => ({ apple: useAppleAuth(), auth: useAuth() }), { wrapper });
+}
+
+type Harness = ReturnType<typeof renderAppleAuth>;
+
+async function readyHarness(): Promise<Harness> {
+  const harness = renderAppleAuth();
+  await waitFor(() => expect(harness.result.current.auth.authStatus).toBe('anonymous'));
+  return harness;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function pressSignIn(harness: Harness): Promise<void> {
+  await act(async () => {
+    harness.result.current.apple.signIn();
+  });
+  await flushMicrotasks();
+}
+
+/** Drive the flow to the inline license step and return the copy shown. */
+async function reachLicenseStep(
+  harness: Harness,
+  credential: AppleAuthenticationCredential,
+): Promise<string | null> {
+  mockSignInAsync.mockResolvedValueOnce(credential);
+  mockOauthApple.mockRejectedValueOnce(new ApiError(409, 'needs_license'));
+  await pressSignIn(harness);
+  await waitFor(() => expect(harness.result.current.apple.status).toBe('needsLicense'));
+  return harness.result.current.apple.error;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLoadToken.mockResolvedValue(null);
+  mockIsAvailableAsync.mockResolvedValue(true);
+  mockSignInAsync.mockResolvedValue(appleCredential());
+  mockOauthApple.mockResolvedValue({ token: SESSION_JWT, user_id: 9, timezone: DEVICE_TIMEZONE });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('useAppleAuth — success', () => {
+  it('authenticates the device when the exchange succeeds', async () => {
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(harness.result.current.auth.authStatus).toBe('authenticated'));
+    expect(mockSaveToken).toHaveBeenCalledWith(SESSION_JWT);
+    expect(harness.result.current.auth.token).toBe(SESSION_JWT);
+    expect(harness.result.current.auth.userTimezone).toBe(DEVICE_TIMEZONE);
+    expect(harness.result.current.apple.status).toBe('idle');
+    expect(harness.result.current.apple.error).toBeNull();
+  });
+
+  it('clears the pending credential once the exchange succeeds', async () => {
+    const harness = await readyHarness();
+    await pressSignIn(harness);
+    await waitFor(() => expect(harness.result.current.auth.authStatus).toBe('authenticated'));
+
+    mockOauthApple.mockClear();
+    await act(async () => {
+      harness.result.current.apple.submitLicenseKey(VALID_LICENSE_KEY);
+    });
+
+    expect(mockOauthApple).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAppleAuth — request payload', () => {
+  it('omits full_name entirely when Apple withholds the name', async () => {
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(mockOauthApple).toHaveBeenCalledTimes(1));
+    expect(mockOauthApple).toHaveBeenCalledWith({
+      id_token: APPLE_ID_TOKEN,
+      timezone: DEVICE_TIMEZONE,
+    });
+    expect(Object.keys(payloadFor(0))).not.toContain('full_name');
+  });
+
+  const NAME_CASES: Array<[Partial<AppleAuthenticationFullName>, string]> = [
+    [{ givenName: GIVEN_NAME, familyName: FAMILY_NAME }, JOINED_NAME],
+    [{ givenName: GIVEN_NAME }, GIVEN_NAME],
+    [{ familyName: FAMILY_NAME }, FAMILY_NAME],
+  ];
+
+  it.each(NAME_CASES)('joins the name parts %o into full_name %p', async (parts, expected) => {
+    mockSignInAsync.mockResolvedValueOnce(appleCredential({ fullName: appleFullName(parts) }));
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(mockOauthApple).toHaveBeenCalledTimes(1));
+    expect(mockOauthApple).toHaveBeenCalledWith({
+      id_token: APPLE_ID_TOKEN,
+      full_name: expected,
+      timezone: DEVICE_TIMEZONE,
+    });
+  });
+
+  const BLANK_NAME_CASES: Array<[string, Partial<AppleAuthenticationFullName>]> = [
+    ['every part is null', {}],
+    ['every supplied part is whitespace', { givenName: '   ', familyName: ' ' }],
+  ];
+
+  it.each(BLANK_NAME_CASES)('sends no full_name key when %s', async (_label, parts) => {
+    mockSignInAsync.mockResolvedValueOnce(appleCredential({ fullName: appleFullName(parts) }));
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(mockOauthApple).toHaveBeenCalledTimes(1));
+    expect(Object.keys(payloadFor(0))).not.toContain('full_name');
+  });
+});
+
+describe('useAppleAuth — needs_license routing', () => {
+  it('routes a 409 to the license step without mutating auth state', async () => {
+    const harness = await readyHarness();
+
+    await reachLicenseStep(harness, appleCredential());
+
+    expect(harness.result.current.apple.status).toBe('needsLicense');
+    expect(harness.result.current.auth.authStatus).toBe('anonymous');
+    expect(harness.result.current.auth.token).toBeNull();
+    expect(mockSaveToken).not.toHaveBeenCalled();
+  });
+
+  // Apple hands over the user's name exactly once — on the very first
+  // authorization. If the license retry dropped it, that name is gone forever.
+  it('re-sends the same id token and name with the license key, without a second sheet', async () => {
+    const harness = await readyHarness();
+    await reachLicenseStep(harness, namedCredential());
+
+    mockOauthApple.mockResolvedValueOnce({ token: SESSION_JWT, user_id: 11 });
+    await act(async () => {
+      harness.result.current.apple.submitLicenseKey(VALID_LICENSE_KEY);
+    });
+
+    await waitFor(() => expect(harness.result.current.auth.authStatus).toBe('authenticated'));
+    expect(mockOauthApple).toHaveBeenNthCalledWith(2, {
+      id_token: APPLE_ID_TOKEN,
+      full_name: JOINED_NAME,
+      license_key: VALID_LICENSE_KEY,
+      timezone: DEVICE_TIMEZONE,
+    });
+    expect(mockSignInAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the user on the license step when the submitted key is also refused', async () => {
+    const harness = await readyHarness();
+    await reachLicenseStep(harness, appleCredential());
+
+    mockOauthApple.mockRejectedValueOnce(new ApiError(409, 'needs_license'));
+    await act(async () => {
+      harness.result.current.apple.submitLicenseKey(VALID_LICENSE_KEY);
+    });
+
+    await waitFor(() => expect(harness.result.current.apple.submitting).toBe(false));
+    expect(harness.result.current.apple.status).toBe('needsLicense');
+    expect(harness.result.current.auth.authStatus).toBe('anonymous');
+    expect(mockSignInAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useAppleAuth — anti-enumeration', () => {
+  it('shows byte-identical refusal copy before and after a license key is submitted', async () => {
+    const harness = await readyHarness();
+    const firstRefusal = await reachLicenseStep(harness, appleCredential());
+
+    mockOauthApple.mockRejectedValueOnce(new ApiError(409, 'needs_license'));
+    await act(async () => {
+      harness.result.current.apple.submitLicenseKey(VALID_LICENSE_KEY);
+    });
+    await waitFor(() => expect(harness.result.current.apple.submitting).toBe(false));
+    const secondRefusal = harness.result.current.apple.error;
+
+    expect(firstRefusal).toBe(USER_FACING_ERROR_MESSAGES.needs_license);
+    expect(secondRefusal).toBe(firstRefusal);
+  });
+});
+
+describe('useAppleAuth — cancellation', () => {
+  it('stays idle and silent when the user closes the Apple sheet', async () => {
+    mockSignInAsync.mockRejectedValueOnce(cancelRejection());
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    expect(mockOauthApple).not.toHaveBeenCalled();
+    expect(harness.result.current.apple.status).toBe('idle');
+    expect(harness.result.current.apple.error).toBeNull();
+    expect(harness.result.current.apple.submitting).toBe(false);
+  });
+
+  it('releases the in-flight guard so a cancelled sheet can be reopened', async () => {
+    mockSignInAsync.mockRejectedValueOnce(cancelRejection());
+    const harness = await readyHarness();
+    await pressSignIn(harness);
+
+    await pressSignIn(harness);
+
+    expect(mockSignInAsync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useAppleAuth — unexpected failures', () => {
+  it('surfaces the fallback copy when the credential carries no identity token', async () => {
+    mockSignInAsync.mockResolvedValueOnce(appleCredential({ identityToken: null }));
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    expect(harness.result.current.apple.error).toBe(APPLE_FALLBACK_COPY);
+    expect(harness.result.current.apple.status).toBe('idle');
+    expect(harness.result.current.apple.submitting).toBe(false);
+    expect(mockOauthApple).not.toHaveBeenCalled();
+  });
+
+  it('releases the guard after a token-less credential so the user can retry', async () => {
+    mockSignInAsync.mockResolvedValueOnce(appleCredential({ identityToken: null }));
+    const harness = await readyHarness();
+    await pressSignIn(harness);
+
+    await pressSignIn(harness);
+
+    expect(mockSignInAsync).toHaveBeenCalledTimes(2);
+  });
+
+  // A cancel is silent; anything else is a real failure and must say so.
+  it('surfaces the fallback copy when the Apple sheet fails for any other reason', async () => {
+    mockSignInAsync.mockRejectedValueOnce(new Error('boom'));
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    expect(harness.result.current.apple.error).toBe(APPLE_FALLBACK_COPY);
+    expect(harness.result.current.apple.status).toBe('idle');
+    expect(harness.result.current.apple.submitting).toBe(false);
+    expect(mockOauthApple).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAppleAuth — token hygiene', () => {
+  it('returns to idle and surfaces the invalid_oauth_token copy on a 401', async () => {
+    mockOauthApple.mockRejectedValueOnce(new ApiError(401, 'invalid_oauth_token'));
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+
+    await waitFor(() => expect(harness.result.current.apple.error).not.toBeNull());
+    expect(harness.result.current.apple.status).toBe('idle');
+    expect(harness.result.current.apple.error).toBe(USER_FACING_ERROR_MESSAGES.invalid_oauth_token);
+    expect(harness.result.current.auth.authStatus).toBe('anonymous');
+  });
+
+  it('discards the pending credential after a 401 so it can never be replayed', async () => {
+    mockOauthApple.mockRejectedValueOnce(new ApiError(401, 'invalid_oauth_token'));
+    const harness = await readyHarness();
+    await pressSignIn(harness);
+    await waitFor(() => expect(harness.result.current.apple.error).not.toBeNull());
+
+    mockOauthApple.mockClear();
+    await act(async () => {
+      harness.result.current.apple.submitLicenseKey(VALID_LICENSE_KEY);
+    });
+
+    expect(mockOauthApple).not.toHaveBeenCalled();
+  });
+
+  it('never leaks the identity token or the name into hook state or error copy', async () => {
+    const harness = await readyHarness();
+    await reachLicenseStep(harness, namedCredential());
+
+    const serialized = JSON.stringify(harness.result.current.apple);
+    expect(serialized).not.toContain(APPLE_ID_TOKEN);
+    expect(serialized).not.toContain(JOINED_NAME);
+    expect(serialized).not.toContain(GIVEN_NAME);
+    expect(harness.result.current.apple.error).not.toContain(APPLE_ID_TOKEN);
+    expect(harness.result.current.apple.error).not.toContain(GIVEN_NAME);
+  });
+});
+
+describe('useAppleAuth — in-flight guard', () => {
+  it('ignores a second tap while an exchange is already in flight', async () => {
+    const pending = deferred<SessionResponse>();
+    mockOauthApple.mockReturnValueOnce(pending.promise);
+    const harness = await readyHarness();
+
+    await pressSignIn(harness);
+    await waitFor(() => expect(mockOauthApple).toHaveBeenCalledTimes(1));
+
+    await pressSignIn(harness);
+
+    expect(mockSignInAsync).toHaveBeenCalledTimes(1);
+    expect(mockOauthApple).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve({ token: SESSION_JWT, user_id: 4 });
+    });
+  });
+
+  it('does not update state when the exchange settles after unmount', async () => {
+    const pending = deferred<SessionResponse>();
+    mockOauthApple.mockReturnValueOnce(pending.promise);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const harness = await readyHarness();
+    await pressSignIn(harness);
+    await waitFor(() => expect(mockOauthApple).toHaveBeenCalledTimes(1));
+
+    harness.unmount();
+    pending.reject(new ApiError(409, 'needs_license'));
+    await flushMicrotasks();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(mockSaveToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAppleSignInAvailable', () => {
+  it('reports available on iOS when Apple says the feature is there', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    mockIsAvailableAsync.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useAppleSignInAvailable());
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('stays unavailable on iOS when Apple reports the feature missing', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    mockIsAvailableAsync.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useAppleSignInAvailable());
+    await waitFor(() => expect(mockIsAvailableAsync).toHaveBeenCalledTimes(1));
+    await flushMicrotasks();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('treats a rejected availability probe as unavailable and stays quiet', async () => {
+    jest.replaceProperty(Platform, 'OS', 'ios');
+    mockIsAvailableAsync.mockRejectedValue(new Error('no native module'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useAppleSignInAvailable());
+    await waitFor(() => expect(mockIsAvailableAsync).toHaveBeenCalledTimes(1));
+    await flushMicrotasks();
+
+    expect(result.current).toBe(false);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  // Reading ``Platform.OS`` at module scope would make this unobservable, so
+  // the probe has to happen inside the effect.
+  it('never probes Apple off iOS', async () => {
+    jest.replaceProperty(Platform, 'OS', 'android');
+    mockIsAvailableAsync.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useAppleSignInAvailable());
+    await flushMicrotasks();
+
+    expect(result.current).toBe(false);
+    expect(mockIsAvailableAsync).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/Auth/auth.styles.ts
+++ b/frontend/src/features/Auth/auth.styles.ts
@@ -7,6 +7,7 @@ import {
   ink,
   onShowcase,
   surface,
+  touchTarget,
   type as typeRamp,
 } from '@/design/tokens';
 
@@ -96,6 +97,10 @@ export const authStyles = StyleSheet.create({
   dividerRow: { flexDirection: 'row', alignItems: 'center', marginBottom: SPACING.lg },
   dividerRule: { flex: 1, height: StyleSheet.hairlineWidth, backgroundColor: surface.hairline },
   dividerLabel: { color: ink.muted, marginHorizontal: SPACING.md },
+  // Apple renders its own button, so all we own is the box it sits in: full
+  // width like the Google button above it, and the shared 44dp floor that
+  // matches ``Button.base.minHeight`` and clears Apple's HIG minimum.
+  appleButton: { width: '100%', height: touchTarget.minimum, marginTop: SPACING.md },
   licenseStep: { marginTop: SPACING.lg },
   licenseStepLead: { color: ink.soft, marginBottom: SPACING.sm },
   link: { textAlign: 'center', color: ink.soft },

--- a/frontend/src/features/Auth/components/LicenseKeyField.tsx
+++ b/frontend/src/features/Auth/components/LicenseKeyField.tsx
@@ -20,11 +20,26 @@ const HELP_LINK_HIT_SLOP = {
   right: HELP_LINK_SLOP,
 };
 
+/**
+ * What the signup form's single license field answers to. Any screen that draws
+ * two of these at once — the social row, with both providers at their license
+ * step — must override all three, or it ships a duplicate accessible name and a
+ * testID two nodes answer to.
+ */
+const DEFAULT_ERROR_TEST_ID = 'signup-license-error';
+const DEFAULT_HELP_TEST_ID = 'signup-license-help';
+const DEFAULT_HELP_LABEL = 'Find your license key';
+
 interface LicenseKeyFieldProps extends TextInputProps {
   /** Inline, field-scoped error copy; hidden when null. */
   error?: string | null;
   /** Opens the "where do I find my key" help page. */
   onPressHelp: () => void;
+  /** Identifiers for the error slot and the help link, scoped by the caller when it draws more than one field. */
+  errorTestID?: string;
+  helpTestID?: string;
+  /** The help link's accessible name — likewise scoped when two links are on screen together. */
+  helpAccessibilityLabel?: string;
 }
 
 /**
@@ -39,10 +54,16 @@ interface LicenseKeyFieldProps extends TextInputProps {
  * while ``autoComplete="off"`` is what suppresses Android's autofill
  * heuristics (which otherwise fire regardless of ``textContentType``) and the
  * browser's form history on web.
+ *
+ * The input's own accessible name arrives through the spread, which is applied
+ * last so a caller drawing two fields can name each one for its provider.
  */
 export function LicenseKeyField({
   error,
   onPressHelp,
+  errorTestID = DEFAULT_ERROR_TEST_ID,
+  helpTestID = DEFAULT_HELP_TEST_ID,
+  helpAccessibilityLabel = DEFAULT_HELP_LABEL,
   ...rest
 }: LicenseKeyFieldProps): React.JSX.Element {
   return (
@@ -64,17 +85,17 @@ export function LicenseKeyField({
           accessibilityRole="alert"
           accessibilityLiveRegion="polite"
           style={styles.fieldError}
-          testID="signup-license-error"
+          testID={errorTestID}
         >
           {error}
         </Text>
       ) : null}
       <TouchableOpacity
-        accessibilityLabel="Find your license key"
+        accessibilityLabel={helpAccessibilityLabel}
         accessibilityRole="link"
         hitSlop={HELP_LINK_HIT_SLOP}
         onPress={onPressHelp}
-        testID="signup-license-help"
+        testID={helpTestID}
       >
         <Text style={styles.helpLink}>Where&apos;s my key?</Text>
       </TouchableOpacity>

--- a/frontend/src/features/Auth/socialFlow.ts
+++ b/frontend/src/features/Auth/socialFlow.ts
@@ -144,6 +144,11 @@ export function useSocialFlowController<C>(
 
   const exchange = useCallback(
     (credential: C, licenseKey?: string) => {
+      // A provider sheet can outlive the screen that opened it, and its promise
+      // settles into this callback afterwards. Refuse the whole exchange once
+      // unmounted, so the write below can never repopulate the credential the
+      // unmount cleanup just cleared.
+      if (!flow.current.mounted) return;
       flow.current.attempt += 1;
       const ticket = flow.current.attempt;
       flow.current.credential = credential;

--- a/frontend/src/features/Auth/socialFlow.ts
+++ b/frontend/src/features/Auth/socialFlow.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+
+import { validateLicenseKey } from './licenseKeyValidation';
+
+import { formatApiError } from '@/api/errorMessages';
+import type { SocialSignInResult } from '@/context/AuthContext';
+
+/** The single, deliberately vague refusal the backend returns for every non-cryptographic failure. */
+const NEEDS_LICENSE_REFUSAL = { status: 409, detail: 'needs_license' };
+
+/**
+ * The one refusal copy, shared by every provider. Resolved through
+ * ``formatApiError`` so it stays tied to the shared error-code map: both 409s —
+ * the first refusal and a refused key — must render byte-identical copy,
+ * because any difference between them would tell an attacker which of the
+ * collapsed causes actually fired. Nothing here may be specialised per
+ * provider for the same reason.
+ */
+const NEEDS_LICENSE_MESSAGE = formatApiError(NEEDS_LICENSE_REFUSAL);
+
+/** What the buttons render. ``needsLicense`` means: show the license step in place. */
+export interface SocialAuthView {
+  status: 'idle' | 'needsLicense';
+  error: string | null;
+  submitting: boolean;
+}
+
+const IDLE_VIEW: SocialAuthView = { status: 'idle', error: null, submitting: false };
+const PROMPTING_VIEW: SocialAuthView = { status: 'idle', error: null, submitting: true };
+
+/**
+ * Everything a flow must read or write synchronously, outside React state.
+ *
+ * ``credential`` is whatever the provider just issued — an ID token for Google,
+ * an ID token plus Apple's one-shot name for Apple — held here and nowhere
+ * else. Never React state, never AsyncStorage, and never navigation params,
+ * which serialize into persisted navigation state: a replayable credential must
+ * not survive the component instance that obtained it. ``attempt`` is the epoch
+ * that lets only the newest exchange write state; ``busy`` guards a second
+ * prompt; ``mounted`` drops a late settle.
+ */
+interface SocialFlow<C> {
+  credential: C | null;
+  attempt: number;
+  busy: boolean;
+  mounted: boolean;
+}
+
+/** Translate an exchange outcome into the view, using the provider's own fallback copy. */
+function viewFor(result: SocialSignInResult, fallbackCopy: string): SocialAuthView {
+  if (result.kind === 'success') return IDLE_VIEW;
+  if (result.kind === 'needs_license') {
+    return { status: 'needsLicense', error: NEEDS_LICENSE_MESSAGE, submitting: false };
+  }
+  return {
+    status: 'idle',
+    error: formatApiError(result.error, { fallback: fallbackCopy }),
+    submitting: false,
+  };
+}
+
+/**
+ * Apply an exchange outcome: keep the credential only while the license step is
+ * still live — a success or any failure discards it, so no path can replay a
+ * credential the server has already judged.
+ */
+function settle<C>(
+  flow: SocialFlow<C>,
+  credential: C,
+  result: SocialSignInResult,
+  fallbackCopy: string,
+): SocialAuthView {
+  const view = viewFor(result, fallbackCopy);
+  flow.credential = view.status === 'needsLicense' ? credential : null;
+  flow.busy = false;
+  return view;
+}
+
+/**
+ * Re-send the credential we are already holding, with the key the user typed.
+ * Validation runs first, so a key we can already tell is malformed costs no
+ * round trip; with nothing pending the submit is a silent no-op.
+ */
+function submitKey<C>(
+  flow: SocialFlow<C>,
+  key: string,
+  exchange: (_credential: C, _licenseKey: string) => void,
+  setView: Dispatch<SetStateAction<SocialAuthView>>,
+): void {
+  if (flow.busy) return;
+  const invalid = validateLicenseKey(key);
+  if (invalid !== null) {
+    setView((prev) => ({ ...prev, error: invalid }));
+    return;
+  }
+  if (flow.credential !== null) exchange(flow.credential, key);
+}
+
+/** Per-instance mutable flow state, wiped on unmount so nothing outlives the screen. */
+function useSocialFlow<C>(): MutableRefObject<SocialFlow<C>> {
+  const flow = useRef<SocialFlow<C>>({ credential: null, attempt: 0, busy: false, mounted: true });
+  useEffect(() => {
+    // The record itself is created once and never replaced, so the cleanup can
+    // safely close over it rather than re-reading the ref.
+    const state = flow.current;
+    state.mounted = true;
+    return () => {
+      state.mounted = false;
+      state.credential = null;
+    };
+  }, []);
+  return flow;
+}
+
+/** The provider-neutral half of a social sign-in hook. */
+export interface SocialFlowController<C> {
+  view: SocialAuthView;
+  /** True while a prompt or an exchange is already running. */
+  isBusy: () => boolean;
+  /** Arm the in-flight guard and show the "connecting" view before prompting. */
+  beginPrompt: () => void;
+  /** Trade the credential for a session; pass a license key on the retry leg. */
+  exchange: (_credential: C, _licenseKey?: string) => void;
+  /** Drop the guard and show ``message`` — ``null`` for an outcome the user chose. */
+  release: (_message: string | null) => void;
+  submitLicenseKey: (_key: string) => void;
+}
+
+/**
+ * The whole flow every provider shares: view state, the credential ref, the
+ * exchange with its epoch and mount guards, and the inline license retry.
+ *
+ * ``send`` is the only provider-specific piece — it forwards the held
+ * credential (and the key, when there is one) to the matching AuthContext
+ * action.
+ */
+export function useSocialFlowController<C>(
+  send: (_credential: C, _licenseKey: string | undefined) => Promise<SocialSignInResult>,
+  fallbackCopy: string,
+): SocialFlowController<C> {
+  const [view, setView] = useState<SocialAuthView>(IDLE_VIEW);
+  const flow = useSocialFlow<C>();
+
+  const exchange = useCallback(
+    (credential: C, licenseKey?: string) => {
+      flow.current.attempt += 1;
+      const ticket = flow.current.attempt;
+      flow.current.credential = credential;
+      flow.current.busy = true;
+      setView((prev) => ({ ...prev, error: null, submitting: true }));
+      void send(credential, licenseKey).then((result) => {
+        if (!flow.current.mounted || flow.current.attempt !== ticket) return;
+        setView(settle(flow.current, credential, result, fallbackCopy));
+      });
+    },
+    [fallbackCopy, flow, send],
+  );
+
+  const release = useCallback(
+    (message: string | null) => {
+      flow.current.busy = false;
+      if (!flow.current.mounted) return;
+      setView((prev) => ({ ...prev, error: message, submitting: false }));
+    },
+    [flow],
+  );
+
+  const beginPrompt = useCallback(() => {
+    flow.current.credential = null;
+    flow.current.busy = true;
+    setView(PROMPTING_VIEW);
+  }, [flow]);
+
+  const isBusy = useCallback(() => flow.current.busy, [flow]);
+
+  const submitLicenseKey = useCallback(
+    (key: string) => submitKey(flow.current, key, exchange, setView),
+    [exchange, flow],
+  );
+
+  return { view, isBusy, beginPrompt, exchange, release, submitLicenseKey };
+}

--- a/frontend/src/features/Auth/useAppleAuth.ts
+++ b/frontend/src/features/Auth/useAppleAuth.ts
@@ -57,11 +57,16 @@ function joinFullName(fullName: AppleAuthenticationFullName | null): string | un
  * Ask Apple to authorize us. Returns ``null`` when the sheet came back without
  * an identity token: there is nothing to exchange, and no reason to spend a
  * round trip finding that out.
+ *
+ * Absent and blank are the same answer. A whitespace-only token is a dead
+ * sheet dressed as a credential — not something to ask the server to judge —
+ * so both spellings take the identical fallback path.
  */
 async function requestAppleCredential(): Promise<AppleCredential | null> {
   const credential = await signInAsync({ requestedScopes: REQUESTED_SCOPES });
-  if (credential.identityToken === null) return null;
-  return { idToken: credential.identityToken, fullName: joinFullName(credential.fullName) };
+  const idToken = credential.identityToken;
+  if (idToken === null || idToken.trim() === '') return null;
+  return { idToken, fullName: joinFullName(credential.fullName) };
 }
 
 /**

--- a/frontend/src/features/Auth/useAppleAuth.ts
+++ b/frontend/src/features/Auth/useAppleAuth.ts
@@ -1,0 +1,141 @@
+import {
+  isAvailableAsync,
+  signInAsync,
+  AppleAuthenticationScope,
+  type AppleAuthenticationFullName,
+} from 'expo-apple-authentication';
+import { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { useSocialFlowController, type SocialAuthView } from './socialFlow';
+
+import { useAuth } from '@/context/AuthContext';
+
+/** Copy for failures with no backend code of their own (a dead Apple sheet). */
+const APPLE_FALLBACK = "We couldn't finish that Apple sign-in. Try again in a moment.";
+
+/** The coded rejection Apple raises when the user backs out of the sheet. */
+const USER_CANCELED_CODE = 'ERR_REQUEST_CANCELED';
+
+/**
+ * The name is asked for because Apple will never offer it again, and the email
+ * because the ladder needs an address the provider has vouched for. Both arrive
+ * only on the very first authorization.
+ */
+const REQUESTED_SCOPES = [AppleAuthenticationScope.FULL_NAME, AppleAuthenticationScope.EMAIL];
+
+/**
+ * What one Apple authorization is worth to us: the token the backend verifies,
+ * and the one-shot name that must survive as far as the request which creates
+ * the account.
+ */
+interface AppleCredential {
+  idToken: string;
+  fullName?: string;
+}
+
+/** Public shape of the flow, as {@link useAppleAuth} hands it to the UI. */
+export interface AppleAuthState extends SocialAuthView {
+  signIn: () => void;
+  submitLicenseKey: (_key: string) => void;
+}
+
+/**
+ * Apple hands the name over in parts, any of which may be absent or blank.
+ * Given name first, family name second, one space between whatever survives —
+ * and nothing at all when nothing does, because an empty string would write a
+ * blank display name over the column's honest ``NULL``.
+ */
+function joinFullName(fullName: AppleAuthenticationFullName | null): string | undefined {
+  const parts = [fullName?.givenName, fullName?.familyName]
+    .map((part) => part?.trim() ?? '')
+    .filter((part) => part.length > 0);
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+/**
+ * Ask Apple to authorize us. Returns ``null`` when the sheet came back without
+ * an identity token: there is nothing to exchange, and no reason to spend a
+ * round trip finding that out.
+ */
+async function requestAppleCredential(): Promise<AppleCredential | null> {
+  const credential = await signInAsync({ requestedScopes: REQUESTED_SCOPES });
+  if (credential.identityToken === null) return null;
+  return { idToken: credential.identityToken, fullName: joinFullName(credential.fullName) };
+}
+
+/**
+ * A closed sheet is the user's decision, not a failure — it gets silence. Read
+ * the code defensively: a rejection is only conventionally an object.
+ */
+function isUserCancellation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  return 'code' in err && err.code === USER_CANCELED_CODE;
+}
+
+/**
+ * "Continue with Apple": authorize, trade the identity token for a session, and
+ * fall into the inline license step when the server asks for a key.
+ *
+ * The credential — token *and* name — is held by the shared flow for the life
+ * of the exchange and re-sent on the license retry, because that retry is the
+ * request that creates the row and Apple will not offer the name a second time.
+ * The sheet therefore opens exactly once per attempt.
+ */
+export function useAppleAuth(): AppleAuthState {
+  const { loginWithApple } = useAuth();
+
+  const send = useCallback(
+    (credential: AppleCredential, licenseKey: string | undefined) =>
+      loginWithApple(credential.idToken, credential.fullName, licenseKey),
+    [loginWithApple],
+  );
+
+  const { view, isBusy, beginPrompt, exchange, release, submitLicenseKey } =
+    useSocialFlowController<AppleCredential>(send, APPLE_FALLBACK);
+
+  const signIn = useCallback(() => {
+    if (isBusy()) return;
+    beginPrompt();
+    void requestAppleCredential().then(
+      (credential) => {
+        if (credential === null) release(APPLE_FALLBACK);
+        else exchange(credential);
+      },
+      (err: unknown) => release(isUserCancellation(err) ? null : APPLE_FALLBACK),
+    );
+  }, [beginPrompt, exchange, isBusy, release]);
+
+  return { ...view, signIn, submitLicenseKey };
+}
+
+/**
+ * Whether this device can offer Sign in with Apple (iOS 13+ only).
+ *
+ * ``Platform.OS`` is read inside the effect rather than at module scope: the
+ * platform is a run-time fact, and freezing it at import time would make the
+ * off-iOS branch unobservable. A rejected probe — an older OS, or a build with
+ * no native module — simply leaves the option hidden, which is the honest
+ * outcome and not something to log about.
+ */
+export function useAppleSignInAvailable(): boolean {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return undefined;
+    let live = true;
+    void isAvailableAsync().then(
+      (supported) => {
+        if (live) setAvailable(supported);
+      },
+      () => {
+        /* unsupported platform or missing native module: stay hidden, stay quiet */
+      },
+    );
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return available;
+}

--- a/frontend/src/features/Auth/useGoogleAuth.ts
+++ b/frontend/src/features/Auth/useGoogleAuth.ts
@@ -1,15 +1,12 @@
 import { useAuthRequest } from 'expo-auth-session/providers/google';
 import * as WebBrowser from 'expo-web-browser';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Platform } from 'react-native';
 
-import { validateLicenseKey } from './licenseKeyValidation';
 import { googleClientIds } from './oauthConfig';
+import { useSocialFlowController, type SocialAuthView } from './socialFlow';
 
-import { formatApiError } from '@/api/errorMessages';
 import { useAuth } from '@/context/AuthContext';
-import type { GoogleSignInResult } from '@/context/AuthContext';
 
 // Completes the redirect leg on web, where the auth session finishes in a
 // popup that has to hand its result back to this window. Must run at module
@@ -32,111 +29,15 @@ const GOOGLE_REQUEST_CONFIG = {
   responseType: Platform.OS === 'web' ? ID_TOKEN_RESPONSE_TYPE : undefined,
 };
 
-/** The single, deliberately vague refusal the backend returns for every non-cryptographic failure. */
-const NEEDS_LICENSE_REFUSAL = { status: 409, detail: 'needs_license' };
-
-/**
- * The one refusal copy. Resolved through ``formatApiError`` so it stays tied to
- * the shared error-code map: both 409s — the first refusal and a refused key —
- * must render byte-identical copy, because any difference between them would
- * tell an attacker which of the collapsed causes actually fired.
- */
-const NEEDS_LICENSE_MESSAGE = formatApiError(NEEDS_LICENSE_REFUSAL);
-
 /** Copy for failures with no backend code of their own (a dead browser sheet). */
 const GOOGLE_FALLBACK = "We couldn't finish that Google sign-in. Try again in a moment.";
 
 type GoogleAuthResponse = ReturnType<typeof useAuthRequest>[1];
 
-/** What the buttons render. ``needsLicense`` means: show the license step in place. */
-interface GoogleAuthView {
-  status: 'idle' | 'needsLicense';
-  error: string | null;
-  submitting: boolean;
-}
-
 /** Public shape of the flow, as {@link useGoogleAuth} hands it to the UI. */
-export interface GoogleAuthState extends GoogleAuthView {
+export interface GoogleAuthState extends SocialAuthView {
   signIn: () => void;
   submitLicenseKey: (_key: string) => void;
-}
-
-const IDLE_VIEW: GoogleAuthView = { status: 'idle', error: null, submitting: false };
-const PROMPTING_VIEW: GoogleAuthView = { status: 'idle', error: null, submitting: true };
-
-/**
- * Everything the flow must read or write synchronously, outside React state.
- *
- * ``idToken`` is the credential Google just issued, held here — never in state,
- * AsyncStorage, or navigation params — so it lives and dies with this component
- * instance. ``attempt`` is the epoch that lets only the newest exchange write
- * state; ``busy`` guards a second prompt; ``mounted`` drops a late settle.
- */
-interface GoogleFlow {
-  idToken: string | null;
-  attempt: number;
-  busy: boolean;
-  mounted: boolean;
-}
-
-function viewFor(result: GoogleSignInResult): GoogleAuthView {
-  if (result.kind === 'success') return IDLE_VIEW;
-  if (result.kind === 'needs_license') {
-    return { status: 'needsLicense', error: NEEDS_LICENSE_MESSAGE, submitting: false };
-  }
-  return {
-    status: 'idle',
-    error: formatApiError(result.error, { fallback: GOOGLE_FALLBACK }),
-    submitting: false,
-  };
-}
-
-/**
- * Apply an exchange outcome: keep the ID token only while the license step is
- * still live — a success or any failure discards it, so no path can replay a
- * token the server has already judged.
- */
-function settle(flow: GoogleFlow, idToken: string, result: GoogleSignInResult): GoogleAuthView {
-  const view = viewFor(result);
-  flow.idToken = view.status === 'needsLicense' ? idToken : null;
-  flow.busy = false;
-  return view;
-}
-
-/**
- * Re-send the token we are already holding, with the key the user typed.
- * Validation runs first, so a key we can already tell is malformed costs no
- * round trip; with nothing pending the submit is a silent no-op.
- */
-function submitKey(
-  flow: GoogleFlow,
-  key: string,
-  exchange: (_idToken: string, _licenseKey: string) => void,
-  setView: Dispatch<SetStateAction<GoogleAuthView>>,
-): void {
-  if (flow.busy) return;
-  const invalid = validateLicenseKey(key);
-  if (invalid !== null) {
-    setView((prev) => ({ ...prev, error: invalid }));
-    return;
-  }
-  if (flow.idToken !== null) exchange(flow.idToken, key);
-}
-
-/** Per-instance mutable flow state, wiped on unmount so nothing outlives the screen. */
-function useGoogleFlow(): MutableRefObject<GoogleFlow> {
-  const flow = useRef<GoogleFlow>({ idToken: null, attempt: 0, busy: false, mounted: true });
-  useEffect(() => {
-    // The record itself is created once and never replaced, so the cleanup can
-    // safely close over it rather than re-reading the ref.
-    const state = flow.current;
-    state.mounted = true;
-    return () => {
-      state.mounted = false;
-      state.idToken = null;
-    };
-  }, []);
-  return flow;
 }
 
 /**
@@ -170,51 +71,23 @@ function useResponseBridge(
  * "Continue with Google": prompt for an ID token, trade it for a session, and
  * fall into the inline license step when the server asks for a key.
  *
- * The only module in the app that talks to ``expo-auth-session``.
+ * The only module in the app that talks to ``expo-auth-session``. Everything
+ * that is not Google-shaped — the held credential, the epoch and mount guards,
+ * the license retry — lives in the shared flow controller.
  */
 export function useGoogleAuth(): GoogleAuthState {
   const { loginWithGoogle } = useAuth();
   const [, response, promptAsync] = useAuthRequest(GOOGLE_REQUEST_CONFIG);
-  const [view, setView] = useState<GoogleAuthView>(IDLE_VIEW);
-  const flow = useGoogleFlow();
-
-  const exchange = useCallback(
-    (idToken: string, licenseKey?: string) => {
-      flow.current.attempt += 1;
-      const ticket = flow.current.attempt;
-      flow.current.idToken = idToken;
-      flow.current.busy = true;
-      setView((prev) => ({ ...prev, error: null, submitting: true }));
-      void loginWithGoogle(idToken, licenseKey).then((result) => {
-        if (!flow.current.mounted || flow.current.attempt !== ticket) return;
-        setView(settle(flow.current, idToken, result));
-      });
-    },
-    [flow, loginWithGoogle],
-  );
-
-  const release = useCallback(
-    (message: string | null) => {
-      flow.current.busy = false;
-      setView((prev) => ({ ...prev, error: message, submitting: false }));
-    },
-    [flow],
-  );
+  const { view, isBusy, beginPrompt, exchange, release, submitLicenseKey } =
+    useSocialFlowController<string>(loginWithGoogle, GOOGLE_FALLBACK);
 
   useResponseBridge(response, exchange, release);
 
   const signIn = useCallback(() => {
-    if (flow.current.busy) return;
-    flow.current.idToken = null;
-    flow.current.busy = true;
-    setView(PROMPTING_VIEW);
+    if (isBusy()) return;
+    beginPrompt();
     void promptAsync().catch(() => release(GOOGLE_FALLBACK));
-  }, [flow, promptAsync, release]);
-
-  const submitLicenseKey = useCallback(
-    (key: string) => submitKey(flow.current, key, exchange, setView),
-    [exchange, flow],
-  );
+  }, [beginPrompt, isBusy, promptAsync, release]);
 
   return { ...view, signIn, submitLicenseKey };
 }


### PR DESCRIPTION
## Summary

- Adds **Continue with Apple** beside Continue with Google in the social auth row, exchanging Apple's identity token at `POST /auth/oauth/apple` (the endpoint shipped in #1988). A `409 needs_license` drops into the same inline Gumroad license step Google already uses, so finishing signup costs one field and never a second trip through the Apple sheet. This closes App Store guideline 4.8 for shipping Google login on iOS.
- **Apple's name arrives exactly once, on the very first authorization, and never again.** The joined name is held alongside the identity token in the component-instance flow ref and re-sent on the license-retry leg — that retry is the request that creates the account, so dropping the name there would lose it permanently. `expo-apple-authentication@~7.1.3` (the Expo SDK 52 line) and `ios.usesAppleSignIn: true` land the entitlement.
- Factors the provider-neutral half of the Google hook into `socialFlow.ts`; both providers now share one implementation of credential hygiene, the epoch/in-flight/mount guards, and the inline license retry, so they cannot drift apart.

### Decisions worth stating

**The credential never enters persisted state.** Identity token and name live in a `useRef` for the life of the exchange — never React state, never AsyncStorage, and never navigation params, which serialize into persisted navigation state where a replayable credential must not survive. Both are discarded on success, on any refusal, on a new attempt, and on unmount; the exchange now refuses to run at all once unmounted, so a sheet that outlives its screen cannot repopulate a cleared ref.

**The 409 copy is deliberately generic and byte-identical** across the first refusal and a refused retry key, and identical across both providers — with a test asserting that identity. The backend collapses every non-cryptographic refusal (no license, a bad license, an unverified or absent email, a disabled account) into one indistinguishable 409 precisely to kill an account-enumeration oracle; making the Apple message more specific, or branching it per cause, would rebuild that oracle in the client. Same reasoning as #1990.

**`loginWithApple(idToken, fullName?, licenseKey?)` departs from the issue body's `loginWithApple(licenseKey?)` on purpose** — the same departure `loginWithGoogle` already made. The context takes the credential per call and never retains it; the caller owns its lifetime.

**`invalid_oauth_token` copy is now provider-neutral.** Both OAuth routes return that one detail string, so `'That Google sign-in could not be verified.'` misattributed half of those failures to the wrong provider.

**A duplicate accessible name became reachable with a second provider.** Google and Apple can each sit at the license step simultaneously and nothing disables the other's button, so a screen reader and voice control were handed two identically-named fields, help links, and submit buttons plus a colliding testID. Every identifier is now suffixed with the provider whose step it belongs to; `LicenseKeyField` keeps its old unscoped values as defaults, leaving the signup form's single field untouched.

**Apple's button is Apple's own `AppleAuthenticationButton`**, as their HIG and the App Store guidelines require — never a facsimile — which also means it has no `disabled` prop, so the in-flight guard lives in the press handler. It sits in the same full-width 44dp box as the Google button and flips light/dark against the theme. It mounts only where `isAvailableAsync()` reports support (a capability check, not just `Platform.OS`), so Android and web render no slot at all: no placeholder, no layout shift. `Platform.OS` is read inside the effect rather than at module scope so the off-iOS branch stays observable.

## Test plan

- `./scripts/frontend/check-all.sh` → exit 0. All five checks green: audit gate (`audit-gate.mjs`, clean with the one pre-existing allowlisted advisory — the new dependency added no transitives), ESLint `--max-warnings=0` with sonarjs + unicorn, Prettier, `tsc --noEmit` strict, Jest **445 suites / 5166 tests**.
- `pre-commit` ran on both commits: eslint, prettier, typecheck, frontend tests, detect-secrets, commitlint all pass.
- TDD throughout: tests written first and observed RED (`Cannot find module '../useAppleAuth'`, missing `auth.oauthApple`, Google-branded 401 copy), then GREEN. The a11y-scoping fix was likewise RED first (12 failures) before implementation.
- New `useAppleAuth.test.tsx` (33 tests) covers: success → authenticated; `full_name` omitted as a *key* when Apple withholds the name; the join cases including trim-then-join ordering; **the name surviving the license-retry leg with `signInAsync` called exactly once**; 409 → license step with auth state untouched; byte-identical refusal copy; `ERR_REQUEST_CANCELED` silent with the guard released; a null *or* blank identity token taking the fallback path with no round trip; any other sheet rejection surfacing copy; 401 discarding the credential so it can never be replayed; the token and name absent from every storage call; the in-flight guard; a post-unmount settle writing nothing; and `useAppleSignInAvailable` true/false/rejected on iOS and never probing off it.
- `SocialAuthButtons.test.tsx` extended to 23 tests: Apple below Google, no slot and no placeholder when unavailable (with the baseline asserted so an always-null component cannot satisfy it), the row surviving an unconfigured Google without ever calling the Google hook, per-provider press/busy/license routing, scoped labels and testIDs with both license steps open, and the theme-contrast button style.
- `useGoogleAuth.test.tsx` (489 lines, 24 tests) and `SignupScreen.test.tsx` are **unmodified** and green — they are the safety net for the `socialFlow.ts` extraction.
- Gate 2.5: `code-review-orchestrator` returned **CLEAN** (security, implementation, test, and dependency reviewers, no blockers). Its non-blocking findings are addressed in the second commit.

Backend-only note: no migration, no backend change — `/auth/oauth/apple`, the `AuthIdentity` model, and the first-auth `display_name` write already shipped.

Closes #1951
Refs #1947
