### PR TITLE
perf(tooling): get check-all under the 10-minute ceiling by running the suite once

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -64,10 +64,24 @@ jobs:
           # Verify branch coverage meets the threshold by parsing coverage.xml.
           # Threshold starts at 80% (current baseline ~82%); tighten as test
           # coverage improves, especially in services/botmason.py (70%).
-          # Error suppression removed: a pytest crash (collection/import/plugin
-          # error) must fail this step, not let the parser read a stale or
-          # partial coverage.xml from a prior run.
-          pytest --cov=src --cov-report=xml --cov-branch -q --no-header
+          #
+          # The report is regenerated from the coverage data the pre-push-hook
+          # step above already collected (backend-tests-coverage runs the whole
+          # suite under --cov), rather than by running the suite a second time
+          # in the same job. Staleness is not reachable here: the checkout is
+          # fresh and both .coverage and coverage.xml are gitignored, so no
+          # artifact can predate this job. A pytest crash (collection/import/
+          # plugin error) fails the step that ran it, and coverage data that
+          # never arrived fails the guard below - never a silent skip.
+          # The --include filter reproduces the {src, scripts} file set that
+          # step measured (verified identical: 190 files either way, and a
+          # branch rate of 92.33% vs 92.44% - run-to-run jitter, against an
+          # 80% gate).
+          if [ ! -f .coverage ]; then
+            echo "::error::.coverage not found - the test step collected no coverage data"
+            exit 1
+          fi
+          coverage xml -o coverage.xml --include="src/*,scripts/*"
           python3 -c "
           import os, sys, xml.etree.ElementTree as ET
           if not os.path.exists('coverage.xml'):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,16 +62,13 @@ fixable = ["ALL"]
 # (when run from repo root by pre-commit).
 "tests/**/*.py" = ["S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003"]
 "backend/tests/**/*.py" = ["S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003"]
-# Script meta-tests additionally shell out to repo-owned scripts with literal
-# argv (S603/S404): the shell script *is* the unit under test, so there is no
-# in-process seam to drive it through. per-file-ignores do not inherit, so the
-# tests/** list above is repeated rather than extended.
-"tests/scripts/**/*.py" = [
-  "S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003", "S404", "S603",
-]
-"backend/tests/scripts/**/*.py" = [
-  "S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003", "S404", "S603",
-]
+# Script meta-tests shell out to repo-owned scripts with literal argv (S603):
+# the shell script *is* the unit under test, so there is no in-process seam to
+# drive it through. ruff unions the ignore lists of every matching pattern, so
+# this only adds to the tests/** list above. Both spellings again, for the same
+# reason.
+"tests/scripts/**/*.py" = ["S603"]
+"backend/tests/scripts/**/*.py" = ["S603"]
 "conftest.py" = ["S101"]
 "backend/conftest.py" = ["S101"]
 # Issue #272: ``lifespan`` deliberately lazy-imports ``models`` (one-time

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,6 +62,16 @@ fixable = ["ALL"]
 # (when run from repo root by pre-commit).
 "tests/**/*.py" = ["S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003"]
 "backend/tests/**/*.py" = ["S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003"]
+# Script meta-tests additionally shell out to repo-owned scripts with literal
+# argv (S603/S404): the shell script *is* the unit under test, so there is no
+# in-process seam to drive it through. per-file-ignores do not inherit, so the
+# tests/** list above is repeated rather than extended.
+"tests/scripts/**/*.py" = [
+  "S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003", "S404", "S603",
+]
+"backend/tests/scripts/**/*.py" = [
+  "S101", "S105", "S106", "S107", "PLR2004", "FBT001", "FBT003", "S404", "S603",
+]
 "conftest.py" = ["S101"]
 "backend/conftest.py" = ["S101"]
 # Issue #272: ``lifespan`` deliberately lazy-imports ``models`` (one-time

--- a/backend/tests/scripts/test_coverage_report_only.py
+++ b/backend/tests/scripts/test_coverage_report_only.py
@@ -1,0 +1,339 @@
+"""Tests for the coverage consolidation in ``scripts/backend/coverage.sh``.
+
+``check-all.sh`` ran the entire backend suite twice. Stage 6 (``test.sh
+--unit``) and stage 7 (``coverage.sh``) each executed the same few thousand
+tests, because ``[tool.pytest.ini_options] addopts`` already injects
+``--cov=src --cov=scripts`` and ``--cov-fail-under=90`` into every pytest
+process: stage 6 was already enforcing the threshold and already writing
+``coverage.xml``, and stage 7 bought nothing but a second seven-minute wait.
+Together they pushed the gate past the ten-minute per-command ceiling that
+kills an agent mid-run, which turns the local gate into something operators
+skip rather than something that predicts CI.
+
+The fix is to let stage 7 report from the coverage data stage 6 already wrote.
+That trades duplicated work for a new way to fail open: a report rendered from
+a data file that is absent, or left over from an unrelated run, prints a number
+nobody earned. So these tests pin the whole contract, not just the speedup:
+``--report-only`` must never start a test runner, must still pass the 90%
+threshold to the reporter, must still emit the XML report CI consumes, and must
+refuse loudly when the coverage data file does not exist.
+
+The scripts are driven through fake ``pytest`` and ``coverage`` executables in a
+``tmp_path`` directory prepended to ``PATH``; each records its argv to a log
+named by an environment variable and exits 0. Nothing here runs a real suite,
+parses real coverage data, or writes inside the checkout. The ``check-all.sh``
+wiring is asserted by reading the script rather than by executing it, since
+executing it would invoke the very long suite this change exists to stop
+running twice.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts" / "backend"
+_COVERAGE_SCRIPT = _SCRIPTS_DIR / "coverage.sh"
+_CHECK_ALL_SCRIPT = _SCRIPTS_DIR / "check-all.sh"
+
+# Log destinations for the two shims; read back as "who was invoked, with what".
+_PYTEST_LOG_ENV = "ADEPTHOOD_FAKE_PYTEST_LOG"
+_COVERAGE_LOG_ENV = "ADEPTHOOD_FAKE_COVERAGE_LOG"
+_SHIM_MODE = 0o755
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+# coverage.py's own convention for locating its data file.
+COVERAGE_DATA_FILE_ENV = "COVERAGE_FILE"
+
+REPORT_ONLY_FLAG = "--report-only"
+XML_FLAG = "--xml"
+COVERAGE_REPORT_COMMAND = "report"
+COVERAGE_XML_COMMAND = "xml"
+# The gate itself. A consolidation that drops this flag reports a percentage
+# without failing on it, which is a silently weakened threshold.
+COVERAGE_THRESHOLD_FLAG = "--fail-under=90"
+PYTEST_THRESHOLD_FLAG = "--cov-fail-under=90"
+
+MISSING_DATA_EXIT_CODE = 2
+# The wording the operator needs: which artifact is missing, and where it was
+# looked for. Pinned as a substring so phrasing stays the implementer's choice.
+MISSING_DATA_MESSAGE = "coverage data"
+
+TEST_RUNNER_SCRIPT = "test.sh"
+COVERAGE_RUNNER_SCRIPT = "coverage.sh"
+UNIT_TESTS_CHECK = "Unit tests"
+COVERAGE_CHECK = "Coverage report"
+EXPECTED_CHECK_NAMES = (
+    "Linting",
+    "Formatting",
+    "Type checking",
+    "Security checks",
+    "Complexity analysis",
+    UNIT_TESTS_CHECK,
+    COVERAGE_CHECK,
+)
+_RUN_CHECK_CALL_PREFIX = 'run_check "'
+# Artifacts a previous run leaves behind; reporting from them is stale data.
+STALE_COVERAGE_ARTIFACTS = (".coverage", "coverage.xml")
+
+_SHIM_TEMPLATE = """#!/usr/bin/env bash
+printf "%s\\n" "$*" >> "${log_env_var}"
+exit 0
+"""
+
+
+def _write_shim(path: Path, log_env_var: str) -> None:
+    """Write an executable that appends its argv to a log file and exits 0.
+
+    Args:
+        path: Destination of the fake executable; its filename is the command
+            name that will be shadowed on ``PATH``.
+        log_env_var: Name of the environment variable holding the log path.
+    """
+    path.write_text(_SHIM_TEMPLATE.format(log_env_var=log_env_var))
+    path.chmod(_SHIM_MODE)
+
+
+def _read_log(path: Path) -> list[str]:
+    """Return one entry per recorded invocation, empty when never invoked.
+
+    Args:
+        path: Log file written by a shim; absent until its command runs once.
+
+    Returns:
+        The recorded argv lines with surrounding whitespace and blanks removed.
+    """
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+
+@dataclass(frozen=True)
+class _ShimHarness:
+    """The shimmed environment plus the recorders that observe what ran."""
+
+    env: dict[str, str]
+    pytest_log: Path
+    coverage_log: Path
+    coverage_data: Path
+
+    def pytest_calls(self) -> list[str]:
+        """Return the argv of every fake ``pytest`` invocation."""
+        return _read_log(self.pytest_log)
+
+    def coverage_calls(self) -> list[str]:
+        """Return the argv of every fake ``coverage`` invocation."""
+        return _read_log(self.coverage_log)
+
+    def coverage_calls_named(self, command: str) -> list[str]:
+        """Return the fake ``coverage`` invocations whose subcommand matches.
+
+        Args:
+            command: The coverage.py subcommand, such as ``report`` or ``xml``.
+
+        Returns:
+            The matching argv lines, in invocation order.
+        """
+        return [call for call in self.coverage_calls() if call.split()[0] == command]
+
+
+@pytest.fixture
+def harness(tmp_path: Path) -> _ShimHarness:
+    """Shadow ``pytest`` and ``coverage`` on ``PATH`` with argv recorders.
+
+    The real commands are never reachable from the scripts under test, so a
+    regression that re-runs the suite shows up as a recorded ``pytest``
+    invocation rather than as a seven-minute test.
+
+    Args:
+        tmp_path: Per-test directory holding the shims, the logs, and a stand-in
+            coverage data file.
+
+    Returns:
+        The environment that activates the shims plus the paths to read back.
+    """
+    shim_dir = tmp_path / "shims"
+    shim_dir.mkdir()
+    _write_shim(shim_dir / "pytest", _PYTEST_LOG_ENV)
+    _write_shim(shim_dir / "coverage", _COVERAGE_LOG_ENV)
+
+    pytest_log = tmp_path / "pytest-calls.log"
+    coverage_log = tmp_path / "coverage-calls.log"
+    coverage_data = tmp_path / ".coverage"
+    coverage_data.write_text("stand-in for the data file stage 6 writes\n")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env['PATH']}"
+    env[_PYTEST_LOG_ENV] = str(pytest_log)
+    env[_COVERAGE_LOG_ENV] = str(coverage_log)
+    env[COVERAGE_DATA_FILE_ENV] = str(coverage_data)
+
+    return _ShimHarness(
+        env=env,
+        pytest_log=pytest_log,
+        coverage_log=coverage_log,
+        coverage_data=coverage_data,
+    )
+
+
+def _run_coverage_script(
+    env: dict[str, str],
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real ``coverage.sh`` with the shims in place.
+
+    Args:
+        env: Environment activating the shims.
+        *args: Flags to pass to the script.
+
+    Returns:
+        The completed process, never raising on a non-zero exit code.
+    """
+    return subprocess.run(
+        [str(_COVERAGE_SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+
+
+def _run_check_invocations() -> list[str]:
+    """Return the ``run_check`` call lines of check-all.sh, excluding its definition."""
+    return [
+        line.strip()
+        for line in _CHECK_ALL_SCRIPT.read_text().splitlines()
+        if line.strip().startswith(_RUN_CHECK_CALL_PREFIX)
+    ]
+
+
+def test_report_only_reports_from_disk_without_running_the_suite(
+    harness: _ShimHarness,
+) -> None:
+    """``--report-only`` renders the existing data instead of re-running pytest.
+
+    The recorded invocations carry the whole contract: zero test runs (the point
+    of the change), one ``coverage report`` still carrying the 90% threshold (so
+    the consolidation cannot quietly drop the gate), and one ``coverage xml`` (so
+    the artifact CI consumes is still produced).
+    """
+    result = _run_coverage_script(harness.env, REPORT_ONLY_FLAG, XML_FLAG)
+
+    assert result.returncode == 0, result.stderr
+    assert harness.pytest_calls() == [], (
+        "--report-only must report from the coverage data on disk; "
+        "invoking pytest reintroduces the duplicated suite run"
+    )
+
+    report_calls = harness.coverage_calls_named(COVERAGE_REPORT_COMMAND)
+    assert len(report_calls) == 1, harness.coverage_calls()
+    assert COVERAGE_THRESHOLD_FLAG in report_calls[0].split(), (
+        f"the report must still fail under 90%; got: {report_calls[0]}"
+    )
+    assert len(harness.coverage_calls_named(COVERAGE_XML_COMMAND)) == 1, (
+        f"--xml must still write coverage.xml; got: {harness.coverage_calls()}"
+    )
+
+
+def test_report_only_fails_loudly_when_the_coverage_data_is_missing(
+    harness: _ShimHarness,
+    tmp_path: Path,
+) -> None:
+    """A missing data file is an error, never a quiet pass or a stale number.
+
+    This is the fail-open the consolidation could introduce: with nothing on
+    disk to report, the only safe outcomes are a non-zero exit and a message
+    naming the file that was looked for. Falling back to running the suite would
+    silently restore the duplicated run, so that is asserted against too.
+    """
+    missing = tmp_path / "never-written" / ".coverage"
+    env = {**harness.env, COVERAGE_DATA_FILE_ENV: str(missing)}
+
+    result = _run_coverage_script(env, REPORT_ONLY_FLAG)
+
+    assert result.returncode == MISSING_DATA_EXIT_CODE, result.stderr
+    assert MISSING_DATA_MESSAGE in result.stderr.lower(), (
+        f"stderr must say the coverage data is missing; got: {result.stderr!r}"
+    )
+    assert str(missing) in result.stderr, (
+        f"stderr must name the path it looked for; got: {result.stderr!r}"
+    )
+    assert harness.pytest_calls() == [], (
+        "missing coverage data must abort, not fall back to running the suite"
+    )
+
+
+def test_check_all_triggers_at_most_one_test_run() -> None:
+    """Exactly one stage runs the suite, and the coverage stage only reports.
+
+    Read statically because executing check-all.sh would run the full suite this
+    change exists to stop running twice.
+    """
+    calls = _run_check_invocations()
+    test_calls = [call for call in calls if TEST_RUNNER_SCRIPT in call]
+    coverage_calls = [call for call in calls if COVERAGE_RUNNER_SCRIPT in call]
+
+    assert len(test_calls) == 1, calls
+    assert len(coverage_calls) == 1, calls
+    assert REPORT_ONLY_FLAG in coverage_calls[0].split(), (
+        f"the coverage stage must report from disk, not re-run pytest: {coverage_calls[0]}"
+    )
+
+
+def test_check_all_still_reports_all_seven_checks() -> None:
+    """The operator-visible summary must not shrink as the stages consolidate.
+
+    Speeding the gate up by deleting a check is not the fix being asked for, so
+    every named check keeps its own pass or fail line.
+    """
+    calls = _run_check_invocations()
+
+    for name in EXPECTED_CHECK_NAMES:
+        assert any(call.startswith(f'{_RUN_CHECK_CALL_PREFIX}{name}"') for call in calls), (
+            f"check {name!r} disappeared from the summary; got: {calls}"
+        )
+    assert len(calls) == len(EXPECTED_CHECK_NAMES), calls
+
+
+def test_check_all_purges_stale_coverage_artifacts_before_the_test_stage() -> None:
+    """Yesterday's data file must not survive into today's report.
+
+    Reporting from disk is only trustworthy if the disk was cleared first:
+    coverage.py appends parallel data files, and a leftover ``coverage.xml``
+    would be handed to CI as if it described this run.
+    """
+    text = _CHECK_ALL_SCRIPT.read_text()
+    marker = f'{_RUN_CHECK_CALL_PREFIX}{UNIT_TESTS_CHECK}"'
+    assert marker in text
+    preamble = text.split(marker)[0]
+
+    for artifact in STALE_COVERAGE_ARTIFACTS:
+        assert artifact in preamble, (
+            f"{artifact} must be purged before the suite runs, "
+            "or the coverage report can describe an earlier run"
+        )
+
+
+def test_coverage_script_without_flags_still_runs_the_suite(
+    harness: _ShimHarness,
+) -> None:
+    """Standalone use is unchanged: no flags still means one full pytest run.
+
+    The consolidation belongs to check-all.sh. Anyone invoking coverage.sh
+    directly still gets a measured run, threshold included.
+    """
+    result = _run_coverage_script(harness.env)
+
+    assert result.returncode == 0, result.stderr
+    calls = harness.pytest_calls()
+    assert len(calls) == 1, calls
+    assert PYTEST_THRESHOLD_FLAG in calls[0].split(), (
+        f"the standalone run must keep its own threshold; got: {calls[0]}"
+    )
+    assert harness.coverage_calls_named(COVERAGE_REPORT_COMMAND) == []

--- a/backend/tests/scripts/test_coverage_report_only.py
+++ b/backend/tests/scripts/test_coverage_report_only.py
@@ -20,11 +20,13 @@ refuse loudly when the coverage data file does not exist.
 
 The scripts are driven through fake ``pytest`` and ``coverage`` executables in a
 ``tmp_path`` directory prepended to ``PATH``; each records its argv to a log
-named by an environment variable and exits 0. Nothing here runs a real suite,
-parses real coverage data, or writes inside the checkout. The ``check-all.sh``
-wiring is asserted by reading the script rather than by executing it, since
-executing it would invoke the very long suite this change exists to stop
-running twice.
+named by an environment variable and exits with a status a second environment
+variable supplies (0 unless a test asks otherwise). That knob is what lets the
+suite prove the reporter's failures are honored rather than merely that the
+threshold flag was passed. Nothing here runs a real suite, parses real coverage
+data, or writes inside the checkout. The ``check-all.sh`` wiring is asserted by
+reading the script rather than by executing it, since executing it would invoke
+the very long suite this change exists to stop running twice.
 """
 
 from __future__ import annotations
@@ -44,6 +46,10 @@ _CHECK_ALL_SCRIPT = _SCRIPTS_DIR / "check-all.sh"
 # Log destinations for the two shims; read back as "who was invoked, with what".
 _PYTEST_LOG_ENV = "ADEPTHOOD_FAKE_PYTEST_LOG"
 _COVERAGE_LOG_ENV = "ADEPTHOOD_FAKE_COVERAGE_LOG"
+# Exit status each shim returns; unset means 0, so only tests about failure
+# handling have to think about it.
+_PYTEST_EXIT_ENV = "ADEPTHOOD_FAKE_PYTEST_EXIT"
+_COVERAGE_EXIT_ENV = "ADEPTHOOD_FAKE_COVERAGE_EXIT"
 _SHIM_MODE = 0o755
 _SUBPROCESS_TIMEOUT_SECONDS = 60
 
@@ -59,10 +65,23 @@ COVERAGE_XML_COMMAND = "xml"
 COVERAGE_THRESHOLD_FLAG = "--fail-under=90"
 PYTEST_THRESHOLD_FLAG = "--cov-fail-under=90"
 
-MISSING_DATA_EXIT_CODE = 2
+# The script's own documented exit codes: 1 means the measured coverage fell
+# short, 2 means coverage could not be measured or reported at all. Conflating
+# them tells an operator with a corrupt data file to go write tests.
+BELOW_THRESHOLD_EXIT_CODE = 1
+COVERAGE_ERROR_EXIT_CODE = 2
+
+# coverage.py's own statuses, from ``coverage.cmdline``: ``FAIL_UNDER`` for a
+# coverage shortfall and ``ERR`` for anything else that went wrong. The script
+# consumes these, so the two must not be read as interchangeable failures.
+COVERAGE_PY_FAIL_UNDER_STATUS = 2
+COVERAGE_PY_ERROR_STATUS = 1
+
 # The wording the operator needs: which artifact is missing, and where it was
 # looked for. Pinned as a substring so phrasing stays the implementer's choice.
 MISSING_DATA_MESSAGE = "coverage data"
+# The claim a threshold miss must make, and that a reporter error must not.
+BELOW_THRESHOLD_MESSAGE = "below threshold"
 
 TEST_RUNNER_SCRIPT = "test.sh"
 COVERAGE_RUNNER_SCRIPT = "coverage.sh"
@@ -83,19 +102,23 @@ STALE_COVERAGE_ARTIFACTS = (".coverage", "coverage.xml")
 
 _SHIM_TEMPLATE = """#!/usr/bin/env bash
 printf "%s\\n" "$*" >> "${log_env_var}"
-exit 0
+exit "${{{exit_env_var}:-0}}"
 """
 
 
-def _write_shim(path: Path, log_env_var: str) -> None:
-    """Write an executable that appends its argv to a log file and exits 0.
+def _write_shim(path: Path, log_env_var: str, exit_env_var: str) -> None:
+    """Write an executable that appends its argv to a log file, then exits.
 
     Args:
         path: Destination of the fake executable; its filename is the command
             name that will be shadowed on ``PATH``.
         log_env_var: Name of the environment variable holding the log path.
+        exit_env_var: Name of the environment variable holding the status to
+            exit with; unset means 0, so the shim succeeds by default.
     """
-    path.write_text(_SHIM_TEMPLATE.format(log_env_var=log_env_var))
+    path.write_text(
+        _SHIM_TEMPLATE.format(log_env_var=log_env_var, exit_env_var=exit_env_var),
+    )
     path.chmod(_SHIM_MODE)
 
 
@@ -141,6 +164,18 @@ class _ShimHarness:
         """
         return [call for call in self.coverage_calls() if call.split()[0] == command]
 
+    def with_coverage_exit(self, status: int) -> dict[str, str]:
+        """Return the environment with the fake ``coverage`` failing on purpose.
+
+        Args:
+            status: Exit status the shim returns, standing in for one of
+                coverage.py's own.
+
+        Returns:
+            A copy of the shim environment; the fixture's own stays untouched.
+        """
+        return {**self.env, _COVERAGE_EXIT_ENV: str(status)}
+
 
 @pytest.fixture
 def harness(tmp_path: Path) -> _ShimHarness:
@@ -148,7 +183,8 @@ def harness(tmp_path: Path) -> _ShimHarness:
 
     The real commands are never reachable from the scripts under test, so a
     regression that re-runs the suite shows up as a recorded ``pytest``
-    invocation rather than as a seven-minute test.
+    invocation rather than as a seven-minute test. Both shims succeed unless a
+    test asks for a failure via :meth:`_ShimHarness.with_coverage_exit`.
 
     Args:
         tmp_path: Per-test directory holding the shims, the logs, and a stand-in
@@ -159,8 +195,8 @@ def harness(tmp_path: Path) -> _ShimHarness:
     """
     shim_dir = tmp_path / "shims"
     shim_dir.mkdir()
-    _write_shim(shim_dir / "pytest", _PYTEST_LOG_ENV)
-    _write_shim(shim_dir / "coverage", _COVERAGE_LOG_ENV)
+    _write_shim(shim_dir / "pytest", _PYTEST_LOG_ENV, _PYTEST_EXIT_ENV)
+    _write_shim(shim_dir / "coverage", _COVERAGE_LOG_ENV, _COVERAGE_EXIT_ENV)
 
     pytest_log = tmp_path / "pytest-calls.log"
     coverage_log = tmp_path / "coverage-calls.log"
@@ -168,6 +204,9 @@ def harness(tmp_path: Path) -> _ShimHarness:
     coverage_data.write_text("stand-in for the data file stage 6 writes\n")
 
     env = dict(os.environ)
+    # Inherited values would silently make every shim fail; each test opts in.
+    env.pop(_PYTEST_EXIT_ENV, None)
+    env.pop(_COVERAGE_EXIT_ENV, None)
     env["PATH"] = f"{shim_dir}{os.pathsep}{env['PATH']}"
     env[_PYTEST_LOG_ENV] = str(pytest_log)
     env[_COVERAGE_LOG_ENV] = str(coverage_log)
@@ -257,7 +296,7 @@ def test_report_only_fails_loudly_when_the_coverage_data_is_missing(
 
     result = _run_coverage_script(env, REPORT_ONLY_FLAG)
 
-    assert result.returncode == MISSING_DATA_EXIT_CODE, result.stderr
+    assert result.returncode == COVERAGE_ERROR_EXIT_CODE, result.stderr
     assert MISSING_DATA_MESSAGE in result.stderr.lower(), (
         f"stderr must say the coverage data is missing; got: {result.stderr!r}"
     )
@@ -267,6 +306,62 @@ def test_report_only_fails_loudly_when_the_coverage_data_is_missing(
     assert harness.pytest_calls() == [], (
         "missing coverage data must abort, not fall back to running the suite"
     )
+
+
+def test_report_only_fails_the_build_when_the_reporter_reports_a_shortfall(
+    harness: _ShimHarness,
+) -> None:
+    """A threshold miss fails the gate and produces no passing artifact.
+
+    Passing ``--fail-under`` to the reporter only matters if the reporter's
+    verdict is honored, so the shortfall is simulated at its source: coverage.py
+    exiting with its ``FAIL_UNDER`` status. The XML report is asserted absent
+    because shipping CI an artifact rendered by a run that failed its own
+    threshold is precisely the fail-open the consolidation must not open.
+    """
+    env = harness.with_coverage_exit(COVERAGE_PY_FAIL_UNDER_STATUS)
+
+    result = _run_coverage_script(env, REPORT_ONLY_FLAG, XML_FLAG)
+
+    assert result.returncode == BELOW_THRESHOLD_EXIT_CODE, (
+        f"a shortfall must fail the build; got exit {result.returncode} "
+        f"with stderr: {result.stderr!r}"
+    )
+    assert BELOW_THRESHOLD_MESSAGE in result.stderr.lower(), (
+        f"stderr must name the shortfall; got: {result.stderr!r}"
+    )
+    assert harness.coverage_calls_named(COVERAGE_XML_COMMAND) == [], (
+        f"a failing report must not go on to write coverage.xml; got: {harness.coverage_calls()}"
+    )
+    assert harness.pytest_calls() == [], (
+        "a shortfall must be reported, not re-measured by running the suite"
+    )
+
+
+def test_report_only_distinguishes_a_reporter_error_from_a_shortfall(
+    harness: _ShimHarness,
+) -> None:
+    """An unreadable data file is an error, not a coverage shortfall.
+
+    coverage.py returns its generic error status for a corrupt data file or a
+    bad configuration, which says nothing about how much code the suite covered.
+    Collapsing it into the shortfall exit sends the operator off to write tests
+    they do not need while the broken toolchain goes unmentioned, so the script
+    keeps the two exit codes its own documentation promises.
+    """
+    env = harness.with_coverage_exit(COVERAGE_PY_ERROR_STATUS)
+
+    result = _run_coverage_script(env, REPORT_ONLY_FLAG)
+
+    assert result.returncode == COVERAGE_ERROR_EXIT_CODE, (
+        f"a reporter error must exit {COVERAGE_ERROR_EXIT_CODE}, not "
+        f"{BELOW_THRESHOLD_EXIT_CODE}; got exit {result.returncode} "
+        f"with stderr: {result.stderr!r}"
+    )
+    assert BELOW_THRESHOLD_MESSAGE not in result.stderr.lower(), (
+        f"a reporter error must not be reported as missing coverage; got: {result.stderr!r}"
+    )
+    assert result.stderr.strip(), "a failing run must tell the operator something"
 
 
 def test_check_all_triggers_at_most_one_test_run() -> None:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@ scripts/
 │   ├── format.sh      # ruff format
 │   ├── typecheck.sh   # mypy
 │   ├── test.sh        # pytest (--unit / --integration / --e2e / --all)
-│   ├── coverage.sh    # pytest with coverage (≥90%)
+│   ├── coverage.sh    # pytest with coverage (≥90%); --report-only reports on existing data
 │   ├── security.sh    # bandit + pip-audit
 │   ├── complexity.sh  # radon + xenon
 │   └── pr-status.sh   # gh CLI workflow monitor for PRs

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -32,8 +32,8 @@ Runs:
   3. Type checking (MyPy)
   4. Security checks (Bandit + Safety)
   5. Complexity analysis (Radon)
-  6. Unit tests
-  7. Coverage report
+  6. Unit tests (measured under coverage)
+  7. Coverage report (reports on the data step 6 wrote; no second test run)
 
 OPTIONS:
     --verbose   Show detailed output
@@ -114,8 +114,14 @@ run_check "Formatting" "format.sh" --check
 run_check "Type checking" "typecheck.sh"
 run_check "Security checks" "security.sh"
 run_check "Complexity analysis" "complexity.sh"
+# The coverage stage reports on whatever data is on disk, so the disk has to
+# be cleared first: coverage.py appends parallel data files, and a leftover
+# .coverage or coverage.xml would be reported - and handed to CI - as if it
+# described this run.
+rm -f .coverage .coverage.* coverage.xml
+
 run_check "Unit tests" "test.sh" --unit
-run_check "Coverage report" "coverage.sh"
+run_check "Coverage report" "coverage.sh" --report-only --xml
 
 echo "=== Quality Checks Summary ==="
 echo "Passed: ${#PASSED_CHECKS[@]}"

--- a/scripts/backend/coverage.sh
+++ b/scripts/backend/coverage.sh
@@ -11,6 +11,12 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
 # never drift into enforcing two different percentages.
 COVERAGE_THRESHOLD=90
 
+# coverage.py's own exit status for a percentage that missed --fail-under (see
+# its `coverage.cmdline`). Every other non-zero status it returns means the
+# report could not be produced at all, which says nothing about how much code
+# the suite covered -- so the two must not be reported as the same failure.
+COVERAGE_PY_FAIL_UNDER_STATUS=2
+
 HTML_REPORT=false
 XML_REPORT=false
 REPORT_ONLY=false
@@ -53,7 +59,8 @@ OPTIONS:
 EXIT CODES:
     0           Coverage threshold met
     1           Coverage below threshold
-    2           Error running coverage (including missing coverage data)
+    2           Coverage could not be reported: missing coverage data, or the
+                report itself failed (unreadable data, bad configuration)
 
 EXAMPLES:
     $(basename "$0")                     # Run coverage with terminal report
@@ -96,10 +103,24 @@ if $REPORT_ONLY; then
 
     echo "Reporting from existing coverage data: $COVERAGE_DATA_FILE"
 
-    coverage report "--fail-under=$COVERAGE_THRESHOLD" || {
+    # A shortfall and a broken reporter are different verdicts for the operator:
+    # one means write more tests, the other means the coverage data or config is
+    # unusable. The status is captured with `||` rather than inside an
+    # `if ! ...` body, where `$?` would already have been reset to 0 by the
+    # negation.
+    REPORT_STATUS=0
+    coverage report "--fail-under=$COVERAGE_THRESHOLD" || REPORT_STATUS=$?
+
+    if [ "$REPORT_STATUS" -eq "$COVERAGE_PY_FAIL_UNDER_STATUS" ]; then
         echo "✗ Coverage below threshold" >&2
         exit 1
-    }
+    fi
+
+    if [ "$REPORT_STATUS" -ne 0 ]; then
+        echo "✗ Coverage report failed (coverage exited $REPORT_STATUS)" >&2
+        echo "  The coverage data or configuration is unusable, not undercovered." >&2
+        exit 2
+    fi
 
     if $XML_REPORT; then
         coverage xml

--- a/scripts/backend/coverage.sh
+++ b/scripts/backend/coverage.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # scripts/coverage.sh - Run tests with coverage report
-# Usage: ./scripts/coverage.sh [--html] [--xml] [--verbose] [--help]
+# Usage: ./scripts/coverage.sh [--report-only] [--html] [--xml] [--verbose] [--help]
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
 
+# The gate itself, named once so the measured run and the report-only run can
+# never drift into enforcing two different percentages.
+COVERAGE_THRESHOLD=90
+
 HTML_REPORT=false
 XML_REPORT=false
+REPORT_ONLY=false
 VERBOSE=false
 
 # Parse command line arguments
@@ -22,6 +27,10 @@ while [[ $# -gt 0 ]]; do
             XML_REPORT=true
             shift
             ;;
+        --report-only)
+            REPORT_ONLY=true
+            shift
+            ;;
         --verbose)
             VERBOSE=true
             shift
@@ -30,23 +39,27 @@ while [[ $# -gt 0 ]]; do
             cat << EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Run tests with coverage report.
+Run tests with coverage report, or report on an earlier run's coverage data.
 
 OPTIONS:
-    --html      Generate HTML coverage report
-    --xml       Generate XML coverage report (for CI)
-    --verbose   Show detailed output
-    --help      Display this help message
+    --report-only   Report from the coverage data an earlier run left on disk;
+                    does not run the tests. Reads \${COVERAGE_FILE:-.coverage}
+                    under backend/ and fails when that file is absent.
+    --html          Generate HTML coverage report
+    --xml           Generate XML coverage report (for CI)
+    --verbose       Show detailed output
+    --help          Display this help message
 
 EXIT CODES:
     0           Coverage threshold met
     1           Coverage below threshold
-    2           Error running coverage
+    2           Error running coverage (including missing coverage data)
 
 EXAMPLES:
-    $(basename "$0")          # Run coverage with terminal report
-    $(basename "$0") --html   # Generate HTML report
-    $(basename "$0") --xml    # Generate XML report for CI
+    $(basename "$0")                     # Run coverage with terminal report
+    $(basename "$0") --html              # Generate HTML report
+    $(basename "$0") --xml               # Generate XML report for CI
+    $(basename "$0") --report-only --xml # Report on the previous run's data
 EOF
             exit 0
             ;;
@@ -66,13 +79,50 @@ fi
 
 echo "=== Coverage Report ==="
 
+# --report-only renders the data an earlier pytest run already wrote, so a
+# caller that has just run the suite (check-all.sh) does not pay for a second
+# one. COVERAGE_FILE is coverage.py's own convention for locating that data.
+if $REPORT_ONLY; then
+    COVERAGE_DATA_FILE="${COVERAGE_FILE:-.coverage}"
+
+    # With nothing on disk there is no honest report to print, and running the
+    # suite here would silently restore the duplicated run this flag exists to
+    # avoid. Refuse loudly instead, naming the file that was looked for.
+    if [ ! -f "$COVERAGE_DATA_FILE" ]; then
+        echo "✗ No coverage data at $COVERAGE_DATA_FILE" >&2
+        echo "  Run the suite first; --report-only never runs it." >&2
+        exit 2
+    fi
+
+    echo "Reporting from existing coverage data: $COVERAGE_DATA_FILE"
+
+    coverage report "--fail-under=$COVERAGE_THRESHOLD" || {
+        echo "✗ Coverage below threshold" >&2
+        exit 1
+    }
+
+    if $XML_REPORT; then
+        coverage xml
+        echo "XML report generated as coverage.xml"
+    fi
+
+    if $HTML_REPORT; then
+        coverage html
+        echo "HTML report generated in htmlcov/"
+    fi
+
+    echo "✓ Coverage threshold met"
+
+    exit 0
+fi
+
 # Build pytest arguments
 PYTEST_ARGS=(
     -v
     --cov=src
     --cov-branch
     --cov-report=term-missing
-    --cov-fail-under=90
+    "--cov-fail-under=$COVERAGE_THRESHOLD"
 )
 
 # Add HTML report if requested


### PR DESCRIPTION
## Summary

- **`scripts/backend/check-all.sh` ran the entire backend suite twice.** Stage 6 (`test.sh --unit`) and stage 7 (`coverage.sh`) selected an identical test set, and `backend/pyproject.toml`'s pytest `addopts` already inject `--cov=src --cov=scripts --cov-report=xml --cov-fail-under=90` into *every* pytest process — so stage 6 was already enforcing the 90% gate on branch-enabled data and already writing `coverage.xml`. Stage 7 bought nothing but a second ~407s wait, putting the documented Gate 2 command past the 10-minute per-command ceiling that has already killed two Ralph workers mid-run.
- **`coverage.sh` gains `--report-only`:** it renders the data an earlier run left on disk (via coverage.py's own `COVERAGE_FILE` convention) instead of re-running pytest — still passing the 90% threshold to the reporter, still writing the `coverage.xml` CI consumes. Absent data is a loud `exit 2`, never a fallback run and never a stale number; `check-all.sh` purges `.coverage`, `.coverage.*` and `coverage.xml` before the test stage so the report can only describe the run that just happened. All seven checks keep their own pass/fail line and no threshold moved.
- **CI's `backend-quality` job had the same defect from the other end** — the `Run pre-push hooks` step runs the whole suite under coverage and the `Branch coverage ≥80%` step then ran it *again*, which is why that job has been clocked at 27–30 minutes. It now regenerates the report from the data already collected.
- Also fixed while proving the gate: `--report-only` now distinguishes coverage.py's `FAIL_UNDER` (2) from `ERR` (1), so an operator with a corrupt data file is no longer told their tests are under-covered.

## Measured before/after (this worktree, 3340 tests)

| Stage | Before | After |
| --- | ---: | ---: |
| Dependency drift + lint + format + typecheck + security + complexity | 17.2s | 17.2s |
| Unit tests (`test.sh --unit`) | 407.6s | 407.6s |
| Coverage report (`coverage.sh`) | 406.7s | **~1.3s** |
| **Total** | **831.5s (13m52s)** | **403.4s (6m43s)** |

The "before" total is the sum of the individually measured stages, because the whole command *cannot* complete inside the ceiling — that is the defect. The "after" number is a single end-to-end foreground `./scripts/backend/check-all.sh`, exit 0, `Passed: 7 / Failed: 0`. Two independent runs: 426.5s and 403.4s. That is a ~51% reduction and roughly 3 minutes of headroom under the 600s ceiling.

## What was checked so this is not a weakened gate

- **The two stages ran the same tests.** `test.sh --unit` applies `-m "not integration and not e2e"`; no test in the repo carries either marker, and `pytest --collect-only -q` hashes **identically** with and without the marker expression. Zero deselection.
- **The threshold still fails the build.** `coverage report --fail-under=90` reads the same combined data file under the same `[tool.coverage.*]` config and yields the same number the pytest run printed (97% TOTAL). pytest-cov's `Central.finish()` combines `parallel=true` data into the plain `.coverage` file at session end, so the data is there to report on.
- **A failing report is honored, not just requested.** New tests drive the reporter to fail at its source: a shortfall must fail the build *and* must not go on to write a passing `coverage.xml`; a reporter error must not be reported as missing coverage. Verified against real coverage 7.14.1 with a corrupt data file, not only against the shim.
- **The CI derivation is equivalent.** `coverage xml --include="src/*,scripts/*"` off the pre-push hook's data yields **190 files, 92.44%** branch-rate versus the old step's **190 files, 92.33%** — run-to-run jitter, against an 80% gate.
- No threshold, marker, `-x`, sampling, deselection, skip, `noqa`, or `type: ignore` anywhere in the diff. `pytest-xdist` was considered and **rejected**: it is not a pinned dependency, and `backend/conftest.py` shares a module-level in-memory engine/session factory, mutates `app.dependency_overrides`, and holds a module-level rate limiter — not demonstrably parallel-safe. Removing the duplicate run alone clears the ceiling, and a flaky parallel suite would be worse than a slow serial one.

## Test plan

- **Gate 1 (new tests, `backend/tests/scripts/test_coverage_report_only.py`):** 8 tests driving the real scripts through `PATH` shims that record argv and return a configurable exit status. They pin that `--report-only` starts **zero** test runners, still passes `--fail-under=90`, still emits the XML, refuses loudly with `exit 2` when the data file is absent, honors both of the reporter's failure modes distinctly, keeps `coverage.sh`-with-no-flags running the suite exactly once, and — read statically from `check-all.sh` — that exactly one stage can trigger a pytest run while all seven check names survive and the stale artifacts are purged first.
- **Gate 2:** `./scripts/backend/check-all.sh` → exit 0 in 403.37s, all seven checks reported and passed individually (`Reporting from existing coverage data: .coverage` in the stage-7 output).
- Real smoke tests: `coverage.sh --report-only --xml` → exit 0 in 1.25s, 97% TOTAL, `coverage.xml` written; `COVERAGE_FILE=/nonexistent/.coverage` → exit 2 naming the path; a junk data file → real coverage.py `ERR` surfaced as exit 2, not as a shortfall.
- `pre-commit run` on every changed file (incl. `shellcheck`, `ruff`, `mypy`, `bandit`, `detect-secrets`) → pass. `xenon src/ --max-absolute A --max-modules A --max-average A` and `radon mi src/ -n B -s` → pass.
- **Gate 2.5:** `code-review-orchestrator` over the diff → `CLEAN`, no blocking findings. Its two substantive non-blocking findings (the exit-code conflation, and the missing "is a failing report honored?" test) are fixed in the third commit; its lint-config finding is fixed too — `ruff` unions the ignore lists of every matching glob, so the repeated base list was redundant and `S404` was a preview rule with no effect, leaving `S603` as the only load-bearing addition.

## Graph

skipped: fresh worktree ships no `graphify-out/graph.json`, and the change is shell scripts, a CI workflow, and a meta-test — no application symbols are touched, so `affected` has nothing to say. Worth saving as a trace after merge: *backend pytest `addopts` already inject the full coverage gate into every run, so any script adding its own `--cov` flags is duplicating a gate rather than adding one.*

## Known, unchanged exposure

`coverage` is invoked as a CLI by both the new `--report-only` path and the CI step, but it is pinned only transitively (via `pytest-cov==7.1.0`); `backend/requirements-lock.txt` is compiled from `requirements.txt` and covers prod dependencies only. Installation is guaranteed — pytest-cov cannot function without it — and the CI step already parsed a coverage.py-generated `coverage.xml` before this change, so the schema exposure is not new. Pinning dev-side transitives is a separate concern from this issue.

Closes #2016
