### PR TITLE
feat(backend): HttpCreekVaultClient — pooled, typed HTTP adapter behind the existing CreekVaultClient protocol

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -142,6 +142,20 @@ GOOGLE_OAUTH_CLIENT_IDS=  # e.g. 1234-ios.apps.googleusercontent.com,1234-web.ap
 # closed: unset means Sign in with Apple rejects every token.
 APPLE_OAUTH_CLIENT_IDS=  # e.g. com.adepthood.app,com.adepthood.web
 
+# Creek Vault integration
+#
+# Wholly optional. Leaving CREEK_VAULT_URL unset selects the local fallback
+# client: the app is fully functional without a vault, with Postgres as the sole
+# system of record and every vault-backed feature degrading to its local path.
+# A plaintext http:// URL is refused at construction for any non-loopback host,
+# because the request carries the bearer key below (http://localhost stays
+# allowed so a vault can be run locally).
+CREEK_VAULT_URL=  # e.g. https://vault.example.com
+CREEK_VAULT_API_KEY=  # bearer credential; used only to build the Authorization header
+# Which transport a configured vault is reached over: mcp (default) or http.
+# An unrecognized value fails the build of the client rather than guessing.
+CREEK_VAULT_PROTOCOL=mcp
+
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production
 # RAILWAY_PUBLIC_DOMAIN=your-app.up.railway.app

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -74,6 +74,7 @@ from services.content_repository import (
     content_version_info,
     get_content_repository,
 )
+from services.creek_vault_client import close_creek_vault_http_pool
 
 logger = logging.getLogger(__name__)
 
@@ -532,6 +533,12 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     _log_botmason_provider()
 
     yield
+
+    # The pooled Creek Vault connection must not outlive the app: closing it on
+    # shutdown releases its sockets deterministically instead of leaving an open
+    # httpx client to be reclaimed during interpreter teardown. A no-op when no
+    # vault was ever contacted, since the pool builds lazily.
+    await close_creek_vault_http_pool()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -36,7 +36,11 @@ Transport security: both configured transports refuse a plaintext ``http://``
 URL to any non-loopback host, because every request carries the
 ``CREEK_VAULT_API_KEY`` bearer credential (and, over MCP, each call's tier
 metadata) that must never cross a network in cleartext -- TLS misconfiguration
-fails closed at construction, before the key is bound to anything.
+fails closed at construction, before the key is bound to anything. Both also
+refuse a URL carrying userinfo, a query, or a fragment: userinfo is itself a
+credential that httpx would log unmasked and turn into a Basic-auth downgrade
+of our bearer, and a query or fragment would silently redirect the credential
+away from the endpoint the operator configured.
 :class:`_McpStreamableHttpTransport` speaks MCP streamable-HTTP framing
 (initialize, then ``tools/call``); :class:`HttpCreekVaultClient` speaks
 request/response JSON over a shared, credential-free pooled connection
@@ -53,13 +57,14 @@ per-capability fallback rules; Creek's published contract owns the wire shapes.
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import NoReturn, Protocol
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 
 import httpx
 from mcp import ClientSession
@@ -90,16 +95,31 @@ _VAULT_TIMEOUT_SECONDS = 10.0
 
 # The same budget applied to each phase of an HTTP call separately -- connect,
 # read, write, and pool acquisition -- rather than as httpx's bare scalar. Naming
-# every phase keeps the ceiling explicit and total: a vault that accepts the
-# connection and then never answers is bounded by the read phase, and a starved
-# connection pool is bounded by the pool phase, so no phase can silently inherit
-# an unbounded default.
+# every phase means none can silently inherit an unbounded default: a vault that
+# accepts the connection and then goes quiet is bounded by the read phase, and a
+# starved connection pool is bounded by the pool phase. These are per-phase
+# budgets, *not* a request deadline -- httpx restarts the read budget on every
+# socket read, so a vault that trickles stays inside all four indefinitely.
+# Bounding the call as a whole is :data:`_VAULT_TOTAL_DEADLINE_SECONDS`'s job.
 _VAULT_HTTP_TIMEOUT = httpx.Timeout(
     connect=_VAULT_TIMEOUT_SECONDS,
     read=_VAULT_TIMEOUT_SECONDS,
     write=_VAULT_TIMEOUT_SECONDS,
     pool=_VAULT_TIMEOUT_SECONDS,
 )
+
+# How many per-phase budgets one whole capability fetch may span. Three is the
+# count of phases a single GET actually traverses -- pool acquisition, connect,
+# read -- so a request that is legitimately slow at every one of them still
+# finishes inside the deadline, while a vault that never finishes does not.
+_VAULT_DEADLINE_PHASE_BUDGETS = 3
+
+# Wall-clock ceiling (seconds) on one whole capability fetch. Necessary because
+# httpx's phase budgets are not a request deadline: the ``read`` timeout is
+# restarted by every socket read, so a vault trickling one byte just inside it
+# stays within all four budgets forever while holding a pooled connection and a
+# worker -- and the journal write path handshakes on every write.
+_VAULT_TOTAL_DEADLINE_SECONDS = _VAULT_TIMEOUT_SECONDS * _VAULT_DEADLINE_PHASE_BUDGETS
 
 # How a "MAJOR.MINOR.PATCH" version string decomposes, and how many of its
 # leading components must match for two contract versions to interoperate. ADR
@@ -183,19 +203,61 @@ _PROTOCOL_MCP = "mcp"
 _PROTOCOL_HTTP = "http"
 
 
-def _require_secure_vault_url(url: str) -> None:
-    """Reject a plaintext vault URL to a non-loopback host, failing closed.
+# URL components a configured vault URL must not carry, in the order their
+# names are reported. ``userinfo`` (the ``user:pass@`` prefix) is itself a
+# credential: httpx renders it *unmasked* in ``str(url)`` -- which is what its
+# own INFO request log formats -- and, absent an explicit ``auth=``, derives
+# ``BasicAuth`` from it whose auth flow *assigns* ``Authorization``, silently
+# replacing our bearer with a weaker scheme. ``query`` and ``fragment`` break
+# the capability URL instead: it is built by appending a path to the configured
+# string, so either one swallows that path and aims the credential at an
+# endpoint the operator never configured.
+_FORBIDDEN_URL_PARTS = ("userinfo", "query", "fragment")
 
-    A configured vault is reached over :class:`_McpStreamableHttpTransport`,
-    whose MCP streamable-HTTP session sends the ``CREEK_VAULT_API_KEY`` bearer
-    credential (and each call's tier metadata) over the wire. Allowing a
-    plaintext ``http://`` URL to a remote host would expose that credential in
-    cleartext, so a misconfiguration raises
-    here rather than silently leaking. Plaintext to a loopback host is permitted
-    for local development. The message names only the scheme and host -- never
-    the API key.
+
+def _forbidden_url_parts(parsed: SplitResult) -> tuple[str, ...]:
+    """Return the names of the disallowed components ``parsed`` carries.
+
+    Userinfo counts as present whenever either half is set, so a degenerate
+    ``https://user@host`` (empty password) is caught alongside the full form.
+    """
+    carried = (
+        parsed.username is not None or parsed.password is not None,
+        bool(parsed.query),
+        bool(parsed.fragment),
+    )
+    return tuple(name for name, found in zip(_FORBIDDEN_URL_PARTS, carried, strict=True) if found)
+
+
+def _require_bare_vault_url(parsed: SplitResult) -> None:
+    """Reject a vault URL carrying userinfo, a query, or a fragment.
+
+    The message names only the offending *component names*: it reaches logs,
+    and one of the components it can name -- userinfo -- is a credential, so
+    echoing any value here would be the very leak this check exists to prevent.
+    """
+    parts = _forbidden_url_parts(parsed)
+    if parts:
+        raise ValueError(f"CREEK_VAULT_URL must not carry these URL components: {', '.join(parts)}")
+
+
+def _require_secure_vault_url(url: str) -> None:
+    """Reject a vault URL that is unsafe to bind a credential to, failing closed.
+
+    Guards both configured transports -- :class:`_McpStreamableHttpTransport`
+    and :class:`HttpCreekVaultClient` -- each of which sends the
+    ``CREEK_VAULT_API_KEY`` bearer credential (and, over MCP, each call's tier
+    metadata) over the wire, so any future transport must keep calling it too.
+    Two rules: the URL must carry no userinfo, query, or fragment
+    (:func:`_require_bare_vault_url`, applied to every scheme), and a plaintext
+    ``http://`` URL is allowed only to a loopback host, since cleartext to a
+    remote host would expose the credential on the network. A misconfiguration
+    raises here rather than silently leaking, before the key is bound to
+    anything. The message names only component names, the scheme, and the host
+    -- never the API key.
     """
     parsed = urlsplit(url)
+    _require_bare_vault_url(parsed)
     if parsed.scheme == "https":
         return
     if parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS:
@@ -525,6 +587,12 @@ class HandshakeDegradeReason(enum.StrEnum):
     while an unreachable vault is an infrastructure problem, and a malformed
     payload is a vault bug. Values are the wire strings telemetry counts by, so
     they are part of this module's contract and must not be reworded casually.
+
+    ``UNREACHABLE`` is the widest of the four and its name slightly overstates
+    it: every non-2xx status lands there too, so it also absorbs a 401 (a bad
+    credential -- a configuration problem) and a 500 (a vault-side fault).
+    Telemetry should read it as "the call did not complete", not strictly as
+    "the network is down".
     """
 
     UNREACHABLE = "unreachable"
@@ -550,7 +618,13 @@ def _build_pooled_vault_client() -> httpx.AsyncClient:
     header per request; the pool contributes only the reused connection and the
     timeout budget.
     """
-    return httpx.AsyncClient(timeout=_VAULT_HTTP_TIMEOUT)
+    # ``follow_redirects`` is pinned rather than inherited from httpx's default:
+    # not following redirects is a security property here, not a preference.
+    # httpx preserves an *explicitly set* ``Authorization`` header across a
+    # same-scheme cross-host redirect, so a hijacked or compromised vault could
+    # 302 our bearer straight to an attacker's host. Refusing to follow turns
+    # that into a non-2xx status, which degrades the handshake to unreachable.
+    return httpx.AsyncClient(timeout=_VAULT_HTTP_TIMEOUT, follow_redirects=False)
 
 
 class _VaultHttpPool:
@@ -655,6 +729,15 @@ class HttpCreekVaultClient:
         Resolved per call rather than in ``__init__`` so merely constructing an
         adapter never forces the pool into existence, and so a pool closed and
         later reopened is picked up without rebuilding the adapter.
+
+        One narrow window remains, by choice: a request that has already taken
+        the pooled client when :func:`close_creek_vault_http_pool` runs at
+        shutdown will see httpx's ``RuntimeError("Cannot send a request, as the
+        client has been closed.")``. That is deliberately *not* in any degrade
+        set -- catching bare ``RuntimeError`` would mask genuine bugs, and this
+        one can only surface as a process is already stopping. The pool
+        self-heals for every later call, because :meth:`_VaultHttpPool.aclose`
+        nulls the slot and the next :meth:`get` builds a fresh client.
         """
         if self._http_client is not None:
             return self._http_client
@@ -669,11 +752,19 @@ class HttpCreekVaultClient:
         non-JSON body raises ``json.JSONDecodeError``; both are degraded by the
         caller. A body that decodes to something other than a JSON object is a
         malformed payload, so it raises ``TypeError`` rather than being cast.
+
+        The request runs under a whole-call deadline because httpx's ``read``
+        budget is per socket-read rather than a deadline, so a trickling vault
+        would otherwise hold this coroutine (and its pooled connection) open
+        indefinitely. Expiry raises ``TimeoutError``, an ``OSError`` subclass,
+        so it lands in the caller's existing transport branch and degrades to
+        unreachable -- the degrade set is unchanged.
         """
-        response = await self._active_client().get(
-            f"{self._url}{_CAPABILITIES_PATH}",
-            headers={"Authorization": f"Bearer {self._api_key}"},
-        )
+        async with asyncio.timeout(_VAULT_TOTAL_DEADLINE_SECONDS):
+            response = await self._active_client().get(
+                f"{self._url}{_CAPABILITIES_PATH}",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+            )
         response.raise_for_status()
         payload = response.json()
         if not isinstance(payload, Mapping):

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -1,11 +1,11 @@
-"""Concrete Creek Vault MCP client adapters and their factory.
+"""Concrete Creek Vault client adapters and their factory.
 
 This is the service-layer counterpart to the pure :mod:`domain.creek_vault`
 seam, following the same domain-protocol -> service-adapter pattern as
 :mod:`services.marginalia` and the env-var config / error-normalization pattern
 as :mod:`services.botmason`.
 
-Two implementations of :class:`~domain.creek_vault.CreekVaultClient` live here:
+Three implementations of :class:`~domain.creek_vault.CreekVaultClient` live here:
 
 * :class:`McpCreekVaultClient` -- talks to a real vault over an injected
   :class:`VaultTransport`. It is written to **degrade, never crash**:
@@ -14,20 +14,34 @@ Two implementations of :class:`~domain.creek_vault.CreekVaultClient` live here:
   per-capability call normalizes any transport exception to
   :class:`CreekVaultUnavailableError` with a **static, capability-named message**
   that never echoes the entry body or the API key.
+* :class:`HttpCreekVaultClient` -- talks to a real vault over plain HTTP/JSON,
+  handshaking with a single ``GET /v1/capabilities``. It degrades the same way,
+  and additionally records *which* failure mode degraded it
+  (:class:`HandshakeDegradeReason`) so contract-version skew stays countable
+  apart from a vault that is merely unreachable. Its per-capability calls all
+  refuse for now: Creek's ratified ``/v1`` request/response shapes have not
+  shipped, and guessing a wire format is worse than staying local.
 * :class:`LocalFallbackCreekVaultClient` -- the no-vault path. Handshake reports
   unavailable, nothing is supported, ingest is a silent no-op (operator Postgres
   stays the system of record), and the read/compute capabilities raise
   :class:`CreekCapabilityUnsupportedError`.
 
-:func:`build_creek_vault_client` chooses between them from ``CREEK_VAULT_URL``,
-so an unconfigured deployment transparently gets the local fallback.
+:func:`build_creek_vault_client` chooses between them from ``CREEK_VAULT_URL``
+(unset means the local fallback, so an unconfigured deployment transparently
+degrades) and ``CREEK_VAULT_PROTOCOL`` (which transport a configured vault is
+reached over, defaulting to MCP so an existing deployment keeps its behavior
+until it opts in).
 
-Transport security: :class:`_McpStreamableHttpTransport` speaks MCP
-streamable-HTTP framing (initialize, then ``tools/call``) and refuses a
-plaintext ``http://`` URL to any non-loopback host, because every session
-carries the ``CREEK_VAULT_API_KEY`` bearer credential (and each call's tier
+Transport security: both configured transports refuse a plaintext ``http://``
+URL to any non-loopback host, because every request carries the
+``CREEK_VAULT_API_KEY`` bearer credential (and, over MCP, each call's tier
 metadata) that must never cross a network in cleartext -- TLS misconfiguration
-fails closed at construction. This seam does not itself encrypt the entry
+fails closed at construction, before the key is bound to anything.
+:class:`_McpStreamableHttpTransport` speaks MCP streamable-HTTP framing
+(initialize, then ``tools/call``); :class:`HttpCreekVaultClient` speaks
+request/response JSON over a shared, credential-free pooled connection
+(:class:`_VaultHttpPool`), building its authorization header per call so the
+pooled connection never holds the key. This seam does not itself encrypt the entry
 *body*: the end-to-end, ciphertext-only intimate-transit rule of Decision 6
 in ``docs/adr/0004-creek-vault-http-application-boundary.md`` (a user-held
 key the operator cannot decrypt) is enforced where the body is assembled, in
@@ -39,11 +53,12 @@ per-capability fallback rules; Creek's published contract owns the wire shapes.
 
 from __future__ import annotations
 
+import enum
 import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import Protocol
+from typing import NoReturn, Protocol
 from urllib.parse import urlsplit
 
 import httpx
@@ -73,10 +88,28 @@ from schemas.wheel import WheelBalanceResponse
 # or hung vault can block a request before adepthood degrades to local.
 _VAULT_TIMEOUT_SECONDS = 10.0
 
-# The major component of the contract version we will interoperate with. A vault
-# advertising a different major is treated as incompatible and degrades to
-# unavailable rather than risking a call under a surface we do not understand.
-_CONTRACT_MAJOR = CONTRACT_VERSION.split(".")[0]
+# The same budget applied to each phase of an HTTP call separately -- connect,
+# read, write, and pool acquisition -- rather than as httpx's bare scalar. Naming
+# every phase keeps the ceiling explicit and total: a vault that accepts the
+# connection and then never answers is bounded by the read phase, and a starved
+# connection pool is bounded by the pool phase, so no phase can silently inherit
+# an unbounded default.
+_VAULT_HTTP_TIMEOUT = httpx.Timeout(
+    connect=_VAULT_TIMEOUT_SECONDS,
+    read=_VAULT_TIMEOUT_SECONDS,
+    write=_VAULT_TIMEOUT_SECONDS,
+    pool=_VAULT_TIMEOUT_SECONDS,
+)
+
+# How a "MAJOR.MINOR.PATCH" version string decomposes, and how many of its
+# leading components must match for two contract versions to interoperate. ADR
+# 0004 Decision 4: while the contract is pre-1.0 a minor bump *is* the breaking
+# change, so client and server must match on exact major.minor; from 1.0 onward
+# minors are forward-compatible and only the major must match.
+_VERSION_MAJOR_INDEX = 0
+_PRE_1_0_MAJOR = "0"
+_PRE_1_0_MATCHED_COMPONENTS = 2
+_POST_1_0_MATCHED_COMPONENTS = 1
 
 # Transport-layer failures we normalize to a degraded state. ``OSError`` covers
 # connection/timeout errors, ``httpx.HTTPError`` covers every httpx transport
@@ -113,18 +146,41 @@ _JOURNAL_OK_STATUS = "ok"
 # degrade to unavailable exactly like a transport error, never propagate.
 _PARSE_ERROR_TYPES: tuple[type[Exception], ...] = (KeyError, TypeError, AttributeError, ValueError)
 
+
+class _IncompatibleContractVersionError(Exception):
+    """A vault advertised a contract version this client will not interoperate with.
+
+    Module-private and control-flow only: it exists so a version mismatch stays
+    *distinguishable* from an unreachable or malformed vault while still
+    degrading to the same caller-visible unavailable result (ADR 0004
+    Decision 4). It carries no payload, so it can never echo a vault response.
+    Deliberately not a :class:`~domain.creek_vault.CreekVaultError`: it never
+    escapes this module.
+    """
+
+
 # Everything a handshake probe swallows into an "unavailable" result: transport
-# failures (the vault is unreachable) and parsing failures (its payload is
-# malformed). Combining them keeps the degradation path a single ``except``.
+# failures (the vault is unreachable), parsing failures (its payload is
+# malformed), and contract-version skew. Combining them keeps the MCP
+# degradation path a single ``except``; the HTTP client splits them back out to
+# record which one it hit, without changing what any caller sees.
 _HANDSHAKE_DEGRADE_ERRORS: tuple[type[Exception], ...] = (
     *_TRANSPORT_ERROR_TYPES,
     *_PARSE_ERROR_TYPES,
+    _IncompatibleContractVersionError,
 )
 
 # Hosts for which a plaintext ``http://`` vault URL is tolerated: a developer
 # running the vault on the same machine. Every other host must use TLS so the
 # bearer credential and tier metadata never cross a network in cleartext.
 _LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Which transport a *configured* vault is reached over. MCP stays the default so
+# an existing deployment keeps its current behavior until it opts into HTTP; an
+# unrecognized value is a configuration error, never a silent fallback.
+_PROTOCOL_ENV_VAR = "CREEK_VAULT_PROTOCOL"
+_PROTOCOL_MCP = "mcp"
+_PROTOCOL_HTTP = "http"
 
 
 def _require_secure_vault_url(url: str) -> None:
@@ -227,20 +283,43 @@ def _parse_attestation(raw: object) -> Mapping[str, object] | None:
     raise TypeError("handshake attestation must be a mapping or null")
 
 
+def _contract_version_compatible(advertised: str, pinned: str = CONTRACT_VERSION) -> bool:
+    """Return whether a vault's ``advertised`` contract version is safe to call.
+
+    Implements ADR 0004 Decision 4. While ``pinned`` is pre-1.0 the comparison is
+    on exact ``major.minor``: with the major stuck at ``0`` a major-only check is
+    a no-op, and a pre-1.0 minor bump is precisely the breaking change worth
+    catching (``0.3.0`` against a ``0.2.x`` pin is rejected; ``0.2.7`` against
+    ``0.2.1`` is accepted -- patch is free to vary). From 1.0 onward the rule
+    relaxes to a major match, since minors are then forward-compatible.
+
+    ``pinned`` is a parameter rather than a closed-over constant so the post-1.0
+    branch is exercisable while the shipped pin is still pre-1.0.
+    """
+    pinned_components = pinned.split(".")
+    matched = (
+        _PRE_1_0_MATCHED_COMPONENTS
+        if pinned_components[_VERSION_MAJOR_INDEX] == _PRE_1_0_MAJOR
+        else _POST_1_0_MATCHED_COMPONENTS
+    )
+    return advertised.split(".")[:matched] == pinned_components[:matched]
+
+
 def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
     """Parse a well-formed handshake payload into a populated result.
 
-    Reads and version-checks the contract before anything else: a major-version
-    mismatch returns unavailable directly (we will not call an incompatible
-    surface). Then honors the vault's own ``available`` field, fail-closed: a
+    Reads and version-checks the contract before anything else: an incompatible
+    version raises :class:`_IncompatibleContractVersionError` (we will not call a
+    surface we do not understand), which every caller degrades to unavailable.
+    Then honors the vault's own ``available`` field, fail-closed: a
     reachable server is not necessarily an available vault, so anything other
     than a literal ``True`` (including a missing field) degrades to
     unavailable. Any missing key or wrong-typed field raises out of the helpers
     and is caught by :meth:`McpCreekVaultClient.handshake`.
     """
     contract_version = _require_str(payload, "contract_version")
-    if contract_version.split(".")[0] != _CONTRACT_MAJOR:
-        return HandshakeResult.unavailable()
+    if not _contract_version_compatible(contract_version):
+        raise _IncompatibleContractVersionError
     if payload.get("available") is not True:
         return HandshakeResult.unavailable()
     return HandshakeResult(
@@ -437,6 +516,229 @@ class McpCreekVaultClient:
         )
 
 
+class HandshakeDegradeReason(enum.StrEnum):
+    """Why a handshake degraded to :meth:`HandshakeResult.unavailable`.
+
+    Callers still see exactly one degraded state -- that is the whole point of
+    the unavailable result -- but operators need these apart: a contract-version
+    skew is a coordination problem with a specific remedy (align the two pins),
+    while an unreachable vault is an infrastructure problem, and a malformed
+    payload is a vault bug. Values are the wire strings telemetry counts by, so
+    they are part of this module's contract and must not be reworded casually.
+    """
+
+    UNREACHABLE = "unreachable"
+    MALFORMED_PAYLOAD = "malformed_payload"
+    INCOMPATIBLE_VERSION = "incompatible_version"
+    VAULT_REPORTED_UNAVAILABLE = "vault_reported_unavailable"
+
+
+# The vault's capability document, relative to the configured base URL. The one
+# endpoint adepthood can call today: Creek's ratified ``/v1`` request/response
+# shapes for the other capabilities have not shipped.
+_CAPABILITIES_PATH = "/v1/capabilities"
+
+
+def _build_pooled_vault_client() -> httpx.AsyncClient:
+    """Build the process-wide vault HTTP client: bare, credential-free, budget-bound.
+
+    Deliberately carries no ``base_url`` and no authorization header. The pooled
+    connection is shared by every :class:`HttpCreekVaultClient` in the process,
+    so binding a URL or a credential to it would both leak the key into a
+    long-lived object and invalidate the pool whenever the vault is
+    reconfigured. Each adapter supplies its own absolute URL and builds its own
+    header per request; the pool contributes only the reused connection and the
+    timeout budget.
+    """
+    return httpx.AsyncClient(timeout=_VAULT_HTTP_TIMEOUT)
+
+
+class _VaultHttpPool:
+    """Lazily built, closable holder for the shared vault HTTP client.
+
+    An object rather than a module-level mutable, so building and closing the
+    connection pool needs no ``global`` rebinding and so a test can substitute a
+    pool with a scripted factory. Building is deferred until the first request:
+    constructing a vault adapter must not open a connection pool, since an
+    adapter is built per call site while a deployment with no reachable vault
+    should never allocate one at all.
+    """
+
+    def __init__(self, build: Callable[[], httpx.AsyncClient] | None = None) -> None:
+        """Store the client factory (defaulting to the production one) unbuilt."""
+        self._build = build if build is not None else _build_pooled_vault_client
+        self._client: httpx.AsyncClient | None = None
+
+    def get(self) -> httpx.AsyncClient:
+        """Return the pooled client, building it on first use and reusing it after."""
+        if self._client is None:
+            self._client = self._build()
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the pooled client if one was built; idempotent by design.
+
+        Clears the slot before awaiting the close so a repeat call (shutdown can
+        be reached by more than one path) is a silent no-op, and so a later
+        :meth:`get` builds a fresh client rather than handing back a closed one.
+        """
+        client, self._client = self._client, None
+        if client is not None:
+            await client.aclose()
+
+
+# The process-wide pool every HTTP vault adapter borrows its connection from.
+_VAULT_HTTP_POOL = _VaultHttpPool()
+
+
+async def close_creek_vault_http_pool() -> None:
+    """Release the shared vault HTTP connection pool (call at app shutdown)."""
+    await _VAULT_HTTP_POOL.aclose()
+
+
+def _refuse_unratified(capability: CreekCapability) -> NoReturn:
+    """Refuse a capability whose request/response shape adepthood cannot know yet.
+
+    Raised with ``from None`` so no upstream exception rides along as a cause or
+    context -- the same privacy discipline the transport-error paths follow.
+    """
+    raise CreekCapabilityUnsupportedError(_unsupported_message(capability)) from None
+
+
+class HttpCreekVaultClient:
+    """A :class:`CreekVaultClient` that speaks plain HTTP/JSON to a configured vault.
+
+    Handshakes with a single ``GET /v1/capabilities`` carrying a bearer
+    ``Authorization`` header, caches the result so :meth:`is_available` and
+    :meth:`supports` stay cheap synchronous reads, and records
+    :attr:`last_degrade_reason` when the probe fails. Like the MCP client it
+    **degrades, never crashes**: :meth:`handshake` collapses every transport,
+    parsing, and version failure into :meth:`HandshakeResult.unavailable`.
+
+    The capability calls all refuse with
+    :class:`CreekCapabilityUnsupportedError`, *including* ones the vault
+    advertises. Creek's ratified ``/v1`` request/response shapes for them have
+    not shipped upstream, and this adapter will not guess a wire format: a
+    refusal degrades the caller onto its local pipeline, whereas a wrong guess
+    would send real journal content into a surface nobody has agreed on. Wiring
+    them up is follow-on work, gated on that document.
+
+    A plain class on purpose -- no dataclass, no custom ``__repr__`` -- so the
+    default object repr can never render the bearer credential this instance
+    holds.
+    """
+
+    def __init__(
+        self, url: str, api_key: str, *, http_client: httpx.AsyncClient | None = None
+    ) -> None:
+        """Validate the URL, then bind the credential, the client, and a safe cache.
+
+        :func:`_require_secure_vault_url` runs first, before the key is stored
+        anywhere, so a plaintext remote URL fails closed with the credential
+        still only a parameter. ``http_client`` is an injection seam for tests;
+        production leaves it ``None`` and borrows the shared pool per call. The
+        handshake cache is seeded unavailable so a client that never handshook
+        supports nothing.
+        """
+        _require_secure_vault_url(url)
+        self._api_key = api_key
+        # Trailing slashes are stripped so a configured URL with or without one
+        # yields the same capability URL rather than a double-slashed path.
+        self._url = url.rstrip("/")
+        self._http_client = http_client
+        self._last_handshake = HandshakeResult.unavailable()
+        self._degrade_reason: HandshakeDegradeReason | None = None
+
+    def _active_client(self) -> httpx.AsyncClient:
+        """Return the injected client, or borrow the shared pool's (built on demand).
+
+        Resolved per call rather than in ``__init__`` so merely constructing an
+        adapter never forces the pool into existence, and so a pool closed and
+        later reopened is picked up without rebuilding the adapter.
+        """
+        if self._http_client is not None:
+            return self._http_client
+        return _VAULT_HTTP_POOL.get()
+
+    async def _fetch_capabilities(self) -> Mapping[str, object]:
+        """Fetch and minimally narrow the vault's capability document.
+
+        The authorization header is built here, per call, so the credential
+        lives only for the duration of the request and never on the shared
+        pooled client. A non-2xx status raises ``httpx.HTTPStatusError`` and a
+        non-JSON body raises ``json.JSONDecodeError``; both are degraded by the
+        caller. A body that decodes to something other than a JSON object is a
+        malformed payload, so it raises ``TypeError`` rather than being cast.
+        """
+        response = await self._active_client().get(
+            f"{self._url}{_CAPABILITIES_PATH}",
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise TypeError("creek vault capability payload must be a JSON object")
+        return payload
+
+    async def _probe(self) -> tuple[HandshakeResult, HandshakeDegradeReason | None]:
+        """Run one capability probe, mapping each failure mode to its own reason.
+
+        The ``except`` clauses are split (where the MCP client uses one combined
+        set) purely to attribute the degradation: every branch returns the same
+        canonical unavailable result. ``httpx.HTTPError`` covers connection
+        failures, timeouts, and every non-2xx status raised by
+        ``raise_for_status``; ``OSError`` covers a socket-level failure that
+        escapes httpx's own hierarchy. A payload that parsed but whose vault
+        reported itself unavailable is not an error at all -- it is the vault
+        answering honestly -- and is recorded as such.
+        """
+        try:
+            result = _parse_handshake(await self._fetch_capabilities())
+        except _IncompatibleContractVersionError:
+            return HandshakeResult.unavailable(), HandshakeDegradeReason.INCOMPATIBLE_VERSION
+        except (httpx.HTTPError, OSError):
+            return HandshakeResult.unavailable(), HandshakeDegradeReason.UNREACHABLE
+        except _PARSE_ERROR_TYPES:
+            return HandshakeResult.unavailable(), HandshakeDegradeReason.MALFORMED_PAYLOAD
+        if not result.available:
+            return result, HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
+        return result, None
+
+    async def handshake(self) -> HandshakeResult:
+        """Probe the vault, cache the result and its degrade reason, and return it."""
+        self._last_handshake, self._degrade_reason = await self._probe()
+        return self._last_handshake
+
+    @property
+    def last_degrade_reason(self) -> HandshakeDegradeReason | None:
+        """Why the last handshake degraded, or ``None`` if it succeeded (or never ran)."""
+        return self._degrade_reason
+
+    def is_available(self) -> bool:
+        """Return whether the cached handshake found a usable vault."""
+        return self._last_handshake.available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Return whether the cached handshake advertised ``capability``."""
+        return capability in self._last_handshake.capabilities
+
+    async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Refuse ingest: the ``/v1`` write shape is unratified (Postgres stays authoritative)."""
+        _refuse_unratified(CreekCapability.JOURNAL)
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Refuse classification: its ``/v1`` request/response shape is unratified."""
+        _refuse_unratified(CreekCapability.CLASSIFY)
+
+    async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> str:
+        """Refuse reflection: its ``/v1`` request/response shape is unratified."""
+        _refuse_unratified(CreekCapability.REFLECT)
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Refuse a wheel read: its ``/v1`` request/response shape is unratified."""
+        _refuse_unratified(CreekCapability.WHEEL)
+
+
 class LocalFallbackCreekVaultClient:
     """The no-vault :class:`CreekVaultClient`: local pipeline stays authoritative.
 
@@ -592,9 +894,14 @@ def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVa
 
     When ``CREEK_VAULT_URL`` is unset or empty, no vault is configured and a
     :class:`LocalFallbackCreekVaultClient` is returned so the app runs fully on
-    its local pipeline. Otherwise an :class:`McpCreekVaultClient` is returned
-    over the injected ``transport`` (tests supply a fake) or a freshly built
-    :class:`_McpStreamableHttpTransport` bound to the configured URL and API key.
+    its local pipeline -- checked first, so it holds whatever the protocol
+    selector says. Otherwise :data:`_PROTOCOL_ENV_VAR` picks the transport: an
+    :class:`HttpCreekVaultClient` for ``http``, or (by default) an
+    :class:`McpCreekVaultClient` over the injected ``transport`` (tests supply a
+    fake) or a freshly built :class:`_McpStreamableHttpTransport` bound to the
+    configured URL and API key. An unrecognized selector raises rather than
+    silently falling back, since guessing a transport would send vault traffic
+    somewhere the operator did not choose.
     """
     # ``CREEK_VAULT_URL`` being unset or empty is the signal that no vault is
     # configured; the bearer credential is read only to build the transport's
@@ -603,4 +910,11 @@ def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVa
     if not url:
         return LocalFallbackCreekVaultClient()
     api_key = os.getenv("CREEK_VAULT_API_KEY", "")
-    return McpCreekVaultClient(transport=transport or _McpStreamableHttpTransport(url, api_key))
+    protocol = os.getenv(_PROTOCOL_ENV_VAR, _PROTOCOL_MCP).strip().lower()
+    if protocol == _PROTOCOL_HTTP:
+        return HttpCreekVaultClient(url, api_key)
+    if protocol == _PROTOCOL_MCP:
+        return McpCreekVaultClient(transport=transport or _McpStreamableHttpTransport(url, api_key))
+    # Names only the offending value: the message reaches logs, and the URL and
+    # the bearer credential must never travel with it.
+    raise ValueError(f"unsupported {_PROTOCOL_ENV_VAR} value: {protocol!r}")

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -9,8 +9,9 @@ has not shipped.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Callable, Coroutine, Mapping, Sequence
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
@@ -34,10 +35,12 @@ from main import app, lifespan
 from services.creek_vault_client import (
     _VAULT_HTTP_TIMEOUT,
     _VAULT_TIMEOUT_SECONDS,
+    _VAULT_TOTAL_DEADLINE_SECONDS,
     HandshakeDegradeReason,
     HttpCreekVaultClient,
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
+    _build_pooled_vault_client,
     _contract_version_compatible,
     _VaultHttpPool,
     build_creek_vault_client,
@@ -53,11 +56,36 @@ _API_KEY = "creek-vault-test-key"  # pragma: allowlist secret
 
 _SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"
 
+# A password smuggled into the URL's userinfo component. httpx renders userinfo
+# unmasked in ``str(url)`` and in its own INFO request log, and derives Basic
+# auth from it that silently replaces our bearer -- so the adapter must refuse
+# such a URL, and its refusal message must not repeat this value.
+_URL_PASSWORD = "URLPASSWORD_DO_NOT_LEAK"  # pragma: allowlist secret
+
+_USERINFO_VAULT_URL = f"https://opuser:{_URL_PASSWORD}@vault.example.test"
+
+# A configured URL carrying a path prefix: still legal, and the capability path
+# must be appended to it rather than replacing it.
+_PATH_VAULT_URL = f"{_VAULT_URL}/vault/"
+
 _ENTRY_BODY = "a floor-level journal entry"
 
 _CREATED_AT = datetime(2026, 7, 31, 12, 0, tzinfo=UTC)
 
 _POOL_ATTR = "services.creek_vault_client._VAULT_HTTP_POOL"
+
+_DEADLINE_ATTR = "services.creek_vault_client._VAULT_TOTAL_DEADLINE_SECONDS"
+
+# A whole-request deadline short enough to expire during a test, paired with a
+# handler sleep two orders of magnitude longer so the deadline -- never the
+# sleep -- is what ends the call. The sleep is cancelled the moment the deadline
+# fires, so the test costs milliseconds, not seconds.
+_TINY_DEADLINE_SECONDS = 0.02
+_SLOW_HANDLER_SLEEP_SECONDS = 5.0
+
+# The redirect status a hijacked or misconfigured vault would answer with; it
+# must degrade rather than forward the bearer to the Location host.
+_REDIRECT_STATUS_FOUND = 302
 
 _PROTOCOL_MEMBERS = (
     "handshake",
@@ -70,7 +98,11 @@ _PROTOCOL_MEMBERS = (
 )
 
 Handler = Callable[[httpx.Request], httpx.Response]
-ClientFactory = Callable[[Handler], httpx.AsyncClient]
+# Narrower than ``Awaitable`` on purpose: ``httpx.MockTransport`` accepts a
+# coroutine function specifically, so a wider alias fails to type-check at the
+# call site.
+AsyncHandler = Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+ClientFactory = Callable[[Handler | AsyncHandler], httpx.AsyncClient]
 
 
 def _handshake_payload(
@@ -119,6 +151,27 @@ def _raising_handler(exc: Exception) -> Handler:
         raise exc
 
     return _handle
+
+
+def _redirect_handler(location: str) -> Handler:
+    """Return a handler answering with a redirect to ``location`` and no body."""
+
+    def _handle(_request: httpx.Request) -> httpx.Response:
+        """Answer with the fixed redirect."""
+        return httpx.Response(_REDIRECT_STATUS_FOUND, headers={"Location": location})
+
+    return _handle
+
+
+async def _slow_handler(_request: httpx.Request) -> httpx.Response:
+    """Sleep far past any plausible deadline instead of answering.
+
+    Stands in for a vault that accepts the connection and then trickles: every
+    per-phase httpx budget stays unexhausted, so only a whole-request deadline
+    can end the call.
+    """
+    await asyncio.sleep(_SLOW_HANDLER_SLEEP_SECONDS)
+    return httpx.Response(200, json={})
 
 
 def _healthy_handler(capabilities: Sequence[str]) -> Handler:
@@ -195,7 +248,7 @@ async def http_clients() -> AsyncGenerator[ClientFactory, None]:
     """Yield a factory for MockTransport-backed clients, closing each afterwards."""
     created: list[httpx.AsyncClient] = []
 
-    def _build(handler: Handler) -> httpx.AsyncClient:
+    def _build(handler: Handler | AsyncHandler) -> httpx.AsyncClient:
         """Build one in-memory client and register it for teardown."""
         client = httpx.AsyncClient(
             transport=httpx.MockTransport(handler), timeout=_VAULT_HTTP_TIMEOUT
@@ -367,6 +420,46 @@ async def test_pooled_client_carries_the_explicit_timeout() -> None:
     client = pool.get()
     assert client.timeout == _VAULT_HTTP_TIMEOUT
     await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pooled_client_refuses_to_follow_redirects() -> None:
+    """The pooled client pins redirect-following off rather than inheriting the default."""
+    client = _build_pooled_vault_client()
+    try:
+        assert client.follow_redirects is False
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_a_redirecting_vault_degrades_instead_of_forwarding_the_bearer(
+    http_clients: ClientFactory,
+) -> None:
+    """A 302 degrades to unreachable: the bearer is never re-sent to the Location host."""
+    handler = _redirect_handler("https://attacker.example.test/v1/capabilities")
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+    assert client.last_degrade_reason is HandshakeDegradeReason.UNREACHABLE
+
+
+def test_the_total_deadline_exceeds_a_single_phase_budget() -> None:
+    """The whole-request deadline leaves room for a slow connect *and* a slow read."""
+    assert _VAULT_TOTAL_DEADLINE_SECONDS > _VAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_a_trickling_vault_is_bounded_by_the_whole_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    http_clients: ClientFactory,
+) -> None:
+    """A call that outlives the deadline degrades to unreachable rather than hanging."""
+    monkeypatch.setattr(_DEADLINE_ATTR, _TINY_DEADLINE_SECONDS)
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(_slow_handler))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+    assert client.last_degrade_reason is HandshakeDegradeReason.UNREACHABLE
 
 
 @pytest.mark.asyncio
@@ -573,6 +666,46 @@ def test_http_factory_accepts_a_plaintext_loopback_url(monkeypatch: pytest.Monke
     monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
     monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
     assert isinstance(build_creek_vault_client(), HttpCreekVaultClient)
+
+
+@pytest.mark.parametrize(
+    ("url", "part"),
+    [
+        pytest.param(_USERINFO_VAULT_URL, "userinfo", id="userinfo"),
+        pytest.param(f"{_VAULT_URL}/api?tenant=1", "query", id="query"),
+        pytest.param(f"{_VAULT_URL}#frag", "fragment", id="fragment"),
+    ],
+)
+def test_http_client_rejects_a_url_carrying_userinfo_query_or_fragment(url: str, part: str) -> None:
+    """Userinfo (a credential, and a silent Basic-auth downgrade), query, and fragment refuse."""
+    with pytest.raises(ValueError, match=part) as exc_info:
+        HttpCreekVaultClient(url, _SENTINEL_KEY)
+    message = str(exc_info.value)
+    assert _URL_PASSWORD not in message
+    assert _SENTINEL_KEY not in message
+
+
+def test_mcp_transport_rejects_a_url_carrying_userinfo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The MCP transport shares the validator, so it refuses the same URL shapes."""
+    monkeypatch.setenv("CREEK_VAULT_URL", _USERINFO_VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _SENTINEL_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "mcp")
+    with pytest.raises(ValueError, match="userinfo") as exc_info:
+        build_creek_vault_client()
+    message = str(exc_info.value)
+    assert _URL_PASSWORD not in message
+    assert _SENTINEL_KEY not in message
+
+
+@pytest.mark.asyncio
+async def test_a_url_with_a_path_prefix_keeps_it_in_the_capability_url(
+    http_clients: ClientFactory,
+) -> None:
+    """A path prefix stays legal and the capability path is appended to it."""
+    handler = _RecordingHandler(_handshake_payload([CreekCapability.JOURNAL.value]))
+    client = HttpCreekVaultClient(_PATH_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    assert (await client.handshake()).available is True
+    assert str(handler.requests[0].url) == f"{_VAULT_URL}/vault/v1/capabilities"
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -49,7 +49,7 @@ _VAULT_URL = "https://vault.example.test"
 
 _CAPABILITIES_URL = f"{_VAULT_URL}/v1/capabilities"
 
-_API_KEY = "creek-vault-test-key"
+_API_KEY = "creek-vault-test-key"  # pragma: allowlist secret
 
 _SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"
 

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -1,0 +1,667 @@
+"""Tests for the HTTP/JSON Creek Vault adapter in services.creek_vault_client.
+
+Every case drives the adapter through an ``httpx.MockTransport`` handler, so no
+test touches a network or waits on real time. The capability payload asserted
+here is the only response shape adepthood can know today -- the one it already
+parses. Nothing beyond it is invented, because Creek's ratified ``/v1`` document
+has not shipped.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from conftest import test_engine
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultClient,
+    HandshakeResult,
+    VaultIngestRequest,
+    VaultTierCeiling,
+)
+from main import app, lifespan
+from services.creek_vault_client import (
+    _VAULT_HTTP_TIMEOUT,
+    _VAULT_TIMEOUT_SECONDS,
+    HandshakeDegradeReason,
+    HttpCreekVaultClient,
+    LocalFallbackCreekVaultClient,
+    McpCreekVaultClient,
+    _contract_version_compatible,
+    _VaultHttpPool,
+    build_creek_vault_client,
+    close_creek_vault_http_pool,
+)
+from services.creek_vault_write import VaultWriteStatus, store_and_classify
+
+_VAULT_URL = "https://vault.example.test"
+
+_CAPABILITIES_URL = f"{_VAULT_URL}/v1/capabilities"
+
+_API_KEY = "creek-vault-test-key"
+
+_SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"
+
+_ENTRY_BODY = "a floor-level journal entry"
+
+_CREATED_AT = datetime(2026, 7, 31, 12, 0, tzinfo=UTC)
+
+_POOL_ATTR = "services.creek_vault_client._VAULT_HTTP_POOL"
+
+_PROTOCOL_MEMBERS = (
+    "handshake",
+    "is_available",
+    "supports",
+    "ingest",
+    "classify",
+    "reflect",
+    "wheel",
+)
+
+Handler = Callable[[httpx.Request], httpx.Response]
+ClientFactory = Callable[[Handler], httpx.AsyncClient]
+
+
+def _handshake_payload(
+    capabilities: Sequence[str],
+    contract_version: str = CONTRACT_VERSION,
+    ontology_version: str = "aptitude-wavelength/2026-05-23",
+    attestation: Mapping[str, object] | None = None,
+    *,
+    available: bool = True,
+) -> dict[str, object]:
+    """Build the only capability response shape adepthood already parses."""
+    return {
+        "available": available,
+        "capabilities": list(capabilities),
+        "contract_version": contract_version,
+        "ontology_version": ontology_version,
+        "attestation": attestation,
+    }
+
+
+def _json_handler(payload: object, status_code: int = 200) -> Handler:
+    """Return a handler answering every request with ``payload`` as JSON."""
+
+    def _handle(_request: httpx.Request) -> httpx.Response:
+        """Answer with the fixed JSON payload and status."""
+        return httpx.Response(status_code, json=payload)
+
+    return _handle
+
+
+def _text_handler(body: str, status_code: int = 200) -> Handler:
+    """Return a handler answering with a non-JSON text body (a proxy error page)."""
+
+    def _handle(_request: httpx.Request) -> httpx.Response:
+        """Answer with the fixed text body and status."""
+        return httpx.Response(status_code, text=body)
+
+    return _handle
+
+
+def _raising_handler(exc: Exception) -> Handler:
+    """Return a handler that raises ``exc`` instead of answering."""
+
+    def _handle(_request: httpx.Request) -> httpx.Response:
+        """Raise the stored transport exception."""
+        raise exc
+
+    return _handle
+
+
+def _healthy_handler(capabilities: Sequence[str]) -> Handler:
+    """Return a handler answering with a healthy capability payload."""
+    return _json_handler(_handshake_payload(capabilities))
+
+
+def _payload_without_contract_version() -> dict[str, object]:
+    """Build a capability payload whose contract_version key is absent."""
+    payload = _handshake_payload([CreekCapability.JOURNAL.value])
+    del payload["contract_version"]
+    return payload
+
+
+def _ingest_request() -> VaultIngestRequest:
+    """Build a minimal ingest request for the refusal paths."""
+    return VaultIngestRequest(
+        entry_id=7,
+        body=_ENTRY_BODY,
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
+    )
+
+
+class _RecordingHandler:
+    """Handler that records every request it serves and answers with a fixed payload."""
+
+    def __init__(self, payload: Mapping[str, object]) -> None:
+        """Store the payload to answer with and start an empty request log."""
+        self._payload = dict(payload)
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Record the request and answer 200 with the stored payload."""
+        self.requests.append(request)
+        return httpx.Response(200, json=self._payload)
+
+
+class _CountingClientBuild:
+    """Client factory that records every httpx client it builds."""
+
+    def __init__(self, handler: Handler) -> None:
+        """Store the handler each built client answers from."""
+        self._handler = handler
+        self.built: list[httpx.AsyncClient] = []
+
+    def __call__(self) -> httpx.AsyncClient:
+        """Build one MockTransport-backed client and record it."""
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handler), timeout=_VAULT_HTTP_TIMEOUT
+        )
+        self.built.append(client)
+        return client
+
+
+@asynccontextmanager
+async def _isolated_factory_patch() -> AsyncGenerator[None, None]:
+    """Point main's session factory at the conftest SQLite engine for lifespan runs."""
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    with patch("main.async_session_factory", new=factory):
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _closed_vault_pool() -> AsyncGenerator[None, None]:
+    """Close the module-level vault HTTP pool after every test so none is GC'd open."""
+    yield
+    await close_creek_vault_http_pool()
+
+
+@pytest_asyncio.fixture
+async def http_clients() -> AsyncGenerator[ClientFactory, None]:
+    """Yield a factory for MockTransport-backed clients, closing each afterwards."""
+    created: list[httpx.AsyncClient] = []
+
+    def _build(handler: Handler) -> httpx.AsyncClient:
+        """Build one in-memory client and register it for teardown."""
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), timeout=_VAULT_HTTP_TIMEOUT
+        )
+        created.append(client)
+        return client
+
+    yield _build
+    for client in created:
+        await client.aclose()
+
+
+async def _call_capability(client: HttpCreekVaultClient, capability: CreekCapability) -> object:
+    """Invoke the client method that implements ``capability``."""
+    if capability is CreekCapability.JOURNAL:
+        return await client.ingest(_ingest_request())
+    if capability is CreekCapability.CLASSIFY:
+        return await client.classify(_ENTRY_BODY, VaultTierCeiling.OPEN)
+    if capability is CreekCapability.REFLECT:
+        return await client.reflect(_ENTRY_BODY, VaultTierCeiling.OPEN)
+    return await client.wheel()
+
+
+@pytest.mark.asyncio
+async def test_http_client_satisfies_the_vault_client_protocol(
+    http_clients: ClientFactory,
+) -> None:
+    """The HTTP adapter is assignable to the domain protocol and exposes every member."""
+    client: CreekVaultClient = HttpCreekVaultClient(
+        _VAULT_URL,
+        _API_KEY,
+        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+    )
+    for name in _PROTOCOL_MEMBERS:
+        assert callable(getattr(client, name)), name
+
+
+@pytest.mark.asyncio
+async def test_fresh_http_client_reports_unavailable_before_any_handshake(
+    http_clients: ClientFactory,
+) -> None:
+    """A client that has not handshaken yet fails safe: unavailable, nothing supported."""
+    client = HttpCreekVaultClient(
+        _VAULT_URL,
+        _API_KEY,
+        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+    )
+    assert client.is_available() is False
+    assert client.supports(CreekCapability.JOURNAL) is False
+
+
+@pytest.mark.asyncio
+async def test_handshake_gets_v1_capabilities_with_bearer_auth(
+    http_clients: ClientFactory,
+) -> None:
+    """The handshake is a single GET of /v1/capabilities carrying the bearer key."""
+    handler = _RecordingHandler(_handshake_payload([CreekCapability.JOURNAL.value]))
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    await client.handshake()
+    assert len(handler.requests) == 1
+    request = handler.requests[0]
+    assert request.method == "GET"
+    assert str(request.url) == _CAPABILITIES_URL
+    assert request.headers["Authorization"] == f"Bearer {_API_KEY}"
+
+
+@pytest.mark.asyncio
+async def test_healthy_handshake_narrows_capabilities_and_drops_unknown_ones(
+    http_clients: ClientFactory,
+) -> None:
+    """A healthy payload populates the result and silently drops unknown capability strings."""
+    handler = _healthy_handler(
+        [CreekCapability.JOURNAL.value, CreekCapability.REFLECT.value, "creek.telepathy"]
+    )
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    result = await client.handshake()
+    assert result.available is True
+    assert result.capabilities == frozenset({CreekCapability.JOURNAL, CreekCapability.REFLECT})
+    assert result.contract_version == CONTRACT_VERSION
+    assert client.is_available() is True
+    assert client.supports(CreekCapability.JOURNAL) is True
+    assert client.supports(CreekCapability.REFLECT) is True
+    assert client.supports(CreekCapability.CLASSIFY) is False
+    assert client.last_degrade_reason is None
+
+
+@pytest.mark.asyncio
+async def test_factory_builds_one_http_client_for_every_vault_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two vault clients share one pooled httpx client across both of their handshakes."""
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
+    handler = _RecordingHandler(_handshake_payload([CreekCapability.JOURNAL.value]))
+    build = _CountingClientBuild(handler)
+    pool = _VaultHttpPool(build=build)
+    monkeypatch.setattr(_POOL_ATTR, pool)
+
+    first = build_creek_vault_client()
+    second = build_creek_vault_client()
+    assert first is not second
+    assert (await first.handshake()).available is True
+    assert (await second.handshake()).available is True
+
+    assert len(build.built) == 1
+    assert pool.get() is build.built[0]
+    assert len(handler.requests) == 2
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_builds_lazily_exactly_once() -> None:
+    """The pool builds on first get and returns that same client on every later get."""
+    build = _CountingClientBuild(_healthy_handler([CreekCapability.JOURNAL.value]))
+    pool = _VaultHttpPool(build=build)
+    assert len(build.built) == 0
+    client = pool.get()
+    assert pool.get() is client
+    assert len(build.built) == 1
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_close_pool_closes_the_client_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown closes the pooled client, and closing again is a silent no-op."""
+    build = _CountingClientBuild(_healthy_handler([CreekCapability.JOURNAL.value]))
+    pool = _VaultHttpPool(build=build)
+    monkeypatch.setattr(_POOL_ATTR, pool)
+    client = pool.get()
+
+    await close_creek_vault_http_pool()
+    assert client.is_closed is True
+
+    await close_creek_vault_http_pool()
+    assert len(build.built) == 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_closes_the_vault_http_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """App shutdown awaits the pool-close hook so no httpx client outlives the process."""
+    monkeypatch.setenv("SKIP_STARTUP_SEED", "1")
+    spy = AsyncMock()
+    with patch("main.close_creek_vault_http_pool", new=spy):
+        async with _isolated_factory_patch(), lifespan(app):
+            pass
+    spy.assert_awaited_once()
+
+
+def test_vault_http_timeout_pins_every_phase_to_the_budget() -> None:
+    """Connect, read, write, and pool timeouts are each set to the vault budget."""
+    phases = (
+        _VAULT_HTTP_TIMEOUT.connect,
+        _VAULT_HTTP_TIMEOUT.read,
+        _VAULT_HTTP_TIMEOUT.write,
+        _VAULT_HTTP_TIMEOUT.pool,
+    )
+    for phase in phases:
+        assert phase is not None
+        assert phase == _VAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_pooled_client_carries_the_explicit_timeout() -> None:
+    """The pool's own client is built with the module's fully specified timeout."""
+    pool = _VaultHttpPool()
+    client = pool.get()
+    assert client.timeout == _VAULT_HTTP_TIMEOUT
+    await pool.aclose()
+
+
+@pytest.mark.asyncio
+async def test_hung_vault_degrades_within_the_timeout_budget(
+    http_clients: ClientFactory,
+) -> None:
+    """A read timeout degrades to unavailable and is reported as unreachable, never raised."""
+    handler = _raising_handler(httpx.ReadTimeout("vault never answered"))
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+    assert client.last_degrade_reason is HandshakeDegradeReason.UNREACHABLE
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [
+        pytest.param(_raising_handler(httpx.ConnectError("refused")), id="connection_refused"),
+        pytest.param(_json_handler({"detail": "boom"}, 500), id="server_error"),
+        pytest.param(_json_handler({"detail": "unauthorized"}, 401), id="unauthorized"),
+        pytest.param(_text_handler("<html><body>Bad Gateway</body></html>"), id="non_json_body"),
+        pytest.param(_json_handler([1, 2, 3]), id="json_is_not_an_object"),
+        pytest.param(_json_handler(_payload_without_contract_version()), id="missing_version"),
+        pytest.param(
+            _json_handler(_handshake_payload([CreekCapability.JOURNAL.value], "0.3.0")),
+            id="incompatible_version",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handshake_degrades_to_unavailable_without_raising(
+    handler: Handler,
+    http_clients: ClientFactory,
+) -> None:
+    """Every unhealthy vault response collapses to the one canonical unavailable result."""
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+    assert client.is_available() is False
+    assert client.supports(CreekCapability.JOURNAL) is False
+
+
+@pytest.mark.parametrize(
+    ("handler", "expected"),
+    [
+        pytest.param(
+            _json_handler(_handshake_payload([CreekCapability.JOURNAL.value], "0.3.0")),
+            HandshakeDegradeReason.INCOMPATIBLE_VERSION,
+            id="incompatible_version",
+        ),
+        pytest.param(
+            _raising_handler(httpx.ConnectError("refused")),
+            HandshakeDegradeReason.UNREACHABLE,
+            id="unreachable",
+        ),
+        pytest.param(
+            _text_handler("<html><body>Bad Gateway</body></html>"),
+            HandshakeDegradeReason.MALFORMED_PAYLOAD,
+            id="malformed_payload",
+        ),
+        pytest.param(
+            _json_handler(_handshake_payload([CreekCapability.JOURNAL.value], available=False)),
+            HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE,
+            id="vault_reported_unavailable",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_degrade_reason_distinguishes_the_failure_modes(
+    handler: Handler,
+    expected: HandshakeDegradeReason,
+    http_clients: ClientFactory,
+) -> None:
+    """Each degrade path records its own reason so version skew is visible separately."""
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    await client.handshake()
+    assert client.last_degrade_reason is expected
+
+
+@pytest.mark.asyncio
+async def test_incompatible_and_unreachable_return_the_same_degraded_result(
+    http_clients: ClientFactory,
+) -> None:
+    """Callers see one degraded state; only the internal degrade reason differs."""
+    skewed = HttpCreekVaultClient(
+        _VAULT_URL,
+        _API_KEY,
+        http_client=http_clients(
+            _json_handler(_handshake_payload([CreekCapability.JOURNAL.value], "0.3.0"))
+        ),
+    )
+    offline = HttpCreekVaultClient(
+        _VAULT_URL,
+        _API_KEY,
+        http_client=http_clients(_raising_handler(httpx.ConnectError("refused"))),
+    )
+    skewed_result = await skewed.handshake()
+    offline_result = await offline.handshake()
+    assert skewed_result == offline_result == HandshakeResult.unavailable()
+    assert skewed.last_degrade_reason is HandshakeDegradeReason.INCOMPATIBLE_VERSION
+    assert offline.last_degrade_reason is HandshakeDegradeReason.UNREACHABLE
+
+
+def test_degrade_reason_wire_values_are_stable() -> None:
+    """The degrade reasons carry the exact strings telemetry will count."""
+    assert [reason.value for reason in HandshakeDegradeReason] == [
+        "unreachable",
+        "malformed_payload",
+        "incompatible_version",
+        "vault_reported_unavailable",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("advertised", "pinned", "compatible"),
+    [
+        pytest.param("0.3.0", "0.2.0", False, id="pre_1_0_minor_bump_rejected"),
+        pytest.param("0.2.7", "0.2.1", True, id="pre_1_0_patch_bump_accepted"),
+        pytest.param("1.5.0", "1.2.0", True, id="post_1_0_forward_minor_accepted"),
+        pytest.param("2.0.0", "1.2.0", False, id="post_1_0_major_bump_rejected"),
+    ],
+)
+def test_contract_version_compatibility_rule(
+    advertised: str, pinned: str, compatible: bool
+) -> None:
+    """Pre-1.0 requires an exact major.minor match; 1.0 and later relaxes to major-match."""
+    assert _contract_version_compatible(advertised, pinned) is compatible
+
+
+def test_contract_version_compatible_defaults_to_the_pinned_constant() -> None:
+    """The pinned contract version is, trivially, compatible with itself."""
+    assert _contract_version_compatible(CONTRACT_VERSION) is True
+
+
+@pytest.mark.parametrize("url", ["", None], ids=["empty", "unset"])
+@pytest.mark.parametrize("protocol", [None, "mcp", "http"], ids=["unset", "mcp", "http"])
+def test_factory_returns_local_fallback_when_no_url_under_every_protocol(
+    url: str | None, protocol: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No configured vault URL means the local fallback, whatever the protocol says."""
+    if url is None:
+        monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
+    else:
+        monkeypatch.setenv("CREEK_VAULT_URL", url)
+    if protocol is None:
+        monkeypatch.delenv("CREEK_VAULT_PROTOCOL", raising=False)
+    else:
+        monkeypatch.setenv("CREEK_VAULT_PROTOCOL", protocol)
+    assert isinstance(build_creek_vault_client(), LocalFallbackCreekVaultClient)
+
+
+@pytest.mark.parametrize("protocol", [None, "mcp", "MCP "], ids=["unset", "mcp", "padded_upper"])
+def test_factory_keeps_mcp_as_the_default_protocol(
+    protocol: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unset, lowercase, or whitespace-padded mcp selector still yields the MCP adapter."""
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
+    if protocol is None:
+        monkeypatch.delenv("CREEK_VAULT_PROTOCOL", raising=False)
+    else:
+        monkeypatch.setenv("CREEK_VAULT_PROTOCOL", protocol)
+    assert isinstance(build_creek_vault_client(), McpCreekVaultClient)
+
+
+def test_factory_returns_http_client_when_protocol_is_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The http selector swaps in the HTTP/JSON adapter."""
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+    assert isinstance(build_creek_vault_client(), HttpCreekVaultClient)
+
+
+def test_factory_rejects_an_unknown_protocol_naming_only_the_bad_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrecognized protocol fails loudly and names the offending value, not the key."""
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _SENTINEL_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "grpc")
+    with pytest.raises(ValueError, match="grpc") as exc_info:
+        build_creek_vault_client()
+    assert _SENTINEL_KEY not in str(exc_info.value)
+
+
+def test_http_factory_rejects_a_plaintext_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plaintext to a remote host fails closed at construction, before the key is bound."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "http://vault.example.test")
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _SENTINEL_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+    with pytest.raises(ValueError, match="https") as exc_info:
+        build_creek_vault_client()
+    message = str(exc_info.value)
+    assert "http" in message
+    assert "vault.example.test" in message
+    assert _SENTINEL_KEY not in message
+
+
+def test_http_factory_accepts_a_plaintext_loopback_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plaintext to loopback stays allowed so a developer can run a vault locally."""
+    monkeypatch.setenv("CREEK_VAULT_URL", "http://localhost:8000")
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+    assert isinstance(build_creek_vault_client(), HttpCreekVaultClient)
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [
+        CreekCapability.JOURNAL,
+        CreekCapability.CLASSIFY,
+        CreekCapability.REFLECT,
+        CreekCapability.WHEEL,
+    ],
+)
+@pytest.mark.asyncio
+async def test_advertised_capabilities_are_still_refused(
+    capability: CreekCapability,
+    http_clients: ClientFactory,
+) -> None:
+    """Even an advertised capability is refused, since its payload shape is unratified."""
+    advertised = [
+        CreekCapability.JOURNAL.value,
+        CreekCapability.CLASSIFY.value,
+        CreekCapability.REFLECT.value,
+        CreekCapability.WHEEL.value,
+    ]
+    client = HttpCreekVaultClient(
+        _VAULT_URL, _API_KEY, http_client=http_clients(_healthy_handler(advertised))
+    )
+    await client.handshake()
+    assert client.supports(capability) is True
+    with pytest.raises(CreekCapabilityUnsupportedError) as exc_info:
+        await _call_capability(client, capability)
+    assert capability.value in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_write_path_degrades_instead_of_losing_an_entry(
+    http_clients: ClientFactory,
+) -> None:
+    """A refused ingest degrades the write path rather than raising or dropping the entry."""
+    client = HttpCreekVaultClient(
+        _VAULT_URL,
+        _API_KEY,
+        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+    )
+    outcome = await store_and_classify(
+        client,
+        entry_id=7,
+        body=_ENTRY_BODY,
+        classification="public",
+        created_at=_CREATED_AT,
+    )
+    assert outcome.status is VaultWriteStatus.DEGRADED
+    assert outcome.vault_ref is None
+    assert outcome.tags == ()
+
+
+@pytest.mark.asyncio
+async def test_api_key_never_leaks_into_logs_repr_or_errors(
+    caplog: pytest.LogCaptureFixture,
+    http_clients: ClientFactory,
+) -> None:
+    """No log record, repr, or exception text ever carries the bearer credential."""
+    caplog.set_level(logging.DEBUG)
+    healthy = HttpCreekVaultClient(
+        _VAULT_URL,
+        _SENTINEL_KEY,
+        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+    )
+    hung = HttpCreekVaultClient(
+        _VAULT_URL,
+        _SENTINEL_KEY,
+        http_client=http_clients(_raising_handler(httpx.ReadTimeout("vault never answered"))),
+    )
+    failing = HttpCreekVaultClient(
+        _VAULT_URL,
+        _SENTINEL_KEY,
+        http_client=http_clients(_json_handler({"detail": "boom"}, 500)),
+    )
+    for client in (healthy, hung, failing):
+        await client.handshake()
+    with pytest.raises(CreekCapabilityUnsupportedError) as exc_info:
+        await healthy.ingest(_ingest_request())
+
+    assert _SENTINEL_KEY not in caplog.text
+    for record in caplog.records:
+        assert _SENTINEL_KEY not in record.getMessage()
+    for client in (healthy, hung, failing):
+        assert _SENTINEL_KEY not in repr(client)
+        assert _SENTINEL_KEY not in str(client)
+        assert repr(client) == object.__repr__(client)
+    assert _SENTINEL_KEY not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True


### PR DESCRIPTION
## Summary

Adds `HttpCreekVaultClient` — an HTTP/JSON adapter implementing the **existing**
`domain.creek_vault.CreekVaultClient` protocol over one long-lived, pooled
`httpx.AsyncClient`. It handshakes with a single `GET /v1/capabilities` and is
selected by configuration *alongside* — not instead of — the MCP client. No
caller changes, no capability behavior changes, and the default protocol is
deliberately **not** flipped.

The defect being fixed is that `_McpStreamableHttpTransport.call` opens and
`initialize()`s a brand-new MCP session for **every single operation**, so a
journal save that ingests then reflects pays three full connect + initialize
round-trips. This lands the pooled path that ends that, per ADR 0004.

**What it does**

- `HttpCreekVaultClient` satisfies the protocol structurally (mypy strict proves
  it via an annotated assignment in the tests). Handshake never raises: every
  transport, parse and version failure returns `HandshakeResult.unavailable()`.
- A lazily built, process-wide `_VaultHttpPool` holds exactly one
  `httpx.AsyncClient` per app lifetime, closed after `yield` in `main.py`'s
  lifespan. The pooled client is deliberately **bare** — no `base_url`, no auth
  header — so the credential never lives on a long-lived object and the pool
  stays valid across reconfigured per-request adapters. `Authorization: Bearer`
  is built per call from `CREEK_VAULT_API_KEY`.
- Connect, read, write and pool timeouts are all set explicitly, plus a
  whole-request wall-clock deadline (see Security below for why the four phase
  budgets alone are not a ceiling).
- `CREEK_VAULT_PROTOCOL` selects the transport: `mcp` (unchanged default) or
  `http`. An unrecognized value raises rather than silently falling back.
  `CREEK_VAULT_URL` unset still yields `LocalFallbackCreekVaultClient` on every
  path — that check runs first, so it holds under every protocol value.
- `_require_secure_vault_url` is reused unchanged as the fail-closed TLS gate
  (and hardened further, below).

**Also lands ADR 0004 Decision 4's exact-minor version rule.** The old gate
compared `_CONTRACT_MAJOR` only, which is a no-op by construction while the
contract is pinned pre-1.0 — the major is `0` for every version pair we could
see, so a `0.1.x` vault read as compatible with our `0.2.0`. `_contract_version_compatible`
now requires an exact `major.minor` match while pre-1.0 and relaxes to
major-match at 1.0+, with the ADR's two worked examples pinned as tests. The
ADR assigns this comparison code to this issue explicitly.

`HandshakeDegradeReason` keeps `incompatible_version`, `unreachable`,
`malformed_payload` and `vault_reported_unavailable` **distinguishable
internally** — the seam the telemetry issue builds on — while every one of them
still returns the identical `HandshakeResult.unavailable()` to callers.

## Deviations from the issue, stated plainly

- **The vendored fixture bundle in the issue's file list was impossible.**
  `backend/tests/fixtures/creek_v1/**` does not exist because creek-vault#1072
  **has shipped nothing** — there is no published bundle to vendor. Tests use
  hand-built `httpx.MockTransport` responses reusing the one payload shape
  adepthood already parses. Nothing else was invented.
- **`ingest` / `classify` / `reflect` / `wheel` refuse with
  `CreekCapabilityUnsupportedError`, including for capabilities the vault
  advertises.** Creek's ratified `/v1` request/response shapes for those are
  still `PENDING creek-vault#1072`, and guessing a wire format would send real
  journal content into a surface nobody agreed on. #2046/#2047 own them.
  `creek_vault_write._try_ingest` catches `CreekVaultError`, so a write degrades
  to `DEGRADED` and **no journal entry is ever lost** — there is a test for
  exactly that path.

## Security

A read-only audit reproduced two real defects against the running code, both
fixed here (third commit):

- **A `CREEK_VAULT_URL` carrying userinfo leaked a credential into INFO logs and
  silently downgraded the auth scheme.** `httpx.URL.__str__` does not mask the
  password (only `__repr__` does) and httpx's own INFO request log formats the
  URL with `%s`, so the URL password was written verbatim on every handshake.
  Worse, httpx derives `BasicAuth` from userinfo absent an explicit `auth=`, and
  its auth flow *assigns* `Authorization` — so `CREEK_VAULT_API_KEY` was never
  sent at all. The shared validator now refuses userinfo, query and fragment,
  naming only component *names* (userinfo is itself a credential). This hardens
  the MCP transport on the same seam for free.
- **`follow_redirects=False` is now pinned explicitly** rather than inherited.
  httpx preserves an explicitly-set `Authorization` header across a same-scheme
  cross-host redirect, so a hijacked vault could 302 the bearer to an attacker
  host. Not following turns that into a non-2xx that degrades.
- **A real whole-request deadline.** httpx's `read` budget restarts on every
  socket read, so a trickling vault stayed inside all four phase budgets
  indefinitely while holding a pooled connection and a worker — and the write
  path handshakes on every journal write. `TimeoutError` is an `OSError`
  subclass, so it degrades on the existing branch with the degrade set unchanged.

Verified clean: the bearer cannot reach a log record, repr, exception message,
or traceback cause (httpx masks `authorization` in `Headers.__repr__` and never
logs headers; every raise site uses `from None`). TLS fails closed before the
key is bound. No journal content crosses the wire on this path — capabilities
only. `.secrets.baseline` is **unchanged**; the fake test key uses the repo's
established inline `# pragma: allowlist secret`.

Known residual, deliberately not bolted on here: no byte ceiling on the
capability response body, consistent with the module's existing documented
deferral for the wheel payload. Reachability requires a hostile vault the
operator explicitly configured.

## Test plan

- `./scripts/backend/check-all.sh` — **7/7 passed**, total coverage 97%
  (`creek_vault_client.py` 99%; the only uncovered lines are the pre-existing
  MCP `_connect_streamable_http` network seam).
- `backend/tests/test_creek_vault_http_client.py` — new, **57 tests**, one per
  acceptance criterion: protocol conformance; exactly one `AsyncClient` per app
  lifetime with reuse asserted by identity; close-on-shutdown plus an autouse
  fixture so no client is ever GC'd open; all four timeout phases explicit and a
  hung server degrading within budget with no real sleep; capability narrowing
  with unknown strings dropped; seven no-raise degrade cases (refused, 500, 401,
  non-JSON, non-object JSON, missing version, incompatible version); the
  distinguishability seam; the factory matrix under every protocol value; TLS
  fail-closed; and the credential absent from logs, repr, exception text and
  `__cause__` on every failure path.
- **174 pre-existing vault/lifespan tests pass with zero edits to any of them**,
  including the `test_contract_version_docs.py` drift guard, which is untouched
  and unweakened.
- Run by hand because `scripts/backend/complexity.sh` does not actually run them
  (#2055): `xenon --max-absolute A --max-modules A --max-average A src/` exit 0;
  `radon mi -n B src/` silent. Module MI `A (35.59)`, floor is 20.
- `ruff check` + `ruff format --check` + `mypy` (399 files, tests included) +
  interrogate 96.6% + bandit + pip-audit + detect-secrets all clean.

Closes #2045
Refs #2043
