### PR TITLE
fix(backend): key throttles on the IPv6 delegated prefix, not the address

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -369,6 +369,7 @@ than a migration.
 | `LLM_MODEL` | No | Provider default | `gpt-4o-mini` (OpenAI) or `claude-sonnet-4-20250514` (Anthropic) |
 | `WEB_CONCURRENCY` | No | `2` | Number of Uvicorn worker processes |
 | `TRUSTED_PROXY_CIDRS` | Recommended in prod | *(empty)* | Comma-separated IPs/CIDRs of the reverse proxies you operate, e.g. the platform ingress range. Until it is set, `X-Forwarded-For` is ignored (every client behind the ingress shares one rate-limit bucket and one audited IP) and `X-Forwarded-Proto` is untrusted, so redirects and absolute URLs stay `http://`. Never list a public range you do not control. |
+| `IPV6_THROTTLE_PREFIX_LEN` | No | `64` | Bit length of the IPv6 prefix that throttle keys (the rate limiter and the invalid-license throttle) group on, so one subscriber's delegated address range can't mint one bucket per address. Audit rows always keep the full address regardless. Valid range `1`-`128`; anything else falls back to the default rather than being clamped. A smaller number covers a larger delegation: lower it to `56`/`48` if you see IPv6 abuse, raise it to `128` to restore per-address keying (which reopens the bypass). |
 | `BOTMASON_SYSTEM_PROMPT` | No | Built-in | Path to prompt file or inline text |
 | `EMAIL_BACKEND` | No | `console` | `console` (logs the email locally) or `smtp` (delivers via SMTP). Required: `smtp` in production. |
 | `SMTP_HOST` | If `EMAIL_BACKEND=smtp` | — | SMTP relay hostname, e.g. `smtp.sendgrid.net` |
@@ -495,6 +496,44 @@ the real peer address, then list only that proxy in
 `TRUSTED_PROXY_CIDRS`.  Operators investigating an abuse report
 should treat the audit `ip_address` as authoritative only to the
 extent the ingress chain, and this configuration, are trusted.
+
+Once a peer address is resolved, the rate limiter and the
+invalid-license throttle key on it a little differently than the
+audit rows do: an IPv6 address is grouped onto its delegated prefix
+(`IPV6_THROTTLE_PREFIX_LEN`, default `64`) rather than kept exact,
+because a residential or cloud subscriber owns an entire delegated
+prefix and could otherwise rotate through it to mint one throttle
+bucket per address and never trip the cap.  IPv4 is never affected
+-- one client, one address.  This changes throttle keys only: the
+audit rows (`LoginAttempt.ip_address`,
+`PasswordResetToken.requested_ip`) always record the exact address,
+never the prefix, so an operator tracing an abusive IP in the audit
+log will not find it truncated.  The value IS the prefix length, so
+a *smaller* number covers a *larger* delegation.  An integer outside
+`1`-`128`, or a non-integer, falls back to the default of `64`
+rather than being clamped, since silently disabling the grouping is
+worse than ignoring a typo.
+
+`64` is the *smallest* delegation a subscriber receives, not the
+typical one.  A customer handed a `/56` still holds 256 `/64`s and a
+`/48` holds 65,536, so the hourly caps are divided by that much for
+them and the same rotation works one level up.  If you see licence
+grinding or signup abuse from IPv6, `IPV6_THROTTLE_PREFIX_LEN=56`
+(or `48`) is the lever.  The default stays at `64` because widening
+it for everyone would merge unrelated customers on any ISP that does
+delegate a `/64` each -- the collateral this setting is deliberately
+avoiding on the IPv4 side.
+
+The grouping cuts the other way too, and it is worth knowing before
+you debug a support ticket.  A `/64` is exactly one LAN, so an
+office or campus on SLAAC, a VPN exit pool, or a NAT64/CGN pool is a
+single throttle bucket for all of its users -- against the 60/minute
+global default, 5/minute login, and 3/hour password reset.  That is
+the same treatment those users would already get behind a NATted
+IPv4 address, but it is a change from per-address keying.  If such a
+site is your traffic and you see spurious `429`s, setting `128`
+restores exact per-address keying, at the cost of reopening the
+address-rotation bypass this setting exists to close.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -94,6 +94,37 @@ GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 # then claim to be any client it likes.
 TRUSTED_PROXY_CIDRS=  # e.g. 10.0.0.0/8,192.0.2.10
 
+# How much of an IPv6 address identifies one subscriber, for the throttle keys
+# above (the per-route rate limiter and the hourly invalid-license throttle).
+# Read at request time, so retuning it needs no restart. Default 64 is the
+# size residential and cloud upstreams are expected to delegate. The value IS
+# the prefix length, so a SMALLER number covers a LARGER delegation. Valid
+# values are an integer in [1, 128]; anything else -- non-integer, empty, 0,
+# negative, or over 128 -- falls back to the default rather than being
+# clamped, because 0 would collapse every IPv6 client on earth into one bucket
+# (a self-inflicted denial of service on legitimate users) and clamping 129
+# down would silently disable the grouping.
+#
+# Affects throttle keys only: audit rows (LoginAttempt.ip_address,
+# PasswordResetToken.requested_ip, the password_reset_event log) always keep
+# the exact address, never the prefix. IPv4 is never affected -- one client,
+# one address.
+#
+# 64 is the SMALLEST delegation a subscriber gets, not the typical one. An ISP
+# that hands out a /56 leaves that customer 256 buckets, and a /48 leaves
+# 65,536 -- so the hourly caps are still divided by that much for them. If you
+# see licence grinding or signup abuse from IPv6, set 56 (or 48): that is the
+# lever. The default stays at 64 because widening it by default would merge
+# unrelated customers on any ISP that does delegate a /64 each.
+#
+# It cuts the other way too. A /64 is exactly one LAN, so an office or campus
+# on SLAAC, a VPN exit pool, or a NAT64/CGN pool is a single bucket for all of
+# its users -- the same treatment they would already get behind a NATted IPv4
+# address, but a change from per-address keying. If such a site is your traffic
+# and you see spurious 429s, 128 restores exact per-address keying, at the cost
+# of reopening the address-rotation bypass this setting exists to close.
+IPV6_THROTTLE_PREFIX_LEN=  # e.g. 56 -- bit length of the delegated IPv6 prefix (default 64)
+
 # Comma-separated Google OAuth client IDs (iOS / Android / web) accepted as the
 # ``aud`` claim of a submitted id_token. Read at request time, so rotating or
 # adding a platform needs no restart. Fails closed: unset means Google sign-in

--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -9,6 +9,17 @@ from the right, because a client can prepend entries that the proxy appends
 to.  Unset or blank config trusts nobody: the header is ignored everywhere and
 every control keys on the socket peer.
 
+One trust walk, two answers.  ``resolve_client_ip`` says *who was this,
+exactly* and belongs in audit rows and logs, where forensic precision is the
+whole point.  ``client_throttle_key`` says *whose budget does this spend* and
+belongs in every limiter, where the unit has to be a customer rather than an
+address: a residential IPv6 subscriber is delegated an entire /64, so keying a
+throttle on the full address hands one subscriber 2**64 buckets and no cap can
+ever trip.  IPv4 has no such gift -- one client, one address -- so it is keyed
+on the address unchanged; grouping it by prefix would make unrelated customers
+behind one carrier NAT throttle each other.  Both projections read the same
+resolved address object so they can never drift apart on trust.
+
 Deliberately a leaf module -- it imports nothing of ours.  :mod:`rate_limit`
 and ``routers.auth`` both need this answer, and ``rate_limit_keys`` documents
 the import cycle between those two that a dependency-free module avoids.
@@ -23,6 +34,18 @@ from fastapi import Request
 
 # Comma-separated IPs and/or CIDR blocks naming the proxies we operate.
 TRUSTED_PROXIES_ENV_VAR = "TRUSTED_PROXY_CIDRS"
+
+# How much of an IPv6 address identifies the subscriber rather than the host
+# they picked this second.  Configurable because an upstream that delegates
+# wider than a /64 needs a wider bucket to hold one customer.
+IPV6_THROTTLE_PREFIX_ENV_VAR = "IPV6_THROTTLE_PREFIX_LEN"
+
+# The size residential upstreams are expected to delegate, and the fallback for
+# any configured value we cannot use.
+DEFAULT_IPV6_THROTTLE_PREFIX_LEN = 64
+
+# A prefix length is a bit count, so anything below one bit is not a prefix.
+_MIN_IPV6_THROTTLE_PREFIX_LEN = 1
 
 # Both the config variable and the forwarded header are comma-separated lists.
 _ENTRY_SEPARATOR = ","
@@ -51,6 +74,14 @@ def _parse_address(value: str) -> _Address | None:
     """Parse ``value`` as an IP literal, or None when it is not one."""
     try:
         return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _parse_prefix_length(raw: str) -> int | None:
+    """Parse one config value as a bit count, or None when it is not one."""
+    try:
+        return int(raw)
     except ValueError:
         return None
 
@@ -108,6 +139,26 @@ def _trusted_networks() -> list[_Network]:
     return [network for network in parsed if network is not None]
 
 
+def _throttle_prefix_length() -> int:
+    """Read the IPv6 throttle prefix length from the environment at call time.
+
+    Reading per call means retuning the bucket needs no restart, exactly as for
+    the proxy allowlist.  Only an integer in ``[1, IPV6LENGTH]`` is a usable
+    prefix, and every other value degrades to the default rather than being
+    clamped into range: ``0`` would collapse every IPv6 client on earth into one
+    bucket -- a self-inflicted denial of service on all legitimate IPv6 users --
+    and clamping ``129`` down would silently disable the grouping altogether.
+    The default is the only value an operator would have chosen deliberately, so
+    it is the only safe reading of a typo.
+    """
+    configured = _parse_prefix_length(os.getenv(IPV6_THROTTLE_PREFIX_ENV_VAR, ""))
+    if configured is None or not (
+        _MIN_IPV6_THROTTLE_PREFIX_LEN <= configured <= ipaddress.IPV6LENGTH
+    ):
+        return DEFAULT_IPV6_THROTTLE_PREFIX_LEN
+    return configured
+
+
 def _is_trusted(address: _Address, networks: list[_Network]) -> bool:
     """Return True when ``address`` sits inside one of our proxy networks."""
     return any(address in network for network in networks)
@@ -153,21 +204,70 @@ def _socket_peer(request: Request) -> _Address | None:
     return None if peer is None else _client_address(peer.host)
 
 
-def resolve_client_ip(request: Request) -> str:
-    """Return the address to charge this request to: throttles and audit agree on it.
+def _throttle_key(address: _Address) -> str:
+    """Return the budget ``address`` spends from: its prefix if IPv6, itself if IPv4.
+
+    CIDR text is the form on purpose.  ``ipaddress`` compresses a network
+    canonically, so the two limiter backends -- which compare keys for byte
+    equality -- cannot mint a duplicate bucket for one prefix, and the key
+    states the prefix it was cut at, so retuning the config visibly re-buckets
+    rather than quietly reusing stale counters.  The key namespaces stay
+    disjoint by construction: IPv4 keys are dotted quads carrying neither ``:``
+    nor ``/``, IPv6 prefix keys always carry ``/``, the unknown-client answer
+    carries neither, and authenticated keys carry a ``user:`` prefix.
+
+    ``_unmapped`` has already folded ``::ffff:203.0.113.5`` into an IPv4
+    address, so a mapped literal takes the IPv4 arm for free -- prefixing it
+    would group the whole mapped range, i.e. the entire IPv4 internet, into a
+    single bucket.
+    """
+    if not isinstance(address, ipaddress.IPv6Address):
+        return str(address)
+    prefixed = f"{address}/{_throttle_prefix_length()}"
+    return str(ipaddress.ip_network(prefixed, strict=False))
+
+
+def _resolved_client(request: Request) -> _Address | None:
+    """Return the address to charge this request to, or None when there is none.
 
     Falls back to the socket peer whenever the forwarded chain cannot be
     trusted or cannot be believed -- an unvouched peer, a missing header, a
     chain of nothing but our own proxies, or a chosen hop that is not an IP
-    literal.  A peer that is not an IP literal itself resolves to
-    ``_UNKNOWN_CLIENT``, so a junk or over-wide value can reach neither a
-    rate-limit key nor an audit column.
+    literal.  A peer that is not an IP literal itself yields None, so a junk or
+    over-wide value can reach neither a rate-limit key nor an audit column.
+
+    The single shared resolution behind both projections below: one trust walk,
+    one canonicalisation of mapped literals, one rejection of zone ids, so what
+    a throttle charges and what an audit row records can never drift apart.
     """
     peer = _socket_peer(request)
     if peer is None:
-        return _UNKNOWN_CLIENT
+        return None
     networks = _trusted_networks()
     if not _is_trusted(peer, networks):
-        return str(peer)
+        return peer
     hop = _client_hop(_forwarded_hops(request), networks)
-    return str(peer if hop is None else hop)
+    return peer if hop is None else hop
+
+
+def resolve_client_ip(request: Request) -> str:
+    """Return exactly who made this request, for audit rows and logs.
+
+    The forensic projection: the full address, never widened, because an audit
+    trail that names a /64 names a few billion hosts and identifies nobody.
+    Throttles must not use this -- see :func:`client_throttle_key`.
+    """
+    address = _resolved_client(request)
+    return _UNKNOWN_CLIENT if address is None else str(address)
+
+
+def client_throttle_key(request: Request) -> str:
+    """Return whose budget this request spends, for every rate limiter.
+
+    The throttle projection: the same resolved client as
+    :func:`resolve_client_ip`, but grouped onto the prefix its subscriber was
+    delegated when it is IPv6, so rotating through that delegation cannot buy a
+    fresh bucket per request.
+    """
+    address = _resolved_client(request)
+    return _UNKNOWN_CLIENT if address is None else _throttle_key(address)

--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -150,6 +150,13 @@ def _throttle_prefix_length() -> int:
     and clamping ``129`` down would silently disable the grouping altogether.
     The default is the only value an operator would have chosen deliberately, so
     it is the only safe reading of a typo.
+
+    The range check asks only whether a value is a prefix, not whether it is a
+    wise one.  ``IPV6LENGTH`` itself is the deliberate opt-out -- it restores
+    exact per-address keying, and with it the rotation this module groups
+    against -- and a very small value groups very coarsely on purpose.  Both are
+    an operator's call to make; only a value that is not a prefix at all is
+    a typo this can recognise as such.
     """
     configured = _parse_prefix_length(os.getenv(IPV6_THROTTLE_PREFIX_ENV_VAR, ""))
     if configured is None or not (
@@ -215,6 +222,12 @@ def _throttle_key(address: _Address) -> str:
     disjoint by construction: IPv4 keys are dotted quads carrying neither ``:``
     nor ``/``, IPv6 prefix keys always carry ``/``, the unknown-client answer
     carries neither, and authenticated keys carry a ``user:`` prefix.
+
+    That ``/`` is also the separator ``limits`` joins its composite bucket key
+    with, so it is worth saying why introducing one here is safe: a collision
+    would need a key that is a strict prefix of another ending exactly at a
+    separator, i.e. a bare IPv6 address with no ``/N`` suffix, and no branch
+    below can emit one.
 
     ``_unmapped`` has already folded ``::ffff:203.0.113.5`` into an IPv4
     address, so a mapped literal takes the IPv4 arm for free -- prefixing it

--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -5,19 +5,23 @@ from limits.storage import MemoryStorage
 from limits.strategies import MovingWindowRateLimiter
 from slowapi import Limiter
 
-from client_ip import resolve_client_ip
+from client_ip import client_throttle_key
 
 # Default rate limit applied to all endpoints that don't declare their own.
 # Auth endpoints override this with stricter per-route limits (3/min signup,
 # 5/min login). The global default protects against scraping and general abuse.
 DEFAULT_RATE_LIMIT = "60/minute"
 
-# Rate limiter keyed by the trusted-proxy-resolved client address, so it agrees
-# with the invalid-license throttle and the audit trail instead of keying on a
-# forgeable header or on a proxy every user shares. Shared across routers so all
-# endpoints use a single limiter with consistent state. Building the limiter at
-# import time is safe: the trusted-proxy config is read per request.
-limiter = Limiter(key_func=resolve_client_ip, default_limits=[DEFAULT_RATE_LIMIT])
+# Rate limiter keyed by the trusted-proxy-resolved *throttle* key rather than a
+# forgeable header or a proxy every user shares: one customer, one budget. That
+# key groups an IPv6 client onto its delegated prefix, so rotating inside it
+# cannot buy fresh buckets, while the audit trail keeps the exact address.
+# Shared across routers so all endpoints use a single limiter with consistent
+# state; slowapi captures this key function into each per-route limit at
+# decoration time, which happens on import, after this line. Building the
+# limiter at import time is safe: both the trusted-proxy allowlist and the
+# prefix length are read per request.
+limiter = Limiter(key_func=client_throttle_key, default_limits=[DEFAULT_RATE_LIMIT])
 
 # Second-layer throttle for signup attempts that fail license verification:
 # distinct from the 3/minute signup limit above so a license brute-forcer is
@@ -29,14 +33,18 @@ _invalid_license_limiter = MovingWindowRateLimiter(_invalid_license_storage)
 _INVALID_LICENSE_ITEM = RateLimitItemPerHour(INVALID_LICENSE_MAX_PER_HOUR)
 
 
-def record_invalid_license_attempt(client_ip: str) -> bool:
-    """Count one invalid-license signup attempt for ``client_ip``.
+def record_invalid_license_attempt(throttle_key: str) -> bool:
+    """Count one invalid-license signup attempt against ``throttle_key``.
+
+    Takes a throttle key rather than an exact address so an IPv6 subscriber
+    cannot refill the cap by presenting a new address from their own delegated
+    prefix on every guess.
 
     Returns True while the client remains under the hourly cap (the attempt
     is recorded against the moving window); returns False once the cap is
     exceeded, at which point the caller should answer 429.
     """
-    return _invalid_license_limiter.hit(_INVALID_LICENSE_ITEM, client_ip)
+    return _invalid_license_limiter.hit(_INVALID_LICENSE_ITEM, throttle_key)
 
 
 def reset_invalid_license_attempts() -> None:

--- a/backend/src/rate_limit_keys.py
+++ b/backend/src/rate_limit_keys.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException, Request
 
-from client_ip import resolve_client_ip
+from client_ip import client_throttle_key
 from routers.auth import extract_user_id_from_authorization
 
 
@@ -25,9 +25,12 @@ def per_user_rate_limit_key(request: Request) -> str:
     the credential. Decoding here costs one HMAC-SHA256 per request which is
     dominated by the work the limited endpoints do.
 
-    Falls back to the trusted-proxy-resolved client address for malformed or
-    missing tokens so the limiter never receives an empty key (and so any
-    pre-auth probe is still throttled before FastAPI's DI rejects it).
+    Falls back to the trusted-proxy-resolved client throttle key for malformed
+    or missing tokens so the limiter never receives an empty key (and so any
+    pre-auth probe is still throttled before FastAPI's DI rejects it).  That
+    fallback is purely a throttle key and is never audited, so it takes the
+    prefix-grouped form: leaving it on the full address would reopen the same
+    rotation bypass on exactly the pre-auth traffic it exists to throttle.
     """
     try:
         return f"user:{extract_user_id_from_authorization(request.headers.get('authorization'))}"
@@ -35,4 +38,4 @@ def per_user_rate_limit_key(request: Request) -> str:
         # Malformed / missing token (the only thing the decode raises) → fall
         # back to the IP key. A non-HTTP error is a programmer bug and must
         # propagate rather than be silently masked as an anonymous request.
-        return resolve_client_ip(request)
+        return client_throttle_key(request)

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -23,7 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
-from client_ip import resolve_client_ip
+from client_ip import client_throttle_key, resolve_client_ip
 from database import get_session
 from domain.dates import ensure_aware
 from domain.entitlements import (
@@ -512,12 +512,12 @@ async def _reject_invalid_license(
 ) -> NoReturn:
     """Reject a signup whose license failed verification (anti-enumeration).
 
-    Counts the attempt toward the per-IP invalid-license cap, records an
+    Counts the attempt toward the invalid-license cap, records an
     email-mismatch marker server-side (fingerprint only — never the raw
     email or key), spends the dummy bcrypt verify for timing parity, then
     raises the generic 400 — or 429 once the hourly cap is exceeded.
     """
-    allowed = record_invalid_license_attempt(resolve_client_ip(request))
+    allowed = record_invalid_license_attempt(client_throttle_key(request))
     if outcome is LicenseOutcome.EMAIL_MISMATCH:
         logger.info(
             "signup_license_rejected",
@@ -1953,7 +1953,7 @@ async def _resolve_existing_account(
 
 
 async def _count_invalid_license_attempt(request: Request, license_key: str | None) -> None:
-    """Charge a failed non-blank key against the per-IP hourly cap.
+    """Charge a failed non-blank key against the hourly cap for this client.
 
     Without this the OAuth route would be a free bypass of the brute-force
     throttle ``/auth/signup`` enforces: an attacker could grind license keys
@@ -1962,7 +1962,7 @@ async def _count_invalid_license_attempt(request: Request, license_key: str | No
     """
     if not (license_key or "").strip():
         return
-    if record_invalid_license_attempt(resolve_client_ip(request)):
+    if record_invalid_license_attempt(client_throttle_key(request)):
         return
     raise HTTPException(
         status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/backend/tests/routers/test_rate_limit_key_errors.py
+++ b/backend/tests/routers/test_rate_limit_key_errors.py
@@ -18,6 +18,11 @@ from rate_limit_keys import per_user_rate_limit_key
 # its own module globals at call time, so monkeypatch it there.
 _TARGET = "rate_limit_keys.extract_user_id_from_authorization"
 
+# One residential IPv6 subscriber is delegated a whole /64, so keying the
+# anonymous fallback on the full address hands them 2**64 buckets.
+_IPV6_CLIENT = "2001:db8:1:1::1"
+_IPV6_CLIENT_KEY = "2001:db8:1:1::/64"  # pragma: allowlist secret
+
 
 def _request(*, authorization: str | None = None, client_ip: str = "203.0.113.7") -> Request:
     headers = [(b"authorization", authorization.encode())] if authorization is not None else []
@@ -42,6 +47,28 @@ def test_malformed_token_falls_back_to_ip(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(_TARGET, _raise)
     assert per_user_rate_limit_key(_request(client_ip="198.51.100.4")) == "198.51.100.4"
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer garbage"])
+def test_anonymous_ipv6_fallback_keys_on_the_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    authorization: str | None,
+) -> None:
+    """The unauthenticated fallback must group an IPv6 client by delegated prefix.
+
+    Pre-auth probes are exactly the traffic this fallback throttles, so keying
+    them on the full address lets one subscriber rotate through their /64 and
+    never spend the same bucket twice.
+    """
+
+    def _raise(_auth: str | None) -> int:
+        raise HTTPException(status_code=401, detail="invalid")
+
+    monkeypatch.setattr(_TARGET, _raise)
+
+    key = per_user_rate_limit_key(_request(authorization=authorization, client_ip=_IPV6_CLIENT))
+
+    assert key == _IPV6_CLIENT_KEY
 
 
 def test_programmer_bug_propagates(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/security/test_throttle_key.py
+++ b/backend/tests/security/test_throttle_key.py
@@ -20,11 +20,13 @@ independent of anything the throttle answer does.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
 from starlette.requests import Request
 
 from client_ip import (
@@ -36,7 +38,10 @@ from client_ip import (
 )
 from database import get_session
 from main import app
+from models.password_reset_token import PasswordResetToken
+from models.user import User
 from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
+from routers.auth import _hash_password
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -95,6 +100,19 @@ _SCOPED_IPV6_HOP = f"fe80::1%{_LONG_ZONE_ID}"
 # literal (39 chars) plus the longest prefix suffix ("/128").
 _MAX_THROTTLE_KEY_LENGTH = 43
 
+# The worst case that reaches that bound, so the bound is driven rather than
+# merely declared: the widest literal there is, cut at the shortest prefix
+# length whose network address still needs all eight groups written out.
+_WIDEST_IPV6_ADDRESS = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"  # pragma: allowlist secret
+_LONGEST_KEY_PREFIX_LEN = 113
+_LONGEST_THROTTLE_KEY = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:8000/113"  # pragma: allowlist secret
+
+# Every prefix length the module accepts, swept to prove no configuration can
+# produce a key wider than the bound above.
+_SHORTEST_PREFIX_LEN = 1
+_FULL_ADDRESS_PREFIX_LEN = 128
+_ALL_PREFIX_LENGTHS = range(_SHORTEST_PREFIX_LEN, _FULL_ADDRESS_PREFIX_LEN + 1)
+
 _CIDR_MARKER = "/"
 
 _SIGNUP_PATH = "/auth/signup"
@@ -109,6 +127,11 @@ _DETAIL_THROTTLED = "too_many_license_attempts"
 _RESET_PATH = "/auth/password-reset/request"
 _RESET_REQUESTS_PER_HOUR = 3
 _UNREGISTERED_EMAIL = "nobody@example.com"
+
+# Only a registered email reaches the branch that writes an audit row, so the
+# end-to-end audit case has to seed a user first.
+_REGISTERED_EMAIL = "audited@example.com"
+_REGISTERED_PASSWORD = "correct-horse-battery-staple"  # pragma: allowlist secret
 
 
 def _make_request(peer: tuple[str, int] | None, forwarded: str | None = None) -> Request:
@@ -218,7 +241,35 @@ def test_scoped_ipv6_hop_neither_crashes_nor_widens_the_key(
 
     assert key == _PROXY_PEER
     assert _LONG_ZONE_ID not in key
-    assert len(key) <= _MAX_THROTTLE_KEY_LENGTH
+
+
+def _key_at_prefix_length(monkeypatch: pytest.MonkeyPatch, prefix_len: int, address: str) -> str:
+    """Return the throttle key for ``address`` with ``prefix_len`` configured."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, str(prefix_len))
+    return client_throttle_key(_proxied(monkeypatch, address))
+
+
+def test_widest_ipv6_input_at_any_prefix_length_stays_within_the_key_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No address and no configured prefix length can produce a key wider than the bound.
+
+    The bound is what every consumer of a key is sized against -- the limiter
+    backends and the audit column beside them -- so it is only a real bound if
+    some test can falsify it.  Sweeping every accepted prefix length across the
+    widest literal that exists is the whole input space for key width, and its
+    worst case is pinned as a literal: an unbounded value reaching a key, or a
+    key rendered uncompressed, changes the answer here.
+    """
+    keys = [
+        _key_at_prefix_length(monkeypatch, prefix_len, _WIDEST_IPV6_ADDRESS)
+        for prefix_len in _ALL_PREFIX_LENGTHS
+    ]
+    worst_case = _key_at_prefix_length(monkeypatch, _LONGEST_KEY_PREFIX_LEN, _WIDEST_IPV6_ADDRESS)
+
+    assert max(len(key) for key in keys) == _MAX_THROTTLE_KEY_LENGTH
+    assert worst_case == _LONGEST_THROTTLE_KEY
+    assert len(worst_case) == _MAX_THROTTLE_KEY_LENGTH
 
 
 def test_audit_answer_and_throttle_answer_do_not_converge(
@@ -417,3 +468,54 @@ async def test_per_route_limiter_buckets_by_prefix_not_by_address(
 
     assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert neighbour.status_code == HTTPStatus.ACCEPTED
+
+
+async def _seed_registered_user(db_session: AsyncSession, email: str) -> None:
+    """Insert an active user so a reset request takes its token-minting branch."""
+    db_session.add(
+        User(
+            email=email,
+            password_hash=await _hash_password(_REGISTERED_PASSWORD),
+            created_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+
+
+async def _recorded_request_ip(db_session: AsyncSession) -> str:
+    """Return the ``requested_ip`` written on the only reset-token row."""
+    rows = (await db_session.execute(select(PasswordResetToken))).scalars().all()
+    assert len(rows) == 1
+    return rows[0].requested_ip
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("wire_email_sender")
+async def test_audit_row_keeps_the_full_ipv6_address_the_throttle_grouped_away(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real IPv6 request must persist the exact address, never the prefix it throttles on.
+
+    The unit test above pins the two projections apart in isolation, but the
+    constraint the split exists to satisfy is a property of the whole request
+    path: widening the throttle must not widen the audit trail, or every reset
+    row would name a few billion hosts and identify nobody.  Wiring the audit
+    write to the throttle key -- the obvious way to "simplify" this module back
+    into one function -- is exactly what this catches.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+    await _seed_registered_user(db_session, _REGISTERED_EMAIL)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        accepted = await client.post(
+            _RESET_PATH,
+            json={"email": _REGISTERED_EMAIL},
+            headers={"X-Forwarded-For": _IPV6_CLIENT},
+        )
+
+    assert accepted.status_code == HTTPStatus.ACCEPTED
+    recorded = await _recorded_request_ip(db_session)
+    assert recorded == _IPV6_CLIENT
+    assert recorded != _IPV6_CLIENT_KEY
+    assert _CIDR_MARKER not in recorded

--- a/backend/tests/security/test_throttle_key.py
+++ b/backend/tests/security/test_throttle_key.py
@@ -1,0 +1,419 @@
+"""Throttle keys must group an IPv6 client by its delegated prefix, not its address.
+
+A residential IPv6 customer is handed a whole /64, so a single subscriber owns
+2**64 source addresses and can present a fresh one on every request.  Keying a
+throttle on the full address therefore hands that subscriber 2**64 independent
+buckets and no hourly cap can ever trip.  IPv4 has no such gift -- one client,
+one address -- so grouping IPv4 by prefix would only make unrelated customers
+behind one carrier NAT throttle each other.
+
+The answer is a deliberate split of one question into two: ``resolve_client_ip``
+keeps answering "who was this, exactly" for audit rows, while
+``client_throttle_key`` answers "whose budget does this spend".  These tests pin
+both halves and, crucially, pin that they do not silently converge.
+
+The harness below duplicates a little of the audit-contract suite on purpose:
+that suite is the regression proof for the audit answer and must stay
+independent of anything the throttle answer does.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from client_ip import (
+    DEFAULT_IPV6_THROTTLE_PREFIX_LEN,
+    IPV6_THROTTLE_PREFIX_ENV_VAR,
+    TRUSTED_PROXIES_ENV_VAR,
+    client_throttle_key,
+    resolve_client_ip,
+)
+from database import get_session
+from main import app
+from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from httpx import Response
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# Documentation-range addresses only (RFC 5737 for IPv4, RFC 3849 for IPv6) so
+# no case can be mistaken for traffic on a real network.
+_TRUSTED_PROXY_NET = "192.0.2.0/24"
+_PROXY_PEER = "192.0.2.10"
+_UNTRUSTED_PEER = "198.51.100.7"
+_IPV4_CLIENT = "203.0.113.5"
+# Same /24 as the client above: proof that IPv4 is NOT grouped by prefix.
+_IPV4_SAME_SLASH_24 = "203.0.113.9"
+# A dual-stack listener reports an IPv4 connection in this mapped form.
+_MAPPED_IPV4_CLIENT = f"::ffff:{_IPV4_CLIENT}"
+_PEER_PORT = 51_234
+
+# Two addresses a single subscriber can present from one delegated /64, and the
+# prefix both must collapse onto.  The literal is the point: both limiter
+# backends compare keys for byte equality, so the textual form is the contract.
+_IPV6_CLIENT = "2001:db8:1:1::1"
+_IPV6_SAME_SLASH_64 = "2001:db8:1:1:ffff::2"
+_IPV6_CLIENT_KEY = "2001:db8:1:1::/64"  # pragma: allowlist secret
+
+# A genuinely different subscriber: adjacent /64, must never share a budget.
+_IPV6_OTHER_CLIENT = "2001:db8:1:2::1"
+_IPV6_OTHER_CLIENT_KEY = "2001:db8:1:2::/64"  # pragma: allowlist secret
+
+# Widening the prefix is an operator decision, so it is configuration.  At /56
+# the first two addresses merge and the third stays separate.
+_WIDER_PREFIX_LEN = "56"
+_IPV6_SAME_SLASH_56 = "2001:db8:1:5f::1"
+_IPV6_OUTSIDE_SLASH_56 = "2001:db8:1:100::1"
+_IPV6_WIDE_KEY = "2001:db8:1::/56"
+_IPV6_OUTSIDE_WIDE_KEY = "2001:db8:1:100::/56"
+
+# A prefix length that is not an integer in [1, 128] is an operator typo, and
+# ``0`` in particular would collapse every IPv6 client on earth into one bucket.
+# Degrading to the known-good default is the only safe reading of any of them.
+_INVALID_PREFIX_LENGTHS = ["abc", "", "0", "-1", "129", "64.5"]
+
+# The answer for any peer that cannot be turned into an IP literal.
+_UNKNOWN_CLIENT = "unknown"
+_MALFORMED_PEER = "not-an-ip"
+
+# ``ipaddress`` accepts a zone id of any length, so a hop can parse cleanly and
+# still be unboundedly wide; a zone id also names an interface on one machine
+# and so cannot identify anyone across a proxy hop.
+_OVERLONG_ZONE_LENGTH = 200
+_LONG_ZONE_ID = "z" * _OVERLONG_ZONE_LENGTH
+_SCOPED_IPV6_HOP = f"fe80::1%{_LONG_ZONE_ID}"
+
+# The widest key the split can legitimately produce: a fully expanded IPv6
+# literal (39 chars) plus the longest prefix suffix ("/128").
+_MAX_THROTTLE_KEY_LENGTH = 43
+
+_CIDR_MARKER = "/"
+
+_SIGNUP_PATH = "/auth/signup"
+_SIGNUP_PASSWORD = "securepassword123"  # pragma: allowlist secret
+_LICENSE_KEY = "ABCD1234-EF56-7890-TEST"  # pragma: allowlist secret
+_PRODUCT_IDS_ENV_VAR = "GUMROAD_APTITUDE_PRODUCT_IDS"
+_ALLOWLISTED_PRODUCT = "prod_alpha"
+_VERIFY_SEAM = "domain.entitlements.verify_license"
+_DETAIL_INVALID_LICENSE = "invalid_license"
+_DETAIL_THROTTLED = "too_many_license_attempts"
+
+_RESET_PATH = "/auth/password-reset/request"
+_RESET_REQUESTS_PER_HOUR = 3
+_UNREGISTERED_EMAIL = "nobody@example.com"
+
+
+def _make_request(peer: tuple[str, int] | None, forwarded: str | None = None) -> Request:
+    """Build a bare ASGI request with the given socket peer and forwarded header."""
+    headers = [] if forwarded is None else [(b"x-forwarded-for", forwarded.encode())]
+    return Request({"type": "http", "headers": headers, "client": peer})
+
+
+def _proxied(monkeypatch: pytest.MonkeyPatch, forwarded: str) -> Request:
+    """Return a request from ``forwarded`` arriving through a trusted proxy."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+    return _make_request((_PROXY_PEER, _PEER_PORT), forwarded)
+
+
+def test_addresses_in_one_delegated_prefix_share_a_throttle_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two addresses from one subscriber's /64 must spend one budget.
+
+    The expected value is asserted as a literal because both limiter backends
+    compare keys for byte equality: an equivalent network object rendered any
+    other way would silently mint a second bucket.
+    """
+    first = client_throttle_key(_proxied(monkeypatch, _IPV6_CLIENT))
+    second = client_throttle_key(_proxied(monkeypatch, _IPV6_SAME_SLASH_64))
+
+    assert first == _IPV6_CLIENT_KEY
+    assert second == _IPV6_CLIENT_KEY
+
+
+def test_addresses_in_different_prefixes_get_different_throttle_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Separate /64s are separate subscribers, so exhausting one must not touch the other."""
+    first = client_throttle_key(_proxied(monkeypatch, _IPV6_CLIENT))
+    second = client_throttle_key(_proxied(monkeypatch, _IPV6_OTHER_CLIENT))
+
+    assert first == _IPV6_CLIENT_KEY
+    assert second == _IPV6_OTHER_CLIENT_KEY
+    assert first != second
+
+
+def test_ipv4_throttle_key_is_the_resolved_address_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IPv4 clients own one address each, so the throttle key stays the address.
+
+    Grouping IPv4 by prefix would make every unrelated customer behind one
+    carrier NAT share a budget -- a denial of service dressed as a fix.
+    """
+    request = _proxied(monkeypatch, _IPV4_CLIENT)
+
+    assert client_throttle_key(request) == resolve_client_ip(request)
+    assert client_throttle_key(request) == _IPV4_CLIENT
+
+
+def test_ipv4_neighbours_in_one_slash_24_keep_separate_throttle_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two IPv4 addresses in one /24 are two customers and must not be merged."""
+    first = client_throttle_key(_proxied(monkeypatch, _IPV4_CLIENT))
+    second = client_throttle_key(_proxied(monkeypatch, _IPV4_SAME_SLASH_24))
+
+    assert first == _IPV4_CLIENT
+    assert second == _IPV4_SAME_SLASH_24
+    assert first != second
+
+
+def test_ipv4_mapped_literal_takes_the_ipv4_throttle_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mapped literal is an IPv4 host wearing IPv6 syntax; prefixing it would be wrong.
+
+    Treating it as IPv6 would group the whole ``::ffff:0:0/96`` mapped range,
+    i.e. the entire IPv4 internet, into a single throttle bucket.
+    """
+    mapped = client_throttle_key(_proxied(monkeypatch, _MAPPED_IPV4_CLIENT))
+    plain = client_throttle_key(_proxied(monkeypatch, _IPV4_CLIENT))
+
+    assert mapped == _IPV4_CLIENT
+    assert mapped == plain
+    assert _CIDR_MARKER not in mapped
+
+
+@pytest.mark.parametrize("peer", [None, (_MALFORMED_PEER, _PEER_PORT)])
+def test_unkeyable_peer_yields_the_same_unknown_answer_as_the_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    peer: tuple[str, int] | None,
+) -> None:
+    """No keyable peer must degrade to a constant, never crash the request."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+    request = _make_request(peer, _IPV6_CLIENT)
+
+    assert client_throttle_key(request) == _UNKNOWN_CLIENT
+    assert client_throttle_key(request) == resolve_client_ip(request)
+
+
+def test_scoped_ipv6_hop_neither_crashes_nor_widens_the_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zone id parses as an address but identifies nobody across a proxy hop.
+
+    Accepting it would key on an unbounded attacker-chosen string; the request
+    must fall back to the socket peer instead.
+    """
+    key = client_throttle_key(_proxied(monkeypatch, _SCOPED_IPV6_HOP))
+
+    assert key == _PROXY_PEER
+    assert _LONG_ZONE_ID not in key
+    assert len(key) <= _MAX_THROTTLE_KEY_LENGTH
+
+
+def test_audit_answer_and_throttle_answer_do_not_converge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One request, two answers: the audit trail keeps the address, the throttle the prefix.
+
+    Asserted together so a future refactor cannot quietly collapse the split
+    back into one function without a test noticing.
+    """
+    request = _proxied(monkeypatch, _IPV6_CLIENT)
+
+    assert resolve_client_ip(request) == _IPV6_CLIENT
+    assert client_throttle_key(request) == _IPV6_CLIENT_KEY
+    assert resolve_client_ip(request) != client_throttle_key(request)
+
+
+def test_configured_prefix_length_widens_the_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operators whose upstream delegates wider than a /64 can say so in config.
+
+    At /56 the two addresses that differ only inside that prefix merge, while an
+    address outside it keeps its own budget.
+    """
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, _WIDER_PREFIX_LEN)
+
+    inside = client_throttle_key(_proxied(monkeypatch, _IPV6_CLIENT))
+    also_inside = client_throttle_key(_proxied(monkeypatch, _IPV6_SAME_SLASH_56))
+    outside = client_throttle_key(_proxied(monkeypatch, _IPV6_OUTSIDE_SLASH_56))
+
+    assert inside == _IPV6_WIDE_KEY
+    assert also_inside == _IPV6_WIDE_KEY
+    assert outside == _IPV6_OUTSIDE_WIDE_KEY
+
+
+def test_unset_prefix_length_uses_the_documented_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no configuration the key is a /64, the prefix size subscribers are delegated."""
+    monkeypatch.delenv(IPV6_THROTTLE_PREFIX_ENV_VAR, raising=False)
+
+    key = client_throttle_key(_proxied(monkeypatch, _IPV6_CLIENT))
+
+    assert key == _IPV6_CLIENT_KEY
+    assert key.endswith(f"{_CIDR_MARKER}{DEFAULT_IPV6_THROTTLE_PREFIX_LEN}")
+
+
+@pytest.mark.parametrize("configured", _INVALID_PREFIX_LENGTHS)
+def test_unusable_prefix_length_falls_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+) -> None:
+    """A config typo must degrade to the known-good default rather than be clamped.
+
+    Clamping ``0`` up to ``1`` would still merge half the IPv6 internet into one
+    bucket, and clamping ``129`` down would silently disable the grouping; only
+    the default is a value an operator would have chosen on purpose.
+    """
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, configured)
+
+    key = client_throttle_key(_proxied(monkeypatch, _IPV6_CLIENT))
+
+    assert key == _IPV6_CLIENT_KEY
+
+
+@asynccontextmanager
+async def _peer_client(
+    db_session: AsyncSession,
+    peer: tuple[str, int],
+) -> AsyncIterator[AsyncClient]:
+    """Yield a client whose ASGI socket peer is ``peer``, still bound to the test DB."""
+
+    async def _override_get_session() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    transport = ASGITransport(app=app, client=peer)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+
+def _arm_invalid_license_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the license allowlist at one product whose verifier never matches."""
+
+    async def _verify_never_matches(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setenv(_PRODUCT_IDS_ENV_VAR, _ALLOWLISTED_PRODUCT)
+    monkeypatch.setattr(_VERIFY_SEAM, _verify_never_matches)
+
+
+def _rotating_ipv6(index: int) -> str:
+    """Return attempt ``index`` presented from a fresh address in the client's own /64."""
+    return f"2001:db8:1:1::{index + 1:x}"
+
+
+async def _attempt_signup(client: AsyncClient, forwarded: str, email: str) -> Response:
+    """Send one signup whose license can never verify."""
+    return await client.post(
+        _SIGNUP_PATH,
+        json={"email": email, "password": _SIGNUP_PASSWORD, "license_key": _LICENSE_KEY},
+        headers={"X-Forwarded-For": forwarded},
+    )
+
+
+async def _request_reset(client: AsyncClient, forwarded: str) -> Response:
+    """Send one password-reset request for an unregistered email."""
+    return await client.post(
+        _RESET_PATH,
+        json={"email": _UNREGISTERED_EMAIL},
+        headers={"X-Forwarded-For": forwarded},
+    )
+
+
+async def _exhaust_license_budget(client: AsyncClient) -> Response:
+    """Spend the whole hourly license budget of one /64 and return the next attempt."""
+    for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
+        rejected = await _attempt_signup(
+            client, _rotating_ipv6(attempt), f"rotate-{attempt}@example.com"
+        )
+        assert rejected.status_code == HTTPStatus.BAD_REQUEST
+        assert rejected.json()["detail"] == _DETAIL_INVALID_LICENSE
+    return await _attempt_signup(
+        client,
+        _rotating_ipv6(INVALID_LICENSE_MAX_PER_HOUR),
+        "rotate-final@example.com",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_license_gate
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_rotating_inside_one_prefix_cannot_outrun_the_license_cap(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subscriber presenting a new address per attempt must still hit the hourly cap.
+
+    This is the bypass itself: every request comes from the same delegated /64,
+    which is one customer, so the cap has to bind on the prefix.  Keying on the
+    full address gives that customer 2**64 buckets and the cap never trips.
+    """
+    _arm_invalid_license_gate(monkeypatch)
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        capped = await _exhaust_license_budget(client)
+
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert capped.json()["detail"] == _DETAIL_THROTTLED
+
+
+@pytest.mark.asyncio
+@pytest.mark.real_license_gate
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_exhausting_one_prefix_leaves_a_neighbouring_prefix_untouched(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefix grouping must stop at the prefix boundary, not punish the next subscriber.
+
+    Without this the cure is worse than the bug: one abusive customer would lock
+    out everyone their upstream happens to number nearby.
+    """
+    _arm_invalid_license_gate(monkeypatch)
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        capped = await _exhaust_license_budget(client)
+        neighbour = await _attempt_signup(client, _IPV6_OTHER_CLIENT, "neighbour@example.com")
+
+    assert neighbour.status_code == HTTPStatus.BAD_REQUEST
+    assert neighbour.json()["detail"] == _DETAIL_INVALID_LICENSE
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+@pytest.mark.asyncio
+async def test_per_route_limiter_buckets_by_prefix_not_by_address(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The slowapi limiter shares the throttle key, so address rotation cannot refill it.
+
+    The license cap is only one of two throttles a rotating client can outrun;
+    this covers the per-route limiter, which the rate limiter must therefore be
+    left enabled for.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    async with _peer_client(db_session, (_PROXY_PEER, _PEER_PORT)) as client:
+        for attempt in range(_RESET_REQUESTS_PER_HOUR):
+            allowed = await _request_reset(client, _rotating_ipv6(attempt))
+            assert allowed.status_code == HTTPStatus.ACCEPTED
+        capped = await _request_reset(client, _rotating_ipv6(_RESET_REQUESTS_PER_HOUR))
+        neighbour = await _request_reset(client, _IPV6_OTHER_CLIENT)
+
+    assert capped.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert neighbour.status_code == HTTPStatus.ACCEPTED


### PR DESCRIPTION
## Summary

- Making `X-Forwarded-For` trustworthy closed the *header* route to a fresh throttle bucket per request. This closes the *address* route. A residential IPv6 subscriber — and a cloud VM — is delegated an entire **/64**, so one customer legitimately owns 2\*\*64 source addresses. Keying the throttle on the full address handed that one customer 2\*\*64 buckets, and `INVALID_LICENSE_MAX_PER_HOUR = 10` never tripped. IPv4 was never affected: one client, one address.
- **The split is the substance, not truncation.** `client_ip.py` grows one shared resolution, `_resolved_client` — the single trust walk, the single canonicalisation of IPv4-mapped literals, the single rejection of zone ids. `resolve_client_ip` is the *forensic* projection over it (the exact address, byte-identical to before, because an audit row naming a /64 names a few billion hosts and identifies nobody). `client_throttle_key` is the *budget* projection (IPv6 collapses onto its delegated prefix; IPv4 stays itself). Sharing the resolution is what makes drift structurally impossible rather than merely unlikely.
- **Only throttles moved:** the slowapi `Limiter` key_func, `per_user_rate_limit_key`'s anonymous fallback (pre-auth probes are exactly the traffic it exists to cap), and both `record_invalid_license_attempt` call sites. The three audit sites — `LoginAttempt.ip_address`, `PasswordResetToken.requested_ip`, and the `password_reset_event` log field — are untouched. `INVALID_LICENSE_MAX_PER_HOUR` is still 10 and the 429 path is unchanged; only the key changed.
- **IPv4 is deliberately not grouped.** A /24-style grouping would make unrelated customers behind one carrier NAT throttle each other. Pinned by a test asserting two addresses in one /24 keep separate keys, and another asserting the IPv4 throttle key is byte-identical to `resolve_client_ip`.
- **Prefix length is configuration with a safe default**, following the `TRUSTED_PROXY_CIDRS` precedent: `IPV6_THROTTLE_PREFIX_LEN`, default `64`, read per request so retuning needs no restart. Only an integer in `[1, 128]` is usable; everything else **falls back to the default rather than being clamped** — `0` would collapse every IPv6 client on earth into one bucket (a self-inflicted DoS on legitimate users) and clamping `129` down would silently disable the grouping.

### Accepted residual, documented rather than hidden

`/64` is the *smallest* delegation a subscriber receives, not the typical one. A customer holding a `/56` still owns 256 prefixes and a `/48` owns 65,536, so the same rotation works one level up at 256x-65,536x — a large improvement on 2\*\*64, but not zero. The default stays at 64 because widening it for everyone would merge unrelated customers on any ISP that *does* delegate a /64 each; `IPV6_THROTTLE_PREFIX_LEN=56` is the lever, and `backend/.env.example` and `DEPLOYMENT.md` now name it instead of saying "not security-critical". The inverse is documented too: a /64 is exactly one LAN, so an office on SLAAC, a VPN exit pool or a NAT64/CGN pool is now one bucket — what a spurious-429 support ticket will look like, with `128` as the explicitly-priced escape hatch.

## Test plan

RED first, and the bypass reproduced before it was closed:

- **The bypass itself.** Behind a trusted proxy, `INVALID_LICENSE_MAX_PER_HOUR` signups each from a *different* address inside one /64, then one more. Against the pre-fix code this returned `400 invalid_license` — observed, that is the demonstration the hole was real — and now returns `429 too_many_license_attempts`.
- **No collateral.** After exhausting one /64, a client in a neighbouring /64 still gets `400 invalid_license`, so the cure does not lock out the next subscriber.
- **The slowapi half**, not just the licence cap: rotating inside one /64 against `/auth/password-reset/request` (3/hour) caps at the 4th; a different /64 still gets `202`.
- **The audit contract end to end** — a reset request from `2001:db8:1:1::1` reads its `PasswordResetToken` row back and asserts `requested_ip` is the exact address with no prefix marker. The 30 pre-existing client-IP cases are **untouched and green**, which is the proof the audit answer did not move.
- Unit: same-/64 → identical key pinned to the literal `2001:db8:1:1::/64` (both limiter backends compare keys for byte equality, so the textual form is the contract); different /64s → different keys; IPv4 unchanged and un-grouped; `::ffff:203.0.113.5` takes the IPv4 path; junk/absent peer and a 200-char zone id → `unknown`, no crash; `IPV6_THROTTLE_PREFIX_LEN=56` merges and a parametrized sweep of unusable values each behaves as the default.

Verification I ran myself rather than taking on report:

- **Mutation check.** Reverting `_throttle_key` to return the full address fails **16 tests**, including all three integration cases. Three further mutations (audit wired to the throttle projection; canonicalisation dropped; key namespace prefixed) each fail exactly the test that should catch them.
- **Namespace disjointness, by execution** over IPv4, IPv4-mapped, `::1`, `::`, all-`ffff`, `64:ff9b::`, `2002::`, `fe80::`: IPv6 keys always carry `/`, IPv4 keys never do, `unknown` and `user:<int>` carry neither.
- **Key width is bounded at exactly 43 chars** (worst case `ffff:ffff:ffff:ffff:ffff:ffff:ffff:8000/113`), swept over all 128 prefix lengths and now pinned by a test — the previous bound assertion was vacuous against a 10-char IPv4 key.
- **`int()` edge cases**: `" 64 "` / `"+64"` / `"6_4"` / `"064"` → 64; `"0"` / `"-1"` / `"129"` / `"64.5"` / `"abc"` / `""` / `"0x40"` / `"1e2"` → default; a 10^6-digit value returns the default in 0.32 ms.

Gates: `./scripts/backend/check-all.sh` exit 0 — **3310 passed, 2 skipped, 96.97% coverage**. `xenon src/ --max-absolute A --max-modules A --max-average A` and `radon mi src/ -n B -s` both exit 0 (every block in `client_ip.py` A-grade); these are the pre-push hooks `check-all.sh` omits. Gate 2.5 `code-review-orchestrator` returned **CLEAN**. Backend only; no frontend files, no migration.

## Follow-ups filed (out of scope, not fixed here)

- #2008 — warn at startup when `IPV6_THROTTLE_PREFIX_LEN` is unusable (the runtime fallback is silent by design; logging per request would be a flood lever).
- #2009 — pre-existing: the invalid-licence cap is charged *after* the outbound Gumroad call, so it never gates that call.
- #2010 — pre-existing: the moving-window counter store retains every key for process lifetime. This change makes it strictly better (one entry per /64 instead of per address).

Closes #1998
