### PR TITLE
feat(backend): warn at startup when IPV6_THROTTLE_PREFIX_LEN is unusable

### DIFF
--- a/backend/src/client_ip.py
+++ b/backend/src/client_ip.py
@@ -47,8 +47,12 @@ IPV6_THROTTLE_PREFIX_ENV_VAR = "IPV6_THROTTLE_PREFIX_LEN"
 # any configured value we cannot use.
 DEFAULT_IPV6_THROTTLE_PREFIX_LEN = 64
 
-# A prefix length is a bit count, so anything below one bit is not a prefix.
-_MIN_IPV6_THROTTLE_PREFIX_LEN = 1
+# A prefix length is a bit count, so anything below one bit is not a prefix and
+# nothing wider than the address itself is one either.  Both are public because
+# the boot-time config check quotes this range back to the operator, and a range
+# stated in two places is a range that eventually disagrees with itself.
+MIN_IPV6_THROTTLE_PREFIX_LEN = 1
+MAX_IPV6_THROTTLE_PREFIX_LEN = ipaddress.IPV6LENGTH
 
 # Both the config variable and the forwarded header are comma-separated lists.
 _ENTRY_SEPARATOR = ","
@@ -87,6 +91,23 @@ def _parse_prefix_length(raw: str) -> int | None:
         return int(raw)
     except ValueError:
         return None
+
+
+def _usable_prefix_length(raw: str) -> int | None:
+    """Return the prefix ``raw`` asks for, or None when it does not name one.
+
+    The single judgement of what counts as a prefix, so the runtime and the
+    boot-time check below cannot come to different conclusions about the same
+    string: whatever the runtime would discard is exactly what boot announces.
+    ``int`` tolerates surrounding whitespace, so a padded value is configuration
+    rather than a typo, and a blank value names no prefix at all.
+    """
+    configured = _parse_prefix_length(raw)
+    if configured is None:
+        return None
+    if not (MIN_IPV6_THROTTLE_PREFIX_LEN <= configured <= MAX_IPV6_THROTTLE_PREFIX_LEN):
+        return None
+    return configured
 
 
 def _is_scoped(address: _Address) -> bool:
@@ -146,13 +167,12 @@ def _throttle_prefix_length() -> int:
     """Read the IPv6 throttle prefix length from the environment at call time.
 
     Reading per call means retuning the bucket needs no restart, exactly as for
-    the proxy allowlist.  Only an integer in ``[1, IPV6LENGTH]`` is a usable
-    prefix, and every other value degrades to the default rather than being
-    clamped into range: ``0`` would collapse every IPv6 client on earth into one
-    bucket -- a self-inflicted denial of service on all legitimate IPv6 users --
-    and clamping ``129`` down would silently disable the grouping altogether.
-    The default is the only value an operator would have chosen deliberately, so
-    it is the only safe reading of a typo.
+    the proxy allowlist.  Anything that is not a usable prefix degrades to the
+    default rather than being clamped into range: ``0`` would collapse every
+    IPv6 client on earth into one bucket -- a self-inflicted denial of service
+    on all legitimate IPv6 users -- and clamping ``129`` down would silently
+    disable the grouping altogether.  The default is the only value an operator
+    would have chosen deliberately, so it is the only safe reading of a typo.
 
     The range check asks only whether a value is a prefix, not whether it is a
     wise one.  ``IPV6LENGTH`` itself is the deliberate opt-out -- it restores
@@ -160,13 +180,13 @@ def _throttle_prefix_length() -> int:
     against -- and a very small value groups very coarsely on purpose.  Both are
     an operator's call to make; only a value that is not a prefix at all is
     a typo this can recognise as such.
+
+    Deliberately silent about that fallback.  This runs on every IPv6 request,
+    so logging here would turn one typo into a log flood at request rate; the
+    announcement belongs to boot, via :func:`unusable_throttle_prefix_config`.
     """
-    configured = _parse_prefix_length(os.getenv(IPV6_THROTTLE_PREFIX_ENV_VAR, ""))
-    if configured is None or not (
-        _MIN_IPV6_THROTTLE_PREFIX_LEN <= configured <= ipaddress.IPV6LENGTH
-    ):
-        return DEFAULT_IPV6_THROTTLE_PREFIX_LEN
-    return configured
+    configured = _usable_prefix_length(os.getenv(IPV6_THROTTLE_PREFIX_ENV_VAR, ""))
+    return DEFAULT_IPV6_THROTTLE_PREFIX_LEN if configured is None else configured
 
 
 def _is_trusted(address: _Address, networks: list[_Network]) -> bool:
@@ -310,3 +330,25 @@ def peer_is_trusted_proxy(connection: HTTPConnection) -> bool:
     """
     peer = _socket_peer(connection)
     return peer is not None and _is_trusted(peer, _trusted_networks())
+
+
+def unusable_throttle_prefix_config() -> str | None:
+    """Return the configured prefix value the runtime cannot use, else None.
+
+    Exists so a caller that *can* log -- boot, once -- can say what the silent
+    per-request fallback in :func:`_throttle_prefix_length` swallowed.  This
+    module stays a leaf and stays quiet: it reports the finding and lets its
+    caller decide what to do about it.
+
+    Unset and blank both answer None.  ``backend/.env.example`` ships the
+    variable present but empty, so treating blank as a mistake would fire the
+    warning on every stock boot and teach operators to ignore it.  The value
+    comes back verbatim rather than stripped, because the operator has to
+    recognise what they typed -- a stray space is the whole bug.
+    """
+    raw = os.getenv(IPV6_THROTTLE_PREFIX_ENV_VAR)
+    if raw is None or not raw.strip():
+        return None
+    if _usable_prefix_length(raw) is not None:
+        return None
+    return raw

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -18,7 +18,14 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from client_ip import TRUSTED_PROXIES_ENV_VAR
+from client_ip import (
+    DEFAULT_IPV6_THROTTLE_PREFIX_LEN,
+    IPV6_THROTTLE_PREFIX_ENV_VAR,
+    MAX_IPV6_THROTTLE_PREFIX_LEN,
+    MIN_IPV6_THROTTLE_PREFIX_LEN,
+    TRUSTED_PROXIES_ENV_VAR,
+    unusable_throttle_prefix_config,
+)
 from database import async_session_factory, get_session
 from errors import install_exception_handlers
 from middleware import (
@@ -315,6 +322,43 @@ def validate_trusted_proxy_config() -> None:
     )
 
 
+def validate_ipv6_throttle_prefix_config() -> None:
+    """Announce a throttle prefix length the runtime read and could not use.
+
+    The per-request path degrades to the default in silence, and it has to:
+    it runs on every IPv6 request, so a typo that logged there would arrive at
+    request rate.  Boot is the one place the finding can be stated once, which
+    makes this the only signal an operator who typed ``4 8`` for ``48`` will
+    ever get -- the app otherwise looks perfectly healthy while throttling on a
+    prefix nobody asked for.
+
+    Unlike ``validate_trusted_proxy_config`` this is not gated on ``ENV``.  That
+    check warns about an *unset* variable, which is the normal local state; this
+    one warns about a value that was typed wrong, and a value typed wrong in
+    staging is wrong there too -- staging, hand-tuned, is exactly where it gets
+    typed.  Never raises: a mistuned bucket is a degraded state, not a broken
+    one, and taking a deploy down over a fallback that already worked would be
+    a worse outage than the typo.
+    """
+    raw = unusable_throttle_prefix_config()
+    if raw is None:
+        return
+    logger.warning(
+        "ipv6_throttle_prefix_unusable: %s is set to %r, which is not an "
+        "integer in [%d, %d], so the configured value is ignored and IPv6 "
+        "throttle keys group on the default /%d prefix instead of the one you "
+        "asked for. The value is a prefix length in bits, so a smaller number "
+        "covers a larger delegation and %d restores exact per-address keying "
+        "-- backend/.env.example documents the format",
+        IPV6_THROTTLE_PREFIX_ENV_VAR,
+        raw,
+        MIN_IPV6_THROTTLE_PREFIX_LEN,
+        MAX_IPV6_THROTTLE_PREFIX_LEN,
+        DEFAULT_IPV6_THROTTLE_PREFIX_LEN,
+        MAX_IPV6_THROTTLE_PREFIX_LEN,
+    )
+
+
 def _rate_limit_exceeded_handler(_request: Request, exc: Exception) -> JSONResponse:
     """Return a JSON 429 response with Retry-After header when rate limit is exceeded.
 
@@ -461,6 +505,10 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # client behind the ingress shares one throttle bucket and one audit IP --
     # a state only this warning makes visible.
     validate_trusted_proxy_config()
+
+    # A prefix length that is not a prefix length is discarded silently on every
+    # request, so boot is the only place a typo in it can be said out loud.
+    validate_ipv6_throttle_prefix_config()
 
     # ritual-practice ops: on every boot, seed the catalog (stages, presets,
     # course content) so a fresh database is immediately usable.

--- a/backend/tests/test_ipv6_throttle_prefix_startup_config.py
+++ b/backend/tests/test_ipv6_throttle_prefix_startup_config.py
@@ -1,0 +1,253 @@
+"""Tests for the startup IPv6 throttle-prefix configuration check.
+
+Contract: ``IPV6_THROTTLE_PREFIX_LEN`` is read per request, and any value that
+is not an integer in ``[1, 128]`` silently degrades to the default -- an
+operator who typed ``4 8`` for ``48`` gets the behaviour they did not ask for
+and no signal that they typed it.  Boot therefore announces an unusable value
+once, with a single ``ipv6_throttle_prefix_unusable`` warning naming the
+variable, the offending value, and the default that replaced it.
+
+Three boundaries the announcement must respect.  It is not gated on ``ENV``: a
+staging box tuned by hand is exactly where the typo is made, and unlike an
+unconfigured proxy allowlist a bad prefix length is wrong everywhere, not just
+in production.  Unset and blank stay silent, because ``.env.example`` ships the
+variable blank and an unset value is the deliberate "use the default" answer.
+And nothing about the runtime changes: the per-request path still degrades to
+the default and still says nothing, so a hot loop cannot turn a typo into a log
+flood.
+
+No path raises -- a typo must not stop a boot -- and every call below that
+reaches its assertions is that proof.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from client_ip import (
+    DEFAULT_IPV6_THROTTLE_PREFIX_LEN,
+    IPV6_THROTTLE_PREFIX_ENV_VAR,
+    MAX_IPV6_THROTTLE_PREFIX_LEN,
+    _throttle_prefix_length,
+    unusable_throttle_prefix_config,
+)
+from main import validate_ipv6_throttle_prefix_config
+
+ENV_VAR = "ENV"
+UNUSABLE_MARKER = "ipv6_throttle_prefix_unusable"
+MAIN_LOGGER = "main"
+EXPECTED_WARNING_COUNT = 1
+
+# The advice has to point the right way round.  The value is a prefix length, so
+# an operator who wants one bucket to cover a wider delegation has to make the
+# number smaller, and the maximum is the opt-out that restores exact keying --
+# telling them to raise it would be precisely backwards, and pinning the wording
+# is the only thing that stops a later edit flipping it.
+WIDENING_DIRECTION = "smaller number covers a larger delegation"
+EXACT_KEYING_ADVICE = f"{MAX_IPV6_THROTTLE_PREFIX_LEN} restores exact per-address keying"
+
+# The issue's own example: a space where the operator meant nothing at all.
+TYPO_VALUE = "4 8"
+
+# One usable value, as text and as the integer the runtime must return for it.
+USABLE_VALUE = "48"
+USABLE_PREFIX_LEN = 48
+
+# Not a prefix at all: out of range at either end, or not an integer.
+UNUSABLE_VALUES = ["0", "129", "-1", "64.5", "abc"]
+
+# Both ends of the range, an ordinary tuning, and a padded value -- ``int()``
+# accepts surrounding whitespace, so " 48 " is configuration, not a typo.
+USABLE_VALUES = ["1", "48", "64", "128", " 48 "]
+
+# Unset and blank both mean "I did not configure this".
+ABSENT_VALUES = [None, "", "   "]
+
+ENV_VALUES = [None, "development", "staging", "production"]
+
+
+def _unusable_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the captured records carrying the unusable-config marker."""
+    return [record for record in caplog.records if UNUSABLE_MARKER in record.getMessage()]
+
+
+def _set_prefix_env(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    """Set the prefix-length variable, treating None as unset."""
+    if value is None:
+        monkeypatch.delenv(IPV6_THROTTLE_PREFIX_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, value)
+
+
+def test_typo_warns_once_naming_variable_value_and_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The warning has to be actionable: which variable, what was read, what was used."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    warnings = _unusable_warnings(caplog)
+    assert len(warnings) == EXPECTED_WARNING_COUNT
+    assert warnings[0].levelno == logging.WARNING
+    message = warnings[0].getMessage()
+    assert IPV6_THROTTLE_PREFIX_ENV_VAR in message
+    assert TYPO_VALUE in message
+    assert str(DEFAULT_IPV6_THROTTLE_PREFIX_LEN) in message
+
+
+def test_warning_points_the_operator_the_right_way(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Advice that pointed the wrong way would be worse than no advice at all."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    message = _unusable_warnings(caplog)[0].getMessage()
+    assert WIDENING_DIRECTION in message
+    assert EXACT_KEYING_ADVICE in message
+
+
+@pytest.mark.parametrize("value", UNUSABLE_VALUES)
+def test_values_that_are_not_prefixes_warn_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    value: str,
+) -> None:
+    """Every value the runtime would silently discard is announced exactly once."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, value)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    assert len(_unusable_warnings(caplog)) == EXPECTED_WARNING_COUNT
+
+
+@pytest.mark.parametrize("value", USABLE_VALUES)
+def test_usable_values_stay_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    value: str,
+) -> None:
+    """A value the runtime honours has nothing to announce, padding included."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, value)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    assert _unusable_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("value", ABSENT_VALUES)
+def test_unset_and_blank_stay_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    value: str | None,
+) -> None:
+    """Not configuring the variable is the normal case and must not warn anybody."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    _set_prefix_env(monkeypatch, value)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    assert _unusable_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("env_value", ENV_VALUES)
+def test_warning_is_not_gated_on_env(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    env_value: str | None,
+) -> None:
+    """A bad prefix length is wrong in every environment, not just production."""
+    if env_value is None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(ENV_VAR, env_value)
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_ipv6_throttle_prefix_config()
+
+    assert len(_unusable_warnings(caplog)) == EXPECTED_WARNING_COUNT
+
+
+def test_check_reads_the_environment_afresh_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The check keeps no state: it announces, returns, and judges the next read anew."""
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+
+    validate_ipv6_throttle_prefix_config()
+
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, USABLE_VALUE)
+
+    validate_ipv6_throttle_prefix_config()
+
+    assert len(_unusable_warnings(caplog)) == EXPECTED_WARNING_COUNT
+
+
+def test_per_request_path_falls_back_silently(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The runtime keeps degrading quietly: one boot warning, not one per request."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+    caplog.set_level(logging.DEBUG)
+
+    assert _throttle_prefix_length() == DEFAULT_IPV6_THROTTLE_PREFIX_LEN
+    assert caplog.records == []
+
+
+def test_per_request_path_still_honours_a_usable_value(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Adding the boot check changes no runtime answer and emits no runtime record."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, USABLE_VALUE)
+    caplog.set_level(logging.DEBUG)
+
+    assert _throttle_prefix_length() == USABLE_PREFIX_LEN
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize("value", UNUSABLE_VALUES)
+def test_unusable_config_reports_the_raw_value(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    """The raw text is what the operator has to recognise, so it is what comes back."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, value)
+
+    assert unusable_throttle_prefix_config() == value
+
+
+def test_unusable_config_reports_the_typo_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The typo survives the round trip intact, spaces and all."""
+    monkeypatch.setenv(IPV6_THROTTLE_PREFIX_ENV_VAR, TYPO_VALUE)
+
+    assert unusable_throttle_prefix_config() == TYPO_VALUE
+
+
+@pytest.mark.parametrize("value", [*USABLE_VALUES, *ABSENT_VALUES])
+def test_usable_and_absent_config_reports_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+) -> None:
+    """Nothing to report covers both a value we honour and a value never given."""
+    _set_prefix_env(monkeypatch, value)
+
+    assert unusable_throttle_prefix_config() is None


### PR DESCRIPTION
## Summary

`IPV6_THROTTLE_PREFIX_LEN` is read per request by `client_ip._throttle_prefix_length`, and any value that is not an integer in `[1, 128]` degrades to the default of `64`. That fallback is the right runtime behaviour, but it is silent: an operator who deliberately widens the throttle bucket to `48` and types `4 8` gets `64` and never finds out.

This announces the discarded value **once at boot**, beside `validate_trusted_proxy_config`:

- `client_ip.py` — extracts the parse + range decision into one private `_usable_prefix_length` helper so the runtime and the boot check can never disagree about the same string, promotes the range bounds to public `MIN_/MAX_IPV6_THROTTLE_PREFIX_LEN` constants, and adds a public `unusable_throttle_prefix_config()` that *reports* the finding. The module keeps logging nothing and importing nothing of ours — it is deliberately a leaf, and the per-request path stays silent because it runs on every IPv6 request, where a typo that logged would arrive at request rate.
- `main.py` — adds `validate_ipv6_throttle_prefix_config()` in the established `validate_*_config` shape (one structured `logger.warning`, never raises) and calls it from `lifespan` right after the trusted-proxy check.

The rendered warning:

> `ipv6_throttle_prefix_unusable: IPV6_THROTTLE_PREFIX_LEN is set to '4 8', which is not an integer in [1, 128], so the configured value is ignored and IPv6 throttle keys group on the default /64 prefix instead of the one you asked for. The value is a prefix length in bits, so a smaller number covers a larger delegation and 128 restores exact per-address keying -- backend/.env.example documents the format`

Three deliberate calls:

- **Not gated on `ENV`.** `validate_trusted_proxy_config` is production-only because it warns about an *unset* variable, which is the normal local state. This warns about a value that was typed wrong, and staging — hand-tuned — is exactly where that happens.
- **Unset and blank stay silent.** `backend/.env.example` ships `IPV6_THROTTLE_PREFIX_LEN=` empty, so warning on blank would fire on every stock boot and train operators to ignore it. `" 48 "` is usable too (`int()` accepts padding) and stays silent.
- **Direction verified against `DEPLOYMENT.md`.** The value *is* the prefix length, so a **smaller** number covers a **larger** delegation and `128` restores exact per-address keying. Telling an operator to raise it to widen the bucket would be exactly backwards; a test now pins the wording so a later edit cannot flip it.

Runtime behaviour is unchanged and nothing new can raise. Value is logged with `%r` so a newline-bearing env value cannot forge a log line.

## Test plan

New `backend/tests/test_ipv6_throttle_prefix_startup_config.py` (36 cases), modelled on the `test_trusted_proxy_startup_config.py` precedent — written first and watched fail on the missing API, then made green:

- `4 8` warns exactly once at WARNING, naming the variable, the discarded value and the default.
- `0`, `129`, `-1`, `64.5`, `abc` each warn once; `1`, `48`, `64`, `128`, `" 48 "` stay silent; unset, `""`, `"   "` stay silent.
- The tuning direction is asserted verbatim, so a wrong-polarity edit fails the suite.
- The warning fires with `ENV` unset / `development` / `staging` / `production`.
- The per-request path is unchanged and emits **zero** records at DEBUG: `_throttle_prefix_length()` returns `64` for the typo and `48` for `48`.
- The check holds no state across calls and never raises.

Gate 2 run individually (`check-all.sh` exceeds the per-command time ceiling — see #2016):

- `lint.sh --check`, `format.sh --check`, `typecheck.sh` (mypy strict, 186 files), `security.sh` (bandit + pip-audit), `complexity.sh` — all pass.
- `xenon src/ --max-absolute A --max-modules A --max-average A` and `radon mi src/ -n B -s` — pass (pre-push-only hooks, not in `check-all.sh`).
- `test.sh --unit` and `coverage.sh`: **3376 passed**, 2 skipped, 96.99% line / 92.16% branch. `client_ip.py` 100% line + 100% branch; `main.py` 100% branch. Existing `tests/security/test_throttle_key.py` untouched and green.

Gate 2.5: `code-review-orchestrator` over the diff returned CLEAN; its one non-blocking finding (the direction wording was not pinned by a test) is fixed in this branch.

Closes #2008