### PR TITLE
chore(agents): give security and documentation specialists Bash

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -47,12 +47,24 @@ the spawn mechanism, which is always the conductor. Only the two orchestrators
 (chief-architect, code-review-orchestrator) hold the `Task` tool; the six
 specialists are leaf workers that do their own work and do not sub-delegate.
 
-The two **Gate 1** specialists — `test-specialist` and `implementation-specialist`
-— also hold `Bash`, because their handoff contracts assert an *observed* result
-(`Status: RED` / `Status: GREEN`). Without it those lines were self-reported from
-reading the code and the conductor had to re-verify everything itself. The other
-four specialists stay read-only/edit-only: their contracts report findings, not
-run outcomes.
+**Four specialists hold `Bash`**, because their handoff contracts assert an
+*observed* result rather than a reading of the code: `test-specialist` and
+`implementation-specialist` (`Status: RED` / `Status: GREEN`),
+`security-specialist` (`Status: HARDENED`, plus a workflow that says "write a
+failing security test first" and "verify with `scripts/backend/security.sh`" —
+both impossible without it), and `documentation-specialist` (`Status:
+DOCUMENTED`, gated on `interrogate` actually passing). Each of their contracts
+carries an `Observed:` line and the rule that a status is a claim about a run,
+never an expectation.
+
+Without `Bash` those statuses were self-reported, and the conductor had to
+re-verify every one — which it did not always do. Two concrete costs paid before
+the grant: a security assessment accepted as verified while its claimed coverage
+had never been executed, and a docs change that told operators to *raise* a
+prefix length when the fix required *lowering* it.
+
+The remaining two stay edit-only by design: `performance-specialist` and
+`dependency-review-specialist` report findings, not run outcomes.
 
 > **Frontmatter caveat.** The Claude Code runtime only reads `name`,
 > `description`, `tools`, and `model`. The extra fields here — `level`, `phase`,

--- a/.claude/agents/documentation-specialist.md
+++ b/.claude/agents/documentation-specialist.md
@@ -3,7 +3,7 @@ name: documentation-specialist
 description: "Writes and updates documentation for a change — Python docstrings (interrogate ≥85%), TSDoc, README/module docs, and ADRs. Select when the chief-architect flags a docs gap (new public API or changed behavior), and as the documentation-dimension reviewer. Docs must match the implementation exactly."
 level: 2
 phase: Cleanup
-tools: Read,Write,Edit,Grep,Glob
+tools: Read,Write,Edit,Grep,Glob,Bash
 model: sonnet
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
@@ -39,8 +39,17 @@ as the **documentation-dimension reviewer**.
    usage example for new public APIs.
 4. Verify backend docstring coverage holds (`interrogate`, part of
    `scripts/backend/check-all.sh`); keep markdown clean for the pre-commit hooks.
+   **You have `Bash` — actually run them** rather than assuming the threshold
+   still holds.
 5. Ensure docs match the implementation **exactly** — a wrong doc is worse than
    none. Hand back the Handoff block below.
+
+   **Check the instruction you just wrote by following it.** Where a doc tells an
+   operator to set a value, run a command, or flip a flag, verify the direction is
+   right — a docs change in this repo once told operators to *raise* a prefix
+   length when the fix required *lowering* it, which would have left them
+   believing they had changed something. Where an example is runnable, run it.
+   Never run `jest --coverage` locally (it fills the disk and bricks the lane).
 
 ## Handoff (return this — terse; the conductor consumes it, not a human)
 
@@ -48,9 +57,13 @@ as the **documentation-dimension reviewer**.
 Status: DOCUMENTED | BLOCKED
 Files touched: <paths>
 Verify with: interrogate (via scripts/backend/check-all.sh) + markdown hooks
+Observed: <what you actually ran and what it printed>
 Surfaces documented: <docstrings / README / ADR — 1 line each>
 Follow-ups filed: <#N, or "none">
 ```
+
+`Status` is a claim about an **observed** run, never an expectation. If you could
+not run the checks, say so here rather than asserting a status.
 
 ## Review mode
 

--- a/.claude/agents/security-specialist.md
+++ b/.claude/agents/security-specialist.md
@@ -3,7 +3,7 @@ name: security-specialist
 description: "Hardens and audits security-sensitive code — auth/JWT, CORS, secrets, user input validation, DB queries, file/network I/O. Select when the chief-architect flags a security risk, and as the security-dimension reviewer. Applies the repo `security` skill + OWASP Top 10 to the FastAPI + React Native stack."
 level: 2
 phase: Implementation,Cleanup
-tools: Read,Write,Edit,Grep,Glob
+tools: Read,Write,Edit,Grep,Glob,Bash
 model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
@@ -40,9 +40,20 @@ reviewer**. Reasoning runs on Opus — security is a judgment role.
    crosses, what could be abused.
 3. **Write a failing security test first** (e.g. rejects a forged/expired JWT,
    rejects malformed input, denies cross-user access), then implement the control
-   to make it pass.
+   to make it pass. **You have `Bash` — actually run it.** Watch it fail for the
+   right reason before you write the control; a test that passes before the
+   control exists proves nothing.
 4. Verify with `scripts/backend/security.sh` (bandit + pip-audit) and the
    `security` skill checklist; confirm no secret is committed (detect-secrets).
+   **Run these; do not infer them from reading the code.**
+
+   **Prove the vulnerability, not just the patch.** A finding you cannot
+   demonstrate is a hypothesis. Where the threat is reachable in a test, exercise
+   it against the *unpatched* code first and say so in the Handoff — several
+   real defects in this repo passed a green suite and a clean review because the
+   claim was reasoned rather than run. When a library's behavior is load-bearing
+   to your assessment, read the *installed* source rather than trusting its docs.
+   Never run `jest --coverage` locally (it fills the disk and bricks the lane).
 5. Ensure errors fail closed and reveal nothing about internals, then hand back
    the Handoff block below.
 
@@ -52,9 +63,15 @@ reviewer**. Reasoning runs on Opus — security is a judgment role.
 Status: HARDENED | FINDINGS | BLOCKED
 Files touched: <paths, incl. the failing-then-passing security test>
 Verify with: scripts/backend/security.sh + <the test command>
+Observed: <what you actually ran and what it printed — RED before, GREEN after>
 Threats closed: <IDOR / forged-JWT / injection / … — 1 line each>
 Residual risk / follow-ups: <notes, or "none">
 ```
+
+`Status` is a claim about an **observed** run, never an expectation. If you could
+not run the checks, say so here rather than asserting a status — an honest
+"unverified, here is why" is worth more to the conductor than a colour it has to
+re-prove.
 
 ## Review mode
 


### PR DESCRIPTION
## Summary

`security-specialist` and `documentation-specialist` both assert an **observed** result in their handoff contracts while having no way to observe anything. Their own workflows already told them to run things:

- security, step 3: *"Write a failing security test first … then implement the control to make it pass"* — and step 4: *"Verify with `scripts/backend/security.sh` (bandit + pip-audit)"*
- documentation, step 4: *"Verify backend docstring coverage holds (`interrogate`)"*

Neither held `Bash`. So `Status: HARDENED` and `Status: DOCUMENTED` were read off the code, and the conductor had to re-verify — which it did not always do.

This mirrors PR #1970, which granted `Bash` to the two Gate 1 specialists for the identical reason.

## Why now — two costs already paid

- **A security assessment was accepted as verified when its claimed coverage had never been executed.** Recent lanes had to re-run the tests a specialist said covered a vector, because the report could not be evidence.
- **A docs change told operators to *raise* `IPV6_THROTTLE_PREFIX_LEN` for a /56 or /48 delegation** — the value *is* the prefix length, so it needed *lowering*. Anyone following it would have changed nothing and believed otherwise. Caught only because the worker re-read the instruction.

## What changed

- Both frontmatters gain `Bash`.
- Both contracts gain an **`Observed:`** line and the rule that a status is a claim about a run, never an expectation — with explicit permission to report "unverified, here is why" instead of asserting a colour.
- **Security** gains *"prove the vulnerability, not just the patch"*: where a threat is reachable in a test, exercise it against the **unpatched** code first, and read **installed** library source when its behaviour is load-bearing. Both are drawn from real defects in this repo that cleared a green suite and a clean review because the claim was reasoned rather than run.
- **Documentation** gains *"check the instruction you just wrote by following it"* — verify the direction of any operator-facing instruction, and run runnable examples.
- Both carry the local `jest --coverage` prohibition, which they can now actually trip.
- `.claude/agents/README.md` updated: four specialists hold `Bash`, and the note explains why the other two do not.

`performance-specialist` and `dependency-review-specialist` stay edit-only by design — their contracts report findings, not run outcomes.

## Test plan

Agent config only; no application code.

- `pre-commit run --files <the 3 changed files>` — green.
- `grep -n "^tools:" .claude/agents/*.md` confirms exactly four specialists hold `Bash` (test, implementation, security, documentation) and that `performance` / `dependency-review` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
