### PR TITLE
fix(ralph): recap Review-iterations metric — parse the verdict line, not body substrings

### DIFF
--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import re
 from collections import Counter
 from collections.abc import Iterable
 
@@ -38,23 +39,31 @@ def parse_iso(timestamp: str) -> dt.datetime:
     return dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
 
 
+# The reviewer's verdict line, in any of its published shapes ("Verdict: LGTM",
+# "## Verdict: COMMENTS", "**Verdict:** CHANGES_REQUESTED", ...). Anchored to
+# the start of a line so verdict tokens mentioned in prose never match.
+_VERDICT_LINE = re.compile(
+    r"^\s*(?:#+\s*|\*\*)?VERDICT[:*\s]+(LGTM|CHANGES_REQUESTED|CHANGES REQUESTED|COMMENTS)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
 def normalize_verdict(raw: str) -> str | None:
     """Collapse a Claude review comment body to a single verdict token.
 
-    Returns None when the body carries no recognizable verdict line, so callers
-    can ignore non-review comments. The check mirrors the grep ladder in
-    `iteration-trigger.yml`: CHANGES_REQUESTED wins over a bare LGTM mention so
-    a comment that says "this is not yet LGTM, changes requested" is counted as
-    a change request.
+    Only line-anchored `Verdict:` lines count — the same anchored parse
+    `iteration-trigger.yml`'s grep ladder uses — because real review bodies
+    routinely mention the other tokens in prose (a COMMENTS review saying
+    "not yet LGTM", an LGTM review describing CHANGES_REQUESTED behavior).
+    When several verdict lines appear, the last one wins: earlier matches are
+    usually quotes of a previous round, and the reviewer's authoritative
+    verdict line trails the comment. Returns None when no verdict line is
+    present, so callers can ignore non-review comments.
     """
-    upper = raw.upper()
-    if "VERDICT" not in upper:
+    matches = _VERDICT_LINE.findall(raw)
+    if not matches:
         return None
-    if "CHANGES_REQUESTED" in upper or "CHANGES REQUESTED" in upper:
-        return CHANGES_REQUESTED
-    if "LGTM" in upper:
-        return LGTM
-    return COMMENTS
+    return matches[-1].upper().replace(" ", "_")
 
 
 def iterations_before_lgtm(verdicts: list[str]) -> int | None:

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -55,6 +55,56 @@ def test_normalize_verdict_defaults_to_comments() -> None:
     assert rs.normalize_verdict("Some notes.\nVerdict: COMMENTS") == rs.COMMENTS
 
 
+def test_normalize_verdict_comments_with_lgtm_in_prose_is_comments() -> None:
+    # Real reviewer pattern: a COMMENTS verdict whose rationale says the PR is
+    # "mergeable as-is" and name-drops LGTM. Body-wide substring search would
+    # misread this as LGTM and the review round would vanish from the metric.
+    body = (
+        "Solid change overall. This is mergeable as-is and close to LGTM,\n"
+        "but the docstring drift below is worth a pass first.\n\n"
+        "## Verdict: COMMENTS\n"
+    )
+    assert rs.normalize_verdict(body) == rs.COMMENTS
+
+
+def test_normalize_verdict_lgtm_with_changes_requested_in_prose_is_lgtm() -> None:
+    # Real reviewer pattern: an LGTM verdict describing CHANGES_REQUESTED
+    # behavior in prose. Body-wide substring search would misread this as
+    # CHANGES_REQUESTED and the PR would drop out of the average as never-LGTM'd.
+    body = (
+        "The retry path now handles the CHANGES_REQUESTED wake correctly.\n\n"
+        "**Verdict: LGTM**\n"
+    )
+    assert rs.normalize_verdict(body) == rs.LGTM
+
+
+def test_normalize_verdict_bold_colon_changes_requested() -> None:
+    assert rs.normalize_verdict("**Verdict:** CHANGES_REQUESTED") == rs.CHANGES_REQUESTED
+
+
+def test_normalize_verdict_none_when_verdict_only_in_prose() -> None:
+    # The word "verdict" in running prose is not a verdict line.
+    body = "Still waiting on the reviewer's verdict before merging this one."
+    assert rs.normalize_verdict(body) is None
+
+
+def test_normalize_verdict_last_verdict_line_wins() -> None:
+    # A review quoting an earlier round's verdict line: the trailing verdict
+    # line is the authoritative one.
+    body = (
+        "Previously I said:\n"
+        "Verdict: CHANGES_REQUESTED\n"
+        "All of that is addressed now.\n\n"
+        "## Verdict: LGTM\n"
+    )
+    assert rs.normalize_verdict(body) == rs.LGTM
+
+
+def test_normalize_verdict_is_case_insensitive() -> None:
+    assert rs.normalize_verdict("verdict: lgtm") == rs.LGTM
+    assert rs.normalize_verdict("## verdict: changes requested") == rs.CHANGES_REQUESTED
+
+
 # ---------- iterations_before_lgtm ----------
 
 
@@ -69,6 +119,19 @@ def test_iterations_before_lgtm_zero_for_clean_merge() -> None:
 
 def test_iterations_before_lgtm_none_when_never_lgtm() -> None:
     assert rs.iterations_before_lgtm([rs.CHANGES_REQUESTED, rs.COMMENTS]) is None
+
+
+def test_iterations_before_lgtm_counts_comments_round_from_raw_bodies() -> None:
+    # Integration through normalize_verdict: a COMMENTS round whose prose
+    # mentions LGTM must still count as one feedback round before the real
+    # LGTM — the user-visible "Review iterations" bug read this as 0.
+    bodies = [
+        "Close to LGTM but see the notes.\n\n## Verdict: COMMENTS",
+        "All addressed.\n\n## Verdict: LGTM",
+    ]
+    verdicts = [v for v in (rs.normalize_verdict(b) for b in bodies) if v is not None]
+    assert verdicts == [rs.COMMENTS, rs.LGTM]
+    assert rs.iterations_before_lgtm(verdicts) == 1
 
 
 # ---------- merge_rate ----------


### PR DESCRIPTION
## Problem

The Discord recap's "Review iterations" metric under-counts COMMENTS rounds. `scripts/ralph/stats.py::normalize_verdict()` classified a review comment by substring search over the ENTIRE body with precedence `CHANGES_REQUESTED > LGTM > COMMENTS`. Real reviewer comments routinely mention the other verdict tokens in prose, so:

- a `## Verdict: COMMENTS` review whose rationale says "not yet LGTM" / "mergeable as-is" was misread as **LGTM** — the COMMENTS round vanished and the metric read 0 rounds (the reported symptom);
- a `## Verdict: LGTM` review that recaps prior feedback or describes CHANGES_REQUESTED behavior was misread as **CHANGES_REQUESTED** — the PR dropped out of the reached-LGTM average entirely.

Both shapes occurred on real PRs tonight (Creek-Vault #1095's COMMENTS review, #1099's LGTM review).

## Fix

`normalize_verdict` now extracts the verdict from the canonical anchored verdict **line** — the same pattern `pr-ready.sh` and the review skills use — with the LAST verdict line winning (earlier matches are usually quotes) and `None` when no line states a token. Public signature unchanged; `iterations_before_lgtm` needs no change and now correctly counts COMMENTS rounds preceding an LGTM.

TDD RED→GREEN: new `test_recap_stats.py` cases reproducing both misread shapes (plus no-token-stated, last-line-wins, case-insensitivity, space-vs-underscore spellings, and `iterations_before_lgtm([COMMENTS, LGTM]) == 1`) failed against the unmodified classifier and pass after the fix. Full recap suite + ralph shell suites green locally; `pre-commit run --all-files` green.

Companion fix merged in Creek-Vault#1102 (same classifier bug in adapted form, plus its iteration-trigger first-vs-last verdict-line grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_