### PR TITLE
feat(ralph): adopt and merge Dependabot PRs, guarded by a freshness check

### DIFF
--- a/.claude/agents/ralph-worker.md
+++ b/.claude/agents/ralph-worker.md
@@ -27,6 +27,18 @@ worktree). Your whole job is to carry your issue from Gate 1 through Gate 2.5 an
   (`.ralph/worktrees/issue-<N>`), already created off the latest `origin/main`
   on branch `issue/<N>-<slug>`.
 
+### Exception: an adopted `dependencies` lane
+
+For a `dependencies` issue the orchestrator used `fleet.sh adopt`, so your
+worktree sits on **Dependabot's own branch** (e.g. `dependabot/pip/…`), not an
+`issue/<N>-<slug>` branch, and a PR against `main` already exists. Push your
+commits to that branch; do **not** run `gh pr create`. Run
+`scripts/ralph/fleet.sh sync "$RALPH_ISSUE"` first — the bot branch is usually
+well behind `main` — then adapt forward per `scripts/ralph/PROMPT.md`. Your push
+to that branch is also what makes the Claude review runnable on it (the review
+job skips only while the PR is untouched by anyone but Dependabot), so an adapted
+bump goes through Gate 4 normally.
+
 ## The one rule that makes parallelism safe: stay in your worktree
 
 **Every file read, edit, test run, commit, and `check-all.sh` invocation happens
@@ -76,7 +88,15 @@ So, concretely:
   orchestrator owns the serialized-merge + `fleet.sh sync` step (see `FLEET.md`).
   If it hands you a post-sync conflict to resolve, fix it as a Gate-1 change and
   push normally (the sync used a merge, so no force-push is ever needed).
-- Never open a second PR for your issue, and never pick up a different issue.
+  **The one carve-out is an adopted `dependencies` lane** (above): there you run
+  `scripts/ralph/fleet.sh sync "$RALPH_ISSUE"` yourself, once, as your first
+  action. That is still the orchestrator's mechanism — `fleet.sh sync`, a merge,
+  never a hand-rolled `git merge` and never a rebase — just run at the only moment
+  the orchestrator cannot, since a bot branch arrives many commits stale and every
+  minute you spend adapting against that stale base is wasted.
+- Never open a second PR for your issue, and never pick up a different issue. In
+  an adopted `dependencies` lane that means no `gh pr create` at all — the
+  Dependabot PR is your PR.
 - Never weaken a gate. The anti-bypass block in
   `.claude/agents/shared/adepthood-constraints.md` is non-negotiable.
 - Never use the Task-tracking tools (TaskCreate/…) for this work — the GitHub

--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -89,11 +89,19 @@ scripts/ralph/fleet.sh free                  # open slots right now
 ```
 If `scripts/ralph/.paused` exists: `ScheduleWakeup` (~1800s, reason "ralph paused") and end the turn. Do not pick or work.
 
-Snapshot **every in-flight Ralph PR** with its mergeability, CI, and verdict:
+Snapshot **every in-flight Ralph PR** with its mergeability, CI, and verdict.
+The pool is the union of **two trusted authors** — `@me` and `app/dependabot`.
+Dependabot's PRs are authored by the bot, so an `--author "@me"` query never
+matches them and bridged `dependencies` lanes rot outside the loop; dropping
+`--author` entirely is not the fix, because that would sweep an outside
+contributor's WIP PR into the merge pool. The `Closes|Fixes|Resolves` body
+filter stays on both:
 ```bash
-gh pr list --state open --author "@me" \
-  --json number,headRefName,body,mergeable,mergeStateStatus \
-  --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#[0-9]+"))'
+for RALPH_AUTHOR in "@me" "app/dependabot"; do
+  gh pr list --state open --author "$RALPH_AUTHOR" \
+    --json number,headRefName,body,mergeable,mergeStateStatus \
+    --jq '.[] | select(.body | test("(?i)(closes|fixes|resolves)\\s+#[0-9]+"))'
+done
 ```
 Each in-flight PR is a lane in Gate 3/4; each occupied worktree without a PR yet
 is a lane still building (its worker is running in the background). Together they
@@ -110,9 +118,13 @@ eyeball the CI rollup or grep `gh pr checks` (its output is TAB-delimited, so a
 `': pending'` grep silently misses a still-running check and a false READY can
 merge a pending/failing PR). The helper keys CI off the `gh pr checks` **exit
 code** (`0`=green, `8`=pending, else=failed) and only honours an LGTM verdict
-posted **after** the PR's HEAD commit (stale-verdict guard):
+posted **after** the PR's HEAD commit (stale-verdict guard). It also proves
+freshness against `main` with the compare API rather than trusting
+`mergeStateStatus`, and honours the `do-not-auto-merge` human hold. Capture the
+exit code alongside the token — the helper exits non-zero when it cannot classify
+a lane, and an unchecked `$STATUS` would just come back empty:
 ```bash
-STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM")   # ready | behind | pending | ci-failed | awaiting-review
+STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM") && RC=0 || RC=$?   # ready | ready-unreviewed | behind | pending | ci-failed | awaiting-review | optout
 ```
 Read the PR's comments once for context (which issue it closes, verdict text):
 ```bash
@@ -120,9 +132,9 @@ gh pr view "$PR_NUM" --comments --json state,mergeable,mergeStateStatus,statusCh
 ```
 Then act on `$STATUS`:
 
-- **`ready`** (`Verdict: LGTM` fresh + CI green + `mergeStateStatus` `CLEAN`,
-  i.e. up-to-date with `main`). **Merge it now** — do not wait for any other
-  lane:
+- **`ready`** (`Verdict: LGTM` fresh + CI green + `mergeStateStatus` `CLEAN` +
+  the compare API reporting `behind_by == 0`). **Merge it now** — do not wait for
+  any other lane:
   ```bash
   gh pr merge "$PR_NUM" --squash --delete-branch
   ISSUE_N=<issue this PR closed>
@@ -133,9 +145,39 @@ Then act on `$STATUS`:
   ```
   (Idempotent if `iteration-trigger.yml` or a prior wake already merged it — the
   PR shows MERGED; do the same close + `release` + state bump.)
-- **`behind`** (`LGTM` + green but `mergeStateStatus` is `BEHIND` — a sibling
-  merged after this lane went green). **Do not merge stale.** Sync it and let CI
-  re-run:
+- **`ready-unreviewed`** (green + `CLEAN` + `behind_by == 0`, but the review gate
+  does not exist for this PR: `claude-review` reported `SKIPPED`, Dependabot
+  authored it **and** pushed its HEAD commit, and at least one non-review check
+  actually passed). **Merge it only for a `dependencies` lane** — the merge steps
+  are otherwise identical to `ready`. That is the only PR class where the review
+  gate provably cannot exist: `claude-code-review.yml` skips runs Dependabot itself
+  triggers because GitHub withholds the OAuth secret from them. The helper already
+  enforces the Dependabot conditions, so this token on any other lane means
+  the review workflow is **misconfigured** — leave that lane alone and investigate
+  before merging anything.
+  What replaces Gate 4 here is green CI **verified against current `main`**
+  (`behind_by == 0`, so the green is today's `main`, not a stale base) plus the
+  `do-not-auto-merge` hold, which is checked first and would have printed
+  `optout`. That substitution is only honest when CI actually ran, so the helper
+  also requires a real non-review check to have SUCCEEDED: every test workflow is
+  `paths:`-filtered to its own sources, so a `github-actions` ecosystem bump
+  touches only `.github/workflows/*.yml`, matches none of them, and would
+  otherwise read as "green" with zero checks — on precisely the PRs that rewire
+  the workflows holding our secrets. And because the rollup is per-HEAD-commit, it
+  requires Dependabot to have pushed that commit too: a bot force-push (a
+  `@dependabot recreate`, a group recomputation) after we adapted a branch would
+  otherwise re-clear our hand-written code as never-touched.
+  Note the narrow scope: a bump that needed a sync or a forward
+  adaptation gets a **real** Claude review, because our push makes the review job
+  runnable on the bot's branch — so `ready-unreviewed` only ever applies to a bump
+  that was already current with `main` and already green, i.e. one nobody touched.
+- **`behind`** (`LGTM` + green but not current with `main` — a sibling merged
+  after this lane went green). This fires on `mergeStateStatus` `BEHIND` **and**
+  on the far more common case where GitHub says `CLEAN` yet the compare API
+  reports `behind_by > 0`: GitHub only computes `BEHIND` when the base branch
+  enforces strict status checks, which this repo does not. Same remedy either
+  way. **Do not merge stale** — a branch's own green CI says nothing about
+  today's `main`:
   ```bash
   scripts/ralph/fleet.sh sync "$ISSUE_N" || echo "SYNC-CONFLICT $ISSUE_N"
   ```
@@ -154,11 +196,28 @@ Then act on `$STATUS`:
   conflict (`fleet.sh sync` → conflict-fix worker → push); the post-resolution
   push triggers the PR's real CI + review.
 - **`ci-failed`** — a check failed. Advance it via Step 2 (`ci-debugging`).
+- **`optout`** — the PR, or the issue it closes, carries `do-not-auto-merge`.
+  **Leave it entirely alone**: do not merge it, do not sync it, do not dispatch a
+  `ci-debugging` or `address-feedback` worker at it. A human owns this PR. Do not
+  `assign`/`adopt` a worktree for it either, and skip it when refilling in Step 4.
+  A lane it already occupies **stays occupied**: `fleet.sh reconcile` releases only
+  on `MERGED`/`CLOSED`, and you are told above not to touch this lane, so a PR
+  labelled mid-flight holds its worktree until the human resolves it (or runs
+  `fleet.sh release <N>` to take the slot back). That is deliberate — releasing it
+  would discard the work a human paused, which is the opposite of a hold.
+  The label must **exist in the repo** before anyone can apply it:
+  `scripts/setup-scan-labels.sh` creates it idempotently, and
+  `.github/workflows/labels-bootstrap.yml` (`workflow_dispatch`) is how to run
+  that. A hold nobody can apply is not a control.
+- **`RC` non-zero** (`$STATUS` empty) — the helper hit a tooling error (API
+  failure, expired token), so this lane **could not be classified**. Leave it
+  exactly as it is this wake: do not merge, do not sync, do not dispatch a
+  worker. The next wake retries it.
 
-You may merge more than one lane in a wake, but **re-check `mergeStateStatus`
-before each merge** — merging one lane can push the others `BEHIND`. Serialized,
-always up-to-date: correctness holds; a ready lane is never held back by a slow
-sibling.
+You may merge more than one lane in a wake, but **re-run `pr-ready.sh` before
+each merge** — merging one lane pushes every other lane behind `main`, and only
+that helper's compare probe can see it. Serialized, always up-to-date:
+correctness holds; a ready lane is never held back by a slow sibling.
 
 If any merge happened, commit the `state.json` bump **once** — a single commit
 covering every merge this wake (state-only changes may go directly on `main`).
@@ -179,13 +238,28 @@ reuses the existing branch):
   re-clear Gate 2/2.5, push.
 - **In progress** (CI running, or verdict not yet posted): do nothing — this
   lane's PR subscription (Step 5) wakes you when it changes.
-- **`dependencies` PRs** (from `dependabot-to-ralph-issue.yml`): the in-flight PR
-  is **Dependabot's own branch** (linked via `Closes`). Push Gate-1/Gate-3 fixes
-  **to that branch**, never a fresh branch or second PR. A breaking major is a
-  normal Gate-1 TDD adaptation — never pin back, suppress, or weaken a gate.
-  Dependabot stops rebasing once the PR carries a non-Dependabot commit. The three
-  SDK-tied pins (styleq, expo-av, expo-notifications) are deferred to the Expo SDK
-  53 epic (#885).
+- **`dependencies` PRs** (from `dependabot-to-ralph-issue.yml`): these are
+  **adopted, never built**. The in-flight PR is already **Dependabot's own
+  branch** (linked via `Closes`), so attach the lane to that branch rather than
+  cutting a new one:
+  ```bash
+  WT=$(scripts/ralph/fleet.sh adopt "$ISSUE_N" "$PR_NUM")   # lane on the bot's head branch
+  ```
+  The worker's **first** action in an adopted lane is `scripts/ralph/fleet.sh
+  sync "$ISSUE_N"` — a bot branch is typically many commits behind `main`, and
+  debugging its CI against a stale base wastes the whole lane. Then fix forward
+  on that branch: push Gate-1/Gate-3 fixes **to it**, never a fresh branch and
+  never a second PR. A breaking major is a normal Gate-1 TDD adaptation —
+  **never pin a dependency back, never remove a pin from a grouped PR to make
+  the group green** (the group lands whole or not at all), never suppress, never
+  weaken a gate. Dependabot stops rebasing once the PR carries a non-Dependabot
+  commit. SDK-tied exclusions need no handling here: `.github/dependabot.yml`
+  enforces them at source with `ignore:` version ranges (`styleq >=0.2.0`,
+  `expo-av >=16.0.0`, `expo-notifications >=0.30.0`, and ~20 more, all deferred
+  to the Expo SDK 53 epic #885), so Dependabot never opens such a PR. The loop
+  deliberately does **not** re-encode that list: a name-only blocklist would be
+  both redundant and wrong — it would defer an allowed in-range patch such as
+  `styleq 0.1.4`.
 
 These fix-workers are background too — launch, don't await.
 
@@ -242,6 +316,15 @@ labelled, so `release` its worktree (`scripts/ralph/fleet.sh release "$N"`) so
 the slot refills on the next wake; a `pr_opened` worker leaves its worktree in
 Gate 3/4.
 
+**Do not set `RALPH_EXCLUDE_LABELS`** — in particular, do not add `dependencies`
+to it. A bridged `dependencies` issue is already never picked here: `pick-next.sh`
+scans open PR bodies for `(closes|fixes|resolves) #N`, and the bridge appends
+`Closes #<issue>` to the Dependabot PR, so the issue reads as in-flight and the
+picker skips it. Those issues are adopted in Step 2, not assigned in Step 4.
+The override is also a hazard in its own right: it **replaces** the default
+exclusion list rather than adding to it, so setting it silently re-admits
+`epic`, `blocked`, `wontfix`, `do-not-auto-merge`, and the rest.
+
 ### Step 5 — Arm per-lane wakes, then end the turn
 
 You want a wake the moment **any single lane** changes — not a barrier that waits
@@ -260,8 +343,10 @@ for all of them. Arrange, in this order of preference:
    does not stack subscriptions, so just (re)subscribe every open PR each wake.
    Unsubscribe a PR once it merges/closes.
 3. **`ScheduleWakeup` fallback** (~1200–1800s): webhooks do **not** deliver CI
-   *success*, `BEHIND→green` transitions, or merges, so keep one modest fallback
+   *success*, `behind`→green transitions, or merges, so keep one modest fallback
    armed to re-poll Step 0–4 for any lane that quietly went green or up-to-date.
+   A lane going stale is invisible to webhooks entirely — `main` moving emits no
+   event on the lane's PR — so this fallback is the only thing that notices it.
 
 Then **end the turn.** Do not run a Monitor that waits for all lanes to be
 terminal — that is the barrier this design removes. Each independent wake re-runs
@@ -273,12 +358,15 @@ Step 0 and merges/refills whatever is ready.
 
 Pool of 4: issues A, B, C, D building in parallel. B is a tiny fix, D is a large
 feature.
-1. B finishes Gate 2.5, opens its PR; CI + review pass → B is `LGTM`+green+`CLEAN`.
+1. B finishes Gate 2.5, opens its PR; CI + review pass and it is current with
+   `main`, so `pr-ready.sh` prints `ready`.
 2. A wake fires (B's verdict). Step 1 merges **B now** — A, C, D are untouched and
    still mid-gate. Step 4 sees a free slot and assigns **E**, launching its worker.
 3. D is still at Gate 1. It never blocked B, and B's merge didn't wait for D.
-4. C later goes `LGTM`+green but is now `BEHIND` (B and E landed). Step 1 syncs C;
-   CI re-runs; C merges on the next wake once green. D keeps going the whole time.
+4. C later goes `LGTM`+green, but B and E landed meanwhile, so it is two commits
+   behind `main`. GitHub still calls C `CLEAN` — only the compare probe sees it —
+   and `pr-ready.sh` prints `behind`. Step 1 syncs C; CI re-runs; C merges on the
+   next wake once green. D keeps going the whole time.
 
 Continuous throughput, four lanes always busy, merges strictly serialized and
 always up-to-date.
@@ -292,7 +380,21 @@ still worktree-isolated, same gates, same drop-backs.
 
 ## Hard rules (do not deviate)
 - **Merges to `main` are serialized and always up-to-date.** Merge a lane only
-  when `LGTM` + green + `mergeStateStatus == CLEAN`; a `BEHIND` lane syncs first.
+  when `pr-ready.sh` prints `ready` — or `ready-unreviewed` on a `dependencies`
+  lane, per the rule below. Every other token syncs, waits, or is fixed first, and
+  no other evidence merges a lane.
+- **"Up to date" means `behind_by == 0`, never `mergeStateStatus`.** `CLEAN` is
+  not a freshness signal in a repo without strict status checks.
+- **A Dependabot PR merges on exactly the same evidence as any other lane** —
+  freshness-verified green CI against current `main` plus a fresh `LGTM` verdict.
+  No extra human sign-off is required or waited for; `do-not-auto-merge` on the
+  PR (or its linked issue) is the per-PR human hold. **One exception, and only
+  one:** a bump nobody had to touch never gets a verdict at all (the review job
+  skips runs Dependabot triggers), so `pr-ready.sh` prints `ready-unreviewed` and
+  that lane merges on verified-current green CI alone — where "green" means the
+  helper also proved at least one real check passed, since a workflow-only bump
+  can match every `paths:` filter's complement and land zero checks. No other PR
+  class may ever merge without `LGTM`.
 - **Never make a fast lane wait on a slow one.** No per-tick barrier, no
   all-lanes Monitor. Act on whichever lane a wake is about; refill freed slots
   immediately.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Skip Dependabot PRs: GitHub does not expose Actions secrets (incl.
-    # CLAUDE_CODE_OAUTH_TOKEN) to dependabot-triggered runs, so the action would
-    # hard-fail before reviewing and block the PR's required check. Dependency
-    # bumps merge on green CI + human judgment instead.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Skip runs Dependabot itself triggered: GitHub withholds Actions secrets
+    # (incl. CLAUDE_CODE_OAUTH_TOKEN) from a run whose ACTOR is Dependabot, so
+    # the action would hard-fail before reviewing and block the PR's check. That
+    # withholding is keyed to the actor, not to who opened the PR — and the PR's
+    # author stays `dependabot[bot]` forever, so keying the skip there suppressed
+    # the review permanently on bot PRs we had already pushed to, the very runs
+    # where the secrets ARE available. Once one of our commits lands on the
+    # branch, the synchronize run is ours and the bump gets a real review.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -11,7 +11,9 @@ name: Dependabot → Ralph Issue Bridge
 # Two triggers, one idempotent reconciler:
 #   - pull_request_target (dependabot-only): real-time, links a PR as it opens.
 #   - workflow_dispatch + schedule: backfill / safety net; clears the existing
-#     backlog and re-links any PR whose body Dependabot later overwrites.
+#     backlog, re-links any PR whose body Dependabot later overwrites, and closes
+#     bridge issues whose PR is gone (a superseded PR closes unmerged, so its
+#     `Closes` never fires and the issue would rot as a stale adoption ticket).
 #
 # SECURITY — pull_request_target runs with the base-repo token (it has
 # issues:write / pull-requests:write, which a dependabot-triggered
@@ -94,6 +96,15 @@ jobs:
           # comment in the issue body; the dedup check greps for it so re-runs
           # never double-file.
           marker_for() { printf '<!-- dependabot-pr:%s -->' "$1"; }
+
+          # The inverse of marker_for: recover the PR number from an issue body,
+          # empty when the body carries no marker. Builds its pattern FROM
+          # marker_for so the marker's shape stays defined in exactly one place.
+          pr_from_marker() {
+            local pattern
+            pattern="$(marker_for '\([0-9][0-9]*\)')"
+            printf '%s' "$1" | sed -n "s/.*$pattern.*/\1/p" | head -n 1
+          }
 
           # True if a PR body already links an issue via Closes/Fixes/Resolves.
           body_links_issue() {
@@ -253,12 +264,55 @@ jobs:
             bridge_pr "$num" "$ttl"
           done
 
-          # Surface every deferred label-verify failure at once and fail the
-          # run, so the batch completes but a permission gap or persistent API
-          # flake is never silently swallowed. Each issue is filed and its PR
-          # linked, so the only manual step is adding the missing label(s).
+          # Close orphaned bridge issues. A Dependabot PR that is superseded by a
+          # newer grouped PR closes WITHOUT merging, so its `Closes #N` never
+          # fires and the issue stays open forever — and pick-next.sh's in-flight
+          # scan only sees OPEN PRs, so the next Ralph tick would hand that issue
+          # to a worker who builds it on a brand-new branch and opens a second PR.
+          echo "Reconciler: closing bridge issues whose PR is closed or merged."
+          bridged="$(gh issue list --repo "$REPO" --label dependencies --state open \
+            --limit 200 --json number,body)"
+          bridged_count="$(printf '%s' "$bridged" | jq 'length')"
+          echo "Found $bridged_count open dependencies issue(s)."
+
+          for i in $(seq 0 $((bridged_count - 1))); do
+            inum="$(printf '%s' "$bridged" | jq -r ".[$i].number")"
+            ibody="$(printf '%s' "$bridged" | jq -r ".[$i].body")"
+            # No marker ⇒ not a bridge issue ⇒ none of this job's business.
+            linked_pr="$(pr_from_marker "$ibody")"
+            if [ -z "$linked_pr" ]; then
+              continue
+            fi
+            linked_state="$(gh pr view "$linked_pr" --repo "$REPO" \
+              --json state --jq .state 2>/dev/null || true)"
+            # An OPEN PR is the healthy in-flight case; an unreadable state (PR
+            # deleted, transient API error) is left alone rather than guessed at.
+            if [ "$linked_state" != "CLOSED" ] && [ "$linked_state" != "MERGED" ]; then
+              continue
+            fi
+            # A superseded PR was never planned to land; a merged one completed.
+            if [ "$linked_state" = "MERGED" ]; then
+              close_reason="completed"
+            else
+              close_reason="not planned"
+            fi
+            # Same convention as the label failures above: record and continue, so
+            # one un-closable issue never skips the rest of the batch.
+            if gh issue close "$inum" --repo "$REPO" --reason "$close_reason" \
+              --comment "Dependabot PR #$linked_pr is $linked_state, so this adoption ticket is obsolete. Closing it so it is not picked up as new work." >/dev/null; then
+              echo "Closed orphaned issue #$inum (PR #$linked_pr $linked_state)."
+            else
+              reconcile_failures+=("could not close orphaned issue #$inum whose PR #$linked_pr is $linked_state")
+              echo "Close failed for issue #$inum — recorded; continuing the batch." >&2
+            fi
+          done
+
+          # Surface every deferred failure at once and fail the run, so the batch
+          # completes but a permission gap or persistent API flake is never
+          # silently swallowed. Every issue is filed and its PR linked, so the
+          # manual steps are only the ones named below.
           if [ "${#reconcile_failures[@]}" -gt 0 ]; then
-            echo "::error::${#reconcile_failures[@]} bridged PR(s) could not have their 'dependencies' label verified; add the label(s) by hand (details below)." >&2
+            echo "::error::${#reconcile_failures[@]} reconciler step(s) need a manual fix — add the missing 'dependencies' label(s) or close the named issue(s) by hand (details below)." >&2
             for failure in "${reconcile_failures[@]}"; do
               echo "::error::$failure" >&2
             done

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -95,8 +95,29 @@ jobs:
           TOTAL=$(jq '[.check_runs[] | select(.conclusion != "skipped" and .conclusion != "neutral")] | length' runs.json)
           GREEN=$(jq '[.check_runs[] | select(.conclusion == "success")] | length'                             runs.json)
 
+          # Green + LGTM is not enough to clear a merge. The same two conditions
+          # scripts/ralph/pr-ready.sh enforces apply here, or this job would clear
+          # the very lanes that helper refuses: a branch behind its base (whose
+          # green proves nothing about today's main) and one a human put on hold.
+          # A missing PR object yields no labels, so both fail closed.
+          PR_JSON=$(gh api "repos/$REPO/pulls/$PR" 2>/dev/null || echo '{}')
+          BASE=$(jq -r '.base.ref // empty' <<<"$PR_JSON")
+          HELD=$(jq -r 'if .labels == null then "unknown"
+                        elif ([.labels[].name] | index("do-not-auto-merge")) then "yes"
+                        else "no" end' <<<"$PR_JSON")
+          # behind_by counts base commits the head lacks; anything but a literal
+          # 0 - including an empty answer from a failed or malformed compare - is
+          # "not current".
+          BEHIND=$(gh api "repos/$REPO/compare/$BASE...$SHA?per_page=1" --jq '.behind_by' 2>/dev/null || true)
+
           if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
-            ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."
+            if [ "$HELD" != "no" ]; then
+              ACTION="NOT cleared to merge: the do-not-auto-merge hold is set on this PR (or its labels could not be read). A human owns this one - leave it alone."
+            elif [ "$BEHIND" != "0" ]; then
+              ACTION="NOT cleared to merge: this head is not current with ${BASE:-its base} (behind_by='${BEHIND}'). Sync main in and let CI re-run first."
+            else
+              ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."
+            fi
           else
             ACTION="pull comment ${ID} to see in-depth feedback and continue iterating"
           fi

--- a/scripts/ralph/FLEET.md
+++ b/scripts/ralph/FLEET.md
@@ -22,9 +22,16 @@ predict which files a change will touch before we make it. So the loop never
 - **Merge pessimistically, but never with a barrier.** Merges to `main` are
   **serialized** (one at a time — the single orchestrator session serializes them
   for free) and each merge is **always up-to-date**: a lane merges only when it is
-  `LGTM` + CI-green + up-to-date with `main` (`mergeStateStatus == CLEAN`). If a
-  sibling merged after this lane went green, the lane is `BEHIND`; it **syncs the
-  new `main` into its branch (by merge, not rebase — a plain push updates the PR
+  `LGTM` + CI-green + **proven** current with `main` — the compare API's
+  `behind_by == 0`, as `pr-ready.sh` measures it. `mergeStateStatus` is *not* a
+  freshness signal: GitHub computes `BEHIND` only when the base branch enforces
+  strict/up-to-date status checks, which this repo does not, so a branch many
+  commits behind `main` reports `CLEAN`. The `BEHIND` path below was designed but
+  had never once fired here, so lanes were routinely merging out of date on a
+  green that proved nothing about today's `main`. `CLEAN` is retained only as the
+  sole signal for `DIRTY`/`CONFLICTING`/`BLOCKED`/`DRAFT`/`UNKNOWN`. If a sibling
+  merged after this lane went green, the lane is behind; it **syncs the new
+  `main` into its branch (by merge, not rebase — a plain push updates the PR
   and re-runs CI, never a force-push)** and merges on a later wake once green
   again. A lane that cannot cleanly sync **drops to Gate 1**. This sync is **lazy**
   — a lane only pays it when it is itself about to merge, not proactively every
@@ -40,8 +47,8 @@ the real, updated `main`), and it **never** stalls a ready lane behind a slow on
 ```
 pick optimistically ──▶ N lanes build in parallel (isolated worktrees)
         │
-   a lane goes LGTM+green ──▶ up-to-date (CLEAN)? ──▶ merge NOW, refill its slot
-        │                 ──▶ BEHIND? ── sync main in (lazy) ── re-green ── merge next wake
+   a lane goes LGTM+green ──▶ current (behind_by == 0)? ──▶ merge NOW, refill slot
+        │                 ──▶ behind? ── sync main in (lazy) ── re-green ── merge next wake
    sync conflict?         ──▶ that lane drops to Gate 1 (never a forced merge)
 ```
 
@@ -70,9 +77,11 @@ On each wake it:
 
 1. **Reconciles** — releases worktrees whose PR merged/closed (`fleet.sh
    reconcile`), freeing their slots.
-2. **Merges every ready lane** — any PR that is `LGTM` + green + up-to-date
-   (`mergeStateStatus == CLEAN`) merges *now*, serialized; a `BEHIND` lane lazily
-   syncs first and merges on a later wake. A ready lane never waits for a slow one.
+2. **Merges every ready lane** — any PR that `pr-ready.sh` calls `ready`
+   (`LGTM` + green + `CLEAN` + the compare API's `behind_by == 0`; `CLEAN` alone
+   is not freshness — see above) merges *now*, serialized; a lane that is behind
+   lazily syncs first and merges on a later wake. A ready lane never waits for a
+   slow one.
 3. **Advances failing lanes** — a `ralph-worker` is dispatched into the worktree
    of any PR that needs a fix (CI failure → `ci-debugging`; `CHANGES_REQUESTED` →
    `address-feedback`).
@@ -81,7 +90,7 @@ On each wake it:
 5. **Arms per-lane wakes** — background workers wake it on their own completion;
    each in-flight PR is `subscribe_pr_activity`-subscribed so its CI/verdict wakes
    it independently; a modest `ScheduleWakeup` backstops the CI-success /
-   `BEHIND→green` transitions the webhook doesn't deliver. Then it ends the turn.
+   behind→green transitions the webhook doesn't deliver. Then it ends the turn.
 
 **Workers are background tasks.** Each `ralph-worker` is launched with
 `run_in_background: true` and **never awaited** — launch, end the turn, and let its
@@ -110,7 +119,85 @@ filters and open-PR exclusion, it:
 
 These heuristics only reduce *sync churn*; they are **not** the correctness
 mechanism. Correctness is the serialized, always-up-to-date merge (lazy sync +
-re-green when `BEHIND`) described above.
+re-green when behind) described above.
+
+## Dependency lanes (Dependabot)
+
+`.github/workflows/dependabot-to-ralph-issue.yml` files one `dependencies` issue
+per bot PR and appends `Closes #<issue>` to that PR, so **the Dependabot PR is
+Ralph's in-flight PR**. The loop therefore **adopts** such a lane instead of
+building it: `fleet.sh adopt <issue> <PR>` puts the worktree on Dependabot's own
+head branch, so fixes push there and a second PR is never opened.
+
+**The picker needs no `RALPH_EXCLUDE_LABELS` override.** A bridged issue is
+already never picked: `pick-next.sh` scans open PR bodies for
+`(closes|fixes|resolves) #N`, and the bridge put `Closes #<issue>` there, so the
+issue already reads as in-flight. Setting the override is a hazard in its own
+right — it **replaces** the default exclusion list rather than adding to it, so
+it silently re-admits `epic`, `blocked`, `wontfix`, `do-not-auto-merge`, and the
+rest.
+
+### `pr-ready.sh` tokens
+
+One token per lane, exactly one action. This table, `pr-ready.sh`'s header, and
+`.claude/commands/ralph-tick.md` Step 1 must always agree.
+
+| Token | Means | Remedy |
+| --- | --- | --- |
+| `ready` | fresh `LGTM` + CI green + `CLEAN` + `behind_by == 0`. | Merge now. |
+| `ready-unreviewed` | CI green *with at least one non-review check actually `SUCCESS`* + `CLEAN` + `behind_by == 0`, but this PR has no review gate: Dependabot both authored it and pushed its HEAD commit, and every `claude-review` entry reported `SKIPPED`. | Merge — on a `dependencies` lane only. On any other lane the review workflow is misconfigured: stop and investigate. |
+| `behind` | `LGTM` + green but not current with `main`. | `fleet.sh sync <N>`; merge on a later wake once re-green. |
+| `pending` | CI still running. | Wait for a later wake. |
+| `ci-failed` | a check failed or errored. | Dispatch a `ci-debugging` worker into the lane. |
+| `awaiting-review` | no fresh `LGTM` — missing, stale, or non-LGTM. | Wait; `address-feedback` on `CHANGES_REQUESTED`. |
+| `optout` | `do-not-auto-merge` on the PR or on the issue it closes. | Leave the lane entirely alone — no merge, no sync, no worker, and never `assign`/`adopt` a new one. A worktree it already holds **stays held** (`reconcile` releases only on `MERGED`/`CLOSED`): releasing it would discard work a human paused. Run `fleet.sh release <N>` by hand to take the slot back. |
+| *non-zero exit* | could not classify (API failure, expired token). | Leave the lane alone this wake; the next wake retries. |
+
+**Gate 4 on a bot PR.** `claude-code-review.yml` skips runs whose `github.actor`
+is Dependabot, because GitHub withholds Actions secrets from them. That skip was
+re-keyed from the PR's author to the actor, so once one of our commits lands on
+the bot branch — which every synced or adapted lane produces — the review runs
+and the bump clears Gate 4 normally. `ready-unreviewed` therefore covers only the
+residual case: a bump already current with `main` and already green, that nobody
+had to touch. The whole merge evidence there is green CI **verified against
+current `main`**, and `pr-ready.sh` pins each word of that:
+
+- **Green must mean CI ran.** `gh pr checks` exits 0 when every check merely
+  skipped, and each test workflow is `paths:`-filtered to its own sources — so a
+  `github-actions` ecosystem bump (only `.github/workflows/*.yml`) matches none
+  and lands **zero** checks. At least one non-review check must report `SUCCESS`,
+  or "green CI replaces the review" is a claim about nothing, on exactly the PRs
+  that rewire the workflows holding our secrets.
+- **Untouched must mean untouched.** The rollup is per-HEAD-commit, so a bot
+  force-push (`@dependabot recreate`, a group recomputation) after we adapted a
+  branch would hand back a fresh all-`SKIPPED` rollup with the author still
+  `app/dependabot`. The PR's author *and* its HEAD commit's author must both be
+  Dependabot.
+- **Never a human PR.** The author match is exact (`app/dependabot`), so no skip
+  condition landing on the review workflow can leak this token onto a human lane.
+
+**Consent.** The previous operating rule — a bot-PR merge needs the repo owner's
+explicit OK — is *replaced* by that evidence, not silently dropped. The per-PR
+human hold is the `do-not-auto-merge` label on the PR or on its bridge issue: its
+**absence** is what lets a lane merge, and its presence stops the loop dead
+(`optout`). An *undeterminable* hold (the label lookup failed) is a tooling error
+that stalls the lane, never a silent "no hold". The label must exist in the repo
+for a human to apply it — `scripts/setup-scan-labels.sh` creates it idempotently,
+run via `.github/workflows/labels-bootstrap.yml` (`workflow_dispatch`).
+
+**A grouped bump lands whole or not at all.** Never remove a pin from the group
+and never pin one back to make it green — adapt the code instead.
+
+**SDK exclusions live in `.github/dependabot.yml`**, as `ignore:` version ranges
+(`styleq >=0.2.0`, `expo-av >=16.0.0`, `expo-notifications >=0.30.0`, and ~20
+more, deferred to epic #885), so Dependabot never opens such a PR. The loop
+deliberately does **not** re-encode that list: a name-only blocklist would be
+both redundant and wrong — it would defer an allowed in-range patch such as
+`styleq 0.1.4`.
+
+**Orphan cleanup.** A bot PR closed *without* merging leaves its bridge issue
+orphaned — the `Closes` never fires, and the picker's in-flight scan sees only
+open PRs — so the bridge workflow's reconciler closes those.
 
 ## Configuration (`scripts/ralph/state.json`)
 
@@ -140,6 +227,7 @@ back to the one-issue-at-a-time loop with zero other changes.
 | `count` / `free` | Active count / remaining capacity (honors `parallel_enabled`). |
 | `path <N>` | Worktree path for issue N (exit 1 if none). |
 | `assign <N> <slug>` | Create/reuse a worktree off `origin/main`; prints its path; refuses when full. |
+| `adopt <N> <PR>` | Create/reuse a worktree for issue N on PR's **existing** head branch (a bot PR's), so fixes push there instead of opening a second PR; prints its path; refuses a fork PR, a full fleet, and reuse of an existing worktree that sits on a different branch (an `assign`ed lane would push to `issue/<N>-<slug>` and open that second PR). |
 | `sync <N>` | Merge latest `origin/main` into issue N's branch (no force-push); exit 3 on conflict (aborted, left clean). |
 | `release <N>` | Remove issue N's worktree + delete its branch. |
 | `reconcile` | Release worktrees whose PR merged/closed or whose issue is closed; prune. |
@@ -149,27 +237,43 @@ GitHub**, never from stored bookkeeping, so the loop stays re-entrant.
 
 ## Tests
 
-Two offline suites cover the fleet, both run in CI by
+Five offline suites cover the fleet — four shell, one Python — all run in CI by
 `.github/workflows/ralph-recap-tests.yml` on any `scripts/ralph/**` change:
 
 - `scripts/ralph/test_fleet.sh` builds a throwaway repo (with an `origin` remote
-  and a fake `gh`) and exercises assign / list / count / free / path / sync
-  (clean **and** conflicting) / release / reconcile.
+  and a fake `gh`) and exercises assign / adopt / list / count / free / path /
+  sync (clean **and** conflicting) / release / reconcile.
 - `scripts/ralph/test_pick_next.sh` stubs `gh` and exercises the picker's
   parallel-awareness: first-worker-lowest, worktree exclusion, in-flight-PR
   exclusion, the `solo` guard (candidate and active), the same-epic guard, the
   `parallelizable` override, and `RALPH_RESPECT_EPICS=0`.
+- `scripts/ralph/test_pr_ready.sh` stubs `gh` and pins every status token: CI
+  classification from the **exit code** (8 ⇒ `pending`, never `ready`), the
+  stale-verdict guard, the `do-not-auto-merge` hold — including that it resolves
+  the *last* issue link in the body and that an unreadable label answer fails
+  closed (exit 2, not "no hold") — the freshness guard (`CLEAN` is not proof of
+  being current) and its laziness (only a would-be-`ready` lane pays for the
+  compare probe), and the `ready-unreviewed` path.
+- `scripts/ralph/test_ensure_issue_label.sh` covers `ensure-issue-label.sh`, the
+  prove-it-stuck labeller the Dependabot bridge files its issues with.
+- `pytest scripts/ralph` (`test_recap_stats.py`) covers the recap's pure stats
+  math and its backlog filter.
 
 ```bash
 bash scripts/ralph/test_fleet.sh
 bash scripts/ralph/test_pick_next.sh
+bash scripts/ralph/test_pr_ready.sh
+bash scripts/ralph/test_ensure_issue_label.sh
+python -m pytest scripts/ralph -q
 ```
 
 ## Failure modes and how they're handled
 
 | Scenario | Handling |
 | --- | --- |
-| Two "independent" issues touch the same file | Whichever merges first wins; the other goes `BEHIND`, lazily syncs main in, re-greens, then merges. A sync conflict ⇒ drops to Gate 1. Never a broken merge. |
+| Two "independent" issues touch the same file | Whichever merges first wins; the other reads `behind`, lazily syncs main in, re-greens, then merges. A sync conflict ⇒ drops to Gate 1. Never a broken merge. |
+| A lane is green but out of date with `main` | Its own green proves nothing about today's `main`. `pr-ready.sh` derives freshness from the compare API (`behind_by`), not `mergeStateStatus`, so this reads `behind` even while GitHub says `CLEAN`; the lane syncs, re-greens, and merges on a later wake. |
+| A bot PR whose review job cannot run | Untouched Dependabot PRs trigger no `claude-review` (no secrets for bot-actor runs). Any commit of ours on that branch makes the job runnable, so a synced or adapted bump clears Gate 4 normally; an untouched, already-current, already-green bump merges as `ready-unreviewed` on freshness-verified CI that demonstrably ran, with no `do-not-auto-merge` hold set. |
 | A slow lane would stall a fast one | It can't — lanes are independent; a ready lane merges immediately and its slot refills without waiting on any sibling. |
 | A worker crashes / abandons an issue | `reconcile` releases it once its PR closes; an un-PR'd stale worktree is re-detected and either resumed or released on the next wake. |
 | Fleet silts up with merged work | `reconcile` at the top of every wake GCs merged/closed worktrees. |

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -130,10 +130,22 @@ graph/memory …` and commit both (small Markdown notes; repo Q&A only).
 - Never write to `main` directly (except `scripts/ralph/state.json`, which the
   orchestrator handles).
 - Never force-push. Rewrite on a fresh branch if needed.
-- **`dependencies` issues:** the in-flight PR is Dependabot's own branch
-  (linked via `Closes`); push fixes **there**, not a fresh branch. A breaking
-  major is a normal Gate-1 TDD adaptation — never pin back, suppress, or weaken
-  a gate. The three SDK-tied pins are deferred to the Expo SDK 53 epic (#885).
+- **`dependencies` issues are ADOPTED, never built.** Your worktree is already
+  checked out on Dependabot's own branch and a PR against `main` already exists
+  (linked via `Closes`). **Never create a branch and never run `gh pr create`** —
+  a second PR is the failure mode this path exists to prevent; you push commits
+  to the branch you are on. Your **first** action is
+  `scripts/ralph/fleet.sh sync "$RALPH_ISSUE"`: a bot branch is usually many
+  commits behind `main`, and adapting against a stale base is wasted work. Then
+  adapt **forward**. A breaking major is a normal Gate-1 TDD adaptation — never
+  pin a dependency back, never drop a pin from a grouped bump to make the group
+  green (the group lands whole or not at all), never suppress, never weaken a
+  gate. SDK-tied exclusions are not your problem: `.github/dependabot.yml`
+  enforces them at source with `ignore:` version ranges (deferred to the Expo
+  SDK 53 epic #885), so such a PR never reaches you. Your push to the bot branch
+  is what makes the Claude review runnable on it — the review job skips only
+  while the PR is untouched by anyone but Dependabot — so an adapted bump goes
+  through Gate 4 normally.
 - Never disable a CI check or pre-commit hook, and never lower a quality
   threshold to pass. No `# noqa` / `# type: ignore` / `// @ts-ignore` /
   `// eslint-disable` / `@pytest.mark.skip` without an `Issue #N`

--- a/scripts/ralph/fleet.sh
+++ b/scripts/ralph/fleet.sh
@@ -35,6 +35,11 @@
 #   path <N>         Print the worktree path for issue N (empty + exit 1 if none).
 #   assign <N> <slug>  Create (or reuse) a worktree for issue N off origin/main;
 #                      prints its absolute path. Refuses if the fleet is full.
+#   adopt <N> <PR>   The bot-PR variant of assign: create (or reuse) a worktree
+#                      for issue N attached to PR's EXISTING head branch (e.g.
+#                      Dependabot's), so fixes push to that branch instead of
+#                      opening a second PR. Prints its absolute path. Refuses a
+#                      fork PR (its branch is not pushable) and a full fleet.
 #   sync <N>         Integrate the latest origin/main into issue N's worktree
 #                      branch by MERGE (no history rewrite ⇒ a plain push updates
 #                      the PR; no force-push, ever). Exit 0 clean, exit 3 on
@@ -55,9 +60,18 @@ die() {
   exit 1
 }
 
-# Resolve the repository root so the script works from any worktree/subdir.
+# Resolve the MAIN worktree's root, so the script works from any worktree/subdir.
+# `git rev-parse --show-toplevel` cannot do this: run inside a linked worktree it
+# returns that worktree, so every lane path would be computed relative to another
+# lane and `list`/`sync` would see no fleet at all — yet a synced worker's FIRST
+# action is `fleet.sh sync` from inside its own worktree. `git worktree list`
+# always prints the main worktree first, which is the one holding `.ralph/`.
 repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
+  local main
+  main="$(git worktree list --porcelain 2>/dev/null |
+    awk '/^worktree /{print substr($0, 10); exit}')" || true
+  [[ -n "$main" ]] || die "not inside a git repository"
+  printf '%s\n' "$main"
 }
 
 # Read an integer/bool field from state.json with a fallback. Pure-python so we
@@ -196,6 +210,76 @@ cmd_assign() {
   printf '%s\n' "$dir"
 }
 
+# Attach a lane to a PR's own head branch. The local branch name must equal
+# headRefName EXACTLY: cmd_reconcile finds lanes with `gh pr list --head
+# "$branch"`, so any deviation silently breaks worktree GC.
+cmd_adopt() {
+  local issue="$1" pr="${2:-}" root dir head_line head_ref is_fork on_branch
+  [[ -n "$issue" && -n "$pr" ]] || die "adopt: usage: adopt <issue> <pr>"
+  [[ "$issue" =~ ^[0-9]+$ ]] || die "adopt: issue must be numeric, got '$issue'"
+  [[ "$pr" =~ ^[0-9]+$ ]] || die "adopt: PR must be numeric, got '$pr'"
+  root="$(repo_root)"
+  dir="$(issue_dir "$issue")"
+
+  command -v gh >/dev/null 2>&1 || die "adopt: gh CLI required"
+  head_line="$(gh pr view "$pr" --json headRefName,isCrossRepository \
+    --jq '(.headRefName // "") + "|" + ((.isCrossRepository // false) | tostring)' \
+    2>/dev/null || true)"
+  # Split on the LAST separator, not the first: git permits '|' inside a branch
+  # name, so a head branch called `foo|false` would otherwise shift the fields
+  # and hand the fork test the string "false|true" — a fork PR reading as
+  # same-repo, with the truncated name then matching some unrelated base-repo
+  # branch. isCrossRepository is the final field, so the last '|' is the seam.
+  head_ref="${head_line%|*}"
+  is_fork="${head_line##*|}"
+  [[ -n "$head_ref" ]] || die "adopt: could not resolve the head branch of PR #$pr"
+  # A fork's branch lives in another repository — we cannot push fixes to it.
+  # Demand the literal "false": any other answer (including a malformed or
+  # truncated one) means the PR's origin is undetermined, which must refuse.
+  [[ "$is_fork" == "false" ]] ||
+    die "adopt: PR #$pr is cross-repository or its origin is undeterminable; its branch is not pushable"
+
+  # Re-entrant: an existing worktree for this issue is reused — but only if it is
+  # already on the PR's head branch. A lane `assign` created sits on
+  # `issue/<N>-<slug>`, and silently reusing it would push the fix to a branch the
+  # PR does not track: a second PR, and a lane `reconcile` can never find again.
+  if [[ -d "$dir" ]]; then
+    on_branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    [[ "$on_branch" == "$head_ref" ]] ||
+      die "adopt: worktree for issue $issue is on '$on_branch', not PR #$pr's '$head_ref' — release it first"
+    printf '%s\n' "$dir"
+    return 0
+  fi
+
+  # Enforce the cap only when creating a *new* worktree.
+  if [[ "$(cmd_free)" -le 0 ]]; then
+    die "adopt: fleet is full ($(count_active)/$(max_workers) workers active)"
+  fi
+
+  # The bot branch is usually pushed after this clone existed, so fetch the ref
+  # itself rather than trust a possibly-absent origin/<ref>. The explicit refspec
+  # guarantees the tracking ref below exists, and its `+` accepts the bot's
+  # force-pushes — it updates only refs/remotes, never a local branch.
+  git -C "$root" fetch --quiet origin "+refs/heads/$head_ref:refs/remotes/origin/$head_ref" \
+    || die "adopt: could not fetch origin/$head_ref"
+  mkdir -p "$root/$WORKTREE_ROOT"
+
+  if git -C "$root" show-ref --verify --quiet "refs/heads/$head_ref"; then
+    # Never reset, never force: a local tip the remote no longer contains means
+    # the bot force-pushed, and attaching would build on state that is gone.
+    # Both revs are fully qualified: a tag sharing the branch's name outranks the
+    # branch in `git rev-parse`, so unqualified names would test one object while
+    # `worktree add` below checks out another.
+    git -C "$root" merge-base --is-ancestor \
+      "refs/heads/$head_ref" "refs/remotes/origin/$head_ref" \
+      || die "adopt: local '$head_ref' diverged from origin/$head_ref — resolve by hand, then re-adopt"
+    git -C "$root" worktree add "$dir" "$head_ref" >&2
+  else
+    git -C "$root" worktree add --track -b "$head_ref" "$dir" "origin/$head_ref" >&2
+  fi
+  printf '%s\n' "$dir"
+}
+
 # Normalize an arbitrary title fragment into a safe kebab slug. Truncate first,
 # then trim a trailing hyphen so a mid-word cut never yields a dangling '-'.
 sanitize_slug() {
@@ -266,7 +350,7 @@ cmd_reconcile() {
 }
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,51p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-1}"
 }
 
@@ -280,6 +364,7 @@ main() {
     free)      cmd_free ;;
     path)      cmd_path "${1:-}" ;;
     assign)    cmd_assign "${1:-}" "${2:-}" ;;
+    adopt)     cmd_adopt "${1:-}" "${2:-}" ;;
     sync)      cmd_sync "${1:-}" ;;
     release)   cmd_release "${1:-}" ;;
     reconcile) cmd_reconcile ;;

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -5,11 +5,23 @@
 # (ralph-tick.md Step 1). Prints exactly one status token and exits 0 (it is a
 # query — a non-zero exit means a usage/tooling error, never a PR verdict):
 #
-#   ready            LGTM (fresh) + CI green + up-to-date with main  → merge now
-#   behind           LGTM (fresh) + CI green but mergeStateStatus BEHIND → sync first
+#   ready            LGTM (fresh) + CI green + verified current with main → merge now
+#   ready-unreviewed CI green (with real checks that actually passed) + verified
+#                    current with main, but this PR HAS no review gate: Dependabot
+#                    authored it AND pushed its HEAD commit, and `claude-review`
+#                    reported SKIPPED → the orchestrator decides (see below)
+#   behind           LGTM (fresh) + CI green but the branch is not current → sync first
 #   pending          CI still running → wait for a later wake
 #   ci-failed        CI has a failing/errored check → Step 2 (ci-debugging)
 #   awaiting-review  no fresh LGTM verdict (missing, stale, or non-LGTM) → wait / Step 2
+#   optout           `do-not-auto-merge` on the PR or on the issue it closes → the
+#                    loop does not act on this PR AT ALL (no merge, no sync, no
+#                    ci-debugging worker); a human owns it. Checked first, and an
+#                    unreadable label answer exits 2 rather than assuming no hold.
+#
+# An UNDETERMINABLE opt-out (the label or body lookup failed) is deliberately one of
+# those tooling errors: reading a failed lookup as "unlabelled" would let a rate limit
+# or an expired token silently defeat the one control a human retains over this loop.
 #
 # WHY THIS EXISTS: the previous all-lanes Monitor grepped `gh pr checks` output
 # for ': pending'. That output is TAB-delimited (name<TAB>pending<TAB>...), so the
@@ -18,9 +30,47 @@
 # the `gh pr checks` EXIT CODE, which is authoritative: 0 = all passed, 8 = some
 # pending, anything else = failure. No text parsing of the checks table at all.
 #
+# WHY `ready-unreviewed` EXISTS: `claude-code-review.yml` cannot run while a PR
+# is untouched by anyone but Dependabot (GitHub withholds the OAuth secret from
+# runs Dependabot triggers), so such a PR never grows a verdict and could only
+# ever print `awaiting-review` — a lane that waits for `ready` would hang forever
+# on exactly the PRs auto-adoption exists to merge. Any bump we push to (a sync
+# or a forward-adaptation) makes the review job runnable and lands back on the
+# normal `ready` path; this token covers only the residual case of a bump already
+# current and already green, where nothing of ours is ever pushed. It is a
+# SEPARATE token rather than a looser `ready` on purpose: `ready` keeps its full
+# four-part meaning (fresh LGTM + green CI + CLEAN + `behind_by == 0`), so the
+# decision to merge something no reviewer ever saw is made visibly by the
+# orchestrator, never silently here.
+#
+# Two conditions beyond "Dependabot authored it" make that safe, because the
+# token's justification is "green CI against current main replaces the review":
+#   * At least one NON-review check must have actually SUCCEEDED. `gh pr checks`
+#     exits 0 when every check merely skipped, and every test workflow here is
+#     `paths:`-filtered to its own sources — so a `github-actions` ecosystem bump
+#     (which touches only `.github/workflows/*.yml`) matches none of them and
+#     lands zero checks. Without this, "green" would mean "no CI ran at all" on
+#     exactly the PRs that rewire the workflows holding our secrets.
+#   * Dependabot must also have pushed the HEAD commit. `statusCheckRollup` is
+#     per-HEAD-commit, so a bot force-push (a `@dependabot recreate`, a group
+#     recomputation) after we adapted a branch would otherwise hand a fresh
+#     all-SKIPPED rollup back to this token and re-clear hand-written — possibly
+#     already-rejected — code as never-touched.
+#
 # Stale-verdict guard: a review verdict only counts when it was posted AFTER the
 # PR's HEAD commit. An LGTM from before the latest push is stale (it reviewed
 # older code) and must not gate a merge.
+#
+# Freshness guard: `mergeStateStatus` is NOT a freshness signal. GitHub only
+# reports BEHIND when the base branch enforces strict/up-to-date status checks,
+# which this repo does not — so a branch many commits behind `main` reports
+# CLEAN, and its own green CI proves nothing about today's `main`. (A grouped pip
+# bump 17 commits behind carried a ruff major that lints 144 errors against
+# current `main`; merging its stale green would have turned `main` red.)
+# Freshness therefore comes from the compare API's `behind_by`, and CLEAN is kept
+# alongside it because DIRTY/CONFLICTING/BLOCKED/DRAFT/UNKNOWN are invisible to
+# `behind_by`. The probe is LAZY by design — only a lane that would otherwise
+# print `ready` pays for it, so the orchestrator never sync-thrashes.
 #
 # Usage:  pr-ready.sh <PR_NUMBER> [--repo <owner/repo>]
 set -euo pipefail
@@ -29,13 +79,47 @@ set -euo pipefail
 # contract: 0 = pass, 8 = pending, other = failure).
 readonly CHECKS_PENDING_EC=8
 
+# The per-PR/per-issue human hold. `pick-next.sh` already excludes issues wearing
+# it from work entirely; this honours the same meaning on the PR side.
+readonly OPTOUT_LABEL="do-not-auto-merge"
+
+# The issue-link vocabulary the rest of the loop uses (pick-next.sh's in-flight
+# scan, the Dependabot bridge). Case-insensitive via `grep -i`.
+readonly ISSUE_LINK_RE='(closes|fixes|resolves)[[:space:]]+#[0-9]+'
+
+# Placeholder slug `gh` substitutes from the current repo when no --repo is given.
+readonly CURRENT_REPO_SLUG='{owner}/{repo}'
+
+# The one PR class whose review gate provably cannot exist. Dependabot spells its
+# login differently per field, and both spellings are exact-match tightness guards
+# on `ready-unreviewed` — without them, any future skip condition on the review
+# workflow would start auto-merging unreviewed human PRs. `gh pr view --json
+# author` reports the app form (NOT the `dependabot[bot]` form the Actions context
+# uses), while a commit's `authors[].login` reports the bot-user form. Both were
+# read off a live bump to confirm.
+readonly DEPENDABOT_AUTHOR="app/dependabot"
+readonly DEPENDABOT_COMMIT_AUTHOR="dependabot[bot]"
+
+# The `claude-code-review.yml` job name as it appears in the status rollup, and
+# the conclusions GitHub reports for a job whose `if:` evaluated false and for one
+# that genuinely passed.
+readonly REVIEW_CHECK_NAME="claude-review"
+readonly SKIPPED_CONCLUSION="SKIPPED"
+readonly SUCCESS_CONCLUSION="SUCCESS"
+
+# How many non-review checks must have actually passed before "CI is green" may
+# stand in for a review. One is enough to prove CI ran at all, which is the whole
+# claim; all-skipped is what this rules out.
+readonly MIN_NON_REVIEW_SUCCESSES=1
+
 die() { echo "pr-ready: $1" >&2; exit 2; }
 
 pr=""
+repo_slug=""
 repo_args=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo) [[ $# -ge 2 ]] || die "--repo needs a value"; repo_args+=(--repo "$2"); shift 2 ;;
+    --repo) [[ $# -ge 2 ]] || die "--repo needs a value"; repo_args+=(--repo "$2"); repo_slug="$2"; shift 2 ;;
     -*)     die "unknown option: $1" ;;
     *)      [[ -z "$pr" ]] || die "unexpected extra argument: $1"; pr="$1"; shift ;;
   esac
@@ -59,6 +143,54 @@ readonly VERDICT_LGTM_RE="${VERDICT_RE}+lgtm"
 # tripping `set -u` on bash 3.2 (stock /bin/bash on macOS).
 gh_args=("$pr" ${repo_args[@]+"${repo_args[@]}"})
 
+# --- opt-out, checked FIRST so a held PR is never even probed ---------------
+# Labels arrive one per line, so match whole lines: `do-not-auto-merge-after-
+# review` is a different label and must not read as an opt-out. The list is
+# passed as an argument rather than piped in, because a pipeline would run the
+# reader in a subshell: its failure could not stop the script, and `pipefail`
+# would hand the whole test a non-zero status even when the hold WAS on stdout.
+has_optout_label() { printf '%s\n' "$1" | grep -qxF "$OPTOUT_LABEL"; }
+
+# One object's labels, one per line. Non-zero (not empty output) on API failure,
+# so the caller can refuse to classify rather than infer "unlabelled" — see the
+# die messages below.
+labels_of() { # labels_of <pr|issue> <number>
+  gh "$1" view "$2" ${repo_args[@]+"${repo_args[@]}"} --json labels --jq '.labels[].name'
+}
+
+# The last issue this PR's body closes, or empty when it links none. LAST, not
+# first: the repo's PR-body convention puts `Closes #N` at the end, and the
+# Dependabot bridge appends it after the bot's release notes — whose upstream
+# changelog lines ("* Fixes #<n>") would otherwise be read as the governing
+# link and send the hold lookup below at an unrelated issue number.
+linked_issue() {
+  local body="$1"
+  { printf '%s' "$body" | grep -oiE "$ISSUE_LINK_RE" || true; } | tail -n 1 | tr -dc '0-9'
+}
+
+# An undeterminable hold is a TOOLING error, never "no hold". Reading a failed
+# lookup as unlabelled would let a rate limit, a 5xx, or an expired token
+# silently defeat the one control a human has over this loop and auto-merge the
+# PR they reserved. `die` exits 2, which this script's contract already defines
+# as a tooling error and never a verdict: the orchestrator acts on no lane it
+# cannot classify, and the next wake retries.
+pr_labels="$(labels_of pr "$pr")" ||
+  die "could not read labels of PR #$pr; refusing to guess whether $OPTOUT_LABEL is set"
+if has_optout_label "$pr_labels"; then
+  echo "optout"; exit 0
+fi
+
+pr_body="$(gh pr view "${gh_args[@]}" --json body --jq '.body')" ||
+  die "could not read the body of PR #$pr; refusing to guess whether a linked issue carries $OPTOUT_LABEL"
+issue_n="$(linked_issue "$pr_body")"
+if [[ -n "$issue_n" ]]; then
+  issue_labels="$(labels_of issue "$issue_n")" ||
+    die "could not read labels of issue #$issue_n (linked by PR #$pr); refusing to guess whether $OPTOUT_LABEL is set"
+  if has_optout_label "$issue_labels"; then
+    echo "optout"; exit 0
+  fi
+fi
+
 # --- CI state from the exit code, not the text table -----------------------
 ci_ec=0
 gh pr checks "${gh_args[@]}" >/dev/null 2>&1 || ci_ec=$?
@@ -69,13 +201,21 @@ elif [[ "$ci_ec" -ne 0 ]]; then
 fi
 
 # --- CI is green: check mergeability + a FRESH LGTM verdict -----------------
-# One call yields "<mergeStateStatus>|<HEAD committedDate>", another the latest
-# top-level verdict as "<createdAt>|<isLGTM>". gh applies --jq server-side.
+# One call yields "<mergeStateStatus>|<HEAD committedDate>|<HEAD author login>",
+# another the latest top-level verdict as "<createdAt>|<isLGTM>". gh applies --jq
+# server-side. The HEAD author rides along here rather than in its own call: it is
+# only needed by `review_gate_absent`, and `gh` already hands us the commit.
+# (`gh` caps `commits` at 100. That is already how `head_date` is derived, and it
+# fails CLOSED for the author too: on an adopted lane the bot's bump is commit 1
+# and ours follow, so a truncated tail can only ever read as one of OURS.)
 merge_line="$(gh pr view "${gh_args[@]}" \
   --json mergeStateStatus,commits \
-  --jq '(.mergeStateStatus // "") + "|" + (.commits[-1].committedDate // "")')"
-merge_state="${merge_line%%|*}"
-head_date="${merge_line#*|}"
+  --jq '(.mergeStateStatus // "") + "|" + (.commits[-1].committedDate // "") + "|" + (.commits[-1].authors[0].login // "")')"
+# Split by field count, not by seeking one separator: an enum, an RFC3339 stamp,
+# and a login can none of them contain `|`, so a surplus field means the answer is
+# malformed — blanked here so every branch below fails closed on it.
+IFS='|' read -r merge_state head_date head_author merge_rest <<<"$merge_line"
+[[ -z "$merge_rest" ]] || { merge_state=""; head_date=""; head_author=""; }
 
 verdict_line="$(gh pr view "${gh_args[@]}" \
   --json comments \
@@ -89,15 +229,86 @@ if [[ -z "$head_date" ]]; then
   echo "awaiting-review"; exit 0
 fi
 
+# True when every comma-separated conclusion is SKIPPED. Walked by parameter
+# expansion rather than a `printf | tr | grep -q` pipeline, because `grep -q`
+# closing the pipe early is a SIGPIPE/`pipefail` inversion in the one test gating
+# unreviewed merges. The appended comma makes a trailing empty field — a
+# still-queued run — a value that must MATCH rather than one word splitting drops.
+all_conclusions_skipped() {
+  local remaining="$1," entry
+  while [[ -n "$remaining" ]]; do
+    entry="${remaining%%,*}"
+    [[ "$entry" == "$SKIPPED_CONCLUSION" ]] || return 1
+    remaining="${remaining#*,}"
+  done
+}
+
+# True only when this PR has no review gate to wait for: Dependabot authored it,
+# Dependabot also pushed its HEAD commit (so nothing of ours is on the branch —
+# see the force-push note in the header), at least one non-review check actually
+# SUCCEEDED (so "green" is not "nothing ran"), and every `claude-review` entry in
+# its rollup reported SKIPPED (the rollup carries one entry per triggering event,
+# so a single non-SKIPPED entry means the job did run and a verdict is genuinely
+# owed). Fails CLOSED: a failed call, an empty author, a malformed answer, or no
+# `claude-review` entry at all all read as "the gate exists", so an unreadable
+# answer can only ever hold the lane at `awaiting-review`. LAZY like
+# `branch_is_current` — only a lane already lacking a fresh verdict pays.
+review_gate_absent() {
+  local line author conclusions passes rest
+  line="$(gh pr view "${gh_args[@]}" --json author,statusCheckRollup \
+    --jq "(.author.login // \"\") + \"|\" + ([.statusCheckRollup[]? | select((.name // \"\") == \"$REVIEW_CHECK_NAME\") | (.conclusion // \"\")] | join(\",\")) + \"|\" + ([.statusCheckRollup[]? | select((.name // \"\") != \"$REVIEW_CHECK_NAME\" and (.conclusion // \"\") == \"$SUCCESS_CONCLUSION\")] | length | tostring)" \
+    2>/dev/null)" || return 1
+  # Split by field count, not by seeking the first or last separator: a login, a
+  # list of enum conclusions, and a count can none of them contain `|`, so a
+  # surplus field means a malformed answer and no `|` in any value can shift the
+  # fields under us — which seeking either end would allow.
+  IFS='|' read -r author conclusions passes rest <<<"$line"
+  [[ -z "$rest" ]] || return 1
+  [[ "$author" == "$DEPENDABOT_AUTHOR" ]] || return 1
+  # $head_author came from the mergeStateStatus,commits call above — no extra API
+  # round trip, and the empty default fails closed exactly like the rest.
+  [[ "$head_author" == "$DEPENDABOT_COMMIT_AUTHOR" ]] || return 1
+  [[ "$passes" =~ ^[0-9]+$ ]] || return 1
+  [[ "$passes" -ge "$MIN_NON_REVIEW_SUCCESSES" ]] || return 1
+  [[ -n "$conclusions" ]] || return 1
+  all_conclusions_skipped "$conclusions"
+}
+
 # Fresh LGTM ⇔ latest verdict is LGTM AND its createdAt is strictly newer than
 # the HEAD commit. RFC3339 UTC timestamps are fixed-width, so a lexical string
 # compare is a correct chronological compare (portable — no date arithmetic).
+# Absent that, the lane waits for review unless there is no review to wait for,
+# in which case it still has to clear every non-review condition below.
+ready_token="ready"
 if [[ "$verdict_lgtm" != "true" || -z "$verdict_date" ]] || ! [[ "$verdict_date" > "$head_date" ]]; then
-  echo "awaiting-review"; exit 0
+  review_gate_absent || { echo "awaiting-review"; exit 0; }
+  ready_token="ready-unreviewed"
 fi
 
-if [[ "$merge_state" == "CLEAN" ]]; then
-  echo "ready"
+# True only when the compare API proves the head is 0 commits behind its base.
+# Fails CLOSED: an API error, an empty answer, or a non-integer all read as "not
+# current", because `behind`'s remedy (fleet.sh sync) is always safe and a false
+# `ready` is not.
+branch_is_current() {
+  local ref_line base head_oid slug behind
+  ref_line="$(gh pr view "${gh_args[@]}" --json baseRefName,headRefOid \
+    --jq '(.baseRefName // "") + "|" + (.headRefOid // "")' 2>/dev/null)" || return 1
+  base="${ref_line%%|*}"
+  head_oid="${ref_line#*|}"
+  [[ -n "$base" && -n "$head_oid" ]] || return 1
+  slug="$CURRENT_REPO_SLUG"
+  [[ -z "$repo_slug" ]] || slug="$repo_slug"
+  behind="$(gh api "repos/$slug/compare/$base...$head_oid?per_page=1" \
+    --jq '.behind_by' 2>/dev/null)" || return 1
+  [[ "$behind" =~ ^[0-9]+$ ]] || return 1
+  [[ "$behind" -eq 0 ]]
+}
+
+# CLEAN is kept as well as the freshness probe: it is the only signal for
+# DIRTY/CONFLICTING/BLOCKED/DRAFT/UNKNOWN, and short-circuiting on it keeps the
+# probe off every lane that is not already one step from merging.
+if [[ "$merge_state" == "CLEAN" ]] && branch_is_current; then
+  echo "$ready_token"
 else
   echo "behind"
 fi

--- a/scripts/ralph/test_fleet.sh
+++ b/scripts/ralph/test_fleet.sh
@@ -4,7 +4,9 @@
 # Offline tests for fleet.sh — the git/worktree/slot logic that never touches
 # GitHub. We build a throwaway git repo (with an `origin` remote so `fetch` and
 # `origin/main` resolve) and a fake `gh` on PATH for the reconcile test, then
-# exercise assign / list / count / free / path / sync / release / reconcile.
+# exercise assign / list / count / free / path / sync / release / reconcile, plus
+# `adopt` — the bot-PR variant of assign that attaches a lane to a PR's EXISTING
+# head branch so fixes land on that branch instead of opening a second PR.
 #
 # Run:  bash scripts/ralph/test_fleet.sh
 set -euo pipefail
@@ -118,8 +120,23 @@ BIN="$WORK/bin"; mkdir -p "$BIN"
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 # real gh applies --jq, so emit the already-extracted scalar — branch-aware.
+# `pr view --json headRefName,isCrossRepository` resolves to
+# "<headRefName>|<isCrossRepository>"; only PR $FORK_PR comes from a fork.
+# HEAD_LINE_RAW, when set, is emitted verbatim so a test can feed a malformed or
+# truncated answer that the well-formed template could not express.
 args="$*"
 case "$args" in
+  *"pr view"*"--json headRefName"*)
+    if [[ -n "${HEAD_LINE_RAW:-}" ]]; then printf '%s\n' "$HEAD_LINE_RAW"; exit 0; fi
+    pr=""
+    for tok in "$@"; do
+      if [[ "$tok" =~ ^[0-9]+$ ]]; then pr="$tok"; break; fi
+    done
+    if [[ -n "${FORK_PR:-}" && "$pr" == "$FORK_PR" ]]; then
+      printf '%s|true\n' "${HEAD_REF:-}"
+    else
+      printf '%s|false\n' "${HEAD_REF:-}"
+    fi ;;
   *"pr list"*"--json state"*)
     if [[ "$args" == *"--head $MERGED_BRANCH"* ]]; then echo 'MERGED'; else echo ''; fi ;;
   *"pr list"*) echo '' ;;
@@ -138,6 +155,215 @@ chmod +x "$BIN/gh"
   "$FLEET" reconcile >/dev/null 2>&1)
 check "reconcile released only the merged worker" "1" "$(run count)"
 check "the open worker survived reconcile"        "105" "$(run active)"
+
+# --- adopt: attach a lane to a bot PR's existing head branch ----------------
+# The branch name carries slashes on purpose — ref handling must survive them.
+# It is pushed AFTER the clone, so adopt has to fetch it like the real loop does.
+BOT_BRANCH="dependabot/pip/backend/pip-patch-minor-f1456b4b2b"
+(
+  cd "$WORK/upstream"
+  git checkout -q -b "$BOT_BRANCH"
+  echo "ruff==0.16.0" > BUMP.txt && git add -A && git commit -qm "bump deps"
+  git checkout -q main
+)
+export HEAD_REF="$BOT_BRANCH" FORK_PR=""
+run_gh() { (cd "$REPO" && PATH="$BIN:$PATH" "$FLEET" "$@"); }
+
+# `|| true` keeps a failing adopt from aborting the run, so every later
+# assertion still reports; the placeholder path keeps git off the real repo.
+ADIR="$(run_gh adopt 201 901 2>/dev/null || true)"
+ADIR="${ADIR:-$WORK/adopt-missing}"
+[[ -d "$ADIR" ]] && ok "adopt created worktree dir" || bad "adopt created worktree dir"
+check "adopt uses the standard slot name" "issue-201" "$(basename "$ADIR")"
+ABR="$(cd "$ADIR" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+check "adopted lane sits on the PR head branch" "$BOT_BRANCH" "$ABR"
+[[ -f "$ADIR/BUMP.txt" ]] && ok "adopted lane has the bot branch content" \
+  || bad "adopted lane has the bot branch content"
+if (cd "$REPO" && git for-each-ref --format='%(refname:short)' 'refs/heads/issue/201-*' | grep -q .); then
+  bad "adopt created no issue/201-* branch"
+else
+  ok "adopt created no issue/201-* branch"
+fi
+
+# --- an adopted lane is a first-class fleet member --------------------------
+check "count sees the adopted lane"  "2"       "$(run count)"
+check "free accounts for it"         "2"       "$(run free)"
+check "active lists it"              "105 201" "$(run active)"
+check "path resolves it"             "$ADIR"   "$(run path 201)"
+
+# --- adopt is idempotent (re-entrant) --------------------------------------
+ADIR2="$(run_gh adopt 201 901 2>/dev/null || true)"
+check "re-adopt returns same dir"     "$ADIR" "$ADIR2"
+check "re-adopt creates no second worktree" "2" "$(run count)"
+
+# --- adopt honours the same cap as assign ----------------------------------
+printf '{"max_workers": 4, "parallel_enabled": false}\n' > "$REPO/scripts/ralph/state.json"
+if run_gh adopt 202 902 >/dev/null 2>&1; then
+  bad "adopt refused when fleet full"
+else
+  ok "adopt refused when fleet full"
+fi
+check "count unchanged after refused adopt" "2" "$(run count)"
+printf '{"max_workers": 4, "parallel_enabled": true}\n' > "$REPO/scripts/ralph/state.json"
+
+# --- adopt refuses a fork PR: we cannot push to another repo's branch -------
+rc=0
+(FORK_PR=903 run_gh adopt 203 903) >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then ok "adopt refuses a cross-repository PR"; else bad "adopt refuses a cross-repository PR"; fi
+if run path 203 >/dev/null 2>&1; then
+  bad "refused fork adopt created no worktree"
+else
+  ok "refused fork adopt created no worktree"
+fi
+
+# --- adopt validates its arguments -----------------------------------------
+if run_gh adopt abc 901 >/dev/null 2>&1; then
+  bad "adopt refuses a non-numeric issue"
+else
+  ok "adopt refuses a non-numeric issue"
+fi
+if run_gh adopt 204 xyz >/dev/null 2>&1; then
+  bad "adopt refuses a non-numeric PR"
+else
+  ok "adopt refuses a non-numeric PR"
+fi
+
+# --- sync on an adopted lane: main merges INTO the bot branch --------------
+(
+  cd "$WORK/upstream"
+  echo adopted > ADOPTED.txt && git add -A && git commit -qm "advance main again"
+)
+if run sync 201 >/dev/null 2>&1; then ok "sync on adopted lane exits 0"; else bad "sync on adopted lane exits 0"; fi
+[[ -f "$ADIR/ADOPTED.txt" ]] && ok "adopted lane picked up new main file" \
+  || bad "adopted lane picked up new main file"
+[[ -f "$ADIR/BUMP.txt" ]] && ok "adopted lane kept the bot commit (merge, not reset)" \
+  || bad "adopted lane kept the bot commit (merge, not reset)"
+
+# --- release on an adopted lane: local branch only, remote untouched -------
+run release 201 >/dev/null 2>&1
+[[ -d "$ADIR" ]] && bad "release removed the adopted worktree" \
+  || ok "release removed the adopted worktree"
+check "count back to 1 after release" "1" "$(run count)"
+if (cd "$REPO" && git show-ref --verify --quiet "refs/heads/$BOT_BRANCH"); then
+  bad "release deleted the local bot branch"
+else
+  ok "release deleted the local bot branch"
+fi
+if (cd "$WORK/upstream" && git show-ref --verify --quiet "refs/heads/$BOT_BRANCH"); then
+  ok "release left the remote bot branch intact"
+else
+  bad "release left the remote bot branch intact"
+fi
+
+# --- reconcile releases a merged adopted lane, keeps the open one ----------
+run_gh adopt 201 901 >/dev/null 2>&1 || true
+check "two lanes before adopted reconcile" "2" "$(run count)"
+(cd "$REPO" && PATH="$BIN:$PATH" MERGED_BRANCH="$BOT_BRANCH" \
+  "$FLEET" reconcile >/dev/null 2>&1)
+check "reconcile released the merged adopted lane" "1" "$(run count)"
+check "the unrelated open lane survived"           "105" "$(run active)"
+
+# --- adopt: '|' is legal in a branch name, so the fork refusal must not be
+# --- bypassable by naming a branch after the field separator ----------------
+# The exploit: a FORK PR whose head branch is `main-shim|false` answers
+# "main-shim|false|true". Splitting on the FIRST '|' yields head_ref=main-shim and
+# is_fork="false|true" — never equal to "true", so the fork refusal stays silent
+# and the lane attaches to the unrelated base-repo branch `main-shim`, which the
+# worker then pushes to.
+SHIM_BRANCH="main-shim"
+PIPE_BRANCH="main-shim|false"
+STRAY_BRANCH="stray-base-branch"
+(
+  cd "$WORK/upstream"
+  git checkout -q -b "$SHIM_BRANCH" main
+  echo "unrelated base-repo branch" > SHIM.txt && git add -A && git commit -qm "shim branch"
+  git checkout -q -b "$PIPE_BRANCH" main
+  echo "bot work" > PIPE.txt && git add -A && git commit -qm "pipe-named head branch"
+  git checkout -q -b "$STRAY_BRANCH" main
+  echo "another base-repo branch" > STRAY.txt && git add -A && git commit -qm "stray branch"
+  git checkout -q main
+)
+rc=0
+(HEAD_REF="$PIPE_BRANCH" FORK_PR=911 run_gh adopt 301 911) >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "adopt refuses a fork PR whose branch name contains '|'"
+else
+  bad "adopt refuses a fork PR whose branch name contains '|'"
+fi
+if run path 301 >/dev/null 2>&1; then
+  bad "the refused pipe-named fork adopt created no worktree"
+else
+  ok "the refused pipe-named fork adopt created no worktree"
+fi
+if (cd "$REPO" && git show-ref --verify --quiet "refs/heads/$SHIM_BRANCH"); then
+  bad "the refused fork adopt never attached to the base-repo branch"
+else
+  ok "the refused fork adopt never attached to the base-repo branch"
+fi
+
+# The legal-branch twin: refusing every '|' would break a valid branch name, so a
+# same-repo pipe-named head must still adopt onto that branch exactly.
+PDIR="$(HEAD_REF="$PIPE_BRANCH" run_gh adopt 302 912 2>/dev/null || true)"
+PDIR="${PDIR:-$WORK/adopt-pipe-missing}"
+[[ -d "$PDIR" ]] && ok "adopt accepts a same-repo pipe-named head branch" \
+  || bad "adopt accepts a same-repo pipe-named head branch"
+PBR="$(cd "$PDIR" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+check "the pipe-named lane sits on the whole branch name" "$PIPE_BRANCH" "$PBR"
+[[ -f "$PDIR/PIPE.txt" ]] && ok "the pipe-named lane has that branch's content" \
+  || bad "the pipe-named lane has that branch's content"
+run release 302 >/dev/null 2>&1
+
+# Fail closed on an unparseable head lookup: an answer that cannot be split leaves
+# the PR's origin undetermined, which must refuse rather than proceed. The name it
+# would fall back to is a real base-repo branch, so proceeding is not harmless.
+rc=0
+(HEAD_LINE_RAW="$STRAY_BRANCH" run_gh adopt 303 913) >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "adopt refuses a head lookup with no separator"
+else
+  bad "adopt refuses a head lookup with no separator"
+fi
+rc=0
+(HEAD_LINE_RAW="$STRAY_BRANCH|" run_gh adopt 303 913) >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "adopt refuses an empty isCrossRepository field"
+else
+  bad "adopt refuses an empty isCrossRepository field"
+fi
+if run path 303 >/dev/null 2>&1; then
+  bad "the malformed head lookups created no worktree"
+else
+  ok "the malformed head lookups created no worktree"
+fi
+
+# --- the divergence guard must vet the BRANCH, not a same-named tag ---------
+# A tag outranks a branch in `git rev-parse`'s disambiguation while `git worktree
+# add` picks the branch, so bare rev names would vet a different object than the
+# one checked out — here the tag is not an ancestor of the remote and the guard
+# would refuse a perfectly healthy lane.
+SHADOW_BRANCH="dependabot/pip/backend/shadowed"
+(
+  cd "$WORK/upstream"
+  git checkout -q -b "$SHADOW_BRANCH" main
+  echo shadowed > SHADOW.txt && git add -A && git commit -qm "shadowed bot branch"
+  git checkout -q main
+  echo later > LATER.txt && git add -A && git commit -qm "advance main past the bot branch"
+)
+(
+  cd "$REPO"
+  git fetch -q origin "+refs/heads/$SHADOW_BRANCH:refs/remotes/origin/$SHADOW_BRANCH"
+  git branch "$SHADOW_BRANCH" "refs/remotes/origin/$SHADOW_BRANCH" >/dev/null
+  git fetch -q origin main
+  git tag "$SHADOW_BRANCH" origin/main
+)
+SDIR="$(HEAD_REF="$SHADOW_BRANCH" run_gh adopt 304 914 2>/dev/null || true)"
+SDIR="${SDIR:-$WORK/adopt-shadow-missing}"
+[[ -d "$SDIR" ]] && ok "adopt vets the branch, not a tag of the same name" \
+  || bad "adopt vets the branch, not a tag of the same name"
+SHEAD="$(cd "$SDIR" 2>/dev/null && git rev-parse HEAD 2>/dev/null || true)"
+check "the shadowed lane checked out the branch tip" \
+  "$(cd "$REPO" && git rev-parse "refs/heads/$SHADOW_BRANCH")" "$SHEAD"
+run release 304 >/dev/null 2>&1
 
 # --- summary ----------------------------------------------------------------
 echo

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -8,6 +8,16 @@
 # verdict only counts when it is fresher than the PR's HEAD commit (stale-verdict
 # guard). We put a fake, arg-aware `gh` on PATH and assert every classification.
 #
+# Three further dimensions are pinned here: a `do-not-auto-merge` opt-out that
+# short-circuits every other check; a freshness guard proving `CLEAN` alone
+# never means "up to date with main" — plus that the freshness probe stays LAZY
+# (a pending/red/unreviewed lane must never pay for it); and `ready-unreviewed`,
+# the token for a Dependabot PR whose review gate provably cannot run, which must
+# stay tight enough that no human PR ever reaches it — so "green" has to mean CI
+# actually ran (an all-skipped rollup is not a review), the bot has to have pushed
+# HEAD (a force-push must not re-clear our commits), and both `gh` answers are
+# parsed by field count so a stray `|` fails closed.
+#
 # Run:  bash scripts/ralph/test_pr_ready.sh
 set -euo pipefail
 
@@ -20,6 +30,14 @@ bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
 check() { # check <desc> <expected> <actual>
   if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
 }
+probed() { # probed <desc> <yes|no> <sentinel path> — did the compare probe run?
+  if [[ -e "$3" ]]; then check "$1" "$2" "yes"; else check "$1" "$2" "no"; fi
+}
+no_merge_token() { # no_merge_token <desc> <token> — any token the loop won't merge on
+  # For malformed answers the property is what matters, not which refusal token:
+  # `ready` and `ready-unreviewed` both merge, so only those two are wrong.
+  if [[ "$2" != "ready" && "$2" != "ready-unreviewed" ]]; then ok "$1"; else bad "$1 (got '$2')"; fi
+}
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -30,19 +48,89 @@ mkdir -p "$BIN"
 #   CHECKS_EC     — exit code `gh pr checks` should return (0 green / 8 pending / other failed)
 #   MERGE_STATE   — mergeStateStatus (CLEAN / BEHIND / ...)
 #   HEAD_DATE     — RFC3339 committedDate of the PR HEAD commit
+#   HEAD_AUTHOR   — `authors[0].login` of that same HEAD commit, the third field of
+#                   the `--json mergeStateStatus,commits` answer; defaults to the
+#                   bot-user spelling so a case can vary one condition at a time,
+#                   and any other value means one of OURS pushed last
 #   VERDICT       — the "<createdAt>|<isLGTM>" scalar the verdict jq resolves to
 #   COMMENTS_JSON — raw `--json comments` payload; when set, the stub runs the
 #                   REAL jq with pr-ready.sh's own `--jq` expression against it,
 #                   so the production verdict regex is genuinely exercised
 #                   (otherwise a scalar stub would mask a broken regex).
+#   PR_LABELS     — comma-separated labels for `pr view --json labels`
+#   PR_LABELS_EC  — exit code that same call returns (non-0 = API failure)
+#   ISSUE_LABELS  — comma-separated labels for `issue view --json labels` on the
+#                   issue the PR body links via Closes|Fixes|Resolves #N
+#   ISSUE_LABELS_FOR — when set, ISSUE_LABELS answers ONLY that issue number and
+#                   every other issue reads as unlabelled, so a test can pin
+#                   WHICH of several linked issues the hold lookup resolved
+#   ISSUE_LABELS_EC — exit code that same call returns (non-0 = API failure)
+#   PR_BODY       — the body `pr view --json body` returns
+#   PR_BODY_EC    — exit code that same call returns (non-0 = API failure)
+#   BASE_REF / HEAD_OID — the "<baseRefName>|<headRefOid>" compare inputs
+#   BEHIND_BY     — `.behind_by` from `gh api .../compare/<base>...<head>`; set it
+#                   empty or non-numeric to exercise the fail-closed path
+#   COMPARE_EC    — exit code that same compare call returns (non-0 = API failure)
+#   COMPARE_SENTINEL — file the stub touches when the compare endpoint is hit, so
+#                   a test can prove the freshness probe stayed lazy
+#   PR_AUTHOR     — `.author.login` for `pr view --json author,statusCheckRollup`;
+#                   `app/dependabot` is the one value that can clear the review
+#                   gate, and the empty default fails closed to awaiting-review
+#   REVIEW_CONCLUSIONS — comma-joined `claude-review` conclusions from that same
+#                   rollup (the real shape repeats one entry per triggering
+#                   event, e.g. `SKIPPED,SKIPPED`); empty = no such check
+#   NON_REVIEW_SUCCESSES — third field of that same answer: how many NON-review
+#                   checks reported SUCCESS; defaults to 1, so a case sets 0 to
+#                   isolate the all-skipped rollup that `gh pr checks` still exits
+#                   0 on
+#   ROLLUP_JSON   — raw `--json author,statusCheckRollup` payload; when set the stub
+#                   runs the REAL jq with pr-ready.sh's own `--jq` against it (and
+#                   PR_AUTHOR/REVIEW_CONCLUSIONS/NON_REVIEW_SUCCESSES are ignored),
+#                   so the production SUCCESS filter is genuinely exercised
+#   REVIEW_EC     — exit code that same call returns (non-0 = API failure)
+#   REVIEW_SENTINEL — file the stub touches when the review-gate endpoint is hit,
+#                   so a test can prove that probe stayed lazy too
 # Real gh applies --jq, so — like test_fleet.sh — the stub emits the already
-# extracted scalar and branches on which --json field the caller asked for.
+# extracted scalar and branches on which --json field the caller asked for. Label
+# lists arrive one-per-line, exactly as `--jq '.labels[].name'` yields them.
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 args="$*"
 case "$args" in
+  "api "*"compare"*)
+    [[ -n "${COMPARE_SENTINEL:-}" ]] && : > "$COMPARE_SENTINEL"
+    printf '%s\n' "${BEHIND_BY-0}"    # `-` not `:-` so an empty value stays empty
+    exit "${COMPARE_EC:-0}" ;;
   *"pr checks"*)            exit "${CHECKS_EC:-0}" ;;
-  *"--json mergeStateStatus"*) printf '%s|%s\n' "${MERGE_STATE:-CLEAN}" "${HEAD_DATE:-}" ;;
+  *"pr view"*"--json labels"*)
+    printf '%s' "${PR_LABELS:-}" | tr ',' '\n'
+    exit "${PR_LABELS_EC:-0}" ;;
+  *"issue view"*"--json labels"*)
+    n=""
+    for tok in "$@"; do
+      if [[ "$tok" =~ ^[0-9]+$ ]]; then n="$tok"; break; fi
+    done
+    if [[ -z "${ISSUE_LABELS_FOR:-}" || "$n" == "$ISSUE_LABELS_FOR" ]]; then
+      printf '%s' "${ISSUE_LABELS:-}" | tr ',' '\n'
+    fi
+    exit "${ISSUE_LABELS_EC:-0}" ;;
+  *"pr view"*"--json body"*)
+    printf '%s\n' "${PR_BODY:-}"
+    exit "${PR_BODY_EC:-0}" ;;
+  *"pr view"*"--json baseRefName"*) printf '%s|%s\n' "${BASE_REF:-main}" "${HEAD_OID:-c0ffee1}" ;;
+  *"pr view"*"--json author"*)
+    [[ -n "${REVIEW_SENTINEL:-}" ]] && : > "$REVIEW_SENTINEL"
+    if [[ -n "${ROLLUP_JSON:-}" ]]; then
+      expr="" prev=""
+      for a in "$@"; do [[ "$prev" == "--jq" ]] && expr="$a"; prev="$a"; done
+      printf '%s' "$ROLLUP_JSON" | jq -rc "$expr"
+    else
+      # `-` not `:-` on the count so a test can send an empty (non-numeric) field
+      printf '%s|%s|%s\n' "${PR_AUTHOR:-}" "${REVIEW_CONCLUSIONS:-}" "${NON_REVIEW_SUCCESSES-1}"
+    fi
+    exit "${REVIEW_EC:-0}" ;;
+  *"--json mergeStateStatus"*)
+    printf '%s|%s|%s\n' "${MERGE_STATE:-CLEAN}" "${HEAD_DATE:-}" "${HEAD_AUTHOR-dependabot[bot]}" ;;
   *"--json comments"*)
     if [[ -n "${COMMENTS_JSON:-}" ]]; then
       expr="" prev=""
@@ -138,6 +226,347 @@ if command -v jq >/dev/null 2>&1; then
 else
   echo "  skip - real-jq verdict-regex cases (jq not installed)"
 fi
+
+# --- opt-out: a human owns this PR, the loop must not act on it -------------
+OPTOUT="do-not-auto-merge"
+
+check "opt-out label on the PR → optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_LABELS="$OPTOUT" run 100)"
+
+check "opt-out label on the linked issue → optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_BODY="Bumps ruff to 0.16.0. Closes #1982" \
+     ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# Checked FIRST: opt-out wins even while CI is still running.
+check "opt-out short-circuits pending CI" "optout" \
+  "$(CHECKS_EC=8 PR_LABELS="dependencies,$OPTOUT" run 100)"
+
+# Dependabot's own labels must not be read as an opt-out.
+check "dependabot labels without the opt-out → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_LABELS="dependencies,python" BEHIND_BY=0 run 100)"
+
+# Exact label match: a label that merely CONTAINS the opt-out name is not one.
+check "label containing the opt-out name is not an opt-out" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_LABELS="$OPTOUT-after-review" BEHIND_BY=0 run 100)"
+
+# Linking an issue is not itself an opt-out — only the label on it is.
+check "linked issue without the opt-out label → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_BODY="Closes #1982" ISSUE_LABELS="dependencies" BEHIND_BY=0 run 100)"
+
+# --- an UNDETERMINABLE hold is a tooling error, never "no hold" -------------
+# Every world below is an otherwise-perfect ready lane, so the failed lookup is
+# the only difference: swallowing it would let a rate limit, a 5xx, or an expired
+# token auto-merge the very PR a human reserved.
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_LABELS_EC=1 run 100)" || rc=$?
+check "PR label lookup failure exits 2" "2" "$rc"
+check "PR label lookup failure prints no verdict" "" "$out"
+
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_BODY_EC=1 run 100)" || rc=$?
+check "PR body lookup failure exits 2" "2" "$rc"
+check "PR body lookup failure prints no verdict" "" "$out"
+
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_BODY="Closes #1982" ISSUE_LABELS_EC=1 run 100)" || rc=$?
+check "linked-issue label lookup failure exits 2" "2" "$rc"
+check "linked-issue label lookup failure prints no verdict" "" "$out"
+
+# Control: failing closed did not break the happy path.
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_LABELS="dependencies,python" PR_BODY="Closes #1982" ISSUE_LABELS="dependencies" \
+   run 100)" || rc=$?
+check "all three lookups succeed with no hold → ready" "ready" "$out"
+check "a classified lane exits 0" "0" "$rc"
+
+# --- the hold lookup resolves the LAST issue link, not the first ------------
+# A bot PR body embeds the dependency's own changelog, whose "* Fixes #456" lines
+# sit BEFORE the bridge's appended Closes. Reading the first link would point the
+# hold lookup at an unrelated tracker's issue and miss the hold on the bridge one.
+CHANGELOG_BODY="Bumps ruff from 0.15.0 to 0.16.0.
+
+Release notes:
+* Fixes #456 panic in the formatter
+* Resolves #789 for the import sorter
+
+Closes #1982"
+
+check "hold on the last-linked issue outranks a changelog link" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_BODY="$CHANGELOG_BODY" ISSUE_LABELS_FOR=1982 \
+     ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# The twin: exactly one link is read, and it is the last — a hold on an issue the
+# changelog merely mentions governs somebody else's repository, not this PR.
+check "hold on a changelog-linked issue is not this PR's hold" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_BODY="$CHANGELOG_BODY" ISSUE_LABELS_FOR=456 ISSUE_LABELS="$OPTOUT" run 100)"
+
+# --- freshness: CLEAN is NOT proof of being up to date with main ------------
+# GitHub only reports BEHIND when the base branch enforces strict status checks,
+# which this repo does not. A grouped pip bump sitting 17 commits behind main can
+# be MERGEABLE+CLEAN with its own checks green; merging it lands a ruff major bump
+# that was never compiled against today's main and turns main red.
+check "green + CLEAN + fresh LGTM but 17 commits behind → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=17 run 100)"
+
+check "green + CLEAN + fresh LGTM + behind_by 0 → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=0 run 100)"
+
+check "green + CLEAN + fresh LGTM + behind_by 1 → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=1 run 100)"
+
+# Fail closed: an unusable freshness answer must never be read as up-to-date.
+check "compare API error → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     COMPARE_EC=1 BEHIND_BY=0 run 100)"
+
+check "compare returns empty → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY='' run 100)"
+
+check "compare returns non-numeric → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=null run 100)"
+
+# behind_by is irrelevant once GitHub already says BEHIND.
+check "green + BEHIND + fresh LGTM + behind_by 0 → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=BEHIND HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=0 run 100)"
+
+# --- laziness: only a would-be-ready lane may pay for the compare probe -----
+# FLEET.md makes syncing lazy; probing freshness on every unready lane would make
+# the orchestrator sync-thrash. BEHIND_BY=17 stays set to prove the token comes
+# from the earlier check, not from a probe.
+S_PENDING="$WORK/compare-pending"
+check "pending stays pending with a stale branch" "pending" \
+  "$(CHECKS_EC=8 BEHIND_BY=17 COMPARE_SENTINEL="$S_PENDING" run 100)"
+probed "pending lane never probes freshness" "no" "$S_PENDING"
+
+S_FAILED="$WORK/compare-ci-failed"
+check "ci-failed stays ci-failed with a stale branch" "ci-failed" \
+  "$(CHECKS_EC=1 BEHIND_BY=17 COMPARE_SENTINEL="$S_FAILED" run 100)"
+probed "ci-failed lane never probes freshness" "no" "$S_FAILED"
+
+S_REVIEW="$WORK/compare-awaiting-review"
+check "stale verdict stays awaiting-review with a stale branch" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$STALE|true" \
+     BEHIND_BY=17 COMPARE_SENTINEL="$S_REVIEW" run 100)"
+probed "unreviewed lane never probes freshness" "no" "$S_REVIEW"
+
+S_READY="$WORK/compare-ready"
+check "ready lane still classifies as ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     BEHIND_BY=0 COMPARE_SENTINEL="$S_READY" run 100)"
+probed "would-be-ready lane does probe freshness" "yes" "$S_READY"
+
+S_OPTOUT="$WORK/compare-optout"
+check "opt-out lane classifies as optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_LABELS="$OPTOUT" BEHIND_BY=17 COMPARE_SENTINEL="$S_OPTOUT" run 100)"
+probed "opt-out lane never probes freshness" "no" "$S_OPTOUT"
+
+# --- ready-unreviewed: the PR class whose review gate cannot exist -----------
+# `claude-code-review.yml` never runs while Dependabot is the only pusher (GitHub
+# withholds the OAuth secret from runs it triggers), so the job reports SKIPPED,
+# no verdict is ever posted, and `awaiting-review` would hang the lane forever.
+DEPENDABOT="app/dependabot"
+# The commit form of the same identity. `pr view --json author` reports the app
+# slug above; a commit's `authors[].login` reports this — both read off a live bump.
+DEPENDABOT_COMMIT="dependabot[bot]"
+SKIPPED="SKIPPED"
+NO_VERDICT="|false"
+
+check "reviewless dependabot bump + green + CLEAN + behind_by 0 → ready-unreviewed" "ready-unreviewed" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
+
+# The rollup carries one entry per triggering event (push + pull_request), so a
+# repeated SKIPPED is the ordinary live shape, not an anomaly.
+check "duplicate SKIPPED rollup entries → ready-unreviewed" "ready-unreviewed" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED,$SKIPPED" BEHIND_BY=0 run 100)"
+
+# `ready` keeps its full four-part meaning: a reviewed PR is never downgraded to
+# the token that asks the orchestrator to decide.
+check "reviewless setup but WITH a fresh LGTM → plain ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
+
+# With the review gate gone the freshness guard carries the whole safety burden,
+# so it must still bind exactly as hard as it does on the `ready` path.
+check "reviewless + 17 commits behind → behind, never ready-unreviewed" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=17 run 100)"
+
+check "reviewless + DIRTY → behind, never ready-unreviewed" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=DIRTY HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
+
+# The tightness guard: should a future skip condition land on that workflow, a
+# human PR reporting SKIPPED must NOT start auto-merging unreviewed.
+check "human-authored PR with a SKIPPED claude-review → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="Geoffe-Ga" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
+
+# One entry that did run means the job DID review this code and a verdict is owed.
+check "not every claude-review conclusion SKIPPED → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED,SUCCESS" BEHIND_BY=0 run 100)"
+
+# A still-queued run reports an empty conclusion: that differs from SKIPPED, and
+# must not be read as "there was no entry".
+check "a queued (empty) conclusion alongside SKIPPED → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED," BEHIND_BY=0 run 100)"
+
+# No claude-review entry at all is unproven, not proof of absence — fail closed.
+check "dependabot PR with no claude-review entry → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="" BEHIND_BY=0 run 100)"
+
+# An unreadable answer may only ever hold the lane, never release it.
+check "review-gate lookup failure → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" REVIEW_EC=1 BEHIND_BY=0 run 100)"
+
+# --- "green" must mean CI RAN, not that nothing ran -------------------------
+# A `github-actions` ecosystem bump touches only `.github/workflows/*.yml`, which
+# matches no test workflow's `paths:` filter — so every check skips, `gh pr checks`
+# exits 0 anyway, and this token would merge an unreviewed, untested rewrite of the
+# workflows that hold our PAT and API tokens.
+check "reviewless bump where NO non-review check succeeded → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" NON_REVIEW_SUCCESSES=0 \
+     BEHIND_BY=0 run 100)"
+
+# The positive twin: one non-review check that actually passed is the whole claim
+# behind the token, so the guard discriminates rather than refusing every bump.
+check "same bump with one non-review SUCCESS → ready-unreviewed" "ready-unreviewed" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" NON_REVIEW_SUCCESSES=1 \
+     BEHIND_BY=0 run 100)"
+
+# Same pair through the REAL rollup jq, so the `conclusion == SUCCESS` filter is
+# exercised rather than stubbed: a scalar count would mask a filter that counts
+# every non-review check regardless of how it ended.
+if command -v jq >/dev/null 2>&1; then
+  rj() { printf '{"author":{"login":"%s"},"statusCheckRollup":[%s]}' "$DEPENDABOT" "$1"; }
+  REVIEW_ENTRY='{"name":"claude-review","conclusion":"SKIPPED"}'
+
+  # Present but not SUCCESS — a skipped job and a still-queued one (null) — is
+  # exactly the all-skipped rollup, so neither may count toward the requirement.
+  check "non-review checks present but none SUCCESS → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+       ROLLUP_JSON="$(rj "$REVIEW_ENTRY,{\"name\":\"backend\",\"conclusion\":\"SKIPPED\"},{\"name\":\"frontend\",\"conclusion\":null}")" \
+       run 100)"
+
+  check "real rollup with one non-review SUCCESS → ready-unreviewed" "ready-unreviewed" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+       ROLLUP_JSON="$(rj "$REVIEW_ENTRY,{\"name\":\"backend\",\"conclusion\":\"SUCCESS\"},{\"name\":\"frontend\",\"conclusion\":null}")" \
+       run 100)"
+else
+  echo "  skip - real-jq rollup cases (jq not installed)"
+fi
+
+# --- the bot must also have pushed HEAD -------------------------------------
+# `statusCheckRollup` is per-HEAD-commit: a `@dependabot recreate` force-push over
+# our adaptation commits hands back a fresh all-SKIPPED rollup while the PR author
+# stays the bot, re-clearing hand-written code as never-touched.
+check "reviewless rollup but OUR commit is HEAD → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" HEAD_AUTHOR="Geoffe-Ga" \
+     BEHIND_BY=0 run 100)"
+
+# The two spellings are distinct on purpose: the app slug is what `--json author`
+# reports and is never what a commit's `authors[].login` says.
+check "the PR-author spelling as HEAD-commit author → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" HEAD_AUTHOR="$DEPENDABOT" \
+     BEHIND_BY=0 run 100)"
+
+# --- both answers are parsed by FIELD COUNT, so a stray `|` fails closed -----
+# A login, an enum, an RFC3339 stamp and a count can none of them contain `|`, so a
+# surplus field means a malformed answer — trimming it to fit is the `|` bypass
+# already found and fixed once in fleet.sh.
+check "a surplus field in the review-gate answer → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" NON_REVIEW_SUCCESSES='1|x' \
+     BEHIND_BY=0 run 100)"
+
+no_merge_token "a surplus field in the mergeState answer yields no merge token (any refusal will do)" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
+     HEAD_AUTHOR="$DEPENDABOT_COMMIT|x" BEHIND_BY=0 run 100)"
+
+# The human hold outranks the new token exactly as it outranks `ready`.
+check "opt-out on a would-be ready-unreviewed PR → optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 \
+     PR_LABELS="dependencies,$OPTOUT" run 100)"
+
+# --- laziness: the review-gate probe costs nothing on lanes it cannot help ---
+# Same contract as the compare probe. PR_AUTHOR stays set to the one value that
+# WOULD clear the gate, so a fired sentinel is the only thing under test.
+S_GATE_LGTM="$WORK/gate-fresh-lgtm"
+check "fresh LGTM still classifies as ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" REVIEW_SENTINEL="$S_GATE_LGTM" run 100)"
+probed "a fresh verdict never probes the review gate" "no" "$S_GATE_LGTM"
+
+S_GATE_PENDING="$WORK/gate-pending"
+check "reviewless lane with pending CI stays pending" "pending" \
+  "$(CHECKS_EC=8 PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
+     REVIEW_SENTINEL="$S_GATE_PENDING" run 100)"
+probed "pending lane never probes the review gate" "no" "$S_GATE_PENDING"
+
+S_GATE_FAILED="$WORK/gate-ci-failed"
+check "reviewless lane with red CI stays ci-failed" "ci-failed" \
+  "$(CHECKS_EC=1 PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
+     REVIEW_SENTINEL="$S_GATE_FAILED" run 100)"
+probed "ci-failed lane never probes the review gate" "no" "$S_GATE_FAILED"
+
+S_GATE_OPTOUT="$WORK/gate-optout"
+check "reviewless lane under a hold stays optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+     PR_LABELS="$OPTOUT" PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
+     REVIEW_SENTINEL="$S_GATE_OPTOUT" run 100)"
+probed "opt-out lane never probes the review gate" "no" "$S_GATE_OPTOUT"
+
+S_GATE_NONE="$WORK/gate-no-verdict"
+check "no-verdict lane classifies as ready-unreviewed" "ready-unreviewed" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
+     REVIEW_SENTINEL="$S_GATE_NONE" run 100)"
+probed "no-verdict lane does probe the review gate" "yes" "$S_GATE_NONE"
+
+# --- cross-file coupling: the review check's NAME ---------------------------
+# pr-ready.sh matches the review check by the literal string `claude-review`, which
+# only holds while that job key carries no `name:` override — GitHub would then
+# report the override instead and every Dependabot lane would wedge at
+# awaiting-review forever, with no error anywhere to explain it.
+REVIEW_WORKFLOW="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/claude-code-review.yml"
+job_keys="$(awk '$0 == "  claude-review:" {j = 1; next}
+                 j && /^  [^[:space:]#]/ {exit}
+                 j && /^    [^[:space:]#]/ {sub(/:.*/, "", $1); print $1}' \
+            "$REVIEW_WORKFLOW" 2>/dev/null || true)"
+
+check "the claude-review job key still exists" "yes" \
+  "$(grep -qx '  claude-review:' "$REVIEW_WORKFLOW" 2>/dev/null && echo yes || echo no)"
+check "the claude-review job declares no name: override" "" \
+  "$(printf '%s\n' "$job_keys" | grep -x name || true)"
 
 # --- summary ---------------------------------------------------------------
 echo

--- a/scripts/setup-scan-labels.sh
+++ b/scripts/setup-scan-labels.sh
@@ -30,6 +30,9 @@ label "P3" "0E8A16" "Hygiene: dead code, types, docs, TODOs"
 echo "Consumption gate…"
 label "agent-ready" "1D76DB" "Fully specified; Ralph may pick up"
 
+echo "Human-hold label (honoured by pick-next.sh and pr-ready.sh)…"
+label "do-not-auto-merge" "5319E7" "Human hold: Ralph will not adopt, fix, or merge this PR/issue"
+
 echo "Scan provenance labels…"
 for scan in deps security bugs dead-code complexity coverage perf todo \
             types mutation docs a11y; do


### PR DESCRIPTION
## Summary

Lets the Ralph loop adopt and merge Dependabot PRs — including grouped ones — on a
normal tick, and closes the stale-green hole that made doing so unsafe.

- **Freshness guard (`pr-ready.sh`).** `mergeStateStatus == CLEAN` was being read as
  "up to date with `main`". It is not: GitHub computes `BEHIND` only when the base
  branch enforces strict/up-to-date status checks, which this repo does not, so a
  branch many commits behind `main` reports `CLEAN`. `ready` now additionally
  requires the compare API's `behind_by == 0`. This applies to **every** lane, not
  just Dependabot's — the designed `BEHIND` -> sync path had never once fired here.
- **Adoption (`fleet.sh adopt <issue> <pr>`).** Puts a lane's worktree on the bot
  PR's **existing** head branch, so fixes push there and a second PR is never
  opened. Refuses a fork PR, a diverged local branch, and a full fleet.
- **Human hold (`optout`).** `do-not-auto-merge` on the PR or the issue it closes
  means the loop does not act on that PR at all. An *undeterminable* hold (label
  lookup failed) exits 2 rather than reading as "no hold".
- **Gate 4 for bot PRs.** `claude-code-review.yml` skipped on the PR's *author*,
  which never changes — so a bot PR could never get a verdict and `pr-ready.sh`
  could never say `ready`. Re-keyed to `github.actor`, so any commit of ours makes
  the review runnable. The residual case gets a distinct `ready-unreviewed` token.
- **Orphan cleanup.** The bridge reconciler now closes bridge issues whose PR
  closed without merging, so the backlog stops accruing stale adoption tickets.

`pick-next.sh` is deliberately **unchanged**: a bridged issue is already never
picked, because the picker's in-flight scan matches the `Closes #<issue>` the
bridge appends to the bot PR. No `RALPH_EXCLUDE_LABELS` override is needed — and
the docs now say why using one is a hazard (it *replaces* the default exclusion
list rather than adding to it).

## The consent decision, stated plainly

The standing operating rule was that **a bot-PR merge needs the repo owner's
explicit OK**. This PR replaces that rule rather than silently dropping it. What
replaces it:

1. **Green CI verified against *current* `main`** — not the stale base the PR's own
   checks ran on. This is the substantive upgrade: the human was approving a green
   badge that could be, and was, stale.
2. **A fresh `Verdict: LGTM`**, posted after the PR's HEAD commit — unchanged.
3. **`do-not-auto-merge`** on the PR or its bridge issue as the per-PR human hold,
   with an unreadable hold treated as a tooling error, not as "no hold".
4. **SDK-scale pairings excluded at source** by `.github/dependabot.yml`'s `ignore:`
   ranges, so such a PR never opens.

**Majors are not specially held.** A major that needs code changes fails CI against
fresh `main` and routes to a Gate-1 adaptation on the bot branch automatically; a
major that passes everything carries no more risk signal than a minor. Holding them
would also apply a stricter standard to a version bump than the fleet already
applies to the human-authored feature code it merges autonomously on an LGTM. The
per-PR lever for "this one needs me" is `do-not-auto-merge`.

**The one genuine relaxation is `ready-unreviewed`.** Element 2 above cannot exist
for a Dependabot PR nobody has pushed to: GitHub withholds Actions secrets from
bot-actor runs, so `claude-review` reports `SKIPPED` and no verdict is ever posted.
Waiting for it is a deadlock, not a gate. That case therefore merges on elements 1,
3 and 4 alone. It is narrowed as far as it goes: `pr-ready.sh` requires the PR's
author to be `app/dependabot` **and** every `claude-review` rollup entry to be
`SKIPPED`, and `ralph-tick.md` merges the token only on a `dependencies` lane. Any
bump that needed a sync or an adaptation carries a commit of ours, which makes the
review job runnable, so it clears Gate 4 normally — `ready-unreviewed` only ever
covers a bump that was already current and already green.

If you would rather keep a human in that loop, the smallest change is to make
`ralph-tick.md` treat `ready-unreviewed` as "leave for a human" instead of "merge";
the token exists precisely so that decision lives in one legible place.

## The failure this prevents (measured, not hypothetical)

PR #1981 — grouped pip bump, 9 pins — was green on its own checks while sitting
**17 commits behind `main`** (`mergeable: MERGEABLE`; the compare API reported
`behind_by: 17`). It bumped `ruff 0.15.22 -> 0.16.0`, which produced **144 lint
errors** against the then-current tree (143 x `ISC004`, 1 x `LOG004`) because the
repo lints with `select = ["ALL"]`. An auto-merge trusting the PR's own checks
would have turned `main` red. Under this change that PR reads `behind`, syncs, and
its real breakage surfaces as a Gate-1 adaptation on Dependabot's own branch —
which is exactly how it was resolved by hand.

## Notable design choices

- **The freshness guard went into `pr-ready.sh`, not a bot-specific wrapper.** The
  defect was never Dependabot-specific; scoping the fix to bot PRs would have left
  the other four lanes merging stale. Expect *more* `behind` verdicts and more
  syncs than before — that is the designed path finally firing, not a regression.
- **The probe is lazy.** Freshness and review-gate lookups run only on the path
  that would otherwise print `ready`. `FLEET.md` makes syncing lazy on purpose;
  probing every pending/red/unreviewed lane would sync-thrash the fleet, and each
  sync invalidates that lane's LGTM under the stale-verdict guard.
- **`CLEAN` is kept alongside `behind_by`.** It is the only signal for
  `DIRTY`/`CONFLICTING`/`BLOCKED`/`DRAFT`/`UNKNOWN`, which `behind_by` cannot see.
- **No SDK blocklist in the loop.** The `#885` pins are already excluded by
  `.github/dependabot.yml` with *version-range* precision. Re-encoding them as a
  name-only list in the loop would be both redundant and wrong — it would defer an
  allowed in-range patch such as `styleq 0.1.4`.
- **`do-not-auto-merge` did not exist as a repo label** despite being referenced by
  `pick-next.sh`. Added to `scripts/setup-scan-labels.sh` (the idempotent
  `gh label create --force` bootstrap) so the documented opt-out is real.

## Blockers found and fixed during self-review

Gate 2.5 review found five, each verified against live PRs before fixing:

1. **`ready-unreviewed` could merge a PR on which *zero CI ran*.** `gh pr checks`
   exits **0** when every check is `skipping`, not only when checks pass — verified
   on a `github-actions` bump whose whole rollup was `claude-review=SKIPPED,
   Post merge recap=SKIPPED`. Every workflow is `paths:`-filtered to its own
   sources, so an action bump (touching only `.github/workflows/*.yml`) matches
   none of them and runs nothing. The bumped action then executes in workflows
   holding a real PAT and three API tokens. `ready-unreviewed` now also requires at
   least one **non-review check with a `SUCCESS` conclusion**.
2. **`ready-unreviewed` did not enforce "nobody touched it".** `statusCheckRollup`
   is per-HEAD-commit, so a Dependabot force-push over our adaptation
   (`@dependabot recreate`) resets it to all-`SKIPPED` while the PR author stays
   the bot. Now the **HEAD commit's** author must also be `dependabot[bot]`.
3. **`fleet.sh` was broken when run from inside a linked worktree.**
   `git rev-parse --show-toplevel` returns the *worktree* there, so `sync` died
   with "no worktree for issue N" — and the new docs make `fleet.sh sync` the
   adopted worker's first action. `list`/`free` were also silently reporting an
   empty fleet, which would have over-allocated past the worker cap. `repo_root()`
   now resolves the main worktree from `git worktree list --porcelain`.
4. **The `do-not-auto-merge` label did not exist in the repo**, so the control that
   replaces owner consent was unappliable. Created it (`gh label create --force`)
   and added it to `scripts/setup-scan-labels.sh` so it is reproducible.
5. **`iteration-trigger.yml` was issuing "cleared to squash merge" on green+LGTM
   alone**, consulting neither `behind_by` nor the hold — which would have
   falsified this PR's central invariant from a second code path. It now checks
   both, failing closed, and names the blocker instead of clearing.

Both `|`-delimited `gh` scalars are parsed by **field count** (`IFS='|' read -r a b
c rest`, non-empty `rest` fails closed) rather than by seeking a separator, because
a `|` is a legal git branch-name character and was already proven to bypass the
fork check once.

## Risks to weigh

- **`claude-code-review.yml`'s `if:` is the one line that cannot be exercised
  locally.** It takes effect on the next `synchronize` run of a bot PR carrying one
  of our commits. GitHub withholds secrets from runs whose *actor* is Dependabot,
  so a run triggered by our push should have them — but if the action hard-fails
  anyway the check goes red and that lane churns. Reverting is a one-line change.
- **This PR cannot review itself.** It edits `claude-code-review.yml`, so
  `claude-code-action` self-skips by anti-tamper and posts no verdict — the
  workflow's own designed path for "the workflow change is reviewed manually".
  `pr-ready.sh` will therefore report `awaiting-review` on this PR indefinitely; it
  needs a human merge. That seems right for a PR that changes the auto-merge
  policy. The same mechanism wedges any future bump of that workflow's actions,
  which is filed as #2026.
- **The bridge workflow's new issue-closing loop has no test harness** (neither did
  the rest of that file). It is confined to the `schedule`/`workflow_dispatch`
  reconciler path, never `pull_request_target`, and filters on the `dependencies`
  label plus the `<!-- dependabot-pr:N -->` marker. `permissions:` is byte-identical
  to `main` in all three touched workflows, and no `ref:` was added to any checkout.
- **Expect more `behind` verdicts and more syncs.** That is the designed path
  finally firing. A side effect is that `DRAFT`/`BLOCKED`/`UNKNOWN` also read as
  `behind` and get a sync that cannot help them — filed as #2025.

## Follow-ups filed

- **#2025** — `pr-ready.sh` routes `DRAFT`/`BLOCKED`/`UNKNOWN` to a sync that
  cannot help, so those lanes churn a worker per wake.
- **#2026** — a PR editing `claude-code-review.yml` wedges at `awaiting-review`
  forever (self-skip exits 0, so the check is `SUCCESS` with no verdict).
- **#2027** — an issue-level `do-not-auto-merge` hold is lost when Dependabot
  rewrites the PR body and erases the `Closes` line.

## Test plan

- `bash scripts/ralph/test_pr_ready.sh` — **78 passed** (was 14). New: the `optout`
  hold and its fail-closed behaviour, last-issue-link resolution, the freshness
  guard including the `behind_by: 17` regression, fail-closed on every bad compare
  answer, sentinel-proven laziness on the pending/red/unreviewed/optout paths, the
  full `ready-unreviewed` matrix (including the zero-CI and force-push holes and
  both `|`-injection shapes), and an assertion that the `claude-review` job key
  still exists and gains no `name:` override — the cross-file coupling that would
  otherwise wedge every Dependabot lane silently.
- `bash scripts/ralph/test_fleet.sh` — **63 passed** (was 25). New: `adopt` onto a
  slashed bot branch, no `issue/<N>-*` branch created, cap and re-entrancy, fork
  refusal (including a `|` in the branch name), malformed head answers, sync,
  release, reconcile, and the tag-shadowing divergence guard.
- `bash scripts/ralph/test_pick_next.sh` 23 passed;
  `bash scripts/ralph/test_ensure_issue_label.sh` 111 passed;
  `python -m pytest scripts/ralph` 75 passed — all unchanged.
- `shellcheck --severity=warning scripts/ralph/*.sh scripts/setup-scan-labels.sh`
  clean; every changed workflow parses as YAML; pre-commit green on commit. Suites
  re-run under stock macOS `/bin/bash` 3.2 as well as bash 5, and again after
  merging `origin/main`.
- `bash scripts/ralph/fleet.sh list` now reports the real fleet from *inside* a
  linked worktree, which it did not before.
- Three defects found by security review are each now covered by a regression
  assertion proven to fail against the pre-fix code: the human hold failing **open**
  on any `gh` error (including a `pipefail` case where the hold was on stdout), the
  hold lookup resolving an *upstream changelog's* issue number instead of the bridge
  issue's, and the fork refusal being bypassable via a `|` in the branch name.

No Python or TypeScript changed, so the backend and frontend suites are untouched.

Closes #2017
