### PR TITLE
fix(ralph): changes-requested verdicts wake the watcher + exec-bit regression guard

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -124,7 +124,7 @@ freshness against `main` with the compare API rather than trusting
 exit code alongside the token — the helper exits non-zero when it cannot classify
 a lane, and an unchecked `$STATUS` would just come back empty:
 ```bash
-STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM") && RC=0 || RC=$?   # ready | ready-unreviewed | behind | pending | ci-failed | awaiting-review | optout
+STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM") && RC=0 || RC=$?   # ready | ready-unreviewed | behind | pending | ci-failed | changes-requested | awaiting-review | optout
 ```
 Read the PR's comments once for context (which issue it closes, verdict text):
 ```bash
@@ -184,9 +184,17 @@ Then act on `$STATUS`:
   A clean sync → dispatch its `ralph-worker` to re-clear Gate 2 locally and push;
   it re-merges on a later wake once green. `SYNC-CONFLICT` → that lane drops to
   Gate 1 (worker resolves the conflict as a root-cause change, re-greens, pushes).
-- **`pending`** / **`awaiting-review`** — CI is still running or no fresh LGTM
-  verdict exists yet. Leave the lane; its Step 5 wake (webhook subscription, or
-  the local `watch-pr.sh` watcher) fires when CI or the verdict changes. **Exception — missing review usually means a merge
+- **`changes-requested`** — a fresh verdict (posted after this HEAD) that is
+  not `LGTM`: `CHANGES_REQUESTED` or `COMMENTS`. **Gate 4 failed** — advance it
+  via Step 2 (`address-feedback`). Never leave this lane to wait: the verdict
+  already arrived, and this token exists precisely so the watcher wakes on it
+  instead of sleeping out its timeout (a fresh non-LGTM used to read as
+  `awaiting-review`, which the watcher counts as in-flight).
+- **`pending`** / **`awaiting-review`** — CI is still running, or the verdict
+  is genuinely missing or stale (predates HEAD; a fresh non-LGTM prints
+  `changes-requested` instead). Leave the lane; its Step 5 wake (webhook
+  subscription, or the local `watch-pr.sh` watcher) fires when CI or the
+  verdict changes. **Exception — missing review usually means a merge
   conflict:** if the verdict never arrives and the `claude-review` check is
   absent from the rollup entirely, check
   `gh pr view N --json mergeable,mergeStateStatus` FIRST. A `CONFLICTING`/`DIRTY`
@@ -229,7 +237,8 @@ into that PR's worktree only if it needs a fix (re-attach a worktree with
 `scripts/ralph/fleet.sh assign "$N" "<slug>"` if reconcile removed it — `assign`
 reuses the existing branch):
 
-- **Gate 4 failed** (`CHANGES_REQUESTED`/`COMMENTS`): worker runs the
+- **Gate 4 failed** (`pr-ready.sh` printed `changes-requested`: the fresh
+  verdict is `CHANGES_REQUESTED`/`COMMENTS`): worker runs the
   **`address-feedback`** flow in the worktree — triage, TDD fix loop dispatching
   the specialist that owns each comment, re-clear Gate 2 + Gate 2.5, push, reply,
   resolve threads.

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -43,4 +43,5 @@ jobs:
           bash scripts/ralph/test_pick_next.sh
           bash scripts/ralph/test_pr_ready.sh
           bash scripts/ralph/test_watch_pr.sh
+          bash scripts/ralph/test_exec_bits.sh
           bash scripts/ralph/test_ensure_issue_label.sh

--- a/scripts/ralph/FLEET.md
+++ b/scripts/ralph/FLEET.md
@@ -153,7 +153,8 @@ One token per lane, exactly one action. This table, `pr-ready.sh`'s header, and
 | `behind` | `LGTM` + green but not current with `main`. | `fleet.sh sync <N>`; merge on a later wake once re-green. |
 | `pending` | CI still running. | Wait for a later wake. |
 | `ci-failed` | a check failed or errored. | Dispatch a `ci-debugging` worker into the lane. |
-| `awaiting-review` | no fresh `LGTM` — missing, stale, or non-LGTM. | Wait; `address-feedback` on `CHANGES_REQUESTED`. |
+| `changes-requested` | a fresh verdict (posted after HEAD) that is not `LGTM` — `CHANGES_REQUESTED` or `COMMENTS`. Gate 4 failed. | Dispatch an `address-feedback` worker into the lane. Terminal for `watch-pr.sh` — the watcher exits on it, so the verdict is a wake, never a timeout. |
+| `awaiting-review` | no verdict yet, or only a stale one that predates HEAD (a fresh non-LGTM is `changes-requested` instead). | Wait for the review or re-review; `watch-pr.sh` counts this as in-flight. |
 | `optout` | `do-not-auto-merge` on the PR or on the issue it closes. | Leave the lane entirely alone — no merge, no sync, no worker, and never `assign`/`adopt` a new one. A worktree it already holds **stays held** (`reconcile` releases only on `MERGED`/`CLOSED`): releasing it would discard work a human paused. Run `fleet.sh release <N>` by hand to take the slot back. |
 | *non-zero exit* | could not classify (API failure, expired token). | Leave the lane alone this wake; the next wake retries. |
 
@@ -241,7 +242,7 @@ GitHub**, never from stored bookkeeping, so the loop stays re-entrant.
 
 ## Tests
 
-Five offline suites cover the fleet — four shell, one Python — all run in CI by
+Seven offline suites cover the fleet — six shell, one Python — all run in CI by
 `.github/workflows/ralph-recap-tests.yml` on any `scripts/ralph/**` change:
 
 - `scripts/ralph/test_fleet.sh` builds a throwaway repo (with an `origin` remote
@@ -257,7 +258,15 @@ Five offline suites cover the fleet — four shell, one Python — all run in CI
   the *last* issue link in the body and that an unreadable label answer fails
   closed (exit 2, not "no hold") — the freshness guard (`CLEAN` is not proof of
   being current) and its laziness (only a would-be-`ready` lane pays for the
-  compare probe), and the `ready-unreviewed` path.
+  compare probe), the `ready-unreviewed` path, and the `changes-requested`
+  split (a fresh non-LGTM verdict is actionable; missing/stale keeps waiting).
+- `scripts/ralph/test_watch_pr.sh` covers `watch-pr.sh`, the per-lane hot
+  watcher local sessions background: pidfile idempotence, the
+  in-flight→terminal-token exit (including that `changes-requested` ends the
+  watch), API-error tolerance, the `gone` exit, and the timeout.
+- `scripts/ralph/test_exec_bits.sh` asserts every `scripts/ralph/*.sh` is
+  committed `100755` (`git ls-files -s`), so a directly-invoked script can
+  never again ship exiting 126 — the mode CI's `bash <script>` launches mask.
 - `scripts/ralph/test_ensure_issue_label.sh` covers `ensure-issue-label.sh`, the
   prove-it-stuck labeller the Dependabot bridge files its issues with.
 - `pytest scripts/ralph` (`test_recap_stats.py`) covers the recap's pure stats
@@ -267,6 +276,8 @@ Five offline suites cover the fleet — four shell, one Python — all run in CI
 bash scripts/ralph/test_fleet.sh
 bash scripts/ralph/test_pick_next.sh
 bash scripts/ralph/test_pr_ready.sh
+bash scripts/ralph/test_watch_pr.sh
+bash scripts/ralph/test_exec_bits.sh
 bash scripts/ralph/test_ensure_issue_label.sh
 python -m pytest scripts/ralph -q
 ```

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -13,7 +13,10 @@
 #   behind           LGTM (fresh) + CI green but the branch is not current → sync first
 #   pending          CI still running → wait for a later wake
 #   ci-failed        CI has a failing/errored check → Step 2 (ci-debugging)
-#   awaiting-review  no fresh LGTM verdict (missing, stale, or non-LGTM) → wait / Step 2
+#   changes-requested  a FRESH verdict (posted after the PR's HEAD commit) that
+#                    is not LGTM (CHANGES_REQUESTED/COMMENTS) → Step 2
+#                    (address-feedback): Gate 4 has spoken and wants changes
+#   awaiting-review  no verdict yet, or only a stale one (predates HEAD) → wait
 #   optout           `do-not-auto-merge` on the PR or on the issue it closes → the
 #                    loop does not act on this PR AT ALL (no merge, no sync, no
 #                    ci-debugging worker); a human owns it. Checked first, and an
@@ -59,7 +62,20 @@
 #
 # Stale-verdict guard: a review verdict only counts when it was posted AFTER the
 # PR's HEAD commit. An LGTM from before the latest push is stale (it reviewed
-# older code) and must not gate a merge.
+# older code) and must not gate a merge — and a stale non-LGTM likewise reads as
+# `awaiting-review` (the re-review is owed), never as `changes-requested`.
+#
+# WHY `changes-requested` EXISTS (upstream report Creek-Vault#1097): this token
+# used to be folded into `awaiting-review`, which watch-pr.sh counts as
+# in-flight — so the hot watch could wake on an LGTM in seconds but slept out
+# its full timeout on the one Gate 4 outcome that needs the orchestrator
+# SOONER. Splitting it lets the watcher exit on it with no change to its
+# in-flight set. Precedence is untouched: the check sits exactly where
+# `awaiting-review` is emitted — after optout/pending/ci-failed and the
+# missing-HEAD fail-closed guard — and fail-closed behaviour is preserved: an
+# unreadable verdict lookup still aborts non-zero (a tooling error, no token),
+# and a malformed freshness/flag field degrades to `awaiting-review`, never to
+# the new token.
 #
 # Freshness guard: `mergeStateStatus` is NOT a freshness signal. GitHub only
 # reports BEHIND when the base branch enforces strict/up-to-date status checks,
@@ -277,10 +293,20 @@ review_gate_absent() {
 # Fresh LGTM ⇔ latest verdict is LGTM AND its createdAt is strictly newer than
 # the HEAD commit. RFC3339 UTC timestamps are fixed-width, so a lexical string
 # compare is a correct chronological compare (portable — no date arithmetic).
-# Absent that, the lane waits for review unless there is no review to wait for,
-# in which case it still has to clear every non-review condition below.
+# Absent that, three states stay distinguishable because they route differently
+# (see the header): a FRESH non-LGTM verdict is `changes-requested` — the
+# review ran and wants changes, so neither waiting nor `ready-unreviewed` can
+# ever apply — while a missing or stale verdict waits as `awaiting-review`
+# unless there is no review to wait for, in which case the lane still has to
+# clear every non-review condition below. The freshness test mirrors the LGTM
+# one exactly, and the flag must be the literal jq `false`: a malformed field
+# (a stray `|` shifting it) matches neither branch and degrades to
+# `awaiting-review` — fail closed, never a fresh-verdict claim.
 ready_token="ready"
 if [[ "$verdict_lgtm" != "true" || -z "$verdict_date" ]] || ! [[ "$verdict_date" > "$head_date" ]]; then
+  if [[ "$verdict_lgtm" == "false" && -n "$verdict_date" ]] && [[ "$verdict_date" > "$head_date" ]]; then
+    echo "changes-requested"; exit 0
+  fi
   review_gate_absent || { echo "awaiting-review"; exit 0; }
   ready_token="ready-unreviewed"
 fi

--- a/scripts/ralph/test_exec_bits.sh
+++ b/scripts/ralph/test_exec_bits.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/ralph/test_exec_bits.sh
+#
+# Regression guard for the executable bits on the Ralph shell tooling
+# (upstream report Creek-Vault#1096): watch-pr.sh shipped there as 100644, so
+# the documented direct invocation — `scripts/ralph/watch-pr.sh <PR>`, exactly
+# what ralph-tick.md Step 5 tells the orchestrator to background — exited 126
+# on every local session, and the armed watcher silently never existed. CI
+# never noticed because the suites are launched via `bash <script>`, which
+# ignores the mode entirely.
+#
+# So this suite asserts the mode git RECORDS (`git ls-files -s`), not the
+# checkout's, and covers every scripts/ralph/*.sh: the launchers because
+# ralph-tick.md and fleet.sh invoke them directly, and the test suites because
+# their own `Run:` headers document direct invocation too. It still catches a
+# regression when run via `bash` — the index is the artifact that ships.
+#
+# Run:  bash scripts/ralph/test_exec_bits.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+
+# The one mode a directly-invoked script may ship with. 100644 exits 126 at
+# launch; anything else (a symlink, a gitlink) is not a script at all.
+readonly EXECUTABLE_MODE="100755"
+
+listed=0
+while read -r mode _ _ path; do
+  listed=$((listed + 1))
+  if [[ "$mode" == "$EXECUTABLE_MODE" ]]; then
+    ok "$path is $EXECUTABLE_MODE"
+  else
+    bad "$path is $mode, not $EXECUTABLE_MODE — its documented direct invocation exits 126"
+  fi
+done < <(git -C "$DIR" ls-files -s -- '*.sh')
+
+# The guard must be guarding something: an empty listing means the lookup
+# itself broke (wrong directory, not a git checkout), not that all is well.
+if [[ "$listed" -gt 0 ]]; then
+  ok "the guard covered $listed tracked shell scripts under scripts/ralph/"
+else
+  bad "git ls-files listed no scripts/ralph/*.sh — the guard checked nothing"
+fi
+
+# --- summary ---------------------------------------------------------------
+echo
+echo "exec-bit tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -6,7 +6,9 @@
 # lane. CI state is keyed off the `gh pr checks` EXIT CODE (0=green, 8=pending,
 # else=failed), never a text grep of its TAB-delimited output, and an LGTM
 # verdict only counts when it is fresher than the PR's HEAD commit (stale-verdict
-# guard). We put a fake, arg-aware `gh` on PATH and assert every classification.
+# guard). A fresh verdict that is NOT LGTM is its own token, `changes-requested`
+# — distinct from the missing/stale `awaiting-review`, so watch-pr.sh can wake
+# on it. We put a fake, arg-aware `gh` on PATH and assert every classification.
 #
 # Three further dimensions are pinned here: a `do-not-auto-merge` opt-out that
 # short-circuits every other check; a freshness guard proving `CLEAN` alone
@@ -177,13 +179,31 @@ check "green + BEHIND + fresh LGTM → behind" "behind" \
 check "green + CLEAN + STALE LGTM → awaiting-review" "awaiting-review" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$STALE|true" run 100)"
 
-# --- no verdict yet → awaiting-review --------------------------------------
-check "green + CLEAN + no verdict → awaiting-review" "awaiting-review" \
+# --- changes-requested: a fresh non-LGTM verdict is actionable, not in-flight
+# Upstream report Creek-Vault#1097: collapsing "missing", "stale", and "fresh
+# non-LGTM" into one token made watch-pr.sh (whose in-flight set contains
+# awaiting-review) structurally blind to a CHANGES_REQUESTED/COMMENTS verdict —
+# the one Gate 4 outcome that needs the orchestrator SOONER. The four-way
+# distinction pinned here: missing and stale verdicts genuinely wait
+# (awaiting-review); a verdict posted AFTER HEAD that is not LGTM is a Gate 4
+# failure the watcher must wake on (changes-requested).
+check "no verdict yet → awaiting-review" "awaiting-review" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="|false" run 100)"
 
-# --- fresh but non-LGTM verdict (e.g. changes requested) → awaiting-review --
-check "green + CLEAN + fresh non-LGTM → awaiting-review" "awaiting-review" \
+check "stale non-LGTM verdict → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$STALE|false" run 100)"
+
+check "fresh LGTM + green + current → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 run 100)"
+
+check "green + CLEAN + fresh non-LGTM → changes-requested" "changes-requested" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|false" run 100)"
+
+# Fail closed: only the literal jq `false` flag on a provably fresh timestamp
+# may claim the new token — a malformed flag (a stray `|` shifting fields, a
+# non-boolean) degrades to awaiting-review, never to changes-requested.
+check "malformed verdict flag → awaiting-review, never changes-requested" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|garbage" run 100)"
 
 # --- REAL jq: exercise the production verdict regex against real bodies ----
 # The verdict `claude-code-review.yml` posts is `## Verdict: <X>` at the END of a
@@ -200,8 +220,9 @@ if command -v jq >/dev/null 2>&1; then
        run 100)"
 
   # `**Verdict:** CHANGES_REQUESTED` whose prose mentions "LGTM" must NOT count as
-  # LGTM — the exact false-positive a whole-body match would cause.
-  check "real CHANGES_REQUESTED w/ 'LGTM' in prose → awaiting-review" "awaiting-review" \
+  # LGTM — the exact false-positive a whole-body match would cause. It IS a
+  # fresh non-LGTM verdict, so it classifies as changes-requested.
+  check "real CHANGES_REQUESTED w/ 'LGTM' in prose → changes-requested" "changes-requested" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
        COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"Not ready for LGTM yet.\n\n**Verdict:** CHANGES_REQUESTED\n"}')" \
        run 100)"
@@ -378,6 +399,12 @@ check "opt-out lane classifies as optout" "optout" \
      PR_LABELS="$OPTOUT" BEHIND_BY=17 COMPARE_SENTINEL="$S_OPTOUT" run 100)"
 probed "opt-out lane never probes freshness" "no" "$S_OPTOUT"
 
+S_CHANGES="$WORK/compare-changes-requested"
+check "fresh non-LGTM stays changes-requested with a stale branch" "changes-requested" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|false" \
+     BEHIND_BY=17 COMPARE_SENTINEL="$S_CHANGES" run 100)"
+probed "changes-requested lane never probes freshness" "no" "$S_CHANGES"
+
 # --- ready-unreviewed: the PR class whose review gate cannot exist -----------
 # `claude-code-review.yml` never runs while Dependabot is the only pusher (GitHub
 # withholds the OAuth secret from runs it triggers), so the job reports SKIPPED,
@@ -525,6 +552,15 @@ check "fresh LGTM still classifies as ready" "ready" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" REVIEW_SENTINEL="$S_GATE_LGTM" run 100)"
 probed "a fresh verdict never probes the review gate" "no" "$S_GATE_LGTM"
+
+# A fresh non-LGTM verdict answers the review question by itself: the review
+# ran and wants changes, so ready-unreviewed can never apply and the gate probe
+# would be a wasted API call on every lane awaiting its fix worker.
+S_GATE_CHANGES="$WORK/gate-changes-requested"
+check "fresh non-LGTM still classifies as changes-requested" "changes-requested" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|false" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" REVIEW_SENTINEL="$S_GATE_CHANGES" run 100)"
+probed "a fresh non-LGTM verdict never probes the review gate" "no" "$S_GATE_CHANGES"
 
 S_GATE_PENDING="$WORK/gate-pending"
 check "reviewless lane with pending CI stays pending" "pending" \

--- a/scripts/ralph/test_watch_pr.sh
+++ b/scripts/ralph/test_watch_pr.sh
@@ -134,6 +134,22 @@ check "watcher polled exactly three times" "3" "$(cat "$COUNT_FILE")"
 run_watch behind pending behind
 check "behind is a terminal token" "WATCH 103 behind" "$(watch 103 1 30)"
 
+# changes-requested — a fresh non-LGTM verdict (upstream Creek-Vault#1097) —
+# must END the watch promptly: Gate 4 has already spoken and the orchestrator
+# owes the lane an address-feedback worker, so sleeping out the timeout on it
+# is the exact latency the watcher exists to remove. The fix lives entirely in
+# pr-ready.sh's vocabulary: the token falls outside IN_FLIGHT_TOKENS, so the
+# in-flight set itself must stay exactly (pending, awaiting-review) — adding
+# the new token there would silence this wake again.
+run_watch changes pending awaiting-review changes-requested
+rc=0
+out="$(watch 112 1 30)" || rc=$?
+check "a fresh non-LGTM verdict ends the watch with its token" "WATCH 112 changes-requested" "$out"
+check "a changes-requested watch exits 0" "0" "$rc"
+check "watcher stopped polling the moment the verdict token arrived" "3" "$(cat "$COUNT_FILE")"
+check "IN_FLIGHT_TOKENS still lists exactly pending and awaiting-review" "1" \
+  "$(grep -c 'IN_FLIGHT_TOKENS=("pending" "awaiting-review")' "$SRC" || true)"
+
 # --- pidfile idempotence: blind re-launch every wake must be free ------------
 sleep 60 &
 HOLDER=$!

--- a/scripts/ralph/watch-pr.sh
+++ b/scripts/ralph/watch-pr.sh
@@ -42,8 +42,12 @@ readonly DEFAULT_TIMEOUT_SECONDS=1800
 readonly MAX_QUIET_ERRORS=3
 
 # The two pr-ready.sh tokens that mean "still in flight — keep waiting". Every
-# other token (ready, ready-unreviewed, behind, ci-failed, optout) is terminal
-# for the watch: the orchestrator has something to act on RIGHT NOW.
+# other token (ready, ready-unreviewed, behind, ci-failed, changes-requested,
+# optout) is terminal for the watch: the orchestrator has something to act on
+# RIGHT NOW. changes-requested — a fresh non-LGTM verdict — is DELIBERATELY
+# outside this set (upstream report Creek-Vault#1097): a lane whose review
+# wants changes needs the orchestrator sooner, not a timeout, so the wake falls
+# out of pr-ready.sh's vocabulary with no change here. Do not add it.
 readonly IN_FLIGHT_TOKENS=("pending" "awaiting-review")
 
 die() {


### PR DESCRIPTION
## Summary

Ports the hot-watch verdict fix to adepthood. Upstream reports (filed against Creek-Vault's copy of the tooling this repo shares — cross-repo references, deliberately not `Closes`):

- **Geoffe-Ga/Creek-Vault#1097** — `pr-ready.sh` conflated three lane states under `awaiting-review`: verdict *missing*, verdict *stale* (predates HEAD), and a **fresh non-LGTM verdict** (`CHANGES_REQUESTED`/`COMMENTS`). `watch-pr.sh` counts `awaiting-review` as in-flight, so the hot watch woke in seconds on an LGTM but slept out its full 1800s timeout on the one Gate 4 outcome that needs the orchestrator sooner (observed live upstream: `WATCH 1095 timeout awaiting-review` ~24 min after a fresh `COMMENTS` verdict).
- **Geoffe-Ga/Creek-Vault#1096** — the same PR shipped `watch-pr.sh`/`test_watch_pr.sh` as `100644` there, so the documented direct invocation exited 126. **Adepthood's copies were already committed `100755`** — this PR adds only the prevention test.

## Changes

1. **`pr-ready.sh`**: a fresh verdict (posted after the PR's HEAD commit) that is not LGTM now prints **`changes-requested`**. Emitted exactly where `awaiting-review` was — after `optout`/`pending`/`ci-failed` and the missing-HEAD fail-closed guard — so every other token's precedence is untouched. Missing and stale verdicts keep `awaiting-review`. Fail-closed preserved: an unreadable verdict lookup still aborts non-zero (tooling error, no token), and a malformed freshness/flag field degrades to `awaiting-review`, never the new token. Bonus the RED run surfaced: a fresh non-LGTM Dependabot lane previously fell through to the review-gate probe and could classify **`ready-unreviewed`** — a review that has spoken is never "no review to wait for"; it now short-circuits to `changes-requested` (and stays lazy: no compare probe, no review-gate probe).
2. **`watch-pr.sh`**: **no logic change** — the new token falls outside `IN_FLIGHT_TOKENS=(pending awaiting-review)` and becomes a wake automatically. Comment updated; a test pins that the in-flight set stays exactly as-is (adding the token there would silence the wake again).
3. **`test_exec_bits.sh`** (new): asserts via `git ls-files -s` that every `scripts/ralph/*.sh` is committed `100755` — the recorded mode, so it catches regressions even though CI launches suites via `bash`. Wired into the existing `ralph-recap-tests.yml` suite list (no second workflow).
4. **Routing docs**: `ralph-tick.md` Step 1 gains the `changes-requested` bullet (Gate 4 failed → Step 2 `address-feedback`) and narrows `pending`/`awaiting-review` to genuinely missing/stale; Step 2's Gate 4 bullet keys off the token. `FLEET.md` token table updated (also corrected its test list, which had never been updated for `test_watch_pr.sh`).

## RED → GREEN evidence (TDD)

**RED** — new/updated `test_pr_ready.sh` cases against unmodified `pr-ready.sh` (`80 passed, 5 failed`):

```
FAIL  - green + CLEAN + fresh non-LGTM → changes-requested (expected 'changes-requested', got 'awaiting-review')
FAIL  - real CHANGES_REQUESTED w/ 'LGTM' in prose → changes-requested (expected 'changes-requested', got 'awaiting-review')
FAIL  - fresh non-LGTM stays changes-requested with a stale branch (expected 'changes-requested', got 'awaiting-review')
FAIL  - fresh non-LGTM still classifies as changes-requested (expected 'changes-requested', got 'ready-unreviewed')
FAIL  - a fresh non-LGTM verdict never probes the review gate (expected 'no', got 'yes')
```

The four-way distinction is pinned in one block: missing → `awaiting-review`, stale → `awaiting-review`, fresh LGTM + green + current → `ready`, fresh non-LGTM → `changes-requested`, plus a malformed-flag fail-closed case.

**GREEN** — after the fix: `pr-ready tests: 85 passed, 0 failed`.

**Notes on the two suites that pass immediately (by design):**
- `test_watch_pr.sh` (`25 passed`): the new `pending → awaiting-review → changes-requested` case exits `WATCH 112 changes-requested` against the *unchanged* watcher — that is the point of the fix's shape (the wake falls out of `pr-ready.sh`'s vocabulary). The case also greps the source to pin `IN_FLIGHT_TOKENS` unchanged.
- `test_exec_bits.sh` (`11 passed`): exec bits were already correct here. Verified the guard actually guards by temporarily dropping the bit in the index (`git update-index --chmod=-x scripts/ralph/watch-pr.sh`) → `10 passed, 1 failed`, exit 1 — then restored.

## Gate results

- All seven ralph suites green locally: `test_fleet` 63, `test_pick_next` 23, `test_pr_ready` 85, `test_watch_pr` 25, `test_exec_bits` 11, `test_ensure_issue_label` 111, `pytest scripts/ralph` 75.
- `pre-commit run --all-files`: all hooks passed (incl. shellcheck, eslint, tsc, jest).

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_