### PR TITLE
fix(frontend): stop the Map cold-start fetch looping on an empty success

### DIFF
--- a/frontend/src/features/Map/Map.styles.ts
+++ b/frontend/src/features/Map/Map.styles.ts
@@ -67,6 +67,14 @@ const styles = StyleSheet.create({
     textAlign: CENTER,
     paddingHorizontal: spacing(2),
   },
+  // A load that returned nothing is not a failure, so the headline reads in
+  // plain ink rather than the alarm colour; the hint/retry are shared.
+  emptyText: {
+    color: ink.primary,
+    fontSize: 14,
+    textAlign: CENTER,
+    paddingHorizontal: spacing(2),
+  },
   // The human "what to do next" line under the verbatim server message.
   errorHint: {
     color: ink.muted,

--- a/frontend/src/features/Map/MapScreen.tsx
+++ b/frontend/src/features/Map/MapScreen.tsx
@@ -26,6 +26,7 @@ import {
   selectCurrentStage,
   selectCycleNumber,
   selectStages,
+  selectStagesAttempted,
   selectStagesError,
   selectStagesLoading,
   useStageStore,
@@ -913,6 +914,26 @@ const MapError = ({
   </View>
 );
 
+// A load that succeeded with nothing: calm, not alarming — say so plainly and
+// offer the same explicit retry, rather than leaving a spinner or a blank grid.
+const MapEmpty = ({ onRetry }: { onRetry: () => void }): React.JSX.Element => (
+  <View style={styles.centered} testID="map-empty">
+    <Text style={styles.emptyText}>The map has nothing to show yet.</Text>
+    <Text style={styles.errorHint}>
+      Your stages haven&apos;t arrived from the server. Try again in a moment.
+    </Text>
+    <TouchableOpacity
+      onPress={onRetry}
+      accessibilityRole="button"
+      accessibilityLabel="Try again"
+      style={styles.errorRetry}
+      testID="map-empty-retry"
+    >
+      <Text style={styles.errorRetryText}>Try again</Text>
+    </TouchableOpacity>
+  </View>
+);
+
 // Non-blocking banner for a refresh that failed while cached stages are shown,
 // so a stale map no longer hides the failure (the cold-start MapError covers
 // the no-stages case). Retry re-runs the same loader.
@@ -1320,17 +1341,19 @@ const useMapDrawer = (
   return { drawer, onDrawerSelectStage };
 };
 
-/** Read the five Map-relevant slices of the stage store in one place. */
+/** Read the Map-relevant slices of the stage store in one place. */
 const useMapStageStore = () => ({
   stages: useStageStore(selectStages),
   loading: useStageStore(selectStagesLoading),
   error: useStageStore(selectStagesError),
+  hasAttempted: useStageStore(selectStagesAttempted),
   storeCurrentStage: useStageStore(selectCurrentStage),
   cycleNumber: useStageStore(selectCycleNumber),
 });
 
 const MapScreen = (): React.JSX.Element => {
-  const { stages, loading, error, storeCurrentStage, cycleNumber } = useMapStageStore();
+  const { stages, loading, error, hasAttempted, storeCurrentStage, cycleNumber } =
+    useMapStageStore();
   // Prefer the date-driven stage; the server's count-based one is the fallback.
   const currentStage = useDerivedCurrentStage(storeCurrentStage);
   // Additive overlay: a failed/loading read leaves the map empty so every Aspect reads thin.
@@ -1344,14 +1367,15 @@ const MapScreen = (): React.JSX.Element => {
     [stages],
   );
 
-  // A failed load leaves the store at exactly {stages: [], loading: false}, so the
-  // ``error`` term is what stops this cold-start fetch re-firing forever. Recovery
-  // is the retry button: loadStages clears ``error`` itself, re-arming the guard.
+  // One automatic attempt per session: a load that fails — or succeeds with an
+  // empty list — lands back on this guard's shape, so only the store's recorded
+  // attempt stops it re-firing. Every later attempt is user-initiated; the
+  // store's logout ``reset`` clears the flag and re-arms the cold start.
   useEffect(() => {
-    if (stages.length === 0 && !loading && !error) {
+    if (stages.length === 0 && !loading && !error && !hasAttempted) {
       void stageService.loadStages();
     }
-  }, [stages.length, loading, error]);
+  }, [stages.length, loading, error, hasAttempted]);
 
   const handleRefresh = useCallback(() => void stageService.loadStages(), []);
   const handleCloseModal = useCallback(() => setActiveStage(null), []);
@@ -1362,6 +1386,7 @@ const MapScreen = (): React.JSX.Element => {
 
   if (loading && stages.length === 0) return <MapLoading />;
   if (error && stages.length === 0) return <MapError message={error} onRetry={handleRefresh} />;
+  if (hasAttempted && stages.length === 0) return <MapEmpty onRetry={handleRefresh} />;
 
   return (
     <MapContent

--- a/frontend/src/features/Map/__tests__/MapScreenRefetchLoop.test.tsx
+++ b/frontend/src/features/Map/__tests__/MapScreenRefetchLoop.test.tsx
@@ -166,4 +166,51 @@ describe('MapScreen — cold-start fetch is not a retry loop', () => {
     expect(tree.root.findByProps({ testID: 'journey-read' })).toBeTruthy();
     expect(mockListAll).toHaveBeenCalledTimes(2);
   });
+
+  it('fetches the stage list exactly once when the server returns an empty list', async () => {
+    mockListAll.mockResolvedValue([]);
+
+    const tree = renderMap();
+    await flushRounds();
+
+    // A load that succeeds with nothing leaves the store back at its guard-passing
+    // shape, so only a recorded attempt can stop the effect re-arming itself.
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+    expect(tree.root.findByProps({ testID: 'map-empty' })).toBeTruthy();
+    expect(tree.root.findAllByProps({ testID: 'map-loading' })).toHaveLength(0);
+    expect(tree.root.findAllByProps({ testID: 'map-error' })).toHaveLength(0);
+  });
+
+  it('renders the empty state with a way forward instead of a spinner', async () => {
+    mockListAll.mockResolvedValue([]);
+
+    const tree = renderMap();
+    await flushRounds();
+
+    const retry = tree.root.findByProps({ testID: 'map-empty-retry' });
+    expect(retry.props.accessibilityRole).toBe('button');
+    expect(retry.props.accessibilityLabel).toBe('Try again');
+
+    act(() => retry.props.onPress());
+    await flushRounds();
+
+    expect(mockListAll).toHaveBeenCalledTimes(2);
+    expect(tree.root.findByProps({ testID: 'map-empty' })).toBeTruthy();
+  });
+
+  it('a logout reset re-arms the cold-start fetch on a fresh mount', async () => {
+    mockListAll.mockResolvedValue([]);
+
+    const first = renderMap();
+    await flushRounds();
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+
+    act(() => first.unmount());
+    act(() => useStageStore.getState().reset());
+
+    renderMap();
+    await flushRounds();
+
+    expect(mockListAll).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/src/features/Map/__tests__/mapTestHarness.ts
+++ b/frontend/src/features/Map/__tests__/mapTestHarness.ts
@@ -88,6 +88,8 @@ export interface MapMockState {
   currentStage: number;
   loading: boolean;
   error: string | null;
+  /** Whether a stage load has been started at least once this session. */
+  hasAttempted: boolean;
   cycleNumber: number;
   derivedStage: number | null;
   derivedWeek: number | null;
@@ -104,6 +106,7 @@ function createDefaultState(): MapMockState {
     currentStage: 1,
     loading: false,
     error: null,
+    hasAttempted: false,
     cycleNumber: 1,
     derivedStage: 1,
     derivedWeek: 1,
@@ -149,7 +152,7 @@ export const mockIsStageUnlocked = (
 
 /** Build the ``useStageStore`` state slice from the current ``mockMapState``. */
 export function buildMockStageState() {
-  const { stages, currentStage, loading, error, cycleNumber } = mockMapState;
+  const { stages, currentStage, loading, error, hasAttempted, cycleNumber } = mockMapState;
   return {
     stages,
     stagesByNumber: Object.fromEntries(stages.map((s) => [s.stageNumber, s])),
@@ -157,11 +160,13 @@ export function buildMockStageState() {
     currentStage,
     loading,
     error,
+    hasAttempted,
     cycleNumber,
     setStages: jest.fn(),
     setCurrentStage: jest.fn(),
     setLoading: jest.fn(),
     setError: jest.fn(),
+    markAttempted: jest.fn(),
     updateStageProgress: jest.fn(),
     setCycleNumber: jest.fn(),
   };
@@ -253,6 +258,7 @@ export function mockStageStoreModule() {
     selectCurrentStage: (s: { currentStage: unknown }) => s.currentStage,
     selectStagesLoading: (s: { loading: unknown }) => s.loading,
     selectStagesError: (s: { error: unknown }) => s.error,
+    selectStagesAttempted: (s: { hasAttempted: boolean }) => s.hasAttempted,
     selectCycleNumber: (s: { cycleNumber: number }) => s.cycleNumber,
     selectStageByNumber:
       (n: number | null | undefined) => (s: { stagesByNumber: Record<number, unknown> }) =>

--- a/frontend/src/features/Map/services/__tests__/stageService.test.ts
+++ b/frontend/src/features/Map/services/__tests__/stageService.test.ts
@@ -145,6 +145,33 @@ describe('stageService', () => {
     expect(state.stages).toHaveLength(0);
   });
 
+  it('loadStages marks the attempt when the request resolves', async () => {
+    mockList.mockResolvedValueOnce([makeApiStage(1)]);
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    expect(useStageStore.getState().hasAttempted).toBe(true);
+  });
+
+  it('loadStages marks the attempt when the request rejects', async () => {
+    // Marking at request start, not on success: a failed load must count too.
+    mockList.mockRejectedValueOnce(new Error('Network error'));
+
+    const { stageService } = require('../stageService');
+    const { useStageStore } = require('../../../../store/useStageStore');
+
+    await act(async () => {
+      await stageService.loadStages();
+    });
+
+    expect(useStageStore.getState().hasAttempted).toBe(true);
+  });
+
   it('loadStages maps StageData metadata fields correctly', async () => {
     mockList.mockResolvedValueOnce([
       makeApiStage(1, {

--- a/frontend/src/features/Map/services/stageService.ts
+++ b/frontend/src/features/Map/services/stageService.ts
@@ -91,6 +91,9 @@ export const stageService = {
     const store = useStageStore.getState();
     store.setLoading(true);
     store.setError(null);
+    // Marked at request start, not on settle, so the attempt lands in the same
+    // synchronous window as ``setLoading`` — an unmount mid-flight still counts.
+    store.markAttempted();
     try {
       const apiStages = await stagesApi.listAll(token);
       // Sort descending by stage_number (10 at top, 1 at bottom) to match

--- a/frontend/src/store/__tests__/useStageStore.test.ts
+++ b/frontend/src/store/__tests__/useStageStore.test.ts
@@ -26,12 +26,7 @@ const makeStage = (stageNumber: number, overrides: Partial<StageData> = {}): Sta
 describe('useStageStore', () => {
   beforeEach(() => {
     const { useStageStore } = require('../useStageStore');
-    act(() => {
-      useStageStore.getState().setStages([]);
-      useStageStore.getState().setCurrentStage(1);
-      useStageStore.getState().setLoading(false);
-      useStageStore.getState().setError(null);
-    });
+    act(() => useStageStore.getState().reset());
   });
 
   it('starts with empty stages, no loading, no error', () => {
@@ -138,6 +133,33 @@ describe('useStageStore', () => {
     act(() => useStageStore.getState().setStages([makeStage(7)]));
     act(() => resetAllStores());
     expect(useStageStore.getState().stages).toEqual([]);
+  });
+
+  describe('hasAttempted', () => {
+    it('is false before any load has been started', () => {
+      const { useStageStore } = require('../useStageStore');
+      expect(useStageStore.getState().hasAttempted).toBe(false);
+    });
+
+    it('markAttempted() records that a load has been started', () => {
+      const { useStageStore } = require('../useStageStore');
+      act(() => useStageStore.getState().markAttempted());
+      expect(useStageStore.getState().hasAttempted).toBe(true);
+    });
+
+    it('reset() clears hasAttempted so a fresh sign-in loads again', () => {
+      const { useStageStore } = require('../useStageStore');
+      act(() => useStageStore.getState().markAttempted());
+      act(() => useStageStore.getState().reset());
+      expect(useStageStore.getState().hasAttempted).toBe(false);
+    });
+
+    it('selectStagesAttempted reads hasAttempted from state', () => {
+      const { useStageStore, selectStagesAttempted } = require('../useStageStore');
+      expect(selectStagesAttempted(useStageStore.getState())).toBe(false);
+      act(() => useStageStore.getState().markAttempted());
+      expect(selectStagesAttempted(useStageStore.getState())).toBe(true);
+    });
   });
 
   describe('cycleNumber', () => {

--- a/frontend/src/store/useStageStore.ts
+++ b/frontend/src/store/useStageStore.ts
@@ -27,12 +27,15 @@ export interface StageStoreState {
   cycleNumber: number;
   loading: boolean;
   error: string | null;
+  /** Whether a stage load has been started at least once since the last reset. */
+  hasAttempted: boolean;
 
   setStages: (_stages: StageData[]) => void;
   setCurrentStage: (_stageNumber: number) => void;
   setCycleNumber: (_cycleNumber: number) => void;
   setLoading: (_loading: boolean) => void;
   setError: (_error: string | null) => void;
+  markAttempted: () => void;
   updateStageProgress: (_stageNumber: number, _progress: number) => void;
   /** BUG-FE-STATE-001: wipe every field back to its initial value on logout. */
   reset: () => void;
@@ -46,6 +49,7 @@ const INITIAL_STATE = {
   cycleNumber: 1,
   loading: false,
   error: null as string | null,
+  hasAttempted: false,
 };
 
 const stageCollection = createNormalizedById<StageData>((stage) => stage.stageNumber);
@@ -65,6 +69,7 @@ export const useStageStore = create<StageStoreState>((set) => ({
   setCycleNumber: (cycleNumber) => set({ cycleNumber }),
   setLoading: (loading) => set({ loading }),
   setError: (error) => set({ error }),
+  markAttempted: () => set({ hasAttempted: true }),
   updateStageProgress: (stageNumber, progress) =>
     set((state) => {
       const existing = state.stagesByNumber[stageNumber];
@@ -106,3 +111,4 @@ export const selectCurrentStage = (state: StageStoreState): number => state.curr
 export const selectCycleNumber = (state: StageStoreState): number => state.cycleNumber;
 export const selectStagesLoading = (state: StageStoreState): boolean => state.loading;
 export const selectStagesError = (state: StageStoreState): string | null => state.error;
+export const selectStagesAttempted = (state: StageStoreState): boolean => state.hasAttempted;


### PR DESCRIPTION
## Summary

- **Closes the last hole in the Map cold-start refetch loop.** The effect guarded
  on `stages.length === 0 && !loading && !error`. A load that *succeeds with an
  empty list* leaves the store at `{stages: [], loading: false, error: null}`, so
  the `loading` flip re-runs the effect, the guard is satisfied again, and it
  fetches forever. (The *failure* branch was closed earlier by the `error` term;
  that coverage is untouched.) Observed on the RED run: 13 calls in 8 flush
  rounds where 1 was expected.
- **The fix records the attempt in the store, not in a ref.** State alone cannot
  distinguish "never attempted" from "attempted, server returned nothing", so
  `useStageStore` gains `hasAttempted` (in `INITIAL_STATE`, plus `markAttempted()`
  and `selectStagesAttempted`), and the guard becomes
  `stages.length === 0 && !loading && !error && !hasAttempted`.
  **Logout re-arm:** `reset()` already spreads `INITIAL_STATE`, so it clears the
  flag for free and the next sign-in fetches again. A component-level `useRef` was
  deliberately rejected — a ref outlives the store lifecycle and would block that
  legitimate re-fetch. There is an explicit regression test for it.
- **`loadStages` marks at request start**, beside `setLoading(true)` and before the
  `await`, so the flag lands in the same synchronous window as `loading` (a
  double-mount is doubly blocked, and an unmount mid-flight still counts). Tests
  pin the flag on both the resolve and the reject path.
- **An empty-but-successful load now renders something.** A new `MapEmpty` view
  (third early return, after loading and error, so neither is shadowed) says so
  plainly and offers the same explicit "Try again" affordance as the error state
  — no permanent spinner, no bare blank map. It carries no `alert` role or live
  region: a resolved-empty result is not a failure.

This state is not reachable today (the backend seeds ten stages), so this is
latent-defect work — which makes the tests as much the deliverable as the fix.
They are the only thing that will notice if the store's state shape drifts later.

## Test plan

- **Gate 1 RED, observed before the fix:** the empty-response test failed with
  `Expected 1, Received 13` (sustained refetch across the bounded flush rounds);
  the empty-state test failed on the missing `map-empty-retry` node; the
  logout-reset test failed at 16 calls. Store/service tests failed on the absent
  field, action, and selector.
- **New tests** (extending `MapScreenRefetchLoop.test.tsx`, which drives the real
  store + real service with only the network mocked):
  - a sustained empty success fetches **exactly once** — a bounded call-count
    assertion, not merely "it stops";
  - the empty state exposes its retry with the right role/label, and pressing it
    yields **exactly 2** total calls — the user-initiated retry is the only second
    fetch, and a second empty success still does not re-arm;
  - after `useStageStore.getState().reset()` (logout) a fresh mount fetches
    **again** — exactly 2 total.
  - `useStageStore`: `hasAttempted` defaults false, `markAttempted()` sets it,
    `reset()` clears it, `selectStagesAttempted` reads it.
  - `stageService`: the attempt is marked on both the resolve and the reject path.
- The three pre-existing `MapScreenRefetchLoop` error-branch tests are byte
  identical and still pass.
- `./scripts/frontend/check-all.sh` exits **0** (audit gate, ESLint, Prettier,
  `tsc --noEmit`, Jest: 446 suites / 5179 tests). Verified in the worktree by the
  conductor, not only by the specialist.
- Gate 2.5 `code-review-orchestrator`: **CLEAN**, no blocking findings.

## Follow-ups filed (out of scope here)

- #2002 — `PracticeScreen`'s stage cold-start fetch has no `hasAttempted` guard
  (does not loop, but re-fires redundantly on every mount).
- #2003 — `stageService` has no request-generation guard, so a response that
  resolves after `reset()` or after a newer load can clobber the store.
- #2004 — `MapLoading` has no timeout and no way forward if a request never
  settles.

Closes #1995
