### PR TITLE
ci(graph): federate adepthood-docs into pan-graph as satellite #6 (#2041)

### DIFF
--- a/.github/workflows/graph-federate.yml
+++ b/.github/workflows/graph-federate.yml
@@ -2,8 +2,9 @@ name: Graph federate
 
 # Merges adepthood's own code graph with the published knowledge graphs of its
 # satellite repos (Creek-Vault, aptitude-course, wavelength-demo,
-# WavelengthWatch) into one pan-graph and publishes it on the SAME rolling
-# `knowledge-graph` release that graph-build and graph-semantic maintain.
+# WavelengthWatch, adepthood-docs) into one pan-graph and publishes it on the
+# SAME rolling `knowledge-graph` release that graph-build and graph-semantic
+# maintain.
 #
 # This workflow uploads ONLY pan-graph.json + pan-meta.json. It NEVER writes
 # graph.json / graph-meta.json, so it cannot clobber the assets that graph-build
@@ -119,13 +120,14 @@ jobs:
           mkdir -p fed
           # name|human-repo|url — ORDER IS SIGNIFICANT: it fixes the merge-graphs
           # argument order and therefore the deterministic per-repo node-id
-          # prefixes in the pan-graph. All four satellites have default branch
+          # prefixes in the pan-graph. All five satellites have default branch
           # `main` (verified), which the raw.githubusercontent.com URLs pin.
           satellites=(
             "creek|Creek-Vault|https://github.com/Geoffe-Ga/Creek-Vault/releases/download/knowledge-graph/graph.json"
             "course|aptitude-course|https://raw.githubusercontent.com/Geoffe-Ga/aptitude-course/main/graphify-out/graph.json"
             "demo|wavelength-demo|https://raw.githubusercontent.com/Geoffe-Ga/wavelength-demo/main/graphify-out/graph.json"
             "watch|WavelengthWatch|https://raw.githubusercontent.com/Geoffe-Ga/WavelengthWatch/main/graphify-out/graph.json"
+            "docs|adepthood-docs|https://raw.githubusercontent.com/Geoffe-Ga/adepthood-docs/main/graphify-out/graph.json"
           )
           : > fed/present.txt
           present=()
@@ -149,7 +151,7 @@ jobs:
               rm -rf "fed/$name"
             fi
           done
-          # Single source of truth for the meta step: a five-repo manifest with
+          # Single source of truth for the meta step: a six-repo manifest with
           # present flags. adepthood is always present here (its fetch is fatal).
           # The satellite table is serialized straight out of the bash array so it
           # can never drift from the loop above.

--- a/scripts/graph/README.md
+++ b/scripts/graph/README.md
@@ -184,17 +184,18 @@ The ledger also feeds the Discord Ralph recap's knowledge-graph line — see
 after `graph-build`'s 04:40 code rebuild — plus manual `workflow_dispatch`
 and `repository_dispatch` (event type `graph-updated`, which a satellite
 repo can send to poke a re-federation). It merges adepthood's own code graph
-with the published knowledge graphs of four satellite repos (Creek-Vault,
-aptitude-course, wavelength-demo, WavelengthWatch) into one
+with the published knowledge graphs of five satellite repos (Creek-Vault,
+aptitude-course, wavelength-demo, WavelengthWatch, adepthood-docs) into one
 `pan-graph.json`, published on the SAME rolling `knowledge-graph` release
 that `graph-build` and `graph-semantic` maintain.
 
-The five source graphs come from two mechanisms. aptitude-course,
-wavelength-demo, and WavelengthWatch commit theirs in-tree at
-`graphify-out/graph.json` on `main`, fetched over
-`raw.githubusercontent.com`. Creek-Vault's graph is ~30 MB and is never
-committed — it ships as a rolling release asset instead. adepthood's own
-graph comes from its own `knowledge-graph` release, same as above.
+The six source graphs come from two mechanisms. aptitude-course,
+wavelength-demo, WavelengthWatch, and adepthood-docs (the prose-only docs
+corpus repo) commit theirs in-tree at `graphify-out/graph.json` on `main`,
+fetched over `raw.githubusercontent.com`. Creek-Vault's graph is ~30 MB and
+is never committed — it ships as a rolling release asset instead.
+adepthood's own graph comes from its own `knowledge-graph` release, same as
+above.
 
 An unfetchable satellite logs a `::warning` and is excluded from that
 build; only a missing adepthood-own graph fails the job. `pan-meta.json`
@@ -213,9 +214,10 @@ $0 / `GITHUB_TOKEN`-only: the built-in token (`contents: write`) covers the
 own-graph download and the release publish; every satellite fetch —
 including Creek-Vault's release asset — is unauthenticated public HTTPS.
 
-**GO-PRIVATE caveat**: every satellite fetch assumes the repo is public. If
-any satellite ever goes private, its fetch starts 404ing *and* — the
-dangerous half — a pan-graph already carrying its structure must move off
+**GO-PRIVATE caveat**: every satellite fetch — adepthood-docs included —
+assumes the repo is public. If any satellite ever goes private, its fetch
+starts 404ing *and* — the dangerous half — a pan-graph already carrying
+its structure must move off
 this public release; distribution needs revisiting then (an authenticated
 fetch plus a private artifact store), not a token quietly wired into the
 fetch step.


### PR DESCRIPTION
Closes #2041

## What

Adds `Geoffe-Ga/adepthood-docs` as the sixth source in the nightly pan-graph federation:

- `.github/workflows/graph-federate.yml`: adepthood-docs joins the in-tree-satellite fetch list (`raw.githubusercontent.com/.../main/graphify-out/graph.json`), participating in the existing unfetchable-satellite `::warning` + exclusion behavior — a missing docs graph degrades to a warning, never fails the job. `pan-meta.json`'s `repos` map and `repos_present`/`repos_missing` are built from the satellite list, so they cover the new entry with no further changes.
- `scripts/graph/README.md`: Federation section updated five → six sources, noting adepthood-docs is the prose-only docs corpus (graph committed in-tree like the other small satellites, 319 nodes / 345 edges at time of writing) and that the GO-PRIVATE caveat covers it too.

## Context

adepthood-docs#6 (merged) gave the docs repo a committed `graphify-out/graph.json` on `main`, built with the same pinned `graphifyy` toolchain. This PR completes epic Geoffe-Ga/adepthood-docs#1's federation criterion: docs corpus queryable through `pan-graph.json`.

## Validation

- `pre-commit run --all-files` green locally (full hook suite).
- Pre-push gate (backend tests + coverage + complexity) passed before the branch push.
- The raw graph URL serves valid JSON from adepthood-docs `main`.
- Real end-to-end proof is the next `graph-federate` run (nightly 06:10 UTC cron, or manual dispatch): `pan-meta.json` should list adepthood-docs as present with nonzero nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_