### PR TITLE
refactor(backend): resolve X-Forwarded-Proto in app middleware, not uvicorn

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -479,23 +479,56 @@ password-reset audit rows (`LoginAttempt.ip_address`,
 instead -- which behind any real ingress means every client shares
 one rate-limit bucket and one audited address.
 
-The same variable also feeds uvicorn's `--forwarded-allow-ips`, so
-it governs whether `X-Forwarded-Proto` is trusted too.  Until it is
-set, the app believes it is serving `http`, so the trailing-slash
-redirect and any absolute URL it builds stay `http://` -- which
-browsers refuse to follow cross-origin.  A production boot without
-it set logs a `trusted_proxies_unconfigured` warning at startup.
-Write entries in network-address form (`10.0.0.0/8`), not host form
-(`10.0.0.5/8`): uvicorn's parser rejects the latter silently, so
-`X-Forwarded-Proto` trust quietly stops working while the rest of
-the app keeps working.
+The same variable governs whether `X-Forwarded-Proto` is trusted.
+Until it is set, the app believes it is serving `http`, so the
+trailing-slash redirect and any absolute URL it builds stay
+`http://` -- which browsers refuse to follow cross-origin.  A
+production boot without it set logs a `trusted_proxies_unconfigured`
+warning at startup.
+
+Both decisions are taken inside the application, against this one
+variable: the forwarded-proto middleware for the scheme, `client_ip`
+for the address.  The runtime image starts uvicorn with
+`--no-proxy-headers` on purpose.  The explicit negative is required:
+that switch is the flag pair `--proxy-headers/--no-proxy-headers`
+and it defaults to **enabled**, so merely omitting it leaves
+uvicorn's own layer mounted and trusting loopback.  While that layer
+is mounted it rewrites the socket peer from the left-most,
+caller-chosen `X-Forwarded-For` entry as well as the scheme, before
+any application code runs and under a second trust set the app never
+sees.
+
+Do **not** set `FORWARDED_ALLOW_IPS`.  It is an environment variable
+uvicorn reads directly (a common PaaS copy-paste), and it is the way
+that server-side layer gets widened without any flag appearing in
+the image's `CMD`.  `--no-proxy-headers` disarms it, and the
+application ignores it entirely: `TRUSTED_PROXY_CIDRS` is the only
+forwarding trust set that has any effect here.
+
+The innermost trusted proxy must still **set** (replace)
+`X-Forwarded-Proto` to the client-facing scheme as a single value
+(`proxy_set_header X-Forwarded-Proto $scheme;` in nginx) rather than
+pass the caller's through.  The middleware takes the *last* field
+line, which is the proxy's only if the proxy actually writes one; a
+trusted proxy -- or an L4 hop -- that forwards the caller's header
+unmodified hands the caller the scheme, because the caller's line is
+then the only line.  `proxy_set_header` replaces, which is why it is
+the safe form.  A proxy that appends to an existing header instead
+produces a comma-joined value, which is ignored, and the redirect
+then falls back to `http://`.  When several field lines arrive, the
+last one wins, and only `http`, `https`, `ws`, and `wss` are
+accepted.
 
 For self-managed deployments, terminate TLS at a proxy (nginx,
 Caddy, Cloudflare) that strips inbound `X-Forwarded-For` and appends
 the real peer address, then list only that proxy in
-`TRUSTED_PROXY_CIDRS`.  Operators investigating an abuse report
-should treat the audit `ip_address` as authoritative only to the
-extent the ingress chain, and this configuration, are trusted.
+`TRUSTED_PROXY_CIDRS`.  That variable accepts only IP addresses and
+CIDR blocks, so the proxy has to reach the app over TCP: a proxy
+connected over a unix socket has no IP peer, can never be trusted,
+and its `X-Forwarded-Proto` is ignored (redirects stay `http://`).
+Operators investigating an abuse report should treat the audit
+`ip_address` as authoritative only to the extent the ingress chain,
+and this configuration, are trusted.
 
 Once a peer address is resolved, the rate limiter and the
 invalid-license throttle key on it a little differently than the

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -83,15 +83,20 @@ GUMROAD_TOKEN_PACK_SIZES=  # Credits per pack, e.g. ghi789:100,jkl012:500
 # limiter, the hourly invalid-license throttle, and the login / password-reset
 # audit rows -- keys on the socket peer instead. Behind a real ingress that
 # socket peer is the ingress itself, so leaving this unset gives every client on
-# the internet ONE shared rate-limit bucket and one audited address. It also
-# decides whether X-Forwarded-Proto is believed: until it is set, the app thinks
-# it is serving http, so absolute URLs and the trailing-slash redirect stay
-# http:// and browsers refuse to follow them cross-origin. When it does apply, the
-# forwarded chain is read RIGHT TO LEFT, so entries a client prepends sit behind
-# the hop your proxy appended and can never win. Set this only when the app
-# genuinely sits behind a proxy (e.g. the platform's ingress range on Railway),
-# and never to a public range you do not control: every address inside it can
-# then claim to be any client it likes.
+# the internet ONE shared rate-limit bucket and one audited address. The app's
+# own forwarded-proto middleware also reads this value to decide whether
+# X-Forwarded-Proto is believed -- uvicorn's own proxy-header layer is
+# explicitly disabled (--no-proxy-headers), so this variable is the only
+# forwarding trust set. Until it is set, the app thinks it is serving http, so
+# absolute URLs and the trailing-slash redirect stay http:// and browsers refuse
+# to follow them cross-origin. Only a single bare scheme token (http, https, ws,
+# or wss) is honored; a comma-joined chain -- produced when a proxy appends to
+# rather than replaces the header -- is ignored entirely. When it does apply,
+# the forwarded chain is read RIGHT TO LEFT, so entries a client prepends sit
+# behind the hop your proxy appended and can never win. Set this only when the
+# app genuinely sits behind a proxy (e.g. the platform's ingress range on
+# Railway), and never to a public range you do not control: every address
+# inside it can then claim to be any client it likes.
 TRUSTED_PROXY_CIDRS=  # e.g. 10.0.0.0/8,192.0.2.10
 
 # How much of an IPv6 address identifies one subscriber, for the throttle keys

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,17 +62,16 @@ EXPOSE 8000
 # `src.main:app`) because PYTHONPATH is set to /app/src; this matches the
 # module layout used in tests.
 #
-# --proxy-headers lets uvicorn believe X-Forwarded-Proto, which the app needs to
-# know it is served over https: without it, redirects (e.g. the trailing-slash
-# 307) and any absolute URL it builds downgrade to http://, which browsers
-# refuse to follow cross-origin.  --forwarded-allow-ips names the peers allowed
-# to assert that, and it reads the same TRUSTED_PROXY_CIDRS the application
-# uses, so one setting governs both layers and they cannot drift apart.  A
-# wildcard here would trust every forwarding peer and so let any client rewrite
-# its own address: uvicorn overwrites the socket peer with the left-most,
-# caller-chosen X-Forwarded-For entry, forging rate-limit keys and audit rows
-# before application code runs.  The default is loopback, so an unset variable
-# fails closed onto the real socket peer -- and, stated plainly, proto trust is
-# off in that state too, so the https-dependent redirects above only work once
-# an operator sets the variable to the platform's ingress range.
-CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2} --proxy-headers --forwarded-allow-ips=${TRUSTED_PROXY_CIDRS:-127.0.0.1}"]
+# --no-proxy-headers explicitly disables uvicorn's ProxyHeadersMiddleware.  The
+# switch is the pair --proxy-headers/--no-proxy-headers and it defaults to
+# ENABLED, so leaving it out is not the same as turning it off: the layer would
+# still mount, trusting whatever FORWARDED_ALLOW_IPS names (default 127.0.0.1).
+# That matters because the layer rewrites scope["client"] from the left-most --
+# i.e. caller-chosen -- X-Forwarded-For entry as well as the scheme from
+# X-Forwarded-Proto, before any application code runs and under a second trust
+# set the app never sees.  With it off, the application owns the whole
+# forwarding policy against TRUSTED_PROXY_CIDRS: the forwarded-proto middleware
+# for the scheme, client_ip for the address.  One trust set, one parser.  The
+# flag also disarms FORWARDED_ALLOW_IPS, which would otherwise re-arm that layer
+# from the environment without any flag appearing in this CMD.
+CMD ["sh", "-c", "python -m alembic upgrade head && python -m uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${WEB_CONCURRENCY:-2} --no-proxy-headers"]

--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -7,7 +7,9 @@ header is therefore evidence only when the socket peer is itself a proxy the
 operator declared in ``TRUSTED_PROXY_CIDRS``, and even then the chain is read
 from the right, because a client can prepend entries that the proxy appends
 to.  Unset or blank config trusts nobody: the header is ignored everywhere and
-every control keys on the socket peer.
+every control keys on the socket peer.  The same trust walk also decides
+whether ``X-Forwarded-Proto`` is believed, through
+:func:`peer_is_trusted_proxy`.
 
 One trust walk, two answers.  ``resolve_client_ip`` says *who was this,
 exactly* and belongs in audit rows and logs, where forensic precision is the
@@ -31,6 +33,7 @@ import ipaddress
 import os
 
 from fastapi import Request
+from starlette.requests import HTTPConnection
 
 # Comma-separated IPs and/or CIDR blocks naming the proxies we operate.
 TRUSTED_PROXIES_ENV_VAR = "TRUSTED_PROXY_CIDRS"
@@ -205,9 +208,14 @@ def _client_hop(hops: list[str], networks: list[_Network]) -> _Address | None:
     return None
 
 
-def _socket_peer(request: Request) -> _Address | None:
-    """Return the peer that opened the connection, or None when there is none to key on."""
-    peer = request.client
+def _socket_peer(connection: HTTPConnection) -> _Address | None:
+    """Return the peer that opened the connection, or None when there is none to key on.
+
+    Typed on :class:`HTTPConnection` rather than :class:`Request` because only
+    ``.client`` is read, and the scheme decision below runs before a request
+    body exists.  ``Request`` is a subclass, so every caller here is unaffected.
+    """
+    peer = connection.client
     return None if peer is None else _client_address(peer.host)
 
 
@@ -284,3 +292,21 @@ def client_throttle_key(request: Request) -> str:
     """
     address = _resolved_client(request)
     return _UNKNOWN_CLIENT if address is None else _throttle_key(address)
+
+
+def peer_is_trusted_proxy(connection: HTTPConnection) -> bool:
+    """Report whether the socket peer is one of the proxies the operator declared.
+
+    The trust projection: exactly the decision :func:`_resolved_client` takes
+    before it will read ``X-Forwarded-For``, exposed so that whoever is allowed
+    to report the scheme and whoever is allowed to report the client address are
+    settled against one allowlist and one parser.  Two trust walks could
+    disagree; one cannot.
+
+    Because it goes through ``_socket_peer`` it inherits that resolution
+    wholesale -- the IPv4-mapped folding that lets a plain IPv4 config entry
+    still name a proxy a dual-stack listener reports as ``::ffff:...``, and the
+    rejection of scoped IPv6 literals -- rather than re-deciding any of it here.
+    """
+    peer = _socket_peer(connection)
+    return peer is not None and _is_trusted(peer, _trusted_networks())

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -23,6 +23,7 @@ from database import async_session_factory, get_session
 from errors import install_exception_handlers
 from middleware import (
     CorrelationIdMiddleware,
+    ForwardedProtoMiddleware,
     RequestLoggingMiddleware,
     SecurityHeadersMiddleware,
 )
@@ -287,10 +288,12 @@ def validate_trusted_proxy_config() -> None:
     from another.  Every control that keys on an address -- the per-route rate
     limiter, the hourly invalid-license throttle, the login and password-reset
     audit rows -- then sees the ingress itself, so one bucket and one audited
-    address cover the whole internet.  The same variable governs uvicorn's
-    proxy-header trust set, so ``X-Forwarded-Proto`` is untrusted too and the
-    app believes it is serving http, which downgrades redirects and any
-    absolute URL it builds.
+    address cover the whole internet.  The same variable gates
+    :class:`ForwardedProtoMiddleware`, so ``X-Forwarded-Proto`` is untrusted too
+    and the app believes it is serving http, which downgrades redirects and any
+    absolute URL it builds.  The runtime image disables uvicorn's own
+    proxy-header layer outright, so this one variable really is the whole
+    forwarding policy.
 
     Nothing else surfaces this: the degraded behaviour looks like ordinary
     operation until a brute-forcer is throttled alongside honest traffic or an
@@ -305,9 +308,9 @@ def validate_trusted_proxy_config() -> None:
     logger.warning(
         "trusted_proxies_unconfigured: %s is unset, so X-Forwarded-For is "
         "ignored and every client behind the ingress shares one rate-limit "
-        "bucket and one audited IP address; X-Forwarded-Proto is not trusted "
-        "either, so redirects and absolute URLs stay http://. Set it to the "
-        "platform's ingress range -- backend/.env.example documents the format",
+        "bucket and one audited IP address; the app ignores X-Forwarded-Proto from "
+        "every peer too, so redirects and absolute URLs stay http://. Set it to "
+        "the platform's ingress range -- backend/.env.example documents the format",
         TRUSTED_PROXIES_ENV_VAR,
     )
 
@@ -500,16 +503,23 @@ install_exception_handlers(app)
 # becomes the OUTERMOST layer.  We register innermost-first so the actual
 # request flow becomes:
 #
-#   RequestLoggingMiddleware  (outermost; always emits an access record)
-#   -> CorrelationIdMiddleware  (mints / honours X-Request-ID)
-#      -> SecurityHeadersMiddleware  (CSP / HSTS / Referrer-Policy / etc.)
-#         -> CORSMiddleware  (preflight handling + ACAO / ACAC)
-#            -> SlowAPIMiddleware  (rate-limit; innermost so 429s carry headers)
-#               -> route handler
+#   ForwardedProtoMiddleware  (outermost; settles scope["scheme"])
+#   -> RequestLoggingMiddleware  (always emits an access record)
+#      -> CorrelationIdMiddleware  (mints / honours X-Request-ID)
+#         -> SecurityHeadersMiddleware  (CSP / HSTS / Referrer-Policy / etc.)
+#            -> CORSMiddleware  (preflight handling + ACAO / ACAC)
+#               -> SlowAPIMiddleware  (rate-limit; innermost so 429s carry headers)
+#                  -> route handler
 #
 # Putting CORS *inside* SecurityHeaders means preflight (BUG-APP-002) and
 # rate-limited responses inherit the security-header set; putting trace-id
 # outside CORS means even preflight responses echo ``X-Request-ID``.
+#
+# Forwarded-proto has to be outermost of all: Starlette's ``Router`` builds the
+# trailing-slash 307's ``Location`` from ``scope["scheme"]``, so the scheme has
+# to be settled before anything routes, and settling it above every other layer
+# means any of them that later reads the scheme sees the client-facing one
+# rather than the ingress hop's.
 origins = get_cors_origins()
 _assert_credentials_safe(origins)
 
@@ -528,6 +538,7 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(ForwardedProtoMiddleware)
 
 # Register feature routers
 app.include_router(admin_router)

--- a/backend/src/middleware/__init__.py
+++ b/backend/src/middleware/__init__.py
@@ -3,7 +3,7 @@
 The classes live in dedicated modules so :mod:`main` can wire them in the
 exact outer-to-inner order the security model requires (BUG-APP-001):
 
-    logging → trace-id → security-headers → CORS → rate-limit
+    forwarded-proto → logging → trace-id → security-headers → CORS → rate-limit
 
 Starlette adds middleware in LIFO order (the last ``add_middleware`` call
 becomes the outermost layer), so :mod:`main` registers them bottom-up.  The
@@ -13,6 +13,7 @@ without reaching into nested modules.
 
 from __future__ import annotations
 
+from middleware.forwarded_proto import ForwardedProtoMiddleware
 from middleware.logging import RequestLoggingMiddleware
 from middleware.security_headers import SecurityHeadersMiddleware
 
@@ -24,6 +25,7 @@ from observability import CorrelationIdMiddleware
 
 __all__ = [
     "CorrelationIdMiddleware",
+    "ForwardedProtoMiddleware",
     "RequestLoggingMiddleware",
     "SecurityHeadersMiddleware",
 ]

--- a/backend/src/middleware/forwarded_proto.py
+++ b/backend/src/middleware/forwarded_proto.py
@@ -1,0 +1,125 @@
+"""Forwarded-proto middleware -- believe the scheme only from a declared proxy.
+
+``X-Forwarded-Proto`` is the only way an app behind a TLS-terminating ingress
+can know it is really being served over https, and getting it wrong is visible:
+the router's trailing-slash 307 and every absolute URL the app mints are built
+from ``scope["scheme"]``, so an unbelieved header downgrades a browser to
+plaintext and a forged one lets any caller declare its own request was
+TLS-protected.  This layer resolves the scheme against the same
+``TRUSTED_PROXY_CIDRS`` walk :mod:`client_ip` performs for the client address,
+so one allowlist and one parser settle both questions.
+
+Five decisions here are the ones a future reader will otherwise re-litigate:
+
+*Pure ASGI, not ``BaseHTTPMiddleware``.*  The whole concern is scope-in,
+nothing-out: there is no response to inspect or rewrite.  ``BaseHTTPMiddleware``
+would buy nothing for that and would cost something real -- it wraps the inner
+app in an anyio task group, and putting one outside ``RequestLoggingMiddleware``
+would change how an inner-middleware panic propagates to the access log.
+
+*Outermost.*  Starlette's ``Router`` builds the trailing-slash redirect's
+``Location`` from ``scope["scheme"]``, so the scheme has to be settled before
+anything routes.  Sitting above every other layer as well is what makes the
+answer uniform: no layer in between reads the scheme today, but any that came
+to would see the client-facing one rather than the hop the ingress spoke to us
+over, which is the reading each of them would want.  Because that second half
+has no observable consequence yet, the position is pinned by an explicit
+ordering assertion in ``tests/middleware/test_middleware_stack.py`` rather than
+by any behaviour a request can show.
+
+*The last field line wins.*  A proxy appends its own line rather than replacing
+the caller's, so the last line is the only one it authored -- the same
+right-most reading ``client_ip`` applies to the forwarded chain.  A plain
+header lookup returns the *first* line, which is precisely the one a caller can
+prepend.
+
+*No comma splitting.*  A comma-joined chain is not a scheme, and the caller
+controls the left of any chain it can get merged into one field line, so
+splitting would hand it authorship of the value.  Refusing the whole line is
+uvicorn's own reading and costs a misconfigured deployment its scheme upgrade
+while costing an attacker the forgery.  Case folding is the one deliberate
+divergence from uvicorn, which only strips: schemes are case-insensitive per
+RFC 3986, so this layer accepts ``HTTPS`` where uvicorn rejects it -- a more
+permissive reading, and the correct one.
+
+*HTTP scopes only.*  There is deliberately no websocket arm: the backend serves
+no websocket routes, so one would be unreachable, untested code.  Every other
+scope type is handed on with the mapping untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlette.requests import HTTPConnection
+
+from client_ip import peer_is_trusted_proxy
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+# ASGI scope keys this layer reads, plus the only one whose value it ever
+# changes: "scheme".  (Building an HTTPConnection has Starlette's Headers rebind
+# scope["headers"] to an equal list, which changes no value.)
+_HTTP_SCOPE_TYPE = "http"
+_SCOPE_TYPE_KEY = "type"
+_SCHEME_SCOPE_KEY = "scheme"
+
+_FORWARDED_PROTO_HEADER = "x-forwarded-proto"
+
+# The schemes a forwarded value may name, matching the set uvicorn's own
+# proxy-headers middleware accepts.  Anything outside it -- junk, an absolute
+# URL, a comma-joined chain, an empty value -- is not a scheme token and leaves
+# the socket scheme standing.  ``ws``/``wss`` are here because uvicorn's set has
+# them, not because anything upstream serves websockets: only a vouched proxy
+# can put one on an HTTP scope, so it is that proxy's misconfiguration to make
+# rather than a caller's to exploit, and narrowing the set would buy nothing.
+_ACCEPTED_SCHEMES = frozenset({"http", "https", "ws", "wss"})
+
+
+def _forwarded_scheme(connection: HTTPConnection) -> str | None:
+    """Return the scheme a vouched peer reported, or None when there is none to believe.
+
+    Reads every ``X-Forwarded-Proto`` field line and takes the last, which is
+    the proxy-authored one; scheme tokens are case-insensitive, so a shouting
+    proxy is still understood.
+    """
+    lines = connection.headers.getlist(_FORWARDED_PROTO_HEADER)
+    if not lines:
+        return None
+    reported = lines[-1].strip().lower()
+    return reported if reported in _ACCEPTED_SCHEMES else None
+
+
+def _apply_forwarded_scheme(scope: Scope) -> None:
+    """Raise ``scope["scheme"]`` to the forwarded one when the peer may say so.
+
+    Fails closed at the first gate: for a peer the allowlist does not name the
+    header is never even consulted, so an unvouched caller's value cannot leak
+    into any later decision.  ``scope["client"]`` is never touched -- that
+    answer belongs to :mod:`client_ip`, at the moment it is asked for.
+    """
+    connection = HTTPConnection(scope)
+    if not peer_is_trusted_proxy(connection):
+        return
+    scheme = _forwarded_scheme(connection)
+    if scheme is not None:
+        scope[_SCHEME_SCOPE_KEY] = scheme
+
+
+class ForwardedProtoMiddleware:
+    """Settle the request scheme from ``X-Forwarded-Proto`` before anything routes."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Wrap ``app``, which sees the scope only after the scheme is settled."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Resolve the scheme for HTTP scopes, then delegate to the wrapped app.
+
+        The scope-type guard comes first so lifespan and websocket scopes are
+        passed on as the exact object received, untouched and unexamined.
+        """
+        if scope[_SCOPE_TYPE_KEY] == _HTTP_SCOPE_TYPE:
+            _apply_forwarded_scheme(scope)
+        await self.app(scope, receive, send)

--- a/backend/src/middleware/logging.py
+++ b/backend/src/middleware/logging.py
@@ -1,4 +1,8 @@
-"""Request-logging middleware — outermost layer of the ASGI stack.
+"""Request-logging middleware — outermost layer that touches the response.
+
+Only :class:`middleware.forwarded_proto.ForwardedProtoMiddleware` sits above
+it, and that layer only settles ``scope["scheme"]`` on the way in — it wraps no
+response — so the access record below still describes the whole response path.
 
 Sits *outside* :class:`observability.CorrelationIdMiddleware` so the
 log line emitted for every request always carries a ``trace_id`` field

--- a/backend/tests/middleware/test_forwarded_proto.py
+++ b/backend/tests/middleware/test_forwarded_proto.py
@@ -1,0 +1,359 @@
+"""Forwarded-proto resolution: the scheme is evidence only from a trusted peer.
+
+``X-Forwarded-Proto`` is written by whoever is talking to us, so honouring it
+unconditionally lets any caller declare its plaintext request was TLS-protected
+-- which flips ``request.url.scheme`` and, with it, every absolute URL the
+application mints.  These tests pin an application middleware that reuses the
+same ``TRUSTED_PROXY_CIDRS`` trust walk :mod:`client_ip` already performs: an
+unvouched peer, an unset allowlist, or a value that is not a bare scheme token
+all leave the socket scheme exactly as the server saw it.
+
+The probe app below fakes the ASGI socket peer through ``ASGITransport`` and
+reports the scheme a route observes.  Two cases drive the real application
+instead and read the ``Location`` of a trailing-slash redirect, because that
+redirect must not downgrade a client from HTTPS to HTTP behind a
+TLS-terminating proxy.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from client_ip import TRUSTED_PROXIES_ENV_VAR
+from main import app
+from middleware import ForwardedProtoMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from starlette.types import Message, Scope
+
+# Documentation-range addresses (RFC 5737) matching the trust tests in
+# ``tests/security/test_client_ip.py``, so no case can be mistaken for a real
+# network and both suites describe the same allowlist.
+_TRUSTED_PROXY_NET = "192.0.2.0/24"
+_PROXY_PEER = "192.0.2.10"
+_UNTRUSTED_PEER = "198.51.100.7"
+_PEER_PORT = 51_234
+
+_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto"
+_FORWARDED_FOR_HEADER = "X-Forwarded-For"
+_HTTP = "http"
+_HTTPS = "https"
+
+# A forwarded chain naming somebody other than the socket peer, so a middleware
+# that copied uvicorn's client rewriting would visibly change the reported peer.
+_FORWARDED_CLIENT_IP = "203.0.113.5"
+
+# The probe app's routes, and the keys they report the observed scope under.
+_SCHEME_PATH = "/scheme"
+_SCHEME_KEY = "scheme"
+_PEER_PATH = "/peer"
+_PEER_KEY = "peer"
+
+# The answer the peer route gives when the scope carries no client at all, so a
+# missing peer cannot be mistaken for a rewritten one.
+_NO_PEER = "none"
+
+# ``base_url`` decides the socket scheme the transport writes into the scope,
+# so every case starts from plaintext and the middleware is the only thing that
+# could raise it.
+_BASE_URL = "http://test"
+
+# A collection route whose canonical form carries a trailing slash, so the
+# router answers 307 before any dependency or auth check runs.
+_COLLECTION_PATH = "/practices"
+_LOCATION_HEADER = "location"
+_HTTPS_LOCATION_PREFIX = "https://"
+_HTTP_LOCATION_PREFIX = "http://"
+
+# Values that are not a bare scheme token: junk, an absolute URL, nothing at
+# all, and a token with an interior space.
+_UNKNOWN_SCHEME_VALUES = ["gopher", "https://evil.example", "", "HTTP S"]
+
+# A proxy chain, which this middleware deliberately does not split.
+_APPENDED_PROTO_CHAIN = "https, http"
+
+_UPPERCASE_HTTPS = "HTTPS"
+
+# Non-HTTP scope fixtures: a scheme value no ASGI server would ever set, so an
+# assertion on it can only pass if the middleware left the mapping alone.
+_LIFESPAN_SCOPE_TYPE = "lifespan"
+_LIFESPAN_STARTUP_MESSAGE_TYPE = "lifespan.startup"
+_SCOPE_TYPE_KEY = "type"
+_SCOPE_HEADERS_KEY = "headers"
+_SENTINEL_SCHEME = "sentinel-scheme"
+_SPOOFED_PROTO_HEADERS = [(b"x-forwarded-proto", _HTTPS.encode())]
+
+_probe = FastAPI()
+
+
+@_probe.get(_SCHEME_PATH)
+async def _report_scheme(request: Request) -> dict[str, str]:
+    """Report the scheme the middleware left on the ASGI scope."""
+    return {_SCHEME_KEY: request.url.scheme}
+
+
+@_probe.get(_PEER_PATH)
+async def _report_peer(request: Request) -> dict[str, str]:
+    """Report the socket peer the middleware left on the ASGI scope."""
+    peer = request.client
+    return {_PEER_KEY: _NO_PEER if peer is None else peer.host}
+
+
+_probe.add_middleware(ForwardedProtoMiddleware)
+
+
+@asynccontextmanager
+async def _peer_client(target: FastAPI, peer_host: str) -> AsyncIterator[AsyncClient]:
+    """Yield a plaintext client for ``target`` whose ASGI socket peer is ``peer_host``."""
+    transport = ASGITransport(app=target, client=(peer_host, _PEER_PORT))
+    async with AsyncClient(transport=transport, base_url=_BASE_URL) as client:
+        yield client
+
+
+async def _observed_scheme(peer_host: str, forwarded: list[str]) -> str:
+    """Return the scheme the probe route saw, given one field line per entry.
+
+    A proxy that appends its own ``X-Forwarded-Proto`` rather than replacing the
+    caller's produces several field lines, so the list models a real chain.
+    """
+    headers = [(_FORWARDED_PROTO_HEADER, value) for value in forwarded]
+    async with _peer_client(_probe, peer_host) as client:
+        response = await client.get(_SCHEME_PATH, headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    return str(response.json()[_SCHEME_KEY])
+
+
+async def _observed_peer(peer_host: str, forwarded_for: str) -> str:
+    """Return the socket peer the probe route saw, given a forwarded-for chain."""
+    headers = {_FORWARDED_FOR_HEADER: forwarded_for, _FORWARDED_PROTO_HEADER: _HTTPS}
+    async with _peer_client(_probe, peer_host) as client:
+        response = await client.get(_PEER_PATH, headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    return str(response.json()[_PEER_KEY])
+
+
+@pytest.mark.asyncio
+async def test_trusted_proxy_forwarded_proto_upgrades_the_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer inside the allowlist may report that it terminated TLS for the client."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [_HTTPS])
+
+    assert scheme == _HTTPS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("peer_host", [_PROXY_PEER, _UNTRUSTED_PEER])
+async def test_resolving_the_scheme_never_rewrites_the_socket_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    peer_host: str,
+) -> None:
+    """Settling the scheme leaves the peer alone, trusted or not.
+
+    Deciding who the client is belongs to the resolver, at the moment a throttle
+    or an audit row asks; a layer that answered it here from the same forwarded
+    headers would be the server-side rewriting this change exists to remove.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    peer = await _observed_peer(peer_host, _FORWARDED_CLIENT_IP)
+
+    assert peer == peer_host
+
+
+@pytest.mark.asyncio
+async def test_untrusted_peer_cannot_upgrade_the_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer outside the allowlist keeps the scheme the socket actually carried."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_UNTRUSTED_PEER, [_HTTPS])
+
+    assert scheme == _HTTP
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_allowlist_ignores_the_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no allowlist configured nobody is a proxy, so the header is evidence of nothing."""
+    monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [_HTTPS])
+
+    assert scheme == _HTTP
+
+
+@pytest.mark.asyncio
+async def test_trusted_proxy_without_the_header_keeps_the_socket_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vouched peer that says nothing about the scheme changes nothing."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [])
+
+    assert scheme == _HTTP
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("forwarded_value", _UNKNOWN_SCHEME_VALUES)
+async def test_unknown_scheme_value_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+    forwarded_value: str,
+) -> None:
+    """Only a bare scheme token is accepted; anything else leaves the socket scheme."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [forwarded_value])
+
+    assert scheme == _HTTP
+
+
+@pytest.mark.asyncio
+async def test_uppercase_scheme_value_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scheme tokens are case-insensitive, so a shouting proxy is still understood."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [_UPPERCASE_HTTPS])
+
+    assert scheme == _HTTPS
+
+
+@pytest.mark.asyncio
+async def test_appended_proto_chain_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A comma-joined chain is not a scheme, and is deliberately not split apart.
+
+    This is uvicorn's own reading, and it fails closed: the caller controls the
+    left of any chain it can get merged into one field line, so splitting would
+    hand it a way to author the value.  Refusing the whole line costs a
+    misconfigured deployment its scheme upgrade and costs an attacker the
+    forgery.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [_APPENDED_PROTO_CHAIN])
+
+    assert scheme == _HTTP
+
+
+@pytest.mark.asyncio
+async def test_last_forwarded_proto_line_wins_over_a_client_prepended_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The proxy appends its line last, so the last line is the only authored one.
+
+    Reading the first line -- which is what a plain header lookup returns --
+    hands a caller that sent its own ``X-Forwarded-Proto`` authorship of the
+    scheme, exactly as a left-most ``X-Forwarded-For`` read hands it the client
+    address.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    prepended_https = await _observed_scheme(_PROXY_PEER, [_HTTPS, _HTTP])
+    prepended_http = await _observed_scheme(_PROXY_PEER, [_HTTP, _HTTPS])
+
+    assert prepended_https == _HTTP
+    assert prepended_http == _HTTPS
+
+
+@pytest.mark.asyncio
+async def test_trusted_proxy_may_also_report_plain_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted value that matches the socket scheme is honoured and changes nothing."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    scheme = await _observed_scheme(_PROXY_PEER, [_HTTP])
+
+    assert scheme == _HTTP
+
+
+class _ScopeRecorder:
+    """A stub ASGI app that records the scope object it was handed."""
+
+    def __init__(self) -> None:
+        """Start out having seen nothing."""
+        self.seen: Scope | None = None
+
+    async def __call__(self, scope: Scope, _receive: object, _send: object) -> None:
+        """Record ``scope`` by identity and do nothing else."""
+        self.seen = scope
+
+
+async def _empty_receive() -> Message:
+    """Return one ASGI message; the pass-through case never reads the stream."""
+    return {_SCOPE_TYPE_KEY: _LIFESPAN_STARTUP_MESSAGE_TYPE}
+
+
+async def _discard_send(_message: Message) -> None:
+    """Drop an outbound ASGI message."""
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_passes_through_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scopes that are not HTTP requests reach the inner app byte-for-byte unchanged."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+    recorder = _ScopeRecorder()
+    scope = {
+        _SCOPE_TYPE_KEY: _LIFESPAN_SCOPE_TYPE,
+        _SCHEME_KEY: _SENTINEL_SCHEME,
+        _SCOPE_HEADERS_KEY: _SPOOFED_PROTO_HEADERS,
+        "client": (_PROXY_PEER, _PEER_PORT),
+    }
+
+    await ForwardedProtoMiddleware(recorder)(scope, _empty_receive, _discard_send)
+
+    assert recorder.seen is scope
+    assert scope[_SCHEME_KEY] == _SENTINEL_SCHEME
+
+
+async def _redirect_location(peer_host: str, forwarded: str) -> tuple[int, str]:
+    """Return the status and ``Location`` of the real app's trailing-slash redirect."""
+    async with _peer_client(app, peer_host) as client:
+        response = await client.get(
+            _COLLECTION_PATH,
+            headers={_FORWARDED_PROTO_HEADER: forwarded},
+        )
+    return response.status_code, response.headers[_LOCATION_HEADER]
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash_redirect_emits_https_location_for_a_trusted_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behind a TLS-terminating proxy the router's own redirect must stay on HTTPS.
+
+    A redirect that names ``http://`` sends the browser back over plaintext,
+    which either breaks under a strict-transport policy or leaks the request.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    status, location = await _redirect_location(_PROXY_PEER, _HTTPS)
+
+    assert status == HTTPStatus.TEMPORARY_REDIRECT
+    assert location.startswith(_HTTPS_LOCATION_PREFIX)
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash_redirect_stays_http_for_an_untrusted_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unvouched caller cannot talk the router into minting HTTPS absolute URLs."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    status, location = await _redirect_location(_UNTRUSTED_PEER, _HTTPS)
+
+    assert status == HTTPStatus.TEMPORARY_REDIRECT
+    assert location.startswith(_HTTP_LOCATION_PREFIX)

--- a/backend/tests/middleware/test_middleware_stack.py
+++ b/backend/tests/middleware/test_middleware_stack.py
@@ -17,12 +17,34 @@ from __future__ import annotations
 import logging
 
 import pytest
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
+from slowapi.middleware import SlowAPIMiddleware
 
 from main import app
+from middleware import (
+    CorrelationIdMiddleware,
+    ForwardedProtoMiddleware,
+    RequestLoggingMiddleware,
+    SecurityHeadersMiddleware,
+)
 from observability import TRACE_ID_HEADER, TraceIdLogFilter
 
 client = TestClient(app)
+
+# The stack as a request meets it, outermost first.  ``add_middleware`` inserts
+# at the front of ``user_middleware``, so this list is the reverse of the
+# registration order in ``main``.  Compared by class name, as the CORS config
+# test does: Starlette types ``Middleware.cls`` as a factory protocol rather than
+# a class, so the entries and these classes have no comparable static type.
+_OUTER_TO_INNER = [
+    ForwardedProtoMiddleware.__name__,
+    RequestLoggingMiddleware.__name__,
+    CorrelationIdMiddleware.__name__,
+    SecurityHeadersMiddleware.__name__,
+    CORSMiddleware.__name__,
+    SlowAPIMiddleware.__name__,
+]
 
 
 def test_every_middleware_side_effect_fires_on_one_request(
@@ -51,8 +73,28 @@ def test_every_middleware_side_effect_fires_on_one_request(
     # CORSMiddleware exposed the trace id to cross-origin readers.
     exposed = response.headers.get("access-control-expose-headers", "")
     assert TRACE_ID_HEADER.lower() in exposed.lower()
-    # RequestLoggingMiddleware (outermost) emitted the access record.
+    # RequestLoggingMiddleware (outermost logging layer) emitted the access record.
     assert any(r.message == "request_completed" for r in caplog.records)
+
+
+def test_forwarded_proto_middleware_is_the_outermost_layer() -> None:
+    """``ForwardedProtoMiddleware`` must sit above every other layer, and stay there.
+
+    Registration order is asserted directly here, which the behaviour-first
+    cases above deliberately avoid, because this one invariant has no
+    behavioural signature to assert instead.  The scheme has exactly two
+    consumers today -- Starlette's ``Router``, which builds the trailing-slash
+    307's ``Location`` from ``scope["scheme"]``, and any absolute URL a handler
+    mints -- and both sit below *every* user middleware, so the end-to-end
+    redirect cases in ``tests/middleware/test_forwarded_proto.py`` pass from any
+    slot in this list.  They would keep passing if a later change re-registered
+    this layer somewhere inside the stack, at which point every layer above it
+    would silently start reading the ingress hop's scheme rather than the
+    client's.  Pinning the order is the only thing that catches that.
+    """
+    observed = [getattr(entry.cls, "__name__", "") for entry in app.user_middleware]
+
+    assert observed == _OUTER_TO_INNER
 
 
 def test_preflight_response_carries_security_headers() -> None:
@@ -146,7 +188,7 @@ def test_install_trace_id_logging_runs_at_import() -> None:
 def test_request_logging_middleware_emits_one_record_per_request(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The outermost RequestLoggingMiddleware logs an access record on every call."""
+    """The outermost logging layer, RequestLoggingMiddleware, logs a record on every call."""
     with caplog.at_level(logging.INFO, logger="adepthood.access"):
         client.get("/auth/login")
     completed = [r for r in caplog.records if r.message == "request_completed"]

--- a/backend/tests/security/test_client_ip.py
+++ b/backend/tests/security/test_client_ip.py
@@ -9,9 +9,11 @@ the right so a client-prepended entry cannot win.
 
 The integration cases fake the ASGI socket peer through ``ASGITransport`` and
 assert that the slowapi limiter and the invalid-license throttle agree on the
-key the resolver produces.  One case reaches past the application entirely and
-pins the runtime image's uvicorn flags, because a proxy-header trust set
-declared in the CMD overwrites ``request.client`` before this module runs.
+key the resolver produces.  A further group reaches past the application
+entirely and pins the runtime image's uvicorn flags -- both as tokens in the
+Dockerfile CMD and as the ASGI stack uvicorn actually builds from them -- so
+that no server-level layer can rewrite the socket peer or the request scheme
+before this module runs.
 """
 
 from __future__ import annotations
@@ -25,8 +27,10 @@ import pytest
 from annotated_types import MaxLen
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
+from uvicorn.config import Config
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
-from client_ip import TRUSTED_PROXIES_ENV_VAR, resolve_client_ip
+from client_ip import TRUSTED_PROXIES_ENV_VAR, peer_is_trusted_proxy, resolve_client_ip
 from database import get_session
 from main import app
 from models.password_reset_token import PasswordResetToken
@@ -99,6 +103,22 @@ _DOCKERFILE = Path(__file__).resolve().parents[2] / "Dockerfile"
 _CMD_DIRECTIVE = "CMD "
 _WILDCARD_ALLOW_IPS = "--forwarded-allow-ips=*"
 _PROXY_HEADERS_FLAG = "--proxy-headers"
+_FORWARDED_ALLOW_IPS_FLAG = "--forwarded-allow-ips"
+# Uvicorn spells the switch as the pair ``--proxy-headers/--no-proxy-headers``,
+# and the off form contains the on form as a substring, so the CMD has to be
+# compared token by token rather than searched for text.
+_NO_PROXY_HEADERS_FLAG = "--no-proxy-headers"
+_FLAG_VALUE_SEPARATOR = "="
+_CMD_JSON_PUNCTUATION = '[],"'
+
+# The import string the CMD hands uvicorn, resolved through the same
+# ``backend/src`` sys.path entry the suite itself runs on.
+_APP_IMPORT_STRING = "main:app"
+# Uvicorn's own fallback trust set when no allowlist is given, and the
+# environment variable that silently replaces it.
+_UVICORN_DEFAULT_TRUSTED_PEER = "127.0.0.1"
+_FORWARDED_ALLOW_IPS_ENV_VAR = "FORWARDED_ALLOW_IPS"
+_TRUST_EVERY_PEER = "*"
 
 _RESET_PATH = "/auth/password-reset/request"
 _RESET_REQUESTS_PER_HOUR = 3
@@ -330,16 +350,160 @@ def test_runtime_image_never_trusts_every_forwarding_peer() -> None:
     )
 
 
-def test_runtime_image_shares_one_trust_set_with_the_application() -> None:
-    """Whatever uvicorn trusts for proxy headers must be what the app trusts."""
-    cmd = _runtime_cmd()
-    if _PROXY_HEADERS_FLAG not in cmd:
-        return
-    assert TRUSTED_PROXIES_ENV_VAR in cmd, (
-        f"backend/Dockerfile CMD enables {_PROXY_HEADERS_FLAG} without deriving "
-        f"its allowed peers from {TRUSTED_PROXIES_ENV_VAR}; two trust sets that "
-        "can diverge means uvicorn may rewrite request.client for a peer the "
-        "application would never have trusted."
+def _runtime_cmd_tokens() -> list[str]:
+    """Return the runtime CMD split into tokens with its JSON-array punctuation stripped."""
+    return [token.strip(_CMD_JSON_PUNCTUATION) for token in _runtime_cmd().split()]
+
+
+def _runtime_cmd_flag_names() -> set[str]:
+    """Return every option name in the runtime CMD, discarding any attached value."""
+    return {token.split(_FLAG_VALUE_SEPARATOR)[0] for token in _runtime_cmd_tokens()}
+
+
+def _uvicorn_config(*, proxy_headers: bool) -> Config:
+    """Build a uvicorn config for the deployed app, leaving global logging untouched."""
+    return Config(_APP_IMPORT_STRING, proxy_headers=proxy_headers, log_config=None)
+
+
+def _uvicorn_default_config() -> Config:
+    """Build the config uvicorn produces when the command line names no forwarding flag."""
+    return Config(_APP_IMPORT_STRING, log_config=None)
+
+
+def _runtime_proxy_headers() -> bool:
+    """Resolve the ``proxy_headers`` setting the runtime CMD tokens hand uvicorn.
+
+    The switch is a flag pair, so omitting both spellings does not disable
+    anything -- it leaves uvicorn's own default in force.
+    """
+    tokens = _runtime_cmd_tokens()
+    if _NO_PROXY_HEADERS_FLAG in tokens:
+        return False
+    if _PROXY_HEADERS_FLAG in tokens:
+        return True
+    return _uvicorn_default_config().proxy_headers
+
+
+def _loaded_app(config: Config) -> object:
+    """Return the outermost ASGI object uvicorn would serve under ``config``."""
+    config.load()
+    return config.loaded_app
+
+
+def test_runtime_image_disables_uvicorn_proxy_header_handling() -> None:
+    """The CMD must switch the proxy-header layer off explicitly, not merely omit it.
+
+    Uvicorn's ``ProxyHeadersMiddleware`` is all-or-nothing: while it is mounted
+    it rewrites ``scope["client"]`` from ``X-Forwarded-For`` as well as
+    ``scope["scheme"]`` from ``X-Forwarded-Proto``, under its own allowlist
+    parser, before any application code runs.  Two trust sets that can diverge
+    is one too many, so the server-side layer has to be turned off and every
+    forwarding decision taken inside the application against
+    ``TRUSTED_PROXY_CIDRS``.
+    """
+    assert _NO_PROXY_HEADERS_FLAG in _runtime_cmd_tokens(), (
+        f"backend/Dockerfile CMD must pass {_NO_PROXY_HEADERS_FLAG}; leaving the "
+        "flag out keeps uvicorn's ProxyHeadersMiddleware mounted, so a loopback "
+        "caller can still rewrite request.client and the request scheme under a "
+        f"trust set the application never sees, not {TRUSTED_PROXIES_ENV_VAR}."
+    )
+
+
+def test_runtime_image_never_enables_uvicorn_proxy_header_handling() -> None:
+    """No bare enabling token may switch the server-side rewriting layer back on."""
+    assert _PROXY_HEADERS_FLAG not in _runtime_cmd_tokens(), (
+        f"backend/Dockerfile CMD must not pass {_PROXY_HEADERS_FLAG}; uvicorn "
+        "would rewrite request.client from the left-most X-Forwarded-For entry "
+        "under a trust set the application never sees."
+    )
+
+
+def test_runtime_image_declares_no_server_level_forwarding_trust_set() -> None:
+    """The image must name no proxy allowlist of its own, wildcard or otherwise."""
+    assert _FORWARDED_ALLOW_IPS_FLAG not in _runtime_cmd_flag_names(), (
+        f"backend/Dockerfile CMD must not pass {_FORWARDED_ALLOW_IPS_FLAG}; a "
+        "server-level trust set can diverge from the one the application "
+        f"enforces from {TRUSTED_PROXIES_ENV_VAR}."
+    )
+
+
+def test_uvicorn_wraps_the_app_in_a_peer_rewriter_when_no_flag_is_given(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting the flag is not the same as disabling it: the default mounts the rewriter.
+
+    This is the canary that makes the explicit flag mandatory.  If uvicorn ever
+    flips its default, this case fails and the reason for the flag can be
+    revisited; until then it records that a bare command line ships a layer
+    which trusts loopback and rewrites the peer above the application.
+
+    The trust set is read only through ``in``, which is the container protocol
+    the class exposes.  Its address-extraction helper is deliberately left
+    alone: that method has been renamed between uvicorn releases, so a test that
+    called it would pin this suite to one version of a third party rather than
+    to the behaviour we actually depend on.
+    """
+    monkeypatch.delenv(_FORWARDED_ALLOW_IPS_ENV_VAR, raising=False)
+    config = _uvicorn_default_config()
+
+    loaded = _loaded_app(config)
+
+    assert config.proxy_headers is True
+    assert isinstance(loaded, ProxyHeadersMiddleware)
+    # Loopback is vouched for by default, so anything sharing the host -- a
+    # sidecar, another container on the same network namespace -- may rewrite
+    # the peer; a caller out on the internet may not.  That asymmetry is the
+    # whole reason the layer has to be switched off rather than left at its
+    # default.
+    assert _UVICORN_DEFAULT_TRUSTED_PEER in loaded.trusted_hosts
+    assert _CLIENT_IP not in loaded.trusted_hosts
+
+
+def test_uvicorn_leaves_the_app_unwrapped_when_proxy_headers_are_disabled() -> None:
+    """Turning the setting off is what actually removes the rewriting layer."""
+    loaded = _loaded_app(_uvicorn_config(proxy_headers=False))
+
+    assert not isinstance(loaded, ProxyHeadersMiddleware)
+
+
+def test_runtime_cmd_serves_the_app_with_no_peer_rewriter_above_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Served exactly as the image serves it, nothing above the app can rewrite the peer.
+
+    This ties the Dockerfile to the behaviour it is supposed to buy: the flags
+    the CMD carries are fed to a real uvicorn config, and the loaded stack must
+    hand requests straight to the application.
+    """
+    monkeypatch.delenv(_FORWARDED_ALLOW_IPS_ENV_VAR, raising=False)
+
+    loaded = _loaded_app(_uvicorn_config(proxy_headers=_runtime_proxy_headers()))
+
+    assert not isinstance(loaded, ProxyHeadersMiddleware), (
+        "the flags in backend/Dockerfile CMD leave uvicorn's "
+        "ProxyHeadersMiddleware mounted above the application, so request.client "
+        "and the request scheme are rewritten before resolve_client_ip runs."
+    )
+
+
+def test_forwarded_allow_ips_env_var_cannot_reinstate_a_server_level_trust_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wildcard in the deploy environment must not buy back a trust set the app never sees.
+
+    Uvicorn reads ``FORWARDED_ALLOW_IPS`` when no allowlist is passed, so an
+    operator or platform variable can widen server-side trust to every peer.
+    With the rewriting layer switched off there is nothing for that variable to
+    configure.
+    """
+    monkeypatch.setenv(_FORWARDED_ALLOW_IPS_ENV_VAR, _TRUST_EVERY_PEER)
+
+    loaded = _loaded_app(_uvicorn_config(proxy_headers=_runtime_proxy_headers()))
+
+    assert not isinstance(loaded, ProxyHeadersMiddleware), (
+        f"{_FORWARDED_ALLOW_IPS_ENV_VAR} re-arms uvicorn's ProxyHeadersMiddleware "
+        "to trust every peer because backend/Dockerfile CMD does not disable the "
+        "proxy-header layer outright."
     )
 
 
@@ -396,6 +560,59 @@ def test_ipv4_mapped_socket_peer_is_trusted_by_a_plain_ipv4_config_entry(
     resolved = resolve_client_ip(_make_request((_MAPPED_PROXY_PEER, _PEER_PORT), _CLIENT_IP))
 
     assert resolved == _CLIENT_IP
+
+
+def test_peer_inside_the_configured_range_is_a_trusted_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The trust projection says yes for exactly the peers the allowlist names."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    assert peer_is_trusted_proxy(_make_request((_PROXY_PEER, _PEER_PORT))) is True
+
+
+def test_peer_outside_the_configured_range_is_not_a_trusted_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A peer the allowlist does not name gets no say over any forwarded header."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    assert peer_is_trusted_proxy(_make_request((_UNTRUSTED_PEER, _PEER_PORT))) is False
+
+
+def test_absent_socket_peer_is_not_a_trusted_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection with no peer at all cannot be one of our proxies."""
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _TRUSTED_PROXY_NET)
+
+    assert peer_is_trusted_proxy(_make_request(None)) is False
+
+
+@pytest.mark.parametrize("configured", [None, "", _ALL_GARBAGE_CONFIG])
+def test_unconfigured_trust_makes_every_peer_untrusted(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+) -> None:
+    """Config that names no parseable network vouches for nobody, fail-closed."""
+    if configured is None:
+        monkeypatch.delenv(TRUSTED_PROXIES_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, configured)
+
+    assert peer_is_trusted_proxy(_make_request((_PROXY_PEER, _PEER_PORT))) is False
+
+
+def test_ipv4_mapped_peer_is_trusted_by_a_plain_ipv4_config_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The trust projection folds mapped literals rather than re-deciding trust itself.
+
+    A dual-stack listener reports the proxy as ``::ffff:192.0.2.10``, which no
+    IPv4 entry contains; only reusing the resolver's own canonicalisation keeps
+    the two answers from disagreeing about who a proxy is.
+    """
+    monkeypatch.setenv(TRUSTED_PROXIES_ENV_VAR, _PROXY_PEER)
+
+    assert peer_is_trusted_proxy(_make_request((_MAPPED_PROXY_PEER, _PEER_PORT))) is True
 
 
 def test_padding_and_blank_entries_tolerated_in_config_and_header(


### PR DESCRIPTION
## Summary

Trusting the client-facing **scheme** and trusting the client **address** were a
single setting, because uvicorn bundles both behind `--proxy-headers`. #1986
narrowed `--forwarded-allow-ips` to `TRUSTED_PROXY_CIDRS`, which fixed the address
forgery — and, as a side effect, switched off proto trust too. So today the app
believes it is serving `http`, and the trailing-slash 307 plus every absolute URL
it mints downgrade to `http://`, which browsers refuse to follow cross-origin.

This splits the two concerns so each can be reasoned about, tested, and configured
separately.

**`ForwardedProtoMiddleware`** (new, pure ASGI) settles `scope["scheme"]` inside the
application, gated on `client_ip.peer_is_trusted_proxy` — the *same* trust walk
`resolve_client_ip` already performs, exposed rather than re-implemented, so the two
answers can never drift on who a proxy is. Behaviour:

- **Fails closed at the first gate.** For a peer the allowlist does not name, the
  header is never even read, so an unvouched value cannot leak into a later decision.
- Only `http`, `https`, `ws`, `wss` are accepted (uvicorn's set); anything else leaves
  the socket scheme standing.
- **The last field line wins** — the one a proxy authored, not the one a caller
  prepended. A plain header lookup returns the *first*, which is exactly the
  attacker-controlled one.
- A comma-joined chain is refused outright rather than split, since the caller
  controls the left of any chain it can get merged into one field line.
- It never touches `scope["client"]`. That answer stays with `client_ip`.
- Registered **outermost**, because Starlette's router builds the redirect `Location`
  from `scope["scheme"]` before anything else runs.

### Why `--no-proxy-headers` is load-bearing

The CMD now passes `--no-proxy-headers` explicitly. **The negative is required: the
switch is the flag pair `--proxy-headers/--no-proxy-headers` and it defaults to
ENABLED, so merely omitting the flag is not the same as disabling it.** Left at its
default, uvicorn's `ProxyHeadersMiddleware` stays mounted — trusting loopback,
rewriting `scope["client"]` from the left-most (caller-chosen) `X-Forwarded-For`
entry as well as the scheme, before any application code runs and under a second
trust set the app never sees. It also leaves `FORWARDED_ALLOW_IPS` — an env var
uvicorn reads directly, a common PaaS copy-paste — able to widen that trust to `*`
with no flag visible in the image at all. Switched off, `TRUSTED_PROXY_CIDRS` is the
entire forwarding policy: one trust set, one parser.

### Operator action required

⚠️ **`TRUSTED_PROXY_CIDRS` is currently unset in production.** Until it is set to the
platform ingress range on Railway, *both* halves stay off and fail closed:

- `X-Forwarded-Proto` is ignored from every peer, so redirects and absolute URLs stay
  `http://`.
- `X-Forwarded-For` is ignored, so the rate limiter, the invalid-license throttle, and
  the login / password-reset audit rows all key on the ingress itself — one shared
  bucket and one audited address for every client on the internet.

Neither proto trust nor per-client rate limiting actually works until that variable is
set. A production boot without it logs a `trusted_proxies_unconfigured` warning.
`DEPLOYMENT.md` and `backend/.env.example` document the format, the "do not set
`FORWARDED_ALLOW_IPS`" rule, and why the innermost proxy must **replace** (not append
to) `X-Forwarded-Proto`.

## Test plan

Gate 2 green in-worktree: ruff lint + format, mypy, bandit + pip-audit, xenon A /
radon MI ≥ B, and the full backend suite at **3340 passed, 2 skipped, 96.9% coverage**.

New coverage:

- `tests/middleware/test_forwarded_proto.py` — trusted peer upgrades the scheme;
  untrusted peer does not; unset allowlist trusts nobody; junk / absolute-URL / empty /
  interior-space values ignored; comma chain ignored; uppercase accepted; last field
  line wins over a client-prepended one; the peer is never rewritten; non-HTTP scopes
  pass through by identity; and the real app's trailing-slash 307 emits an `https://`
  `Location` **only** for the trusted peer.
- `tests/security/test_client_ip.py` — `peer_is_trusted_proxy` trust matrix (inside /
  outside range, absent peer, unset / blank / garbage config, IPv4-mapped folding), and
  the Dockerfile pins.

Two things worth calling out in the test design:

1. **The CMD is compared token by token, not by substring** — `--proxy-headers` is a
   substring of `--no-proxy-headers`, so a text search would silently invert.
2. **The flags are fed to a real uvicorn `Config`**, and the loaded stack must hand
   requests straight to the app — so the middleware is pinned to be deciding on
   *un-mutated* input, not merely correct in isolation. A canary test records that
   uvicorn's default *does* mount the rewriter, so a future default flip is caught
   rather than inherited.
3. **Middleware order is asserted directly** in `test_middleware_stack.py`. The
   scheme's only consumer sits below every user middleware, so the end-to-end redirect
   cases would keep passing from any slot in the stack and could not catch a
   re-registration.

Closes #1999
Refs #1986
