### PR TITLE
feat(backend): route journal replication through the HTTP vault client, distinguishing contract failure from unavailability

### DIFF
--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -103,6 +103,24 @@ def tier_ceiling_for(classification: str) -> VaultTierCeiling:
         raise ValueError(f"unknown journal classification: {classification!r}") from None
 
 
+class VaultErrorCode(enum.StrEnum):
+    """The machine-readable failure vocabulary a vault may answer an error with.
+
+    Deliberately closed: these four are the codes Creek has ratified, and they
+    are the *only* strings the adapter may ever parse out of a vault response.
+    Anything else -- a newer code, a typo, or a hostile string smuggling control
+    characters toward a log -- is dropped on the floor rather than stored or
+    rendered, so a vault can never choose what text appears in adepthood's
+    exceptions or telemetry. Values are the wire strings, so they are contract
+    and must not be reworded casually.
+    """
+
+    INVALID_REQUEST = "invalid_request"
+    UNSUPPORTED_CAPABILITY = "unsupported_capability"
+    INCOMPATIBLE_VERSION = "incompatible_version"
+    TEMPORARILY_UNAVAILABLE = "temporarily_unavailable"
+
+
 class CreekVaultError(RuntimeError):
     """Base type for every Creek Vault failure callers should degrade on.
 
@@ -119,6 +137,43 @@ class CreekVaultUnavailableError(CreekVaultError):
     exception. Its message is deliberately static and capability-named -- it
     must never interpolate the entry body or an API key, since exception
     strings surface in logs and tracebacks (privacy invariant).
+    """
+
+
+class CreekVaultContractError(CreekVaultError):
+    """The vault answered, and what it refused was *our* end of the contract.
+
+    Raised when a reachable, authenticated vault rejects the call because the
+    payload we sent, the contract version we pinned, or the capability we
+    claimed is wrong. That makes it a defect on adepthood's side with a concrete
+    remedy (fix the request, realign the pins) -- deliberately a different type
+    from :class:`CreekVaultUnavailableError`, because "the vault said no" and
+    "the vault was not there" call for opposite operator responses and would be
+    indistinguishable if they shared a type.
+
+    ``code`` carries the vault's reason only when it is one of our own
+    :class:`VaultErrorCode` members; an unrecognized wire string is dropped and
+    leaves it ``None``. Like every error in this hierarchy the *message* must
+    stay static and content-free -- exception strings reach logs and tracebacks,
+    so they may never interpolate the entry body, the API key, or any
+    vault-supplied text.
+    """
+
+    def __init__(self, message: str, *, code: VaultErrorCode | None = None) -> None:
+        """Store the static message and, when the vault named one we know, its code."""
+        super().__init__(message)
+        self.code = code
+
+
+class CreekVaultAuthError(CreekVaultError):
+    """A reachable vault rejected our credential.
+
+    Distinct from :class:`CreekVaultUnavailableError` on purpose: a rejected key
+    is a *configuration* problem (unset, stale, or scoped wrong) that a restart
+    or a retry will not cure, and reporting it as "no vault present" would hide
+    a broken deployment behind the same silence as a deliberately vault-less
+    one. Its message is static and capability-named for the same privacy reason
+    as the rest of the hierarchy.
     """
 
 
@@ -190,6 +245,22 @@ class VaultIngestRequest:
     created_at: datetime
 
 
+class VaultIngestAction(enum.StrEnum):
+    """What the vault actually did with an upserted entry.
+
+    Ingest is keyed off the entry's stable id, so a re-send edits one fragment
+    in place instead of creating a second. That makes the outcome three-valued,
+    and the distinction is worth carrying rather than flattening into "stored":
+    ``UNCHANGED`` says a re-send was a no-op, ``UPDATED`` says the vault's copy
+    moved, and only ``CREATED`` is a genuinely new fragment. Values are the wire
+    strings the vault answers with.
+    """
+
+    CREATED = "created"
+    UPDATED = "updated"
+    UNCHANGED = "unchanged"
+
+
 @dataclass(frozen=True)
 class VaultIngestResult:
     """Outcome of an ingest attempt.
@@ -198,10 +269,16 @@ class VaultIngestResult:
     was not durably written -- notably on the local-fallback path, where the
     operator's Postgres remains the sole system of record and ingest is a no-op
     rather than an error.
+
+    ``action`` is what the vault did with the fragment, when it says so. It
+    defaults to ``None`` for the transports that do not report one (the MCP
+    path) and for every not-stored result, so "the vault did not tell us" stays
+    distinguishable from any of the three real outcomes.
     """
 
     stored: bool
     vault_ref: str | None
+    action: VaultIngestAction | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -140,14 +140,31 @@ _PRE_1_0_MAJOR = "0"
 _PRE_1_0_MATCHED_COMPONENTS = 2
 _POST_1_0_MATCHED_COMPONENTS = 1
 
-# Transport-layer failures we normalize to a degraded state. ``OSError`` covers
-# connection/timeout errors, ``httpx.HTTPError`` covers every httpx transport
-# and status failure underneath the MCP session, ``McpError`` covers an MCP
-# protocol failure or a tool call that returned ``isError`` (raised by
-# :func:`_extract_tool_payload` with a static, content-free message),
-# ``ExceptionGroup`` covers a streamable-HTTP connection failure (anyio task
-# groups wrap the underlying ``httpx.ConnectError`` in a builtins
-# ``ExceptionGroup``; catching the ``Exception``-only group -- never
+# Every way an httpx call can fail to land, whether it left this process or
+# not. ``OSError`` covers connection and timeout errors (the whole-request
+# deadline raises ``TimeoutError``, an ``OSError`` subclass), and
+# ``httpx.HTTPError`` covers every transport and status failure.
+# ``httpx.InvalidURL`` has to be named separately because it is *not* an
+# ``HTTPError`` -- httpx raises it, from outside its own hierarchy, while
+# building the request, so an unparseable vault URL would otherwise escape every
+# degrade set and turn an optional replication into an exception on the caller's
+# request path. A URL httpx cannot build a request for is unreachable in exactly
+# the sense a refused connection is (the construction-time validator already
+# refused the *unsafe* URLs, which is a different question), so it degrades the
+# same way rather than raising.
+_HTTP_CALL_FAILED_ERRORS: tuple[type[Exception], ...] = (
+    OSError,
+    httpx.HTTPError,
+    httpx.InvalidURL,
+)
+
+# Transport-layer failures we normalize to a degraded state.
+# :data:`_HTTP_CALL_FAILED_ERRORS` covers the httpx layer underneath the MCP
+# session, ``McpError`` covers an MCP protocol failure or a tool call that
+# returned ``isError`` (raised by :func:`_extract_tool_payload` with a static,
+# content-free message), ``ExceptionGroup`` covers a streamable-HTTP connection
+# failure (anyio task groups wrap the underlying ``httpx.ConnectError`` in a
+# builtins ``ExceptionGroup``; catching the ``Exception``-only group -- never
 # ``BaseExceptionGroup`` -- stays safe under cancellation), and
 # ``json.JSONDecodeError`` covers a content-text block whose body is not JSON.
 # All of these normalize the per-capability path to unavailable exactly as the
@@ -155,8 +172,7 @@ _POST_1_0_MATCHED_COMPONENTS = 1
 # (``json.JSONDecodeError`` is a ``ValueError`` subclass, so it is already
 # covered by the handshake's parse-error set).
 _TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (
-    OSError,
-    httpx.HTTPError,
+    *_HTTP_CALL_FAILED_ERRORS,
     McpError,
     ExceptionGroup,
     json.JSONDecodeError,
@@ -170,6 +186,15 @@ _MCP_TOOL_ERROR_CODE = -32000
 # The status value a ``creek.journal`` response reports on a durable write. Any
 # other status -- or a missing one -- parses conservatively to "not stored".
 _JOURNAL_OK_STATUS = "ok"
+
+# Longest vault-issued fragment id adepthood will keep as an entry's durable
+# reference. Opaque handles are short by nature -- a UUID is 36 characters -- so
+# this is generous by nearly an order of magnitude, and it is a *bound*, not a
+# format: the vault owns the shape of its own ids. It exists because that string
+# is persisted verbatim into a journal entry's unbounded ``vault_ref`` text
+# column on every save, which without a ceiling lets a compromised vault grow
+# the operator's database by as much as it cares to answer with.
+_MAX_FRAGMENT_ID_LENGTH = 256
 
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
@@ -402,16 +427,51 @@ def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
     )
 
 
+def _is_storable_ref(fragment_id: str) -> bool:
+    """Return whether a vault-issued id is safe to persist as an entry's ``vault_ref``.
+
+    Three conditions, and the last two are why this exists. Non-empty, because a
+    blank id is no reference at all. Within :data:`_MAX_FRAGMENT_ID_LENGTH`, so a
+    compromised vault cannot answer every journal save with an arbitrarily large
+    string that lands in an unbounded text column. And printable, because this
+    is the one vault-chosen string adepthood *stores* rather than drops:
+    ``str.isprintable`` rejects NUL (which a Postgres text column refuses
+    outright, turning a hostile response into a failed write of an
+    already-saved entry), CR/LF (log injection, should the ref ever be
+    rendered), and the zero-width and bidi-override codepoints the journal's own
+    write boundary already sanitizes out of user text.
+    """
+    return (
+        bool(fragment_id)
+        and len(fragment_id) <= _MAX_FRAGMENT_ID_LENGTH
+        and fragment_id.isprintable()
+    )
+
+
+def _usable_fragment_id(payload: Mapping[str, object]) -> str | None:
+    """Return the vault's fragment id when it is storable, else ``None``.
+
+    A missing, blank, non-string, oversized, or unprintable id is unusable as a
+    durable reference (see :func:`_is_storable_ref`), and coercing one
+    (``str(7)``) would fabricate a ref the vault never issued. Shared by both
+    transports: an MCP vault gets no wider a channel into the ``vault_ref``
+    column than an HTTP one.
+    """
+    fragment_id = payload.get("fragment_id")
+    if isinstance(fragment_id, str) and _is_storable_ref(fragment_id):
+        return fragment_id
+    return None
+
+
 def _parse_ingest_result(payload: Mapping[str, object]) -> VaultIngestResult:
     """Parse a ``creek.journal`` response, defaulting missing/odd fields conservatively.
 
-    Only an ``"ok"`` status paired with a non-empty string ``fragment_id``
-    counts as durably stored; a missing, empty, or wrong-typed field parses to
-    a not-stored result rather than fabricating a vault ref.
+    Only an ``"ok"`` status paired with a storable ``fragment_id`` counts as
+    durably stored; a missing, empty, wrong-typed, oversized, or unprintable
+    field parses to a not-stored result rather than fabricating a vault ref.
     """
-    fragment_id = payload.get("fragment_id")
-    status_ok = payload.get("status") == _JOURNAL_OK_STATUS
-    if status_ok and isinstance(fragment_id, str) and fragment_id:
+    fragment_id = _usable_fragment_id(payload)
+    if payload.get("status") == _JOURNAL_OK_STATUS and fragment_id is not None:
         return VaultIngestResult(stored=True, vault_ref=fragment_id)
     return VaultIngestResult(stored=False, vault_ref=None)
 
@@ -620,6 +680,11 @@ _CAPABILITIES_PATH = "/v1/capabilities"
 # capability document are the only ``/v1`` shapes Creek has ratified.
 _JOURNAL_ENTRIES_PATH = "/v1/journal-entries/"
 
+# The percent-encoded form of ``.``, used to neutralize a dot segment in an
+# entry id (see :func:`_entry_path_segment`). Uppercase because RFC 3986 names
+# uppercase hex the normal form for percent-encoding.
+_ENCODED_DOT = "%2E"
+
 # Statuses that mean "your credential was refused" rather than "the vault is
 # missing". Checked before any body parsing, since a gateway rejecting the
 # bearer will not answer in the vault's error vocabulary at all.
@@ -729,6 +794,23 @@ def _refuse_unratified(capability: CreekCapability) -> NoReturn:
     raise CreekCapabilityUnsupportedError(_unsupported_message(capability)) from None
 
 
+def _entry_path_segment(entry_id: int) -> str:
+    """Encode an entry id into exactly one path segment that cannot climb out of it.
+
+    ``quote(..., safe="")`` blocks the obvious escape by encoding ``/``, but it
+    leaves a dot alone even with nothing marked safe -- so a segment of ``..``
+    survives encoding intact and every URL parser (httpx included) then
+    normalizes it away, aiming the ``PUT`` one level above the journal
+    collection. Encoding the dot with :data:`_ENCODED_DOT` is what makes the
+    segment inert; a percent-encoded dot is not a dot segment, so nothing
+    normalizes it. An id is an integer today, so this changes no URL adepthood
+    actually builds -- it is here because the entry *body* is what rides on this
+    request, and a future identifier type must not be able to redirect it by its
+    shape alone.
+    """
+    return quote(str(entry_id), safe="").replace(".", _ENCODED_DOT)
+
+
 def _journal_entry_body(request: VaultIngestRequest) -> Mapping[str, object]:
     """Map an ingest request onto the ratified ``/v1`` journal-entry fields.
 
@@ -761,26 +843,15 @@ def _coerce_ingest_action(raw: object) -> VaultIngestAction | None:
         return None
 
 
-def _usable_fragment_id(payload: Mapping[str, object]) -> str | None:
-    """Return the vault's fragment id when it is a non-empty string, else ``None``.
-
-    A blank, missing, or non-string id is unusable as a durable reference, and
-    coercing one (``str(7)``) would fabricate a ref the vault never issued.
-    """
-    fragment_id = payload.get("fragment_id")
-    if isinstance(fragment_id, str) and fragment_id:
-        return fragment_id
-    return None
-
-
 def _parse_http_ingest_result(payload: object) -> VaultIngestResult:
     """Project a 2xx ingest body onto a result, conservatively.
 
-    A durable write needs both halves: an action we recognize *and* a usable
+    A durable write needs both halves: an action we recognize *and* a storable
     fragment id. Anything less -- a body that is not a JSON object, an unknown
-    action, a blank id -- parses to not-stored, which the write path records as
-    a degraded write. That is the safe direction: reporting a write we cannot
-    verify would let the entry look replicated when it is not.
+    action, a blank or oversized or unprintable id -- parses to not-stored,
+    which the write path records as a degraded write. That is the safe
+    direction: reporting a write we cannot verify would let the entry look
+    replicated when it is not.
     """
     if isinstance(payload, Mapping):
         action = _coerce_ingest_action(payload.get("action"))
@@ -963,18 +1034,18 @@ class HttpCreekVaultClient:
 
         The ``except`` clauses are split (where the MCP client uses one combined
         set) purely to attribute the degradation: every branch returns the same
-        canonical unavailable result. ``httpx.HTTPError`` covers connection
-        failures, timeouts, and every non-2xx status raised by
-        ``raise_for_status``; ``OSError`` covers a socket-level failure that
-        escapes httpx's own hierarchy. A payload that parsed but whose vault
-        reported itself unavailable is not an error at all -- it is the vault
-        answering honestly -- and is recorded as such.
+        canonical unavailable result. :data:`_HTTP_CALL_FAILED_ERRORS` covers
+        connection failures, timeouts, every non-2xx status raised by
+        ``raise_for_status``, a socket-level failure escaping httpx's hierarchy,
+        and a URL httpx will not build a request for. A payload that parsed but
+        whose vault reported itself unavailable is not an error at all -- it is
+        the vault answering honestly -- and is recorded as such.
         """
         try:
             result = _parse_handshake(await self._fetch_capabilities())
         except _IncompatibleContractVersionError:
             return HandshakeResult.unavailable(), HandshakeDegradeReason.INCOMPATIBLE_VERSION
-        except (httpx.HTTPError, OSError):
+        except _HTTP_CALL_FAILED_ERRORS:
             return HandshakeResult.unavailable(), HandshakeDegradeReason.UNREACHABLE
         except _PARSE_ERROR_TYPES:
             return HandshakeResult.unavailable(), HandshakeDegradeReason.MALFORMED_PAYLOAD
@@ -1003,21 +1074,22 @@ class HttpCreekVaultClient:
     async def _put_journal_entry(self, request: VaultIngestRequest) -> httpx.Response:
         """Upsert one entry at its own URL, normalizing any transport failure.
 
-        The entry id is percent-encoded with nothing left safe, so it can only
-        ever contribute one path segment -- an id is an integer today, but a URL
+        The entry id contributes exactly one inert path segment
+        (:func:`_entry_path_segment`) -- an id is an integer today, but a URL
         assembled by concatenation is exactly where a future identifier type
-        would otherwise smuggle in a path traversal.
+        would otherwise smuggle in a path traversal, and the entry body is what
+        rides on this request.
 
         Every transport failure (connection refused, a socket error, the
-        whole-request deadline expiring) becomes
-        :class:`CreekVaultUnavailableError` with ``from None``: the original
-        exception's text can carry the URL or the entry body, and neither its
-        message nor its traceback context may ride along.
+        whole-request deadline expiring, a URL httpx will not build a request
+        for) becomes :class:`CreekVaultUnavailableError` with ``from None``: the
+        original exception's text can carry the URL or the entry body, and
+        neither its message nor its traceback context may ride along.
         """
-        entry_url = f"{self._url}{_JOURNAL_ENTRIES_PATH}{quote(str(request.entry_id), safe='')}"
+        entry_url = f"{self._url}{_JOURNAL_ENTRIES_PATH}{_entry_path_segment(request.entry_id)}"
         try:
             return await self._authorized_request("PUT", entry_url, _journal_entry_body(request))
-        except (httpx.HTTPError, OSError):
+        except _HTTP_CALL_FAILED_ERRORS:
             raise CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE) from None
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -18,9 +18,12 @@ Three implementations of :class:`~domain.creek_vault.CreekVaultClient` live here
   handshaking with a single ``GET /v1/capabilities``. It degrades the same way,
   and additionally records *which* failure mode degraded it
   (:class:`HandshakeDegradeReason`) so contract-version skew stays countable
-  apart from a vault that is merely unreachable. Its per-capability calls all
-  refuse for now: Creek's ratified ``/v1`` request/response shapes have not
-  shipped, and guessing a wire format is worse than staying local.
+  apart from a vault that is merely unreachable. Journal ingest is the one
+  capability whose ``/v1`` shape Creek has ratified, so it is wired up as a
+  ``PUT`` of the entry's own URL; classify, reflect, and wheel still refuse,
+  because guessing an unratified wire format is worse than staying local. A
+  failed ingest is *dropped*, not queued -- there is no retry and no backlog
+  today, and the local Postgres row stays the system of record either way.
 * :class:`LocalFallbackCreekVaultClient` -- the no-vault path. Handshake reports
   unavailable, nothing is supported, ingest is a silent no-op (operator Postgres
   stays the system of record), and the read/compute capabilities raise
@@ -63,8 +66,9 @@ import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from http import HTTPStatus
 from typing import NoReturn, Protocol
-from urllib.parse import SplitResult, urlsplit
+from urllib.parse import SplitResult, quote, urlsplit
 
 import httpx
 from mcp import ClientSession
@@ -77,10 +81,15 @@ from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
     CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
     CreekVaultClient,
+    CreekVaultContractError,
+    CreekVaultError,
     CreekVaultUnavailableError,
     HandshakeResult,
     VaultClassification,
+    VaultErrorCode,
+    VaultIngestAction,
     VaultIngestRequest,
     VaultIngestResult,
     VaultTierCeiling,
@@ -601,10 +610,51 @@ class HandshakeDegradeReason(enum.StrEnum):
     VAULT_REPORTED_UNAVAILABLE = "vault_reported_unavailable"
 
 
-# The vault's capability document, relative to the configured base URL. The one
-# endpoint adepthood can call today: Creek's ratified ``/v1`` request/response
-# shapes for the other capabilities have not shipped.
+# The vault's capability document, relative to the configured base URL.
 _CAPABILITIES_PATH = "/v1/capabilities"
+
+# The collection a journal entry is upserted into, relative to the configured
+# base URL. One entry is one resource: the write is a ``PUT`` of the entry's own
+# id, which is what makes a re-send idempotent (the vault edits the fragment it
+# already keyed off that id instead of appending a second one). This and the
+# capability document are the only ``/v1`` shapes Creek has ratified.
+_JOURNAL_ENTRIES_PATH = "/v1/journal-entries/"
+
+# Statuses that mean "your credential was refused" rather than "the vault is
+# missing". Checked before any body parsing, since a gateway rejecting the
+# bearer will not answer in the vault's error vocabulary at all.
+_CREDENTIAL_REJECTED_STATUSES: frozenset[int] = frozenset(
+    {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+)
+
+# Vault error codes that mean adepthood got the call wrong -- a bad payload, a
+# capability we should not have claimed, or a version we should not have pinned.
+# Every one of them is fixed by changing adepthood, so they map to a contract
+# error. ``TEMPORARILY_UNAVAILABLE`` is deliberately absent: it is the vault
+# reporting on itself, which is an availability fault.
+_CONTRACT_ERROR_CODES: frozenset[VaultErrorCode] = frozenset(
+    {
+        VaultErrorCode.INVALID_REQUEST,
+        VaultErrorCode.UNSUPPORTED_CAPABILITY,
+        VaultErrorCode.INCOMPATIBLE_VERSION,
+    }
+)
+
+# The three static, capability-named messages the ingest path may raise with.
+# Built from the capability enum rather than written as literals so they cannot
+# drift from the wire name, and content-free by construction: no branch may
+# interpolate the entry body, the API key, or a vault-supplied string into an
+# exception that will reach a log or a traceback.
+_INGEST_FAILED_MESSAGE = f"creek vault call failed: {CreekCapability.JOURNAL.value}"
+_INGEST_REJECTED_MESSAGE = f"creek vault rejected the request: {CreekCapability.JOURNAL.value}"
+_CREDENTIAL_REJECTED_MESSAGE = (
+    f"creek vault rejected the credential: {CreekCapability.JOURNAL.value}"
+)
+
+# The one not-stored result every unreadable 2xx collapses to. Interned because
+# it is value-identical on each of those paths, and named so no branch is
+# tempted to invent a ``vault_ref`` the vault never issued.
+_NOT_STORED_RESULT = VaultIngestResult(stored=False, vault_ref=None, action=None)
 
 
 def _build_pooled_vault_client() -> httpx.AsyncClient:
@@ -679,6 +729,121 @@ def _refuse_unratified(capability: CreekCapability) -> NoReturn:
     raise CreekCapabilityUnsupportedError(_unsupported_message(capability)) from None
 
 
+def _journal_entry_body(request: VaultIngestRequest) -> Mapping[str, object]:
+    """Map an ingest request onto the ratified ``/v1`` journal-entry fields.
+
+    Exactly three fields, and no more: the entry id travels in the URL (it is
+    the resource), and the tier ceiling the MCP shape carries as a separate
+    ``privacy_tier_ceiling`` is redundant here, since a journal write always
+    stores at the writer's own tier. Sending a field the ratified shape does not
+    name would be guessing.
+    """
+    return {
+        "content": request.body,
+        "timestamp": request.created_at.isoformat(),
+        "tier": request.tier.value,
+    }
+
+
+def _coerce_ingest_action(raw: object) -> VaultIngestAction | None:
+    """Map the vault's reported action onto our enum, or ``None`` if we do not know it.
+
+    Mirrors :func:`_coerce_capability`: an unknown or wrong-typed value is
+    dropped rather than raising, so the string a vault chose can never reach a
+    message or a log. An unknown action is not a durable write, though -- the
+    caller treats ``None`` as "we could not read this response".
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        return VaultIngestAction(raw)
+    except ValueError:
+        return None
+
+
+def _usable_fragment_id(payload: Mapping[str, object]) -> str | None:
+    """Return the vault's fragment id when it is a non-empty string, else ``None``.
+
+    A blank, missing, or non-string id is unusable as a durable reference, and
+    coercing one (``str(7)``) would fabricate a ref the vault never issued.
+    """
+    fragment_id = payload.get("fragment_id")
+    if isinstance(fragment_id, str) and fragment_id:
+        return fragment_id
+    return None
+
+
+def _parse_http_ingest_result(payload: object) -> VaultIngestResult:
+    """Project a 2xx ingest body onto a result, conservatively.
+
+    A durable write needs both halves: an action we recognize *and* a usable
+    fragment id. Anything less -- a body that is not a JSON object, an unknown
+    action, a blank id -- parses to not-stored, which the write path records as
+    a degraded write. That is the safe direction: reporting a write we cannot
+    verify would let the entry look replicated when it is not.
+    """
+    if isinstance(payload, Mapping):
+        action = _coerce_ingest_action(payload.get("action"))
+        fragment_id = _usable_fragment_id(payload)
+        if action is not None and fragment_id is not None:
+            return VaultIngestResult(stored=True, vault_ref=fragment_id, action=action)
+    return _NOT_STORED_RESULT
+
+
+def _vault_error_code(response: httpx.Response) -> VaultErrorCode | None:
+    """Read the vault's own error code from an error body, parsing only what we know.
+
+    Four narrowing steps, each of which fails to ``None`` rather than raising: a
+    body that is not JSON, JSON that is not an object, a ``code`` that is not a
+    string, and a string that is not one of :class:`VaultErrorCode`'s members.
+    The last step is the security-relevant one -- an unrecognized code is
+    *dropped*, never stored or echoed, so a compromised vault cannot inject text
+    (control characters and all) into an exception message or a log record.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    return _coerce_error_code(payload.get("code"))
+
+
+def _coerce_error_code(raw: object) -> VaultErrorCode | None:
+    """Map a wire ``code`` string onto our enum, dropping anything unrecognized."""
+    if not isinstance(raw, str):
+        return None
+    try:
+        return VaultErrorCode(raw)
+    except ValueError:
+        return None
+
+
+def _ingest_failure(response: httpx.Response) -> CreekVaultError:
+    """Classify a non-2xx ingest response into the failure it actually is.
+
+    The order encodes what each answer tells an operator to do:
+
+    1. A refused credential is a configuration fault with its own remedy, and it
+       is decided on the status alone -- a gateway that rejects our bearer never
+       reaches the vault's error vocabulary.
+    2. A code we recognize is authoritative over the status class; the vault
+       naming itself temporarily unavailable is the one such code that is *not*
+       our defect.
+    3. With no readable code, the status class decides: 4xx means the vault
+       faulted the request we sent (ours to fix), and everything else -- 5xx, a
+       redirect we refuse to follow -- means the call did not land (not ours).
+    """
+    if response.status_code in _CREDENTIAL_REJECTED_STATUSES:
+        return CreekVaultAuthError(_CREDENTIAL_REJECTED_MESSAGE)
+    code = _vault_error_code(response)
+    if code in _CONTRACT_ERROR_CODES:
+        return CreekVaultContractError(_INGEST_REJECTED_MESSAGE, code=code)
+    if code is None and response.is_client_error:
+        return CreekVaultContractError(_INGEST_REJECTED_MESSAGE)
+    return CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE)
+
+
 class HttpCreekVaultClient:
     """A :class:`CreekVaultClient` that speaks plain HTTP/JSON to a configured vault.
 
@@ -689,13 +854,22 @@ class HttpCreekVaultClient:
     **degrades, never crashes**: :meth:`handshake` collapses every transport,
     parsing, and version failure into :meth:`HandshakeResult.unavailable`.
 
-    The capability calls all refuse with
-    :class:`CreekCapabilityUnsupportedError`, *including* ones the vault
-    advertises. Creek's ratified ``/v1`` request/response shapes for them have
-    not shipped upstream, and this adapter will not guess a wire format: a
-    refusal degrades the caller onto its local pipeline, whereas a wrong guess
-    would send real journal content into a surface nobody has agreed on. Wiring
-    them up is follow-on work, gated on that document.
+    Journal ingest is the one capability whose ``/v1`` request/response shape
+    Creek has ratified, so :meth:`ingest` is wired up: it gates on the
+    handshake exactly as the MCP client does, sends a ``PUT`` to the entry's own
+    URL, and splits the answer into a durable write, a not-stored write, or one of
+    three failure types (contract, auth, unavailable) an operator can act on
+    differently. A failed ingest is **dropped, not queued** -- there is no retry
+    and no backlog today, and it does not need one, because the local Postgres
+    row is the system of record and the user's save already succeeded.
+
+    :meth:`classify`, :meth:`reflect`, and :meth:`wheel` still refuse with
+    :class:`CreekCapabilityUnsupportedError`, *including* when the vault
+    advertises them. Their shapes have not shipped upstream, and this adapter
+    will not guess a wire format: a refusal degrades the caller onto its local
+    pipeline, whereas a wrong guess would send real journal content into a
+    surface nobody has agreed on. Wiring them up is follow-on work, gated on
+    that document.
 
     A plain class on purpose -- no dataclass, no custom ``__repr__`` -- so the
     default object repr can never render the bearer credential this instance
@@ -743,28 +917,41 @@ class HttpCreekVaultClient:
             return self._http_client
         return _VAULT_HTTP_POOL.get()
 
+    async def _authorized_request(
+        self, method: str, url: str, json_body: Mapping[str, object] | None = None
+    ) -> httpx.Response:
+        """Send one authorized vault request under the whole-request deadline.
+
+        The single place any request leaves this adapter, so the two properties
+        that must hold for *every* call hold once. The authorization header is
+        built here, per call, so the credential lives only for the duration of
+        the request and never on the shared pooled client.
+
+        The deadline is necessary because httpx's ``read`` budget is per
+        socket-read rather than a deadline: a trickling vault would otherwise
+        hold this coroutine (and its pooled connection) open indefinitely.
+        Expiry raises ``TimeoutError``, an ``OSError`` subclass, so it lands in
+        each caller's existing transport branch. The module constant is read at
+        call time rather than captured, so a redeployment (or a test) can move
+        the ceiling without rebuilding the adapter.
+        """
+        async with asyncio.timeout(_VAULT_TOTAL_DEADLINE_SECONDS):
+            return await self._active_client().request(
+                method,
+                url,
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json=json_body,
+            )
+
     async def _fetch_capabilities(self) -> Mapping[str, object]:
         """Fetch and minimally narrow the vault's capability document.
 
-        The authorization header is built here, per call, so the credential
-        lives only for the duration of the request and never on the shared
-        pooled client. A non-2xx status raises ``httpx.HTTPStatusError`` and a
-        non-JSON body raises ``json.JSONDecodeError``; both are degraded by the
-        caller. A body that decodes to something other than a JSON object is a
-        malformed payload, so it raises ``TypeError`` rather than being cast.
-
-        The request runs under a whole-call deadline because httpx's ``read``
-        budget is per socket-read rather than a deadline, so a trickling vault
-        would otherwise hold this coroutine (and its pooled connection) open
-        indefinitely. Expiry raises ``TimeoutError``, an ``OSError`` subclass,
-        so it lands in the caller's existing transport branch and degrades to
-        unreachable -- the degrade set is unchanged.
+        A non-2xx status raises ``httpx.HTTPStatusError`` and a non-JSON body
+        raises ``json.JSONDecodeError``; both are degraded by the caller. A body
+        that decodes to something other than a JSON object is a malformed
+        payload, so it raises ``TypeError`` rather than being cast.
         """
-        async with asyncio.timeout(_VAULT_TOTAL_DEADLINE_SECONDS):
-            response = await self._active_client().get(
-                f"{self._url}{_CAPABILITIES_PATH}",
-                headers={"Authorization": f"Bearer {self._api_key}"},
-            )
+        response = await self._authorized_request("GET", f"{self._url}{_CAPABILITIES_PATH}")
         response.raise_for_status()
         payload = response.json()
         if not isinstance(payload, Mapping):
@@ -813,9 +1000,53 @@ class HttpCreekVaultClient:
         """Return whether the cached handshake advertised ``capability``."""
         return capability in self._last_handshake.capabilities
 
-    async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
-        """Refuse ingest: the ``/v1`` write shape is unratified (Postgres stays authoritative)."""
-        _refuse_unratified(CreekCapability.JOURNAL)
+    async def _put_journal_entry(self, request: VaultIngestRequest) -> httpx.Response:
+        """Upsert one entry at its own URL, normalizing any transport failure.
+
+        The entry id is percent-encoded with nothing left safe, so it can only
+        ever contribute one path segment -- an id is an integer today, but a URL
+        assembled by concatenation is exactly where a future identifier type
+        would otherwise smuggle in a path traversal.
+
+        Every transport failure (connection refused, a socket error, the
+        whole-request deadline expiring) becomes
+        :class:`CreekVaultUnavailableError` with ``from None``: the original
+        exception's text can carry the URL or the entry body, and neither its
+        message nor its traceback context may ride along.
+        """
+        entry_url = f"{self._url}{_JOURNAL_ENTRIES_PATH}{quote(str(request.entry_id), safe='')}"
+        try:
+            return await self._authorized_request("PUT", entry_url, _journal_entry_body(request))
+        except (httpx.HTTPError, OSError):
+            raise CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE) from None
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Upsert ``request`` into the vault, requiring the JOURNAL capability.
+
+        Gated on the cached handshake first, exactly as
+        :meth:`McpCreekVaultClient._invoke` gates: a vault that did not
+        advertise JOURNAL is refused *locally*, so no entry body is ever put on
+        the wire toward a surface that never claimed to accept it.
+
+        The answer splits three ways. A 2xx is projected by
+        :func:`_parse_http_ingest_result`, which reports not-stored rather than
+        inventing a ref it could not read. A 2xx whose body will not decode at
+        all is an unavailable vault, not a failed write -- we cannot tell what
+        happened, and a proxy error page served as 200 is the usual cause. A
+        non-2xx is classified by :func:`_ingest_failure` into the fault it
+        represents. Every raise uses ``from None`` so no vault-supplied text
+        reaches a traceback.
+        """
+        if not self.supports(CreekCapability.JOURNAL):
+            raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.JOURNAL))
+        response = await self._put_journal_entry(request)
+        if not response.is_success:
+            raise _ingest_failure(response) from None
+        try:
+            payload = response.json()
+        except ValueError:
+            raise CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE) from None
+        return _parse_http_ingest_result(payload)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Refuse classification: its ``/v1`` request/response shape is unratified."""

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -692,6 +692,16 @@ _CREDENTIAL_REJECTED_STATUSES: frozenset[int] = frozenset(
     {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
 )
 
+# The two 4xx statuses that are *not* a statement about the request we sent.
+# The rest of the 4xx range faults our payload, but 408 says the vault's own
+# clock ran out waiting and 429 says it is shedding load: both are "come back
+# later" -- an availability story identical to a 5xx, and both are cured by
+# waiting rather than by changing anything in adepthood. Classifying them as
+# contract defects would send an operator hunting a bug that is not there.
+_RETRYABLE_CLIENT_STATUSES: frozenset[int] = frozenset(
+    {HTTPStatus.REQUEST_TIMEOUT, HTTPStatus.TOO_MANY_REQUESTS}
+)
+
 # Vault error codes that mean adepthood got the call wrong -- a bad payload, a
 # capability we should not have claimed, or a version we should not have pinned.
 # Every one of them is fixed by changing adepthood, so they map to a contract
@@ -890,6 +900,17 @@ def _coerce_error_code(raw: object) -> VaultErrorCode | None:
         return None
 
 
+def _faults_our_request(response: httpx.Response) -> bool:
+    """Return whether an uncoded status blames the request adepthood sent.
+
+    True for the 4xx range, minus :data:`_RETRYABLE_CLIENT_STATUSES` -- a
+    throttled or timed-out call says nothing about the payload, so treating it
+    as a contract defect would be a false accusation an operator then has to
+    disprove.
+    """
+    return response.is_client_error and response.status_code not in _RETRYABLE_CLIENT_STATUSES
+
+
 def _ingest_failure(response: httpx.Response) -> CreekVaultError:
     """Classify a non-2xx ingest response into the failure it actually is.
 
@@ -901,16 +922,19 @@ def _ingest_failure(response: httpx.Response) -> CreekVaultError:
     2. A code we recognize is authoritative over the status class; the vault
        naming itself temporarily unavailable is the one such code that is *not*
        our defect.
-    3. With no readable code, the status class decides: 4xx means the vault
+    3. With no readable code, the status class decides: a 4xx means the vault
        faulted the request we sent (ours to fix), and everything else -- 5xx, a
        redirect we refuse to follow -- means the call did not land (not ours).
+       :data:`_RETRYABLE_CLIENT_STATUSES` is the documented exception to that
+       rule: two 4xx statuses describe the vault's own state rather than our
+       request, so they answer to the availability story instead.
     """
     if response.status_code in _CREDENTIAL_REJECTED_STATUSES:
         return CreekVaultAuthError(_CREDENTIAL_REJECTED_MESSAGE)
     code = _vault_error_code(response)
     if code in _CONTRACT_ERROR_CODES:
         return CreekVaultContractError(_INGEST_REJECTED_MESSAGE, code=code)
-    if code is None and response.is_client_error:
+    if code is None and _faults_our_request(response):
         return CreekVaultContractError(_INGEST_REJECTED_MESSAGE)
     return CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE)
 

--- a/backend/src/services/creek_vault_write.py
+++ b/backend/src/services/creek_vault_write.py
@@ -13,6 +13,17 @@ rather than an exception the router must special-case. Per-entry vault
 classification is deferred: the write path never calls a classify capability,
 so a successful write always carries an empty tag tuple.
 
+**A failed replication is dropped, not queued.** There is no retry, no
+dead-letter queue, and no backlog today: a write that degrades is logged with a
+countable :class:`VaultDegradeReason` and then forgotten, and the entry is never
+re-sent unless the user edits it again. That is a deliberate floor, not an
+oversight -- the local Postgres row is the system of record, the user's save
+already succeeded, and the vault holds a convenience copy. Nothing the user can
+see is lost by dropping it, whereas a queue would need durable storage of entry
+bodies outside Postgres, which is a privacy decision nobody has made. The logs
+exist so an operator can tell *why* replication is failing, and how often,
+before that decision is ever needed.
+
 **Intimate content is deliberately not sent here.** An entry classified
 ``intimate`` short-circuits to :attr:`VaultWriteStatus.SKIPPED_INTIMATE` before
 any vault call -- not even a handshake. This is a considered deferral, not a
@@ -27,18 +38,26 @@ depth, so the safe answer is to withhold them here until that channel lands.
 from __future__ import annotations
 
 import enum
+import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 
 from domain.creek_vault import (
     CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
     CreekVaultClient,
+    CreekVaultContractError,
     CreekVaultError,
     VaultIngestRequest,
+    VaultIngestResult,
     tier_ceiling_for,
 )
 from models.journal_entry import JournalClassification
 from services.creek_vault_client import build_creek_vault_client
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class VaultWriteStatus(enum.StrEnum):
@@ -53,6 +72,35 @@ class VaultWriteStatus(enum.StrEnum):
     SKIPPED_INTIMATE = "skipped_intimate"
     UNAVAILABLE = "unavailable"
     DEGRADED = "degraded"
+
+
+class VaultDegradeReason(enum.StrEnum):
+    """Why one vault write failed to replicate, in terms an operator can act on.
+
+    The caller sees a single :attr:`VaultWriteStatus.DEGRADED` -- that is the
+    point of degrading -- so these reasons exist purely so the failures stay
+    countable *apart*, and every one of them has a different remedy: ``CONTRACT``
+    is a defect in adepthood's own request, ``AUTH`` is a credential to rotate,
+    ``UNAVAILABLE`` is infrastructure, ``UNSUPPORTED_CAPABILITY`` is a vault that
+    never offered journal ingest, and ``NOT_STORED`` is a vault that answered
+    successfully yet did not durably keep the entry. Values are the wire strings
+    telemetry counts by, so they are part of this module's contract and must not
+    be reworded casually.
+    """
+
+    CONTRACT = "contract"
+    AUTH = "auth"
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED_CAPABILITY = "unsupported_capability"
+    NOT_STORED = "not_stored"
+
+
+# The two static log events this module emits. Static because a vault error's
+# own message can carry the entry body or a string the vault chose: everything
+# variable travels in the structured ``extra`` fields instead, each of which is
+# either an id, one of our own enum values, or a capability wire name.
+_DEGRADED_EVENT = "creek vault write degraded"
+_INGESTED_EVENT = "creek vault write ingested"
 
 
 @dataclass(frozen=True)
@@ -90,18 +138,94 @@ def _ingest_ready(client: CreekVaultClient) -> bool:
     return client.is_available() and client.supports(CreekCapability.JOURNAL)
 
 
+def _degrade_reason_for(error: CreekVaultError) -> VaultDegradeReason:
+    """Attribute one vault error to the reason an operator would act on.
+
+    Ordered most-specific first, and ``UNAVAILABLE`` is the catch-all rather
+    than a match: a vault error type this module has not heard of is far more
+    likely to be an availability fault than a contract one, and guessing
+    "contract" would send someone hunting a bug in adepthood that is not there.
+    """
+    if isinstance(error, CreekVaultContractError):
+        return VaultDegradeReason.CONTRACT
+    if isinstance(error, CreekVaultAuthError):
+        return VaultDegradeReason.AUTH
+    if isinstance(error, CreekCapabilityUnsupportedError):
+        return VaultDegradeReason.UNSUPPORTED_CAPABILITY
+    return VaultDegradeReason.UNAVAILABLE
+
+
+def _degrade_fields(error: CreekVaultError) -> dict[str, object]:
+    """Build the content-free fields describing why a write degraded.
+
+    ``code`` appears only when the error carries one of *our own*
+    :class:`~domain.creek_vault.VaultErrorCode` members: the adapter has already
+    dropped anything a vault sent that we do not recognize, so this can never
+    put a vault-chosen string into a log line.
+    """
+    fields: dict[str, object] = {"reason": _degrade_reason_for(error).value}
+    if isinstance(error, CreekVaultContractError) and error.code is not None:
+        fields["code"] = error.code.value
+    return fields
+
+
+def _log_extra(request: VaultIngestRequest, fields: Mapping[str, object]) -> dict[str, object]:
+    """Compose the structured payload every vault-write log record carries.
+
+    Deliberately only identifiers and closed vocabularies -- the entry body, the
+    API key, and any raw vault-supplied string are absent by construction rather
+    than by redaction, so there is nothing here to forget to scrub.
+    """
+    return {
+        "capability": CreekCapability.JOURNAL.value,
+        "entry_id": request.entry_id,
+        **fields,
+    }
+
+
+def _log_degraded(request: VaultIngestRequest, fields: Mapping[str, object]) -> None:
+    """Record a dropped replication at WARNING with a static message.
+
+    The exception is deliberately neither formatted into the message nor passed
+    as ``exc_info``: its text may quote the entry body or the vault's own prose,
+    and this record is the one place both would otherwise escape. What an
+    operator needs -- which entry, which capability, which reason -- is in the
+    structured fields.
+    """
+    _LOGGER.warning(_DEGRADED_EVENT, extra=_log_extra(request, fields))
+
+
+def _log_ingested(request: VaultIngestRequest, result: VaultIngestResult) -> None:
+    """Record a durable write at INFO, carrying which action the vault took.
+
+    INFO rather than WARNING because nothing is wrong; the action is worth
+    keeping because it is how an operator sees that a re-sent entry edited its
+    existing fragment instead of creating a second one. Transports that do not
+    report an action log ``None``, which honestly says "the vault did not say".
+    """
+    action = result.action.value if result.action is not None else None
+    _LOGGER.info(_INGESTED_EVENT, extra=_log_extra(request, {"action": action}))
+
+
 async def _try_ingest(client: CreekVaultClient, request: VaultIngestRequest) -> str | None:
     """Attempt an ingest, returning the vault ref on durable storage or ``None``.
 
     A :class:`CreekVaultError` (the seam's normalized transport failure) and a
     ``stored=False`` result both collapse to ``None`` -- the caller treats either
     as a degraded write rather than propagating the error or fabricating a ref.
+    Each path logs its own reason on the way out, because this is where the
+    replication is dropped and nothing downstream will ever hear of it again.
     """
     try:
         result = await client.ingest(request)
-    except CreekVaultError:
+    except CreekVaultError as error:
+        _log_degraded(request, _degrade_fields(error))
         return None
-    return result.vault_ref if result.stored else None
+    if not result.stored:
+        _log_degraded(request, {"reason": VaultDegradeReason.NOT_STORED.value})
+        return None
+    _log_ingested(request, result)
+    return result.vault_ref
 
 
 async def store_and_classify(

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -31,6 +31,7 @@ from domain.creek_vault import (
     VaultWheelBalance,
 )
 from services.creek_vault_client import (
+    _MAX_FRAGMENT_ID_LENGTH,
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
     _extract_tool_payload,
@@ -353,6 +354,24 @@ def test_parse_ingest_result_missing_fragment_id_is_not_stored() -> None:
 def test_parse_ingest_result_empty_fragment_id_is_not_stored() -> None:
     """An ok status with an empty fragment_id parses to stored=False with no vault_ref."""
     result = _parse_ingest_result({"status": "ok", "fragment_id": ""})
+    assert result == VaultIngestResult(stored=False, vault_ref=None)
+
+
+@pytest.mark.parametrize(
+    "fragment_id",
+    [
+        pytest.param("f" * (_MAX_FRAGMENT_ID_LENGTH + 1), id="oversized"),
+        pytest.param("frag\r\n\x00-1", id="unprintable"),
+    ],
+)
+def test_parse_ingest_result_unstorable_fragment_id_is_not_stored(fragment_id: str) -> None:
+    """An ok status whose ref is too long or unprintable is not-stored, on this transport too.
+
+    ``vault_ref`` is persisted verbatim on the entry, so the same bound has to
+    hold whichever transport answered -- an MCP vault gets no wider a channel
+    into that column than an HTTP one.
+    """
+    result = _parse_ingest_result({"status": "ok", "fragment_id": fragment_id})
     assert result == VaultIngestResult(stored=False, vault_ref=None)
 
 

--- a/backend/tests/test_creek_vault_domain.py
+++ b/backend/tests/test_creek_vault_domain.py
@@ -14,6 +14,8 @@ from domain.creek_vault import (
     TIER_CEILING_BY_CLASSIFICATION,
     CreekCapability,
     HandshakeResult,
+    VaultErrorCode,
+    VaultIngestAction,
     VaultIngestRequest,
     VaultTierCeiling,
     tier_ceiling_for,
@@ -103,6 +105,32 @@ class TestCreekCapability:
     def test_wheel_value_is_wire_name(self) -> None:
         """WHEEL's value is the creek.wheel wire name."""
         assert CreekCapability.WHEEL.value == "creek.wheel"
+
+
+class TestRatifiedWireVocabularies:
+    """The two vault-supplied vocabularies, pinned to the exact strings on the wire.
+
+    Both are parsed straight off a vault response and both are closed sets: a
+    value that drifts stops matching what Creek sends, which silently degrades
+    every write rather than failing loudly, so the members are pinned in order.
+    """
+
+    def test_error_codes_are_the_four_ratified_strings(self) -> None:
+        """The error vocabulary is exactly the four codes Creek ratified, in order."""
+        assert [code.value for code in VaultErrorCode] == [
+            "invalid_request",
+            "unsupported_capability",
+            "incompatible_version",
+            "temporarily_unavailable",
+        ]
+
+    def test_ingest_actions_are_the_three_upsert_outcomes(self) -> None:
+        """An upsert reports exactly one of three actions, and they are wire strings."""
+        assert [action.value for action in VaultIngestAction] == [
+            "created",
+            "updated",
+            "unchanged",
+        ]
 
 
 class TestHandshakeResultUnavailable:

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -1,19 +1,22 @@
 """Tests for the HTTP/JSON Creek Vault adapter in services.creek_vault_client.
 
 Every case drives the adapter through an ``httpx.MockTransport`` handler, so no
-test touches a network or waits on real time. The capability payload asserted
-here is the only response shape adepthood can know today -- the one it already
-parses. Nothing beyond it is invented, because Creek's ratified ``/v1`` document
-has not shipped.
+test touches a network or waits on real time. Two response shapes are asserted
+here: the capability document the handshake already parses, and the journal
+ingest exchange -- the one capability whose ``/v1`` shape Creek has ratified.
+Nothing beyond those two is invented.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import AsyncGenerator, Callable, Coroutine, Mapping, Sequence
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from http import HTTPStatus
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -26,8 +29,14 @@ from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
     CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
     CreekVaultClient,
+    CreekVaultContractError,
+    CreekVaultError,
+    CreekVaultUnavailableError,
     HandshakeResult,
+    VaultErrorCode,
+    VaultIngestAction,
     VaultIngestRequest,
     VaultTierCeiling,
 )
@@ -70,7 +79,26 @@ _PATH_VAULT_URL = f"{_VAULT_URL}/vault/"
 
 _ENTRY_BODY = "a floor-level journal entry"
 
+# A body distinct enough to spot anywhere it must never appear: an exception
+# message, a repr, or a log record.
+_SENTINEL_BODY = "SENTINEL_ENTRY_BODY_DO_NOT_LEAK"
+
 _CREATED_AT = datetime(2026, 7, 31, 12, 0, tzinfo=UTC)
+
+# The stable external id the vault keys the stored fragment off, and the URL a
+# PUT for it must land on.
+_ENTRY_ID = 7
+
+_JOURNAL_ENTRY_URL = f"{_VAULT_URL}/v1/journal-entries/{_ENTRY_ID}"
+
+_FRAGMENT_ID = "frag-7"
+
+# A hostile ``code`` a compromised or buggy vault could answer with: an
+# unrecognized value carrying CRLF (log-injection) plus a token that must never
+# be echoed. The adapter may parse only its own enum values, so this whole
+# string has to be dropped rather than stored, formatted, or logged.
+_HOSTILE_CODE_SENTINEL = "HOSTILE_VAULT_CODE_SENTINEL"
+_HOSTILE_VAULT_CODE = f"not_a_real_code\r\n{_HOSTILE_CODE_SENTINEL}"
 
 _POOL_ATTR = "services.creek_vault_client._VAULT_HTTP_POOL"
 
@@ -186,15 +214,34 @@ def _payload_without_contract_version() -> dict[str, object]:
     return payload
 
 
-def _ingest_request() -> VaultIngestRequest:
-    """Build a minimal ingest request for the refusal paths."""
+def _ingest_request(
+    tier: VaultTierCeiling = VaultTierCeiling.OPEN, body: str = _ENTRY_BODY
+) -> VaultIngestRequest:
+    """Build an ingest request at ``tier`` carrying ``body``.
+
+    An entry's own tier and its write ceiling are always the same value on the
+    journal path, so one argument sets both.
+    """
     return VaultIngestRequest(
-        entry_id=7,
-        body=_ENTRY_BODY,
-        tier=VaultTierCeiling.OPEN,
-        tier_ceiling=VaultTierCeiling.OPEN,
+        entry_id=_ENTRY_ID,
+        body=body,
+        tier=tier,
+        tier_ceiling=tier,
         created_at=_CREATED_AT,
     )
+
+
+def _ingest_payload(
+    fragment_id: object = _FRAGMENT_ID,
+    action: str = VaultIngestAction.CREATED.value,
+) -> dict[str, object]:
+    """Build a vault ingest response body carrying ``action`` and ``fragment_id``."""
+    return {"action": action, "fragment_id": fragment_id}
+
+
+def _error_payload(code: str) -> dict[str, object]:
+    """Build a vault error body carrying a machine-readable ``code``."""
+    return {"code": code, "detail": "the vault refused this request"}
 
 
 class _RecordingHandler:
@@ -209,6 +256,102 @@ class _RecordingHandler:
         """Record the request and answer 200 with the stored payload."""
         self.requests.append(request)
         return httpx.Response(200, json=self._payload)
+
+
+@dataclass(frozen=True)
+class _IngestReply:
+    """One scripted answer to a journal-entry PUT: a status plus a JSON or text body."""
+
+    status: int = HTTPStatus.OK
+    payload: object = None
+    text: str | None = None
+
+    def to_response(self) -> httpx.Response:
+        """Build the httpx response this reply describes."""
+        if self.text is not None:
+            return httpx.Response(self.status, text=self.text)
+        return httpx.Response(self.status, json=self.payload)
+
+
+_CREATED_REPLY = _IngestReply(payload=_ingest_payload())
+
+
+class _VaultRouteHandler:
+    """Route-aware handler: a healthy capability GET plus scripted journal PUTs.
+
+    The handshake and the ingest have different shapes and different failure
+    modes, so a test needs to script them independently while still seeing every
+    request that crossed the transport. Replies are consumed in order and the
+    last one repeats, so a two-call test scripts exactly two.
+    """
+
+    def __init__(
+        self,
+        replies: Sequence[_IngestReply] = (),
+        *,
+        capabilities: Sequence[str] = (CreekCapability.JOURNAL.value,),
+        ingest_error: Exception | None = None,
+    ) -> None:
+        """Store the advertised capabilities, the PUT script, and any PUT failure."""
+        self._capabilities = list(capabilities)
+        self._replies = list(replies) or [_CREATED_REPLY]
+        self._ingest_error = ingest_error
+        self.requests: list[httpx.Request] = []
+
+    @property
+    def ingest_requests(self) -> list[httpx.Request]:
+        """Return only the journal-entry PUTs this handler has served."""
+        return [request for request in self.requests if request.method == "PUT"]
+
+    def _next_reply(self) -> _IngestReply:
+        """Return this PUT's scripted reply, repeating the last once the script runs out."""
+        return self._replies[min(len(self.ingest_requests) - 1, len(self._replies) - 1)]
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Record the request, then answer the capability GET or the scripted PUT."""
+        self.requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(HTTPStatus.OK, json=_handshake_payload(self._capabilities))
+        if self._ingest_error is not None:
+            raise self._ingest_error
+        return self._next_reply().to_response()
+
+
+class _SlowIngestHandler:
+    """Handler that handshakes healthily and then trickles forever on the journal PUT."""
+
+    def __init__(self) -> None:
+        """Start an empty request log."""
+        self.requests: list[httpx.Request] = []
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Answer the capability GET at once; never finish the PUT within any deadline."""
+        self.requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(
+                HTTPStatus.OK, json=_handshake_payload([CreekCapability.JOURNAL.value])
+            )
+        await asyncio.sleep(_SLOW_HANDLER_SLEEP_SECONDS)
+        return httpx.Response(HTTPStatus.OK, json=_ingest_payload())
+
+
+async def _handshaken_client(
+    handler: Handler | AsyncHandler,
+    http_clients: ClientFactory,
+    api_key: str = _API_KEY,
+) -> HttpCreekVaultClient:
+    """Build a client over ``handler`` and complete its handshake before returning it."""
+    client = HttpCreekVaultClient(_VAULT_URL, api_key, http_client=http_clients(handler))
+    await client.handshake()
+    return client
+
+
+def _sent_ingest_body(handler: _VaultRouteHandler) -> dict[str, object]:
+    """Return the decoded JSON body of the single journal PUT the handler served."""
+    assert len(handler.ingest_requests) == 1
+    decoded = json.loads(handler.ingest_requests[0].content)
+    assert isinstance(decoded, dict)
+    return decoded
 
 
 class _CountingClientBuild:
@@ -263,8 +406,6 @@ async def http_clients() -> AsyncGenerator[ClientFactory, None]:
 
 async def _call_capability(client: HttpCreekVaultClient, capability: CreekCapability) -> object:
     """Invoke the client method that implements ``capability``."""
-    if capability is CreekCapability.JOURNAL:
-        return await client.ingest(_ingest_request())
     if capability is CreekCapability.CLASSIFY:
         return await client.classify(_ENTRY_BODY, VaultTierCeiling.OPEN)
     if capability is CreekCapability.REFLECT:
@@ -711,7 +852,6 @@ async def test_a_url_with_a_path_prefix_keeps_it_in_the_capability_url(
 @pytest.mark.parametrize(
     "capability",
     [
-        CreekCapability.JOURNAL,
         CreekCapability.CLASSIFY,
         CreekCapability.REFLECT,
         CreekCapability.WHEEL,
@@ -722,7 +862,12 @@ async def test_advertised_capabilities_are_still_refused(
     capability: CreekCapability,
     http_clients: ClientFactory,
 ) -> None:
-    """Even an advertised capability is refused, since its payload shape is unratified."""
+    """Journal is the one ratified capability; every other one is refused even when advertised.
+
+    Their ``/v1`` payload shapes have not shipped, so an advertised
+    classify/reflect/wheel still degrades the caller onto its local pipeline
+    rather than guessing a wire format.
+    """
     advertised = [
         CreekCapability.JOURNAL.value,
         CreekCapability.CLASSIFY.value,
@@ -743,15 +888,19 @@ async def test_advertised_capabilities_are_still_refused(
 async def test_write_path_degrades_instead_of_losing_an_entry(
     http_clients: ClientFactory,
 ) -> None:
-    """A refused ingest degrades the write path rather than raising or dropping the entry."""
-    client = HttpCreekVaultClient(
-        _VAULT_URL,
-        _API_KEY,
-        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+    """A vault that answers the PUT with a fault degrades the write instead of dropping it.
+
+    The vault handshakes healthily and then rejects the ingest itself, so the
+    degrade comes from a real failed write rather than from an unwired
+    capability.
+    """
+    handler = _VaultRouteHandler(
+        [_IngestReply(status=HTTPStatus.INTERNAL_SERVER_ERROR, payload={"detail": "boom"})]
     )
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
     outcome = await store_and_classify(
         client,
-        entry_id=7,
+        entry_id=_ENTRY_ID,
         body=_ENTRY_BODY,
         classification="public",
         created_at=_CREATED_AT,
@@ -759,6 +908,7 @@ async def test_write_path_degrades_instead_of_losing_an_entry(
     assert outcome.status is VaultWriteStatus.DEGRADED
     assert outcome.vault_ref is None
     assert outcome.tags == ()
+    assert len(handler.ingest_requests) == 1
 
 
 @pytest.mark.asyncio
@@ -771,7 +921,16 @@ async def test_api_key_never_leaks_into_logs_repr_or_errors(
     healthy = HttpCreekVaultClient(
         _VAULT_URL,
         _SENTINEL_KEY,
-        http_client=http_clients(_healthy_handler([CreekCapability.JOURNAL.value])),
+        http_client=http_clients(
+            _VaultRouteHandler(
+                [
+                    _IngestReply(
+                        status=HTTPStatus.BAD_REQUEST,
+                        payload=_error_payload(VaultErrorCode.INVALID_REQUEST.value),
+                    )
+                ]
+            )
+        ),
     )
     hung = HttpCreekVaultClient(
         _VAULT_URL,
@@ -785,7 +944,7 @@ async def test_api_key_never_leaks_into_logs_repr_or_errors(
     )
     for client in (healthy, hung, failing):
         await client.handshake()
-    with pytest.raises(CreekCapabilityUnsupportedError) as exc_info:
+    with pytest.raises(CreekVaultContractError) as exc_info:
         await healthy.ingest(_ingest_request())
 
     assert _SENTINEL_KEY not in caplog.text
@@ -798,3 +957,394 @@ async def test_api_key_never_leaks_into_logs_repr_or_errors(
     assert _SENTINEL_KEY not in str(exc_info.value)
     assert exc_info.value.__cause__ is None
     assert exc_info.value.__suppress_context__ is True
+
+
+@pytest.mark.asyncio
+async def test_ingest_puts_v1_journal_entries_with_bearer_and_exact_body(
+    http_clients: ClientFactory,
+) -> None:
+    """One ingest is one PUT of the entry's own URL, carrying exactly three body fields."""
+    handler = _VaultRouteHandler()
+    client = await _handshaken_client(handler, http_clients)
+    await client.ingest(_ingest_request())
+
+    put = handler.ingest_requests[0]
+    assert put.method == "PUT"
+    assert str(put.url) == _JOURNAL_ENTRY_URL
+    assert put.headers["Authorization"] == f"Bearer {_API_KEY}"
+    body = _sent_ingest_body(handler)
+    assert set(body) == {"content", "timestamp", "tier"}
+    assert body["content"] == _ENTRY_BODY
+    assert body["timestamp"] == _CREATED_AT.isoformat()
+    assert body["tier"] == VaultTierCeiling.OPEN.value
+
+
+@pytest.mark.parametrize(
+    "tier",
+    [VaultTierCeiling.OPEN, VaultTierCeiling.PERSONAL],
+    ids=["open", "personal"],
+)
+@pytest.mark.asyncio
+async def test_ingest_sends_the_entrys_own_tier_never_a_lower_ceiling(
+    tier: VaultTierCeiling,
+    http_clients: ClientFactory,
+) -> None:
+    """The stored tier is the writer's own, so the vault never files an entry too widely."""
+    handler = _VaultRouteHandler()
+    client = await _handshaken_client(handler, http_clients)
+    await client.ingest(_ingest_request(tier))
+    assert _sent_ingest_body(handler)["tier"] == tier.value
+
+
+@pytest.mark.parametrize(
+    "action",
+    list(VaultIngestAction),
+    ids=[action.value for action in VaultIngestAction],
+)
+@pytest.mark.asyncio
+async def test_ingest_success_projects_action_and_fragment_id(
+    action: VaultIngestAction,
+    http_clients: ClientFactory,
+) -> None:
+    """Every known action is a durable write whose ref is the vault's own fragment id."""
+    handler = _VaultRouteHandler([_IngestReply(payload=_ingest_payload(action=action.value))])
+    client = await _handshaken_client(handler, http_clients)
+    result = await client.ingest(_ingest_request())
+    assert result.stored is True
+    assert result.vault_ref == _FRAGMENT_ID
+    assert result.action is action
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        pytest.param(_IngestReply(payload=_ingest_payload("")), id="blank_fragment_id"),
+        pytest.param(
+            _IngestReply(payload={"action": VaultIngestAction.CREATED.value}),
+            id="missing_fragment_id",
+        ),
+        pytest.param(_IngestReply(payload=_ingest_payload(_ENTRY_ID)), id="non_string_fragment_id"),
+        pytest.param(
+            _IngestReply(payload=_ingest_payload(action="teleported")), id="unknown_action"
+        ),
+        pytest.param(_IngestReply(payload=[_FRAGMENT_ID]), id="json_is_not_an_object"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ingest_without_a_usable_fragment_id_parses_to_not_stored(
+    reply: _IngestReply,
+    http_clients: ClientFactory,
+) -> None:
+    """A 2xx adepthood cannot read is not-stored: a ref is never fabricated."""
+    client = await _handshaken_client(_VaultRouteHandler([reply]), http_clients)
+    result = await client.ingest(_ingest_request())
+    assert result.stored is False
+    assert result.vault_ref is None
+    assert result.action is None
+
+
+@pytest.mark.asyncio
+async def test_resending_the_same_entry_id_reports_unchanged_with_the_same_fragment(
+    http_clients: ClientFactory,
+) -> None:
+    """Re-sending an entry edits its one fragment in place rather than creating a second."""
+    handler = _VaultRouteHandler(
+        [
+            _CREATED_REPLY,
+            _IngestReply(payload=_ingest_payload(action=VaultIngestAction.UNCHANGED.value)),
+        ]
+    )
+    client = await _handshaken_client(handler, http_clients)
+    first = await client.ingest(_ingest_request())
+    second = await client.ingest(_ingest_request())
+
+    assert [str(request.url) for request in handler.ingest_requests] == [
+        _JOURNAL_ENTRY_URL,
+        _JOURNAL_ENTRY_URL,
+    ]
+    assert first.action is VaultIngestAction.CREATED
+    assert second.action is VaultIngestAction.UNCHANGED
+    assert second.vault_ref == first.vault_ref == _FRAGMENT_ID
+
+
+@pytest.mark.asyncio
+async def test_ingest_400_invalid_request_raises_a_contract_error(
+    http_clients: ClientFactory,
+) -> None:
+    """A rejected payload is our bug, not the vault's absence, and carries its own code."""
+    handler = _VaultRouteHandler(
+        [
+            _IngestReply(
+                status=HTTPStatus.BAD_REQUEST,
+                payload=_error_payload(VaultErrorCode.INVALID_REQUEST.value),
+            )
+        ]
+    )
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekVaultContractError) as exc_info:
+        await client.ingest(_ingest_request())
+    assert exc_info.value.code is VaultErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.parametrize(
+    "status",
+    [HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN],
+    ids=["unauthorized", "forbidden"],
+)
+@pytest.mark.asyncio
+async def test_ingest_401_raises_an_auth_error(
+    status: HTTPStatus,
+    http_clients: ClientFactory,
+) -> None:
+    """A rejected credential is a configuration fault, never reported as a missing vault."""
+    handler = _VaultRouteHandler([_IngestReply(status=status, payload={"detail": "denied"})])
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekVaultAuthError) as exc_info:
+        await client.ingest(_ingest_request())
+    assert not isinstance(exc_info.value, CreekVaultUnavailableError)
+    assert isinstance(exc_info.value, CreekVaultError)
+
+
+@pytest.mark.asyncio
+async def test_ingest_temporarily_unavailable_code_raises_unavailable(
+    http_clients: ClientFactory,
+) -> None:
+    """A vault naming itself temporarily unavailable is an availability fault, not a contract."""
+    handler = _VaultRouteHandler(
+        [
+            _IngestReply(
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                payload=_error_payload(VaultErrorCode.TEMPORARILY_UNAVAILABLE.value),
+            )
+        ]
+    )
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+async def test_ingest_connect_failure_raises_unavailable(
+    http_clients: ClientFactory,
+) -> None:
+    """A vault that handshook and then went unreachable degrades rather than crashing."""
+    handler = _VaultRouteHandler(ingest_error=httpx.ConnectError("refused"))
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [
+        pytest.param(
+            _IngestReply(status=HTTPStatus.BAD_REQUEST, payload={"detail": "nope"}),
+            CreekVaultContractError,
+            id="uncoded_400",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.NOT_FOUND, payload={"detail": "nope"}),
+            CreekVaultContractError,
+            id="uncoded_404",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.CONFLICT, payload={"detail": "nope"}),
+            CreekVaultContractError,
+            id="uncoded_409",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.BAD_REQUEST, text="<html>Bad Request</html>"),
+            CreekVaultContractError,
+            id="non_json_4xx",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.INTERNAL_SERVER_ERROR, payload={"detail": "boom"}),
+            CreekVaultUnavailableError,
+            id="uncoded_500",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.BAD_GATEWAY, payload={"detail": "boom"}),
+            CreekVaultUnavailableError,
+            id="uncoded_502",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_ingest_classifies_an_uncoded_status_by_class(
+    reply: _IngestReply,
+    expected: type[CreekVaultError],
+    http_clients: ClientFactory,
+) -> None:
+    """Without a recognized code, 4xx is our contract fault and 5xx is the vault's."""
+    client = await _handshaken_client(_VaultRouteHandler([reply]), http_clients)
+    with pytest.raises(expected) as exc_info:
+        await client.ingest(_ingest_request())
+    assert type(exc_info.value) is expected
+    assert getattr(exc_info.value, "code", None) is None
+
+
+@pytest.mark.asyncio
+async def test_contract_and_unavailable_ingest_failures_are_distinguishable(
+    http_clients: ClientFactory,
+) -> None:
+    """A bad payload and an unreachable vault raise two types, neither a subclass of the other."""
+    contract_client = await _handshaken_client(
+        _VaultRouteHandler(
+            [
+                _IngestReply(
+                    status=HTTPStatus.BAD_REQUEST,
+                    payload=_error_payload(VaultErrorCode.INVALID_REQUEST.value),
+                )
+            ]
+        ),
+        http_clients,
+    )
+    offline_client = await _handshaken_client(
+        _VaultRouteHandler(ingest_error=httpx.ConnectError("refused")), http_clients
+    )
+    with pytest.raises(CreekVaultError) as contract_info:
+        await contract_client.ingest(_ingest_request())
+    with pytest.raises(CreekVaultError) as offline_info:
+        await offline_client.ingest(_ingest_request())
+
+    contract_error = contract_info.value
+    offline_error = offline_info.value
+    assert type(contract_error) is not type(offline_error)
+    assert not isinstance(contract_error, type(offline_error))
+    assert not isinstance(offline_error, type(contract_error))
+
+
+@pytest.mark.asyncio
+async def test_an_unrecognized_error_code_never_reaches_a_message_or_a_log(
+    caplog: pytest.LogCaptureFixture,
+    http_clients: ClientFactory,
+) -> None:
+    """A vault-supplied code is never parsed, stored, or echoed -- CRLF and all."""
+    caplog.set_level(logging.DEBUG)
+    handler = _VaultRouteHandler(
+        [_IngestReply(status=HTTPStatus.BAD_REQUEST, payload=_error_payload(_HOSTILE_VAULT_CODE))]
+    )
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekVaultContractError) as exc_info:
+        await client.ingest(_ingest_request())
+
+    assert exc_info.value.code is None
+    for rendered in (str(exc_info.value), repr(exc_info.value), caplog.text):
+        assert _HOSTILE_CODE_SENTINEL not in rendered
+        assert "\r\n" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_ingest_is_bounded_by_the_whole_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    http_clients: ClientFactory,
+) -> None:
+    """An ingest that outlives the deadline degrades to unavailable rather than hanging."""
+    monkeypatch.setattr(_DEADLINE_ATTR, _TINY_DEADLINE_SECONDS)
+    client = await _handshaken_client(_SlowIngestHandler(), http_clients)
+    with pytest.raises(CreekVaultUnavailableError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+async def test_ingest_refuses_when_journal_was_not_advertised(
+    http_clients: ClientFactory,
+) -> None:
+    """An unadvertised journal capability refuses locally: no entry body ever leaves."""
+    handler = _VaultRouteHandler(capabilities=[CreekCapability.REFLECT.value])
+    client = await _handshaken_client(handler, http_clients)
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await client.ingest(_ingest_request())
+    assert handler.ingest_requests == []
+
+
+@pytest.mark.asyncio
+async def test_entry_body_and_api_key_never_leak_from_any_ingest_failure(
+    caplog: pytest.LogCaptureFixture,
+    http_clients: ClientFactory,
+) -> None:
+    """No ingest path -- contract, auth, unavailable, or success -- echoes the body or the key."""
+    caplog.set_level(logging.DEBUG)
+    replies = {
+        "contract": _IngestReply(
+            status=HTTPStatus.BAD_REQUEST,
+            payload=_error_payload(VaultErrorCode.INVALID_REQUEST.value),
+        ),
+        "auth": _IngestReply(status=HTTPStatus.UNAUTHORIZED, payload={"detail": "denied"}),
+        "unavailable": _IngestReply(
+            status=HTTPStatus.INTERNAL_SERVER_ERROR, payload={"detail": "boom"}
+        ),
+    }
+    raised: list[CreekVaultError] = []
+    for reply in replies.values():
+        client = await _handshaken_client(_VaultRouteHandler([reply]), http_clients, _SENTINEL_KEY)
+        with pytest.raises(CreekVaultError) as exc_info:
+            await client.ingest(_ingest_request(body=_SENTINEL_BODY))
+        raised.append(exc_info.value)
+    stored = await _handshaken_client(_VaultRouteHandler(), http_clients, _SENTINEL_KEY)
+    assert (await stored.ingest(_ingest_request(body=_SENTINEL_BODY))).stored is True
+
+    assert len(raised) == len(replies)
+    for error in raised:
+        for rendered in (str(error), repr(error)):
+            assert _SENTINEL_BODY not in rendered
+            assert _SENTINEL_KEY not in rendered
+        assert error.__cause__ is None
+        assert error.__suppress_context__ is True
+    assert _SENTINEL_BODY not in caplog.text
+    assert _SENTINEL_KEY not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_intimate_entry_issues_zero_http_requests(
+    http_clients: ClientFactory,
+) -> None:
+    """An intimate entry never reaches the wire -- the transport spy sees nothing at all."""
+    handler = _VaultRouteHandler()
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    outcome = await store_and_classify(
+        client,
+        entry_id=_ENTRY_ID,
+        body=_SENTINEL_BODY,
+        classification="intimate",
+        created_at=_CREATED_AT,
+    )
+    assert outcome.status is VaultWriteStatus.SKIPPED_INTIMATE
+    assert handler.requests == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_classification_sends_nothing_over_http(
+    http_clients: ClientFactory,
+) -> None:
+    """An unrecognized classification fails closed before a single byte is sent."""
+    handler = _VaultRouteHandler()
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    with pytest.raises(ValueError, match="bogus"):
+        await store_and_classify(
+            client,
+            entry_id=_ENTRY_ID,
+            body=_SENTINEL_BODY,
+            classification="bogus",
+            created_at=_CREATED_AT,
+        )
+    assert handler.requests == []
+
+
+@pytest.mark.asyncio
+async def test_write_path_ingests_over_http_end_to_end(
+    http_clients: ClientFactory,
+) -> None:
+    """A healthy vault plus a successful PUT carries the write all the way to INGESTED."""
+    handler = _VaultRouteHandler()
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    outcome = await store_and_classify(
+        client,
+        entry_id=_ENTRY_ID,
+        body=_ENTRY_BODY,
+        classification="public",
+        created_at=_CREATED_AT,
+    )
+    assert outcome.status is VaultWriteStatus.INGESTED
+    assert outcome.vault_ref == _FRAGMENT_ID
+    assert _sent_ingest_body(handler)["tier"] == VaultTierCeiling.OPEN.value

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -17,6 +17,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from http import HTTPStatus
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -42,6 +43,7 @@ from domain.creek_vault import (
 )
 from main import app, lifespan
 from services.creek_vault_client import (
+    _MAX_FRAGMENT_ID_LENGTH,
     _VAULT_HTTP_TIMEOUT,
     _VAULT_TIMEOUT_SECONDS,
     _VAULT_TOTAL_DEADLINE_SECONDS,
@@ -51,6 +53,7 @@ from services.creek_vault_client import (
     McpCreekVaultClient,
     _build_pooled_vault_client,
     _contract_version_compatible,
+    _entry_path_segment,
     _VaultHttpPool,
     build_creek_vault_client,
     close_creek_vault_http_pool,
@@ -99,6 +102,26 @@ _FRAGMENT_ID = "frag-7"
 # string has to be dropped rather than stored, formatted, or logged.
 _HOSTILE_CODE_SENTINEL = "HOSTILE_VAULT_CODE_SENTINEL"
 _HOSTILE_VAULT_CODE = f"not_a_real_code\r\n{_HOSTILE_CODE_SENTINEL}"
+
+# Two fragment ids a compromised vault could answer a healthy 2xx with. The
+# oversized one is storage amplification -- ``vault_ref`` is an unbounded text
+# column written on every journal save -- and the hostile one carries the bytes
+# (NUL, CRLF) that a text column rejects outright and a log line must never
+# receive. Neither may become an entry's durable vault reference.
+_OVERSIZED_FRAGMENT_ID = "f" * (_MAX_FRAGMENT_ID_LENGTH + 1)
+_HOSTILE_FRAGMENT_ID = "frag\r\n\x00-7"
+
+# The longest fragment id that is still storable, so the bound is asserted at
+# its edge rather than merely somewhere beyond it.
+_LONGEST_USABLE_FRAGMENT_ID = "f" * _MAX_FRAGMENT_ID_LENGTH
+
+# A vault URL whose port is not a number. ``urlsplit`` accepts it -- so the
+# construction-time security validator does too, since it never reads the port
+# -- while httpx refuses to build a request for it, raising ``InvalidURL`` from
+# outside its own ``HTTPError`` hierarchy. It stands in for an operator typo (a
+# shell-interpolated port that came out non-numeric), which must degrade like
+# any other unreachable vault rather than raise into the caller's request path.
+_UNPARSEABLE_VAULT_URL = "https://vault.example.test:not-a-port"
 
 _POOL_ATTR = "services.creek_vault_client._VAULT_HTTP_POOL"
 
@@ -454,6 +477,12 @@ async def test_handshake_gets_v1_capabilities_with_bearer_auth(
     assert request.method == "GET"
     assert str(request.url) == _CAPABILITIES_URL
     assert request.headers["Authorization"] == f"Bearer {_API_KEY}"
+    # The shared request helper passes ``json=None`` here so one code path can
+    # serve both the GET and the journal PUT; httpx encodes that as no body at
+    # all, and this pins it -- a GET carrying a body is ambiguous to every proxy
+    # between here and the vault.
+    assert request.content == b""
+    assert "content-type" not in request.headers
 
 
 @pytest.mark.asyncio
@@ -980,6 +1009,29 @@ async def test_ingest_puts_v1_journal_entries_with_bearer_and_exact_body(
 
 
 @pytest.mark.parametrize(
+    "entry_id",
+    [
+        pytest.param("..", id="parent_directory"),
+        pytest.param("../../v1", id="two_levels_up"),
+        pytest.param(".", id="current_directory"),
+        pytest.param("7/../../admin", id="embedded_traversal"),
+    ],
+)
+def test_entry_path_segment_cannot_climb_out_of_the_journal_collection(entry_id: str) -> None:
+    """A dot-segment id stays inside the collection instead of redirecting the body.
+
+    ``entry_id`` is typed ``int``, so this is a guard on the *shape* of the URL
+    builder rather than a reachable input today -- but the entry body rides on
+    this request, so the segment must be inert whatever the identifier type
+    becomes. The cast is the point of the test: it is the future change,
+    written down.
+    """
+    segment = _entry_path_segment(cast("int", entry_id))
+    url = httpx.URL(f"{_VAULT_URL}/v1/journal-entries/{segment}")
+    assert str(url).startswith(f"{_VAULT_URL}/v1/journal-entries/")
+
+
+@pytest.mark.parametrize(
     "tier",
     [VaultTierCeiling.OPEN, VaultTierCeiling.PERSONAL],
     ids=["open", "personal"],
@@ -1028,6 +1080,14 @@ async def test_ingest_success_projects_action_and_fragment_id(
             _IngestReply(payload=_ingest_payload(action="teleported")), id="unknown_action"
         ),
         pytest.param(_IngestReply(payload=[_FRAGMENT_ID]), id="json_is_not_an_object"),
+        pytest.param(
+            _IngestReply(payload=_ingest_payload(_OVERSIZED_FRAGMENT_ID)),
+            id="oversized_fragment_id",
+        ),
+        pytest.param(
+            _IngestReply(payload=_ingest_payload(_HOSTILE_FRAGMENT_ID)),
+            id="unprintable_fragment_id",
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1041,6 +1101,38 @@ async def test_ingest_without_a_usable_fragment_id_parses_to_not_stored(
     assert result.stored is False
     assert result.vault_ref is None
     assert result.action is None
+
+
+@pytest.mark.asyncio
+async def test_ingest_accepts_a_fragment_id_at_the_length_bound(
+    http_clients: ClientFactory,
+) -> None:
+    """The bound refuses only what exceeds it, so a legitimate long handle still stores."""
+    handler = _VaultRouteHandler(
+        [_IngestReply(payload=_ingest_payload(_LONGEST_USABLE_FRAGMENT_ID))]
+    )
+    client = await _handshaken_client(handler, http_clients)
+    result = await client.ingest(_ingest_request())
+    assert result.stored is True
+    assert result.vault_ref == _LONGEST_USABLE_FRAGMENT_ID
+
+
+@pytest.mark.asyncio
+async def test_write_path_degrades_on_an_unstorable_fragment_id(
+    http_clients: ClientFactory,
+) -> None:
+    """A hostile ref never becomes an entry's vault_ref -- the write degrades instead."""
+    handler = _VaultRouteHandler([_IngestReply(payload=_ingest_payload(_HOSTILE_FRAGMENT_ID))])
+    client = HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http_clients(handler))
+    outcome = await store_and_classify(
+        client,
+        entry_id=_ENTRY_ID,
+        body=_ENTRY_BODY,
+        classification="public",
+        created_at=_CREATED_AT,
+    )
+    assert outcome.status is VaultWriteStatus.DEGRADED
+    assert outcome.vault_ref is None
 
 
 @pytest.mark.asyncio
@@ -1328,6 +1420,46 @@ async def test_unknown_classification_sends_nothing_over_http(
             classification="bogus",
             created_at=_CREATED_AT,
         )
+    assert handler.requests == []
+
+
+@pytest.mark.asyncio
+async def test_handshake_degrades_when_httpx_cannot_parse_the_vault_url(
+    http_clients: ClientFactory,
+) -> None:
+    """A vault URL httpx refuses to build a request for is unreachable, not a crash."""
+    handler = _VaultRouteHandler()
+    client = HttpCreekVaultClient(
+        _UNPARSEABLE_VAULT_URL, _API_KEY, http_client=http_clients(handler)
+    )
+    result = await client.handshake()
+    assert result.available is False
+    assert client.last_degrade_reason is HandshakeDegradeReason.UNREACHABLE
+    assert handler.requests == []
+
+
+@pytest.mark.asyncio
+async def test_write_path_degrades_when_httpx_cannot_parse_the_vault_url(
+    http_clients: ClientFactory,
+) -> None:
+    """A misconfigured vault URL degrades the write instead of raising into the caller.
+
+    ``httpx.InvalidURL`` sits outside the ``HTTPError`` hierarchy, so it is the
+    one transport-layer failure that could escape the seam and turn a saved
+    entry into a 500 for the user who saved it.
+    """
+    handler = _VaultRouteHandler()
+    client = HttpCreekVaultClient(
+        _UNPARSEABLE_VAULT_URL, _API_KEY, http_client=http_clients(handler)
+    )
+    outcome = await store_and_classify(
+        client,
+        entry_id=_ENTRY_ID,
+        body=_SENTINEL_BODY,
+        classification="public",
+        created_at=_CREATED_AT,
+    )
+    assert outcome.status is VaultWriteStatus.UNAVAILABLE
     assert handler.requests == []
 
 

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -1250,6 +1250,16 @@ async def test_ingest_connect_failure_raises_unavailable(
             id="non_json_4xx",
         ),
         pytest.param(
+            _IngestReply(status=HTTPStatus.REQUEST_TIMEOUT, payload={"detail": "too slow"}),
+            CreekVaultUnavailableError,
+            id="uncoded_408_is_the_vaults_clock",
+        ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.TOO_MANY_REQUESTS, payload={"detail": "slow down"}),
+            CreekVaultUnavailableError,
+            id="uncoded_429_is_throttling",
+        ),
+        pytest.param(
             _IngestReply(status=HTTPStatus.INTERNAL_SERVER_ERROR, payload={"detail": "boom"}),
             CreekVaultUnavailableError,
             id="uncoded_500",
@@ -1259,6 +1269,11 @@ async def test_ingest_connect_failure_raises_unavailable(
             CreekVaultUnavailableError,
             id="uncoded_502",
         ),
+        pytest.param(
+            _IngestReply(status=HTTPStatus.FOUND, payload={"detail": "elsewhere"}),
+            CreekVaultUnavailableError,
+            id="redirect_we_refuse_to_follow",
+        ),
     ],
 )
 @pytest.mark.asyncio
@@ -1267,7 +1282,7 @@ async def test_ingest_classifies_an_uncoded_status_by_class(
     expected: type[CreekVaultError],
     http_clients: ClientFactory,
 ) -> None:
-    """Without a recognized code, 4xx is our contract fault and 5xx is the vault's."""
+    """Uncoded, a 4xx is our contract fault -- except the two that describe the vault."""
     client = await _handshaken_client(_VaultRouteHandler([reply]), http_clients)
     with pytest.raises(expected) as exc_info:
         await client.ingest(_ingest_request())

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -8,6 +8,7 @@ tests assume.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 
 import pytest
@@ -15,9 +16,14 @@ import pytest
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
+    CreekVaultContractError,
     CreekVaultUnavailableError,
     HandshakeResult,
     VaultClassification,
+    VaultErrorCode,
+    VaultIngestAction,
     VaultIngestRequest,
     VaultIngestResult,
     VaultTierCeiling,
@@ -25,6 +31,7 @@ from domain.creek_vault import (
 )
 from services.creek_vault_client import LocalFallbackCreekVaultClient
 from services.creek_vault_write import (
+    VaultDegradeReason,
     VaultWriteOutcome,
     VaultWriteStatus,
     get_creek_vault_client,
@@ -33,6 +40,16 @@ from services.creek_vault_write import (
 
 _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
 _BODY = "A quiet entry about the week's practice."
+
+_ENTRY_ID = 101
+
+# A body and an error text distinctive enough to spot in any log record. The
+# degrade log must be a static message with content-free structured fields, so
+# neither the writer's words nor a vault's own error prose may appear.
+_SENTINEL_BODY = "SENTINEL_JOURNAL_BODY_DO_NOT_LOG"
+_SENTINEL_ERROR_TEXT = "SENTINEL_VAULT_ERROR_TEXT_DO_NOT_LOG"
+
+_DEGRADED_OUTCOME = VaultWriteOutcome(status=VaultWriteStatus.DEGRADED, vault_ref=None, tags=())
 
 
 class RecordingVaultClient:
@@ -298,3 +315,147 @@ def test_get_creek_vault_client_returns_local_fallback_by_default(
     monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
     client = get_creek_vault_client()
     assert isinstance(client, LocalFallbackCreekVaultClient)
+
+
+def _logged_fields(caplog: pytest.LogCaptureFixture, field: str) -> list[object]:
+    """Return every value of the structured ``field`` across the captured records."""
+    return [
+        value for record in caplog.records if (value := getattr(record, field, None)) is not None
+    ]
+
+
+async def _write_with(
+    caplog: pytest.LogCaptureFixture,
+    ingest: VaultIngestResult | Exception,
+    body: str = _BODY,
+) -> VaultWriteOutcome:
+    """Run one write against a fake scripted with ``ingest``, capturing its logs afresh."""
+    caplog.clear()
+    client = RecordingVaultClient(ingest=ingest)
+    return await store_and_classify(
+        client, body=body, classification="personal", created_at=_CREATED_AT, entry_id=_ENTRY_ID
+    )
+
+
+@pytest.mark.asyncio
+async def test_contract_failure_and_unavailability_log_distinct_reasons(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One degraded outcome, two operator stories: a rejected payload is not a missing vault.
+
+    Both failures must stay invisible to the caller (the entry is saved either
+    way) and yet be countable apart, since a contract fault is fixed by changing
+    adepthood and an availability fault is not.
+    """
+    caplog.set_level(logging.DEBUG)
+    contract_outcome = await _write_with(
+        caplog,
+        CreekVaultContractError(
+            "creek vault rejected the request", code=VaultErrorCode.INVALID_REQUEST
+        ),
+    )
+    contract_reasons = _logged_fields(caplog, "reason")
+    unavailable_outcome = await _write_with(
+        caplog, CreekVaultUnavailableError("creek vault call failed: creek.journal")
+    )
+    unavailable_reasons = _logged_fields(caplog, "reason")
+
+    assert contract_outcome == unavailable_outcome == _DEGRADED_OUTCOME
+    assert contract_reasons == [VaultDegradeReason.CONTRACT.value]
+    assert unavailable_reasons == [VaultDegradeReason.UNAVAILABLE.value]
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_is_logged_as_auth_not_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rejected credential is its own reason: rotating a key is not restarting a vault."""
+    caplog.set_level(logging.DEBUG)
+    outcome = await _write_with(caplog, CreekVaultAuthError("creek vault rejected the credential"))
+    assert outcome == _DEGRADED_OUTCOME
+    assert _logged_fields(caplog, "reason") == [VaultDegradeReason.AUTH.value]
+
+
+@pytest.mark.parametrize(
+    ("ingest", "expected"),
+    [
+        pytest.param(
+            CreekCapabilityUnsupportedError("creek vault capability unsupported: creek.journal"),
+            VaultDegradeReason.UNSUPPORTED_CAPABILITY,
+            id="unsupported_capability",
+        ),
+        pytest.param(
+            VaultIngestResult(stored=False, vault_ref=None),
+            VaultDegradeReason.NOT_STORED,
+            id="not_stored",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_unsupported_capability_and_not_stored_log_their_own_reasons(
+    ingest: VaultIngestResult | Exception,
+    expected: VaultDegradeReason,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refused capability and a vault that simply did not store are separately countable."""
+    caplog.set_level(logging.DEBUG)
+    outcome = await _write_with(caplog, ingest)
+    assert outcome == _DEGRADED_OUTCOME
+    assert _logged_fields(caplog, "reason") == [expected.value]
+
+
+@pytest.mark.asyncio
+async def test_successful_ingest_logs_the_action(caplog: pytest.LogCaptureFixture) -> None:
+    """A durable write records which action the vault took, so edits stay visible."""
+    caplog.set_level(logging.DEBUG)
+    outcome = await _write_with(
+        caplog,
+        VaultIngestResult(stored=True, vault_ref="ref-a", action=VaultIngestAction.UPDATED),
+    )
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.INGESTED, vault_ref="ref-a", tags=()
+    )
+    assert _logged_fields(caplog, "action") == [VaultIngestAction.UPDATED.value]
+
+
+@pytest.mark.parametrize(
+    "ingest",
+    [
+        pytest.param(
+            CreekVaultContractError(_SENTINEL_ERROR_TEXT, code=VaultErrorCode.INVALID_REQUEST),
+            id="contract",
+        ),
+        pytest.param(CreekVaultAuthError(_SENTINEL_ERROR_TEXT), id="auth"),
+        pytest.param(CreekVaultUnavailableError(_SENTINEL_ERROR_TEXT), id="unavailable"),
+        pytest.param(CreekCapabilityUnsupportedError(_SENTINEL_ERROR_TEXT), id="unsupported"),
+        pytest.param(VaultIngestResult(stored=False, vault_ref=None), id="not_stored"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_degrade_logs_never_carry_the_entry_body_or_a_raw_vault_code(
+    ingest: VaultIngestResult | Exception,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every degrade log is a static message plus content-free fields -- no body, no vault prose."""
+    caplog.set_level(logging.DEBUG)
+    await _write_with(caplog, ingest, body=_SENTINEL_BODY)
+
+    assert caplog.records
+    for sentinel in (_SENTINEL_BODY, _SENTINEL_ERROR_TEXT):
+        assert sentinel not in caplog.text
+        for record in caplog.records:
+            assert sentinel not in record.getMessage()
+            assert sentinel not in str(record.__dict__)
+    for code in _logged_fields(caplog, "code"):
+        assert code in {member.value for member in VaultErrorCode}
+
+
+def test_vault_degrade_reason_wire_values_are_stable() -> None:
+    """The degrade reasons carry the exact strings telemetry will count."""
+    assert [reason.value for reason in VaultDegradeReason] == [
+        "contract",
+        "auth",
+        "unavailable",
+        "unsupported_capability",
+        "not_stored",
+    ]

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -1,9 +1,11 @@
 """Integration tests wiring the journal router to the Creek Vault write path.
 
-RED: the create/update journal endpoints do not yet call
-``services.creek_vault_write.store_and_classify`` and ``JournalEntry`` does not
-yet carry ``vault_ref`` / ``vault_tags`` columns, so every test here fails
-until both are implemented.
+These drive the real create/update endpoints against a scripted vault client to
+pin the guarantee the router owes the writer: the entry lands in Postgres and
+comes back to the user whatever the vault does, and the ``vault_ref`` /
+``vault_tags`` columns are reconciled to the write outcome -- written on a
+durable ingest, cleared when an entry turns intimate, and left alone on a
+transient failure so a passing blip never drops a good reference.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -8,6 +8,7 @@ until both are implemented.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from http import HTTPStatus
 
 import pytest
@@ -18,9 +19,12 @@ from sqlmodel import col, select
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
+    CreekVaultContractError,
     CreekVaultUnavailableError,
     HandshakeResult,
     VaultClassification,
+    VaultErrorCode,
+    VaultIngestAction,
     VaultIngestRequest,
     VaultIngestResult,
     VaultTierCeiling,
@@ -102,6 +106,43 @@ class SequencedVaultClient:
     async def wheel(self) -> VaultWheelBalance:
         """Return an empty wheel balance (unused by the write path)."""
         return VaultWheelBalance(aspects=())
+
+
+# The one fragment a vault keyed off a stable entry id keeps handing back, no
+# matter how often the entry is re-sent.
+_STABLE_FRAGMENT_ID = "vault-fragment-stable"
+
+
+def _stable_action(seen: Sequence[str], body: str) -> VaultIngestAction:
+    """Return created on first sight, unchanged for an identical re-send, updated otherwise."""
+    if not seen:
+        return VaultIngestAction.CREATED
+    if seen[-1] == body:
+        return VaultIngestAction.UNCHANGED
+    return VaultIngestAction.UPDATED
+
+
+class StableFragmentVaultClient(SequencedVaultClient):
+    """Fake vault that edits one fragment in place: the ref never changes across re-sends.
+
+    The realistic counterpart to :class:`SequencedVaultClient`'s incrementing
+    refs -- a vault keying its fragment off the entry id answers the same
+    ``fragment_id`` every time and reports what it did in ``action``.
+    """
+
+    def __init__(self) -> None:
+        """Start with no ingested bodies and no recorded actions."""
+        super().__init__()
+        self.actions: list[VaultIngestAction] = []
+        self._bodies: list[str] = []
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Record the request and answer with this entry's one stable fragment id."""
+        self.ingest_calls.append(request)
+        action = _stable_action(self._bodies, request.body)
+        self.actions.append(action)
+        self._bodies.append(request.body)
+        return VaultIngestResult(stored=True, vault_ref=_STABLE_FRAGMENT_ID, action=action)
 
 
 @pytest.mark.asyncio
@@ -309,3 +350,83 @@ async def test_patch_from_intimate_to_personal_ingests(
     row = await _entry_row(db_session, entry_id)
     assert len(fake.ingest_calls) == 1
     assert row.vault_ref == "vault-ref-1"
+
+
+@pytest.mark.asyncio
+async def test_patch_message_edit_with_a_stable_fragment_id_keeps_the_vault_ref(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A vault that edits its fragment in place leaves the persisted ref exactly where it was."""
+    fake = StableFragmentVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_stable_ref")
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": "Original body.", "classification": "public"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+    first_row = await _entry_row(db_session, entry_id)
+    assert first_row.vault_ref == _STABLE_FRAGMENT_ID
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": "Revised body."}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    second_row = await _entry_row(db_session, entry_id)
+    assert fake.actions == [VaultIngestAction.CREATED, VaultIngestAction.UPDATED]
+    assert second_row.vault_ref == _STABLE_FRAGMENT_ID
+
+
+@pytest.mark.asyncio
+async def test_resending_unchanged_content_leaves_one_vault_ref(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-sending identical content reports unchanged and never earns the row a second ref."""
+    fake = StableFragmentVaultClient()
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_unchanged")
+    message = "A body saved twice, word for word."
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": message, "classification": "public"},
+        headers=headers,
+    )
+    entry_id = int(created.json()["id"])
+
+    patched = await async_client.patch(
+        f"/journal/{entry_id}", json={"message": message}, headers=headers
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    row = await _entry_row(db_session, entry_id)
+    assert fake.actions == [VaultIngestAction.CREATED, VaultIngestAction.UNCHANGED]
+    assert row.vault_ref == _STABLE_FRAGMENT_ID
+
+
+@pytest.mark.asyncio
+async def test_entry_saves_locally_when_ingest_raises_a_contract_error(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A contract fault is ours to fix, never the writer's to lose: the entry still saves."""
+    fake = SequencedVaultClient(
+        ingest_error=CreekVaultContractError(
+            "creek vault rejected the request", code=VaultErrorCode.INVALID_REQUEST
+        )
+    )
+    app.dependency_overrides[get_creek_vault_client] = lambda: fake
+    headers = await _signup(async_client, "vault_contract_error")
+
+    resp = await async_client.post(
+        "/journal/",
+        json={"message": "Written against a rejected contract.", "classification": "personal"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    row = await _entry_row(db_session, int(resp.json()["id"]))
+    assert row.vault_ref is None
+    assert len(fake.ingest_calls) == 1

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -96,13 +96,31 @@ deliberately **not** invented in this document.
 Every capability degrades independently; a vault missing one
 capability is still used for the others it supports:
 
-- **JOURNAL** — if absent from the handshake, or the vault is
-  otherwise unavailable, the write path reports `UNAVAILABLE`
-  (`backend/src/services/creek_vault_write.py:83-90`); if the
-  handshake succeeds but the ingest call itself fails, it reports
-  `DEGRADED` (`creek_vault_write.py:153`). The operator's own
-  Postgres remains the sole system of record for that content
-  either way.
+- **JOURNAL** — the one capability with a ratified `/v1` shape, so it
+  is wired up on both transports adepthood can select via
+  `CREEK_VAULT_PROTOCOL` (default `mcp`, unchanged): the MCP client
+  calls the vault's ingest tool directly, and the HTTP client
+  (`CREEK_VAULT_PROTOCOL=http`) gates on the handshake having
+  advertised `creek.journal` — an unadvertised capability is refused
+  locally, with no request sent — before issuing a `PUT` to the
+  entry's own `/v1/journal-entries/{entry_id}` URL
+  (`backend/src/services/creek_vault_client.py:1095-1121`). Either
+  way, if the vault is absent or otherwise unavailable at handshake
+  time, the write path reports `UNAVAILABLE`
+  (`backend/src/services/creek_vault_write.py:266-267`); if the
+  handshake succeeds but the ingest call itself fails — or answers
+  with a payload the client cannot verify as a durably stored write —
+  it reports `DEGRADED` (`creek_vault_write.py:276-277`). Under HTTP,
+  a failed ingest is further classified into one of three kinds an
+  operator can act on differently — a contract violation (bad
+  payload, an unclaimed capability, or a version mismatch), a
+  rejected credential (401/403), or a plain unavailable vault
+  (timeout, 5xx, an unreadable success body) — each logged with its
+  own `VaultDegradeReason` in content-free structured fields
+  (`creek_vault_write.py:77-95`). **A failed replication is dropped,
+  not queued: there is no retry and no backlog.** The write is logged
+  once and forgotten, and the operator's own Postgres remains the
+  sole system of record for that content either way.
 - **REFLECT** — if absent, adepthood falls back to its existing cloud
   LLM reflection path (`backend/src/services/creek_vault_reflect.py:105-120`).
   Content already flagged by the care gate never calls the vault for a


### PR DESCRIPTION
## Summary

Journal saves now replicate to Creek over `PUT /v1/journal-entries/{external_id}` through
`HttpCreekVaultClient`, and — the heart of this issue — **a contract failure is recorded
distinctly from an unavailability failure** instead of both being laundered into one silent
degraded path. A vault that is down and a vault that answered with something we cannot honour
call for opposite operator responses, and until now they were indistinguishable from each
other and from the ordinary no-vault case. That is precisely how the reflect and wheel
mismatches survived shipping undetected.

Postgres remains the system of record throughout: the user's entry is committed before any
vault contact, and no vault outcome can block, fail, or alter the save.

**Domain (`domain/creek_vault.py`)** — extensions only, no existing field or signature changed:
`VaultIngestAction` (`created` / `updated` / `unchanged`), `VaultErrorCode` (the four ratified
codes), a defaulted `VaultIngestResult.action`, and two new errors under the existing
`CreekVaultError`: `CreekVaultContractError` (carrying `.code`) and `CreekVaultAuthError`.
Both are direct children of `CreekVaultError`, so every existing `except CreekVaultError`
degrade path is untouched.

**HTTP adapter** — `ingest()` gates on the handshake exactly as the MCP client does (an
unadvertised capability is refused locally, with no entry body on the wire), then `PUT`s the
entry's own URL with a body of exactly `{content, timestamp, tier}` under the existing
whole-request deadline, pooled connection, and per-call bearer header. A durable write
requires *both* a known `action` and a usable `fragment_id`; anything less parses to
not-stored rather than fabricating a ref. Failures split three ways: contract (`invalid_request`,
`unsupported_capability`, `incompatible_version`, or an uncoded 4xx), auth (401/403), and
unavailable (connect failure, timeout, deadline, 5xx, refused redirect, `temporarily_unavailable`,
or an undecodable 2xx). `classify` / `reflect` / `wheel` still refuse — their `/v1` shapes remain
unratified upstream.

**Write path** — `VaultWriteStatus` and `VaultWriteOutcome` are byte-identical, so every
pre-existing write-path test passes verbatim. The distinction is made observable through a
module logger: a stable `VaultDegradeReason` (`contract` / `auth` / `unavailable` /
`unsupported_capability` / `not_stored`) in content-free structured fields, plus the upsert
`action` on success. Counters are #2049's job; this is the issue's documented escape hatch,
and the reason strings are pinned as wire values so those counters can key off them directly.
The module docstring now states plainly that **a failed replication is dropped, not queued** —
no retry, no backlog.

`CREEK_VAULT_PROTOCOL` still defaults to `mcp`; MCP behavior is unchanged apart from one
deliberate security narrowing noted below.

### Security findings fixed along the way

A security pass over the new network path found three holes, all fixed with tests:

- **`httpx.InvalidURL` escaped every degrade set.** It is not an `httpx.HTTPError` and is
  raised while *building* the request, so a malformed `CREEK_VAULT_URL` (e.g. a bad port)
  raised straight into the request path — 500-ing a journal entry that had already been
  committed, so the user would retry and duplicate it. Now degraded on both transports.
- **A vault-issued `fragment_id` was persisted verbatim** into the unbounded `vault_ref`
  column, letting a compromised vault grow the operator's database at will or smuggle
  NUL/CRLF into it. Now length-bounded and required to be printable. This narrowing is
  shared with the MCP parser, which had the identical hole and is the default protocol —
  the one intentional MCP behavior change in this PR.
- **`quote(id, safe="")` leaves a dot segment intact**, which httpx then normalizes away.
  Not reachable with today's integer ids, but the docstring claimed a defense that was not
  there and the entry body is what rides on that PUT. The path segment is now inert by
  construction.

### Known gap

Creek's ratified `/v1` document (creek-vault#1072) has still shipped nothing. This PR
implements exactly the shapes this issue ratifies — the PUT path and body, the three-valued
`action` with `fragment_id`, and the four-code error vocabulary — and invents nothing beyond
them. Unrecognized wire strings are dropped rather than stored or rendered, which is also the
log-injection defense: a compromised vault cannot choose text that appears in an adepthood
exception or log record.

### Follow-ups the security pass surfaced, deliberately not in scope

- `_record_vault_outcome` runs inside an open transaction, so a hung vault pins a Postgres
  connection for up to two whole-request deadlines per in-flight save. Pre-existing shape,
  but this change makes it content-bearing; the fix (replicate off the request path, or
  release the session first) is architectural.
- `Response.json()` buffers an unbounded body. Pre-existing on the capability GET; a real
  bound needs streaming and is a coherent standalone change.
- httpx's own INFO logger renders the vault-controlled `reason_phrase`. Adepthood's records
  stay clean; quieting httpx is app-wide logging policy.
- A 401 at *handshake* still reads as `UNREACHABLE`, so a fully-revoked key looks like an
  outage. Worth a `CREDENTIAL_REJECTED` handshake reason later.

## Test plan

- `./scripts/backend/check-all.sh` — all 7 checks pass; 3572 tests, 97% coverage against the
  90% gate.
- `pre-commit run --all-files` — every backend hook passes. (The four frontend hooks fail only
  for want of `node_modules` in the worktree; they are gated on `files: ^frontend/` and this
  diff is backend-only.)
- `xenon --max-absolute A --max-modules A --max-average A src/` and `radon mi -n B src/` run by
  hand — both clean. `mypy src tests` clean over 394 files. `interrogate` 96.7%.

Behavior pinned by new tests, criterion by criterion:

- The entry saves and returns in every vault outcome — success, 4xx, 5xx, timeout, connect
  failure, unbuildable URL, no vault configured — asserted at the router level, not just the
  service level.
- Same `entry_id` re-sent with identical content reports `unchanged` against the same
  `fragment_id`, and the persisted `vault_ref` does not change; an edit reports `updated`
  against a stable fragment and likewise keeps the ref.
- An `intimate` entry issues **zero** HTTP requests — asserted on a transport spy, not on the
  response. Same for an unknown classification, which fails closed in `tier_ceiling_for`
  before anything reaches the wire.
- A blank, missing, non-string, oversized, or unprintable `fragment_id` yields `stored=False`
  with no ref — never a fabricated one.
- A 400 `invalid_request` and a connect timeout produce **different** observability outcomes
  while both degrading gracefully; a 401 is recorded as auth, not as vault-absent; and
  neither error type is a subclass of the other.
- A hostile error `code` containing CRLF never reaches an exception message or a log record.
- The entry body and the API key are absent from every exception string, repr, and log record
  at DEBUG across every failure path, with `__cause__ is None` and `__suppress_context__` on
  every raise.

Closes #2046
Refs #2043
