### PR TITLE
fix(backend): bound the invalid-license counter store

### DIFF
--- a/backend/src/rate_limit.py
+++ b/backend/src/rate_limit.py
@@ -1,5 +1,8 @@
 """Shared rate limiter instances for the application."""
 
+import time
+from collections.abc import Callable
+
 from limits import RateLimitItemPerHour
 from limits.storage import MemoryStorage
 from limits.strategies import MovingWindowRateLimiter
@@ -28,9 +31,138 @@ limiter = Limiter(key_func=client_throttle_key, default_limits=[DEFAULT_RATE_LIM
 # capped per hour even if they pace themselves under the per-minute limit.
 INVALID_LICENSE_MAX_PER_HOUR = 10
 
-_invalid_license_storage = MemoryStorage()
-_invalid_license_limiter = MovingWindowRateLimiter(_invalid_license_storage)
-_INVALID_LICENSE_ITEM = RateLimitItemPerHour(INVALID_LICENSE_MAX_PER_HOUR)
+# How many tracked keys it takes before the throttle first scans for keys to
+# evict. A deployment quiet enough to stay under this floor never scans at all,
+# and the floor is also where the mark resets once the store empties out.
+_SWEEP_MIN_TRACKED = 64
+
+# The next scan is scheduled at this multiple of the population that survived
+# the last one, which amortises sweeping: a store holding many genuinely active
+# clients does not pay a full scan on every recorded attempt. Must stay strictly
+# greater than one -- at one, a store of live keys would rescan on every attempt.
+_SWEEP_GROWTH_FACTOR = 2
+
+
+class _InvalidLicenseThrottle:
+    """Hourly invalid-license counter over a self-bounding in-memory store.
+
+    The backing ``MemoryStorage`` empties an expired key's event list but never
+    drops the key itself, so a long-lived process would keep one dict entry per
+    throttle key it had ever seen. This wrapper remembers when each key was last
+    charged and periodically evicts the keys whose window has fully rolled off,
+    bounding the store by the peak concurrent population instead of letting it
+    grow without limit as total traffic accumulates. The mark only ratchets up
+    on a completed sweep and never shrinks, so a burst's dead keys stay resident
+    until traffic climbs back to that peak: the store is bounded, not minimal.
+
+    Eviction can never be premature, which matters because this throttle is a
+    security control: an attacker must not be able to clear their own counter by
+    provoking a sweep. A key's recorded last-attempt reading comes from the same
+    wall clock the ``limits`` moving window stamps its entries with, so it is at
+    or after the newest entry's arrival time; an age strictly greater than one
+    full expiry therefore proves every entry has already left the window. That
+    implication only holds while the clock is the one stamping those entries,
+    which is why the default is wall clock rather than a monotonic source.
+
+    Attributes:
+        storage: Event store backing the moving window.
+        item: The hourly cap this throttle enforces.
+        last_attempt: Raw throttle key to the clock reading of its most recent
+            recorded attempt. Public, along with the rest, so this module's own
+            unit tests can inspect the store without reaching through private
+            names.
+        sweep_at: Tracked-key count at which the next scan runs.
+    """
+
+    def __init__(self, clock: Callable[[], float] = time.time) -> None:
+        """Build an empty throttle.
+
+        Args:
+            clock: Source of the current time, in seconds. In production it must
+                be the same wall clock the moving window stamps its entries
+                with, hence the ``time.time`` default; a deterministic clock
+                injected by tests need only be applied consistently, so it is
+                free to start at any origin.
+        """
+        self.storage = MemoryStorage()
+        self.item = RateLimitItemPerHour(INVALID_LICENSE_MAX_PER_HOUR)
+        self.last_attempt: dict[str, float] = {}
+        self.sweep_at: int = _SWEEP_MIN_TRACKED
+        self._limiter = MovingWindowRateLimiter(self.storage)
+        self._clock = clock
+
+    def record(self, throttle_key: str) -> bool:
+        """Charge one attempt against ``throttle_key``.
+
+        Args:
+            throttle_key: Grouped client key the attempt is charged to.
+
+        Returns:
+            True while the client remains under the hourly cap, False once the
+            cap is spent.
+        """
+        allowed = self._limiter.hit(self.item, throttle_key)
+        # Refreshed even when the attempt was denied, so retention follows the
+        # last attempt rather than the first: a client still hammering after
+        # spending its cap keeps its counter alive instead of ageing out of the
+        # store while it is actively abusing us.
+        self.last_attempt[throttle_key] = self._clock()
+        self._sweep_if_crowded()
+        return allowed
+
+    def exhausted(self, throttle_key: str) -> bool:
+        """Report whether ``throttle_key`` has already spent its hourly budget.
+
+        Args:
+            throttle_key: Grouped client key to peek at.
+
+        Returns:
+            True once the cap is spent. The peek consumes nothing and triggers
+            no sweep, so asking costs the client nothing.
+        """
+        return not self._limiter.test(self.item, throttle_key)
+
+    def reset(self) -> None:
+        """Drop every counter and return the sweep mark to its floor."""
+        self.storage.reset()
+        self.last_attempt.clear()
+        self.sweep_at = _SWEEP_MIN_TRACKED
+
+    def _sweep_if_crowded(self) -> None:
+        """Evict fully rolled-off keys once the tracked set reaches the mark."""
+        if len(self.last_attempt) < self.sweep_at:
+            return
+        now = self._clock()
+        expiry = self.item.get_expiry()
+        # Snapshot: the loop mutates the dict it is walking.
+        for throttle_key, last in list(self.last_attempt.items()):
+            # Strictly greater: the library's own membership test is inclusive
+            # (an entry still occupies a slot while ``atime >= now - expiry``),
+            # so an age of exactly one expiry can still be a live key. Past
+            # that, every entry's arrival time falls below the bound, which
+            # makes evicting a key the library would still count impossible.
+            if now - last > expiry:
+                self._forget(throttle_key)
+        self.sweep_at = max(_SWEEP_MIN_TRACKED, _SWEEP_GROWTH_FACTOR * len(self.last_attempt))
+
+    def _forget(self, throttle_key: str) -> None:
+        """Drop one key from the tracking map and from the event store.
+
+        Args:
+            throttle_key: Raw client key to evict. The store is keyed by the
+                item's namespaced form of it, so purging by the raw key would
+                silently leave the entry behind.
+        """
+        del self.last_attempt[throttle_key]
+        storage_key = self.item.key_for(throttle_key)
+        # Serialise against the library's background sweeper, which truncates
+        # this key's event list under this same lock after reading it; dropping
+        # the key between those two steps would raise on that thread.
+        with self.storage.locks[storage_key]:
+            self.storage.clear(storage_key)
+
+
+_invalid_license_throttle = _InvalidLicenseThrottle()
 
 
 def record_invalid_license_attempt(throttle_key: str) -> bool:
@@ -44,7 +176,7 @@ def record_invalid_license_attempt(throttle_key: str) -> bool:
     is recorded against the moving window); returns False once the cap is
     exceeded, at which point the caller should answer 429.
     """
-    return _invalid_license_limiter.hit(_INVALID_LICENSE_ITEM, throttle_key)
+    return _invalid_license_throttle.record(throttle_key)
 
 
 def invalid_license_cap_exhausted(throttle_key: str) -> bool:
@@ -59,9 +191,9 @@ def invalid_license_cap_exhausted(throttle_key: str) -> bool:
     ``record_invalid_license_attempt``, which the caller applies after a
     verify actually fails.
     """
-    return not _invalid_license_limiter.test(_INVALID_LICENSE_ITEM, throttle_key)
+    return _invalid_license_throttle.exhausted(throttle_key)
 
 
 def reset_invalid_license_attempts() -> None:
     """Clear every invalid-license counter (test isolation between cases)."""
-    _invalid_license_storage.reset()
+    _invalid_license_throttle.reset()

--- a/backend/tests/test_invalid_license_retention.py
+++ b/backend/tests/test_invalid_license_retention.py
@@ -1,0 +1,489 @@
+"""Retention bounds for the invalid-license hourly throttle.
+
+The throttle counts failed licence verifications per client so a brute-forcer
+cannot drive unbounded outbound Gumroad calls. Its backing ``MemoryStorage``
+empties an expired key's event list but never drops the key itself, so a
+long-lived process accumulates one dict entry per throttle key it has ever
+seen. These tests pin the bounded, self-sweeping store that replaces it: keys
+whose last attempt has rolled off the hourly window are evicted, live keys are
+never evicted, and the sweep threshold grows with the live population so
+sweeping stays amortised.
+
+The eviction rule is only safe because the throttle's recorded reading and the
+window entries it is compared against come from one clock. Tests that assert on
+that comparison hand the ``limits`` library the same fake clock the throttle
+runs on, so the whole inequality is executed rather than assumed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import limits.storage.memory
+import limits.strategies
+import pytest
+
+from rate_limit import (
+    _SWEEP_GROWTH_FACTOR,
+    _SWEEP_MIN_TRACKED,
+    INVALID_LICENSE_MAX_PER_HOUR,
+    _invalid_license_throttle,
+    _InvalidLicenseThrottle,
+    invalid_license_cap_exhausted,
+    record_invalid_license_attempt,
+    reset_invalid_license_attempts,
+)
+
+# One second either side of the expiry boundary, so a test can sit just inside
+# the window, exactly on it, or just past it without depending on wall-clock
+# timing.
+_EXPIRY_MARGIN_SECONDS = 1
+
+# How far the ticking clock moves on every read. Any positive step works; the
+# point is only that two successive reads return different values.
+_TICK_SECONDS = 1.0
+
+# Distinct never-seen keys the peek test asks about. More than the sweep floor,
+# so a peek that tracked its keys would trip a sweep as well as leaking them.
+_UNSEEN_PEEK_KEYS = _SWEEP_GROWTH_FACTOR * _SWEEP_MIN_TRACKED
+
+# Keys left standing by the sweep in the floor test. One is enough: the growth
+# factor applied to it lands far below the floor, so only the floor can explain
+# the mark the throttle reschedules at.
+_LONE_SURVIVORS = 1
+
+# Number of full key batches churned through the store in the bound test, and
+# the multiple of the sweep floor the resident set must stay under.
+_CHURN_BATCHES = 16
+_BOUND_MULTIPLE = 3
+
+# How many half-expiry rounds of denied attempts the refresh test drives, so
+# the key's first attempt ages out while its last attempt stays recent.
+_DENIAL_ROUNDS = 3
+
+# Peeks taken mid-budget to prove the non-consuming read really consumes
+# nothing.
+_PEEK_REPEATS = 20
+
+
+class FakeClock:
+    """Deterministic stand-in for ``time.time`` used as an injected clock."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        """Create a clock parked at ``start``.
+
+        Args:
+            start: Initial reading, in seconds.
+        """
+        self.now = start
+
+    def __call__(self) -> float:
+        """Read the clock.
+
+        Returns:
+            The current reading, in seconds.
+        """
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        """Move the clock forward.
+
+        Args:
+            seconds: How many seconds to add to the current reading.
+        """
+        self.now += seconds
+
+
+class TickingClock:
+    """Clock that steps forward on every read.
+
+    A clock that returns the same reading twice cannot show which of two calls
+    happened first. Stepping on each read records the order of the throttle's
+    own reads and the ones ``limits`` takes into the values themselves, which
+    is what makes an ordering assertion possible.
+    """
+
+    def __init__(self, step: float = _TICK_SECONDS) -> None:
+        """Create a clock at zero that steps by ``step`` per read.
+
+        Args:
+            step: Seconds added to the reading after each read.
+        """
+        self.now = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        """Read the clock and advance it.
+
+        Returns:
+            The reading as it stood before this call's step was applied.
+        """
+        reading = self.now
+        self.now += self.step
+        return reading
+
+
+class FakeTimeModule:
+    """Stand-in for the ``time`` module exposing only what ``limits`` reads."""
+
+    def __init__(self, clock: Callable[[], float]) -> None:
+        """Wrap ``clock`` in the module surface ``limits`` calls.
+
+        Args:
+            clock: Source of the current time, in seconds.
+        """
+        self.clock = clock
+
+    def time(self) -> float:
+        """Read the wrapped clock.
+
+        Returns:
+            The current reading, in seconds.
+        """
+        return self.clock()
+
+
+def _share_clock_with_limits(monkeypatch: pytest.MonkeyPatch, clock: Callable[[], float]) -> None:
+    """Make the ``limits`` library read ``clock`` instead of the wall clock.
+
+    The throttle's safety argument compares readings it took itself against the
+    arrival times ``limits`` stamps on its window entries, so the two must come
+    from one clock for a test to observe the comparison at all. The module
+    attribute is replaced wholesale rather than patched onto the real ``time``
+    module, which would hand a fake clock to every other importer in the
+    process.
+
+    Args:
+        monkeypatch: Patcher whose undo restores the real module on teardown.
+        clock: Source of the current time, in seconds, to install.
+    """
+    fake_time = FakeTimeModule(clock)
+    # The moving window reads the clock through the storage today; patching the
+    # strategy module too, which also binds ``time`` at import, keeps the shared
+    # clock honest if that ever changes.
+    monkeypatch.setattr(limits.storage.memory, "time", fake_time, raising=True)
+    monkeypatch.setattr(limits.strategies, "time", fake_time, raising=True)
+
+
+def _record_batch(throttle: _InvalidLicenseThrottle, prefix: str, count: int) -> list[str]:
+    """Record one attempt against ``count`` distinct keys sharing ``prefix``.
+
+    Args:
+        throttle: The throttle under test.
+        prefix: Namespace for the generated keys, unique per batch.
+        count: How many distinct keys to record.
+
+    Returns:
+        The keys that were recorded, in order.
+    """
+    keys = [f"{prefix}-{index}" for index in range(count)]
+    for key in keys:
+        throttle.record(key)
+    return keys
+
+
+def _force_sweep(throttle: _InvalidLicenseThrottle, prefix: str) -> list[str]:
+    """Record just enough fresh keys to push the throttle over its sweep mark.
+
+    Args:
+        throttle: The throttle under test.
+        prefix: Namespace for the generated keys, unique per call.
+
+    Returns:
+        The fresh keys recorded to trigger the sweep.
+
+    Raises:
+        AssertionError: If the throttle has already reached its mark, in which
+            case this call would record nothing and the caller's "and then it
+            sweeps" would be a silent no-op.
+    """
+    needed = throttle.sweep_at - len(throttle.last_attempt)
+    assert needed > 0
+    return _record_batch(throttle, prefix, needed)
+
+
+def test_rolled_off_keys_are_dropped_from_the_event_store() -> None:
+    """Keys whose last attempt predates the window leave both stores."""
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+
+    old_keys = _record_batch(throttle, "old", _SWEEP_MIN_TRACKED // 2)
+    clock.advance(expiry + _EXPIRY_MARGIN_SECONDS)
+    fresh_keys = _force_sweep(throttle, "fresh")
+
+    for key in old_keys:
+        assert key not in throttle.last_attempt
+        assert throttle.item.key_for(key) not in throttle.storage.events
+    for key in fresh_keys:
+        assert key in throttle.last_attempt
+        assert throttle.item.key_for(key) in throttle.storage.events
+
+
+def test_store_size_stays_bounded_under_key_churn() -> None:
+    """The resident key set stays bounded however many keys pass through.
+
+    This is the leak itself: today every distinct throttle key ever seen keeps
+    a permanent entry in the storage's event dict, so the store grows with
+    total traffic rather than with the number of currently rate-limited
+    clients.
+    """
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+
+    for batch in range(_CHURN_BATCHES):
+        _record_batch(throttle, f"batch-{batch}", _SWEEP_MIN_TRACKED)
+        clock.advance(expiry + _EXPIRY_MARGIN_SECONDS)
+
+    distinct_keys_seen = _CHURN_BATCHES * _SWEEP_MIN_TRACKED
+    bound = _BOUND_MULTIPLE * _SWEEP_MIN_TRACKED
+    assert len(throttle.storage.events) <= bound
+    # The storage keeps a second per-key dict of locks, which grows just as
+    # unboundedly as the events if eviction empties one without dropping the
+    # other. Only the library's own clear covers both.
+    assert len(throttle.storage.locks) <= bound
+    assert len(throttle.last_attempt) <= bound
+    assert distinct_keys_seen > _BOUND_MULTIPLE * bound
+
+
+def test_live_key_keeps_its_spent_cap_across_a_sweep() -> None:
+    """A sweep must never hand an exhausted client a fresh hourly budget.
+
+    An attacker who has spent their cap must not be able to clear their own
+    counter by spraying unrelated keys until the store sweeps. The throttle
+    runs on the real clock here, so no key has aged out and eviction of the
+    exhausted key would be a security regression rather than housekeeping.
+    """
+    throttle = _InvalidLicenseThrottle()
+    victim = "victim-client"
+
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR):
+        assert throttle.record(victim) is True
+    assert throttle.record(victim) is False
+
+    _record_batch(throttle, "spray", _SWEEP_GROWTH_FACTOR * _SWEEP_MIN_TRACKED)
+
+    assert throttle.sweep_at > _SWEEP_MIN_TRACKED
+    assert throttle.exhausted(victim) is True
+    assert throttle.record(victim) is False
+    assert victim in throttle.last_attempt
+    assert throttle.item.key_for(victim) in throttle.storage.events
+
+
+def test_key_inside_the_window_is_not_evicted_at_the_boundary() -> None:
+    """Eviction waits for the age to pass a full expiry, not merely reach it.
+
+    The boundary is exclusive because the library's own membership test is
+    inclusive: ``MemoryStorage`` still treats an entry as occupying a slot
+    while its arrival time is no older than exactly one expiry. A key whose
+    last attempt sits precisely on that bound can therefore still be holding
+    its spent cap, and evicting it there would refill an attacker's budget one
+    tick early. Only a strictly greater age proves every entry has left the
+    window, so the throttle must be the stricter of the two.
+    """
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+    survivor = "boundary-client"
+
+    throttle.record(survivor)
+    clock.advance(expiry)
+    _force_sweep(throttle, "on-boundary")
+
+    assert survivor in throttle.last_attempt
+    assert throttle.item.key_for(survivor) in throttle.storage.events
+
+    clock.advance(_EXPIRY_MARGIN_SECONDS)
+    _force_sweep(throttle, "past-boundary")
+
+    assert survivor not in throttle.last_attempt
+    assert throttle.item.key_for(survivor) not in throttle.storage.events
+
+
+def test_last_attempt_is_stamped_after_the_hit_it_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recorded reading lands at or after the newest window entry.
+
+    This inequality is the whole eviction proof. The stamp is taken from the
+    window's own clock *after* the hit that adds the entry, so it is never
+    older than that entry's arrival time; an age past a full expiry therefore
+    proves every entry has already rolled off. Stamping before the hit would
+    invert the inequality and let a sweep evict a key the library still counts,
+    which is an attacker clearing their own counter. The clock steps on every
+    read, so the two orderings yield different readings and this assertion can
+    tell them apart -- and because the library reads that same clock, the
+    comparison is between two genuinely comparable numbers rather than two
+    unrelated timelines.
+    """
+    clock = TickingClock()
+    _share_clock_with_limits(monkeypatch, clock)
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    key = "stamp-order-client"
+
+    assert throttle.record(key) is True
+
+    entries = throttle.storage.events[throttle.item.key_for(key)]
+    assert len(entries) == 1
+    assert throttle.last_attempt[key] >= max(entry.atime for entry in entries)
+
+
+def test_the_window_itself_counts_a_key_until_the_expiry_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spent client is still refused for the whole window, per the library.
+
+    "Still live" has to mean what ``limits`` means by it, not merely what the
+    throttle's own bookkeeping claims. Sharing one clock puts that to the test:
+    a client that has spent its cap is still exhausted a second short of a full
+    expiry, and is refilled only once the window has genuinely rolled past. The
+    retention rule is calibrated against this, so if the two ever disagreed the
+    store would be evicting keys the library would still charge.
+    """
+    clock = FakeClock()
+    _share_clock_with_limits(monkeypatch, clock)
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+    spender = "window-client"
+
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR):
+        assert throttle.record(spender) is True
+    assert throttle.record(spender) is False
+
+    clock.advance(expiry - _EXPIRY_MARGIN_SECONDS)
+    assert throttle.exhausted(spender) is True
+
+    # One further second carries the clock past the boundary itself.
+    clock.advance(_EXPIRY_MARGIN_SECONDS + _EXPIRY_MARGIN_SECONDS)
+    assert throttle.exhausted(spender) is False
+
+
+def test_peeking_at_unseen_keys_allocates_nothing() -> None:
+    """The exhaustion peek is free: it tracks no key and schedules no sweep.
+
+    Every signup attempt peeks before any outbound call is made, so a peek that
+    stamped its key would reintroduce exactly the unbounded growth this store
+    exists to close -- on the hottest path in the flow, keyed by whatever
+    arrives. Nothing may be allocated for a key that has never failed a
+    verification.
+    """
+    throttle = _InvalidLicenseThrottle()
+
+    for index in range(_UNSEEN_PEEK_KEYS):
+        assert throttle.exhausted(f"unseen-{index}") is False
+
+    assert throttle.last_attempt == {}
+    assert len(throttle.storage.events) == 0
+    assert len(throttle.storage.locks) == 0
+    assert throttle.sweep_at == _SWEEP_MIN_TRACKED
+
+
+def test_denied_attempts_keep_the_key_tracked() -> None:
+    """Retention follows the last attempt, not the first.
+
+    A client that keeps hammering after exhausting its cap has a first attempt
+    far outside the window but a very recent last attempt. Refreshing on a
+    denied attempt only ever delays eviction, which is the safe direction: it
+    keeps the counter alive for an actively abusive client.
+    """
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+    half_expiry = expiry // 2
+    persistent = "persistent-client"
+
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR):
+        assert throttle.record(persistent) is True
+    for _ in range(_DENIAL_ROUNDS):
+        clock.advance(half_expiry)
+        assert throttle.record(persistent) is False
+
+    assert _DENIAL_ROUNDS * half_expiry > expiry
+    _force_sweep(throttle, "churn")
+
+    assert persistent in throttle.last_attempt
+    assert throttle.item.key_for(persistent) in throttle.storage.events
+
+
+def test_sweep_threshold_grows_with_the_live_population() -> None:
+    """The next sweep is scheduled off the surviving population, not a constant.
+
+    Rescheduling at a multiple of the live count amortises sweeping: a store
+    holding many genuinely active clients does not pay a full scan on every
+    recorded attempt.
+    """
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+
+    _record_batch(throttle, "doomed", _SWEEP_MIN_TRACKED)
+    clock.advance(expiry + _EXPIRY_MARGIN_SECONDS)
+    survivors = _force_sweep(throttle, "live")
+
+    assert set(throttle.last_attempt) == set(survivors)
+    assert throttle.sweep_at == max(_SWEEP_MIN_TRACKED, _SWEEP_GROWTH_FACTOR * len(survivors))
+    assert throttle.sweep_at > _SWEEP_MIN_TRACKED
+
+
+def test_the_sweep_mark_never_falls_below_its_floor() -> None:
+    """A sweep that leaves almost nobody behind reschedules at the floor.
+
+    The growth factor alone would collapse the mark toward zero as a burst
+    drained away, and a near-empty store would then rescan itself on every
+    single recorded attempt. The floor is what keeps a quiet deployment from
+    sweeping constantly, so it has to be the thing setting the mark here rather
+    than a multiple that happens to be large enough.
+    """
+    clock = FakeClock()
+    throttle = _InvalidLicenseThrottle(clock=clock)
+    expiry = throttle.item.get_expiry()
+
+    doomed = _record_batch(throttle, "doomed", _SWEEP_MIN_TRACKED - _LONE_SURVIVORS)
+    clock.advance(expiry + _EXPIRY_MARGIN_SECONDS)
+    survivors = _record_batch(throttle, "survivor", _LONE_SURVIVORS)
+
+    assert len(doomed) + len(survivors) == _SWEEP_MIN_TRACKED
+    assert set(throttle.last_attempt) == set(survivors)
+    assert _SWEEP_GROWTH_FACTOR * len(survivors) < _SWEEP_MIN_TRACKED
+    assert throttle.sweep_at == _SWEEP_MIN_TRACKED
+
+
+def test_reset_clears_the_store_the_tracking_and_the_threshold() -> None:
+    """Reset restores a pristine throttle, which test isolation depends on."""
+    for index in range(_SWEEP_MIN_TRACKED):
+        record_invalid_license_attempt(f"reset-{index}")
+    exhausted_key = "reset-0"
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR):
+        record_invalid_license_attempt(exhausted_key)
+
+    assert invalid_license_cap_exhausted(exhausted_key) is True
+    assert _invalid_license_throttle.sweep_at > _SWEEP_MIN_TRACKED
+
+    reset_invalid_license_attempts()
+
+    assert _invalid_license_throttle.last_attempt == {}
+    assert len(_invalid_license_throttle.storage.events) == 0
+    assert _invalid_license_throttle.sweep_at == _SWEEP_MIN_TRACKED
+    assert invalid_license_cap_exhausted(exhausted_key) is False
+    assert record_invalid_license_attempt(exhausted_key) is True
+
+
+def test_facade_cap_contract_is_unchanged() -> None:
+    """The public hourly cap behaves exactly as before the store was bounded."""
+    client = "facade-client"
+    assert invalid_license_cap_exhausted(client) is False
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR):
+        assert record_invalid_license_attempt(client) is True
+    assert record_invalid_license_attempt(client) is False
+    assert invalid_license_cap_exhausted(client) is True
+
+    peeker = "facade-peeker"
+    spent = INVALID_LICENSE_MAX_PER_HOUR // 2
+    for _ in range(spent):
+        assert record_invalid_license_attempt(peeker) is True
+    for _ in range(_PEEK_REPEATS):
+        assert invalid_license_cap_exhausted(peeker) is False
+    for _ in range(INVALID_LICENSE_MAX_PER_HOUR - spent):
+        assert record_invalid_license_attempt(peeker) is True
+    assert record_invalid_license_attempt(peeker) is False


### PR DESCRIPTION
## Summary

The hourly invalid-license throttle runs a `MovingWindowRateLimiter` over
`MemoryStorage`. That storage's sweeper truncates an expired key's event list
to empty and pops its lock, but it never pops the key from `events` itself, so
every distinct throttle key the process had ever seen stayed resident for the
life of the process. On a long-lived deployment that is not a bound at all.

This wraps the throttle in a store that evicts. It remembers when each key was
last charged and, once the tracked set reaches a mark, drops the keys whose
window has fully rolled off — purging them through the library's own `clear()`,
which covers the `events`, `locks`, `storage` and `expirations` dicts alike.
Emptying only `events` would have left `locks` growing just as unboundedly;
there is a test for that. The mark then reschedules at twice the surviving
population, so sweeping costs amortised constant time per attempt rather than a
full scan each time, and an attacker cannot pin the store above a fixed
threshold to force one on every request.

**Eviction is provably never premature**, which is the whole difficulty here:
this cap gates outbound Gumroad calls (#2028), so a client who could provoke
eviction of their own live counter would have found a way to refill their
budget. The argument, and the tests that execute it rather than assume it:

- The recorded reading comes from the same wall clock the moving window stamps
  its entries with, and it is taken *after* the hit, so it is never older than
  the newest entry. A test shares one ticking clock with `limits` and asserts
  `last_attempt[key] >= max(entry.atime)` — swapping those two statements in
  `record()` silently inverts the inequality and now fails.
- The comparison is **strictly** greater than one full expiry, because the
  library's own membership test is inclusive (`atime >= now - expiry`): a key
  sitting precisely on the bound may still be live. Past it, every entry has
  provably left the window and the key carries no information.
- Denied attempts refresh the reading too, which only ever *delays* eviction —
  the safe direction, and it keeps the counter alive for a client that is
  actively hammering.

The cap itself is untouched. `INVALID_LICENSE_MAX_PER_HOUR`, both 429 paths,
the non-consuming peek and the three public functions keep their exact names,
signatures and behaviour, so `conftest.py` and `routers/auth.py` needed no
change. The moving window is deliberately retained rather than traded for a
swept fixed-window strategy, which would have handed a brute-forcer twice the
cap across a window boundary — that would have been a weakening of a security
control in a change scoped to retention.

**Known limit, stated plainly:** the store is bounded by *peak* concurrent
population, not current. The mark ratchets up on a sweep and never shrinks, so
a burst's dead keys stay resident until traffic climbs back to that peak. That
closes the unbounded-forever leak, which is what was wrong; a shrinking mark
was judged out of scope and is documented in the class docstring rather than
left implicit.

## Test plan

New `backend/tests/test_invalid_license_retention.py`, 12 tests, all pinning
retention and liveness directly rather than through a proxy like "the endpoint
still 429s":

- **The bound:** 16 batches x 64 distinct keys (1024 total) with the window
  rolling between batches leaves 64 keys resident in `storage.events`,
  `storage.locks` and the tracking map. Measured empirically both ways — with
  the sweep disabled the same scenario retains all 1024, which is the bug.
- **The security guard:** an exhausted client sprays 128 unrelated keys to
  force sweeps and is still refused; its counter and store entry survive.
- **Boundary:** retained at an age of exactly one expiry, evicted past it.
- **Liveness per the library, not just per our bookkeeping:** with the clock
  shared with `limits`, a spent client is still exhausted at `expiry - 1` and
  refilled only after the window genuinely rolls past.
- **The peek is free:** 128 peeks at never-seen keys allocate nothing — this is
  the path every signup attempt takes before any egress, so a peek that tracked
  its keys would reintroduce the same unbounded growth on the hottest path.
- Plus the stamp-ordering invariant, the sweep-mark floor and growth,
  refresh-on-denial, `reset()`, and the unchanged public cap contract.

Each new test was mutation-checked against a throwaway copy of the module: the
swapped stamp/hit order, a stamping `exhausted()`, an events-only purge, a
floor-less reschedule and the `>=` predicate each die on exactly one assertion.

Gates, all run locally on the final state:

- `lint.sh --check`, `format.sh --check`, `typecheck.sh` (mypy strict, 186
  files), `security.sh` (bandit + pip-audit) — green. Also linted with the
  pinned ruff 0.16.0 rather than the stale local venv.
- `xenon --max-absolute A --max-modules A --max-average A src/` and
  `radon mi src/ -n B` — clean (these are not covered by `check-all.sh`).
- `interrogate` 96.6%.
- `test.sh --unit`: **3398 passed, 2 skipped**, total coverage 97.00%;
  `src/rate_limit.py` at **100% line and 100% branch**. The new file was rerun
  3x under random ordering with no flakes. (The repo has no `integration`- or
  `e2e`-marked tests, so this run is the whole suite; `coverage.sh` would be an
  identical second pass.)

Closes #2010
