### PR TITLE
fix(backend): gate the outbound Gumroad verify on the invalid-license cap

### DIFF
--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -47,6 +47,21 @@ def record_invalid_license_attempt(throttle_key: str) -> bool:
     return _invalid_license_limiter.hit(_INVALID_LICENSE_ITEM, throttle_key)
 
 
+def invalid_license_cap_exhausted(throttle_key: str) -> bool:
+    """Report whether ``throttle_key`` has already spent its hourly budget.
+
+    A non-consuming peek at the moving window: it reads the counter without
+    acquiring an entry, so asking costs the client nothing. True means the
+    caller must refuse *before* making any outbound Gumroad call, which is the
+    whole point of the cap -- a throttle that only shapes the response still
+    lets a spent client drive one verify request per allowlisted product on
+    every guess. The consuming charge remains
+    ``record_invalid_license_attempt``, which the caller applies after a
+    verify actually fails.
+    """
+    return not _invalid_license_limiter.test(_INVALID_LICENSE_ITEM, throttle_key)
+
+
 def reset_invalid_license_attempts() -> None:
     """Clear every invalid-license counter (test isolation between cases)."""
     _invalid_license_storage.reset()

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -522,9 +522,10 @@ async def _reject_if_license_cap_exhausted(request: Request, license_key: str | 
     protect -- it passes through to the ordinary ``license_required`` refusal,
     the same exemption ``_count_invalid_license_attempt`` makes.
 
-    The refusal is byte-identical to the in-band 429: same status, same
-    detail, same throttle key, and the same dummy bcrypt so the CPU cost
-    matches every other rejection. Wall-clock parity with the pre-gate 429 is
+    The refusal answers exactly as the in-band 429 does -- same status, same
+    detail, charged against the same throttle key -- and spends the dummy
+    bcrypt that the signup path's own 429 spends, which the OAuth in-band 429
+    skips. Wall-clock parity with the pre-gate 429 is
     deliberately not claimed -- refusing before the Gumroad round trip is
     necessarily faster than refusing after one, and the 429 status already
     discloses the throttled state outright, so there is nothing left for the

--- a/backend/src/routers/auth.py
+++ b/backend/src/routers/auth.py
@@ -43,7 +43,7 @@ from models.login_attempt import LoginAttempt
 from models.password_reset_token import PasswordResetToken
 from models.revoked_token import RevokedToken
 from models.user import DEFAULT_USER_TIMEZONE, DISPLAY_NAME_MAX_LENGTH, User
-from rate_limit import limiter, record_invalid_license_attempt
+from rate_limit import invalid_license_cap_exhausted, limiter, record_invalid_license_attempt
 from schemas.password_reset import (
     PasswordResetAccepted,
     PasswordResetCancel,
@@ -505,6 +505,44 @@ async def _serialize_login(session: AsyncSession, email: str) -> AsyncIterator[N
         yield
 
 
+async def _reject_if_license_cap_exhausted(request: Request, license_key: str | None) -> None:
+    """Refuse a client that has spent its hourly budget, before any Gumroad call.
+
+    This is the front gate of the two-layer cap. The cap exists to stop a
+    client grinding license keys through Gumroad, so it has to be consulted
+    *before* the verify loop rather than only when shaping the response: an
+    unmatched key costs one outbound request per allowlisted product, and a
+    throttle applied afterwards would let a spent client keep paying that cost
+    on every guess. The peek is non-consuming, so asking never charges the
+    client. Deliberately unguarded: a storage failure must propagate rather
+    than be swallowed into an allow, which is the very hole this closes.
+
+    A blank or whitespace-only key short-circuits inside the license gate
+    before any egress, so it is not a guess and there is nothing here to
+    protect -- it passes through to the ordinary ``license_required`` refusal,
+    the same exemption ``_count_invalid_license_attempt`` makes.
+
+    The refusal is byte-identical to the in-band 429: same status, same
+    detail, same throttle key, and the same dummy bcrypt so the CPU cost
+    matches every other rejection. Wall-clock parity with the pre-gate 429 is
+    deliberately not claimed -- refusing before the Gumroad round trip is
+    necessarily faster than refusing after one, and the 429 status already
+    discloses the throttled state outright, so there is nothing left for the
+    timing to leak. This is the doctrine ``_needs_license_conflict``
+    documents. Routing the OAuth rung through here also gives its capped case
+    the dummy verify it previously skipped.
+    """
+    if not (license_key or "").strip():
+        return
+    if not invalid_license_cap_exhausted(client_throttle_key(request)):
+        return
+    await _consume_dummy_password_verify()
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=_DETAIL_TOO_MANY_LICENSE_ATTEMPTS,
+    )
+
+
 async def _reject_invalid_license(
     request: Request,
     email: str,
@@ -516,6 +554,11 @@ async def _reject_invalid_license(
     email-mismatch marker server-side (fingerprint only — never the raw
     email or key), spends the dummy bcrypt verify for timing parity, then
     raises the generic 400 — or 429 once the hourly cap is exceeded.
+
+    That 429 is the second layer of the cap, not a duplicate of the front
+    gate: two concurrent requests can both pass a non-consuming peek with the
+    budget one short, and whichever ``hit`` comes back False here must still
+    answer 429 rather than fall through to the ordinary 400.
     """
     allowed = record_invalid_license_attempt(client_throttle_key(request))
     if outcome is LicenseOutcome.EMAIL_MISMATCH:
@@ -538,12 +581,20 @@ async def _reject_invalid_license(
 async def _verify_signup_license(request: Request, payload: SignupRequest) -> GumroadPurchase:
     """Run the verify-then-create license gate; return the matched purchase.
 
+    The hourly invalid-license cap is consulted first, so a client that has
+    spent its budget is refused before Gumroad is contacted at all; the
+    consuming charge and its backstop 429 come later, once a verify has
+    actually failed. Refusing up front means a capped client holding a
+    genuine key waits out the hour too, which is unavoidable: whether the key
+    is real is unknowable without the request the cap forbids.
+
     Every rejection path spends the same dummy bcrypt verify the success
     path spends on the real hash, so timing does not leak which check
     failed. A Gumroad outage fails closed with 503 before any row is
     written; ``from None`` severs the chain so the caught error's Request
     body (which carries the license key) is unreachable via ``__cause__``.
     """
+    await _reject_if_license_cap_exhausted(request, payload.license_key)
     try:
         check = await verify_aptitude_license(payload.email, payload.license_key)
     except GumroadUnavailableError:
@@ -1959,6 +2010,11 @@ async def _count_invalid_license_attempt(request: Request, license_key: str | No
     throttle ``/auth/signup`` enforces: an attacker could grind license keys
     here at the per-minute rate forever.  A blank key never reached Gumroad and
     is not a guess, so it is not counted.
+
+    This runs after the verify, so the 429 it raises is the concurrency
+    backstop behind ``_reject_if_license_cap_exhausted``, not a duplicate of
+    it: concurrent requests can both clear a non-consuming peek on the last
+    unit of budget, and whichever ``hit`` comes back False must still refuse.
     """
     if not (license_key or "").strip():
         return
@@ -1982,7 +2038,12 @@ async def _verify_oauth_license(
     on the wire.  A Gumroad outage fails closed with 503 before any row is
     written; ``from None`` severs the chain so the caught error's request body
     (which carries the license key) is unreachable via ``__cause__``.
+
+    The hourly cap is consulted before the verify, so a client that has spent
+    its budget here is refused with 429 without Gumroad being contacted; the
+    consuming charge and its backstop stay after the failed verify.
     """
+    await _reject_if_license_cap_exhausted(request, license_key)
     try:
         check = await verify_aptitude_license(email, license_key)
     except GumroadUnavailableError:

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -28,6 +28,7 @@ from sqlmodel import select
 from integrations.gumroad import GumroadUnavailableError
 from models.entitlement import Entitlement
 from models.user import User
+from rate_limit import INVALID_LICENSE_MAX_PER_HOUR
 from schemas.gumroad import GumroadLicenseResult, GumroadPurchase
 
 pytestmark = pytest.mark.real_license_gate
@@ -39,6 +40,7 @@ WEBHOOK_SECRET_ENV = "GUMROAD_WEBHOOK_SECRET"  # pragma: allowlist secret
 GUMROAD_CREDENTIAL_ENV_VARS = (API_TOKEN_ENV, WEBHOOK_SECRET_ENV)
 VERIFY_SEAM = "domain.entitlements.verify_license"
 REJECT_DUPLICATE_SEAM = "routers.auth._reject_duplicate_signup_email"
+CAP_PEEK_SEAM = "routers.auth.invalid_license_cap_exhausted"
 ALLOWED_PRODUCT_ALPHA = "prod_alpha"
 ALLOWED_PRODUCT_BETA = "prod_beta"
 ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
@@ -54,10 +56,10 @@ SALE_ID = "S-900"
 COURSE_ACCESS_KIND = "course_access"
 LICENSE_USES = 1
 JWT_SEGMENT_COUNT = 3
-INVALID_LICENSE_ATTEMPT_CAP = 10
 INVALID_ATTEMPT_EMAIL_PREFIX = "attempt-"
 FINAL_ATTEMPT_EMAIL = "attempt-final@example.com"
 BLANK_LICENSE_KEY = ""
+WHITESPACE_LICENSE_KEY = "   "
 TRUSTED_PROXY_CIDRS_ENV = "TRUSTED_PROXY_CIDRS"
 # Documentation-range prefix (RFC 5737) for the spoofed forwarded addresses.
 SPOOFED_IP_PREFIX = "203.0.113."
@@ -580,7 +582,7 @@ async def _exhaust_invalid_license_cap(async_client: AsyncClient) -> None:
     every one of them has to land on the invalid-license path and charge the
     cap. Requires an already-patched verifier that matches no product.
     """
-    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
+    for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
         response = await async_client.post(
             SIGNUP_PATH,
             json=_signup_payload(email=f"{INVALID_ATTEMPT_EMAIL_PREFIX}{attempt}@example.com"),
@@ -628,7 +630,7 @@ async def test_capped_client_causes_no_outbound_gumroad_call(
 
     await _exhaust_invalid_license_cap(async_client)
     calls_while_uncapped = len(calls)
-    assert calls_while_uncapped == INVALID_LICENSE_ATTEMPT_CAP * ALLOWLIST_PRODUCT_COUNT
+    assert calls_while_uncapped == INVALID_LICENSE_MAX_PER_HOUR * ALLOWLIST_PRODUCT_COUNT
 
     throttled = await async_client.post(
         SIGNUP_PATH,
@@ -638,6 +640,48 @@ async def test_capped_client_causes_no_outbound_gumroad_call(
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert throttled.json()["detail"] == DETAIL_THROTTLED
     assert len(calls) == calls_while_uncapped
+
+
+def _peek_reports_budget_remaining(_key: str) -> bool:
+    """Stand in for the non-consuming peek answering that budget is left."""
+    return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_racing_past_the_peek_is_still_refused_by_the_charge(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consuming charge answers 429 on its own once the peek has been cleared.
+
+    The front gate only peeks, so it cannot serialise anything: with the
+    budget one unit short, two concurrent requests can both read "not
+    exhausted" and both walk on to the verify. Whichever of them then loses
+    the consuming charge has to answer 429 rather than fall through to the
+    ordinary invalid_license, or the cap leaks one extra refusal shape per
+    race. A sequential test cannot produce that interleaving, so the peek is
+    replaced with one that reports budget remaining while the charge stays
+    real -- exactly the state the losing racer observes.
+    """
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+    await _exhaust_invalid_license_cap(async_client)
+    calls_while_uncapped = len(calls)
+
+    monkeypatch.setattr(CAP_PEEK_SEAM, _peek_reports_budget_remaining)
+    throttled = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    # The verify loop ran, so the refusal came from the charge, not the peek.
+    assert len(calls) == calls_while_uncapped + ALLOWLIST_PRODUCT_COUNT
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
 
 
 @pytest.mark.asyncio
@@ -674,10 +718,16 @@ async def test_capped_client_with_valid_license_is_refused_without_gumroad_call(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+@pytest.mark.parametrize(
+    "blank_license_key",
+    [BLANK_LICENSE_KEY, WHITESPACE_LICENSE_KEY],
+    ids=["empty", "whitespace-only"],
+)
 async def test_capped_client_with_blank_license_key_still_gets_license_required(
     async_client: AsyncClient,
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
+    blank_license_key: str,
 ) -> None:
     """A blank key answers license_required even from a capped client, never 429.
 
@@ -685,6 +735,10 @@ async def test_capped_client_with_blank_license_key_still_gets_license_required(
     request, so it is not a guess and there is no egress for the cap to
     protect. Refusing it with the throttle instead would both mislabel a
     malformed request and let an attacker learn where the cap stands.
+
+    A whitespace-only key is blank by the same measure the gate uses, so it
+    is pinned alongside the empty one: dropping the strip would turn it into
+    a throttled guess that also spends outbound Gumroad calls.
     """
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
@@ -693,7 +747,7 @@ async def test_capped_client_with_blank_license_key_still_gets_license_required(
 
     response = await async_client.post(
         SIGNUP_PATH,
-        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL, license_key=BLANK_LICENSE_KEY),
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL, license_key=blank_license_key),
     )
 
     assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -723,7 +777,7 @@ async def test_rotating_x_forwarded_for_cannot_reset_the_invalid_license_cap(
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
 
-    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
+    for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
         response = await async_client.post(
             SIGNUP_PATH,
             json=_signup_payload(email=f"spoofed-{attempt}@example.com"),
@@ -735,7 +789,7 @@ async def test_rotating_x_forwarded_for_cannot_reset_the_invalid_license_cap(
     throttled = await async_client.post(
         SIGNUP_PATH,
         json=_signup_payload(email="spoofed-final@example.com"),
-        headers={"X-Forwarded-For": _spoofed_forwarded_ip(INVALID_LICENSE_ATTEMPT_CAP)},
+        headers={"X-Forwarded-For": _spoofed_forwarded_ip(INVALID_LICENSE_MAX_PER_HOUR)},
     )
 
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS

--- a/backend/tests/routers/test_auth_signup_license.py
+++ b/backend/tests/routers/test_auth_signup_license.py
@@ -6,8 +6,9 @@ everything else) without creating User or Entitlement rows or leaking that
 an account exists; the verifier is consulted only for products on the
 GUMROAD_APTITUDE_PRODUCT_IDS allowlist and stops on the first success; a
 Gumroad outage fails closed with 503; more than ten invalid-license attempts
-per client per hour are throttled with 429; every failure path still spends
-a dummy bcrypt verify for timing parity.
+per client per hour are throttled with 429 and cost Gumroad nothing, because
+the cap is consulted before any outbound verify; every failure path still
+spends a dummy bcrypt verify for timing parity.
 """
 
 from __future__ import annotations
@@ -41,6 +42,8 @@ REJECT_DUPLICATE_SEAM = "routers.auth._reject_duplicate_signup_email"
 ALLOWED_PRODUCT_ALPHA = "prod_alpha"
 ALLOWED_PRODUCT_BETA = "prod_beta"
 ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
+# One outbound verify per allowlisted product is spent on every unmatched key.
+ALLOWLIST_PRODUCT_COUNT = len(ALLOWLIST.split(","))
 UNLISTED_PRODUCT = "prod_unlisted"
 SIGNUP_EMAIL = "seeker@example.com"
 MIXED_CASE_LICENSE_EMAIL = "Seeker@Example.COM"
@@ -52,6 +55,9 @@ COURSE_ACCESS_KIND = "course_access"
 LICENSE_USES = 1
 JWT_SEGMENT_COUNT = 3
 INVALID_LICENSE_ATTEMPT_CAP = 10
+INVALID_ATTEMPT_EMAIL_PREFIX = "attempt-"
+FINAL_ATTEMPT_EMAIL = "attempt-final@example.com"
+BLANK_LICENSE_KEY = ""
 TRUSTED_PROXY_CIDRS_ENV = "TRUSTED_PROXY_CIDRS"
 # Documentation-range prefix (RFC 5737) for the spoofed forwarded addresses.
 SPOOFED_IP_PREFIX = "203.0.113."
@@ -567,6 +573,22 @@ async def test_signup_with_unset_api_token_fails_closed_with_503(
     assert await _count_entitlements(db_session) == 0
 
 
+async def _exhaust_invalid_license_cap(async_client: AsyncClient) -> None:
+    """Spend the client's whole hourly budget on rejected invalid-license signups.
+
+    Each attempt uses a distinct email so nothing is refused as a duplicate:
+    every one of them has to land on the invalid-license path and charge the
+    cap. Requires an already-patched verifier that matches no product.
+    """
+    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
+        response = await async_client.post(
+            SIGNUP_PATH,
+            json=_signup_payload(email=f"{INVALID_ATTEMPT_EMAIL_PREFIX}{attempt}@example.com"),
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+
+
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
 async def test_eleventh_invalid_license_attempt_is_throttled(
@@ -577,21 +599,108 @@ async def test_eleventh_invalid_license_attempt_is_throttled(
     calls: list[tuple[str, str]] = []
     monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
 
-    for attempt in range(INVALID_LICENSE_ATTEMPT_CAP):
-        response = await async_client.post(
-            SIGNUP_PATH,
-            json=_signup_payload(email=f"attempt-{attempt}@example.com"),
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert response.json()["detail"] == DETAIL_INVALID_LICENSE
+    await _exhaust_invalid_license_cap(async_client)
 
     throttled = await async_client.post(
         SIGNUP_PATH,
-        json=_signup_payload(email="attempt-final@example.com"),
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL),
     )
 
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_capped_client_causes_no_outbound_gumroad_call(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client whose hourly budget is spent drives zero further Gumroad calls.
+
+    The cap exists to stop a client grinding license keys through Gumroad, so
+    it has to be consulted before the per-product verify loop runs. Once the
+    budget is gone the refusal must cost Gumroad nothing: no allowlisted
+    product is queried, so the recorded call list cannot grow.
+    """
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+
+    await _exhaust_invalid_license_cap(async_client)
+    calls_while_uncapped = len(calls)
+    assert calls_while_uncapped == INVALID_LICENSE_ATTEMPT_CAP * ALLOWLIST_PRODUCT_COUNT
+
+    throttled = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    assert len(calls) == calls_while_uncapped
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_capped_client_with_valid_license_is_refused_without_gumroad_call(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A capped client is refused even holding a key that would have verified.
+
+    This is the deliberate cost of refusing before the call: whether the key
+    is genuine is unknowable without the very Gumroad request the cap forbids,
+    so the throttle wins and the legitimate buyer waits out the hour. The
+    refusal is the same 429, no outbound call is made, and no account or
+    entitlement is created off an unverified key.
+    """
+    failing_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, failing_calls))
+    await _exhaust_invalid_license_cap(async_client)
+
+    granting_calls: list[tuple[str, str]] = []
+    granting_results = {ALLOWED_PRODUCT_ALPHA: _license_result()}
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub(granting_results, granting_calls))
+
+    throttled = await async_client.post(SIGNUP_PATH, json=_signup_payload())
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    assert granting_calls == []
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_capped_client_with_blank_license_key_still_gets_license_required(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blank key answers license_required even from a capped client, never 429.
+
+    A blank key short-circuits inside the license gate before any Gumroad
+    request, so it is not a guess and there is no egress for the cap to
+    protect. Refusing it with the throttle instead would both mislabel a
+    malformed request and let an attacker learn where the cap stands.
+    """
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+    await _exhaust_invalid_license_cap(async_client)
+    calls_while_uncapped = len(calls)
+
+    response = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL, license_key=BLANK_LICENSE_KEY),
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["detail"] == DETAIL_LICENSE_REQUIRED
+    assert len(calls) == calls_while_uncapped
+    assert await _count_users(db_session) == 0
+    assert await _count_entitlements(db_session) == 0
 
 
 def _spoofed_forwarded_ip(attempt: int) -> str:
@@ -680,3 +789,35 @@ async def test_invalid_license_path_consumes_a_dummy_bcrypt_verify(
     assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json()["detail"] == DETAIL_INVALID_LICENSE
     assert password_verify_spy.await_count + reset_token_spy.await_count >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("allowlisted_products", "disable_rate_limit")
+async def test_throttled_license_path_consumes_a_dummy_bcrypt_verify(
+    async_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The over-cap 429 spends the same dummy bcrypt every other rejection spends.
+
+    Refusing before the outbound call makes the throttled path cheaper than the
+    uncapped one, so the CPU cost has to stay: without it the 429 would answer
+    measurably faster and hand an attacker a timing oracle for the cap state.
+    The spy stands in for the real hash, so it is installed before the budget
+    is spent and its count is compared across the final request only.
+    """
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(VERIFY_SEAM, _make_verify_stub({}, calls))
+    password_verify_spy = AsyncMock(return_value=None)
+    monkeypatch.setattr("routers.auth._consume_dummy_password_verify", password_verify_spy)
+
+    await _exhaust_invalid_license_cap(async_client)
+    awaits_while_uncapped = password_verify_spy.await_count
+
+    throttled = await async_client.post(
+        SIGNUP_PATH,
+        json=_signup_payload(email=FINAL_ATTEMPT_EMAIL),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    assert password_verify_spy.await_count == awaits_while_uncapped + 1

--- a/backend/tests/routers/test_oauth_google.py
+++ b/backend/tests/routers/test_oauth_google.py
@@ -66,6 +66,8 @@ VERIFY_SEAM = "domain.entitlements.verify_license"
 ALLOWED_PRODUCT_ALPHA = "prod_alpha"
 ALLOWED_PRODUCT_BETA = "prod_beta"
 ALLOWLIST = f"{ALLOWED_PRODUCT_ALPHA},{ALLOWED_PRODUCT_BETA}"
+# One outbound verify per allowlisted product is spent on every unmatched key.
+ALLOWLIST_PRODUCT_COUNT = len(ALLOWLIST.split(","))
 
 TEST_CLIENT_ID = "1000000001-adepthood.apps.googleusercontent.com"  # pragma: allowlist secret
 OTHER_CLIENT_ID = "2000000002-attacker.apps.googleusercontent.com"  # pragma: allowlist secret
@@ -105,6 +107,7 @@ BAD_KEY_SUBJECT = "google-sub-badkey-0007"
 COLLISION_SUBJECT = "google-sub-collision-0008"
 UNVERIFIED_SUBJECT = "google-sub-unverified-0009"
 THROTTLE_SUBJECT_PREFIX = "google-sub-throttle-"
+THROTTLE_SUBJECT_FINAL = f"{THROTTLE_SUBJECT_PREFIX}final"
 THROTTLE_EMAIL_PREFIX = "throttle-attempt-"
 
 VALID_LICENSE_KEY = "AAAA1111-BBBB-2222-OAUTH"  # pragma: allowlist secret
@@ -1049,13 +1052,13 @@ async def test_concurrent_first_logins_create_exactly_one_account(
     assert await _count_rows_via(concurrent_session_factory, AuthIdentity) == 1
 
 
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("disable_rate_limit")
-async def test_invalid_license_attempts_share_the_hourly_cap(
-    async_client: AsyncClient,
-    license_verifier: _LicenseVerifier,  # noqa: ARG001 — no key ever verifies
-) -> None:
-    """The OAuth path is not a bypass of signup's invalid-license throttle."""
+async def _exhaust_invalid_license_cap(async_client: AsyncClient) -> None:
+    """Spend the client's whole hourly budget on rejected OAuth license attempts.
+
+    Each attempt carries a distinct subject and email so it reaches the
+    license-gated creation rung rather than logging in, and every one of them
+    charges the cap. Requires an already-stubbed verifier that grants nothing.
+    """
     for attempt in range(INVALID_LICENSE_MAX_PER_HOUR):
         id_token = _mint_token(
             sub=f"{THROTTLE_SUBJECT_PREFIX}{attempt}",
@@ -1068,7 +1071,17 @@ async def test_invalid_license_attempts_share_the_hourly_cap(
         assert response.status_code == HTTPStatus.CONFLICT
         assert response.json()["detail"] == DETAIL_NEEDS_LICENSE
 
-    final_token = _mint_token(sub=f"{THROTTLE_SUBJECT_PREFIX}final", email=UNCLAIMED_EMAIL)
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_invalid_license_attempts_share_the_hourly_cap(
+    async_client: AsyncClient,
+    license_verifier: _LicenseVerifier,  # noqa: ARG001 — no key ever verifies
+) -> None:
+    """The OAuth path is not a bypass of signup's invalid-license throttle."""
+    await _exhaust_invalid_license_cap(async_client)
+
+    final_token = _mint_token(sub=THROTTLE_SUBJECT_FINAL, email=UNCLAIMED_EMAIL)
     throttled = await async_client.post(
         OAUTH_PATH,
         json=_oauth_payload(final_token, license_key=INVALID_LICENSE_KEY),
@@ -1076,6 +1089,33 @@ async def test_invalid_license_attempts_share_the_hourly_cap(
 
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert throttled.json()["detail"] == DETAIL_THROTTLED
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_capped_client_causes_no_outbound_gumroad_call_via_oauth(
+    async_client: AsyncClient,
+    license_verifier: _LicenseVerifier,
+) -> None:
+    """A capped client drives zero further Gumroad calls through the OAuth route.
+
+    The cap is what stops a client grinding license keys through Gumroad, so
+    the OAuth rung has to consult it before the per-product verify loop, not
+    after: once the hourly budget is gone the 429 must cost Gumroad nothing.
+    """
+    await _exhaust_invalid_license_cap(async_client)
+    calls_while_uncapped = len(license_verifier.calls)
+    assert calls_while_uncapped == INVALID_LICENSE_MAX_PER_HOUR * ALLOWLIST_PRODUCT_COUNT
+
+    final_token = _mint_token(sub=THROTTLE_SUBJECT_FINAL, email=UNCLAIMED_EMAIL)
+    throttled = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(final_token, license_key=INVALID_LICENSE_KEY),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    assert len(license_verifier.calls) == calls_while_uncapped
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/routers/test_oauth_google.py
+++ b/backend/tests/routers/test_oauth_google.py
@@ -62,6 +62,7 @@ LOGIN_PATH = "/auth/login"
 # a live network fetch of Google's signing keys, so every test replaces it.
 JWKS_SEAM = "services.oauth_google._get_jwk_client"
 VERIFY_SEAM = "domain.entitlements.verify_license"
+CAP_PEEK_SEAM = "routers.auth.invalid_license_cap_exhausted"
 
 ALLOWED_PRODUCT_ALPHA = "prod_alpha"
 ALLOWED_PRODUCT_BETA = "prod_beta"
@@ -1116,6 +1117,48 @@ async def test_capped_client_causes_no_outbound_gumroad_call_via_oauth(
     assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
     assert throttled.json()["detail"] == DETAIL_THROTTLED
     assert len(license_verifier.calls) == calls_while_uncapped
+
+
+def _peek_reports_budget_remaining(_key: str) -> bool:
+    """Stand in for the non-consuming peek answering that budget is left."""
+    return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_rate_limit")
+async def test_racing_past_the_peek_is_still_refused_by_the_charge(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    license_verifier: _LicenseVerifier,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consuming charge answers 429 on its own once the peek has been cleared.
+
+    The front gate only peeks, so it cannot serialise anything: with the
+    budget one unit short, two concurrent OAuth attempts can both read "not
+    exhausted" and both walk on to the verify. Whichever of them then loses
+    the consuming charge has to answer 429 rather than fall through to the
+    ordinary needs_license 409, or a race hands back the wrong refusal. A
+    sequential test cannot produce that interleaving, so the peek is replaced
+    with one that reports budget remaining while the charge stays real --
+    exactly the state the losing racer observes.
+    """
+    await _exhaust_invalid_license_cap(async_client)
+    calls_while_uncapped = len(license_verifier.calls)
+
+    monkeypatch.setattr(CAP_PEEK_SEAM, _peek_reports_budget_remaining)
+    final_token = _mint_token(sub=THROTTLE_SUBJECT_FINAL, email=UNCLAIMED_EMAIL)
+    throttled = await async_client.post(
+        OAUTH_PATH,
+        json=_oauth_payload(final_token, license_key=INVALID_LICENSE_KEY),
+    )
+
+    assert throttled.status_code == HTTPStatus.TOO_MANY_REQUESTS
+    assert throttled.json()["detail"] == DETAIL_THROTTLED
+    # The verify loop ran, so the refusal came from the charge, not the peek.
+    assert len(license_verifier.calls) == calls_while_uncapped + ALLOWLIST_PRODUCT_COUNT
+    assert await _count_rows(db_session, User) == 0
+    assert await _count_rows(db_session, AuthIdentity) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The hourly invalid-license cap shaped the *response* an attacker got, never the
*outbound call*. Both license-gated rungs — `/auth/signup`
(`_verify_signup_license`) and the OAuth account-creation path
(`_verify_oauth_license`) — verified the submitted key against Gumroad first and
only charged the attempt against the cap afterwards. So a client whose
ten-per-hour budget was long spent still drove **one Gumroad request per
allowlisted product on every guess** (`_first_license_match` walks the whole
allowlist). The only thing bounding that traffic was the 3/minute per-route
signup limit. That is amplification against a third-party API we do not own, and
it burns the seller token's quota.

**The fix consults the cap first.** `invalid_license_cap_exhausted()` is a
non-consuming peek at the moving window (`MovingWindowRateLimiter.test()` from
the already-pinned `limits==5.8.0`), so asking never charges the client. A shared
`_reject_if_license_cap_exhausted()` helper runs as the first statement of both
rungs, before any verify, and turns a spent budget into the same 429 — same
status, same detail, same throttle key.

Three things worth reviewer attention:

- **The in-band 429s stay.** They are the concurrency backstop: two requests can
  both clear a non-consuming peek on the last unit of budget, and whichever loses
  the consuming `hit()` must still refuse. The peek is a front gate, not a
  replacement. Both branches are now pinned by tests that reproduce the losing
  racer deterministically.
- **A capped client holding a genuine license now gets 429** instead of a
  successful signup, until the hour rolls off. This is inherent, not incidental:
  whether the key is real is unknowable without the very request the cap forbids,
  and verifying it "just in case" *is* the vulnerability. Since the throttle key
  groups an IPv6 prefix / shared NAT egress, one abuser can deny signup to buyers
  behind the same egress for the remainder of the hour — the deliberate cost of
  refusing before the call.
- **Blank keys are exempt.** A blank or whitespace-only key short-circuits inside
  the license gate before any egress, so it is not a guess and there is nothing
  for the cap to protect; it keeps answering `license_required` rather than 429.

Timing: the new refusal spends the same dummy bcrypt every other rejection
spends, so CPU parity holds (this actually *adds* a dummy verify the OAuth
in-band 429 previously skipped). Wall-clock parity with the pre-gate 429 is
deliberately not claimed — refusing before a round trip is necessarily faster,
and the 429 status already discloses the throttled state outright. The peek is
unguarded by design: swallowing a storage error would fail *open*, which is the
hole being closed.

`INVALID_LICENSE_MAX_PER_HOUR`, the 429 detail, and the key it is charged
against are all unchanged.

## Test plan

New tests assert on the **call list of the `domain.entitlements.verify_license`
seam** — the function that performs the HTTP egress — not merely on the status
the client sees:

- `test_capped_client_causes_no_outbound_gumroad_call` — after the budget is
  spent, the 11th signup is 429 and the recorded call list does not grow.
- `test_capped_client_causes_no_outbound_gumroad_call_via_oauth` — same
  guarantee on the OAuth rung.
- `test_capped_client_with_valid_license_is_refused_without_gumroad_call` — pins
  the deliberate trade-off: 429, zero outbound calls, zero rows, even holding a
  key that would have verified.
- `test_racing_past_the_peek_is_still_refused_by_the_charge` (both suites) —
  neutralises only the peek, leaving the charge real, to reproduce the losing
  racer; asserts the in-band 429 still fires *and* that the verify loop ran, so a
  429 sourced from the front gate could not pass.
- `test_capped_client_with_blank_license_key_still_gets_license_required` —
  parametrized over empty and whitespace-only keys.
- `test_throttled_license_path_consumes_a_dummy_bcrypt_verify` — the over-cap
  429 still spends the dummy bcrypt.

Verified RED before the fix and GREEN after: the three egress tests failed on the
unpatched code at the call-count assertion (`assert 22 == 20` — the over-cap
attempt walked both allowlisted products) and the valid-key test failed with
`assert 200 == 429`.

Gate 2 on the merged tree (branch is current with `main`, including the
`ruff 0.16` bump):

- `./scripts/backend/test.sh --unit` — 3386 passed, 2 skipped
- `./scripts/backend/coverage.sh` — 96.99%, threshold met
- `lint.sh --check`, `format.sh --check`, `typecheck.sh`, `security.sh` — pass
- `xenon --max-absolute A --max-modules A --max-average A src` — exit 0
- `radon mi src -n B` — exit 0; `interrogate` — 96.6%
- `ruff 0.16.0` (the version now pinned on `main`) over `src` and `tests` — clean

Coverage of the kept backstop branches was checked explicitly: both
`raise HTTPException(...429...)` lines went from 0 hits / 50% branch coverage to
hit with 100% branch coverage.

The non-consuming property of the peek was verified empirically, not just read
from the docs: 1000 consecutive peeks leave the full budget intact, and
`exhausted` flips exactly at the cap boundary, in agreement with the charge.

Closes #2009
