### PR TITLE
fix(ci): label Dependabot bridge issues via REST, with the API's real error

### DIFF
--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -200,10 +200,16 @@ jobs:
             # `body_links_issue` short-circuits any re-run — no duplicate is
             # ever minted while the label is added by hand.
             if [ "$label_ec" -ne 0 ]; then
-              label_error="$label_output"
-              # An empty payload would annotate as a bare `::error::`; give the
-              # exit code itself a voice instead.
-              [ -n "$label_error" ] || label_error="ensure-issue-label.sh exited $label_ec without output; the 'dependencies' label on issue #$issue_num is unverified."
+              # Actions renders only the FIRST line of an `::error::` as an
+              # annotation; every later line falls through as plain log text. So
+              # the annotation is a synthesized one-liner and the verbatim gh
+              # stderr stays where `echo "$label_output"` already put it in full
+              # — feeding the whole block in here would render one line in the UI
+              # and dribble the remainder out as a second, half-rendered copy of
+              # what is already logged. Pointing at the log keeps the diagnostic
+              # fidelity that is this call's whole purpose. Synthesized
+              # unconditionally, so there is no empty payload left to guard.
+              label_error="ensure-issue-label.sh exited $label_ec; the 'dependencies' label on issue #$issue_num is unverified — see the verbatim gh output logged above."
               if [ "$EVENT_NAME" = "pull_request_target" ]; then
                 echo "::error::$label_error" >&2
                 exit 1

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -55,13 +55,19 @@ jobs:
       github.event_name != 'pull_request_target' ||
       github.actor == 'dependabot[bot]'
     steps:
-      - name: Check out repo metadata only (no PR head)
-        # We never check out or build the PR head — only the base repo, for
-        # nothing more than a clean workspace. The bridge reads PR data via the
-        # gh API, not the checkout.
+      - name: Check out base-branch scripts (never the PR head)
+        # LOAD-BEARING, not just a clean workspace: this checkout supplies the
+        # copy of scripts/ralph/ensure-issue-label.sh that the run: block below
+        # executes. Under pull_request_target the default ref is the BASE
+        # branch, so that code is trusted. NEVER add a `ref:` pointing at the PR
+        # head — this job holds a write-capable token, so running head code
+        # would be arbitrary code execution by any PR author.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
+          # The job runs no git commands, so the token has no reason to be
+          # persisted into .git/config where later steps could reuse it.
+          persist-credentials: false
 
       - name: Bridge Dependabot PRs into Ralph issues
         env:
@@ -175,24 +181,29 @@ jobs:
             # re-reach this point (the PR body now links the issue, so
             # `body_links_issue` short-circuits), so the script's diagnosis
             # names the one-time manual fix.
-            local label_output="" label_error=""
-            if label_output="$(scripts/ralph/ensure-issue-label.sh \
-              "$issue_num" dependencies --repo "$REPO" 2>&1)"; then
-              # Even on success the output may carry a ::warning:: about a token
-              # whose gap the fallback papered over — always surface it.
-              echo "$label_output"
-            else
-              label_error="$label_output"
-            fi
+            local label_output="" label_error="" label_ec=0
+            label_output="$(scripts/ralph/ensure-issue-label.sh \
+              "$issue_num" dependencies --repo "$REPO" 2>&1)" || label_ec=$?
+            # Even on success the output may carry a ::warning:: about a token
+            # whose gap the fallback papered over — always surface it.
+            echo "$label_output"
 
-            # Failure handling differs by path. The single-PR event path fails
-            # loud and immediate (exit 1). The reconciler processes a whole
-            # batch, so one PR's label-verify failure must NOT skip every later
-            # PR: record the diagnosis and let the caller continue, then fail
-            # the run once at the end. The issue is filed and its PR is already
-            # linked, so `body_links_issue` short-circuits any re-run — no
-            # duplicate is ever minted while the label is added by hand.
-            if [ -n "$label_error" ]; then
+            # Failure is the EXIT CODE, never output emptiness: a non-zero exit
+            # that printed nothing (killed by a signal, say) is precisely the
+            # failure class the old `|| true` hid.
+            #
+            # Handling then differs by path. The single-PR event path fails loud
+            # and immediate (exit 1). The reconciler processes a whole batch, so
+            # one PR's label-verify failure must NOT skip every later PR: record
+            # the diagnosis and let the caller continue, then fail the run once
+            # at the end. The issue is filed and its PR is already linked, so
+            # `body_links_issue` short-circuits any re-run — no duplicate is
+            # ever minted while the label is added by hand.
+            if [ "$label_ec" -ne 0 ]; then
+              label_error="$label_output"
+              # An empty payload would annotate as a bare `::error::`; give the
+              # exit code itself a voice instead.
+              [ -n "$label_error" ] || label_error="ensure-issue-label.sh exited $label_ec without output; the 'dependencies' label on issue #$issue_num is unverified."
               if [ "$EVENT_NAME" = "pull_request_target" ]; then
                 echo "::error::$label_error" >&2
                 exit 1

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -69,6 +69,11 @@ jobs:
           # deslop.yml) so the issue/PR edits are authored by an account
           # the mobile webhook recognizes; fall back to the run's GITHUB_TOKEN.
           GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT || secrets.GITHUB_TOKEN }}
+          # Second credential for the label call only. This ADDS NO PERMISSION:
+          # it is the run's own token, which the permissions: block above already
+          # grants issues: write. It exists because GH_TOKEN prefers the PAT, and
+          # the PAT is the credential observed to be denied label writes.
+          FALLBACK_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           # Event-driven PR metadata, read ONLY from the trusted event payload.
@@ -155,30 +160,29 @@ jobs:
 
             echo "Linked PR #$pr → issue #$issue_num via Closes."
 
-            # The REST create endpoint silently drops labels when the token
-            # lacks push/triage access — which would break the marker dedup
-            # above (it filters on the `dependencies` label). Re-apply the
-            # label with a dedicated call (that endpoint errors instead of
-            # dropping) and verify it stuck, so a permission gap fails loudly
-            # rather than leaving an unlabeled, picker-invisible issue.
-            # Swallow this call's own error: the read-back verification below is
-            # the authoritative diagnosis, so a failure here would be redundant.
-            gh issue edit "$issue_num" --repo "$REPO" \
-              --add-label dependencies || true
-
-            # Verify the label stuck. Capture the read call's own success
-            # separately from the label match so the two failure modes keep
-            # distinct diagnoses: a failed read is a transient API flake, while
-            # a successful read that omits the label is a real permission gap.
-            # A re-run cannot re-reach this check (the PR body now links the
-            # issue, so `body_links_issue` short-circuits), so both branches
-            # point to the same one-time manual fix: add the label by hand.
-            local labels label_error=""
-            if ! labels="$(gh issue view "$issue_num" --repo "$REPO" \
-              --json labels --jq '.labels[].name')"; then
-              label_error="Could not verify the label on issue #$issue_num (transient GitHub API error); the re-apply may have succeeded — if the issue is missing the label, add it once: gh issue edit $issue_num --add-label dependencies"
-            elif ! printf '%s\n' "$labels" | grep -qx dependencies; then
-              label_error="The 'dependencies' label is absent on issue #$issue_num after re-apply (the token likely lacks Issues/triage permission); add it once by hand: gh issue edit $issue_num --add-label dependencies"
+            # Re-apply the `dependencies` label and prove it stuck: the marker
+            # dedup above filters on that label, so an unlabeled issue is also a
+            # picker-invisible one. Delegated to a script because the obvious
+            # call, `gh issue edit --add-label`, performs the GraphQL mutation
+            # addLabelsToLabelable, which the PAT in GH_TOKEN is observed to be
+            # denied; the `issues: write` declared above governs the run's
+            # GITHUB_TOKEN, which that call never used. The script POSTs to the
+            # REST labels endpoint (needs only issues:write, and errors instead
+            # of dropping), retries once with FALLBACK_GH_TOKEN, verifies by
+            # read-back, and prints the verbatim gh stderr of every failure —
+            # the old `|| true` discarded exactly that answer, leaving the
+            # diagnosis below to guess, and it guessed wrong. A re-run cannot
+            # re-reach this point (the PR body now links the issue, so
+            # `body_links_issue` short-circuits), so the script's diagnosis
+            # names the one-time manual fix.
+            local label_output="" label_error=""
+            if label_output="$(scripts/ralph/ensure-issue-label.sh \
+              "$issue_num" dependencies --repo "$REPO" 2>&1)"; then
+              # Even on success the output may carry a ::warning:: about a token
+              # whose gap the fallback papered over — always surface it.
+              echo "$label_output"
+            else
+              label_error="$label_output"
             fi
 
             # Failure handling differs by path. The single-PR event path fails

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -42,3 +42,4 @@ jobs:
           bash scripts/ralph/test_fleet.sh
           bash scripts/ralph/test_pick_next.sh
           bash scripts/ralph/test_pr_ready.sh
+          bash scripts/ralph/test_ensure_issue_label.sh

--- a/scripts/ralph/ensure-issue-label.sh
+++ b/scripts/ralph/ensure-issue-label.sh
@@ -20,10 +20,15 @@
 #      fallback token rescues the call, because a capability gap papered over by
 #      a second token is still a capability gap worth knowing about.
 #
-# Tokens travel by environment only - never in argv, never echoed, no `set -x`:
+# Tokens travel by environment only - never in an external command's argv (the
+# fallback is passed to a shell function, which stays in-process and off every
+# process listing), never echoed, no `set -x`:
 #   GH_TOKEN           primary token (gh reads it itself)
 #   FALLBACK_GH_TOKEN  optional second token, tried once if the primary fails
 #                      and only when it actually differs from GH_TOKEN
+# That invariant also requires NOT running under GH_DEBUG=api, which makes gh
+# dump request headers - Authorization included - into the very stderr this
+# script reprints verbatim.
 #
 # Usage:  ensure-issue-label.sh <issue-number> <label> [--repo <owner/repo>]
 # Exit:   0 = applied and verified | 1 = label missing/unverifiable | 2 = usage
@@ -55,6 +60,10 @@ done
 [[ "$issue" =~ ^[0-9]+$ ]] || die "$USAGE"
 [[ -n "$label" ]]          || die "$USAGE"
 [[ -n "$repo" ]]           || die "--repo is required when GITHUB_REPOSITORY is unset"
+# $repo is interpolated into an API path, so its shape is a security boundary,
+# not a nicety: `owner/../../user` would redirect the write at another resource.
+# Only the characters GitHub allows in an owner or repo name get through.
+[[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || die "invalid --repo: expected owner/repo"
 
 # --- reporting helpers -------------------------------------------------------
 #
@@ -170,8 +179,10 @@ if [[ "$readback_ec" -ne 0 ]]; then
 fi
 
 # Exact, per-label comparison: a repo label named `<label>-bot` must not be read
-# as `<label>`. -x anchors the whole line, -F keeps the label a literal.
-if ! printf '%s\n' "$labels" | grep -qxF -- "$label"; then
+# as `<label>`. -x anchors the whole line, -F keeps the label a literal. A
+# herestring, not a pipe: under `pipefail` an early-exiting grep can SIGPIPE the
+# writer, which would read here as a false "silently dropped".
+if ! grep -qxF -- "$label" <<<"$labels"; then
   printf 'ensure-issue-label: the %s token API call reported success, but issue #%s does not carry label %s - it was silently dropped.\n' \
     "$applied_by" "$issue" "$label" >&2
   report_block "Labels actually read back from issue #$issue:" "$labels"

--- a/scripts/ralph/ensure-issue-label.sh
+++ b/scripts/ralph/ensure-issue-label.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# scripts/ralph/ensure-issue-label.sh
+#
+# Apply a label to a GitHub issue and PROVE it stuck, reproducing the verbatim
+# stderr of every gh call that fails.
+#
+# WHY THIS EXISTS: the Dependabot-to-Ralph bridge used to label its issues with
+# `gh issue edit N --add-label X || true`, and two things were wrong with that.
+#
+#   1. `gh issue edit --add-label` performs the GraphQL mutation
+#      `addLabelsToLabelable`, which the fine-grained PAT the workflow runs under
+#      is denied ("Resource not accessible by personal access token") even though
+#      the same token creates issues and edits PR bodies in the same run. The
+#      REST endpoint used here, POST /repos/:repo/issues/:n/labels, needs only
+#      `issues: write` and errors instead of silently dropping. Never reach for
+#      `gh issue edit --add-label` in this script: that is the denied call.
+#   2. `|| true` discarded the API's answer, so the workflow could only GUESS at
+#      the cause of a missing label - and guessed wrong. Nothing is swallowed
+#      here: every failing call's stderr is printed verbatim, INCLUDING when the
+#      fallback token rescues the call, because a capability gap papered over by
+#      a second token is still a capability gap worth knowing about.
+#
+# Tokens travel by environment only - never in argv, never echoed, no `set -x`:
+#   GH_TOKEN           primary token (gh reads it itself)
+#   FALLBACK_GH_TOKEN  optional second token, tried once if the primary fails
+#                      and only when it actually differs from GH_TOKEN
+#
+# Usage:  ensure-issue-label.sh <issue-number> <label> [--repo <owner/repo>]
+# Exit:   0 = applied and verified | 1 = label missing/unverifiable | 2 = usage
+set -euo pipefail
+
+readonly USAGE='usage: ensure-issue-label.sh <issue-number> <label> [--repo <owner/repo>]'
+readonly EXIT_LABEL_FAILED=1
+readonly ROLE_PRIMARY=primary
+readonly ROLE_FALLBACK=fallback
+
+die() { echo "ensure-issue-label: $1" >&2; exit 2; }
+
+issue=""
+label=""
+# GITHUB_REPOSITORY is the Actions-native default; --repo wins when given.
+repo="${GITHUB_REPOSITORY:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) [[ $# -ge 2 ]] || die "--repo needs a value"; repo="$2"; shift 2 ;;
+    -*)     die "unknown option: $1" ;;
+    *)
+      if   [[ -z "$issue" ]]; then issue="$1"
+      elif [[ -z "$label" ]]; then label="$1"
+      else die "unexpected extra argument: $1"
+      fi
+      shift ;;
+  esac
+done
+[[ "$issue" =~ ^[0-9]+$ ]] || die "$USAGE"
+[[ -n "$label" ]]          || die "$USAGE"
+[[ -n "$repo" ]]           || die "--repo is required when GITHUB_REPOSITORY is unset"
+
+# --- reporting helpers -------------------------------------------------------
+#
+# Failure text is plain: callers own the `::error::` annotation (the workflow
+# bridge re-emits the captured output that way, and double-prefixing reads
+# badly). The one exception is the fallback-rescue warning below - that path
+# exits 0, so nothing downstream would ever annotate it, yet a capability gap
+# hidden behind a second token is exactly what must not go unnoticed.
+
+# Print a heading followed by a captured gh stderr block, unedited. Verbatim is
+# the whole point: an invented paraphrase is what sent the last investigation
+# down the wrong path.
+report_block() { # report_block <heading> <captured-stderr>
+  printf '%s\n%s\n' "$1" "$2" >&2
+}
+
+# The one-time manual fix for a human. `gh issue edit` is fine from a laptop
+# (an interactive login is not the denied PAT) - it is only wrong for this
+# script's automated path.
+report_remedy() {
+  printf 'One-time manual fix: gh issue edit %s --repo %s --add-label %s\n' \
+    "$issue" "$repo" "$label" >&2
+}
+
+# --- apply -------------------------------------------------------------------
+
+# The REST label call. Reads its token from the environment so no token ever
+# reaches a process listing.
+post_label() {
+  gh api --method POST "repos/$repo/issues/$issue/labels" -f "labels[]=$label"
+}
+
+# Run post_label, optionally under an override token, capturing its stderr in
+# APPLY_STDERR and returning gh's own exit code. The `2>&1 >/dev/null` order
+# routes stderr to the capture and drops the (unused) response body. The
+# assignment lives inside a command substitution, so an override token cannot
+# leak back into this shell's environment.
+apply_label() { # apply_label [override-token]
+  local ec=0
+  if [[ $# -eq 0 ]]; then
+    APPLY_STDERR="$(post_label 2>&1 >/dev/null)" || ec=$?
+  else
+    APPLY_STDERR="$(GH_TOKEN="$1" post_label 2>&1 >/dev/null)" || ec=$?
+  fi
+  return "$ec"
+}
+
+# A fallback is only worth an extra API call when it exists and is a genuinely
+# different credential; retrying the same token would just re-earn the same 403.
+fallback_usable() {
+  [[ -n "${FALLBACK_GH_TOKEN:-}" && "${FALLBACK_GH_TOKEN}" != "${GH_TOKEN:-}" ]]
+}
+
+applied_by=""
+primary_stderr=""
+fallback_stderr=""
+fallback_tried=0
+
+if apply_label; then
+  applied_by="$ROLE_PRIMARY"
+else
+  primary_stderr="$APPLY_STDERR"
+  if fallback_usable; then
+    fallback_tried=1
+    if apply_label "$FALLBACK_GH_TOKEN"; then
+      applied_by="$ROLE_FALLBACK"
+    else
+      fallback_stderr="$APPLY_STDERR"
+    fi
+  fi
+fi
+
+if [[ -z "$applied_by" ]]; then
+  printf 'ensure-issue-label: could not apply label %s to issue #%s in %s.\n' \
+    "$label" "$issue" "$repo" >&2
+  report_block "Verbatim gh stderr from the $ROLE_PRIMARY token attempt:" "$primary_stderr"
+  if [[ "$fallback_tried" -eq 1 ]]; then
+    report_block "Verbatim gh stderr from the $ROLE_FALLBACK token attempt:" "$fallback_stderr"
+  else
+    echo "No usable FALLBACK_GH_TOKEN was set, so only one attempt was made." >&2
+  fi
+  report_remedy
+  exit "$EXIT_LABEL_FAILED"
+fi
+
+# The fallback succeeded, so the run continues - but the primary token's gap is
+# real and must be logged rather than papered over.
+if [[ "$applied_by" == "$ROLE_FALLBACK" ]]; then
+  report_block \
+    "::warning::ensure-issue-label: the $ROLE_PRIMARY token could not apply label $label to issue #$issue; the $ROLE_FALLBACK token succeeded. Verbatim gh stderr from the $ROLE_PRIMARY attempt:" \
+    "$primary_stderr"
+fi
+
+# --- verify ------------------------------------------------------------------
+
+# A 2xx on the POST is not proof: read the labels back. stderr goes to its own
+# file so a failed read reports its real error instead of contaminating the
+# label list.
+readback_stderr="$(mktemp)"
+trap 'rm -f "$readback_stderr"' EXIT
+
+labels=""
+readback_ec=0
+labels="$(gh issue view "$issue" --repo "$repo" \
+  --json labels --jq '.labels[].name' 2>"$readback_stderr")" || readback_ec=$?
+
+if [[ "$readback_ec" -ne 0 ]]; then
+  printf 'ensure-issue-label: applied label %s to issue #%s with the %s token, but the read-back call failed, so the label is UNVERIFIED. This is usually a transient API error and the apply may well have stuck - check the issue before acting.\n' \
+    "$label" "$issue" "$applied_by" >&2
+  report_block "Verbatim gh stderr from the read-back call:" "$(cat "$readback_stderr")"
+  report_remedy
+  exit "$EXIT_LABEL_FAILED"
+fi
+
+# Exact, per-label comparison: a repo label named `<label>-bot` must not be read
+# as `<label>`. -x anchors the whole line, -F keeps the label a literal.
+if ! printf '%s\n' "$labels" | grep -qxF -- "$label"; then
+  printf 'ensure-issue-label: the %s token API call reported success, but issue #%s does not carry label %s - it was silently dropped.\n' \
+    "$applied_by" "$issue" "$label" >&2
+  report_block "Labels actually read back from issue #$issue:" "$labels"
+  report_remedy
+  exit "$EXIT_LABEL_FAILED"
+fi
+
+printf 'ensure-issue-label: label %s applied to issue #%s with the %s token and verified.\n' \
+  "$label" "$issue" "$applied_by"

--- a/scripts/ralph/ensure-issue-label.sh
+++ b/scripts/ralph/ensure-issue-label.sh
@@ -64,6 +64,19 @@ done
 # not a nicety: `owner/../../user` would redirect the write at another resource.
 # Only the characters GitHub allows in an owner or repo name get through.
 [[ "$repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || die "invalid --repo: expected owner/repo"
+# That class is necessary but not sufficient, and the gap is easy to miss: a
+# character class that ADMITS a dot is not the same as one that admits a
+# dot-only SEGMENT. `.` has to stay in the class - GitHub genuinely allows it
+# inside a name, and `owner.name/repo.js` is a real repository - so `../repo`,
+# `./repo` and `owner/..` all satisfy the regex above while still detaching the
+# path from the repo the caller named. One rule closes every variant of that:
+# each segment must carry at least one non-dot character. The regex already
+# guarantees exactly one `/`, so these two expansions ARE the two segments, and
+# both are checked because they interpolate at different depths of the URL.
+has_non_dot_char() { [[ "$1" =~ [^.] ]]; }
+if ! has_non_dot_char "${repo%%/*}" || ! has_non_dot_char "${repo##*/}"; then
+  die "invalid --repo: owner and repo must each contain a non-dot character"
+fi
 
 # --- reporting helpers -------------------------------------------------------
 #

--- a/scripts/ralph/test_ensure_issue_label.sh
+++ b/scripts/ralph/test_ensure_issue_label.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# scripts/ralph/test_ensure_issue_label.sh
+#
+# Offline tests for ensure-issue-label.sh — the label applier the
+# Dependabot-to-Ralph workflow uses to stamp `dependencies` on the issue it
+# files for each bot PR.
+#
+# WHY THIS EXISTS: labelling used to run as `gh issue edit N --add-label X
+# || true`. On a fine-grained PAT that call is denied at the GraphQL layer
+# (addLabelsToLabelable), and `|| true` discarded the error, so the workflow
+# could only GUESS why the label was missing — and guessed wrong. The
+# replacement must (a) apply via the REST labels endpoint, (b) retry once with
+# a distinct fallback token, (c) verify by reading the labels back, and
+# (d) print the VERBATIM stderr of every failing gh call. No swallowed errors,
+# no invented causes.
+#
+# A fake, arg-aware `gh` on PATH makes the API choice observable: an
+# `issue edit` call routes to an unmistakable failure, and every REST POST is
+# logged with the token that made it — so both "wrong API" and "retried when it
+# must not" are caught.
+#
+# Run:  bash scripts/ralph/test_ensure_issue_label.sh
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/ensure-issue-label.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check()    { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected [$2], got [$3])"; fi; }
+contains() { if [[ "$3" == *"$2"* ]]; then ok "$1"; else bad "$1 (needle [$2] absent from [$3])"; fi; }
+lacks()    { if [[ "$3" != *"$2"* ]]; then ok "$1"; else bad "$1 (needle [$2] present in [$3])"; fi; }
+differs()  { if [[ "$2" != "$3" ]]; then ok "$1"; else bad "$1 (both outputs were [$2])"; fi; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+ATTEMPT_LOG="$WORK/attempts"
+export ATTEMPT_LOG
+
+# Fixture identity. The sentinels let the stub tell the two tokens apart and let
+# every scenario assert that neither value is ever echoed back to the log.
+readonly ISSUE=42
+readonly LABEL=dependencies
+readonly REPO=owner/repo
+readonly PRIMARY_SENTINEL=ralph-primary-sentinel
+readonly FALLBACK_SENTINEL=ralph-fallback-sentinel
+export FALLBACK_SENTINEL
+
+# Verbatim gh stderr the stub replays. Case 3 asserts BOTH survive to the log —
+# that pair of assertions is the direct regression guard against `|| true`.
+readonly PRIMARY_ERR='HTTP 403: Resource not accessible by personal access token (https://api.github.com/repos/owner/repo/issues/42/labels)'
+readonly FALLBACK_ERR='HTTP 403: Resource not accessible by integration (https://api.github.com/repos/owner/repo/issues/42/labels)'
+readonly READBACK_ERR='HTTP 502: Bad gateway (https://api.github.com/repos/owner/repo/issues/42)'
+
+# Arg-aware fake gh, driven by env vars each scenario sets:
+#   POST_EC_PRIMARY / POST_ERR_PRIMARY     — REST POST result under the primary token
+#   POST_EC_FALLBACK / POST_ERR_FALLBACK   — same under the fallback token
+#   VIEW_EC / VIEW_ERR / VIEW_LABELS       — read-back result (labels newline separated)
+# Every POST appends the attempting token's role to $ATTEMPT_LOG, so attempt
+# COUNT is a first-class assertion.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"issue edit"*)
+    # The denied GraphQL mutation. Fail loudly so a regression to it is visible.
+    printf 'STUB-FORBIDDEN: gh issue edit uses the denied GraphQL mutation\n' >&2
+    exit 1 ;;
+  *"issue view"*)
+    if [[ -n "${VIEW_ERR:-}" ]]; then printf '%s\n' "$VIEW_ERR" >&2; fi
+    if [[ "${VIEW_EC:-0}" -ne 0 ]]; then exit "${VIEW_EC:-0}"; fi
+    if [[ -n "${VIEW_LABELS:-}" ]]; then printf '%s\n' "$VIEW_LABELS"; fi
+    exit 0 ;;
+  *"api"*"labels"*)
+    role=primary
+    if [[ "${GH_TOKEN:-}" == "$FALLBACK_SENTINEL" ]]; then role=fallback; fi
+    printf '%s\n' "$role" >> "$ATTEMPT_LOG"
+    if [[ "$role" == fallback ]]; then
+      err="${POST_ERR_FALLBACK:-}"; ec="${POST_EC_FALLBACK:-0}"
+    else
+      err="${POST_ERR_PRIMARY:-}"; ec="${POST_EC_PRIMARY:-0}"
+    fi
+    if [[ -n "$err" ]]; then printf '%s\n' "$err" >&2; fi
+    exit "$ec" ;;
+  *)
+    printf 'STUB-UNEXPECTED: %s\n' "$args" >&2
+    exit 1 ;;
+esac
+STUB
+chmod +x "$BIN/gh"
+
+OUT=""
+EC=0
+
+# Reset every stub knob to the all-green default, then a scenario overrides only
+# what it is about. Explicit re-export (not `VAR=x run`) keeps cases isolated.
+scenario() {
+  : > "$ATTEMPT_LOG"
+  export POST_EC_PRIMARY=0 POST_ERR_PRIMARY=""
+  export POST_EC_FALLBACK=0 POST_ERR_FALLBACK=""
+  export VIEW_EC=0 VIEW_ERR="" VIEW_LABELS="agent-ready
+$LABEL"
+  export GH_TOKEN="$PRIMARY_SENTINEL"
+  export FALLBACK_GH_TOKEN="$FALLBACK_SENTINEL"
+}
+
+run() { # run <args...> — combined stdout+stderr into OUT, exit code into EC
+  set +e
+  OUT="$(PATH="$BIN:$PATH" "$SCRIPT" "$@" 2>&1)"
+  EC=$?
+  set -e
+}
+
+run_default() { run "$ISSUE" "$LABEL" --repo "$REPO"; }
+
+attempts()      { awk 'END { print NR }' "$ATTEMPT_LOG"; }
+attempts_with() { grep -c "^$1\$" "$ATTEMPT_LOG" || true; }
+
+# Tokens are secrets: they must never reach stdout/stderr, in any scenario.
+no_leak() {
+  lacks "$1: primary token value not echoed" "$PRIMARY_SENTINEL" "$OUT"
+  lacks "$1: fallback token value not echoed" "$FALLBACK_SENTINEL" "$OUT"
+}
+
+# The one-time manual fix a human runs when automation cannot apply the label.
+remedy_offered() {
+  contains "$1: names the issue in the manual remedy" "gh issue edit $ISSUE" "$OUT"
+  contains "$1: names the label in the manual remedy" "--add-label $LABEL" "$OUT"
+}
+
+# --- 1. primary token applies the label, read-back confirms it ---------------
+scenario
+run_default
+check    "primary success exits 0" "0" "$EC"
+check    "primary success makes exactly one POST" "1" "$(attempts)"
+check    "the single POST used the primary token" "1" "$(attempts_with primary)"
+contains "primary success credits the primary token" "primary" "$OUT"
+contains "primary success names the label" "$LABEL" "$OUT"
+lacks    "primary success never calls gh issue edit" "STUB-FORBIDDEN" "$OUT"
+lacks    "primary success makes no unmodelled gh call" "STUB-UNEXPECTED" "$OUT"
+no_leak  "primary success"
+
+# --- 2. primary denied, fallback rescues — the denial is STILL reported ------
+# A capability gap that the fallback papers over must never go unlogged.
+scenario
+export POST_EC_PRIMARY=1 POST_ERR_PRIMARY="$PRIMARY_ERR"
+run_default
+check    "fallback rescue exits 0" "0" "$EC"
+check    "fallback rescue makes exactly two POSTs" "2" "$(attempts)"
+check    "fallback rescue tried the primary token first" "1" "$(attempts_with primary)"
+check    "fallback rescue retried with the fallback token" "1" "$(attempts_with fallback)"
+contains "fallback rescue still reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
+contains "fallback rescue credits the fallback token" "fallback" "$OUT"
+lacks    "fallback rescue never calls gh issue edit" "STUB-FORBIDDEN" "$OUT"
+no_leak  "fallback rescue"
+
+# --- 3. both tokens denied — BOTH errors verbatim (anti-`|| true`) ----------
+scenario
+export POST_EC_PRIMARY=1 POST_ERR_PRIMARY="$PRIMARY_ERR"
+export POST_EC_FALLBACK=1 POST_ERR_FALLBACK="$FALLBACK_ERR"
+export VIEW_LABELS="agent-ready"
+run_default
+check    "both-denied exits 1" "1" "$EC"
+check    "both-denied made two POSTs" "2" "$(attempts)"
+contains "both-denied reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
+contains "both-denied reports the fallback error verbatim" "$FALLBACK_ERR" "$OUT"
+remedy_offered "both-denied"
+no_leak  "both-denied"
+
+# --- 4. POST claims success but the label is not there (silently dropped) ----
+# `dependencies-bot` is present to catch a substring match standing in for a
+# real per-label comparison.
+scenario
+export VIEW_LABELS="agent-ready
+dependencies-bot"
+run_default
+DROPPED_OUT="$OUT"
+check    "silently-dropped exits 1" "1" "$EC"
+contains "silently-dropped echoes the labels actually read back" "dependencies-bot" "$OUT"
+lacks    "silently-dropped does not blame the read-back call" "$READBACK_ERR" "$OUT"
+remedy_offered "silently-dropped"
+no_leak  "silently-dropped"
+
+# --- 5. the read-back itself errors — a different diagnosis than case 4 ------
+scenario
+export VIEW_EC=1 VIEW_ERR="$READBACK_ERR"
+run_default
+READBACK_OUT="$OUT"
+check    "read-back failure exits 1" "1" "$EC"
+contains "read-back failure reports its error verbatim" "$READBACK_ERR" "$OUT"
+remedy_offered "read-back failure"
+no_leak  "read-back failure"
+differs  "unverifiable and dropped states get distinct diagnoses" \
+         "$DROPPED_OUT" "$READBACK_OUT"
+
+# --- 6. no usable fallback ⇒ exactly ONE attempt -----------------------------
+scenario
+unset FALLBACK_GH_TOKEN
+export POST_EC_PRIMARY=1 POST_ERR_PRIMARY="$PRIMARY_ERR"
+run_default
+check    "unset fallback exits 1" "1" "$EC"
+check    "unset fallback makes exactly one POST" "1" "$(attempts)"
+check    "unset fallback never reaches the fallback branch" "0" "$(attempts_with fallback)"
+contains "unset fallback reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
+no_leak  "unset fallback"
+
+scenario
+export FALLBACK_GH_TOKEN="$PRIMARY_SENTINEL"   # byte-identical to GH_TOKEN
+export POST_EC_PRIMARY=1 POST_ERR_PRIMARY="$PRIMARY_ERR"
+run_default
+check    "identical fallback exits 1" "1" "$EC"
+check    "identical fallback makes exactly one POST" "1" "$(attempts)"
+contains "identical fallback reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
+no_leak  "identical fallback"
+
+# --- 7. usage errors exit 2 (house style: die() in pr-ready.sh) --------------
+scenario
+run
+check "missing issue number exits 2" "2" "$EC"
+no_leak "missing issue number"
+
+scenario
+run "$ISSUE"
+check "missing label exits 2" "2" "$EC"
+check "missing label makes no POST" "0" "$(attempts)"
+no_leak "missing label"
+
+scenario
+run "not-a-number" "$LABEL" --repo "$REPO"
+check "non-numeric issue number exits 2" "2" "$EC"
+check "non-numeric issue number makes no POST" "0" "$(attempts)"
+no_leak "non-numeric issue number"
+
+printf '\nensure-issue-label tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/test_ensure_issue_label.sh
+++ b/scripts/ralph/test_ensure_issue_label.sh
@@ -14,10 +14,14 @@
 # (d) print the VERBATIM stderr of every failing gh call. No swallowed errors,
 # no invented causes.
 #
-# A fake, arg-aware `gh` on PATH makes the API choice observable: an
-# `issue edit` call routes to an unmistakable failure, and every REST POST is
-# logged with the token that made it — so both "wrong API" and "retried when it
-# must not" are caught.
+# A fake, arg-aware `gh` on PATH makes the API choice observable. Every call's
+# full argv is recorded, so the happy path pins the request SHAPE — the HTTP
+# method, the REST labels path, the `labels[]` body parameter, and the absence
+# of any GraphQL call. Both known routes to the denied `addLabelsToLabelable`
+# mutation, the `gh issue edit --add-label` shorthand and a hand-rolled
+# `gh api graphql`, are routed to an unmistakable stub failure. Each REST POST
+# additionally records the token that made it, so "wrong API", "wrong request"
+# and "retried when it must not" are all caught.
 #
 # Run:  bash scripts/ralph/test_ensure_issue_label.sh
 set -euo pipefail
@@ -39,6 +43,10 @@ BIN="$WORK/bin"
 mkdir -p "$BIN"
 ATTEMPT_LOG="$WORK/attempts"
 export ATTEMPT_LOG
+# Full argv of every gh call, one call per line. ATTEMPT_LOG answers "how many
+# POSTs, by which token"; REQ_LOG answers "which API, and with what request".
+REQ_LOG="$WORK/requests"
+export REQ_LOG
 
 # Fixture identity. The sentinels let the stub tell the two tokens apart and let
 # every scenario assert that neither value is ever echoed back to the log.
@@ -59,15 +67,23 @@ readonly READBACK_ERR='HTTP 502: Bad gateway (https://api.github.com/repos/owner
 #   POST_EC_PRIMARY / POST_ERR_PRIMARY     — REST POST result under the primary token
 #   POST_EC_FALLBACK / POST_ERR_FALLBACK   — same under the fallback token
 #   VIEW_EC / VIEW_ERR / VIEW_LABELS       — read-back result (labels newline separated)
-# Every POST appends the attempting token's role to $ATTEMPT_LOG, so attempt
-# COUNT is a first-class assertion.
+# Every call appends its full argv to $REQ_LOG, so the request SHAPE is a
+# first-class assertion; every POST additionally appends the attempting token's
+# role to $ATTEMPT_LOG, so attempt COUNT is one too.
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 args="$*"
+printf '%s\n' "$args" >> "$REQ_LOG"
 case "$args" in
   *"issue edit"*)
-    # The denied GraphQL mutation. Fail loudly so a regression to it is visible.
+    # The denied GraphQL mutation, via the CLI shorthand. Fail loudly so a
+    # regression to it is visible.
     printf 'STUB-FORBIDDEN: gh issue edit uses the denied GraphQL mutation\n' >&2
+    exit 1 ;;
+  *graphql*)
+    # The same denied mutation reached by hand. Checked BEFORE the REST case so
+    # a `-f query=...addLabelsToLabelable...` payload cannot masquerade as one.
+    printf 'STUB-FORBIDDEN: gh api graphql uses the denied GraphQL mutation\n' >&2
     exit 1 ;;
   *"issue view"*)
     if [[ -n "${VIEW_ERR:-}" ]]; then printf '%s\n' "$VIEW_ERR" >&2; fi
@@ -99,12 +115,18 @@ EC=0
 # what it is about. Explicit re-export (not `VAR=x run`) keeps cases isolated.
 scenario() {
   : > "$ATTEMPT_LOG"
+  : > "$REQ_LOG"
   export POST_EC_PRIMARY=0 POST_ERR_PRIMARY=""
   export POST_EC_FALLBACK=0 POST_ERR_FALLBACK=""
   export VIEW_EC=0 VIEW_ERR="" VIEW_LABELS="agent-ready
 $LABEL"
   export GH_TOKEN="$PRIMARY_SENTINEL"
   export FALLBACK_GH_TOKEN="$FALLBACK_SENTINEL"
+  # Pinned, not inherited: GitHub Actions exports GITHUB_REPOSITORY on every
+  # runner, so an unpinned value would make the repo-resolution cases pass or
+  # fail depending on where the suite runs. The case that needs it absent
+  # unsets it explicitly.
+  export GITHUB_REPOSITORY="$REPO"
 }
 
 run() { # run <args...> — combined stdout+stderr into OUT, exit code into EC
@@ -118,6 +140,16 @@ run_default() { run "$ISSUE" "$LABEL" --repo "$REPO"; }
 
 attempts()      { awk 'END { print NR }' "$ATTEMPT_LOG"; }
 attempts_with() { grep -c "^$1\$" "$ATTEMPT_LOG" || true; }
+
+# Recorded requests. `requests` is every gh call; `api_calls` is just the REST
+# ones (`gh api ...`), which is where the label write must happen.
+requests()       { cat "$REQ_LOG"; }
+api_calls()      { grep -e '^api ' "$REQ_LOG" || true; }
+api_call_count() { grep -c -e '^api ' "$REQ_LOG" || true; }
+
+# The whole reason this script exists: the label must never be written through
+# GraphQL, where the workflow's fine-grained PAT is denied.
+rest_only() { lacks "$1: no gh call reaches the GraphQL layer" "graphql" "$(requests)"; }
 
 # Tokens are secrets: they must never reach stdout/stderr, in any scenario.
 no_leak() {
@@ -143,6 +175,19 @@ lacks    "primary success never calls gh issue edit" "STUB-FORBIDDEN" "$OUT"
 lacks    "primary success makes no unmodelled gh call" "STUB-UNEXPECTED" "$OUT"
 no_leak  "primary success"
 
+# The request SHAPE, not just its outcome. Each of these pins one property of
+# the REST call that the fine-grained PAT is actually permitted to make; the
+# needles are built from the fixture constants so the expectation cannot drift
+# away from the arguments the script was handed.
+API_CALLS="$(api_calls)"
+check    "the label write is the only gh api call" "1" "$(api_call_count)"
+contains "the label write uses HTTP POST" "--method POST" "$API_CALLS"
+contains "the label write targets the REST labels endpoint" \
+         "repos/$REPO/issues/$ISSUE/labels" "$API_CALLS"
+contains "the label write sends the label as a labels[] body parameter" \
+         "labels[]=$LABEL" "$API_CALLS"
+rest_only "primary success"
+
 # --- 2. primary denied, fallback rescues — the denial is STILL reported ------
 # A capability gap that the fallback papers over must never go unlogged.
 scenario
@@ -156,6 +201,10 @@ contains "fallback rescue still reports the primary error verbatim" "$PRIMARY_ER
 contains "fallback rescue credits the fallback token" "fallback" "$OUT"
 lacks    "fallback rescue never calls gh issue edit" "STUB-FORBIDDEN" "$OUT"
 no_leak  "fallback rescue"
+rest_only "fallback rescue"
+contains "the fallback retry repeats the same REST labels endpoint" \
+         "repos/$REPO/issues/$ISSUE/labels" "$(api_calls)"
+check    "fallback rescue makes exactly two gh api calls" "2" "$(api_call_count)"
 
 # --- 3. both tokens denied — BOTH errors verbatim (anti-`|| true`) ----------
 scenario
@@ -169,20 +218,26 @@ contains "both-denied reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
 contains "both-denied reports the fallback error verbatim" "$FALLBACK_ERR" "$OUT"
 remedy_offered "both-denied"
 no_leak  "both-denied"
+rest_only "both-denied"
 
 # --- 4. POST claims success but the label is not there (silently dropped) ----
-# `dependencies-bot` is present to catch a substring match standing in for a
-# real per-label comparison.
+# Near-miss labels in BOTH directions: `dependencies-bot` catches a prefix match
+# and `extra-dependencies` catches a suffix-anchored one, so only a whole-line
+# comparison survives.
 scenario
 export VIEW_LABELS="agent-ready
-dependencies-bot"
+dependencies-bot
+extra-dependencies"
 run_default
 DROPPED_OUT="$OUT"
 check    "silently-dropped exits 1" "1" "$EC"
 contains "silently-dropped echoes the labels actually read back" "dependencies-bot" "$OUT"
+contains "a label ENDING in the wanted label is not the wanted label" \
+         "extra-dependencies" "$OUT"
 lacks    "silently-dropped does not blame the read-back call" "$READBACK_ERR" "$OUT"
 remedy_offered "silently-dropped"
 no_leak  "silently-dropped"
+rest_only "silently-dropped"
 
 # --- 5. the read-back itself errors — a different diagnosis than case 4 ------
 scenario
@@ -193,6 +248,7 @@ check    "read-back failure exits 1" "1" "$EC"
 contains "read-back failure reports its error verbatim" "$READBACK_ERR" "$OUT"
 remedy_offered "read-back failure"
 no_leak  "read-back failure"
+rest_only "read-back failure"
 differs  "unverifiable and dropped states get distinct diagnoses" \
          "$DROPPED_OUT" "$READBACK_OUT"
 
@@ -206,6 +262,7 @@ check    "unset fallback makes exactly one POST" "1" "$(attempts)"
 check    "unset fallback never reaches the fallback branch" "0" "$(attempts_with fallback)"
 contains "unset fallback reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
 no_leak  "unset fallback"
+rest_only "unset fallback"
 
 scenario
 export FALLBACK_GH_TOKEN="$PRIMARY_SENTINEL"   # byte-identical to GH_TOKEN
@@ -215,6 +272,7 @@ check    "identical fallback exits 1" "1" "$EC"
 check    "identical fallback makes exactly one POST" "1" "$(attempts)"
 contains "identical fallback reports the primary error verbatim" "$PRIMARY_ERR" "$OUT"
 no_leak  "identical fallback"
+rest_only "identical fallback"
 
 # --- 7. usage errors exit 2 (house style: die() in pr-ready.sh) --------------
 scenario
@@ -233,6 +291,43 @@ run "not-a-number" "$LABEL" --repo "$REPO"
 check "non-numeric issue number exits 2" "2" "$EC"
 check "non-numeric issue number makes no POST" "0" "$(attempts)"
 no_leak "non-numeric issue number"
+
+scenario
+run "$ISSUE" "$LABEL" --repo
+check "--repo with no value exits 2" "2" "$EC"
+check "--repo with no value makes no POST" "0" "$(attempts)"
+no_leak "--repo with no value"
+
+scenario
+run "$ISSUE" "$LABEL" --not-an-option
+check "unknown option exits 2" "2" "$EC"
+check "unknown option makes no POST" "0" "$(attempts)"
+no_leak "unknown option"
+
+scenario
+run "$ISSUE" "$LABEL" "surplus" --repo "$REPO"
+check "extra positional argument exits 2" "2" "$EC"
+check "extra positional argument makes no POST" "0" "$(attempts)"
+no_leak "extra positional argument"
+
+# The Actions-native default is the ONLY other source of the repo, so with it
+# gone and no --repo there is nothing to interpolate into the API path.
+scenario
+unset GITHUB_REPOSITORY
+run "$ISSUE" "$LABEL"
+check "no repo from either source exits 2" "2" "$EC"
+check "no repo from either source makes no POST" "0" "$(attempts)"
+no_leak "no repo from either source"
+
+# --- 8. a repo value is interpolated into an API path, so validate it --------
+# INTENTIONALLY RED: path traversal in --repo must be rejected before it can
+# redirect the write at another resource. Asserted as ONE composite check so the
+# pending guard reads as a single gap rather than two.
+scenario
+run "$ISSUE" "$LABEL" --repo "owner/../../user"
+check "path-traversal --repo is rejected before any gh call" \
+      "ec=2 posts=0" "ec=$EC posts=$(attempts)"
+no_leak "path-traversal --repo"
 
 printf '\nensure-issue-label tests: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/test_ensure_issue_label.sh
+++ b/scripts/ralph/test_ensure_issue_label.sh
@@ -320,14 +320,47 @@ check "no repo from either source makes no POST" "0" "$(attempts)"
 no_leak "no repo from either source"
 
 # --- 8. a repo value is interpolated into an API path, so validate it --------
-# INTENTIONALLY RED: path traversal in --repo must be rejected before it can
-# redirect the write at another resource. Asserted as ONE composite check so the
-# pending guard reads as a single gap rather than two.
+# The shape of $repo is a security boundary, not a nicety: `owner/../../user`
+# walks the REST path back out of `repos/` and would aim the write at an
+# unrelated resource. Rejection must happen BEFORE the first gh call, so each
+# value is one composite check pinning exit code and attempt count together —
+# a guard that only fails after a hopeful POST has already gone out is not a
+# guard, and split assertions would let that half-failure read as half green.
 scenario
 run "$ISSUE" "$LABEL" --repo "owner/../../user"
 check "path-traversal --repo is rejected before any gh call" \
       "ec=2 posts=0" "ec=$EC posts=$(attempts)"
 no_leak "path-traversal --repo"
+
+# The subtle half of the same boundary. `.` is a legal character INSIDE an
+# owner or repo name, so a character-class test alone still admits a segment
+# made of nothing BUT dots: `..` climbs to the parent collection and `.`
+# re-enters the current one, either of which detaches the path from the repo
+# the caller named. Both positions are covered because the two segments are
+# interpolated at different depths of the URL and a check that anchors only the
+# owner half would still let the repo half through.
+for BAD_REPO in "../repo" "owner/.." "./repo" "owner/."; do
+  scenario
+  run "$ISSUE" "$LABEL" --repo "$BAD_REPO"
+  check "dot-segment --repo [$BAD_REPO] is rejected before any gh call" \
+        "ec=2 posts=0" "ec=$EC posts=$(attempts)"
+  no_leak "dot-segment --repo [$BAD_REPO]"
+done
+
+# The counterweight, and the reason the rule above cannot simply be "no dots":
+# GitHub really does allow them inside a name (`owner.name`, `repo.js`), so
+# closing the traversal hole must not start rejecting live repositories. The
+# stub matches on request shape rather than on the repo, so this run goes all
+# the way through apply and read-back; the endpoint assertion then proves the
+# accepted value is carried into the path verbatim rather than merely tolerated.
+readonly DOTTED_REPO="owner.name/repo.js"
+scenario
+run "$ISSUE" "$LABEL" --repo "$DOTTED_REPO"
+check    "dotted-but-legal --repo is accepted and applied" \
+         "ec=0 posts=1" "ec=$EC posts=$(attempts)"
+contains "dotted-but-legal --repo reaches the REST labels endpoint intact" \
+         "repos/$DOTTED_REPO/issues/$ISSUE/labels" "$(api_calls)"
+no_leak  "dotted-but-legal --repo"
 
 printf '\nensure-issue-label tests: %d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- **The real cause, from the run logs — the workflow's own diagnosis was wrong.**
  All four failing runs answered identically:
  `GraphQL: Resource not accessible by personal access token (addLabelsToLabelable)`.
  `gh issue edit --add-label` performs that mutation. The credential is
  `secrets.GEOFFE_GA_PAT` (every bridge issue is authored by the PAT's account,
  not `github-actions[bot]`), and in the *same run* it created the issue and
  edited the PR body — so it can write issues; it is that one mutation it is
  denied. The declared `permissions: issues: write` is real, but it governs the
  run's `GITHUB_TOKEN`, which the label call never used. The annotation blamed
  a missing Issues/triage permission because `|| true` discarded the API's
  answer and the verification step could only infer one.

- **Fix.** Label application moves to `scripts/ralph/ensure-issue-label.sh`,
  which POSTs to REST `repos/:repo/issues/:n/labels` (needs only
  `issues: write`, and errors instead of silently dropping), retries once with
  `FALLBACK_GH_TOKEN` when it differs, reads the labels back to prove the apply
  stuck, and reports which token won. The workflow passes its own
  `GITHUB_TOKEN` as that fallback — **no permission is added or widened**; it is
  the `issues: write` already declared and never reached. The `permissions:`
  block, triggers, actor gate, base-only checkout and env-only PR title are
  untouched.

- **Regression guard.** The verification step stays and now states the API's
  answer instead of guessing: every failing call's stderr is printed verbatim,
  including a `::warning::` when the fallback rescues the call, so a
  papered-over capability gap still shows. The workflow keys its failure branch
  on the exit code rather than on output being non-empty — a non-zero exit that
  printed nothing was the same bug class as `|| true`. The logic left YAML for a
  script so it could be tested: 95 assertions against a stubbed `gh`, run in CI
  by `ralph-recap-tests.yml`.

- Not touched: `pick-next.sh`'s exclusion set. The label is the mechanism, not
  the bug.

## Test plan

- `bash scripts/ralph/test_ensure_issue_label.sh` — 95 passed, 0 failed. The
  suite pins the request shape (`--method POST`, the REST labels endpoint, the
  `labels[]=` body parameter, and that no call reaches the GraphQL layer), both
  verbatim errors surviving a double denial, the primary's error still being
  reported when the fallback rescues the call, exactly one attempt when no
  distinct fallback exists, an exact per-label match (`dependencies-bot` and
  `extra-dependencies` decoys), argument parsing, and that no token value ever
  reaches the log.
- Mutation-tested, independently re-run at review: reintroducing the denied
  mutation via `gh api graphql` fails 33 assertions; `--method GET`, a wrong
  endpoint, a dropped `labels[]`, and a hardcoded repo/issue each fail too.
  Before this PR's test round, all five passed unnoticed.
- `bash scripts/ralph/test_fleet.sh` (25), `test_pick_next.sh` (23),
  `test_pr_ready.sh` (14) — all still green.
- `shellcheck --severity=warning` clean on both shell files, including the
  workflow's extracted `run:` block; `pre-commit` green on every changed file.
- Verified against the live API that `gh api --method POST … -f "labels[]=…"`
  sends `{"labels": ["…"]}` to the documented "Add labels to an issue"
  endpoint (checked with `GH_DEBUG=api` against a nonexistent issue, so nothing
  was mutated).

## What this PR cannot prove

Whether the PAT's REST POST succeeds where its GraphQL mutation was denied, and
whether the `GITHUB_TOKEN` fallback ever fires, only reproduces on a real
Dependabot `pull_request_target` run with the real secret — no local test can
exercise either token. What the tests do prove is the decision logic and the
error-capture contract: that no failure path can be silent again.

Confirmation to look for on the next Dependabot PR (or the Monday reconciler
over an unlinked one): the bridge issue carries `dependencies`, and the run log
names which token applied it — and, if the PAT was denied, quotes the API's
verbatim error rather than a theory about it. A `workflow_dispatch` run with no
unlinked Dependabot PRs proves nothing; it short-circuits. If the log shows the
PAT denied for REST as well, the remedy is a settings change, not a code one:
grant `GEOFFE_GA_PAT` Issues read/write for this repository.

A separate SIGPIPE defect found in the bridge's dedup helper during review was
filed as #2006 rather than fixed here.

Closes #1997
