### PR TITLE
fix(frontend): stop the unbounded stage auto-refetch loop on the Map

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -67,6 +67,31 @@ const styles = StyleSheet.create({
     textAlign: CENTER,
     paddingHorizontal: spacing(2),
   },
+  // The human "what to do next" line under the verbatim server message.
+  errorHint: {
+    color: ink.muted,
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: CENTER,
+    marginTop: spacing(1),
+    paddingHorizontal: spacing(2),
+  },
+  // Stacked under the message in the centered layout rather than sitting inline
+  // like the refresh banner's retry, so it needs its own top margin.
+  errorRetry: {
+    marginTop: spacing(2),
+    minHeight: touchTarget.minimum,
+    justifyContent: CENTER,
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2),
+    borderRadius: radius.sm,
+    backgroundColor: accent.primary,
+  },
+  errorRetryText: {
+    ...editorialType.action,
+    color: accent.onPrimary,
+    textAlign: CENTER,
+  },
 
   // --- The single responsive row grid --------------------------------------
   grid: {

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -882,9 +882,34 @@ const MapLoading = (): React.JSX.Element => (
   </View>
 );
 
-const MapError = ({ message }: { message: string }): React.JSX.Element => (
-  <View style={styles.centered} testID="map-error">
+// Cold-start failure: announce it, say what to do, and offer the same explicit
+// retry the refresh banner and history error use — never a silent auto-retry.
+const MapError = ({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}): React.JSX.Element => (
+  <View
+    style={styles.centered}
+    testID="map-error"
+    accessibilityRole="alert"
+    accessibilityLiveRegion="polite"
+  >
     <Text style={styles.errorText}>{message}</Text>
+    <Text style={styles.errorHint}>
+      Your map isn&apos;t lost — it just couldn&apos;t load. Check your connection and try again.
+    </Text>
+    <TouchableOpacity
+      onPress={onRetry}
+      accessibilityRole="button"
+      accessibilityLabel="Try again"
+      style={styles.errorRetry}
+      testID="map-error-retry"
+    >
+      <Text style={styles.errorRetryText}>Try again</Text>
+    </TouchableOpacity>
   </View>
 );
 
@@ -1319,11 +1344,14 @@ const MapScreen = (): React.JSX.Element => {
     [stages],
   );
 
+  // A failed load leaves the store at exactly {stages: [], loading: false}, so the
+  // ``error`` term is what stops this cold-start fetch re-firing forever. Recovery
+  // is the retry button: loadStages clears ``error`` itself, re-arming the guard.
   useEffect(() => {
-    if (stages.length === 0 && !loading) {
+    if (stages.length === 0 && !loading && !error) {
       void stageService.loadStages();
     }
-  }, [stages.length, loading]);
+  }, [stages.length, loading, error]);
 
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
@@ -1333,7 +1361,7 @@ const MapScreen = (): React.JSX.Element => {
   const { drawer, onDrawerSelectStage } = useMapDrawer(lens);
 
   if (loading && stages.length === 0) return <MapLoading />;
-  if (error && stages.length === 0) return <MapError message={error} />;
+  if (error && stages.length === 0) return <MapError message={error} onRetry={handleRefresh} />;
 
   return (
     <MapContent

--- a/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenColdStart.test.tsx
@@ -8,7 +8,7 @@ import { act, create } from 'react-test-renderer';
 import styles from '../Map.styles';
 import MapScreen from '../MapScreen';
 
-import { mockMapState, resetMapMocks } from './mapTestHarness';
+import { mockLoadStages, mockMapState, resetMapMocks } from './mapTestHarness';
 
 jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
   jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
@@ -39,6 +39,27 @@ jest.mock('../../../api', () => ({
 
 type TestNode = { props: Record<string, unknown> };
 
+const LOAD_ERROR_MESSAGE = 'Could not reach the server.';
+const TRY_AGAIN = 'Try again';
+/** Shortest string the hint line could plausibly be; keeps copy free while still requiring one. */
+const MIN_HINT_LENGTH = 8;
+
+/** The slice of a ``toJSON`` node this file reads; the renderer module ships no types. */
+interface RenderedNode {
+  children: (RenderedNode | string)[] | null;
+}
+
+const collectText = (node: RenderedNode | string | null): string[] => {
+  if (node === null) return [];
+  if (typeof node === 'string') return [node];
+  return (node.children ?? []).flatMap((child) => collectText(child));
+};
+
+const renderedText = (tree: ReturnType<typeof create>): string[] => {
+  const rendered = tree.toJSON();
+  return (Array.isArray(rendered) ? rendered : [rendered]).flatMap((node) => collectText(node));
+};
+
 describe('MapScreen — cold start and metadata edge cases', () => {
   beforeEach(() => {
     resetMapMocks();
@@ -60,6 +81,35 @@ describe('MapScreen — cold start and metadata edge cases', () => {
     const tree = create(<MapScreen />);
     expect(tree.root.findByProps({ testID: 'map-error' })).toBeTruthy();
     expect(tree.root.findByProps({ children: 'Could not reach the server.' })).toBeTruthy();
+  });
+
+  it('announces the cold-start error and offers a retry that reloads the stages', () => {
+    mockMapState.error = LOAD_ERROR_MESSAGE;
+    mockMapState.stages = [];
+    let tree!: ReturnType<typeof create>;
+    act(() => {
+      tree = create(<MapScreen />);
+    });
+
+    const container = tree.root.findByProps({ testID: 'map-error' });
+    expect(container.props.accessibilityRole).toBe('alert');
+    expect(container.props.accessibilityLiveRegion).toBe('polite');
+
+    // A hint line sits alongside the verbatim server message and the button label.
+    const hints = renderedText(tree).filter(
+      (text) =>
+        text !== LOAD_ERROR_MESSAGE && text !== TRY_AGAIN && text.trim().length >= MIN_HINT_LENGTH,
+    );
+    expect(hints).toHaveLength(1);
+
+    const retry = tree.root.findByProps({ testID: 'map-error-retry' });
+    expect(retry.props.accessibilityRole).toBe('button');
+    expect(retry.props.accessibilityLabel).toBe(TRY_AGAIN);
+
+    // A failed cold start must not re-arm itself: the only load is the user's.
+    expect(mockLoadStages).not.toHaveBeenCalled();
+    act(() => retry.props.onPress());
+    expect(mockLoadStages).toHaveBeenCalledTimes(1);
   });
 
   it('omits the free-will description line for a stage that has none', () => {

--- a/frontend/src/features/Map/__tests__/MapScreenRefetchLoop.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenRefetchLoop.test.tsx
@@ -1,0 +1,169 @@
+/* eslint-env jest */
+/* global describe, it, expect, beforeEach, afterEach, jest */
+// The sibling MapScreen suites mock both the stage store and the stage service, so a
+// failed cold-start load never flips real loading/error state. This suite keeps both
+// real and mocks only the network, making the fetch effect's re-entry observable.
+import React from 'react';
+import { Image } from 'react-native';
+import { act, create } from 'react-test-renderer';
+
+import type { Stage } from '../../../api';
+import { useStageStore } from '../../../store/useStageStore';
+import MapScreen from '../MapScreen';
+
+import { mockMapState, resetMapMocks } from './mapTestHarness';
+
+jest.mock('react-native/Libraries/Interaction/InteractionManager', () =>
+  jest.requireActual('./mapTestHarness').mockInteractionManagerModule(),
+);
+jest.mock('../../../navigation/hooks', () =>
+  jest.requireActual('./mapTestHarness').mockNavigationModule(),
+);
+jest.mock('@react-navigation/bottom-tabs', () =>
+  jest.requireActual('./mapTestHarness').mockBottomTabsModule(),
+);
+jest.mock('react-native-safe-area-context', () =>
+  jest.requireActual('./mapTestHarness').mockSafeAreaModule(),
+);
+jest.mock('../../../store/useProgramProgression', () =>
+  jest.requireActual('./mapTestHarness').mockProgramProgressionModule(),
+);
+// The real wheel hook reads a ``wheel`` client this suite's stages-only api mock omits.
+jest.mock('../hooks/useWheelBalance', () =>
+  jest.requireActual('./mapTestHarness').mockWheelBalanceModule(),
+);
+
+const mockListAll = jest.fn<Promise<Stage[]>, [string?]>();
+
+// Only the network boundary is mocked. A never-resolving history keeps the suite free of
+// async churn; the calendar rejects because ``loadStages`` swallows that failure by design.
+jest.mock('../../../api', () => ({
+  stages: {
+    listAll: (...args: [string?]) => mockListAll(...args),
+    history: () => new Promise(() => {}),
+    programCalendar: () => Promise.reject(new Error('calendar unavailable in tests')),
+    beginAgain: () => Promise.reject(new Error('begin-again unused in tests')),
+  },
+}));
+
+/** Bounded on purpose: on today's code the loader re-arms itself, so an unbounded waitFor never settles. */
+const FLUSH_ROUNDS = 8;
+const STAGE_TOTAL = 10;
+const LOAD_ERROR_MESSAGE = 'Could not reach the server.';
+const IMAGE_WIDTH = 100;
+const IMAGE_HEIGHT = 200;
+
+const makeWireStage = (stageNumber: number): Stage => ({
+  id: stageNumber,
+  title: `Stage ${stageNumber}`,
+  subtitle: `Subtitle ${stageNumber}`,
+  stage_number: stageNumber,
+  overview_url: '',
+  category: 'Test',
+  aspect: 'Aspect',
+  spiral_dynamics_color: 'Beige',
+  growing_up_stage: 'Growing',
+  divine_gender_polarity: 'Divine Feminine',
+  relationship_to_free_will: 'Free Will',
+  free_will_description: `Free will at stage ${stageNumber}.`,
+  is_unlocked: stageNumber === 1,
+  progress: 0,
+  manifestations: [],
+});
+
+const wireStages = (): Stage[] =>
+  Array.from({ length: STAGE_TOTAL }, (_, index) => makeWireStage(index + 1));
+
+let mounted: ReturnType<typeof create> | null = null;
+
+const renderMap = (): ReturnType<typeof create> => {
+  let tree!: ReturnType<typeof create>;
+  act(() => {
+    tree = create(<MapScreen />);
+  });
+  mounted = tree;
+  return tree;
+};
+
+// The drain deliberately lets background loads settle outside ``act``, so React's
+// legacy act environment is switched off for its duration and restored after.
+const actEnv = globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+
+/** Advance a fixed number of task turns so a retry storm is counted rather than awaited. */
+const flushRounds = async (): Promise<void> => {
+  const previous = actEnv.IS_REACT_ACT_ENVIRONMENT;
+  actEnv.IS_REACT_ACT_ENVIRONMENT = false;
+  try {
+    for (let round = 0; round < FLUSH_ROUNDS; round += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      act(() => {});
+    }
+  } finally {
+    actEnv.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+};
+
+describe('MapScreen — cold-start fetch is not a retry loop', () => {
+  beforeEach(() => {
+    resetMapMocks();
+    mockMapState.derivedStage = null;
+    mockMapState.derivedWeek = null;
+    // The real store is a module-level singleton, so it must be wiped between tests.
+    useStageStore.getState().reset();
+    mockListAll.mockReset();
+    jest
+      .spyOn(Image, 'getSize')
+      .mockImplementation((_, success) => success(IMAGE_WIDTH, IMAGE_HEIGHT));
+  });
+
+  // Unmount before the next test resets the shared store, so a stale subscriber
+  // cannot re-render off another test's state.
+  afterEach(() => {
+    const tree = mounted;
+    mounted = null;
+    if (tree !== null) act(() => tree.unmount());
+  });
+
+  it('fetches the stage list exactly once when the cold-start load succeeds', async () => {
+    mockListAll.mockResolvedValue(wireStages());
+
+    const tree = renderMap();
+    await flushRounds();
+
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+    expect(tree.root.findAllByProps({ testID: 'map-error' })).toHaveLength(0);
+    expect(tree.root.findByProps({ testID: 'journey-read' })).toBeTruthy();
+  });
+
+  it('fetches the stage list exactly once when the load keeps failing', async () => {
+    mockListAll.mockRejectedValue(new Error(LOAD_ERROR_MESSAGE));
+
+    const tree = renderMap();
+    await flushRounds();
+
+    // The invariant: one automatic attempt on cold start; every further attempt is user-initiated.
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+    expect(tree.root.findByProps({ testID: 'map-error' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'map-error-retry' })).toBeTruthy();
+  });
+
+  it('recovers through the error retry, which is the only second fetch', async () => {
+    mockListAll
+      .mockRejectedValueOnce(new Error(LOAD_ERROR_MESSAGE))
+      .mockResolvedValue(wireStages());
+
+    const tree = renderMap();
+    await flushRounds();
+
+    const retry = tree.root.findByProps({ testID: 'map-error-retry' });
+    expect(retry.props.accessibilityRole).toBe('button');
+    expect(retry.props.accessibilityLabel).toBe('Try again');
+
+    act(() => retry.props.onPress());
+    await flushRounds();
+
+    expect(tree.root.findAllByProps({ testID: 'map-error' })).toHaveLength(0);
+    expect(tree.root.findByProps({ testID: 'journey-read' })).toBeTruthy();
+    expect(mockListAll).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause, not a counter.** `MapScreen`'s cold-start fetch effect guarded on `stages.length === 0 && !loading` — which is *exactly* the state `stageService.loadStages` leaves behind when it fails (`{stages: [], loading: false, error: set}`, `services/stageService.ts:102-106`). Every failure re-armed the effect, so a persistent failure (offline, backend 5xx) became a refetch storm rate-limited only by network latency, running silently behind the full-screen error. The fix adds the missing `error` term to the guard (and `error` to the deps), which closes the state-machine hole. `loadStages` sets `loading` before clearing `error` and sets `error` before dropping `loading`, so **no intermediate state satisfies the guard**. A `hasAttemptedRef` one-shot was considered and rejected: a ref outlives the store and would wrongly block the legitimate re-fetch after `useStageStore.reset()` on logout.
- **Recovery, not a dead end.** Removing the accidental auto-retry would have left the cold-start `MapError` with no way forward, so it gains the recovery path it never had: `accessibilityRole="alert"` + `accessibilityLiveRegion="polite"` so screen readers announce the failure (not colour-only), a hint line saying what to do next, and a `Try again` button wired to the same `handleRefresh` loader the refresh banner uses. `loadStages` clears `error` itself, so the retry re-arms the automatic guard with no separate reset. This reuses the existing `MapRefreshErrorBanner` / history-retry idiom rather than inventing a third.
- **A regression test that actually observes the loop.** The reason this bug passed every gate is that all existing Map suites mock *both* `stageService` and `useStageStore`, so the real `loading` flip never runs. The new suite keeps both real and mocks only the network boundary.

## Test plan

- **New `frontend/src/features/Map/__tests__/MapScreenRefetchLoop.test.tsx`** — real `useStageStore` + real `stageService`, only `../../../api` mocked. Asserts a bound of **exactly one** automatic attempt under sustained failure, using a fixed number of flush rounds rather than an unbounded wait (an always-rejecting loader never lets `waitFor`/`await act` settle — it hung when tried). Verified RED on the pre-fix code with **42** observed `listAll` calls in 8 flush rounds; GREEN at exactly 1 after. Also covers: retry press is the *only* second fetch and repopulates the map, and a successful cold start fetches exactly once.
- **`MapScreenColdStart.test.tsx`** — extended for the alert role + live region, the hint line, the labelled retry button, and that a failed cold start does not re-arm itself (the only load is the user's).
- `./scripts/frontend/check-all.sh` → **exit 0** (446 suites / 5170 tests; lint, prettier, typecheck, audit gate all pass). No `jest --coverage` was run locally.
- Reviewed at Gate 2.5 by the code-review-orchestrator: verdict **CLEAN**. It traced every store transition for both the loop and the converse dead-end cases (remount with stale error, logout `reset()`, `beginAgain`) and confirmed none loops or dead-ends.

## Follow-up filed

The same effect still re-fires if a load *succeeds with an empty list* (`{stages: [], loading: false, error: null}` re-satisfies the guard) — a pre-existing hole in the original guard, out of scope here and needing a design decision (a store-level `hasAttempted`, not a ref). Not reachable today since the backend seeds the ten stages. Filed as #1995.

Closes #1962
