### PR TITLE
fix(tooling): fail check-all when the venv drifts from the pinned requirements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ adepthood/
 # Environment setup (idempotent)
 source .venv/bin/activate           # ALWAYS activate before Python work
 pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+# Installs what is missing but never what is stale; scripts/backend/deps.sh fails the gate on drift
 
 # Quality checks
 pre-commit run --all-files          # Run ALL hooks — do this before every commit

--- a/backend/scripts/check_dependency_drift.py
+++ b/backend/scripts/check_dependency_drift.py
@@ -1,0 +1,584 @@
+"""Fail the backend gate when the active virtualenv drifts from the pinned set.
+
+Every local quality gate measures the packages that are *installed*, not the
+packages that are *pinned*. When those two sets disagree, Gate 2 stops
+predicting Gate 3: a suite can pass locally against an old uvicorn and then
+raise ``AttributeError`` on every CI job, with a green checkmark in between.
+The documented setup command (``pip install -r requirements.txt -r
+requirements-dev.txt``) installs what is missing but never reports what is
+stale, which is what kept the drift invisible.
+
+This check therefore runs first, before anything that would spend minutes
+measuring a lie. It reads already-installed metadata through
+``importlib.metadata`` — no subprocess, no ``pip``, no network — so it costs
+milliseconds. It deliberately does **not** repair the environment: the
+virtualenv is shared by parallel worktrees, so installing mid-run would race
+its siblings. It reports and fails; the operator runs the fix.
+
+The design constraint that shapes every branch below is that this check must
+never fail open. A gate that reports success while having verified nothing is
+worse than no gate at all, because it manufactures confidence. So a package
+that is missing entirely counts as drift, and any line the parser cannot
+interpret — an environment marker, a version range, an unreadable file —
+counts as "could not verify" rather than "fine". The same rule decides the
+emptiest case: a run that ends up comparing no pins at all has learned
+nothing, so it says exactly that instead of claiming everything matched.
+
+Usage:
+
+    python -m scripts.check_dependency_drift                    # the backend pins
+    python -m scripts.check_dependency_drift path/to/reqs.txt   # explicit files
+
+Exit codes:
+    0 — every pin matches the installed distribution.
+    1 — at least one pinned package is missing or at the wrong version.
+    2 — the pin set could not be fully evaluated (unparseable line, missing
+        file, two files pinning one package to different versions, or no pins
+        found to compare at all). No drift was proven, but none was ruled out
+        either.
+    Both non-zero codes fail the gate; the split exists only to tell an
+    operator whether to reinstall or to fix the requirements files.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass, field
+from importlib import metadata
+from pathlib import Path
+
+EXIT_CLEAN = 0
+EXIT_DRIFT = 1
+EXIT_UNVERIFIABLE = 2
+
+REMEDIATION_COMMAND = "pip install -r backend/requirements.txt -r backend/requirements-dev.txt"
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REQUIREMENTS_FILES: tuple[Path, ...] = (
+    _BACKEND_ROOT / "requirements.txt",
+    _BACKEND_ROOT / "requirements-dev.txt",
+)
+
+_MARKER_REASON = (
+    "environment markers are not evaluated by this check; "
+    "extend check_dependency_drift.py or restate the pin without a marker"
+)
+_NOT_A_PIN_REASON = "not an exact == pin"
+_UNSUPPORTED_OPTION_REASON = "unsupported option line"
+_MISSING_FILE_REASON = "requirements file not found"
+
+_NOT_INSTALLED = "(not installed)"
+_NOTHING_VERIFIED = "No pinned packages were found to compare; nothing was verified.\n"
+
+_COMMENT_PREFIX = "#"
+_OPTION_PREFIX = "-"
+_MARKER_SEPARATOR = ";"
+_INCLUDE_OPTIONS = ("-r", "--requirement")
+# An include is the option token plus exactly one path argument.
+_INCLUDE_TOKEN_COUNT = 2
+# Line number reserved for findings about a whole file rather than a line in it.
+_WHOLE_FILE = 0
+
+# ``name[extras]==version``. Anything looser (>=, ~=, a bare name, a URL) is
+# deliberately rejected so it surfaces as unevaluated instead of passing.
+_EXACT_PIN = re.compile(
+    r"^(?P<name>[A-Za-z0-9._-]+)\s*(?:\[[^\]]*\])?\s*==\s*(?P<version>\S+)$",
+)
+_NAME_SEPARATORS = re.compile(r"[-_.]+")
+
+
+@dataclass(frozen=True)
+class PinnedRequirement:
+    """One ``name==version`` pin, with the file and line it came from."""
+
+    name: str
+    version: str
+    source: Path
+    line_number: int
+
+
+@dataclass(frozen=True)
+class Drift:
+    """A pin whose installed version disagrees with the pinned one.
+
+    ``installed`` is ``None`` when the distribution is absent entirely, which
+    is drift rather than an excuse to skip the comparison.
+    """
+
+    name: str
+    pinned: str
+    installed: str | None
+
+
+@dataclass(frozen=True)
+class Unevaluated:
+    """A requirement line the checker declined to interpret, and why.
+
+    ``line_number`` is 0 for findings about a whole file (a path that does not
+    exist), in which case ``text`` repeats the path that was looked up.
+    """
+
+    source: Path
+    line_number: int
+    text: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ConflictingPin:
+    """Two files pinning one package to different versions.
+
+    An unsatisfiable pin set has no "does the install match?" answer to give,
+    so the package is excluded from the drift comparison and reported instead.
+    """
+
+    name: str
+    first: PinnedRequirement
+    second: PinnedRequirement
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """The full outcome of one run: what matched, what drifted, what could not be read."""
+
+    checked: int
+    drifted: tuple[Drift, ...]
+    unevaluated: tuple[Unevaluated, ...]
+    conflicts: tuple[ConflictingPin, ...]
+
+    @property
+    def exit_code(self) -> int:
+        """Return the process exit code for this report."""
+        return _grade(self)
+
+
+def _grade(report: DriftReport) -> int:
+    """Decide a report's exit code, with proven drift outranking uncertainty.
+
+    Args:
+        report: The report to grade.
+
+    Returns:
+        ``EXIT_DRIFT`` when any pin mismatched, ``EXIT_UNVERIFIABLE`` when the
+        pin set could not be fully read — including when there was nothing to
+        compare, since having checked nothing must never be reported the same
+        way as having checked everything and found it sound — and
+        ``EXIT_CLEAN`` only when real pins were compared and all of them held.
+    """
+    if report.drifted:
+        return EXIT_DRIFT
+    if report.unevaluated or report.conflicts or not report.checked:
+        return EXIT_UNVERIFIABLE
+    return EXIT_CLEAN
+
+
+@dataclass(frozen=True)
+class _Include:
+    """A ``-r``/``--requirement`` directive pointing at another requirements file."""
+
+    target: Path
+
+
+@dataclass
+class _Collected:
+    """Mutable accumulator threaded through the recursive file walk."""
+
+    pins: list[PinnedRequirement] = field(default_factory=list)
+    unevaluated: list[Unevaluated] = field(default_factory=list)
+    visited: set[Path] = field(default_factory=set)
+
+
+def normalize_name(name: str) -> str:
+    """Return the PEP 503 normalised form of a distribution name.
+
+    Args:
+        name: A distribution name as spelled in a requirements file.
+
+    Returns:
+        The lowercased name with every run of ``-``, ``_``, or ``.``
+        collapsed to a single ``-``, so ``PyJWT`` and ``pyjwt`` compare equal.
+    """
+    return _NAME_SEPARATORS.sub("-", name).lower()
+
+
+def installed_version(name: str) -> str | None:
+    """Return the installed version of a distribution, or ``None`` if absent.
+
+    Reads the metadata the interpreter already has on disk. It never shells
+    out to ``pip`` and never touches the network, both because this runs at
+    the head of every gate and because the environment is shared.
+
+    Args:
+        name: The distribution name to look up.
+
+    Returns:
+        The installed version string, or ``None`` when the distribution is
+        not installed in the active environment.
+    """
+    try:
+        found = metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+    return found
+
+
+def iter_requirement_lines(path: Path) -> Iterator[tuple[int, str]]:
+    """Yield the meaningful lines of a requirements file.
+
+    Args:
+        path: An existing requirements file.
+
+    Yields:
+        ``(line_number, text)`` pairs — 1-based line numbers and stripped
+        text — for every line that is neither blank nor a whole-line comment.
+    """
+    for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw.strip()
+        if stripped and not stripped.startswith(_COMMENT_PREFIX):
+            yield number, stripped
+
+
+def parse_pin(source: Path, line_number: int, text: str) -> PinnedRequirement | Unevaluated:
+    """Parse one non-option requirement line into a pin, or explain the refusal.
+
+    Args:
+        source: The file the line came from.
+        line_number: The 1-based line number within that file.
+        text: The stripped line, possibly carrying a trailing inline comment.
+
+    Returns:
+        A :class:`PinnedRequirement` for an exact ``name[extras]==version``
+        pin, otherwise an :class:`Unevaluated` naming the reason: an
+        environment marker this checker does not evaluate, or a requirement
+        that is not an exact pin at all.
+    """
+    requirement = text.split(_COMMENT_PREFIX, 1)[0].strip()
+    if _MARKER_SEPARATOR in requirement:
+        return Unevaluated(
+            source=source,
+            line_number=line_number,
+            text=requirement,
+            reason=_MARKER_REASON,
+        )
+    match = _EXACT_PIN.match(requirement)
+    if match is None:
+        return Unevaluated(
+            source=source,
+            line_number=line_number,
+            text=requirement,
+            reason=_NOT_A_PIN_REASON,
+        )
+    return PinnedRequirement(
+        name=normalize_name(match["name"]),
+        version=match["version"],
+        source=source,
+        line_number=line_number,
+    )
+
+
+def _parse_option(source: Path, line_number: int, text: str) -> _Include | Unevaluated:
+    """Interpret a leading-dash line as an include, or decline to interpret it.
+
+    Args:
+        source: The file the line came from.
+        line_number: The 1-based line number within that file.
+        text: The stripped line, starting with ``-``.
+
+    Returns:
+        An :class:`_Include` whose target is resolved relative to the
+        *including* file's directory, or an :class:`Unevaluated` for any other
+        option (index URLs, editable installs, hash modes).
+    """
+    tokens = text.split()
+    if len(tokens) >= _INCLUDE_TOKEN_COUNT and tokens[0] in _INCLUDE_OPTIONS:
+        return _Include(target=source.parent / tokens[1])
+    return Unevaluated(
+        source=source,
+        line_number=line_number,
+        text=text,
+        reason=_UNSUPPORTED_OPTION_REASON,
+    )
+
+
+def classify_line(
+    source: Path,
+    line_number: int,
+    text: str,
+) -> PinnedRequirement | Unevaluated | _Include:
+    """Classify one meaningful requirements line.
+
+    Args:
+        source: The file the line came from.
+        line_number: The 1-based line number within that file.
+        text: The stripped line.
+
+    Returns:
+        An :class:`_Include` to recurse into, a :class:`PinnedRequirement` to
+        compare, or an :class:`Unevaluated` to report.
+    """
+    if text.startswith(_OPTION_PREFIX):
+        return _parse_option(source, line_number, text)
+    return parse_pin(source, line_number, text)
+
+
+def _parse_file(path: Path, collected: _Collected) -> None:
+    """Walk one requirements file, following includes, into ``collected``.
+
+    Args:
+        path: The file to read. A path that does not exist is recorded as an
+            unevaluated finding rather than raised, so a dangling include
+            never turns the gate into a traceback.
+        collected: The accumulator to append pins and findings to.
+    """
+    # Cycle and diamond guard. Resolved only for identity: the *reported*
+    # paths stay as written, since a resolved path can surprise the reader
+    # (on macOS, /var silently becomes /private/var).
+    identity = path.resolve()
+    if identity in collected.visited:
+        return
+    collected.visited.add(identity)
+
+    if not path.is_file():
+        collected.unevaluated.append(
+            Unevaluated(
+                source=path,
+                line_number=_WHOLE_FILE,
+                text=str(path),
+                reason=_MISSING_FILE_REASON,
+            ),
+        )
+        return
+
+    for number, text in iter_requirement_lines(path):
+        _record(classify_line(path, number, text), collected)
+
+
+def _record(item: PinnedRequirement | Unevaluated | _Include, collected: _Collected) -> None:
+    """File one classified line into the accumulator, recursing into includes.
+
+    Args:
+        item: The classification produced by :func:`classify_line`.
+        collected: The accumulator to append to.
+    """
+    if isinstance(item, _Include):
+        _parse_file(item.target, collected)
+    elif isinstance(item, PinnedRequirement):
+        collected.pins.append(item)
+    else:
+        collected.unevaluated.append(item)
+
+
+def _index_pins(
+    pins: Sequence[PinnedRequirement],
+) -> tuple[dict[str, PinnedRequirement], tuple[ConflictingPin, ...]]:
+    """Deduplicate pins by normalised name and detect disagreements.
+
+    Args:
+        pins: Every pin found, in file order, possibly with repeats.
+
+    Returns:
+        A ``(unique, conflicts)`` pair. ``unique`` maps each normalised name
+        to its first pin. A name repeated with the *same* version is agreement
+        (the real files pin uvicorn twice), not a conflict; a name repeated
+        with a different version yields one :class:`ConflictingPin`. A name
+        pinned to three or more different versions reports only the first
+        disagreement — it is excluded from the comparison either way, so the
+        extra detail would not change the verdict.
+    """
+    unique: dict[str, PinnedRequirement] = {}
+    conflicts: dict[str, ConflictingPin] = {}
+    for pin in pins:
+        first = unique.setdefault(pin.name, pin)
+        if first.version != pin.version:
+            conflicts.setdefault(pin.name, ConflictingPin(name=pin.name, first=first, second=pin))
+    return unique, tuple(conflicts.values())
+
+
+def _compare_pins(
+    unique: dict[str, PinnedRequirement],
+    conflicted: frozenset[str],
+    resolver: Callable[[str], str | None],
+) -> tuple[int, tuple[Drift, ...]]:
+    """Compare each unambiguous pin against the environment.
+
+    Args:
+        unique: Normalised name to pin, as built by :func:`_index_pins`.
+        conflicted: Names excluded from the comparison because their pins
+            disagree; they are neither checked nor counted.
+        resolver: Maps a normalised name to its installed version, or ``None``.
+
+    Returns:
+        A ``(checked, drifted)`` pair, with drifted entries sorted by name so
+        the rendered list scans alphabetically rather than in file order.
+    """
+    drifted: list[Drift] = []
+    checked = 0
+    for name, pin in unique.items():
+        if name in conflicted:
+            continue
+        checked += 1
+        found = resolver(name)
+        if found != pin.version:
+            drifted.append(Drift(name=name, pinned=pin.version, installed=found))
+    return checked, tuple(sorted(drifted, key=lambda item: item.name))
+
+
+def check_drift(
+    files: Sequence[Path],
+    *,
+    resolver: Callable[[str], str | None] = installed_version,
+) -> DriftReport:
+    """Compare the pins in ``files`` against the versions the resolver reports.
+
+    Args:
+        files: Requirements files to read. Includes are followed; a file
+            reached twice is read once.
+        resolver: Seam for the version lookup. Defaults to reading real
+            installed metadata; tests substitute a pure mapping so no
+            environment is read.
+
+    Returns:
+        A :class:`DriftReport` carrying every mismatch, every conflicting pin,
+        and every line that could not be evaluated.
+    """
+    collected = _Collected()
+    for path in files:
+        _parse_file(path, collected)
+
+    unique, conflicts = _index_pins(collected.pins)
+    conflicted = frozenset(conflict.name for conflict in conflicts)
+    checked, drifted = _compare_pins(unique, conflicted, resolver)
+
+    return DriftReport(
+        checked=checked,
+        drifted=drifted,
+        unevaluated=tuple(collected.unevaluated),
+        conflicts=conflicts,
+    )
+
+
+def _drift_lines(drifted: tuple[Drift, ...]) -> list[str]:
+    """Render the drift section, ending with the paste-ready fix command.
+
+    Args:
+        drifted: The mismatched packages, already sorted.
+
+    Returns:
+        The rendered lines, without trailing newlines.
+    """
+    verb = "package does" if len(drifted) == 1 else "packages do"
+    lines = [f"Dependency drift: {len(drifted)} {verb} not match the pins."]
+    lines.extend(
+        f"  {item.name}: pinned {item.pinned} / "
+        f"installed {item.installed if item.installed is not None else _NOT_INSTALLED}"
+        for item in drifted
+    )
+    lines.append(f"Fix: {REMEDIATION_COMMAND}")
+    return lines
+
+
+def _conflict_lines(conflicts: tuple[ConflictingPin, ...]) -> list[str]:
+    """Render the conflicting-pins section, citing both file:line locations.
+
+    Args:
+        conflicts: The packages pinned to more than one version.
+
+    Returns:
+        The rendered lines, without trailing newlines.
+    """
+    verb = "package is" if len(conflicts) == 1 else "packages are"
+    lines = [f"Conflicting pins: {len(conflicts)} {verb} pinned to different versions."]
+    lines.extend(
+        f"  {item.name}: {item.first.version} "
+        f"({item.first.source}:{item.first.line_number}) vs {item.second.version} "
+        f"({item.second.source}:{item.second.line_number})"
+        for item in conflicts
+    )
+    return lines
+
+
+def _unevaluated_lines(unevaluated: tuple[Unevaluated, ...]) -> list[str]:
+    """Render the could-not-verify section, quoting each offending line.
+
+    Args:
+        unevaluated: The requirement lines that were not evaluated.
+
+    Returns:
+        The rendered lines, without trailing newlines.
+    """
+    count = len(unevaluated)
+    lines = [f"Cannot verify the pinned set: {count} requirement line(s) were not evaluated."]
+    for item in unevaluated:
+        location = f"{item.source}"
+        if item.line_number != _WHOLE_FILE:
+            location = f"{location}:{item.line_number}"
+        lines.append(f"  {location}: {item.reason}")
+        lines.append(f"    {item.text}")
+    return lines
+
+
+def _finding_lines(report: DriftReport) -> list[str]:
+    """Render every non-empty finding section, in severity order.
+
+    Args:
+        report: The report to render.
+
+    Returns:
+        The rendered lines, empty when the run found nothing at all.
+    """
+    lines: list[str] = []
+    if report.drifted:
+        lines.extend(_drift_lines(report.drifted))
+    if report.conflicts:
+        lines.extend(_conflict_lines(report.conflicts))
+    if report.unevaluated:
+        lines.extend(_unevaluated_lines(report.unevaluated))
+    return lines
+
+
+def render_report(report: DriftReport) -> str:
+    """Render a report as the operator-facing text the gate prints.
+
+    Args:
+        report: The report to render.
+
+    Returns:
+        A newline-terminated block. A clean run is one reassuring line naming
+        how many pins were actually verified, so "checked nothing" can never
+        read the same as "checked everything" — and a run with nothing to
+        compare says so outright instead of borrowing that reassurance.
+    """
+    lines = _finding_lines(report)
+    if lines:
+        return "\n".join(lines) + "\n"
+    if not report.checked:
+        return _NOTHING_VERIFIED
+    return (
+        f"Dependency drift: none. {report.checked} pinned package(s) "
+        "match the active environment.\n"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the check over the given paths, or over the backend pin files.
+
+    Args:
+        argv: Requirements-file paths. ``None`` or empty means
+            ``DEFAULT_REQUIREMENTS_FILES``, read here rather than bound as a
+            default so callers and tests can redirect it.
+
+    Returns:
+        The report's exit code. The report goes to stdout when clean and to
+        stderr otherwise, so a failing gate's output is unambiguous.
+    """
+    paths = [Path(item) for item in argv] if argv else list(DEFAULT_REQUIREMENTS_FILES)
+    report = check_drift(paths)
+    stream = sys.stdout if report.exit_code == EXIT_CLEAN else sys.stderr
+    stream.write(render_report(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via tests/CLI
+    sys.exit(main(sys.argv[1:]))

--- a/backend/tests/scripts/test_check_dependency_drift.py
+++ b/backend/tests/scripts/test_check_dependency_drift.py
@@ -1,0 +1,814 @@
+"""Tests for ``backend/scripts/check_dependency_drift.py``.
+
+The shared virtualenv silently drifted away from the pinned requirements, so
+every local quality gate measured a dependency set CI never uses. The failure
+mode is the expensive kind: a test asserted on a uvicorn internal that exists
+in the installed version and was removed in the pinned one, so the full local
+suite passed while every CI job would have raised ``AttributeError``. Gate 2 is
+only worth running if it predicts Gate 3, and drift removes that faithfulness
+while leaving the green checkmark in place.
+
+These tests therefore pin the checker's *contract*, not the machine it runs on.
+Drift is proven exclusively with synthetic requirements files under ``tmp_path``
+plus a fake version resolver, because the real virtualenv is shared by parallel
+worktrees and must never be read for its drift status, let alone mutated. The
+only contact with the real environment is two ``importlib.metadata`` lookups: a
+package guaranteed to be installed (``pytest``) and one guaranteed not to be.
+Nothing here installs, upgrades, or removes anything.
+
+The zero-argument default path is exercised by monkeypatching the module-level
+constant rather than by running against the real requirements files, so the
+suite never depends on whether the current environment happens to be clean.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from scripts import check_dependency_drift as drift_module
+from scripts.check_dependency_drift import (
+    DEFAULT_REQUIREMENTS_FILES,
+    EXIT_CLEAN,
+    EXIT_DRIFT,
+    EXIT_UNVERIFIABLE,
+    REMEDIATION_COMMAND,
+    ConflictingPin,
+    Drift,
+    DriftReport,
+    PinnedRequirement,
+    Unevaluated,
+    check_drift,
+    installed_version,
+    main,
+    normalize_name,
+    render_report,
+)
+
+MARKER_REASON = (
+    "environment markers are not evaluated by this check; "
+    "extend check_dependency_drift.py or restate the pin without a marker"
+)
+NOT_A_PIN_REASON = "not an exact == pin"
+UNSUPPORTED_OPTION_REASON = "unsupported option line"
+MISSING_FILE_REASON = "requirements file not found"
+NOTHING_VERIFIED_REPORT = "No pinned packages were found to compare; nothing was verified.\n"
+ABSENT_PACKAGE = "adepthood-definitely-not-a-real-package"
+# Two distributions the test run itself guarantees: pytest is running, and
+# pluggy is the plugin system running it.
+PRESENT_PACKAGE = "pytest"
+OTHER_PRESENT_PACKAGE = "pluggy"
+
+
+def _write(path: Path, body: str) -> Path:
+    """Write a dedented requirements file and return its path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body).lstrip("\n"))
+    return path
+
+
+def _installed_pin(name: str) -> str:
+    """Return a one-pin requirements body matching the installed version of ``name``.
+
+    The CLI tests drive ``main``, which always uses the production resolver, so
+    their fixtures need a pin the environment genuinely satisfies. The version is
+    read at test time rather than hardcoded: hardcoding would break on the next
+    dependency bump and would smuggle an assertion about the shared virtualenv's
+    contents into a suite that must never make one. The tests below assert only
+    that the plumbing works, never which version is installed.
+    """
+    version = installed_version(name)
+    assert version is not None, f"{name} must be installed to exercise the real resolver"
+    return f"{name}=={version}\n"
+
+
+def _resolver(installed: dict[str, str]) -> Callable[[str], str | None]:
+    """Build a fake version resolver over a normalised-name mapping.
+
+    This is the seam that makes drift testable: no package metadata is read and
+    no environment is touched. Absent keys model a package that is not
+    installed at all.
+    """
+
+    def _lookup(name: str) -> str | None:
+        return installed.get(name)
+
+    return _lookup
+
+
+def test_exit_code_constants_are_the_documented_shell_codes() -> None:
+    """The three exit codes are the contract between the script and check-all.sh."""
+    assert EXIT_CLEAN == 0
+    assert EXIT_DRIFT == 1
+    assert EXIT_UNVERIFIABLE == 2
+
+
+def test_remediation_command_is_the_documented_reinstall() -> None:
+    """The operator must be able to paste the fix line without editing it."""
+    assert REMEDIATION_COMMAND == (
+        "pip install -r backend/requirements.txt -r backend/requirements-dev.txt"
+    )
+
+
+def test_clean_run_across_two_files_reports_no_drift(tmp_path: Path) -> None:
+    """Every pin in both files matching the environment is the silent, passing case."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        fastapi==0.139.2
+        """,
+    )
+    dev = _write(
+        tmp_path / "requirements-dev.txt",
+        """
+        pytest==9.1.1
+        """,
+    )
+
+    report = check_drift(
+        [runtime, dev],
+        resolver=_resolver({"uvicorn": "0.51.0", "fastapi": "0.139.2", "pytest": "9.1.1"}),
+    )
+
+    assert report.checked == 3
+    assert report.drifted == ()
+    assert report.unevaluated == ()
+    assert report.conflicts == ()
+    assert report.exit_code == EXIT_CLEAN
+    assert render_report(report) == (
+        "Dependency drift: none. 3 pinned package(s) match the active environment.\n"
+    )
+
+
+def test_single_drifted_pin_renders_the_actionable_block(tmp_path: Path) -> None:
+    """One stale package names itself, its two versions, and the exact fix command."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({"uvicorn": "0.44.0"}))
+
+    assert report.drifted == (Drift(name="uvicorn", pinned="0.51.0", installed="0.44.0"),)
+    assert report.checked == 1
+    assert report.exit_code == EXIT_DRIFT
+    assert render_report(report) == (
+        "Dependency drift: 1 package does not match the pins.\n"
+        "  uvicorn: pinned 0.51.0 / installed 0.44.0\n"
+        "Fix: pip install -r backend/requirements.txt -r backend/requirements-dev.txt\n"
+    )
+
+
+def test_multiple_drifted_pins_are_listed_sorted_by_name(tmp_path: Path) -> None:
+    """Offenders read alphabetically, not in file order, so scanning the list is easy."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        fastapi==0.139.2
+        sqlalchemy==2.0.51
+        """,
+    )
+
+    report = check_drift(
+        [runtime],
+        resolver=_resolver(
+            {"uvicorn": "0.44.0", "fastapi": "0.136.0", "sqlalchemy": "2.0.49"},
+        ),
+    )
+
+    assert set(report.drifted) == {
+        Drift(name="fastapi", pinned="0.139.2", installed="0.136.0"),
+        Drift(name="sqlalchemy", pinned="2.0.51", installed="2.0.49"),
+        Drift(name="uvicorn", pinned="0.51.0", installed="0.44.0"),
+    }
+    assert report.checked == 3
+    assert report.exit_code == EXIT_DRIFT
+    assert render_report(report) == (
+        "Dependency drift: 3 packages do not match the pins.\n"
+        "  fastapi: pinned 0.139.2 / installed 0.136.0\n"
+        "  sqlalchemy: pinned 2.0.51 / installed 2.0.49\n"
+        "  uvicorn: pinned 0.51.0 / installed 0.44.0\n"
+        f"Fix: {REMEDIATION_COMMAND}\n"
+    )
+
+
+def test_package_that_is_not_installed_is_drift_not_a_pass(tmp_path: Path) -> None:
+    """A pin with no installed version at all must fail closed, never read as clean."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({}))
+
+    assert report.drifted == (Drift(name="uvicorn", pinned="0.51.0", installed=None),)
+    assert report.exit_code == EXIT_DRIFT
+    assert render_report(report) == (
+        "Dependency drift: 1 package does not match the pins.\n"
+        "  uvicorn: pinned 0.51.0 / installed (not installed)\n"
+        f"Fix: {REMEDIATION_COMMAND}\n"
+    )
+
+
+def test_comments_and_blank_lines_are_skipped_and_inline_comments_stripped(
+    tmp_path: Path,
+) -> None:
+    """Real requirements files carry commentary; none of it may leak into a version."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        # runtime pins
+
+        uvicorn==0.51.0  # pinned for the proxy-headers API
+           # indented commentary about the next pin
+        fastapi==0.139.2
+        """,
+    )
+
+    report = check_drift(
+        [runtime],
+        resolver=_resolver({"uvicorn": "0.51.0", "fastapi": "0.139.2"}),
+    )
+
+    assert report.checked == 2
+    assert report.drifted == ()
+    assert report.unevaluated == ()
+    assert report.exit_code == EXIT_CLEAN
+
+
+def test_extras_are_stripped_from_the_compared_name(tmp_path: Path) -> None:
+    """``uvicorn[standard]`` installs metadata under ``uvicorn``; compare that name."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn[standard]==0.51.0
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({"uvicorn": "0.44.0"}))
+
+    assert report.drifted == (Drift(name="uvicorn", pinned="0.51.0", installed="0.44.0"),)
+    assert report.unevaluated == ()
+    assert report.checked == 1
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("uvicorn", "uvicorn"),
+        ("PyJWT", "pyjwt"),
+        ("types_jsonschema", "types-jsonschema"),
+        ("Types.JsonSchema", "types-jsonschema"),
+        ("ruamel__yaml", "ruamel-yaml"),
+        ("a-_.b", "a-b"),
+    ],
+)
+def test_normalize_name_applies_pep503_normalisation(raw: str, expected: str) -> None:
+    """Distribution names are case- and separator-insensitive; comparison must be too."""
+    assert normalize_name(raw) == expected
+
+
+def test_differently_spelled_same_package_dedups_to_one_pin(tmp_path: Path) -> None:
+    """``PyJWT`` and ``pyjwt`` are one package, so they are one checked pin."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        PyJWT==2.13.0
+        types_jsonschema==4.26.0
+        """,
+    )
+    dev = _write(
+        tmp_path / "requirements-dev.txt",
+        """
+        pyjwt==2.13.0
+        """,
+    )
+
+    report = check_drift(
+        [runtime, dev],
+        resolver=_resolver({"pyjwt": "2.13.0", "types-jsonschema": "4.26.0"}),
+    )
+
+    assert report.checked == 2
+    assert report.conflicts == ()
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_CLEAN
+
+
+def test_identical_pin_in_both_files_is_reported_once(tmp_path: Path) -> None:
+    """The real files pin uvicorn identically twice; that is agreement, not conflict."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        """,
+    )
+    dev = _write(
+        tmp_path / "requirements-dev.txt",
+        """
+        uvicorn==0.51.0
+        """,
+    )
+
+    report = check_drift([runtime, dev], resolver=_resolver({"uvicorn": "0.44.0"}))
+
+    assert report.checked == 1
+    assert report.conflicts == ()
+    assert report.drifted == (Drift(name="uvicorn", pinned="0.51.0", installed="0.44.0"),)
+    assert report.exit_code == EXIT_DRIFT
+
+
+def test_conflicting_pins_are_reported_and_excluded_from_the_comparison(
+    tmp_path: Path,
+) -> None:
+    """An unsatisfiable pin set has no "does the install match?" answer to give."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        # runtime pins
+        uvicorn==0.51.0
+        fastapi==0.139.2
+        """,
+    )
+    dev = _write(
+        tmp_path / "requirements-dev.txt",
+        """
+        # dev pins
+        pytest==9.1.1
+        uvicorn==0.44.0
+        """,
+    )
+
+    report = check_drift(
+        [runtime, dev],
+        resolver=_resolver({"uvicorn": "0.44.0", "fastapi": "0.139.2", "pytest": "9.1.1"}),
+    )
+
+    assert report.conflicts == (
+        ConflictingPin(
+            name="uvicorn",
+            first=PinnedRequirement(
+                name="uvicorn",
+                version="0.51.0",
+                source=runtime,
+                line_number=2,
+            ),
+            second=PinnedRequirement(
+                name="uvicorn",
+                version="0.44.0",
+                source=dev,
+                line_number=3,
+            ),
+        ),
+    )
+    assert report.drifted == ()
+    assert report.checked == 2
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert render_report(report) == (
+        "Conflicting pins: 1 package is pinned to different versions.\n"
+        f"  uvicorn: 0.51.0 ({runtime}:2) vs 0.44.0 ({dev}:3)\n"
+    )
+
+
+def test_conflicts_header_pluralises_for_more_than_one_package(tmp_path: Path) -> None:
+    """Two disagreeing packages read as "packages are", not "package is"."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        # runtime pins
+        fastapi==0.139.2
+        uvicorn==0.51.0
+        """,
+    )
+    dev = _write(
+        tmp_path / "requirements-dev.txt",
+        """
+        fastapi==0.136.0
+        uvicorn==0.44.0
+        """,
+    )
+
+    report = check_drift([runtime, dev], resolver=_resolver({}))
+
+    assert report.checked == 0
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert render_report(report) == (
+        "Conflicting pins: 2 packages are pinned to different versions.\n"
+        f"  fastapi: 0.139.2 ({runtime}:2) vs 0.136.0 ({dev}:1)\n"
+        f"  uvicorn: 0.51.0 ({runtime}:3) vs 0.44.0 ({dev}:2)\n"
+    )
+
+
+def test_environment_marker_line_is_unevaluated_with_an_instructive_reason(
+    tmp_path: Path,
+) -> None:
+    """A marker the checker cannot evaluate is a gap to report, never a silent pass."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        # runtime pins
+        httpx==0.28.1; python_version < "3.13"
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({"httpx": "0.28.1"}))
+
+    assert report.unevaluated == (
+        Unevaluated(
+            source=runtime,
+            line_number=2,
+            text='httpx==0.28.1; python_version < "3.13"',
+            reason=MARKER_REASON,
+        ),
+    )
+    assert report.checked == 0
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert render_report(report) == (
+        "Cannot verify the pinned set: 1 requirement line(s) were not evaluated.\n"
+        f"  {runtime}:2: {MARKER_REASON}\n"
+        '    httpx==0.28.1; python_version < "3.13"\n'
+    )
+
+
+def test_lines_that_are_not_exact_pins_are_unevaluated(tmp_path: Path) -> None:
+    """Ranges, bare names, and URLs cannot be compared, so they must be surfaced."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        ruff>=0.6.0
+        black~=24.3.0
+        wheel
+        https://example.invalid/wheels/pkg-1.0.0-py3-none-any.whl
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({}))
+
+    assert report.unevaluated == (
+        Unevaluated(source=runtime, line_number=1, text="ruff>=0.6.0", reason=NOT_A_PIN_REASON),
+        Unevaluated(source=runtime, line_number=2, text="black~=24.3.0", reason=NOT_A_PIN_REASON),
+        Unevaluated(source=runtime, line_number=3, text="wheel", reason=NOT_A_PIN_REASON),
+        Unevaluated(
+            source=runtime,
+            line_number=4,
+            text="https://example.invalid/wheels/pkg-1.0.0-py3-none-any.whl",
+            reason=NOT_A_PIN_REASON,
+        ),
+    )
+    assert report.checked == 0
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_unsupported_option_lines_are_unevaluated(tmp_path: Path) -> None:
+    """Index URLs and editable installs are options the checker declines to interpret."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        --extra-index-url https://example.invalid/simple
+        -e .
+        uvicorn==0.51.0
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({"uvicorn": "0.51.0"}))
+
+    assert report.unevaluated == (
+        Unevaluated(
+            source=runtime,
+            line_number=1,
+            text="--extra-index-url https://example.invalid/simple",
+            reason=UNSUPPORTED_OPTION_REASON,
+        ),
+        Unevaluated(
+            source=runtime,
+            line_number=2,
+            text="-e .",
+            reason=UNSUPPORTED_OPTION_REASON,
+        ),
+    )
+    assert report.checked == 1
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+@pytest.mark.parametrize("include_option", ["-r", "--requirement"])
+def test_includes_resolve_relative_to_the_including_file(
+    tmp_path: Path,
+    include_option: str,
+) -> None:
+    """An include path is relative to its own file, not to the process working directory."""
+    _write(
+        tmp_path / "reqs" / "sub" / "deeper" / "deepest.txt",
+        """
+        uvicorn==0.51.0
+        """,
+    )
+    _write(
+        tmp_path / "reqs" / "sub" / "more.txt",
+        f"""
+        fastapi==0.139.2
+        {include_option} deeper/deepest.txt
+        """,
+    )
+    base = _write(
+        tmp_path / "reqs" / "base.txt",
+        f"""
+        {include_option} sub/more.txt
+        """,
+    )
+
+    report = check_drift(
+        [base],
+        resolver=_resolver({"uvicorn": "0.51.0", "fastapi": "0.139.2"}),
+    )
+
+    assert report.checked == 2
+    assert report.unevaluated == ()
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_CLEAN
+
+
+def test_include_cycle_terminates_and_counts_each_pin_once(tmp_path: Path) -> None:
+    """Mutually including files must not recurse forever or double-count a pin."""
+    _write(
+        tmp_path / "a.txt",
+        """
+        -r b.txt
+        alpha==1.0.0
+        """,
+    )
+    _write(
+        tmp_path / "b.txt",
+        """
+        -r a.txt
+        beta==2.0.0
+        """,
+    )
+
+    report = check_drift(
+        [tmp_path / "a.txt"],
+        resolver=_resolver({"alpha": "1.0.0", "beta": "2.0.0"}),
+    )
+
+    assert report.checked == 2
+    assert report.unevaluated == ()
+    assert report.exit_code == EXIT_CLEAN
+
+
+def test_missing_top_level_file_is_reported_without_a_traceback(tmp_path: Path) -> None:
+    """A path that does not exist is an unverifiable pin set, not a crash."""
+    missing = tmp_path / "requirements.txt"
+
+    report = check_drift([missing], resolver=_resolver({}))
+
+    assert report.unevaluated == (
+        Unevaluated(
+            source=missing,
+            line_number=0,
+            text=str(missing),
+            reason=MISSING_FILE_REASON,
+        ),
+    )
+    assert report.checked == 0
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert render_report(report) == (
+        "Cannot verify the pinned set: 1 requirement line(s) were not evaluated.\n"
+        f"  {missing}: {MISSING_FILE_REASON}\n"
+        f"    {missing}\n"
+    )
+
+
+def test_missing_include_target_is_reported_against_the_resolved_path(tmp_path: Path) -> None:
+    """A dangling include names the file it looked for, so the operator can find it.
+
+    The finding points at the include target rather than at the including file,
+    and reports the path it looked up as its own text.
+    """
+    base = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        -r missing/other.txt
+        """,
+    )
+
+    report = check_drift([base], resolver=_resolver({"uvicorn": "0.51.0"}))
+
+    expected_target = tmp_path / "missing" / "other.txt"
+    assert len(report.unevaluated) == 1
+    finding = report.unevaluated[0]
+    assert finding.source.resolve() == expected_target.resolve()
+    assert finding.line_number == 0
+    assert finding.text == str(finding.source)
+    assert finding.reason == MISSING_FILE_REASON
+    assert report.checked == 1
+    assert report.drifted == ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_drift_outranks_unevaluated_in_the_exit_code(tmp_path: Path) -> None:
+    """Both findings are reported, but a concrete mismatch is the headline failure."""
+    runtime = _write(
+        tmp_path / "requirements.txt",
+        """
+        uvicorn==0.51.0
+        ruff>=0.6.0
+        """,
+    )
+
+    report = check_drift([runtime], resolver=_resolver({"uvicorn": "0.44.0"}))
+
+    assert report.drifted == (Drift(name="uvicorn", pinned="0.51.0", installed="0.44.0"),)
+    assert report.unevaluated == (
+        Unevaluated(source=runtime, line_number=2, text="ruff>=0.6.0", reason=NOT_A_PIN_REASON),
+    )
+    assert report.exit_code == EXIT_DRIFT
+    assert render_report(report) == (
+        "Dependency drift: 1 package does not match the pins.\n"
+        "  uvicorn: pinned 0.51.0 / installed 0.44.0\n"
+        f"Fix: {REMEDIATION_COMMAND}\n"
+        "Cannot verify the pinned set: 1 requirement line(s) were not evaluated.\n"
+        f"  {runtime}:2: {NOT_A_PIN_REASON}\n"
+        "    ruff>=0.6.0\n"
+    )
+
+
+def test_a_run_that_compared_no_pins_is_unverifiable_not_clean() -> None:
+    """Zero compared pins proves nothing, so it must fail the gate rather than pass it.
+
+    Emptying a requirements file, truncating one in a bad merge, or aiming the
+    CLI at the wrong pair of paths all land here. Reporting success for a run
+    that verified nothing is the fail-open the whole check exists to forbid.
+    """
+    report = DriftReport(checked=0, drifted=(), unevaluated=(), conflicts=())
+
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_render_report_says_plainly_that_nothing_was_verified() -> None:
+    """The zero-pin report must name its cause, never claim everything matched."""
+    report = DriftReport(checked=0, drifted=(), unevaluated=(), conflicts=())
+
+    assert render_report(report) == NOTHING_VERIFIED_REPORT
+
+
+def test_default_resolver_reads_metadata_of_an_installed_package() -> None:
+    """The production resolver must return a real version string for a real package.
+
+    ``pytest`` is by definition installed while this test runs. The assertion is
+    deliberately shape-only: asserting a specific version would couple the suite
+    to the very environment state the checker exists to police.
+    """
+    version = installed_version("pytest")
+
+    assert isinstance(version, str)
+    assert version != ""
+
+
+def test_default_resolver_returns_none_for_an_absent_package() -> None:
+    """A package that is not installed resolves to None rather than raising."""
+    assert installed_version(ABSENT_PACKAGE) is None
+
+
+def test_default_requirements_files_are_the_two_backend_pin_files() -> None:
+    """The default target set is exactly the pair the setup instructions install.
+
+    Only the names, locations, and existence of the files are asserted; their
+    drift status belongs to the operator's environment, never to this suite.
+    """
+    assert len(DEFAULT_REQUIREMENTS_FILES) == 2
+    assert tuple(path.name for path in DEFAULT_REQUIREMENTS_FILES) == (
+        "requirements.txt",
+        "requirements-dev.txt",
+    )
+    assert all(path.parent.name == "backend" for path in DEFAULT_REQUIREMENTS_FILES)
+    assert all(path.is_file() for path in DEFAULT_REQUIREMENTS_FILES)
+
+
+def test_main_writes_a_clean_report_to_stdout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A passing check is ordinary output, so check-all.sh stays quiet on success."""
+    runtime = _write(tmp_path / "requirements.txt", _installed_pin(PRESENT_PACKAGE))
+
+    exit_code = main([str(runtime)])
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_CLEAN
+    assert captured.out == (
+        "Dependency drift: none. 1 pinned package(s) match the active environment.\n"
+    )
+    assert captured.err == ""
+
+
+def test_main_writes_a_drift_report_to_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failing check reports on stderr so the gate's failure output is unambiguous.
+
+    The pinned package is one that cannot exist in any environment, which makes
+    the "not installed" branch deterministic without inspecting real versions.
+    """
+    runtime = _write(tmp_path / "requirements.txt", f"{ABSENT_PACKAGE}==0.0.0\n")
+
+    exit_code = main([str(runtime)])
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_DRIFT
+    assert captured.out == ""
+    assert captured.err == (
+        "Dependency drift: 1 package does not match the pins.\n"
+        f"  {ABSENT_PACKAGE}: pinned 0.0.0 / installed (not installed)\n"
+        f"Fix: {REMEDIATION_COMMAND}\n"
+    )
+
+
+def test_main_writes_an_unverifiable_report_to_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unverifiable pin set fails the gate too, with its own diagnostic code."""
+    runtime = _write(tmp_path / "requirements.txt", "-e .\n")
+
+    exit_code = main([str(runtime)])
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_UNVERIFIABLE
+    assert captured.out == ""
+    assert captured.err == (
+        "Cannot verify the pinned set: 1 requirement line(s) were not evaluated.\n"
+        f"  {runtime}:1: {UNSUPPORTED_OPTION_REASON}\n"
+        "    -e .\n"
+    )
+
+
+def test_main_reports_a_file_with_no_pins_as_unverifiable_on_stderr(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A requirements file left with nothing to compare fails the gate on stderr.
+
+    This is the fail-open the checker must refuse: a truncating merge or an
+    emptied file leaves a parseable file with zero pins, and reporting that as
+    a pass would manufacture the confidence the gate is supposed to earn.
+    """
+    runtime = _write(tmp_path / "requirements.txt", "# every pin was lost in a bad merge\n")
+
+    exit_code = main([str(runtime)])
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_UNVERIFIABLE
+    assert captured.out == ""
+    assert captured.err == NOTHING_VERIFIED_REPORT
+
+
+def test_main_checks_several_explicit_paths(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI takes the runtime and dev files as separate arguments."""
+    runtime = _write(tmp_path / "requirements.txt", _installed_pin(PRESENT_PACKAGE))
+    dev = _write(tmp_path / "requirements-dev.txt", _installed_pin(OTHER_PRESENT_PACKAGE))
+
+    exit_code = main([str(runtime), str(dev)])
+
+    assert exit_code == EXIT_CLEAN
+    assert capsys.readouterr().out == (
+        "Dependency drift: none. 2 pinned package(s) match the active environment.\n"
+    )
+
+
+@pytest.mark.parametrize("argv", [None, []])
+def test_main_without_paths_uses_the_default_requirements_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str] | None,
+) -> None:
+    """No arguments means the backend pin files, looked up when main runs.
+
+    The constant is redirected to a fixture file so the fallback is proven
+    without reading the shared environment's actual drift status.
+    """
+    runtime = _write(tmp_path / "requirements.txt", _installed_pin(PRESENT_PACKAGE))
+    monkeypatch.setattr(drift_module, "DEFAULT_REQUIREMENTS_FILES", (runtime,))
+
+    exit_code = main(argv)
+
+    assert exit_code == EXIT_CLEAN
+    assert capsys.readouterr().out == (
+        "Dependency drift: none. 1 pinned package(s) match the active environment.\n"
+    )

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,8 @@ original scripts assume a flat repo; these have been adapted for the
 ```
 scripts/
 ├── backend/           # Python quality gates — runs against backend/
-│   ├── check-all.sh   # Run lint + format + typecheck + security + complexity + tests
+│   ├── check-all.sh   # Drift preflight, then lint + format + typecheck + security + complexity + tests
+│   ├── deps.sh        # Fail when the venv drifts from the requirements pins
 │   ├── fix-all.sh     # Auto-fix linting and formatting
 │   ├── lint.sh        # ruff
 │   ├── format.sh      # ruff format

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -22,7 +22,11 @@ Usage: $(basename "$0") [OPTIONS]
 
 Run all quality checks in sequence.
 
+A dependency-drift preflight runs first and aborts the whole run when it
+fails, because every check below measures the installed packages.
+
 Runs:
+  0. Dependency drift preflight (deps.sh) - aborts on failure
   1. Linting (Ruff)
   2. Formatting (ruff format)
   3. Type checking (MyPy)
@@ -62,6 +66,25 @@ if $VERBOSE; then
 fi
 
 echo "=== Running All Quality Checks ==="
+echo ""
+
+# Fail-fast preflight, not a collected run_check: every check below measures
+# the *installed* packages, so a verdict produced from a drifted virtualenv
+# does not predict CI. Carrying on would hand back seven meaningless results
+# instead of the one that matters. The frontend suite sets the precedent by
+# putting its audit gate first for the same reason.
+#
+# The exit code is captured with `||` rather than inside an `if ! ...` body,
+# where `$?` would already have been reset to 0 by the negation.
+DRIFT_EXIT=0
+"$SCRIPT_DIR/deps.sh" $VERBOSE_FLAG || DRIFT_EXIT=$?
+if [ "$DRIFT_EXIT" -ne 0 ]; then
+    echo "" >&2
+    echo "Aborting: the active environment does not match the pinned requirements." >&2
+    echo "Every remaining check would measure packages CI never installs." >&2
+    echo "Fix with: pip install -r backend/requirements.txt -r backend/requirements-dev.txt" >&2
+    exit "$DRIFT_EXIT"
+fi
 echo ""
 
 FAILED_CHECKS=()

--- a/scripts/backend/deps.sh
+++ b/scripts/backend/deps.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/deps.sh - Verify the active virtualenv matches the pinned requirements
+# Usage: ./scripts/deps.sh [--verbose] [--help]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+
+VERBOSE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help)
+            cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Compare the versions installed in the active environment against the exact
+pins in backend/requirements.txt and backend/requirements-dev.txt.
+
+Every other quality gate measures the packages that are installed, so a
+drifted environment makes their verdicts unable to predict CI. This check
+reports drift and fails; it never installs or upgrades anything, because the
+environment may be shared by concurrent work.
+
+OPTIONS:
+    --verbose   Show detailed output
+    --help      Display this help message
+
+EXIT CODES:
+    0           Every pin matches the active environment
+    1           At least one package is missing or at the wrong version
+    2           Could not verify the pins (unreadable line, missing file, or
+                conflicting pins across the two requirements files)
+
+EXAMPLES:
+    $(basename "$0")           # Check the backend pins
+    $(basename "$0") --verbose # Show detailed output
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Set verbosity
+if $VERBOSE; then
+    set -x
+fi
+
+echo "=== Dependency Drift (pinned vs installed) ==="
+
+# No "tool missing, skip the check" fallback on purpose: an interpreter that
+# cannot run the checker is a result we failed to obtain, not a pass.
+DRIFT_EXIT=0
+python -m scripts.check_dependency_drift || DRIFT_EXIT=$?
+
+case "$DRIFT_EXIT" in
+    0)
+        echo "✓ Dependency pins match the active environment"
+        ;;
+    1)
+        echo "✗ The active environment has drifted from the pinned requirements" >&2
+        ;;
+    *)
+        echo "✗ Could not verify the pinned requirements" >&2
+        ;;
+esac
+
+exit "$DRIFT_EXIT"


### PR DESCRIPTION
## Summary

- Adds `backend/scripts/check_dependency_drift.py`, a dependency-free checker that compares every exact `==` pin in `backend/requirements.txt` / `backend/requirements-dev.txt` against `importlib.metadata` (no subprocess, no `pip`, no network) and names each mismatch as `pinned X / installed Y` followed by the exact remediation command.
- Wires it in as `scripts/backend/deps.sh` and runs it as a **fail-fast preflight** at the head of `scripts/backend/check-all.sh`: every check below it measures the *installed* packages, so a verdict from a drifted virtualenv does not predict CI, and continuing would hand back seven meaningless results instead of the one that matters. No existing check was reordered, weakened, or skipped.
- Never repairs the environment. The virtualenv is shared by parallel worktrees, so installing mid-run would race its siblings — the check reports and fails, and the operator runs the fix.

### Why this exists

The shared `.venv` silently drifted from the pins, and every local quality gate ran against the wrong versions. It nearly shipped a CI-breaking test: an assertion on `trusted_hosts.get_trusted_client_host(...)` passed locally against the installed uvicorn 0.44.0 and would have raised `AttributeError` on every CI job, because the pinned 0.51.0 removed that method. The documented setup command installs what is missing but never reports what is stale, which is exactly what kept the drift invisible.

### Fail-closed by construction

The whole point is that this check must never report success while having verified nothing — the failure mode it exists to prevent. So:

| situation | outcome |
| --- | --- |
| every pin matches | exit 0 |
| a pin mismatches, or the distribution is missing entirely | exit 1 (drift) |
| an environment marker, a non-`==` line, an unreadable/missing file, or two files pinning one package to different versions | exit 2 (could not verify) |
| **zero pins found to compare at all** | exit 2 — says it verified nothing rather than claiming everything matched |

Both non-zero codes fail the gate; the split only tells the operator whether to reinstall or to fix the requirements files.

Environment markers are deliberately **not** evaluated rather than guessed at. Using `packaging` was rejected because `requirements-lock.txt` pins `packaging==26.2` while the dev environment resolves 26.1, so a direct pin would create a lock-vs-dev conflict; hand-rolling PEP 508 marker evaluation could produce a false pass *or* a false failure. Refusing to guess is the only honest option, and the message says exactly what to do if someone adds a marker. The `-r` include handling resolves targets relative to the including file and is cycle- and diamond-safe.

The zero-pins case was caught by the pre-push self-review, not by the original design: the first cut returned "clean" for a run that compared nothing, which is precisely the `audit-gate.mjs` fail-open pattern this issue cites. It is now a fixture-covered failure.

## Test plan

39 new tests in `backend/tests/scripts/test_check_dependency_drift.py` — **100% line and branch coverage** of the new module, no pragmas.

Drift is proven entirely with **fixtures**: synthetic requirements files under `tmp_path` plus an injected fake version resolver. **No test installs, uninstalls, or downgrades anything, and no test asserts the real virtualenv's drift status** — the shared `.venv` is used read-only. The only real-environment contact is two `importlib.metadata` lookups that exercise the production resolver's found/not-found branches, plus CLI-plumbing fixtures that read an installed version at test time rather than hardcoding one (hardcoding would break on the next dependency bump).

Covered: clean pass; single and multiple drift; missing package; comments, blank lines, and inline comments; extras; PEP 503 name normalisation; identical duplicate pins across both files (the real `uvicorn`/`pydantic`/`pytest`/`sqlmodel` shape) counted once; conflicting pins excluded from comparison; environment markers; non-`==` lines; unsupported option lines; `-r` includes resolved relative to the including file; include cycles; missing files and dangling includes (no traceback); exit-code precedence (drift outranks uncertainty); the zero-pins case; and `main`'s stdout/stderr split. Every rendered line is asserted as a golden string.

Ran locally, each in isolation:

- `scripts/backend/lint.sh --check`, `format.sh --check`, `typecheck.sh`, `security.sh` (bandit + pip-audit) — all pass
- `mypy --strict` on the new module — clean; `interrogate` — 100%
- `xenon --max-absolute A --max-modules A --max-average A` and `radon mi -n B` on the new module — A / A (52); also re-ran `xenon src/` and `radon mi src/ -n B` since `check-all.sh` does not cover them
- `pre-commit run shellcheck` on both shell scripts — pass
- `scripts/backend/test.sh --unit` — **3437 passed, 2 skipped**, total coverage 97.06% (≥90% line, ≥80% branch)
- **Live, read-only:** `scripts/backend/deps.sh` exits 0 against the current environment, reporting all 38 pins matching — the clean path is verified against reality, not a mock
- **Failure paths, proven without touching the shared venv** (synthetic files outside the repo): a stale pin exits 1 with `uvicorn: pinned 0.44.0 / installed 0.51.0` plus the `Fix:` line; an option line, a marker pin, and a dangling `-r` exit 2 with three findings and no traceback; a comment-only file exits 2 with `No pinned packages were found to compare; nothing was verified.`

`coverage.sh` was not run as a separate pass: `test.sh --unit` already executes the full suite with `--cov-branch --cov-fail-under=90`, so it would be a byte-identical second measurement.

Two notes for the reviewer. First, `check-all.sh` captures the child's status with `deps.sh || DRIFT_EXIT=$?` rather than `if ! deps.sh; then RC=$?`, because the negation resets `$?` to 0 and would silently swallow the 1-vs-2 distinction (verified: `bash -c 'if ! (exit 2); then echo $?; fi'` prints `0`). Second, `deps.sh` deliberately omits the "tool not installed, warn and exit 0" fallback its sibling `typecheck.sh` carries — an interpreter that cannot run the checker is a result we failed to obtain, not a pass.

Closes #2015
