### PR TITLE
fix(graph): unbreak graph-build + semantic backend, enforce graph utilization

### DIFF
--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -63,7 +63,10 @@ Route only the dimensions the diff actually touches — no redundant reviews.
    changed a finding, have the conductor record it via `graphify save-result …
    --memory-dir graph/memory/` (`--outcome corrected --correction "…"` when the
    graph was wrong). Those committed Markdown notes feed the weekly `graphify
-   reflect` digest; repo Q&A only, never secrets.
+   reflect` digest; repo Q&A only, never secrets. **Gatecheck:** the tick's
+   planned PR body must carry a truthful `## Graph` line (query used → what it
+   changed, or `skipped: <reason>`); a missing or boilerplate line is a
+   finding, not a pass.
 2. **Primary path — review the applicable dimensions yourself** against each
    specialist's checklist (above) and the shared constraints. You run on Sonnet
    so a single agent can carry every dimension at review-tier cost. **Enhancement:** where

--- a/.github/workflows/graph-build.yml
+++ b/.github/workflows/graph-build.yml
@@ -145,7 +145,8 @@ jobs:
               "built_at": os.environ["BUILT_AT"],
               "sha": os.environ["SHA"],
               "nodes": len(graph.get("nodes", [])),
-              "edges": len(graph.get("edges", [])),
+              # graphify emits node-link JSON: edges live under "links".
+              "edges": len(graph.get("links") or graph.get("edges") or []),
               "graphifyy": os.environ["GRAPHIFYY_VERSION"],
               "kind": "code-only",
           }
@@ -318,7 +319,12 @@ jobs:
             echo "staleness issue #$existing already open — skipping"
             exit 0
           fi
-          # AGE_DAYS arrives via env, never inlined ${{ }} into the run block.
+          # AGE_DAYS arrives via env, never inlined as a workflow expression
+          # in the run block. (Do NOT write the literal expression-delimiter
+          # pair in ANY run script, even inside a shell comment: GitHub
+          # expands expressions before bash ever sees the text, and an empty
+          # one is a compile error that killed every run of this workflow
+          # from Jul 22 to Jul 31 with zero jobs and no error surfaced.)
           body="$(printf 'The knowledge graph semantic layer is %s days old — past the 14-day staleness threshold.\n\nRun the "Graph semantic" workflow (workflow_dispatch on .github/workflows/graph-semantic.yml) to rebuild the semantic layer, then close this issue.\n' "$AGE_DAYS")"
           gh issue create --repo "$GITHUB_REPOSITORY" \
             --title "Knowledge graph semantic layer is stale" \

--- a/scripts/graph/requirements.txt
+++ b/scripts/graph/requirements.txt
@@ -1,1 +1,8 @@
 graphifyy==0.9.26
+# Anthropic SDK for the `--backend claude` semantic pass (graph-semantic.yml).
+# graphifyy treats it as an optional extra, so it must be pinned explicitly —
+# without it every semantic chunk fails with "the 'anthropic' package is
+# required for this backend". Kept on its own line (not the [anthropic]
+# extra) because the workflows parse the graphifyy pin with
+# `sed -n 's/^graphifyy==//p'`. Version matches backend/requirements.txt.
+anthropic==0.120.0

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -120,6 +120,9 @@ behind-main rebases across parallel lanes.
    never `--no-verify`).
 10. **Push & open the PR** with `gh pr create --body-file <tmpfile>`. Body
     includes: `## Summary` (1–3 bullets), `## Test plan` (what you ran),
+    `## Graph` (one truthful line: the `graphify query`/`affected` call that
+    shaped this tick and the node it surfaced, or `skipped: <reason>` —
+    graph absent, trivial mechanical change, etc.; reviewers check this),
     `Closes #$RALPH_ISSUE` on its own line (marks in-flight for the picker and
     auto-closes the issue on merge), and `Refs #<parent-epic>` if the issue
     names one.
@@ -161,7 +164,8 @@ behind-main rebases across parallel lanes.
 ## Definition of done for this call
 - [ ] chief-architect produced the plan; you dispatched the specialists it named
       (and only those).
-- [ ] PR open against `main`; body contains `Closes #$RALPH_ISSUE`.
+- [ ] PR open against `main`; body contains `Closes #$RALPH_ISSUE` and a
+      truthful `## Graph` line (query used → what it changed, or why skipped).
 - [ ] The relevant `./scripts/<side>/check-all.sh` exits 0 (Gate 2 green).
 - [ ] code-review-orchestrator returned `CLEAN` before push (Gate 2.5).
 - [ ] New tests pass; existing tests still pass; thresholds met.


### PR DESCRIPTION
Found while auditing graphify's quantifiable benefits (headline: **175× measured query-token reduction** on the live 47,749-node pan-graph — but the support systems around it had quietly rotted). Three bug fixes + one accountability change:

## 1. `graph-build.yml` has failed every single run since Jul 22 — a `${{ }}` in a *comment*

The workflow has **zero jobs and no surfaced error** on all ~120 runs since #1895 merged, and its nightly cron stopped firing entirely. Root cause (pinpointed with `actionlint`): a shell comment added in #1895 read `# AGE_DAYS arrives via env, never inlined ${{ }} into the run block.` — GitHub expands `${{ }}` expressions **before bash sees the text, even inside comments**, and an empty expression is a workflow-compile error. The comment documenting the injection-safety best practice broke the workflow it was protecting. Evidence: the last successful run built `3401ae8` (the commit *before* #1895); every run of the #1895 file failed; the reworded file passes `actionlint` clean.

Restores: nightly rebuild, ≤24h release freshness (stale since Jul 22), benchmark-trend ledger (why `graph/metrics/` never appeared), and the semantic-staleness alarm.

## 2. `graph-semantic.yml`: both weekly runs failed — missing `anthropic` SDK

The `ANTHROPIC_API_KEY` secret **is** configured and the job runs all the way to extraction, then all 13 chunks die with *"the 'anthropic' package is required for this backend but is not installed"* — graphifyy ships it as an optional extra. Pinned `anthropic==0.120.0` (matching `backend/requirements.txt`) in `scripts/graph/requirements.txt`, on its own line so the workflows' `sed -n 's/^graphifyy==//p'` pin-parsing stays intact. This unblocks the semantic layer: curriculum/docs nodes, named communities, and ontology-spine entity stitching (currently `graphify path "JournalEntry" "Fragment"` finds no cross-repo path — this is why).

## 3. `graph-meta.json` reported `"edges": 0`

graphify emits node-link JSON (edges under `"links"`); the meta writer read only `"edges"`. Now falls back `links → edges → []`.

## 4. Enforce utilization (per owner request)

Telemetry showed **one** `save-result` trace in 13 days against a 175× measured reduction — steering existed (`## Graph first, grep second` in shared constraints), evidence didn't. Rather than more prose, this makes usage a verifiable artifact: worker PR bodies now require a **`## Graph` section** — one truthful line: the `query`/`affected` call that shaped the tick and the node it surfaced, or `skipped: <reason>`. Pinned in `PROMPT.md` step 10 + the completion checklist, and gate-checked at Gate 2.5 (`code-review-orchestrator`: missing/boilerplate line = finding). Cheap to satisfy honestly, awkward to fake, and it generates the usage ledger the system currently lacks.

## Verification

- `actionlint` clean on `graph-build.yml` (and confirmed clean on `graph-semantic` / `graph-federate` / `graph-tests`).
- New pre-commit `pip-audit (graph tooling dependencies)` hook passes with the added pin.
- Post-merge: this PR's own push to `main` triggers `graph-build.yml` — its first successful run since Jul 22 is the acceptance test. Then dispatch "Graph semantic" once (or wait for Monday's now-unbroken cron) to light up the semantic layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_