### PR TITLE
fix(backend): honour X-Forwarded-For only behind a trusted proxy

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -133,6 +133,7 @@ In the backend service's **Variables** tab, add:
 | `LLM_API_KEY` | *(your API key)* | Only if provider is `openai` or `anthropic` |
 | `LLM_MODEL` | *(model name)* | No (sensible defaults built in) |
 | `WEB_CONCURRENCY` | `2` | No (default: 2) |
+| `TRUSTED_PROXY_CIDRS` | *(Railway's ingress range)* | Recommended — without it every client shares one rate-limit bucket and https redirects break |
 
 **Generate a SECRET_KEY:**
 ```bash
@@ -367,6 +368,7 @@ than a migration.
 | `LLM_API_KEY` | If not stub | — | API key for the chosen LLM provider |
 | `LLM_MODEL` | No | Provider default | `gpt-4o-mini` (OpenAI) or `claude-sonnet-4-20250514` (Anthropic) |
 | `WEB_CONCURRENCY` | No | `2` | Number of Uvicorn worker processes |
+| `TRUSTED_PROXY_CIDRS` | Recommended in prod | *(empty)* | Comma-separated IPs/CIDRs of the reverse proxies you operate, e.g. the platform ingress range. Until it is set, `X-Forwarded-For` is ignored (every client behind the ingress shares one rate-limit bucket and one audited IP) and `X-Forwarded-Proto` is untrusted, so redirects and absolute URLs stay `http://`. Never list a public range you do not control. |
 | `BOTMASON_SYSTEM_PROMPT` | No | Built-in | Path to prompt file or inline text |
 | `EMAIL_BACKEND` | No | `console` | `console` (logs the email locally) or `smtp` (delivers via SMTP). Required: `smtp` in production. |
 | `SMTP_HOST` | If `EMAIL_BACKEND=smtp` | — | SMTP relay hostname, e.g. `smtp.sendgrid.net` |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -468,21 +468,33 @@ inbox.  The corresponding runbook lives at `RECOVERY-RUNBOOK.md`
 
 ### Trusted Proxy / X-Forwarded-For
 
-The backend reads the client IP from `X-Forwarded-For` and writes it
-verbatim to `passwordresettoken.requested_ip` and to the
-`password_reset_event` audit log.  This is correct **only when every
-ingress path runs through a trusted reverse proxy that overwrites the
-header**.  Railway's edge network does this by default; if you front
-the API with an additional proxy or expose the container directly to
-the public internet, an attacker can spoof the source IP in the audit
-trail by sending the header themselves.
+`X-Forwarded-For` is honored only when the socket peer is inside
+`TRUSTED_PROXY_CIDRS` (see the variable reference above for the
+exact format).  The default is empty, and the resolver **fails
+closed**: with nothing configured the header is ignored entirely,
+and rate limiting, the invalid-license throttle, and the login /
+password-reset audit rows (`LoginAttempt.ip_address`,
+`PasswordResetToken.requested_ip`) all key on the raw socket peer
+instead -- which behind any real ingress means every client shares
+one rate-limit bucket and one audited address.
 
-For Railway / managed-edge deployments no extra configuration is
-needed.  For self-managed deployments, terminate TLS at a proxy
-(nginx, Caddy, Cloudflare) that strips inbound `X-Forwarded-For` and
-appends the real peer address.  Operators investigating an abuse
-report should treat the `ip_address` audit field as authoritative
-only to the extent the ingress chain is trusted.
+The same variable also feeds uvicorn's `--forwarded-allow-ips`, so
+it governs whether `X-Forwarded-Proto` is trusted too.  Until it is
+set, the app believes it is serving `http`, so the trailing-slash
+redirect and any absolute URL it builds stay `http://` -- which
+browsers refuse to follow cross-origin.  A production boot without
+it set logs a `trusted_proxies_unconfigured` warning at startup.
+Write entries in network-address form (`10.0.0.0/8`), not host form
+(`10.0.0.5/8`): uvicorn's parser rejects the latter silently, so
+`X-Forwarded-Proto` trust quietly stops working while the rest of
+the app keeps working.
+
+For self-managed deployments, terminate TLS at a proxy (nginx,
+Caddy, Cloudflare) that strips inbound `X-Forwarded-For` and appends
+the real peer address, then list only that proxy in
+`TRUSTED_PROXY_CIDRS`.  Operators investigating an abuse report
+should treat the audit `ip_address` as authoritative only to the
+extent the ingress chain, and this configuration, are trusted.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,6 +76,19 @@ GUMROAD_APTITUDE_PRODUCT_IDS=  # APTITUDE course product IDs, e.g. abc123,def456
 GUMROAD_TOKEN_PACK_PRODUCT_IDS=  # Token-pack product IDs, e.g. ghi789,jkl012
 GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 
+# Comma-separated IPs and/or CIDR blocks naming the reverse proxies you operate
+# and therefore trust to write X-Forwarded-For. Read at request time, so
+# rotating the proxy set needs no restart. Fails closed: unset or blank means
+# X-Forwarded-For is ignored everywhere and every control -- the per-route rate
+# limiter, the hourly invalid-license throttle, and the login / password-reset
+# audit rows -- keys on the socket peer instead. When the value does apply, the
+# forwarded chain is read RIGHT TO LEFT, so entries a client prepends sit behind
+# the hop your proxy appended and can never win. Set this only when the app
+# genuinely sits behind a proxy (e.g. the platform's ingress range on Railway),
+# and never to a public range you do not control: every address inside it can
+# then claim to be any client it likes.
+TRUSTED_PROXY_CIDRS=  # e.g. 10.0.0.0/8,192.0.2.10
+
 # Comma-separated Google OAuth client IDs (iOS / Android / web) accepted as the
 # ``aud`` claim of a submitted id_token. Read at request time, so rotating or
 # adding a platform needs no restart. Fails closed: unset means Google sign-in

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -81,7 +81,12 @@ GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 # rotating the proxy set needs no restart. Fails closed: unset or blank means
 # X-Forwarded-For is ignored everywhere and every control -- the per-route rate
 # limiter, the hourly invalid-license throttle, and the login / password-reset
-# audit rows -- keys on the socket peer instead. When the value does apply, the
+# audit rows -- keys on the socket peer instead. Behind a real ingress that
+# socket peer is the ingress itself, so leaving this unset gives every client on
+# the internet ONE shared rate-limit bucket and one audited address. It also
+# decides whether X-Forwarded-Proto is believed: until it is set, the app thinks
+# it is serving http, so absolute URLs and the trailing-slash redirect stay
+# http:// and browsers refuse to follow them cross-origin. When it does apply, the
 # forwarded chain is read RIGHT TO LEFT, so entries a client prepends sit behind
 # the hop your proxy appended and can never win. Set this only when the app
 # genuinely sits behind a proxy (e.g. the platform's ingress range on Railway),

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,10 +62,17 @@ EXPOSE 8000
 # `src.main:app`) because PYTHONPATH is set to /app/src; this matches the
 # module layout used in tests.
 #
-# --proxy-headers + --forwarded-allow-ips="*": the app runs behind Railway's
-# TLS-terminating proxy, so it must trust X-Forwarded-Proto to know it is on
-# https.  Without this, redirects (e.g. the trailing-slash 307) and any absolute
-# URL the app builds downgrade to http://, which browsers refuse to follow on a
-# cross-origin request — saving/loading then fails (#790).  Railway's only
-# ingress is its proxy, so trusting all forwarding peers is safe here.
-CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2} --proxy-headers --forwarded-allow-ips=*"]
+# --proxy-headers lets uvicorn believe X-Forwarded-Proto, which the app needs to
+# know it is served over https: without it, redirects (e.g. the trailing-slash
+# 307) and any absolute URL it builds downgrade to http://, which browsers
+# refuse to follow cross-origin.  --forwarded-allow-ips names the peers allowed
+# to assert that, and it reads the same TRUSTED_PROXY_CIDRS the application
+# uses, so one setting governs both layers and they cannot drift apart.  A
+# wildcard here would trust every forwarding peer and so let any client rewrite
+# its own address: uvicorn overwrites the socket peer with the left-most,
+# caller-chosen X-Forwarded-For entry, forging rate-limit keys and audit rows
+# before application code runs.  The default is loopback, so an unset variable
+# fails closed onto the real socket peer -- and, stated plainly, proto trust is
+# off in that state too, so the https-dependent redirects above only work once
+# an operator sets the variable to the platform's ingress range.
+CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2} --proxy-headers --forwarded-allow-ips=${TRUSTED_PROXY_CIDRS:-127.0.0.1}"]

--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -1,0 +1,123 @@
+"""Resolve the address of the real client, for throttle keys and audit rows.
+
+``X-Forwarded-For`` is written by whoever is talking to us, so honouring it
+unconditionally hands a brute-forcer a fresh throttle bucket per request and
+lets anyone attribute an audited action to an address they do not own.  The
+header is therefore evidence only when the socket peer is itself a proxy the
+operator declared in ``TRUSTED_PROXY_CIDRS``, and even then the chain is read
+from the right, because a client can prepend entries that the proxy appends
+to.  Unset or blank config trusts nobody: the header is ignored everywhere and
+every control keys on the socket peer.
+
+Deliberately a leaf module -- it imports nothing of ours.  :mod:`rate_limit`
+and ``routers.auth`` both need this answer, and ``rate_limit_keys`` documents
+the import cycle between those two that a dependency-free module avoids.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+
+from fastapi import Request
+
+# Comma-separated IPs and/or CIDR blocks naming the proxies we operate.
+TRUSTED_PROXIES_ENV_VAR = "TRUSTED_PROXY_CIDRS"
+
+# Both the config variable and the forwarded header are comma-separated lists.
+_ENTRY_SEPARATOR = ","
+_FORWARDED_FOR_HEADER = "x-forwarded-for"
+
+# Answer for a request whose ASGI scope carries no socket peer at all.
+_UNKNOWN_CLIENT = "unknown"
+
+_Network = ipaddress.IPv4Network | ipaddress.IPv6Network
+_Address = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+def _parse_network(entry: str) -> _Network | None:
+    """Parse one config entry as a network, or None when it is unparseable.
+
+    ``strict=False`` lets a bare address arrive as a single-host network, so
+    operators can list individual proxies and CIDR blocks interchangeably.
+    """
+    try:
+        return ipaddress.ip_network(entry, strict=False)
+    except ValueError:
+        return None
+
+
+def _parse_address(value: str) -> _Address | None:
+    """Parse ``value`` as an IP literal, or None when it is not one."""
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _split_entries(raw: str) -> list[str]:
+    """Split one comma-separated value into stripped, non-blank entries.
+
+    Shared by the config and the header so the two cannot diverge on tolerance:
+    padding, empty entries, and a trailing separator are harmless on both sides,
+    and an empty value yields no entries rather than one blank one.
+    """
+    return [entry.strip() for entry in raw.split(_ENTRY_SEPARATOR) if entry.strip()]
+
+
+def _trusted_networks() -> list[_Network]:
+    """Read the trusted-proxy allowlist from the environment at call time.
+
+    Reading per call means rotating the proxy set needs no restart.  An entry
+    that does not parse is dropped rather than defaulted -- dropping narrows
+    trust, which is the safe direction to fail.
+    """
+    entries = _split_entries(os.getenv(TRUSTED_PROXIES_ENV_VAR, ""))
+    parsed = (_parse_network(entry) for entry in entries)
+    return [network for network in parsed if network is not None]
+
+
+def _is_trusted(host: str, networks: list[_Network]) -> bool:
+    """Return True when ``host`` is an address inside one of our proxy networks."""
+    address = _parse_address(host)
+    return address is not None and any(address in network for network in networks)
+
+
+def _forwarded_hops(request: Request) -> list[str]:
+    """Return the forwarded chain as hops, ordered client-first as the RFC has it."""
+    return _split_entries(request.headers.get(_FORWARDED_FOR_HEADER, ""))
+
+
+def _client_hop(hops: list[str], networks: list[_Network]) -> str | None:
+    """Pick the hop that belongs to the client from a chain we know is vouched.
+
+    Walking from the right skips the proxies we operate and stops at the first
+    address one of them observed, so entries the client prepended sit further
+    left and can never win.  When every hop is one of ours the left-most is the
+    closest thing to a client the chain records.
+    """
+    for hop in reversed(hops):
+        if not _is_trusted(hop, networks):
+            return hop
+    return hops[0] if hops else None
+
+
+def resolve_client_ip(request: Request) -> str:
+    """Return the address to charge this request to: throttles and audit agree on it.
+
+    Falls back to the socket peer whenever the forwarded chain cannot be
+    trusted or cannot be believed -- an unvouched peer, a missing header, or a
+    chosen hop that is not an IP literal.  That keeps junk and forgeries out of
+    both rate-limit keys and audit rows.
+    """
+    peer = request.client
+    if peer is None:
+        # A request with no socket peer cannot be one of our proxies.
+        return _UNKNOWN_CLIENT
+    networks = _trusted_networks()
+    if not _is_trusted(peer.host, networks):
+        return peer.host
+    hop = _client_hop(_forwarded_hops(request), networks)
+    if hop is None or _parse_address(hop) is None:
+        return peer.host
+    return hop

--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -28,7 +28,7 @@ TRUSTED_PROXIES_ENV_VAR = "TRUSTED_PROXY_CIDRS"
 _ENTRY_SEPARATOR = ","
 _FORWARDED_FOR_HEADER = "x-forwarded-for"
 
-# Answer for a request whose ASGI scope carries no socket peer at all.
+# Answer for a request whose socket peer is absent or is not an IP literal.
 _UNKNOWN_CLIENT = "unknown"
 
 _Network = ipaddress.IPv4Network | ipaddress.IPv6Network
@@ -55,6 +55,37 @@ def _parse_address(value: str) -> _Address | None:
         return None
 
 
+def _is_scoped(address: _Address) -> bool:
+    """Report whether an IPv6 literal carries a zone id such as ``fe80::1%eth0``."""
+    return isinstance(address, ipaddress.IPv6Address) and address.scope_id is not None
+
+
+def _unmapped(address: _Address) -> _Address:
+    """Return the IPv4 address behind an IPv4-mapped IPv6 literal, else ``address``.
+
+    ``::ffff:198.51.100.7`` and ``198.51.100.7`` are one host, so they must
+    produce one throttle bucket and one audited address rather than two.
+    """
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    return address
+
+
+def _client_address(value: str) -> _Address | None:
+    """Return the canonical address to key on for ``value``, or None when there is none.
+
+    A zone id names an interface on one machine, so it cannot identify a client
+    seen across a proxy hop -- and ``ipaddress`` accepts a zone id of any
+    length, which would let a hop parse cleanly and still overflow the audit
+    column that stores the result.  Rejecting scoped literals keeps every
+    answer a bounded, comparable address.
+    """
+    address = _parse_address(value)
+    if address is None or _is_scoped(address):
+        return None
+    return _unmapped(address)
+
+
 def _split_entries(raw: str) -> list[str]:
     """Split one comma-separated value into stripped, non-blank entries.
 
@@ -77,47 +108,66 @@ def _trusted_networks() -> list[_Network]:
     return [network for network in parsed if network is not None]
 
 
-def _is_trusted(host: str, networks: list[_Network]) -> bool:
-    """Return True when ``host`` is an address inside one of our proxy networks."""
-    address = _parse_address(host)
-    return address is not None and any(address in network for network in networks)
+def _is_trusted(address: _Address, networks: list[_Network]) -> bool:
+    """Return True when ``address`` sits inside one of our proxy networks."""
+    return any(address in network for network in networks)
 
 
 def _forwarded_hops(request: Request) -> list[str]:
-    """Return the forwarded chain as hops, ordered client-first as the RFC has it."""
-    return _split_entries(request.headers.get(_FORWARDED_FOR_HEADER, ""))
+    """Return the forwarded chain as hops, ordered client-first as the RFC has it.
+
+    Every ``X-Forwarded-For`` field line counts.  HAProxy's ``option
+    forwardfor`` appends a second line rather than extending the first, so
+    reading only the first line would hand a client that sent its own header
+    authorship of the whole chain; joining the lines keeps the proxy-authored
+    hop where it belongs, at the far right.
+    """
+    lines = request.headers.getlist(_FORWARDED_FOR_HEADER)
+    return _split_entries(_ENTRY_SEPARATOR.join(lines))
 
 
-def _client_hop(hops: list[str], networks: list[_Network]) -> str | None:
+def _client_hop(hops: list[str], networks: list[_Network]) -> _Address | None:
     """Pick the hop that belongs to the client from a chain we know is vouched.
 
     Walking from the right skips the proxies we operate and stops at the first
     address one of them observed, so entries the client prepended sit further
-    left and can never win.  When every hop is one of ours the left-most is the
-    closest thing to a client the chain records.
+    left and can never win.  A chain that names nobody outside our own proxies
+    yields None: the left-most entry is exactly the one a client can author, so
+    falling back to it would reinstate the forgery this module exists to stop,
+    and a request whose every hop is ours originated inside our infrastructure,
+    where the socket peer is already the right answer.
     """
     for hop in reversed(hops):
-        if not _is_trusted(hop, networks):
-            return hop
-    return hops[0] if hops else None
+        address = _client_address(hop)
+        if address is None:
+            # The chain records something we cannot attribute to anyone.
+            return None
+        if not _is_trusted(address, networks):
+            return address
+    return None
+
+
+def _socket_peer(request: Request) -> _Address | None:
+    """Return the peer that opened the connection, or None when there is none to key on."""
+    peer = request.client
+    return None if peer is None else _client_address(peer.host)
 
 
 def resolve_client_ip(request: Request) -> str:
     """Return the address to charge this request to: throttles and audit agree on it.
 
     Falls back to the socket peer whenever the forwarded chain cannot be
-    trusted or cannot be believed -- an unvouched peer, a missing header, or a
-    chosen hop that is not an IP literal.  That keeps junk and forgeries out of
-    both rate-limit keys and audit rows.
+    trusted or cannot be believed -- an unvouched peer, a missing header, a
+    chain of nothing but our own proxies, or a chosen hop that is not an IP
+    literal.  A peer that is not an IP literal itself resolves to
+    ``_UNKNOWN_CLIENT``, so a junk or over-wide value can reach neither a
+    rate-limit key nor an audit column.
     """
-    peer = request.client
+    peer = _socket_peer(request)
     if peer is None:
-        # A request with no socket peer cannot be one of our proxies.
         return _UNKNOWN_CLIENT
     networks = _trusted_networks()
-    if not _is_trusted(peer.host, networks):
-        return peer.host
+    if not _is_trusted(peer, networks):
+        return str(peer)
     hop = _client_hop(_forwarded_hops(request), networks)
-    if hop is None or _parse_address(hop) is None:
-        return peer.host
-    return hop
+    return str(peer if hop is None else hop)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from client_ip import TRUSTED_PROXIES_ENV_VAR
 from database import async_session_factory, get_session
 from errors import install_exception_handlers
 from middleware import (
@@ -277,6 +278,40 @@ def validate_gumroad_config() -> None:
     raise RuntimeError(msg)
 
 
+def validate_trusted_proxy_config() -> None:
+    """Announce a production boot that trusts no reverse proxy.
+
+    An unconfigured allowlist is a degraded state, not a broken one, so this
+    never raises on any path: with ``TRUSTED_PROXY_CIDRS`` unset the app is
+    perfectly serviceable, it simply cannot tell one client behind the ingress
+    from another.  Every control that keys on an address -- the per-route rate
+    limiter, the hourly invalid-license throttle, the login and password-reset
+    audit rows -- then sees the ingress itself, so one bucket and one audited
+    address cover the whole internet.  The same variable governs uvicorn's
+    proxy-header trust set, so ``X-Forwarded-Proto`` is untrusted too and the
+    app believes it is serving http, which downgrades redirects and any
+    absolute URL it builds.
+
+    Nothing else surfaces this: the degraded behaviour looks like ordinary
+    operation until a brute-forcer is throttled alongside honest traffic or an
+    audit row names the proxy.  Outside production an unset value is the normal
+    local case (there is no proxy to trust) and stays silent, mirroring
+    ``validate_gumroad_config``'s treatment of a wholly unconfigured pair.
+    """
+    if os.getenv("ENV", "development") != "production":
+        return
+    if os.getenv(TRUSTED_PROXIES_ENV_VAR, "").strip():
+        return
+    logger.warning(
+        "trusted_proxies_unconfigured: %s is unset, so X-Forwarded-For is "
+        "ignored and every client behind the ingress shares one rate-limit "
+        "bucket and one audited IP address; X-Forwarded-Proto is not trusted "
+        "either, so redirects and absolute URLs stay http://. Set it to the "
+        "platform's ingress range -- backend/.env.example documents the format",
+        TRUSTED_PROXIES_ENV_VAR,
+    )
+
+
 def _rate_limit_exceeded_handler(_request: Request, exc: Exception) -> JSONResponse:
     """Return a JSON 429 response with Retry-After header when rate limit is exceeded.
 
@@ -418,6 +453,11 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # than dropping purchase webhooks later, while a wholly unset pair only
     # warns: that is the pre-adoption state, and the endpoints fail closed.
     validate_gumroad_config()
+
+    # A production boot with no proxy allowlist still serves traffic, but every
+    # client behind the ingress shares one throttle bucket and one audit IP --
+    # a state only this warning makes visible.
+    validate_trusted_proxy_config()
 
     # ritual-practice ops: on every boot, seed the catalog (stages, presets,
     # course content) so a fresh database is immediately usable.

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -4,16 +4,20 @@ from limits import RateLimitItemPerHour
 from limits.storage import MemoryStorage
 from limits.strategies import MovingWindowRateLimiter
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+from client_ip import resolve_client_ip
 
 # Default rate limit applied to all endpoints that don't declare their own.
 # Auth endpoints override this with stricter per-route limits (3/min signup,
 # 5/min login). The global default protects against scraping and general abuse.
 DEFAULT_RATE_LIMIT = "60/minute"
 
-# Rate limiter keyed by client IP address. Shared across routers so all
-# endpoints use a single limiter with consistent state.
-limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_RATE_LIMIT])
+# Rate limiter keyed by the trusted-proxy-resolved client address, so it agrees
+# with the invalid-license throttle and the audit trail instead of keying on a
+# forgeable header or on a proxy every user shares. Shared across routers so all
+# endpoints use a single limiter with consistent state. Building the limiter at
+# import time is safe: the trusted-proxy config is read per request.
+limiter = Limiter(key_func=resolve_client_ip, default_limits=[DEFAULT_RATE_LIMIT])
 
 # Second-layer throttle for signup attempts that fail license verification:
 # distinct from the 3/minute signup limit above so a license brute-forcer is

--- a/backend/src/rate_limit_keys.py
+++ b/backend/src/rate_limit_keys.py
@@ -7,8 +7,8 @@ circular import: this module depends on ``routers.auth`` for the JWT decode.
 from __future__ import annotations
 
 from fastapi import HTTPException, Request
-from slowapi.util import get_remote_address
 
+from client_ip import resolve_client_ip
 from routers.auth import extract_user_id_from_authorization
 
 
@@ -25,9 +25,9 @@ def per_user_rate_limit_key(request: Request) -> str:
     the credential. Decoding here costs one HMAC-SHA256 per request which is
     dominated by the work the limited endpoints do.
 
-    Falls back to the remote address for malformed or missing tokens so the
-    limiter never receives an empty key (and so any pre-auth probe is still
-    throttled before FastAPI's DI rejects it).
+    Falls back to the trusted-proxy-resolved client address for malformed or
+    missing tokens so the limiter never receives an empty key (and so any
+    pre-auth probe is still throttled before FastAPI's DI rejects it).
     """
     try:
         return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
@@ -35,4 +35,4 @@ def per_user_rate_limit_key(request: Request) -> str:
         # Malformed / missing token (the only thing the decode raises) → fall
         # back to the IP key. A non-HTTP error is a programmer bug and must
         # propagate rather than be silently masked as an anonymous request.
-        return get_remote_address(request)
+        return resolve_client_ip(request)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from client_ip import resolve_client_ip
 from database import get_session
 from domain.dates import ensure_aware
 from domain.entitlements import (
@@ -357,18 +358,6 @@ def _create_token(user_id: int) -> tuple[str, str]:
     return token, jti
 
 
-def _get_client_ip(request: Request) -> str:
-    """Extract client IP from the request, respecting X-Forwarded-For."""
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        # First address in the chain is the original client
-        return forwarded.split(",")[0].strip()
-    client = request.client
-    if client is not None:
-        return client.host
-    return "unknown"
-
-
 async def _record_attempt(
     session: AsyncSession,
     email: str,
@@ -528,7 +517,7 @@ async def _reject_invalid_license(
     email or key), spends the dummy bcrypt verify for timing parity, then
     raises the generic 400 — or 429 once the hourly cap is exceeded.
     """
-    allowed = record_invalid_license_attempt(_get_client_ip(request))
+    allowed = record_invalid_license_attempt(resolve_client_ip(request))
     if outcome is LicenseOutcome.EMAIL_MISMATCH:
         logger.info(
             "signup_license_rejected",
@@ -765,7 +754,7 @@ async def login(
     payload: AuthRequest,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AuthResponse:
-    ip_address = _get_client_ip(request)
+    ip_address = resolve_client_ip(request)
 
     # Wrap the lockout-check + verify + record sequence in a per-email
     # serialization so concurrent failed attempts cannot all pass the
@@ -1244,7 +1233,7 @@ async def _mint_and_persist_reset_token(
         user_id=user.id,
         lookup_key=_make_lookup_key(plaintext),
         token_hash=await _hash_reset_token(plaintext),
-        requested_ip=_get_client_ip(request),
+        requested_ip=resolve_client_ip(request),
         requested_user_agent=user_agent,
         expires_at=datetime.now(UTC) + _PASSWORD_RESET_TTL,
     )
@@ -1329,7 +1318,7 @@ def _log_reset_event(action: str, email: str, request: Request) -> None:
         extra={
             "action": action,
             "email_fingerprint": _email_log_fingerprint(email),
-            "ip_address": _get_client_ip(request),
+            "ip_address": resolve_client_ip(request),
             "timestamp": datetime.now(UTC).isoformat(),
         },
     )
@@ -1973,7 +1962,7 @@ async def _count_invalid_license_attempt(request: Request, license_key: str | No
     """
     if not (license_key or "").strip():
         return
-    if record_invalid_license_attempt(_get_client_ip(request)):
+    if record_invalid_license_attempt(resolve_client_ip(request)):
         return
     raise HTTPException(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -52,6 +52,9 @@ COURSE_ACCESS_KIND = "course_access"
 LICENSE_USES = 1
 JWT_SEGMENT_COUNT = 3
 INVALID_LICENSE_ATTEMPT_CAP = 10
+TRUSTED_PROXY_CIDRS_ENV = "TRUSTED_PROXY_CIDRS"
+# Documentation-range prefix (RFC 5737) for the spoofed forwarded addresses.
+SPOOFED_IP_PREFIX = "203.0.113."
 # One character past the schema's license_key ceiling; must be rejected by
 # Pydantic before any outbound Gumroad verify runs.
 OVER_LENGTH_LICENSE_KEY = "A" * 129
@@ -585,6 +588,45 @@ async def test_eleventh_invalid_license_attempt_is_throttled(
     throttled = await async_client.post(
         SIGNUP_PATH,
         json=_signup_payload(email="attempt-final@example.com"),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+def _spoofed_forwarded_ip(attempt: int) -> str:
+    """Build a distinct forged X-Forwarded-For value for ``attempt``."""
+    return f"{SPOOFED_IP_PREFIX}{attempt + 1}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_rotating_x_forwarded_for_cannot_reset_the_invalid_license_cap(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh forged X-Forwarded-For per attempt does not mint a fresh hourly bucket.
+
+    With no trusted proxy configured the header carries no authority, so every
+    attempt keys on the socket peer and the cap still trips on the next one.
+    """
+    monkeypatch.delenv(TRUSTED_PROXY_CIDRS_ENV, raising=False)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+
+    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
+        response = await async_client.post(
+            SIGNUP_PATH,
+            json=_signup_payload(email=f"spoofed-{attempt}@example.com"),
+            headers={"X-Forwarded-For": _spoofed_forwarded_ip(attempt)},
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+
+    throttled = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email="spoofed-final@example.com"),
+        headers={"X-Forwarded-For": _spoofed_forwarded_ip(INVALID_LICENSE_ATTEMPT_CAP)},
     )
 
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS

--- a/backend/tests/security/test_client_ip.py
+++ b/backend/tests/security/test_client_ip.py
@@ -1,0 +1,383 @@
+"""Trusted-proxy client-IP resolution: one answer for throttles and audit rows.
+
+``X-Forwarded-For`` is attacker-controlled unless the socket peer is a proxy
+we operate, so honouring it unconditionally lets a license brute-forcer mint
+a fresh throttle bucket per request and write any address it likes into the
+audit trail.  The resolver these tests pin ignores the header entirely unless
+the peer sits inside ``TRUSTED_PROXY_CIDRS``, and then walks the chain from
+the right so a client-prepended entry cannot win.
+
+The integration cases fake the ASGI socket peer through ``ASGITransport`` and
+assert that the slowapi limiter and the invalid-license throttle agree on the
+key the resolver produces.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from client_ip import TRUSTED_PROXIES_ENV_VAR, resolve_client_ip
+from database import get_session
+from main import app
+from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from httpx import Response
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# Documentation-range addresses (RFC 5737) so no test can be mistaken for a
+# real network, plus one RFC 1918 block for the CIDR cases.
+_TRUSTED_PROXY_NET = "192.0.2.0/24"
+_PROXY_PEER = "192.0.2.10"
+_SECOND_PROXY = "192.0.2.11"
+_THIRD_PROXY = "192.0.2.12"
+_UNTRUSTED_PEER = "198.51.100.7"
+_CLIENT_IP = "203.0.113.5"
+_OTHER_CLIENT_IP = "203.0.113.9"
+_PRIVATE_NET = "10.0.0.0/8"
+_PRIVATE_PEER = "10.1.2.3"
+_TRUSTED_IPV6_NET = "2001:db8::/32"
+_IPV6_PROXY_PEER = "2001:db8::1"
+_IPV6_CLIENT = "fd00::42"
+_MALFORMED_HOP = "not-an-ip"
+_MALFORMED_CONFIG_ENTRY = "300.1.2.3/8"
+_PEER_PORT = 51_234
+
+_RESET_PATH = "/auth/password-reset/request"
+_RESET_REQUESTS_PER_HOUR = 3
+_UNREGISTERED_EMAIL = "nobody@example.com"
+
+_SIGNUP_PATH = "/auth/signup"
+_SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
+_LICENSE_KEY = "ABCD1234-EF56-7890-TEST"  # pragma: allowlist secret
+_PRODUCT_IDS_ENV_VAR = "GUMROAD_APTITUDE_PRODUCT_IDS"
+_ALLOWLISTED_PRODUCT = "prod_alpha"
+_VERIFY_SEAM = "domain.entitlements.verify_license"
+_DETAIL_INVALID_LICENSE = "invalid_license"
+_DETAIL_THROTTLED = "too_many_license_attempts"
+_SPOOFED_IP_PREFIX = "203.0.113."
+
+
+def _make_request(peer: tuple[str, int] | None, forwarded: str | None = None) -> Request:
+    """Build a bare ASGI request with the given socket peer and forwarded header."""
+    headers: list[tuple[bytes, bytes]] = []
+    if forwarded is not None:
+        headers.append((b"x-forwarded-for", forwarded.encode()))
+    return Request({"type": "http", "headers": headers, "client": peer})
+
+
+def test_untrusted_peer_ignores_forwarded_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A peer outside the trusted set keys on its own address, header or not."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((_UNTRUSTED_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _UNTRUSTED_PEER
+
+
+def test_trusted_proxy_peer_returns_forwarded_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Behind a configured proxy the single forwarded entry is the client."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _CLIENT_IP
+
+
+def test_rightmost_untrusted_hop_wins_over_client_prepended_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chained proxies resolve right to left, so a prepended entry never wins."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+    chain = f"{_CLIENT_IP}, {_UNTRUSTED_PEER}, {_SECOND_PROXY}"
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), chain))
+
+    assert resolved == _UNTRUSTED_PEER
+    assert resolved != _CLIENT_IP
+
+
+@pytest.mark.parametrize("peer_host", [_PROXY_PEER, _UNTRUSTED_PEER])
+def test_missing_forwarded_header_returns_socket_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    peer_host: str,
+) -> None:
+    """With no header the socket peer answers for trusted and untrusted peers alike."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((peer_host, _PEER_PORT)))
+
+    assert resolved == peer_host
+
+
+@pytest.mark.parametrize("configured", [None, "", "   "])
+def test_unconfigured_trust_ignores_forwarded_header(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+) -> None:
+    """Unset or blank config trusts nobody, so the header is ignored everywhere."""
+    if configured is None:
+        monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, configured)
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _PROXY_PEER
+
+
+def test_cidr_config_entry_trusts_every_member_peer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A CIDR entry grants trust to any peer inside the block."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PRIVATE_NET)
+
+    resolved = resolve_client_ip(_make_request((_PRIVATE_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _CLIENT_IP
+
+
+def test_bare_ip_config_entry_trusts_only_that_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare address is a single-host network: its neighbour gets no trust."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    trusted = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+    neighbour = resolve_client_ip(_make_request((_SECOND_PROXY, _PEER_PORT), _CLIENT_IP))
+
+    assert trusted == _CLIENT_IP
+    assert neighbour == _SECOND_PROXY
+
+
+def test_malformed_config_entry_is_dropped_and_grants_no_trust(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable entry narrows trust to its valid siblings instead of widening it."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, f"{_MALFORMED_CONFIG_ENTRY},{_PROXY_PEER}")
+
+    valid_sibling = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+    stranger = resolve_client_ip(_make_request((_UNTRUSTED_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert valid_sibling == _CLIENT_IP
+    assert stranger == _UNTRUSTED_PEER
+
+
+def test_all_forwarded_entries_trusted_returns_leftmost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When every hop is one of ours the left-most entry is the closest thing to a client."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+    chain = f"{_SECOND_PROXY}, {_THIRD_PROXY}"
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), chain))
+
+    assert resolved == _SECOND_PROXY
+
+
+def test_unparseable_chosen_hop_falls_back_to_socket_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hop that is not an IP literal must not reach a throttle key or an audit row."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _MALFORMED_HOP))
+
+    assert resolved == _PROXY_PEER
+
+
+def test_absent_socket_peer_is_unknown_and_never_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A request with no peer cannot be a trusted proxy, so the header stays ignored."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request(None, _CLIENT_IP))
+
+    assert resolved == "unknown"
+
+
+def test_ipv6_trusted_proxy_returns_forwarded_ipv6_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IPv6 peers and IPv6 forwarded values resolve on the same rules."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_IPV6_NET)
+
+    resolved = resolve_client_ip(_make_request((_IPV6_PROXY_PEER, _PEER_PORT), _IPV6_CLIENT))
+
+    assert resolved == _IPV6_CLIENT
+
+
+def test_padding_and_blank_entries_tolerated_in_config_and_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator padding and a trailing separator change nothing on either side."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, f" {_PROXY_PEER} , ,{_PRIVATE_NET} ")
+
+    resolved = resolve_client_ip(_make_request((_PRIVATE_PEER, _PEER_PORT), f"  {_CLIENT_IP} ,  "))
+
+    assert resolved == _CLIENT_IP
+
+
+@asynccontextmanager
+async def _peer_client(
+    db_session: AsyncSession,
+    peer: tuple[str, int],
+) -> AsyncIterator[AsyncClient]:
+    """Yield a client whose ASGI socket peer is ``peer``, still bound to the test DB."""
+
+    async def _override_get_session() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    transport = ASGITransport(app=app, client=peer)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+
+def _spoofed_ip(index: int) -> str:
+    """Build a distinct forwarded address for attempt ``index``."""
+    return f"{_SPOOFED_IP_PREFIX}{index + 1}"
+
+
+async def _request_reset(client: AsyncClient, forwarded: str) -> Response:
+    """Send one password-reset request for an unregistered email."""
+    return await client.post(
+        _RESET_PATH,
+        json={"email": _UNREGISTERED_EMAIL},
+        headers={"X-Forwarded-For": forwarded},
+    )
+
+
+def _arm_invalid_license_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the license allowlist at one product whose verifier never matches."""
+
+    async def _verify_never_matches(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setenv(_PRODUCT_IDS_ENV_VAR, _ALLOWLISTED_PRODUCT)
+    monkeypatch.setattr(_VERIFY_SEAM, _verify_never_matches)
+
+
+async def _attempt_signup(client: AsyncClient, forwarded: str, email: str) -> Response:
+    """Send one signup whose license can never verify."""
+    return await client.post(
+        _SIGNUP_PATH,
+        json={"email": email, "password": _SIGNUP_PASSWORD, "license_key": _LICENSE_KEY},
+        headers={"X-Forwarded-For": forwarded},
+    )
+
+
+def _proxied_chain(prepended: str, real_client: str) -> str:
+    """Build the header a proxy produces when a client prepends its own entry."""
+    return f"{prepended}, {real_client}"
+
+
+@pytest.mark.asyncio
+async def test_slowapi_buckets_per_forwarded_client_behind_trusted_proxy(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behind a trusted proxy the per-route limiter keys on the forwarded client.
+
+    Exhausting one forwarded client's hourly budget must not spend another
+    client's, otherwise every user behind the proxy shares a single bucket.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        for _ in range(_RESET_REQUESTS_PER_HOUR):
+            allowed = await _request_reset(client, _CLIENT_IP)
+            assert allowed.status_code == HTTPStatus.ACCEPTED
+        capped = await _request_reset(client, _CLIENT_IP)
+        other_client = await _request_reset(client, _OTHER_CLIENT_IP)
+
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert other_client.status_code == HTTPStatus.ACCEPTED
+
+
+@pytest.mark.asyncio
+async def test_slowapi_shares_one_bucket_when_peer_is_untrusted(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no trusted proxy configured, rotating the header cannot buy a fresh budget."""
+    monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+
+    async with _peer_client(db_session, (_UNTRUSTED_PEER, _PEER_PORT)) as client:
+        for attempt in range(_RESET_REQUESTS_PER_HOUR):
+            allowed = await _request_reset(client, _spoofed_ip(attempt))
+            assert allowed.status_code == HTTPStatus.ACCEPTED
+        capped = await _request_reset(client, _spoofed_ip(_RESET_REQUESTS_PER_HOUR))
+
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_license_gate
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_invalid_license_throttle_buckets_per_forwarded_client(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The license throttle keys on the hop the proxy appended, not the one the client sent.
+
+    Every attempt prepends a fresh entry to the chain, so a left-most read
+    hands out an unlimited supply of buckets; the appended hop is constant
+    and must still trip the cap, while a genuinely different client behind
+    the same proxy keeps its own budget.
+    """
+    _arm_invalid_license_gate(monkeypatch)
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
+            rejected = await _attempt_signup(
+                client,
+                _proxied_chain(_spoofed_ip(attempt), _CLIENT_IP),
+                f"capped-{attempt}@example.com",
+            )
+            assert rejected.status_code == HTTPStatus.BAD_REQUEST
+        capped = await _attempt_signup(
+            client,
+            _proxied_chain(_spoofed_ip(INVALID_LICENSE_MAX_PER_HOUR), _CLIENT_IP),
+            "capped-final@example.com",
+        )
+        neighbour = await _attempt_signup(
+            client,
+            _proxied_chain(_CLIENT_IP, _OTHER_CLIENT_IP),
+            "neighbour@example.com",
+        )
+
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert capped.json()["detail"] == _DETAIL_THROTTLED
+    assert neighbour.status_code == HTTPStatus.BAD_REQUEST
+    assert neighbour.json()["detail"] == _DETAIL_INVALID_LICENSE
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_license_gate
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_invalid_license_throttle_ignores_header_from_untrusted_peer(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer outside the configured proxy set keeps one bucket however it labels itself."""
+    _arm_invalid_license_gate(monkeypatch)
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    async with _peer_client(db_session, (_UNTRUSTED_PEER, _PEER_PORT)) as client:
+        for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
+            rejected = await _attempt_signup(
+                client, _spoofed_ip(attempt), f"spoof-{attempt}@example.com"
+            )
+            assert rejected.status_code == HTTPStatus.BAD_REQUEST
+        throttled = await _attempt_signup(
+            client, _spoofed_ip(INVALID_LICENSE_MAX_PER_HOUR), "spoof-final@example.com"
+        )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == _DETAIL_THROTTLED

--- a/backend/tests/security/test_client_ip.py
+++ b/backend/tests/security/test_client_ip.py
@@ -9,22 +9,27 @@ the right so a client-prepended entry cannot win.
 
 The integration cases fake the ASGI socket peer through ``ASGITransport`` and
 assert that the slowapi limiter and the invalid-license throttle agree on the
-key the resolver produces.
+key the resolver produces.  One case reaches past the application entirely and
+pins the runtime image's uvicorn flags, because a proxy-header trust set
+declared in the CMD overwrites ``request.client`` before this module runs.
 """
 
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from http import HTTPStatus
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from annotated_types import MaxLen
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
 
 from client_ip import TRUSTED_PROXIES_ENV_VAR, resolve_client_ip
 from database import get_session
 from main import app
+from models.password_reset_token import PasswordResetToken
 from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
 
 if TYPE_CHECKING:
@@ -47,9 +52,53 @@ _PRIVATE_PEER = "10.1.2.3"
 _TRUSTED_IPV6_NET = "2001:db8::/32"
 _IPV6_PROXY_PEER = "2001:db8::1"
 _IPV6_CLIENT = "fd00::42"
+# A dual-stack listener reports an IPv4 connection in this form, and any caller
+# can write it into the header, so both sides must fold back to the IPv4 address.
+_MAPPED_PREFIX = "::ffff:"
+_MAPPED_CLIENT_IP = f"{_MAPPED_PREFIX}{_CLIENT_IP}"
+_MAPPED_PROXY_PEER = f"{_MAPPED_PREFIX}{_PROXY_PEER}"
 _MALFORMED_HOP = "not-an-ip"
 _MALFORMED_CONFIG_ENTRY = "300.1.2.3/8"
 _PEER_PORT = 51_234
+
+# A config value whose every entry is unparseable leaves no networks at all,
+# which must read exactly like an unset variable rather than like "trust all".
+_ALL_GARBAGE_CONFIG = "garbage,also-garbage"
+
+# The widest possible operator typo: it parses cleanly, so every hop in any
+# chain -- including the client's own address -- counts as one of our proxies.
+_CATCH_ALL_NET = "0.0.0.0/0"
+
+# The answer for any peer we cannot turn into an IP literal.
+_UNKNOWN_CLIENT = "unknown"
+
+# Long enough to overflow every audit column that stores a resolved address.
+_OVERLONG_HOST_LENGTH = 200
+_OVERLONG_PEER_HOST = "A" * _OVERLONG_HOST_LENGTH
+# ``ipaddress`` accepts an arbitrarily long IPv6 zone id, so a hop can parse
+# as a valid address and still be far too wide for the audit column.
+_LONG_ZONE_ID = "z" * _OVERLONG_HOST_LENGTH
+_SCOPED_IPV6_HOP = f"fe80::1%{_LONG_ZONE_ID}"
+
+_AUDIT_IP_COLUMN = "requested_ip"
+
+
+def _audit_ip_max_length() -> int:
+    """Return the declared width of the narrowest column a resolved IP is stored in."""
+    constraints = PasswordResetToken.model_fields[_AUDIT_IP_COLUMN].metadata
+    declared = [item.max_length for item in constraints if isinstance(item, MaxLen)]
+    assert len(declared) == 1
+    return declared[0]
+
+
+# Postgres raises DataError on an over-wide VARCHAR, so anything the resolver
+# returns must fit the audit column or the reset endpoint 500s.
+_AUDIT_IP_MAX_LENGTH = _audit_ip_max_length()
+
+_DOCKERFILE = Path(__file__).resolve().parents[2] / "Dockerfile"
+_CMD_DIRECTIVE = "CMD "
+_WILDCARD_ALLOW_IPS = "--forwarded-allow-ips=*"
+_PROXY_HEADERS_FLAG = "--proxy-headers"
 
 _RESET_PATH = "/auth/password-reset/request"
 _RESET_REQUESTS_PER_HOUR = 3
@@ -66,12 +115,20 @@ _DETAIL_THROTTLED = "too_many_license_attempts"
 _SPOOFED_IP_PREFIX = "203.0.113."
 
 
+def _make_request_with_lines(peer: tuple[str, int] | None, forwarded: list[str]) -> Request:
+    """Build a bare ASGI request carrying one forwarded field line per entry.
+
+    HAProxy's ``option forwardfor`` appends a separate ``X-Forwarded-For`` line
+    when the request already has one, so a real chain can arrive split across
+    several lines with the proxy-authored value last.
+    """
+    headers = [(b"x-forwarded-for", line.encode()) for line in forwarded]
+    return Request({"type": "http", "headers": headers, "client": peer})
+
+
 def _make_request(peer: tuple[str, int] | None, forwarded: str | None = None) -> Request:
     """Build a bare ASGI request with the given socket peer and forwarded header."""
-    headers: list[tuple[bytes, bytes]] = []
-    if forwarded is not None:
-        headers.append((b"x-forwarded-for", forwarded.encode()))
-    return Request({"type": "http", "headers": headers, "client": peer})
+    return _make_request_with_lines(peer, [] if forwarded is None else [forwarded])
 
 
 def test_untrusted_peer_ignores_forwarded_header(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -118,12 +175,12 @@ def test_missing_forwarded_header_returns_socket_peer(
     assert resolved == peer_host
 
 
-@pytest.mark.parametrize("configured", [None, "", "   "])
+@pytest.mark.parametrize("configured", [None, "", "   ", _ALL_GARBAGE_CONFIG])
 def test_unconfigured_trust_ignores_forwarded_header(
     monkeypatch: pytest.MonkeyPatch,
     configured: str | None,
 ) -> None:
-    """Unset or blank config trusts nobody, so the header is ignored everywhere."""
+    """Config that names no parseable network trusts nobody, header or not."""
     if configured is None:
         monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
     else:
@@ -167,14 +224,123 @@ def test_malformed_config_entry_is_dropped_and_grants_no_trust(
     assert stranger == _UNTRUSTED_PEER
 
 
-def test_all_forwarded_entries_trusted_returns_leftmost(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When every hop is one of ours the left-most entry is the closest thing to a client."""
+def test_all_forwarded_entries_trusted_falls_back_to_socket_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chain of nothing but our own proxies yields no client hop at all.
+
+    Returning the left-most entry here reinstates the vulnerability the whole
+    module exists to close: the left-most entry is the one a client can author,
+    and a config that happens to cover the caller's own range turns every
+    request into a self-declared address.  When every hop is a proxy we operate
+    the request originated inside our infrastructure, so the socket peer is the
+    correct key and nothing is lost by ignoring the chain.
+    """
     monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
     chain = f"{_SECOND_PROXY}, {_THIRD_PROXY}"
 
     resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), chain))
 
-    assert resolved == _SECOND_PROXY
+    assert resolved == _PROXY_PEER
+
+
+def test_catch_all_trusted_range_never_honours_a_forwarded_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An over-broad config must fail closed onto the peer, not open onto the header.
+
+    ``0.0.0.0/0`` parses cleanly, so every hop reads as trusted and the chain
+    yields no client hop; the address the caller wrote must not win by default.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _CATCH_ALL_NET)
+
+    resolved = resolve_client_ip(_make_request((_UNTRUSTED_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _UNTRUSTED_PEER
+    assert resolved != _CLIENT_IP
+
+
+def test_forwarded_chain_split_across_header_lines_reads_the_last_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every forwarded field line counts, not just the first one the client sent.
+
+    Under a proxy that appends its own line instead of merging (HAProxy), reading
+    only the first line hands the attacker authorship of the entire chain.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(
+        _make_request_with_lines((_PROXY_PEER, _PEER_PORT), [_CLIENT_IP, _UNTRUSTED_PEER])
+    )
+
+    assert resolved == _UNTRUSTED_PEER
+    assert resolved != _CLIENT_IP
+
+
+@pytest.mark.parametrize("peer_host", [_MALFORMED_HOP, _OVERLONG_PEER_HOST])
+def test_socket_peer_that_is_not_an_ip_literal_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    peer_host: str,
+) -> None:
+    """The peer is validated like a hop, so junk never reaches a key or an audit row."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((peer_host, _PEER_PORT)))
+
+    assert resolved == _UNKNOWN_CLIENT
+
+
+def test_resolved_address_fits_the_audit_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hop with a huge IPv6 zone id parses, so only a width check keeps it out.
+
+    An over-wide value is accepted by SQLite and rejected by Postgres, which
+    turns the password-reset request endpoint into an unauthenticated 500.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _SCOPED_IPV6_HOP))
+
+    assert len(resolved) <= _AUDIT_IP_MAX_LENGTH
+    assert _LONG_ZONE_ID not in resolved
+
+
+def _runtime_cmd() -> str:
+    """Return the runtime image's CMD line from the backend Dockerfile."""
+    lines = _DOCKERFILE.read_text().splitlines()
+    commands = [line for line in lines if line.startswith(_CMD_DIRECTIVE)]
+    assert len(commands) == 1, "expected exactly one CMD directive in backend/Dockerfile"
+    return commands[0]
+
+
+def test_runtime_image_never_trusts_every_forwarding_peer() -> None:
+    """The server's own proxy trust set must not be a wildcard.
+
+    ``--forwarded-allow-ips=*`` makes uvicorn's ProxyHeadersMiddleware trust
+    every peer and overwrite ``scope["client"]`` with the *left-most*
+    ``X-Forwarded-For`` entry -- the one the caller chose.  Every control that
+    reads the socket peer, including this module's fallback, is then keyed on
+    an attacker-supplied string before any application code runs.
+    """
+    assert _WILDCARD_ALLOW_IPS not in _runtime_cmd(), (
+        "backend/Dockerfile CMD must not pass --forwarded-allow-ips=*; the "
+        "wildcard makes uvicorn overwrite request.client with the left-most, "
+        "caller-chosen X-Forwarded-For entry, so throttle keys and audit rows "
+        "are forged before resolve_client_ip is reached."
+    )
+
+
+def test_runtime_image_shares_one_trust_set_with_the_application() -> None:
+    """Whatever uvicorn trusts for proxy headers must be what the app trusts."""
+    cmd = _runtime_cmd()
+    if _PROXY_HEADERS_FLAG not in cmd:
+        return
+    assert TRUSTED_PROXIES_ENV_VAR in cmd, (
+        f"backend/Dockerfile CMD enables {_PROXY_HEADERS_FLAG} without deriving "
+        f"its allowed peers from {TRUSTED_PROXIES_ENV_VAR}; two trust sets that "
+        "can diverge means uvicorn may rewrite request.client for a peer the "
+        "application would never have trusted."
+    )
 
 
 def test_unparseable_chosen_hop_falls_back_to_socket_peer(
@@ -206,6 +372,30 @@ def test_ipv6_trusted_proxy_returns_forwarded_ipv6_client(
     resolved = resolve_client_ip(_make_request((_IPV6_PROXY_PEER, _PEER_PORT), _IPV6_CLIENT))
 
     assert resolved == _IPV6_CLIENT
+
+
+def test_ipv4_mapped_forwarded_hop_resolves_to_its_plain_ipv4_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One host gets one key: the mapped literal cannot buy a second throttle bucket."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    mapped = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _MAPPED_CLIENT_IP))
+    plain = resolve_client_ip(_make_request((_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert mapped == _CLIENT_IP
+    assert mapped == plain
+
+
+def test_ipv4_mapped_socket_peer_is_trusted_by_a_plain_ipv4_config_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dual-stack listener's mapped peer must still read as the configured proxy."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    resolved = resolve_client_ip(_make_request((_MAPPED_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
+
+    assert resolved == _CLIENT_IP
 
 
 def test_padding_and_blank_entries_tolerated_in_config_and_header(

--- a/backend/tests/security/test_password_reset_timing.py
+++ b/backend/tests/security/test_password_reset_timing.py
@@ -27,7 +27,9 @@ from statistics import median
 from typing import TYPE_CHECKING
 
 import pytest
+from sqlmodel import select
 
+from models.password_reset_token import PasswordResetToken
 from models.user import User
 from routers.auth import _consume_dummy_bcrypt, _hash_password
 from services.email import RecordingEmailSender
@@ -68,6 +70,14 @@ _REQUEST_TOLERANCE_FRACTION = 0.5
 _TOLERANCE_MS = 250
 
 _PASSWORD = "correct-horse-battery-staple"  # pragma: allowlist secret
+
+# Environment variable naming the proxy networks whose X-Forwarded-For we honour.
+_TRUSTED_PROXIES_ENV_VAR = "TRUSTED_PROXY_CIDRS"
+
+# Socket peer that ``httpx.ASGITransport`` reports for the ``async_client``
+# fixture; the trusted-proxy config below must name it for the header to count.
+_TRANSPORT_PEER_IP = "127.0.0.1"
+_FORWARDED_CLIENT_IP = "203.0.113.5"
 
 
 pytestmark = pytest.mark.usefixtures("wire_email_sender")
@@ -162,25 +172,57 @@ async def test_request_response_shape_identical_hit_vs_miss(
     assert hit.json() == miss.json()
 
 
+async def _request_reset_behind_forwarded_for(client: AsyncClient, email: str) -> None:
+    """Request a reset for ``email`` carrying a forwarded client address."""
+    response = await client.post(
+        "/auth/password-reset/request",
+        json={"email": email},
+        headers={"X-Forwarded-For": _FORWARDED_CLIENT_IP},
+    )
+    assert response.status_code == 202
+
+
+async def _recorded_request_ip(db_session: AsyncSession) -> str:
+    """Return the ``requested_ip`` written on the only reset-token row."""
+    rows = (await db_session.execute(select(PasswordResetToken))).scalars().all()
+    assert len(rows) == 1
+    return rows[0].requested_ip
+
+
 @pytest.mark.asyncio
 async def test_request_ip_is_recorded_with_x_forwarded_for(
     async_client: AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SPEC R9 audit trail: ``requested_ip`` honours ``X-Forwarded-For``."""
+    """SPEC R9 audit trail: a trusted proxy's ``X-Forwarded-For`` is the recorded IP."""
+    monkeypatch.setenv(_TRUSTED_PROXIES_ENV_VAR, _TRANSPORT_PEER_IP)
     await _seed_user(db_session, "audit@example.com")
-    response = await async_client.post(
-        "/auth/password-reset/request",
-        json={"email": "audit@example.com"},
-        headers={"X-Forwarded-For": "203.0.113.5"},
-    )
-    assert response.status_code == 202
-    from sqlmodel import select  # noqa: PLC0415
 
-    from models.password_reset_token import PasswordResetToken  # noqa: PLC0415
+    await _request_reset_behind_forwarded_for(async_client, "audit@example.com")
 
-    rows = (await db_session.execute(select(PasswordResetToken))).scalars().all()
-    assert rows[0].requested_ip == "203.0.113.5"
+    assert await _recorded_request_ip(db_session) == _FORWARDED_CLIENT_IP
+
+
+@pytest.mark.asyncio
+async def test_request_ip_ignores_x_forwarded_for_without_a_trusted_proxy(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Audit integrity: an unvouched header cannot poison ``requested_ip``.
+
+    With no trusted proxy configured the header is attacker-controlled, so the
+    socket peer is the only address worth writing to the audit trail.
+    """
+    monkeypatch.delenv(_TRUSTED_PROXIES_ENV_VAR, raising=False)
+    await _seed_user(db_session, "spoofed@example.com")
+
+    await _request_reset_behind_forwarded_for(async_client, "spoofed@example.com")
+
+    recorded = await _recorded_request_ip(db_session)
+    assert recorded == _TRANSPORT_PEER_IP
+    assert recorded != _FORWARDED_CLIENT_IP
 
 
 async def _measure_confirm(client: AsyncClient, token: str, new_password: str) -> float:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -13,6 +13,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlmodel import select
 
+from client_ip import TRUSTED_PROXIES_ENV_VAR
 from models.login_attempt import LoginAttempt
 from models.user import User
 from routers.auth import (
@@ -28,6 +29,11 @@ from routers.auth import (
 SIGNUP_URL = "/auth/signup"
 LOGIN_URL = "/auth/login"
 SECRET_KEY = "test-secret-key-for-unit-tests-only"  # pragma: allowlist secret
+
+# Socket peer ``httpx.ASGITransport`` reports for the ``async_client`` fixture,
+# and a documentation-range address for the header that must never outrank it.
+TRANSPORT_PEER_IP = "127.0.0.1"
+FORWARDED_CLIENT_IP = "203.0.113.5"
 
 
 async def _signup(
@@ -621,6 +627,36 @@ async def test_login_records_attempt_on_success(
     success_attempts = [a for a in attempts if a.success]
     assert len(success_attempts) >= 1
     assert success_attempts[0].email == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_login_attempt_records_socket_peer_not_forwarded_header(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unvouched X-Forwarded-For cannot author the audited ``ip_address``.
+
+    This row is what an investigator reads after a credential-stuffing run, so
+    an attacker-chosen address in it makes the trail worthless.
+    """
+    monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+
+    response = await async_client.post(
+        LOGIN_URL,
+        json={
+            "email": "stuffing@example.com",
+            "password": "wrongpassword999",  # pragma: allowlist secret
+        },
+        headers={"X-Forwarded-For": FORWARDED_CLIENT_IP},
+    )
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    result = await db_session.execute(select(LoginAttempt))
+    attempts = list(result.scalars().all())
+    assert len(attempts) == 1
+    assert attempts[0].ip_address == TRANSPORT_PEER_IP
+    assert attempts[0].ip_address != FORWARDED_CLIENT_IP
 
 
 # ── Security headers ────────────────────────────────────────────────────

--- a/backend/tests/test_trusted_proxy_startup_config.py
+++ b/backend/tests/test_trusted_proxy_startup_config.py
@@ -1,0 +1,93 @@
+"""Tests for the startup trusted-proxy configuration check.
+
+Contract: an unconfigured proxy allowlist is a bootable but degraded state, not
+a failure. With ``TRUSTED_PROXY_CIDRS`` unset the forwarded header is ignored
+everywhere, so every client behind the ingress shares one rate-limit bucket and
+one audited address -- an operator has no other signal that this is happening.
+Production therefore announces it with a single ``trusted_proxies_unconfigured``
+warning; a configured production boot and every non-production boot are silent,
+and no path raises.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from client_ip import TRUSTED_PROXIES_ENV_VAR
+from main import validate_trusted_proxy_config
+
+ENV_VAR = "ENV"
+UNCONFIGURED_MARKER = "trusted_proxies_unconfigured"
+MAIN_LOGGER = "main"
+SENTINEL_CIDRS = "192.0.2.0/24"
+
+
+def _unconfigured_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the captured records carrying the unconfigured marker."""
+    return [record for record in caplog.records if UNCONFIGURED_MARKER in record.getMessage()]
+
+
+def test_production_without_trusted_proxies_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Production with no allowlist boots, naming the variable that would fix it."""
+    monkeypatch.setenv(ENV_VAR, "production")
+    monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_trusted_proxy_config()
+
+    warnings = _unconfigured_warnings(caplog)
+    assert len(warnings) == 1
+    assert warnings[0].levelno == logging.WARNING
+    assert TRUSTED_PROXIES_ENV_VAR in warnings[0].getMessage()
+
+
+def test_production_with_trusted_proxies_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A configured production boot has nothing to announce."""
+    monkeypatch.setenv(ENV_VAR, "production")
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, SENTINEL_CIDRS)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_trusted_proxy_config()
+
+    assert _unconfigured_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("env_value", ["development", "staging", None])
+def test_non_production_envs_stay_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    env_value: str | None,
+) -> None:
+    """Outside production an unconfigured allowlist is normal: no warning, no raise."""
+    if env_value is None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(ENV_VAR, env_value)
+    monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_trusted_proxy_config()
+
+    assert _unconfigured_warnings(caplog) == []
+
+
+def test_blank_trusted_proxies_counts_as_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A blank value trusts nobody, exactly like an unset one, and warns the same."""
+    monkeypatch.setenv(ENV_VAR, "production")
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, "   ")
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_trusted_proxy_config()
+
+    assert len(_unconfigured_warnings(caplog)) == 1


### PR DESCRIPTION
## Summary

- **One trusted-proxy-aware resolver now answers "who is this client?" for every
  control that keys on an address.** `X-Forwarded-For` was read unconditionally
  and its first entry taken as the client. That value keys the hourly
  invalid-license throttle and is written to the login / password-reset audit
  rows, so rotating the header per request minted a fresh bucket every time (the
  license-guessing cap never tripped) and let anyone attribute an audited action
  to an address they do not own. slowapi meanwhile keyed on the socket peer, so
  the two controls disagreed about who the client was. `client_ip.py` is a leaf
  module both can import without recreating the `rate_limit` / `routers.auth`
  cycle.
- **The header is evidence only when the socket peer is inside
  `TRUSTED_PROXY_CIDRS`, and the chain is read right to left.** Taking `[0]` is
  wrong even behind a real proxy, because a client can prepend entries the proxy
  then appends to. Config is comma-separated IPs and/or CIDRs, read per request,
  unparseable entries dropped, and **empty by default**: unset means the header
  is ignored everywhere and every control keys on the socket peer.
- **The runtime image was handing the resolver an already-forged peer.** Self
  review caught this after the first commit: `backend/Dockerfile` ran uvicorn
  with `--forwarded-allow-ips=*`, which sets `always_trust`, so
  `ProxyHeadersMiddleware` overwrote `scope["client"]` with the **left-most,
  caller-chosen** `X-Forwarded-For` entry before application code ran. The fix
  was inert in production. uvicorn now derives its trust set from the same
  variable, defaulting to loopback, so one setting governs both layers.
- Four further defects found by the same review, **each reproduced before it was
  fixed**: only the first `X-Forwarded-For` field line was read (HAProxy appends
  a second line, so a client sending its own header authored the whole chain);
  the socket peer was returned unvalidated, so a non-IP or 200-character peer
  reached `requested_ip`, which is `VARCHAR(64)` and would raise on Postgres;
  scoped IPv6 literals carry an unbounded zone id that parses cleanly and
  overflows that same column; and the walk fell back to `hops[0]` when every hop
  parsed as trusted, which an over-broad range such as `0.0.0.0/0` reaches,
  reinstating the original forgery.
- A production boot with no allowlist is a degraded state nothing else surfaces
  (one bucket and one audited address for the whole internet), so it now warns
  at startup, and `DEPLOYMENT.md` / `.env.example` document the fail-closed
  default and its cost.

### Deployment note (please read before merging)

This changes deployed behaviour on purpose. Until `TRUSTED_PROXY_CIDRS` is set
on the Railway service to the platform ingress range:

- every client behind the ingress shares one rate-limit bucket and one audited
  IP address, and
- `X-Forwarded-Proto` is no longer trusted either, so the trailing-slash 307 and
  any absolute URL the app builds stay `http://`.

That is the fail-closed direction the issue requires, and the startup warning
names it, but it needs an operator action to restore per-client limits and https
redirects. Write the value in network-address form (`10.0.0.0/8`), not host form
(`10.0.0.5/8`) -- uvicorn's parser silently rejects the latter.

One further intentional behaviour change: an IPv4-mapped socket peer
(`::ffff:10.0.0.5`, which a dual-stack listener reports for an IPv4 connection)
now matches a plain IPv4 entry. It is socket-derived and so not forgeable; it is
pinned by a test.

## Test plan

Gate 1 was run twice -- the second round after self-review found the blocker
above -- with the failing test observed before each fix.

- New `backend/tests/security/test_client_ip.py` (30 items) pins the issue's five
  properties verbatim, plus CIDR vs bare-IP trust, dropped malformed config,
  IPv6, whitespace tolerance, an unparseable hop, an absent peer, duplicate
  header lines, a non-IP and a 200-character peer, `0.0.0.0/0`, and
  IPv4-mapped folding. `src/client_ip.py` is at **100% line and 100% branch**
  from that file alone; the IPv4-mapped tests were mutation-checked (they fail
  when `_unmapped` is neutered).
- The bypass itself is reproduced end to end: rotating `X-Forwarded-For` across
  the full hourly cap now trips at attempt N+1
  (`test_rotating_x_forwarded_for_cannot_reset_the_invalid_license_cap`), and
  integration tests drive slowapi and the throttle through `ASGITransport` with
  a faked socket peer to prove both key on the same value.
- Audit integrity: `PasswordResetToken.requested_ip` is pinned on both branches,
  and `LoginAttempt.ip_address` -- which had no coverage at all -- now has a test
  that it records the socket peer, not the header.
- `backend/tests/test_trusted_proxy_startup_config.py` covers the production
  warning on every branch. Dockerfile tests assert the CMD can never ship the
  wildcard or drift from the application's trust set.
- `./scripts/backend/check-all.sh` exits 0: **3286 passed, 2 skipped**, coverage
  96.98%. `xenon --max-absolute A --max-modules A --max-average A`, `radon mi -n B`,
  `interrogate` (96.6%), ruff `select=ALL`, ruff-format, mypy strict, bandit and
  detect-secrets all clean. Changed files verified to parse under Python 3.11.
- I independently re-ran every claim the security reviewer made rather than
  taking it on report, and verified the uvicorn/application composition by
  reading the installed `ProxyHeadersMiddleware` source and tracing it by hand.

## Follow-ups filed (deliberately not widened into this PR)

- #1998 -- IPv6 clients can still rotate addresses within their /64 to bypass the
  throttle; needs an audit/throttle key split, not a change to this resolver.
- #1999 -- move `X-Forwarded-Proto` into app middleware gated on the same trust
  check, so `--proxy-headers` can be dropped and the proto tradeoff above goes
  away.
- #2000 -- an integration test that runs the real `ProxyHeadersMiddleware` and
  `resolve_client_ip` together, so the two layers are pinned as agreeing rather
  than assumed to.

Closes #1986
Refs #1948
