### PR TITLE
feat(ci): add an authenticated BOLA/IDOR authorization-matrix DAST check

### DIFF
--- a/.github/workflows/dast-authz.yml
+++ b/.github/workflows/dast-authz.yml
@@ -1,0 +1,124 @@
+name: DAST Authorization Matrix
+
+# Starts an ephemeral instance and asks one question of every route that names
+# an object by id in its path: can identity B reach identity A's object? The
+# in-process suite already asserts specific ownership rules; this job is the one
+# that exercises the whole stack over a real socket, so a middleware or routing
+# change that bypasses those rules surfaces here.
+#
+# ``pull_request`` and never ``pull_request_target``: this job checks out and
+# runs the head of the branch under test, so it must not hold write-scoped
+# credentials.
+
+on:
+  push:
+    paths:
+      - "backend/**"
+      - ".github/workflows/dast-authz.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/dast-authz.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dast-authz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  authz-matrix:
+    runs-on: ubuntu-latest
+    # The two-minute acceptance criterion is enforced inside the harness by
+    # --budget-seconds, which measures the matrix itself; this ceiling only
+    # stops a wedged server or a hung install from running forever.
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aptitude
+          POSTGRES_PASSWORD: aptitude  # pragma: allowlist secret
+          POSTGRES_DB: aptitude
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U aptitude"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://aptitude:aptitude@localhost:5432/aptitude  # pragma: allowlist secret
+      SECRET_KEY: ci-only-secret-do-not-use-in-prod  # pragma: allowlist secret
+      BASE_URL: http://127.0.0.1:8000
+      UVICORN_LOG: /tmp/uvicorn.log
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
+
+      - name: Install backend deps
+        run: |
+          uv pip install --system -r backend/requirements-lock.txt
+          uv pip install --system -r backend/requirements-dev.txt
+
+      - name: Migrate the throwaway database
+        working-directory: backend
+        run: alembic upgrade head
+
+      - name: Start the target instance
+        working-directory: backend
+        env:
+          ENVIRONMENT: development
+          # The matrix sends a distinct forwarded client address per request so
+          # the global per-minute limit cannot turn it into a page of uniform,
+          # meaningless denials. Trusting the loopback proxy is what makes that
+          # header evidence on this instance, which the job started itself; it
+          # changes no code and weakens no production control. Any 429 that
+          # still gets through fails the run rather than passing as a denial.
+          TRUSTED_PROXY_CIDRS: 127.0.0.1/32
+        run: |
+          # Started the way the Dockerfile does -- module ``main`` with
+          # PYTHONPATH=src, not ``src.main`` -- so this job exercises the same
+          # import layout production runs.
+          PYTHONPATH=src python -m uvicorn main:app \
+            --host 127.0.0.1 --port 8000 --log-level warning > "$UVICORN_LOG" 2>&1 &
+
+      - name: Wait for readiness
+        run: |
+          # The startup seeder runs deliberately: the catalog rows it creates are
+          # what several seed strategies resolve against.
+          for _ in $(seq 1 45); do
+            if curl -fsS "$BASE_URL/health/ready" > /dev/null; then
+              echo "instance is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::the instance never became ready"
+          cat "$UVICORN_LOG"
+          exit 1
+
+      - name: Run the authorization matrix
+        working-directory: backend
+        run: |
+          PYTHONPATH=src python -m scripts.dast.authz_matrix \
+            --base-url "$BASE_URL" \
+            --database-url "$DATABASE_URL"
+
+      - name: Server log
+        if: always()
+        run: cat "$UVICORN_LOG" || true

--- a/backend/scripts/dast/README.md
+++ b/backend/scripts/dast/README.md
@@ -48,6 +48,13 @@ Optional flags: `--allowlist PATH`, `--min-routes 20`, `--budget-seconds 120`,
 `3` outranks `1` on purpose. A run that could not prove anything must be louder
 than a run that proved everything was fine.
 
+An instance that cannot be reached, a database that will not take the identity
+rows, an `/openapi.json` that never arrives — all of those are `3` as well, via
+the `require_live_stages_completed` guard, and the report names the stage, the
+target, and the error. That is not a detail: an uncaught exception exits `1`,
+which is bit-for-bit the code for a real finding, so a harness that let one
+escape would report "we found a BOLA" every time the instance was simply down.
+
 ## How one route is probed
 
 A fresh object is seeded **per cell**, as identity A, and then four cells run in

--- a/backend/scripts/dast/README.md
+++ b/backend/scripts/dast/README.md
@@ -1,0 +1,124 @@
+# Authorization-matrix DAST harness
+
+Asks one question of every route that names an object by id in its path: **can
+identity B reach identity A's object?**
+
+The in-process suite (`backend/tests/security/test_idor.py`) already pins the
+specific ownership rules. This harness is the one that exercises the whole stack
+over a real socket, against the application's *own* OpenAPI document, so a route
+that lands without an ownership check is caught the day it ships rather than the
+day somebody remembers to write a test for it.
+
+## Running it locally
+
+```bash
+cd backend
+PYTHONPATH=src python -m scripts.dast.authz_matrix \
+    --base-url http://127.0.0.1:8000 \
+    --database-url "$DATABASE_URL"
+```
+
+`--database-url` is the async URL the instance itself is serving from: the two
+identities are inserted through the application's own ORM, because signup is
+gated on a live license verification that cannot be satisfied across a socket.
+Both tokens are then minted over the real `POST /auth/login`, so every credential
+the matrix sends came out of the genuine auth stack.
+
+Both targets are required and neither has a default: a defaulted base URL is how
+a run silently probes the wrong instance.
+
+The instance must be started with `TRUSTED_PROXY_CIDRS=127.0.0.1/32`. The matrix
+sends a distinct `X-Forwarded-For` per request so the application's global
+per-minute rate limit cannot turn the run into a page of uniform, meaningless
+denials; without that setting the header is ignored (correctly) and the run will
+fail on the throttling guard.
+
+Optional flags: `--allowlist PATH`, `--min-routes 20`, `--budget-seconds 120`,
+`--max-allowlist-fraction 0.5`.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The matrix ran, every cell passed, nothing was left uncovered. |
+| `1` | An authorization finding: a foreign object was reached, or a probe returned a status that is not a denial. |
+| `2` | A route has neither a seed strategy nor an allow-list entry. |
+| `3` | A vacuity guard tripped: the run proved nothing. |
+
+`3` outranks `1` on purpose. A run that could not prove anything must be louder
+than a run that proved everything was fine.
+
+## How one route is probed
+
+A fresh object is seeded **per cell**, as identity A, and then four cells run in
+this order:
+
+1. `CROSS_USER` — B's token against A's object. 403 or 404 passes; a 2xx is the
+   leak, a 401 means B's own credential is broken, a 429 means the limiter
+   answered instead of the application.
+2. `UNAUTH` — no token. Only 401 passes.
+3. `FORGED_JWT` — a well-formed token signed with a key generated on the spot.
+   Only 401 passes.
+4. `POSITIVE_CONTROL` — A against her own object, **last**. Only a 2xx passes.
+
+The last cell is what makes the first one mean anything: a route whose object was
+never really created, or whose replay body was rejected as invalid, denies
+everybody equally, which reads exactly like a correctly guarded route. Running it
+last, on its own fresh object, is what keeps a destructive cross-user leak
+reportable instead of collapsing into a harness error.
+
+## Adding a seed strategy
+
+Add one entry to `SEED_REGISTRY` in `seeds.py`, keyed by the **path-parameter
+name** (`entry_id`, not "journal"). Parameter names are globally consistent in
+this application, which is what lets a two-parameter route be filled by resolving
+each parameter independently.
+
+```python
+"widget_id": SeedSpec(
+    create_method="POST",
+    create_path="/widgets/",
+    payload={"name": "DAST widget {unique}"},
+    id_pointer=("id",),
+),
+```
+
+- `{unique}` in any string is replaced with a fresh random token, which is what
+  keeps a slug or a name from colliding with the object seeded for the previous
+  cell.
+- `{some_id}` is replaced with an object seeded earlier in the same cell. Every
+  parameter a `create_path` interpolates must also appear in `depends_on`.
+- `id_pointer` reads the new id out of the response, traversing lists as well as
+  objects: `("goals", 0, "id")`.
+
+If the operation is a mutating verb that requires fields, add a matching entry to
+`REPLAY_BODIES` too. Without one the replay is answered 422 before the ownership
+check ever runs, and the positive control turns the route inconclusive.
+
+## Adding an allow-list entry
+
+Only when no seed strategy can work. Prefer a seed strategy every time — the
+allow-list may never excuse more than half the routes that carry a path
+parameter, and every entry has to keep matching a live route or the build fails.
+
+```toml
+[[route]]
+method   = "GET"
+path     = "/course/content/{content_id}"
+category = "shared_catalog"
+reason   = "global course catalog; no per-user owner to cross"
+```
+
+Categories: `shared_catalog`, `not_object_scoped`, `admin_only`,
+`capability_token`, `no_seed_strategy`, `known_leak`. Only `known_leak` may carry
+`tracking_issue`, so nothing else can be made to look tracked.
+
+`backend/tests/scripts/dast/test_registry_covers_real_app.py` enforces all of
+this in the fast unit suite with no server: a new router with an id in its path
+fails that test until somebody decides whether it is seedable or excused.
+
+## Scope
+
+Object references in the **path** only. Ids carried in query parameters or
+request bodies are not covered, so a green run must never be read as "no BOLA
+anywhere". The report prints that note on every run for the same reason.

--- a/backend/scripts/dast/allowlist.toml
+++ b/backend/scripts/dast/allowlist.toml
@@ -1,0 +1,162 @@
+# Routes the authorization matrix deliberately does not probe.
+#
+# Every entry needs a method, a path exactly as the OpenAPI document spells it,
+# a category from the closed vocabulary in policy.py, and a reason a reviewer
+# can disagree with. An entry that no longer matches a live route fails the
+# build, so this file cannot become a graveyard, and the allow-list may never
+# excuse more than half the routes that carry a path parameter.
+#
+# Prefer a working seed strategy to an entry here every time.
+
+# --- Templated routes that carry no object reference ------------------------
+# The path parameter names a curriculum position or a public document, not a
+# row somebody owns, so a cross-user probe would be answered 200 by design.
+
+[[route]]
+method   = "GET"
+path     = "/course/site-resources/{slug}/body"
+category = "not_object_scoped"
+reason   = "slug names a published site document, not a per-user row"
+
+[[route]]
+method   = "GET"
+path     = "/course/stages/{stage_number}/content"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; the response is scoped to the caller"
+
+[[route]]
+method   = "GET"
+path     = "/course/stages/{stage_number}/intro"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; the response is scoped to the caller"
+
+[[route]]
+method   = "GET"
+path     = "/course/stages/{stage_number}/intro/body"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; the response is scoped to the caller"
+
+[[route]]
+method   = "GET"
+path     = "/course/stages/{stage_number}/progress"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; progress is read for the caller only"
+
+[[route]]
+method   = "GET"
+path     = "/prompts/{week_number}"
+category = "not_object_scoped"
+reason   = "week_number is a curriculum position; the prompt set is the same for everyone"
+
+[[route]]
+method   = "POST"
+path     = "/prompts/{week_number}/respond"
+category = "not_object_scoped"
+reason   = "week_number is a curriculum position; the response is stored against the caller"
+
+[[route]]
+method   = "GET"
+path     = "/stages/{stage_number}/history"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; history is read for the caller only"
+
+[[route]]
+method   = "GET"
+path     = "/stages/{stage_number}/progress"
+category = "not_object_scoped"
+reason   = "stage_number is a curriculum position; progress is read for the caller only"
+
+# --- Capability tokens ------------------------------------------------------
+# The path carries an unguessable share token rather than a row id: holding the
+# token is the authorization, so reaching the resource with it is the feature.
+
+[[route]]
+method   = "GET"
+path     = "/practices/share/{token}"
+category = "capability_token"
+reason   = "share tokens are bearer capabilities; a second user holding one is the point"
+
+[[route]]
+method   = "POST"
+path     = "/practices/share/{token}/import"
+category = "capability_token"
+reason   = "share tokens are bearer capabilities; a second user holding one is the point"
+
+# --- Shared catalog ---------------------------------------------------------
+
+[[route]]
+method   = "GET"
+path     = "/course/content/{content_id}"
+category = "shared_catalog"
+reason   = "global course catalog; no per-user owner to cross"
+
+[[route]]
+method   = "GET"
+path     = "/course/content/{content_id}/body"
+category = "shared_catalog"
+reason   = "global course catalog; no per-user owner to cross"
+
+[[route]]
+method   = "POST"
+path     = "/course/content/{content_id}/mark-read"
+category = "shared_catalog"
+reason   = "global course catalog; the call mutates only the caller's own read state"
+
+# The seedable practice is a catalog preset, because submitting one is capped at
+# five per minute per user and the matrix needs one per cell. A preset is
+# readable and shareable by every user by design, so a second identity reaching
+# it is the feature rather than a leak. The ownership rule that does exist here
+# -- a draft is visible only to its submitter -- is exercised in-process by
+# tests/security/test_idor.py.
+
+[[route]]
+method   = "GET"
+path     = "/practices/{practice_id}"
+category = "shared_catalog"
+reason   = "approved catalog presets are readable by every authenticated user by design"
+
+[[route]]
+method   = "GET"
+path     = "/practices/{practice_id}/share-links"
+category = "shared_catalog"
+reason   = "the listing is already filtered to the caller's own links, so a preset returns []"
+
+[[route]]
+method   = "POST"
+path     = "/practices/{practice_id}/share-link"
+category = "shared_catalog"
+reason   = "minting a link for a preset is explicitly permitted; presets have no submitter"
+
+# --- Role-gated -------------------------------------------------------------
+
+[[route]]
+method   = "POST"
+path     = "/admin/stage-progress/{user_id}/repair"
+category = "admin_only"
+reason   = "gated on the admin role rather than on ownership; both identities are denied"
+
+# --- No way to create the object from outside the process -------------------
+
+[[route]]
+method   = "POST"
+path     = "/invitations/{invitation_id}/dismiss"
+category = "no_seed_strategy"
+reason   = "invitations are generated server-side; there is no endpoint that creates one"
+
+[[route]]
+method   = "POST"
+path     = "/journal/marginalia/{marginalia_id}/essay"
+category = "no_seed_strategy"
+reason   = "marginalia are model-generated; a fresh entry's marginalia list comes back empty"
+
+[[route]]
+method   = "POST"
+path     = "/journal/suggestions/{suggestion_id}/accept"
+category = "no_seed_strategy"
+reason   = "suggestions are model-generated; a fresh entry's suggestion list comes back empty"
+
+[[route]]
+method   = "POST"
+path     = "/journal/suggestions/{suggestion_id}/dismiss"
+category = "no_seed_strategy"
+reason   = "suggestions are model-generated; a fresh entry's suggestion list comes back empty"

--- a/backend/scripts/dast/allowlist.toml
+++ b/backend/scripts/dast/allowlist.toml
@@ -102,30 +102,34 @@ path     = "/course/content/{content_id}/mark-read"
 category = "shared_catalog"
 reason   = "global course catalog; the call mutates only the caller's own read state"
 
-# The seedable practice is a catalog preset, because submitting one is capped at
-# five per minute per user and the matrix needs one per cell. A preset is
-# readable and shareable by every user by design, so a second identity reaching
-# it is the feature rather than a leak. The ownership rule that does exist here
-# -- a draft is visible only to its submitter -- is exercised in-process by
-# tests/security/test_idor.py.
+# These three are excused because the application deliberately grants every
+# authenticated user access to a preset: ``require_visible_practice`` returns any
+# approved practice to anybody, and the share-link resolver admits a practice
+# whose ``submitted_by_user_id`` is NULL. Probing them cross-user would report a
+# LEAK for behaviour that is the feature, which is how a gate starts crying wolf.
+# The ownership rule that does exist here -- a draft is visible only to its
+# submitter -- is exercised in-process by tests/security/test_idor.py. The seed
+# is a catalog preset for the same reason, plus a mechanical one: submitting is
+# capped at five per minute per user, keyed on the JWT subject, and the matrix
+# needs a practice per cell.
 
 [[route]]
 method   = "GET"
 path     = "/practices/{practice_id}"
 category = "shared_catalog"
-reason   = "approved catalog presets are readable by every authenticated user by design"
+reason   = "any approved preset is readable by every authenticated user by design, so a cross-user read here is the feature and probing it would report a false LEAK"
 
 [[route]]
 method   = "GET"
 path     = "/practices/{practice_id}/share-links"
 category = "shared_catalog"
-reason   = "the listing is already filtered to the caller's own links, so a preset returns []"
+reason   = "reaching a submitter-less preset is permitted by design; the listing is filtered to the caller's own links, so a preset returns []"
 
 [[route]]
 method   = "POST"
 path     = "/practices/{practice_id}/share-link"
 category = "shared_catalog"
-reason   = "minting a link for a preset is explicitly permitted; presets have no submitter"
+reason   = "minting a link for a preset is explicitly permitted (submitted_by_user_id IS NULL passes the resolver), so a denial here is not the expected answer"
 
 # --- Role-gated -------------------------------------------------------------
 

--- a/backend/scripts/dast/authz_matrix.py
+++ b/backend/scripts/dast/authz_matrix.py
@@ -29,7 +29,10 @@ Exit codes:
     2 — at least one route has neither a seed strategy nor an allow-list entry,
         so the matrix does not cover the application it claims to.
     3 — a vacuity guard tripped: the run proved nothing, which outranks both of
-        the above because its "clean" would have been meaningless.
+        the above because its "clean" would have been meaningless. A target that
+        could not be reached at all lands here too, deliberately: an uncaught
+        exception would exit 1, and a consumer keying off the exit code cannot
+        tell that apart from a real finding.
 """
 
 from __future__ import annotations
@@ -44,6 +47,8 @@ from functools import partial
 from pathlib import Path
 
 from httpx import AsyncClient
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from models.user import User
@@ -64,6 +69,7 @@ from scripts.dast.runner import (
     DEFAULT_MIN_ROUTES,
     Bootstrap,
     Identity,
+    LiveTargetError,
     MatrixConfig,
     ReplayBodies,
     forwarded_for,
@@ -93,6 +99,10 @@ _SEED_TIMEZONE = "UTC"
 
 _REQUEST_TIMEOUT_SECONDS = 30.0
 _LOGIN_PATH = "/auth/login"
+
+# What the report says instead of a DSN it could not even parse. Echoing the
+# string back verbatim would put whatever it does contain into the log.
+_UNPARSEABLE_DSN = "<unparseable database URL>"
 
 
 @dataclass(frozen=True)
@@ -133,18 +143,20 @@ def _new_credentials(label: str) -> _Credentials:
     )
 
 
-async def _insert_users(database_url: str, credentials: Sequence[_Credentials]) -> None:
-    """Insert the identities' rows through the application's own ORM.
+def _redacted(database_url: str) -> str:
+    """Render a database URL with its password removed, for a line of output.
 
-    Args:
-        database_url: The async database URL the target instance is using.
-        credentials: The identities to create.
-
-    Signup is gated on a live license verification with no local override, so a
-    row insert is the only way to make an identity from outside the process. The
-    password is hashed with the application's own hasher, which is what lets the
-    real login route accept it a moment later.
+    A report is pasted into issues and CI logs, so the DSN has to be nameable
+    without the credential in it travelling along.
     """
+    try:
+        return make_url(database_url).render_as_string(hide_password=True)
+    except ArgumentError:
+        return _UNPARSEABLE_DSN
+
+
+async def _commit_users(database_url: str, credentials: Sequence[_Credentials]) -> None:
+    """Open an engine of the harness's own, insert every identity's row, dispose of it."""
     engine = create_async_engine(database_url)
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     try:
@@ -160,6 +172,38 @@ async def _insert_users(database_url: str, credentials: Sequence[_Credentials]) 
             await session.commit()
     finally:
         await engine.dispose()
+
+
+async def _insert_users(database_url: str, credentials: Sequence[_Credentials]) -> None:
+    """Insert the identities' rows through the application's own ORM.
+
+    Args:
+        database_url: The async database URL the target instance is using.
+        credentials: The identities to create.
+
+    Raises:
+        LiveTargetError: When the database cannot be reached or will not accept
+            the rows. Left to propagate as-is it would exit the process on 1 --
+            the code that means "a foreign object was reached" -- so it is
+            re-raised as the type the runner reports as a harness error, naming
+            the DSN it could not use. The DSN is scrubbed out of the driver's own
+            message too, because several drivers echo it back.
+
+    Signup is gated on a live license verification with no local override, so a
+    row insert is the only way to make an identity from outside the process. The
+    password is hashed with the application's own hasher, which is what lets the
+    real login route accept it a moment later.
+    """
+    try:
+        await _commit_users(database_url, credentials)
+    except (SQLAlchemyError, OSError) as error:
+        redacted = _redacted(database_url)
+        detail = str(error).replace(database_url, redacted)
+        message = (
+            f"the identity database {redacted} could not be used to insert the identities: "
+            f"{type(error).__name__}: {detail}"
+        )
+        raise LiveTargetError(message) from error
 
 
 async def _login(client: AsyncClient, credentials: _Credentials) -> Identity:

--- a/backend/scripts/dast/authz_matrix.py
+++ b/backend/scripts/dast/authz_matrix.py
@@ -42,7 +42,7 @@ import asyncio
 import secrets
 import sys
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
 
@@ -120,8 +120,10 @@ class HarnessOverrides:
 
     client: AsyncClient | None = None
     bootstrap: Bootstrap | None = None
-    seed_registry: Mapping[str, SeedSpec] = SEED_REGISTRY
-    replay_bodies: ReplayBodies = REPLAY_BODIES
+    # Both constants are ``MappingProxyType``, which Python 3.11 rejects as a
+    # dataclass default; the factories hand back those same shared objects.
+    seed_registry: Mapping[str, SeedSpec] = field(default_factory=lambda: SEED_REGISTRY)
+    replay_bodies: ReplayBodies = field(default_factory=lambda: REPLAY_BODIES)
     auth_probe_path: str = DEFAULT_AUTH_PROBE_PATH
 
 

--- a/backend/scripts/dast/authz_matrix.py
+++ b/backend/scripts/dast/authz_matrix.py
@@ -1,0 +1,296 @@
+"""Run the authenticated BOLA/IDOR authorization matrix against a live instance.
+
+Two identities are created, and the check asks one question of every route that
+addresses an object by id in its path: can identity B reach identity A's object?
+A denial only counts once the same route has answered A herself, which is what
+keeps "everything was refused" from passing as "nothing was wrong".
+
+Signup cannot be used to make those identities -- it is gated on a live license
+verification that cannot be satisfied across a socket -- so the two user rows are
+inserted through the application's own ORM and both tokens are then minted over
+the real login route. The real auth stack still mints and verifies every
+credential the matrix sends; only the row creation is bypassed.
+
+Usage:
+
+    python -m scripts.dast.authz_matrix --base-url URL --database-url URL
+    python -m scripts.dast.authz_matrix --base-url URL --database-url URL \
+        --allowlist path/to/allowlist.toml --min-routes 20 \
+        --budget-seconds 120 --max-allowlist-fraction 0.5
+
+Run it from ``backend/`` with ``PYTHONPATH=src``, the way the other repository
+scripts are invoked, so both the harness package and the application's own
+modules are importable.
+
+Exit codes:
+    0 — the matrix ran, every cell passed, and nothing was left uncovered.
+    1 — an authorization finding: a foreign object was reached, or a probe
+        returned a status that is not a denial.
+    2 — at least one route has neither a seed strategy nor an allow-list entry,
+        so the matrix does not cover the application it claims to.
+    3 — a vacuity guard tripped: the run proved nothing, which outranks both of
+        the above because its "clean" would have been meaningless.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import secrets
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from models.user import User
+from routers.auth import _hash_password
+from scripts.dast.policy import DEFAULT_ALLOWLIST_PATH, load_allowlist
+from scripts.dast.report import (
+    EXIT_AUTHZ_FINDING,
+    EXIT_CLEAN,
+    EXIT_HARNESS_ERROR,
+    EXIT_UNCOVERED,
+    MatrixReport,
+    render_report,
+)
+from scripts.dast.runner import (
+    DEFAULT_AUTH_PROBE_PATH,
+    DEFAULT_BUDGET_SECONDS,
+    DEFAULT_MAX_ALLOWLIST_FRACTION,
+    DEFAULT_MIN_ROUTES,
+    Bootstrap,
+    Identity,
+    MatrixConfig,
+    ReplayBodies,
+    forwarded_for,
+    run_matrix,
+)
+from scripts.dast.seeds import REPLAY_BODIES, SEED_REGISTRY, SeedSpec
+
+# The exit codes are defined once, in the report module, and re-exported here
+# because this script is the only thing CI actually reads them from.
+__all__ = [
+    "EXIT_AUTHZ_FINDING",
+    "EXIT_CLEAN",
+    "EXIT_HARNESS_ERROR",
+    "EXIT_UNCOVERED",
+    "HarnessOverrides",
+    "main",
+]
+
+# Generated per run rather than written down, so there is no credential literal
+# anywhere in the repository and no reusable account left behind.
+_PASSWORD_BYTES = 24
+_EMAIL_TOKEN_BYTES = 4
+# RFC 2606's documentation domain: the email validator rejects reserved TLDs
+# such as ``.invalid`` outright, which would 422 the login before it was tried.
+_EMAIL_DOMAIN = "example.com"
+_SEED_TIMEZONE = "UTC"
+
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_LOGIN_PATH = "/auth/login"
+
+
+@dataclass(frozen=True)
+class HarnessOverrides:
+    """Seams a test may replace, defaulting to the production wiring.
+
+    Attributes:
+        client: An HTTP client to use instead of dialling ``--base-url``.
+        bootstrap: An identity bootstrap to use instead of the ORM insert plus
+            real login.
+        seed_registry: Seed strategies for the target application.
+        replay_bodies: Valid request bodies for the mutating replays.
+        auth_probe_path: The route used to prove authentication works.
+    """
+
+    client: AsyncClient | None = None
+    bootstrap: Bootstrap | None = None
+    seed_registry: Mapping[str, SeedSpec] = SEED_REGISTRY
+    replay_bodies: ReplayBodies = REPLAY_BODIES
+    auth_probe_path: str = DEFAULT_AUTH_PROBE_PATH
+
+
+@dataclass(frozen=True)
+class _Credentials:
+    """One throwaway identity, before it has a token."""
+
+    label: str
+    email: str
+    password: str
+
+
+def _new_credentials(label: str) -> _Credentials:
+    """Mint credentials for one throwaway identity."""
+    return _Credentials(
+        label=label,
+        email=f"dast-{label.lower()}-{secrets.token_hex(_EMAIL_TOKEN_BYTES)}@{_EMAIL_DOMAIN}",
+        password=secrets.token_urlsafe(_PASSWORD_BYTES),
+    )
+
+
+async def _insert_users(database_url: str, credentials: Sequence[_Credentials]) -> None:
+    """Insert the identities' rows through the application's own ORM.
+
+    Args:
+        database_url: The async database URL the target instance is using.
+        credentials: The identities to create.
+
+    Signup is gated on a live license verification with no local override, so a
+    row insert is the only way to make an identity from outside the process. The
+    password is hashed with the application's own hasher, which is what lets the
+    real login route accept it a moment later.
+    """
+    engine = create_async_engine(database_url)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            for item in credentials:
+                session.add(
+                    User(
+                        email=item.email,
+                        password_hash=await _hash_password(item.password),
+                        timezone=_SEED_TIMEZONE,
+                    ),
+                )
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+async def _login(client: AsyncClient, credentials: _Credentials) -> Identity:
+    """Mint one identity's token over the target's real login route."""
+    response = await client.post(
+        _LOGIN_PATH,
+        json={"email": credentials.email, "password": credentials.password},
+        headers={"X-Forwarded-For": forwarded_for()},
+    )
+    response.raise_for_status()
+    return Identity(
+        label=credentials.label,
+        email=credentials.email,
+        token=str(response.json()["token"]),
+    )
+
+
+async def _bootstrap_identities(
+    client: AsyncClient,
+    *,
+    database_url: str,
+) -> tuple[Identity, Identity]:
+    """Create the owner and the intruder, and log them both in.
+
+    Args:
+        client: A client pointed at the target instance.
+        database_url: The database that instance is serving from.
+
+    Returns:
+        The owner first, then the intruder.
+    """
+    owner_credentials = _new_credentials("A")
+    intruder_credentials = _new_credentials("B")
+    await _insert_users(database_url, (owner_credentials, intruder_credentials))
+    return (
+        await _login(client, owner_credentials),
+        await _login(client, intruder_credentials),
+    )
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    """Parse the command line.
+
+    Neither target has a default on purpose: a defaulted base URL is how a run
+    silently probes localhost instead of the ephemeral instance the job started,
+    and a defaulted database URL is how it seeds identities into the wrong place.
+    """
+    parser = argparse.ArgumentParser(
+        prog="authz_matrix",
+        description="Probe every object-scoped route for cross-user access.",
+    )
+    parser.add_argument("--base-url", required=True, help="Base URL of the running instance.")
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="Async database URL that instance is serving from.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=DEFAULT_ALLOWLIST_PATH,
+        help="Opt-out list to load instead of the shipped one.",
+    )
+    parser.add_argument(
+        "--min-routes",
+        type=int,
+        default=DEFAULT_MIN_ROUTES,
+        help="Fail unless at least this many routes were probed.",
+    )
+    parser.add_argument(
+        "--budget-seconds",
+        type=float,
+        default=DEFAULT_BUDGET_SECONDS,
+        help="Fail if the matrix takes longer than this.",
+    )
+    parser.add_argument(
+        "--max-allowlist-fraction",
+        type=float,
+        default=DEFAULT_MAX_ALLOWLIST_FRACTION,
+        help="Fail if the allow-list excuses more than this share of routes.",
+    )
+    return parser.parse_args(argv)
+
+
+def _build_config(args: argparse.Namespace, overrides: HarnessOverrides) -> MatrixConfig:
+    """Fold the command line and the injected seams into one run configuration."""
+    return MatrixConfig(
+        seed_registry=overrides.seed_registry,
+        replay_bodies=overrides.replay_bodies,
+        allowlist=load_allowlist(args.allowlist),
+        auth_probe_path=overrides.auth_probe_path,
+        min_routes=args.min_routes,
+        budget_seconds=args.budget_seconds,
+        max_allowlist_fraction=args.max_allowlist_fraction,
+    )
+
+
+async def _execute(
+    args: argparse.Namespace,
+    config: MatrixConfig,
+    overrides: HarnessOverrides,
+) -> MatrixReport:
+    """Run the matrix, owning the client's lifetime only when it created one."""
+    bootstrap = overrides.bootstrap or partial(
+        _bootstrap_identities,
+        database_url=args.database_url,
+    )
+    if overrides.client is not None:
+        return await run_matrix(overrides.client, bootstrap=bootstrap, config=config)
+    async with AsyncClient(base_url=args.base_url, timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+        return await run_matrix(client, bootstrap=bootstrap, config=config)
+
+
+def main(argv: Sequence[str] | None = None, *, overrides: HarnessOverrides | None = None) -> int:
+    """Run the matrix and report it.
+
+    Args:
+        argv: The command line, without the program name.
+        overrides: Seams a test replaces; production passes nothing.
+
+    Returns:
+        The report's exit code. A clean run reports on stdout and every failure
+        reports on stderr, so a red job's output is unambiguous in the log.
+    """
+    args = _parse_args(argv)
+    settings = overrides if overrides is not None else HarnessOverrides()
+    report = asyncio.run(_execute(args, _build_config(args, settings), settings))
+    stream = sys.stdout if report.exit_code == EXIT_CLEAN else sys.stderr
+    stream.write(render_report(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via tests/CLI
+    sys.exit(main(sys.argv[1:]))

--- a/backend/scripts/dast/discovery.py
+++ b/backend/scripts/dast/discovery.py
@@ -1,0 +1,177 @@
+"""Read the application's own OpenAPI document and decide which routes carry an object id.
+
+A hand-maintained list of endpoints is the quiet way an authorization check
+dies: a router lands, nobody edits the list, and the matrix keeps reporting
+clean over a shrinking share of the application. So the only input here is the
+document the running app serves, and the only judgement is which operations
+address somebody's object by id.
+
+That judgement is deliberately narrow -- a path parameter whose name ends in
+``id`` -- and everything it declines is *kept* rather than dropped.
+``{slug}``, ``{token}``, and ``{stage_number}`` are still discovered, so the
+policy layer can force a written allow-list entry for each instead of letting
+them vanish from the count.
+
+Every function in this module is pure: an OpenAPI mapping in, route specs out.
+Nothing here opens a socket.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+# The verbs an OpenAPI path item may carry; every other key on a path item
+# ("summary", "description", "parameters") is metadata, not an operation.
+_OPERATION_METHODS = frozenset(
+    {"get", "put", "post", "delete", "options", "head", "patch", "trace"},
+)
+
+# ``id``, ``habit_id``, ``user_practice_id`` -- but not ``identity`` or
+# ``idea``, which merely contain the letters.
+_OBJECT_ID_PARAMETER = re.compile(r"(^|_)id$")
+
+_PATH_LOCATION = "path"
+_HEADER_LOCATION = "header"
+_AUTHORIZATION_HEADER = "authorization"
+_PARAMETERS_KEY = "parameters"
+_SECURITY_KEY = "security"
+_PATHS_KEY = "paths"
+_NAME_KEY = "name"
+_LOCATION_KEY = "in"
+
+
+@dataclass(frozen=True)
+class RouteSpec:
+    """One operation of the target application, as the document describes it.
+
+    Attributes:
+        method: The upper-cased HTTP verb.
+        path: The templated path, braces intact, e.g. ``/habits/{habit_id}``.
+        params: The path parameters in declaration order.
+        requires_auth: Whether the operation accepts a credential at all.
+            Login and the health probes do not, which is how the matrix knows
+            not to expect a 401 from them.
+    """
+
+    method: str
+    path: str
+    params: tuple[str, ...]
+    requires_auth: bool
+
+
+def _as_mapping(value: object) -> Mapping[str, object]:
+    """Return ``value`` when it is a mapping, otherwise an empty one.
+
+    A malformed document must produce an empty answer rather than a traceback:
+    the minimum-coverage guard is what turns "nothing was discovered" into a
+    failure, and it can only do that if discovery returns.
+    """
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    """Return ``value`` when it is a non-string sequence, otherwise an empty one."""
+    return value if isinstance(value, Sequence) and not isinstance(value, str) else ()
+
+
+def _merged_parameters(
+    item: Mapping[str, object],
+    operation: Mapping[str, object],
+) -> tuple[Mapping[str, object], ...]:
+    """Return the operation's parameters, including those hoisted to the path item.
+
+    OpenAPI lets a path item declare parameters shared by every operation under
+    it, which FastAPI does not emit but hand-written and generated documents
+    both do. Missing the merge would silently drop the id out of such a route.
+    """
+    merged = (
+        *_as_sequence(item.get(_PARAMETERS_KEY)),
+        *_as_sequence(operation.get(_PARAMETERS_KEY)),
+    )
+    return tuple(_as_mapping(entry) for entry in merged)
+
+
+def _path_parameters(parameters: Sequence[Mapping[str, object]]) -> tuple[str, ...]:
+    """Return the names of the path parameters, in declaration order."""
+    return tuple(
+        str(parameter[_NAME_KEY])
+        for parameter in parameters
+        if parameter.get(_LOCATION_KEY) == _PATH_LOCATION and _NAME_KEY in parameter
+    )
+
+
+def _requires_auth(
+    item: Mapping[str, object],
+    operation: Mapping[str, object],
+    parameters: Sequence[Mapping[str, object]],
+) -> bool:
+    """Report whether the operation takes a credential.
+
+    Two spellings both count: a declared security requirement, and the bare
+    ``authorization`` header parameter FastAPI emits for a header-typed
+    dependency. This application uses the second, but reading only that would
+    make the check brittle the day a router adopts a security scheme.
+    """
+    if _as_sequence(operation.get(_SECURITY_KEY)) or _as_sequence(item.get(_SECURITY_KEY)):
+        return True
+    return any(
+        parameter.get(_LOCATION_KEY) == _HEADER_LOCATION
+        and str(parameter.get(_NAME_KEY, "")).lower() == _AUTHORIZATION_HEADER
+        for parameter in parameters
+    )
+
+
+def _operations(
+    path: str,
+    item: Mapping[str, object],
+) -> list[RouteSpec]:
+    """Return one route spec per operation declared on a single path item."""
+    specs: list[RouteSpec] = []
+    for method, raw_operation in item.items():
+        if method.lower() not in _OPERATION_METHODS:
+            continue
+        operation = _as_mapping(raw_operation)
+        parameters = _merged_parameters(item, operation)
+        specs.append(
+            RouteSpec(
+                method=method.upper(),
+                path=path,
+                params=_path_parameters(parameters),
+                requires_auth=_requires_auth(item, operation, parameters),
+            ),
+        )
+    return specs
+
+
+def discover_routes(openapi: Mapping[str, object]) -> tuple[RouteSpec, ...]:
+    """Return every operation the document declares, ordered by path then method.
+
+    Args:
+        openapi: A parsed OpenAPI document. A document without a usable
+            ``paths`` object yields no routes at all, which the minimum-coverage
+            guard then reports as a harness error rather than a clean run.
+
+    Returns:
+        The operations in a stable ``(path, method)`` order, so the report is
+        diffable and the probe order is reproducible between runs.
+    """
+    specs: list[RouteSpec] = []
+    for path, raw_item in _as_mapping(openapi.get(_PATHS_KEY)).items():
+        specs.extend(_operations(str(path), _as_mapping(raw_item)))
+    return tuple(sorted(specs, key=lambda spec: (spec.path, spec.method)))
+
+
+def is_object_scoped(spec: RouteSpec) -> bool:
+    """Report whether the route addresses somebody's object by id in its path.
+
+    Args:
+        spec: The route to judge.
+
+    Returns:
+        ``True`` when any path parameter is named ``id`` or ends in ``_id``.
+        One such parameter is enough: a route mixing a slug with an entry id
+        still exposes that entry to whoever guesses the number.
+    """
+    return any(_OBJECT_ID_PARAMETER.search(param) for param in spec.params)

--- a/backend/scripts/dast/policy.py
+++ b/backend/scripts/dast/policy.py
@@ -1,0 +1,274 @@
+"""Decide, for each route, whether the matrix probes it, excuses it, or fails on it.
+
+Three outcomes and no fourth. A route is COVERED when the harness can create the
+objects its path names, ALLOWLISTED when somebody wrote down why it cannot be,
+and UNCOVERED otherwise -- which fails the build. There is deliberately no
+implicit skip: an implicit skip is how a shrinking matrix keeps reporting clean.
+
+The allow-list is data, validated on load, and the validation is the point. An
+entry with a blank reason, an invented category, or a typo'd key is how "we'll
+come back to this" becomes permanent, so each of those is a hard error rather
+than a shrug. ``known_leak`` is the single category permitted a
+``tracking_issue``, which is how a deliberately accepted finding stays visible
+instead of being parked under a vaguer heading.
+
+An allow-list entry wins over a working seed strategy. The inverse precedence
+would let a route quietly re-enter the matrix and leave a stale entry behind,
+so opting out stays a deliberate act that has to be deliberately undone.
+
+Everything here is pure: a file path or a route list in, a decision out.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+from scripts.dast.discovery import RouteSpec, is_object_scoped
+from scripts.dast.seeds import SeedSpec
+
+# The shipped opt-out list sits beside the harness so the two are reviewed and
+# moved together.
+DEFAULT_ALLOWLIST_PATH = Path(__file__).resolve().parent / "allowlist.toml"
+
+KNOWN_LEAK_CATEGORY = "known_leak"
+
+# A closed vocabulary: free text would let every awkward route acquire its own
+# bespoke excuse, and the set of excuses is exactly what a reviewer scans.
+ALLOWLIST_CATEGORIES = frozenset(
+    {
+        "shared_catalog",
+        "not_object_scoped",
+        "admin_only",
+        "capability_token",
+        "no_seed_strategy",
+        KNOWN_LEAK_CATEGORY,
+    },
+)
+
+_ROUTE_TABLE = "route"
+_REQUIRED_KEYS = ("method", "path", "category", "reason")
+_TRACKING_ISSUE_KEY = "tracking_issue"
+_PERMITTED_KEYS = frozenset({*_REQUIRED_KEYS, _TRACKING_ISSUE_KEY})
+
+
+class AllowlistError(Exception):
+    """An allow-list file that cannot be trusted to mean what it says."""
+
+
+class Coverage(Enum):
+    """What the matrix will do with one route."""
+
+    COVERED = auto()
+    ALLOWLISTED = auto()
+    UNCOVERED = auto()
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    """One route the matrix deliberately does not probe, and the reason why.
+
+    Attributes:
+        method: The upper-cased HTTP verb.
+        path: The templated path, exactly as the document spells it.
+        category: One of :data:`ALLOWLIST_CATEGORIES`.
+        reason: A sentence a reviewer can disagree with.
+        tracking_issue: Where the remediation is tracked. Permitted only on a
+            ``known_leak`` entry, so nothing else can be made to look tracked.
+    """
+
+    method: str
+    path: str
+    category: str
+    reason: str
+    tracking_issue: int | None = None
+
+
+@dataclass(frozen=True)
+class Classification:
+    """The routes of one document, split into three disjoint buckets.
+
+    Attributes:
+        covered: Routes the matrix will probe for real.
+        allowlisted: Routes with a written opt-out.
+        uncovered: Routes with neither, which fail the build.
+    """
+
+    covered: tuple[RouteSpec, ...]
+    allowlisted: tuple[RouteSpec, ...]
+    uncovered: tuple[RouteSpec, ...]
+
+
+def _reject(index: int, problem: str) -> AllowlistError:
+    """Build the error for one bad entry, citing its position in the file."""
+    return AllowlistError(f"allowlist entry {index}: {problem}")
+
+
+def _require_text(raw: Mapping[str, object], index: int) -> None:
+    """Check that every required key is present and carries real text.
+
+    Args:
+        raw: One ``[[route]]`` table as TOML parsed it.
+        index: The entry's 1-based position, for the error message.
+
+    Raises:
+        AllowlistError: When a key is absent, is not a string, or is blank. A
+            blank justification is worse than none: it looks reviewed and is not.
+    """
+    for key in _REQUIRED_KEYS:
+        if key not in raw:
+            raise _reject(index, f"missing required key '{key}'")
+        value = raw[key]
+        if not isinstance(value, str) or not value.strip():
+            raise _reject(index, f"'{key}' must be a non-empty string")
+
+
+def _require_tracking_issue_is_earned(raw: Mapping[str, object], index: int) -> int | None:
+    """Return the entry's tracking issue, refusing it on any other category.
+
+    Args:
+        raw: One validated ``[[route]]`` table.
+        index: The entry's 1-based position, for the error message.
+
+    Returns:
+        The issue number, or ``None`` when the entry does not cite one.
+
+    Raises:
+        AllowlistError: When a non-leak entry cites tracked work -- nothing may
+            be quietly parked under a softer category -- or when the value is
+            not a number.
+    """
+    tracking = raw.get(_TRACKING_ISSUE_KEY)
+    if tracking is None:
+        return None
+    if raw["category"] != KNOWN_LEAK_CATEGORY:
+        raise _reject(
+            index,
+            f"'{_TRACKING_ISSUE_KEY}' is permitted only on a '{KNOWN_LEAK_CATEGORY}' entry",
+        )
+    if not isinstance(tracking, int):
+        raise _reject(index, f"'{_TRACKING_ISSUE_KEY}' must be an issue number")
+    return tracking
+
+
+def _parse_entry(raw: Mapping[str, object], index: int) -> AllowlistEntry:
+    """Validate one ``[[route]]`` table and build its entry.
+
+    Args:
+        raw: The table as TOML parsed it.
+        index: The entry's 1-based position, for the error message.
+
+    Returns:
+        The validated entry.
+
+    Raises:
+        AllowlistError: On an unknown key (a typo would otherwise be silently
+            ignored and change nothing), a missing or blank required value, or
+            a category outside the closed vocabulary.
+    """
+    unknown = sorted(set(raw) - _PERMITTED_KEYS)
+    if unknown:
+        raise _reject(index, f"unknown key(s): {', '.join(unknown)}")
+    _require_text(raw, index)
+    category = str(raw["category"])
+    if category not in ALLOWLIST_CATEGORIES:
+        known = ", ".join(sorted(ALLOWLIST_CATEGORIES))
+        raise _reject(index, f"'{category}' is not a known category; use one of {known}")
+    return AllowlistEntry(
+        method=str(raw["method"]),
+        path=str(raw["path"]),
+        category=category,
+        reason=str(raw["reason"]),
+        tracking_issue=_require_tracking_issue_is_earned(raw, index),
+    )
+
+
+def load_allowlist(path: Path) -> tuple[AllowlistEntry, ...]:
+    """Read and validate an allow-list file.
+
+    Args:
+        path: The file to read.
+
+    Returns:
+        The entries in file order. A file with no ``[[route]]`` tables loads as
+        empty, because zero opt-outs is the goal state and has to be
+        expressible.
+
+    Raises:
+        AllowlistError: When any entry fails validation.
+    """
+    with path.open("rb") as handle:
+        document = tomllib.load(handle)
+    raw_entries = document.get(_ROUTE_TABLE, [])
+    return tuple(_parse_entry(raw, index) for index, raw in enumerate(raw_entries, start=1))
+
+
+def _is_excused(spec: RouteSpec, allowlist: Sequence[AllowlistEntry]) -> bool:
+    """Report whether an allow-list entry names exactly this operation."""
+    return any(entry.method == spec.method and entry.path == spec.path for entry in allowlist)
+
+
+def _is_probeable(spec: RouteSpec, seed_registry: Mapping[str, SeedSpec]) -> bool:
+    """Report whether the route names an object the harness knows how to create."""
+    return is_object_scoped(spec) and all(param in seed_registry for param in spec.params)
+
+
+def classify_route(
+    spec: RouteSpec,
+    *,
+    seed_registry: Mapping[str, SeedSpec],
+    allowlist: Sequence[AllowlistEntry],
+) -> Coverage:
+    """Decide what the matrix does with one route.
+
+    Args:
+        spec: The route to classify.
+        seed_registry: Seed strategies, keyed by path-parameter name.
+        allowlist: The loaded opt-out entries.
+
+    Returns:
+        ``ALLOWLISTED`` when an entry names this route -- which wins even over a
+        working seed strategy, so removing a route from the allow-list stays a
+        deliberate act. Otherwise ``COVERED`` when the route addresses an object
+        by id and every one of its parameters can be seeded, and ``UNCOVERED``
+        for everything else, including templated routes that carry no id at all.
+    """
+    if _is_excused(spec, allowlist):
+        return Coverage.ALLOWLISTED
+    if _is_probeable(spec, seed_registry):
+        return Coverage.COVERED
+    return Coverage.UNCOVERED
+
+
+def classify_routes(
+    specs: Sequence[RouteSpec],
+    *,
+    seed_registry: Mapping[str, SeedSpec],
+    allowlist: Sequence[AllowlistEntry],
+) -> Classification:
+    """Split a document's routes into the three buckets the report counts.
+
+    Args:
+        specs: Every route the document declares.
+        seed_registry: Seed strategies, keyed by path-parameter name.
+        allowlist: The loaded opt-out entries.
+
+    Returns:
+        The classification. Routes with no path parameters are left out
+        entirely: a collection route carries no object reference, so it is
+        neither probed nor excused, and counting it would inflate the
+        denominator the allow-list bound is measured against.
+    """
+    buckets: dict[Coverage, list[RouteSpec]] = {coverage: [] for coverage in Coverage}
+    for spec in specs:
+        if not spec.params:
+            continue
+        buckets[classify_route(spec, seed_registry=seed_registry, allowlist=allowlist)].append(spec)
+    return Classification(
+        covered=tuple(buckets[Coverage.COVERED]),
+        allowlisted=tuple(buckets[Coverage.ALLOWLISTED]),
+        uncovered=tuple(buckets[Coverage.UNCOVERED]),
+    )

--- a/backend/scripts/dast/report.py
+++ b/backend/scripts/dast/report.py
@@ -1,0 +1,227 @@
+"""Turn a finished run into text an operator can act on, and into an exit code CI reads.
+
+A finding is only useful if the reader can reproduce it without rerunning
+anything, so every failure block names the method, the path template, the exact
+id that was sent, whose object it was, the status the server actually returned,
+and a curl line that reproduces it in one paste. "IDOR on /journal" is a ticket
+nobody can close.
+
+The summary block matters just as much on a green run. It states how many routes
+were discovered, seeded, left uncovered, and excused, so a pass reads as "these
+routes were genuinely probed" rather than as an unqualified thumbs-up. Beside it
+sits the scope note: this check reads object references out of the *path*, so a
+clean result must never be mistaken for "no BOLA anywhere in the app".
+
+The exit-code precedence encodes the same idea. A tripped vacuity guard outranks
+a finding, because a run that proved nothing cannot also be trusted to have
+found everything.
+
+Everything here is pure: a report in, a string or a number out.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from http.client import responses
+
+from scripts.dast.verdict import Cell, CellResult, GuardFailure, Verdict
+
+EXIT_CLEAN = 0
+EXIT_AUTHZ_FINDING = 1
+EXIT_UNCOVERED = 2
+EXIT_HARNESS_ERROR = 3
+
+SCOPE_NOTE = (
+    "scope: object references in the path only; ids carried in query params "
+    "or request bodies are not covered"
+)
+
+# Spelled from the verdict itself rather than repeated inline, so the headline
+# and the grading vocabulary cannot drift apart.
+PASS_HEADLINE = (
+    f"{Verdict.PASS.name}  every probed route denied the intruder and answered its own owner"
+)
+
+# The summary labels are padded to one column so the four counts line up and the
+# block diffs cleanly between runs.
+_SUMMARY_LABEL_WIDTH = 37
+# Wide enough for DELETE, which keeps the path column aligned across verbs.
+_METHOD_WIDTH = 6
+# The curl repro wraps onto a continuation line indented under the command.
+_REPRO_INDENT = " " * 20
+
+_ACTOR_BY_CELL = {
+    Cell.CROSS_USER: "user B token",
+    Cell.UNAUTH: "no token",
+    Cell.FORGED_JWT: "forged token",
+    Cell.POSITIVE_CONTROL: "user A token",
+}
+
+_EXPECTATION_BY_CELL = {
+    Cell.CROSS_USER: "403/404",
+    Cell.UNAUTH: "401",
+    Cell.FORGED_JWT: "401",
+    Cell.POSITIVE_CONTROL: "2xx",
+}
+
+# Shell variables rather than real tokens: a report is pasted into issues.
+_TOKEN_VARIABLE_BY_CELL: dict[Cell, str | None] = {
+    Cell.CROSS_USER: "$B_TOKEN",
+    Cell.UNAUTH: None,
+    Cell.FORGED_JWT: "$FORGED_TOKEN",
+    Cell.POSITIVE_CONTROL: "$A_TOKEN",
+}
+
+
+@dataclass(frozen=True)
+class MatrixReport:
+    """Everything one run produced, and the two things a caller wants from it.
+
+    Attributes:
+        base_url: The instance that was probed, used to build repro commands.
+        discovered: How many object-scoped routes the document declared.
+        seeded: How many routes had their objects created successfully.
+        uncovered: Routes the harness could neither probe nor excuse, rendered
+            as ``"METHOD /path"``.
+        allowlisted: How many routes carry a written opt-out.
+        results: Every graded cell, in the order it ran.
+        guard_failures: Every vacuity guard that tripped.
+        elapsed_seconds: Wall-clock time the matrix took.
+    """
+
+    base_url: str
+    discovered: int
+    seeded: int
+    uncovered: tuple[str, ...]
+    allowlisted: int
+    results: tuple[CellResult, ...]
+    guard_failures: tuple[GuardFailure, ...]
+    elapsed_seconds: float
+
+    @property
+    def findings(self) -> tuple[CellResult, ...]:
+        """Return the cells that did not pass; passing cells are counted, not printed."""
+        return tuple(result for result in self.results if result.verdict is not Verdict.PASS)
+
+    @property
+    def exit_code(self) -> int:
+        """Return the process exit code, most-untrustworthy outcome first.
+
+        A tripped guard outranks a finding because a run that could not prove
+        anything must be louder than a run that proved everything was fine, and
+        a proven leak outranks a coverage gap because it is the more urgent of
+        the two. Both are still printed.
+        """
+        if self.guard_failures:
+            return EXIT_HARNESS_ERROR
+        if self.findings:
+            return EXIT_AUTHZ_FINDING
+        if self.uncovered:
+            return EXIT_UNCOVERED
+        return EXIT_CLEAN
+
+
+def _status_text(status: int) -> str:
+    """Render a status as its number and reason phrase, e.g. ``204 No Content``."""
+    return f"{status} {responses.get(status, '')}".rstrip()
+
+
+def _curl_flags(result: CellResult) -> str:
+    """Render the curl command up to but not including the URL."""
+    parts = ["curl"]
+    if result.route.method != "GET":
+        parts.extend(("-X", result.route.method))
+    token = _TOKEN_VARIABLE_BY_CELL[result.cell]
+    if token is not None:
+        parts.extend(("-H", f'"Authorization: Bearer {token}"'))
+    return " ".join(parts)
+
+
+def render_curl(result: CellResult, *, base_url: str) -> str:
+    """Render a finding as a single pasteable curl command.
+
+    Args:
+        result: The cell to reproduce.
+        base_url: The instance that was probed.
+
+    Returns:
+        One command line. The wrapped form printed in the report is this same
+        command split across two lines, so the two can never disagree.
+    """
+    return f"{_curl_flags(result)} {base_url}{result.resolved_path}"
+
+
+def _summary_line(label: str, value: str) -> str:
+    """Render one aligned ``label : value`` line of the summary block."""
+    return f"  {label:<{_SUMMARY_LABEL_WIDTH}}: {value}\n"
+
+
+def _summary_lines(report: MatrixReport) -> list[str]:
+    """Render the four counts that quantify what the run actually probed."""
+    return [
+        _summary_line("routes discovered from /openapi.json", f"{report.discovered} object-scoped"),
+        _summary_line("seeded as user A", str(report.seeded)),
+        _summary_line("UNCOVERED (no seed strategy)", str(len(report.uncovered))),
+        _summary_line("allow-listed", str(report.allowlisted)),
+    ]
+
+
+def _finding_block(result: CellResult, base_url: str) -> list[str]:
+    """Render one failing cell as its four-line, self-contained block."""
+    ids = ", ".join(f"{name}={value}" for name, value in result.object_ids)
+    return [
+        f"  FAIL  {result.route.method:<{_METHOD_WIDTH}} {result.route.path}\n",
+        (
+            f"        {_ACTOR_BY_CELL[result.cell]} + user A {ids}  ->  "
+            f"{_status_text(result.status)}   (expected {_EXPECTATION_BY_CELL[result.cell]})\n"
+        ),
+        f"        repro: {_curl_flags(result)} \\\n",
+        f"{_REPRO_INDENT}{base_url}{result.resolved_path}\n",
+        "\n",
+    ]
+
+
+def _finding_lines(findings: Sequence[CellResult], base_url: str) -> list[str]:
+    """Render every failing cell."""
+    return [line for result in findings for line in _finding_block(result, base_url)]
+
+
+def _uncovered_lines(uncovered: Sequence[str]) -> list[str]:
+    """Render the routes with neither a seed strategy nor an allow-list entry."""
+    lines = []
+    for item in uncovered:
+        method, _, path = item.partition(" ")
+        lines.append(f"  UNCOVERED  {method:<{_METHOD_WIDTH}} {path}\n")
+    return lines
+
+
+def _guard_lines(guard_failures: Sequence[GuardFailure]) -> list[str]:
+    """Render every tripped vacuity guard, each naming itself."""
+    return [f"  HARNESS ERROR  {failure.guard}: {failure.detail}\n" for failure in guard_failures]
+
+
+def render_report(report: MatrixReport) -> str:
+    """Render a finished run as the text the gate prints.
+
+    Args:
+        report: The run to render.
+
+    Returns:
+        A newline-terminated block: the coverage summary and scope note first,
+        so even a failing run states what it managed to cover, then the tripped
+        guards, the findings, and the uncovered routes. A run with none of those
+        ends on a headline that says what was proven rather than staying silent.
+    """
+    lines = [
+        f"  authorization matrix: {report.base_url} ({report.elapsed_seconds:.1f}s)\n",
+        *_summary_lines(report),
+        f"  {SCOPE_NOTE}\n",
+        "\n",
+        *_guard_lines(report.guard_failures),
+        *_finding_lines(report.findings, report.base_url),
+        *_uncovered_lines(report.uncovered),
+    ]
+    if report.exit_code == EXIT_CLEAN:
+        lines.append(f"  {PASS_HEADLINE}\n")
+    return "".join(lines)

--- a/backend/scripts/dast/runner.py
+++ b/backend/scripts/dast/runner.py
@@ -180,8 +180,10 @@ class MatrixConfig:
         max_allowlist_fraction: The share of routes the allow-list may excuse.
     """
 
-    seed_registry: Mapping[str, SeedSpec] = SEED_REGISTRY
-    replay_bodies: ReplayBodies = REPLAY_BODIES
+    # Both constants are ``MappingProxyType``, which Python 3.11 rejects as a
+    # dataclass default; the factories hand back those same shared objects.
+    seed_registry: Mapping[str, SeedSpec] = field(default_factory=lambda: SEED_REGISTRY)
+    replay_bodies: ReplayBodies = field(default_factory=lambda: REPLAY_BODIES)
     allowlist: tuple[AllowlistEntry, ...] = ()
     auth_probe_path: str = DEFAULT_AUTH_PROBE_PATH
     min_routes: int = DEFAULT_MIN_ROUTES

--- a/backend/scripts/dast/runner.py
+++ b/backend/scripts/dast/runner.py
@@ -1,0 +1,445 @@
+"""Drive the matrix against a running instance: the one module that does any I/O.
+
+Everything the harness knows how to decide lives in the pure modules beside this
+one. What is left here is the part that cannot be pure -- issuing requests -- and
+it is deliberately narrow: an ``httpx.AsyncClient`` and an identity bootstrap are
+handed in, so the whole matrix can be exercised in-process against a throwaway
+application with no socket, no database, and no server to start.
+
+Three decisions in here carry most of the weight.
+
+A fresh object is seeded for every *cell*, not merely for every route. A route
+whose cross-user cell is a ``DELETE`` destroys the very row its positive control
+needs; sharing one object across the four cells would leave that control
+answering 404, which grades as inconclusive and hides a genuine mutating leak
+behind a harness error.
+
+The owner's own call runs last, after the probes that might destroy its object,
+for the same reason.
+
+Every request carries its own forwarded client address. The application applies
+a global per-minute rate limit, and a throttled matrix answers uniformly no to
+everything -- which is indistinguishable from an application that denies
+correctly. Spreading the requests keeps the limiter out of the way, and the
+throttling guard fails the run outright if a single 429 gets through anyway.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from time import perf_counter
+
+import jwt
+from httpx import AsyncClient, Response
+
+from scripts.dast.discovery import RouteSpec, discover_routes, is_object_scoped
+from scripts.dast.policy import AllowlistEntry, Classification, classify_routes
+from scripts.dast.report import MatrixReport
+from scripts.dast.seeds import (
+    REPLAY_BODIES,
+    SEED_REGISTRY,
+    UNIQUE_FIELD,
+    SeedSpec,
+    create_body,
+    render_text,
+    replay_body,
+    resolve_id,
+    seed_order,
+)
+from scripts.dast.verdict import (
+    CELL_ORDER,
+    Cell,
+    CellResult,
+    GuardFailure,
+    judge,
+    require_allowlist_bounded,
+    require_auth_established,
+    require_minimum_coverage,
+    require_no_throttling,
+    require_positive_controls,
+    require_seeded_resources,
+    require_within_budget,
+)
+
+DEFAULT_MIN_ROUTES = 20
+DEFAULT_BUDGET_SECONDS = 120.0
+DEFAULT_MAX_ALLOWLIST_FRACTION = 0.5
+
+# A collection route that needs a credential: probed with and without one, it
+# proves both that the token works and that refusals are possible at all.
+DEFAULT_AUTH_PROBE_PATH = "/habits/"
+
+_OPENAPI_PATH = "/openapi.json"
+_SUCCESS_FLOOR = 200
+_SUCCESS_CEILING = 300
+
+# Enough entropy that two objects seeded a millisecond apart cannot collide on a
+# unique slug or a habit name.
+_UNIQUE_TOKEN_BYTES = 5
+
+# The forged credential is signed with a key generated here and shared with
+# nobody, which is the whole point: a valid-shaped token that no deployment can
+# possibly verify.
+_FORGED_KEY_BYTES = 32
+_FORGED_ALGORITHM = "HS256"
+_FORGED_SUBJECT = "1"
+_FORGED_LIFETIME = timedelta(hours=1)
+
+# Requests are spread across a private /8 so the per-minute limiter, which keys
+# on the forwarded client address, never sees the same caller twice.
+_FORWARDED_PREFIX = "10"
+_FORWARDED_OCTETS = 3
+_OCTET_RANGE = 256
+
+ReplayBodies = Mapping[tuple[str, str], Mapping[str, object]]
+
+
+@dataclass(frozen=True)
+class Identity:
+    """One logged-in actor of the matrix.
+
+    Attributes:
+        label: How the report names this actor, ``"A"`` or ``"B"``.
+        email: The address the identity was created with.
+        token: A bearer token minted by the target's own login route.
+    """
+
+    label: str
+    email: str
+    token: str
+
+
+# Injected so production can insert user rows through the application's own ORM
+# while a stub supplies identities its in-memory store already knows.
+Bootstrap = Callable[[AsyncClient], Awaitable[tuple[Identity, Identity]]]
+
+
+@dataclass(frozen=True)
+class MatrixConfig:
+    """Everything one run needs beyond a client and an identity bootstrap.
+
+    Bundled into one frozen object rather than passed as eight keyword
+    arguments, so adding a knob does not widen every signature between here and
+    the CLI.
+
+    Attributes:
+        seed_registry: Seed strategies, keyed by path-parameter name.
+        replay_bodies: Valid request bodies for the mutating replays.
+        allowlist: The loaded opt-out entries.
+        auth_probe_path: The route used to prove authentication works.
+        min_routes: The floor the coverage guard enforces.
+        budget_seconds: The ceiling the time-box guard enforces.
+        max_allowlist_fraction: The share of routes the allow-list may excuse.
+    """
+
+    seed_registry: Mapping[str, SeedSpec] = SEED_REGISTRY
+    replay_bodies: ReplayBodies = REPLAY_BODIES
+    allowlist: tuple[AllowlistEntry, ...] = ()
+    auth_probe_path: str = DEFAULT_AUTH_PROBE_PATH
+    min_routes: int = DEFAULT_MIN_ROUTES
+    budget_seconds: float = DEFAULT_BUDGET_SECONDS
+    max_allowlist_fraction: float = DEFAULT_MAX_ALLOWLIST_FRACTION
+
+
+@dataclass
+class _Session:
+    """The mutable state of one run: who is logged in, and what has been seen."""
+
+    client: AsyncClient
+    config: MatrixConfig
+    owner: Identity
+    intruder: Identity
+    forged_token: str
+    statuses: list[int] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _AuthProbe:
+    """What the auth probe route answered, with and without a credential."""
+
+    authenticated_status: int
+    unauthenticated_status: int
+
+
+@dataclass(frozen=True)
+class _Outcome:
+    """One finished run, before it is graded into a report."""
+
+    routes: tuple[RouteSpec, ...]
+    classification: Classification
+    probe: _AuthProbe
+    results: tuple[CellResult, ...]
+    seeded: int
+    unseedable: tuple[str, ...]
+    statuses: tuple[int, ...]
+    elapsed_seconds: float
+
+
+def forwarded_for() -> str:
+    """Return a fresh forwarded client address for one request.
+
+    Drawn from a private /8 with a cryptographic source, so ~400 requests share
+    a key with vanishing probability and no request can inherit the previous
+    one's rate-limit budget.
+    """
+    octets = (str(secrets.randbelow(_OCTET_RANGE)) for _ in range(_FORWARDED_OCTETS))
+    return ".".join((_FORWARDED_PREFIX, *octets))
+
+
+def _forged_token() -> str:
+    """Mint a well-formed JWT signed with a key no deployment can verify."""
+    claims = {
+        "sub": _FORGED_SUBJECT,
+        "exp": datetime.now(UTC) + _FORGED_LIFETIME,
+    }
+    return jwt.encode(claims, secrets.token_urlsafe(_FORGED_KEY_BYTES), algorithm=_FORGED_ALGORITHM)
+
+
+def _is_success(status: int) -> bool:
+    """Report whether ``status`` is a 2xx."""
+    return _SUCCESS_FLOOR <= status < _SUCCESS_CEILING
+
+
+async def _send(
+    session: _Session,
+    method: str,
+    path: str,
+    *,
+    token: str | None,
+    body: Mapping[str, object] | None = None,
+) -> Response:
+    """Issue one request, recording its status for the throttling guard."""
+    headers = {"X-Forwarded-For": forwarded_for()}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    response = await session.client.request(method, path, headers=headers, json=body)
+    session.statuses.append(response.status_code)
+    return response
+
+
+async def _seed_one(session: _Session, spec: SeedSpec, values: dict[str, str]) -> str | None:
+    """Create one object as the owner and return its id, or ``None`` on failure."""
+    fields: dict[str, object] = {**values, UNIQUE_FIELD: secrets.token_hex(_UNIQUE_TOKEN_BYTES)}
+    response = await _send(
+        session,
+        spec.create_method,
+        render_text(spec.create_path, fields),
+        token=session.owner.token,
+        body=create_body(spec, fields),
+    )
+    if not _is_success(response.status_code):
+        return None
+    return resolve_id(response.json(), spec.id_pointer)
+
+
+async def _seed_cell(session: _Session, route: RouteSpec) -> dict[str, str] | None:
+    """Create a fresh object for every parameter of one route, dependencies first.
+
+    Args:
+        session: The run's state.
+        route: The route whose parameters need objects.
+
+    Returns:
+        The seeded ids keyed by parameter name, or ``None`` when any create
+        failed -- in which case the route is reported as unseedable rather than
+        probed against ids that do not exist.
+    """
+    values: dict[str, str] = {}
+    for param in seed_order(route.params, session.config.seed_registry):
+        seeded = await _seed_one(session, session.config.seed_registry[param], values)
+        if seeded is None:
+            return None
+        values[param] = seeded
+    return values
+
+
+def _token_for(session: _Session, cell: Cell) -> str | None:
+    """Return the credential one cell sends, or ``None`` for the unauthenticated cell."""
+    if cell is Cell.CROSS_USER:
+        return session.intruder.token
+    if cell is Cell.FORGED_JWT:
+        return session.forged_token
+    if cell is Cell.POSITIVE_CONTROL:
+        return session.owner.token
+    return None
+
+
+async def _run_cell(session: _Session, route: RouteSpec, cell: Cell) -> CellResult | None:
+    """Seed a fresh object, probe one route with one credential, and grade the answer."""
+    values = await _seed_cell(session, route)
+    if values is None:
+        return None
+    resolved = render_text(route.path, values)
+    response = await _send(
+        session,
+        route.method,
+        resolved,
+        token=_token_for(session, cell),
+        body=replay_body(route, session.config.replay_bodies),
+    )
+    return CellResult(
+        route=route,
+        cell=cell,
+        resolved_path=resolved,
+        object_ids=tuple((param, values[param]) for param in route.params),
+        status=response.status_code,
+        verdict=judge(cell, response.status_code),
+    )
+
+
+async def _run_route(session: _Session, route: RouteSpec) -> tuple[CellResult, ...] | None:
+    """Run all four cells of one route in order, or report it unseedable."""
+    results: list[CellResult] = []
+    for cell in CELL_ORDER:
+        result = await _run_cell(session, route, cell)
+        if result is None:
+            return None
+        results.append(result)
+    return tuple(results)
+
+
+async def _probe_auth(session: _Session) -> _AuthProbe:
+    """Ask the probe route the same question twice: with a credential, and without."""
+    path = session.config.auth_probe_path
+    authenticated = await _send(session, "GET", path, token=session.owner.token)
+    unauthenticated = await _send(session, "GET", path, token=None)
+    return _AuthProbe(
+        authenticated_status=authenticated.status_code,
+        unauthenticated_status=unauthenticated.status_code,
+    )
+
+
+async def _probe_routes(
+    session: _Session,
+    covered: Sequence[RouteSpec],
+) -> tuple[tuple[CellResult, ...], tuple[str, ...]]:
+    """Probe every covered route, collecting the cells and the routes that would not seed."""
+    results: list[CellResult] = []
+    unseedable: list[str] = []
+    for route in covered:
+        cells = await _run_route(session, route)
+        if cells is None:
+            unseedable.append(f"{route.method} {route.path}")
+            continue
+        results.extend(cells)
+    return tuple(results), tuple(unseedable)
+
+
+def _collect_guards(outcome: _Outcome, config: MatrixConfig) -> tuple[GuardFailure, ...]:
+    """Run every vacuity guard and keep the ones that tripped.
+
+    Args:
+        outcome: The finished run.
+        config: The thresholds the run was given.
+
+    Returns:
+        Every failure, in guard order. All guards run even once one has failed,
+        because an operator fixing a broken run wants the whole list rather than
+        one symptom at a time.
+
+    ``require_allowlist_is_live`` is deliberately absent: an entry outliving the
+    route it excuses is a property of the shipped allow-list rather than of one
+    run, and it is enforced against the application's own document in the fast
+    unit suite, which is both earlier feedback and independent of which instance
+    this run happens to be pointed at.
+    """
+    classification = outcome.classification
+    considered = (
+        len(classification.covered)
+        + len(classification.allowlisted)
+        + len(classification.uncovered)
+    )
+    probed = len({(result.route.method, result.route.path) for result in outcome.results})
+    candidates = (
+        require_auth_established(
+            authenticated_status=outcome.probe.authenticated_status,
+            unauthenticated_status=outcome.probe.unauthenticated_status,
+        ),
+        require_positive_controls(outcome.results),
+        require_minimum_coverage(probed, minimum=config.min_routes),
+        require_seeded_resources(outcome.seeded),
+        require_no_throttling(outcome.statuses),
+        require_allowlist_bounded(
+            len(classification.allowlisted),
+            considered,
+            max_fraction=config.max_allowlist_fraction,
+        ),
+        require_within_budget(outcome.elapsed_seconds, budget_seconds=config.budget_seconds),
+    )
+    return tuple(failure for failure in candidates if failure is not None)
+
+
+def _build_report(outcome: _Outcome, config: MatrixConfig, base_url: str) -> MatrixReport:
+    """Assemble the report from a finished run."""
+    uncovered = tuple(
+        sorted(
+            [f"{route.method} {route.path}" for route in outcome.classification.uncovered]
+            + list(outcome.unseedable),
+        ),
+    )
+    return MatrixReport(
+        base_url=base_url,
+        discovered=sum(1 for route in outcome.routes if is_object_scoped(route)),
+        seeded=outcome.seeded,
+        uncovered=uncovered,
+        allowlisted=len(outcome.classification.allowlisted),
+        results=outcome.results,
+        guard_failures=_collect_guards(outcome, config),
+        elapsed_seconds=outcome.elapsed_seconds,
+    )
+
+
+async def run_matrix(
+    client: AsyncClient,
+    *,
+    bootstrap: Bootstrap,
+    config: MatrixConfig,
+) -> MatrixReport:
+    """Run the whole authorization matrix against one instance.
+
+    Args:
+        client: An HTTP client already pointed at the target. Its lifetime
+            belongs to the caller.
+        bootstrap: Creates the two identities and logs them both in. Injected
+            because production inserts user rows through the application's own
+            ORM before minting tokens over the real login route, while a stub
+            has no database to insert into.
+        config: The tables and thresholds this run uses.
+
+    Returns:
+        The graded report. Failures inside the matrix -- a route that will not
+        seed, an owner who cannot reach their own object -- are reported rather
+        than raised, so a run always produces a verdict instead of a traceback.
+    """
+    started = perf_counter()
+    owner, intruder = await bootstrap(client)
+    session = _Session(
+        client=client,
+        config=config,
+        owner=owner,
+        intruder=intruder,
+        forged_token=_forged_token(),
+    )
+    probe = await _probe_auth(session)
+    document = await _send(session, "GET", _OPENAPI_PATH, token=None)
+    routes = discover_routes(document.json())
+    classification = classify_routes(
+        routes,
+        seed_registry=config.seed_registry,
+        allowlist=config.allowlist,
+    )
+    results, unseedable = await _probe_routes(session, classification.covered)
+    outcome = _Outcome(
+        routes=routes,
+        classification=classification,
+        probe=probe,
+        results=results,
+        seeded=len(classification.covered) - len(unseedable),
+        unseedable=unseedable,
+        statuses=tuple(session.statuses),
+        elapsed_seconds=perf_counter() - started,
+    )
+    return _build_report(outcome, config, str(client.base_url))

--- a/backend/scripts/dast/runner.py
+++ b/backend/scripts/dast/runner.py
@@ -22,18 +22,29 @@ a global per-minute rate limit, and a throttled matrix answers uniformly no to
 everything -- which is indistinguishable from an application that denies
 correctly. Spreading the requests keeps the limiter out of the way, and the
 throttling guard fails the run outright if a single 429 gets through anyway.
+
+Because this is the module that touches the network, it is also the module that
+must never let the network end the process. An uncaught exception exits 1, and 1
+is the code for a genuine authorization finding -- so an unreachable instance
+would report as a BOLA. Every live stage therefore runs inside :func:`_stage`,
+which turns an operational failure into a named guard failure and lets the run
+finish as an ordinary report with exit code 3.
 """
 
 from __future__ import annotations
 
 import secrets
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from json import JSONDecodeError
+from textwrap import shorten
 from time import perf_counter
 
 import jwt
-from httpx import AsyncClient, Response
+from httpx import AsyncClient, HTTPError, Response
+from sqlalchemy.exc import SQLAlchemyError
 
 from scripts.dast.discovery import RouteSpec, discover_routes, is_object_scoped
 from scripts.dast.policy import AllowlistEntry, Classification, classify_routes
@@ -54,9 +65,11 @@ from scripts.dast.verdict import (
     Cell,
     CellResult,
     GuardFailure,
+    LiveFailure,
     judge,
     require_allowlist_bounded,
     require_auth_established,
+    require_live_stages_completed,
     require_minimum_coverage,
     require_no_throttling,
     require_positive_controls,
@@ -95,6 +108,38 @@ _FORWARDED_OCTETS = 3
 _OCTET_RANGE = 256
 
 ReplayBodies = Mapping[tuple[str, str], Mapping[str, object]]
+
+
+class LiveTargetError(Exception):
+    """A resource the run depends on could not be reached or used.
+
+    Raised where the failing resource is not the HTTP target the runner already
+    names -- the identity bootstrap's database above all -- so the message can
+    carry that resource itself. The runner reports it as a harness error instead
+    of letting it leave the process, because an uncaught exception exits 1, the
+    same code the gate uses for a genuine authorization finding.
+    """
+
+
+# Failures of the target, its database, or the network in between: each leaves
+# the matrix with nothing to say about authorization, so each is reported rather
+# than raised. Deliberately narrow -- a ``TypeError`` in the harness is a bug and
+# must still surface as one -- and deliberately all ``Exception`` subclasses, so
+# ``KeyboardInterrupt`` and ``SystemExit`` are never captured here.
+_OPERATIONAL_ERRORS = (HTTPError, OSError, SQLAlchemyError, JSONDecodeError, LiveTargetError)
+
+# The live stages, phrased the way the report should name them.
+_STAGE_BOOTSTRAP = "the identity bootstrap"
+_STAGE_AUTH_PROBE = "the auth probe"
+_STAGE_DISCOVERY = f"the {_OPENAPI_PATH} fetch"
+_STAGE_PROBES = "the route probes"
+
+# One driver error can run to several paragraphs; a gate's output wants a line.
+_MAX_SUMMARY_CHARS = 240
+
+# The auth probe of a run that never reached it: no status at all, which is not
+# 200 and not 401, so nothing downstream can read it as a healthy answer.
+_NO_STATUS = 0
 
 
 @dataclass(frozen=True)
@@ -166,7 +211,13 @@ class _AuthProbe:
 
 @dataclass(frozen=True)
 class _Outcome:
-    """One finished run, before it is graded into a report."""
+    """One finished run, before it is graded into a report.
+
+    ``live_failure`` is set only when a stage of live I/O failed outright, in
+    which case every other field is empty by construction. That is deliberate:
+    the tallies of a run that broke off partway are not numbers anybody should
+    read as coverage, and reporting zero says plainly that nothing was proven.
+    """
 
     routes: tuple[RouteSpec, ...]
     classification: Classification
@@ -176,6 +227,38 @@ class _Outcome:
     unseedable: tuple[str, ...]
     statuses: tuple[int, ...]
     elapsed_seconds: float
+    live_failure: LiveFailure | None = None
+
+
+class _StageError(Exception):
+    """An operational failure, tagged with the live stage it happened in."""
+
+    def __init__(self, stage: str, cause: Exception) -> None:
+        """Record which stage failed and what it raised."""
+        super().__init__(f"{stage}: {cause}")
+        self.stage = stage
+        self.cause = cause
+
+
+@contextmanager
+def _stage(name: str) -> Iterator[None]:
+    """Tag any operational failure raised inside the block with the stage's name.
+
+    Args:
+        name: How the report should name what was being done.
+
+    Yields:
+        Nothing; the block is the stage.
+
+    Raises:
+        _StageError: When the target, its database, or the network failed. Every
+            other exception passes through untouched, because a bug in the
+            harness must not be laundered into "the instance was unreachable".
+    """
+    try:
+        yield
+    except _OPERATIONAL_ERRORS as error:
+        raise _StageError(name, error) from error
 
 
 def forwarded_for() -> str:
@@ -301,6 +384,29 @@ async def _run_route(session: _Session, route: RouteSpec) -> tuple[CellResult, .
     return tuple(results)
 
 
+async def _fetch_document(session: _Session) -> Mapping[str, object]:
+    """Fetch the target's own OpenAPI document.
+
+    Args:
+        session: The run's state.
+
+    Returns:
+        The parsed document, or an empty one when the body is valid JSON that is
+        not a document at all -- which the coverage guard then reports as a
+        harness error, the same as any other run that probed nothing.
+
+    ``raise_for_status`` is what turns an instance answering 404 or 502 here into
+    a named failure rather than a parse error three lines later.
+    """
+    response = await _send(session, "GET", _OPENAPI_PATH, token=None)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, Mapping):
+        return {}
+    document: Mapping[str, object] = payload
+    return document
+
+
 async def _probe_auth(session: _Session) -> _AuthProbe:
     """Ask the probe route the same question twice: with a credential, and without."""
     path = session.config.auth_probe_path
@@ -346,6 +452,12 @@ def _collect_guards(outcome: _Outcome, config: MatrixConfig) -> tuple[GuardFailu
     unit suite, which is both earlier feedback and independent of which instance
     this run happens to be pointed at.
     """
+    live = require_live_stages_completed(outcome.live_failure)
+    if live is not None:
+        # A run that broke off has nothing trustworthy to say about coverage,
+        # seeding, or throttling, and the other guards would only restate that
+        # one collapse in seven less useful ways.
+        return (live,)
     classification = outcome.classification
     considered = (
         len(classification.covered)
@@ -392,6 +504,82 @@ def _build_report(outcome: _Outcome, config: MatrixConfig, base_url: str) -> Mat
     )
 
 
+async def _collect_outcome(
+    client: AsyncClient,
+    *,
+    bootstrap: Bootstrap,
+    config: MatrixConfig,
+    started: float,
+) -> _Outcome:
+    """Run every live stage in order and gather what they saw.
+
+    Each stage is named as it runs, so a failure can say which one of them the
+    run died in rather than only that something did.
+    """
+    with _stage(_STAGE_BOOTSTRAP):
+        owner, intruder = await bootstrap(client)
+    session = _Session(
+        client=client,
+        config=config,
+        owner=owner,
+        intruder=intruder,
+        forged_token=_forged_token(),
+    )
+    with _stage(_STAGE_AUTH_PROBE):
+        probe = await _probe_auth(session)
+    with _stage(_STAGE_DISCOVERY):
+        routes = discover_routes(await _fetch_document(session))
+    classification = classify_routes(
+        routes,
+        seed_registry=config.seed_registry,
+        allowlist=config.allowlist,
+    )
+    with _stage(_STAGE_PROBES):
+        results, unseedable = await _probe_routes(session, classification.covered)
+    return _Outcome(
+        routes=routes,
+        classification=classification,
+        probe=probe,
+        results=results,
+        seeded=len(classification.covered) - len(unseedable),
+        unseedable=unseedable,
+        statuses=tuple(session.statuses),
+        elapsed_seconds=perf_counter() - started,
+    )
+
+
+def _summarize(cause: Exception) -> str:
+    """Render one operational failure as a single actionable line.
+
+    A :class:`LiveTargetError` already names what failed and which resource was
+    involved, so repeating its class name would be noise. Anything else is named
+    by its type, which for a driver or transport error is the useful half.
+    """
+    described = (
+        str(cause) if isinstance(cause, LiveTargetError) else f"{type(cause).__name__}: {cause}"
+    )
+    return shorten(described, width=_MAX_SUMMARY_CHARS, placeholder=" ...")
+
+
+def _failed_outcome(error: _StageError, *, target: str, elapsed_seconds: float) -> _Outcome:
+    """Describe a run that never reached a verdict, so it still becomes a report."""
+    return _Outcome(
+        routes=(),
+        classification=Classification(covered=(), allowlisted=(), uncovered=()),
+        probe=_AuthProbe(authenticated_status=_NO_STATUS, unauthenticated_status=_NO_STATUS),
+        results=(),
+        seeded=0,
+        unseedable=(),
+        statuses=(),
+        elapsed_seconds=elapsed_seconds,
+        live_failure=LiveFailure(
+            stage=error.stage,
+            target=target,
+            summary=_summarize(error.cause),
+        ),
+    )
+
+
 async def run_matrix(
     client: AsyncClient,
     *,
@@ -410,36 +598,23 @@ async def run_matrix(
         config: The tables and thresholds this run uses.
 
     Returns:
-        The graded report. Failures inside the matrix -- a route that will not
-        seed, an owner who cannot reach their own object -- are reported rather
-        than raised, so a run always produces a verdict instead of a traceback.
+        The graded report -- always a report, never a traceback. Failures inside
+        the matrix (a route that will not seed, an owner who cannot reach their
+        own object) are graded as such, and failures of the live target itself
+        (a refused connection, a database that will not take the identity
+        insert) come back as the live-stage guard. Both are exit code 3, which
+        no consumer can confuse with the 1 an uncaught exception would produce.
     """
     started = perf_counter()
-    owner, intruder = await bootstrap(client)
-    session = _Session(
-        client=client,
-        config=config,
-        owner=owner,
-        intruder=intruder,
-        forged_token=_forged_token(),
-    )
-    probe = await _probe_auth(session)
-    document = await _send(session, "GET", _OPENAPI_PATH, token=None)
-    routes = discover_routes(document.json())
-    classification = classify_routes(
-        routes,
-        seed_registry=config.seed_registry,
-        allowlist=config.allowlist,
-    )
-    results, unseedable = await _probe_routes(session, classification.covered)
-    outcome = _Outcome(
-        routes=routes,
-        classification=classification,
-        probe=probe,
-        results=results,
-        seeded=len(classification.covered) - len(unseedable),
-        unseedable=unseedable,
-        statuses=tuple(session.statuses),
-        elapsed_seconds=perf_counter() - started,
-    )
-    return _build_report(outcome, config, str(client.base_url))
+    target = str(client.base_url)
+    try:
+        outcome = await _collect_outcome(
+            client, bootstrap=bootstrap, config=config, started=started
+        )
+    except _StageError as error:
+        outcome = _failed_outcome(
+            error,
+            target=target,
+            elapsed_seconds=perf_counter() - started,
+        )
+    return _build_report(outcome, config, target)

--- a/backend/scripts/dast/seeds.py
+++ b/backend/scripts/dast/seeds.py
@@ -1,0 +1,361 @@
+"""Create the objects the matrix probes, and carry the bodies its replays need.
+
+Two tables and the small amount of pure logic that reads them.
+
+``SEED_REGISTRY`` is keyed by *path-parameter name* rather than by resource,
+which is what lets a two-parameter route like
+``/practice-recipes/{recipe_id}/apply-to/{user_practice_id}`` be filled without
+a bespoke rule: each parameter is resolved independently, and parameter names
+are globally consistent in this application. Every payload lives in this one
+table so a schema change has exactly one place to land.
+
+``REPLAY_BODIES`` supplies a valid request body for the mutating verbs that
+require one. Without it a replayed ``PUT`` returns 422 before the ownership
+check ever runs -- which is not a denial, merely a probe that proved nothing.
+The positive control catches that automatically, but the point is to exercise
+the real cell, so the bodies are here.
+
+Two substitutions run over both tables, and both are ordinary ``str.format``
+fields so a spec reads as the request it will become. ``{some_id}`` is filled
+from an object seeded earlier in the same cell, which is how a dependent create
+path finds its parent; ``{unique}`` is filled with a fresh random token, which
+is what keeps a slug or a habit name from colliding with the object seeded for
+the previous cell.
+
+The two top-level tables are read-only proxies so they can be bound as
+configuration defaults; everything nested inside them is a plain dict, because
+these payloads are handed straight to a JSON encoder that refuses a proxy.
+
+Everything here is pure. The requests themselves belong to the runner.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from scripts.dast.discovery import RouteSpec
+
+# Only these verbs carry a request body in this application; sending one on a
+# GET or DELETE would be noise the server has to ignore.
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+# The field every payload and create path may interpolate to stay unique across
+# the four cells of a route.
+UNIQUE_FIELD = "unique"
+
+# Stage 1 is the curriculum's entry point, so it is the one stage every fresh
+# identity can select a practice for.
+_SEED_STAGE_NUMBER = 1
+
+# A sense-grounding practice is seeded rather than a meditation timer because
+# the recipe-application route refuses a mode mismatch: recipes are
+# grounding-only, so the practice a recipe is applied to has to match.
+_SENSE_GROUNDING = "sense_grounding"
+_SENSE_PROMPT = "Notice one thing you can see"
+_SIGHT_TAG = "sight"
+
+_RECIPE_STEP: dict[str, object] = {
+    "tag_slug": _SIGHT_TAG,
+    "tag_label": "Sight",
+    "prompt_label": _SENSE_PROMPT,
+    "target_count": 1,
+}
+
+_HABIT_FIELDS: dict[str, object] = {
+    "icon": "star",
+    "start_date": "2024-01-01",
+    "energy_cost": 1,
+    "energy_return": 2,
+}
+
+_SEED_NOTE = "seeded by the authorization matrix"
+_REPLAY_NAME = "dast replay"
+
+
+@dataclass(frozen=True)
+class SeedSpec:
+    """How to create one object of the kind a path parameter names.
+
+    Attributes:
+        create_method: The verb of the create request.
+        create_path: Its path, which may itself interpolate an earlier seed.
+        payload: The request body, whose string values may interpolate an
+            earlier seed or ``{unique}``.
+        id_pointer: How to read the new object's id out of the response, e.g.
+            ``("id",)`` or ``("goals", 0, "id")``.
+        depends_on: Parameters that must be seeded first. Every parameter the
+            create path interpolates has to appear here, or the ordering would
+            be luck.
+    """
+
+    create_method: str
+    create_path: str
+    payload: Mapping[str, object]
+    id_pointer: tuple[str | int, ...]
+    depends_on: tuple[str, ...] = ()
+
+
+SEED_REGISTRY: Mapping[str, SeedSpec] = MappingProxyType(
+    {
+        "habit_id": SeedSpec(
+            create_method="POST",
+            create_path="/habits/",
+            payload={"name": "DAST habit {unique}", **_HABIT_FIELDS},
+            id_pointer=("id",),
+        ),
+        # Creating a habit auto-creates its three goals, so the same call is
+        # also the only way to obtain a goal the caller owns.
+        "goal_id": SeedSpec(
+            create_method="POST",
+            create_path="/habits/",
+            payload={"name": "DAST goal carrier {unique}", **_HABIT_FIELDS},
+            id_pointer=("goals", 0, "id"),
+        ),
+        "entry_id": SeedSpec(
+            create_method="POST",
+            create_path="/journal/",
+            payload={"message": _SEED_NOTE},
+            id_pointer=("id",),
+        ),
+        "group_id": SeedSpec(
+            create_method="POST",
+            create_path="/goal-groups/",
+            payload={"name": "DAST group {unique}"},
+            id_pointer=("id",),
+        ),
+        "tag_id": SeedSpec(
+            create_method="POST",
+            create_path="/practice-tags/",
+            payload={"slug": "dast_tag_{unique}", "label": "DAST tag {unique}"},
+            id_pointer=("id",),
+        ),
+        "recipe_id": SeedSpec(
+            create_method="POST",
+            create_path="/practice-recipes/",
+            payload={
+                "slug": "dast_recipe_{unique}",
+                "name": "DAST recipe {unique}",
+                "mode": _SENSE_GROUNDING,
+                "steps": [_RECIPE_STEP],
+            },
+            id_pointer=("id",),
+        ),
+        # Read from the catalog rather than submitted, because submitting is
+        # capped at five practices per minute per user and the matrix needs one
+        # for every cell of every route that names a practice. The three routes
+        # that address this id directly are allow-listed for the same reason a
+        # preset is safe to reuse here: nothing can destroy it and everyone may
+        # read it. It is a prerequisite for the objects that *are* probed --
+        # share links and user-practices, both of which stay fresh per cell.
+        # Stage 1's canonical preset is a sense-grounding practice, and it is
+        # the first practice row the seeder inserts, so an unordered listing
+        # returns it first. That is what lets a recipe be applied to it without
+        # a mode mismatch. Should the seeder ever put a non-grounding practice
+        # first, the recipe-application route's positive control returns 400 and
+        # the run fails naming that route -- loudly, not silently.
+        "practice_id": SeedSpec(
+            create_method="GET",
+            create_path=f"/practices/?stage_number={_SEED_STAGE_NUMBER}",
+            payload={},
+            id_pointer=(0, "id"),
+        ),
+        "user_practice_id": SeedSpec(
+            create_method="POST",
+            create_path="/user-practices/",
+            payload={"practice_id": "{practice_id}", "stage_number": _SEED_STAGE_NUMBER},
+            id_pointer=("id",),
+            depends_on=("practice_id",),
+        ),
+        "share_link_id": SeedSpec(
+            create_method="POST",
+            create_path="/practices/{practice_id}/share-link",
+            payload={},
+            id_pointer=("id",),
+            depends_on=("practice_id",),
+        ),
+        "promotion_id": SeedSpec(
+            create_method="POST",
+            create_path="/journal/{entry_id}/promote",
+            payload={"anchor_start": 0, "anchor_end": 4},
+            id_pointer=("id",),
+            depends_on=("entry_id",),
+        ),
+    },
+)
+
+
+REPLAY_BODIES: Mapping[tuple[str, str], Mapping[str, object]] = MappingProxyType(
+    {
+        ("PUT", "/goal-groups/{group_id}"): {"name": _REPLAY_NAME},
+        ("PUT", "/goals/{goal_id}"): {
+            "title": _REPLAY_NAME,
+            "tier": "low",
+            "target": 1,
+            "target_unit": "reps",
+            "frequency": 1,
+            "frequency_unit": "day",
+        },
+        ("PUT", "/habits/{habit_id}"): {"name": "DAST replayed habit", **_HABIT_FIELDS},
+        ("PUT", "/habits/{habit_id}/goals/units"): {
+            "target_unit": "reps",
+            "frequency": 1,
+            "frequency_unit": "day",
+        },
+        ("PATCH", "/journal/{entry_id}"): {"title": _REPLAY_NAME},
+        ("POST", "/journal/{entry_id}/promote"): {"anchor_start": 0, "anchor_end": 4},
+        ("PATCH", "/practice-recipes/{recipe_id}"): {
+            "name": _REPLAY_NAME,
+            "steps": [_RECIPE_STEP],
+        },
+        ("PATCH", "/practice-tags/{tag_id}"): {"label": _REPLAY_NAME},
+        ("PATCH", "/promotions/{promotion_id}"): {"included_in_entry_id": None},
+    },
+)
+
+
+def render_text(template: str, values: Mapping[str, object]) -> str:
+    """Interpolate seeded ids and the unique token into one template string.
+
+    Args:
+        template: A path or payload string with ``{name}`` fields.
+        values: The seeded ids of this cell plus ``unique``.
+
+    Returns:
+        The rendered string. A field the mapping cannot supply raises, which is
+        the loud failure a silently unsubstituted path would not be.
+    """
+    return template.format(**values)
+
+
+def _render_value(value: object, values: Mapping[str, object]) -> object:
+    """Interpolate a string leaf, or pass any other JSON value through."""
+    if isinstance(value, str):
+        return render_text(value, values)
+    return value
+
+
+def render_payload(
+    payload: Mapping[str, object],
+    values: Mapping[str, object],
+) -> dict[str, object]:
+    """Render a create payload against this cell's seeded ids.
+
+    Args:
+        payload: The spec's declared body.
+        values: The seeded ids of this cell plus ``unique``.
+
+    Returns:
+        A JSON-ready body. Only top-level string values are interpolated;
+        numbers and nested structures are constant by construction, so they are
+        copied through untouched.
+    """
+    return {key: _render_value(value, values) for key, value in payload.items()}
+
+
+def create_body(spec: SeedSpec, values: Mapping[str, object]) -> dict[str, object] | None:
+    """Render a create request's body, or return ``None`` for a verb that takes none.
+
+    Args:
+        spec: The seed strategy being run.
+        values: The seeded ids of this cell plus ``unique``.
+
+    Returns:
+        The rendered body for a mutating create, and ``None`` for a read -- a
+        catalog lookup is a legitimate way to obtain a prerequisite id, and
+        attaching a JSON body to it would be noise.
+    """
+    if spec.create_method not in _BODY_METHODS:
+        return None
+    return render_payload(spec.payload, values)
+
+
+def _visit(
+    param: str,
+    registry: Mapping[str, SeedSpec],
+    ordered: list[str],
+    pending: set[str],
+) -> None:
+    """Append ``param`` after its dependencies, skipping anything already placed.
+
+    ``pending`` holds the parameters whose dependencies are still being walked,
+    so a registry that somehow described a cycle degrades to a partial order
+    instead of recursing until the interpreter gives up.
+    """
+    if param in ordered or param in pending or param not in registry:
+        return
+    pending.add(param)
+    for dependency in registry[param].depends_on:
+        _visit(dependency, registry, ordered, pending)
+    ordered.append(param)
+
+
+def seed_order(params: Sequence[str], registry: Mapping[str, SeedSpec]) -> tuple[str, ...]:
+    """Return the parameters to seed, dependencies first.
+
+    Args:
+        params: The path parameters of the route being probed.
+        registry: The seed strategies to resolve against.
+
+    Returns:
+        Each parameter once, preceded by whatever it depends on. Parameters the
+        registry does not know are dropped here; the policy layer has already
+        refused to call such a route covered.
+    """
+    ordered: list[str] = []
+    pending: set[str] = set()
+    for param in params:
+        _visit(param, registry, ordered, pending)
+    return tuple(ordered)
+
+
+def _descend(node: object, step: str | int) -> object:
+    """Take one step into a parsed JSON body, or return ``None`` if it does not fit."""
+    if isinstance(node, Mapping):
+        return node.get(step)
+    if isinstance(node, list) and isinstance(step, int) and step < len(node):
+        return node[step]
+    return None
+
+
+def resolve_id(body: object, pointer: Sequence[str | int]) -> str | None:
+    """Read the new object's id out of a create response.
+
+    Args:
+        body: The parsed response body.
+        pointer: The path to the id, e.g. ``("goals", 0, "id")``.
+
+    Returns:
+        The id as text, or ``None`` when the response does not have the shape
+        the spec expects. A missing id is reported as an unseedable route rather
+        than raised, so one changed response schema cannot abort the whole run.
+    """
+    current: object = body
+    for step in pointer:
+        current = _descend(current, step)
+        if current is None:
+            return None
+    return str(current)
+
+
+def replay_body(
+    route: RouteSpec,
+    replay_bodies: Mapping[tuple[str, str], Mapping[str, object]],
+) -> Mapping[str, object] | None:
+    """Return the body to send when replaying one route, if it takes one.
+
+    Args:
+        route: The route being probed.
+        replay_bodies: The configured bodies, keyed by ``(method, path)``.
+
+    Returns:
+        ``None`` for verbs that carry no body. For a mutating verb, the
+        configured body or an empty object: an operation that declares a request
+        body and receives none is answered 422 before it ever reaches the
+        ownership check, so sending ``{}`` is strictly better than sending
+        nothing.
+    """
+    if route.method not in _BODY_METHODS:
+        return None
+    return replay_bodies.get((route.method, route.path), {})

--- a/backend/scripts/dast/seeds.py
+++ b/backend/scripts/dast/seeds.py
@@ -142,12 +142,28 @@ SEED_REGISTRY: Mapping[str, SeedSpec] = MappingProxyType(
             },
             id_pointer=("id",),
         ),
-        # Read from the catalog rather than submitted, because submitting is
-        # capped at five practices per minute per user and the matrix needs one
-        # for every cell of every route that names a practice. The three routes
-        # that address this id directly are allow-listed for the same reason a
-        # preset is safe to reuse here: nothing can destroy it and everyone may
-        # read it. It is a prerequisite for the objects that *are* probed --
+        # Read from the catalog rather than submitted, for two reasons.
+        #
+        # The first is that probing a *shared* practice is the only honest thing
+        # to do here: the application deliberately lets any authenticated user
+        # reach a preset. ``require_visible_practice`` returns any approved
+        # practice to anybody, and the share-link resolver admits a practice
+        # whose ``submitted_by_user_id`` is NULL by design. Cross-user access to
+        # a preset is therefore the feature, and the three routes that address
+        # this id directly are allow-listed saying exactly that -- a matrix that
+        # probed them against a submitted practice instead would report a
+        # false-positive LEAK and teach everyone to ignore the gate. The
+        # ownership rule that does exist (a draft is visible only to its
+        # submitter) is pinned in-process by tests/security/test_idor.py.
+        #
+        # The second is mechanical: submitting is capped at five practices per
+        # minute per user, keyed on the JWT subject rather than the client
+        # address, so the per-request forwarded address the rest of the matrix
+        # relies on cannot spread that cost -- and the matrix needs a practice
+        # for every cell of every route that names one.
+        #
+        # Reusing one preset across cells is safe because nothing here can
+        # destroy it. It is a prerequisite for the objects that *are* probed --
         # share links and user-practices, both of which stay fresh per cell.
         # Stage 1's canonical preset is a sense-grounding practice, and it is
         # the first practice row the seeder inserts, so an unordered listing

--- a/backend/scripts/dast/verdict.py
+++ b/backend/scripts/dast/verdict.py
@@ -107,6 +107,22 @@ class GuardFailure:
     detail: str
 
 
+@dataclass(frozen=True)
+class LiveFailure:
+    """A stage of live I/O that failed outright instead of answering something.
+
+    Attributes:
+        stage: What the run was doing, phrased for the report -- e.g.
+            ``"the identity bootstrap"``.
+        target: The instance the run was pointed at.
+        summary: The exception's type and message, shortened to one line.
+    """
+
+    stage: str
+    target: str
+    summary: str
+
+
 def _is_success(status: int) -> bool:
     """Report whether ``status`` is a 2xx."""
     return _SUCCESS_FLOOR <= status < _SUCCESS_CEILING
@@ -174,6 +190,30 @@ def judge(cell: Cell, status: int) -> Verdict:
     if cell is Cell.POSITIVE_CONTROL:
         return _judge_control(status)
     return _judge_probe(cell, status)
+
+
+def require_live_stages_completed(failure: LiveFailure | None) -> GuardFailure | None:
+    """Prove every stage of live I/O reached an answer instead of erroring out.
+
+    Args:
+        failure: The stage that failed, or ``None`` when all of them completed.
+
+    Returns:
+        ``None`` when the run got far enough to have a verdict of its own. An
+        instance that refuses the connection, a database that will not accept
+        the identity insert, a login that answers something unexpected -- each
+        leaves the matrix having probed nothing, and each would otherwise leave
+        the process on an uncaught exception, which exits 1: bit-for-bit the
+        code for a genuine authorization finding. Reporting it here is what
+        keeps "the harness never authenticated" distinguishable from "user B
+        read user A's journal".
+    """
+    if failure is None:
+        return None
+    return GuardFailure(
+        guard="require_live_stages_completed",
+        detail=f"{failure.stage} against {failure.target} failed: {failure.summary}",
+    )
 
 
 def require_auth_established(

--- a/backend/scripts/dast/verdict.py
+++ b/backend/scripts/dast/verdict.py
@@ -1,0 +1,372 @@
+"""Grade one probe, and refuse to call a run clean when it proved nothing.
+
+Two things live here because they answer the same question from opposite ends.
+:func:`judge` decides what a single response means; the ``require_*`` guards
+decide whether the run that produced those responses is worth believing at all.
+
+The grading vocabulary is deliberately wider than "denied or not". A ``401`` on
+the cross-user cell is a broken credential, not a denial; a ``5xx`` is a handler
+that reached the row before it checked who was asking; a ``429`` is a rate
+limiter turning the whole matrix into uniform, meaningless refusals. Collapsing
+any of those into "fine" is how a check reports clean while having exercised
+nothing.
+
+The guards exist for the same reason. A harness that cannot authenticate sees
+every request answered 401, finds no IDOR, and reports success. Each guard
+below closes one route to that false pass, and each returns either a
+:class:`GuardFailure` naming itself or ``None`` -- never a bare bool, so the
+report can say which guard tripped and why.
+
+``CellResult`` and ``GuardFailure`` live here rather than in the report module
+because the runner produces them and the report consumes them; putting the
+types beside the grader keeps the dependency pointing one way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum, auto
+from http import HTTPStatus
+
+from scripts.dast.discovery import RouteSpec
+from scripts.dast.policy import AllowlistEntry
+
+_SUCCESS_FLOOR = 200
+_SUCCESS_CEILING = 300
+_SERVER_ERROR_FLOOR = 500
+
+# The two statuses this codebase uses to refuse a cross-user request. The split
+# is deliberate: ownership denials 403, while the enumeration-safe resources
+# (goals, marginalia, journal entries) collapse to 404 on purpose.
+_ACCEPTABLE_DENIALS = frozenset({HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND})
+
+
+class Cell(Enum):
+    """One square of the matrix: which credential met which object."""
+
+    CROSS_USER = auto()
+    UNAUTH = auto()
+    FORGED_JWT = auto()
+    POSITIVE_CONTROL = auto()
+
+
+# The owner's own call runs last. Running it first against a route whose
+# cross-user cell is destructive would let that cell inherit a live row, delete
+# it, and leave every later probe reading a 404 as a correct denial.
+CELL_ORDER: tuple[Cell, ...] = (
+    Cell.CROSS_USER,
+    Cell.UNAUTH,
+    Cell.FORGED_JWT,
+    Cell.POSITIVE_CONTROL,
+)
+
+
+class Verdict(Enum):
+    """What one graded response means. Every value but ``PASS`` fails the build."""
+
+    PASS = auto()
+    LEAK = auto()
+    SERVER_ERROR = auto()
+    AUTH_BROKEN = auto()
+    THROTTLED = auto()
+    INCONCLUSIVE = auto()
+
+
+@dataclass(frozen=True)
+class CellResult:
+    """One probe, fully described, so a finding can be triaged without a rerun.
+
+    Attributes:
+        route: The operation that was probed.
+        cell: Which credential was used.
+        resolved_path: The path actually requested, ids substituted in.
+        object_ids: The ``(parameter, id)`` pairs that were sent, in path order.
+        status: The status the server returned.
+        verdict: The grade :func:`judge` gave that status.
+    """
+
+    route: RouteSpec
+    cell: Cell
+    resolved_path: str
+    object_ids: tuple[tuple[str, str], ...]
+    status: int
+    verdict: Verdict
+
+
+@dataclass(frozen=True)
+class GuardFailure:
+    """A vacuity guard that tripped, named so the report can say which one.
+
+    Attributes:
+        guard: The guard function's own name.
+        detail: One sentence an operator can act on.
+    """
+
+    guard: str
+    detail: str
+
+
+def _is_success(status: int) -> bool:
+    """Report whether ``status`` is a 2xx."""
+    return _SUCCESS_FLOOR <= status < _SUCCESS_CEILING
+
+
+def _judge_denial(cell: Cell, status: int) -> Verdict:
+    """Grade a non-2xx, non-throttled, non-5xx response on a probing cell.
+
+    Args:
+        cell: The cell being graded; never ``POSITIVE_CONTROL``.
+        status: The observed status.
+
+    Returns:
+        For the cross-user cell, ``PASS`` on 403/404 and ``AUTH_BROKEN`` on 401
+        -- the intruder's token is supposed to be valid, so a 401 means the run
+        learned nothing about authorization. For the token-less cells only a
+        401 passes. Anything else is ``INCONCLUSIVE``: a status nobody thought
+        about must never default to acceptable.
+    """
+    if cell is not Cell.CROSS_USER:
+        return Verdict.PASS if status == HTTPStatus.UNAUTHORIZED else Verdict.INCONCLUSIVE
+    if status == HTTPStatus.UNAUTHORIZED:
+        return Verdict.AUTH_BROKEN
+    return Verdict.PASS if status in _ACCEPTABLE_DENIALS else Verdict.INCONCLUSIVE
+
+
+def _judge_control(status: int) -> Verdict:
+    """Grade the owner's own call, which is asked one question: did it succeed?
+
+    A control that could not succeed makes the intruder's denial meaningless, so
+    every non-2xx is inconclusive -- including the 422 a mutating replay with an
+    invalid body returns, and the 429 a throttled run would show.
+    """
+    return Verdict.PASS if _is_success(status) else Verdict.INCONCLUSIVE
+
+
+def _judge_probe(cell: Cell, status: int) -> Verdict:
+    """Grade a cell that was supposed to be refused.
+
+    A 2xx is the ``LEAK`` this whole check exists to catch. A 429 means the rate
+    limiter, not the application, produced the refusal, and a 5xx means the
+    handler reached the row before it checked who was asking; neither is a
+    denial. What is left goes to the per-cell denial table.
+    """
+    if _is_success(status):
+        return Verdict.LEAK
+    if status == HTTPStatus.TOO_MANY_REQUESTS:
+        return Verdict.THROTTLED
+    if status >= _SERVER_ERROR_FLOOR:
+        return Verdict.SERVER_ERROR
+    return _judge_denial(cell, status)
+
+
+def judge(cell: Cell, status: int) -> Verdict:
+    """Grade one response as a total function of its cell and status.
+
+    Args:
+        cell: Which credential produced this response.
+        status: The status the server returned.
+
+    Returns:
+        The verdict. The owner's own call is graded on whether it succeeded;
+        every other cell is graded on whether it was genuinely refused.
+    """
+    if cell is Cell.POSITIVE_CONTROL:
+        return _judge_control(status)
+    return _judge_probe(cell, status)
+
+
+def require_auth_established(
+    *,
+    authenticated_status: int,
+    unauthenticated_status: int,
+) -> GuardFailure | None:
+    """Prove the credential works *and* that the auth layer is engaged at all.
+
+    Args:
+        authenticated_status: What the probe route returned with the owner's token.
+        unauthenticated_status: What it returned with no token.
+
+    Returns:
+        ``None`` only when the first is 200 and the second is 401. Both halves
+        matter: the first proves the token is accepted, the second proves
+        refusals are possible. Without the second, an application whose auth was
+        entirely bypassed would sail through every later cell.
+    """
+    if authenticated_status == HTTPStatus.OK and unauthenticated_status == HTTPStatus.UNAUTHORIZED:
+        return None
+    return GuardFailure(
+        guard="require_auth_established",
+        detail=(
+            f"the auth probe returned {authenticated_status} with the owner's token and "
+            f"{unauthenticated_status} without one; expected 200 and 401"
+        ),
+    )
+
+
+def require_positive_controls(results: Sequence[CellResult]) -> GuardFailure | None:
+    """Prove every probed route could be reached by the owner of its object.
+
+    Args:
+        results: Every graded cell of the run.
+
+    Returns:
+        ``None`` when each route's ``POSITIVE_CONTROL`` succeeded. A route whose
+        object was never really created, or whose replay body was rejected as
+        invalid, denies everybody equally -- which reads exactly like a
+        correctly guarded route and is the false green this harness exists to
+        forbid.
+    """
+    failed = sorted(
+        f"{result.route.method} {result.route.path}"
+        for result in results
+        if result.cell is Cell.POSITIVE_CONTROL and result.verdict is not Verdict.PASS
+    )
+    if not failed:
+        return None
+    return GuardFailure(
+        guard="require_positive_controls",
+        detail=(
+            f"{len(failed)} route(s) could not be reached by their own owner, "
+            f"so their denials prove nothing: {', '.join(failed)}"
+        ),
+    )
+
+
+def require_minimum_coverage(probed: int, *, minimum: int) -> GuardFailure | None:
+    """Prove the matrix still covers the application it is supposed to cover.
+
+    Args:
+        probed: How many routes produced cells.
+        minimum: The floor the run was told to expect.
+
+    Returns:
+        ``None`` when at least ``minimum`` routes were probed. Zero catches an
+        empty or garbled document, which would otherwise score a perfect clean
+        run; the floor catches the slower failure where a matrix quietly shrinks
+        and nobody notices.
+    """
+    if probed >= minimum:
+        return None
+    return GuardFailure(
+        guard="require_minimum_coverage",
+        detail=f"only {probed} route(s) were probed; at least {minimum} were expected",
+    )
+
+
+def require_seeded_resources(seeded: int) -> GuardFailure | None:
+    """Prove at least one real object existed for the probes to address.
+
+    Args:
+        seeded: How many routes had their objects created successfully.
+
+    Returns:
+        ``None`` once anything was seeded. With nothing seeded every probe
+        addresses an id that never existed, so every 404 is meaningless.
+    """
+    if seeded > 0:
+        return None
+    return GuardFailure(
+        guard="require_seeded_resources",
+        detail="no objects were created, so every probe addressed an id that never existed",
+    )
+
+
+def require_no_throttling(statuses: Sequence[int]) -> GuardFailure | None:
+    """Prove the rate limiter never turned a probe into a false denial.
+
+    Args:
+        statuses: Every status the run observed, seeding included.
+
+    Returns:
+        ``None`` when no response was throttled. One 429 anywhere is enough to
+        fail: the harness spreads requests across forwarded client keys
+        precisely so this cannot happen, so a single throttled response means
+        that mechanism stopped working and the run's denials are suspect.
+    """
+    throttled = sum(1 for status in statuses if status == HTTPStatus.TOO_MANY_REQUESTS)
+    if not throttled:
+        return None
+    return GuardFailure(
+        guard="require_no_throttling",
+        detail=f"{throttled} of {len(statuses)} responses were 429; results are inconclusive",
+    )
+
+
+def require_allowlist_is_live(
+    allowlist: Sequence[AllowlistEntry],
+    routes: Sequence[RouteSpec],
+) -> GuardFailure | None:
+    """Prove every allow-list entry still names a route of the running application.
+
+    Args:
+        allowlist: The loaded opt-out entries.
+        routes: Every route the current document declares.
+
+    Returns:
+        ``None`` when each entry matches a live route. A renamed route leaves
+        its excuse behind, and the excuse keeps excusing nothing; left unchecked
+        the allow-list becomes a graveyard whose size guard eventually fires for
+        reasons nobody can reconstruct.
+    """
+    live = {(route.method, route.path) for route in routes}
+    stale = sorted(
+        f"{entry.method} {entry.path}"
+        for entry in allowlist
+        if (entry.method, entry.path) not in live
+    )
+    if not stale:
+        return None
+    return GuardFailure(
+        guard="require_allowlist_is_live",
+        detail=f"{len(stale)} allow-list entry(s) no longer match any route: {', '.join(stale)}",
+    )
+
+
+def require_allowlist_bounded(
+    allowlisted: int,
+    considered: int,
+    *,
+    max_fraction: float,
+) -> GuardFailure | None:
+    """Prove the opt-out list still excuses a minority of the application.
+
+    Args:
+        allowlisted: How many routes carry an allow-list entry.
+        considered: How many routes were classified at all.
+        max_fraction: The permitted share, inclusive.
+
+    Returns:
+        ``None`` while the share is within bounds. Multiplication rather than
+        division keeps an empty document -- zero considered, zero allow-listed
+        -- from raising instead of reporting.
+    """
+    if allowlisted <= considered * max_fraction:
+        return None
+    return GuardFailure(
+        guard="require_allowlist_bounded",
+        detail=(
+            f"{allowlisted} of {considered} route(s) are allow-listed, "
+            f"above the permitted {max_fraction:.0%}"
+        ),
+    )
+
+
+def require_within_budget(elapsed_seconds: float, *, budget_seconds: float) -> GuardFailure | None:
+    """Prove the matrix finished inside its time box.
+
+    Args:
+        elapsed_seconds: Wall-clock time the matrix took.
+        budget_seconds: The ceiling the run was given.
+
+    Returns:
+        ``None`` for a run inside its budget. Enforcing the limit here rather
+        than in the workflow measures the matrix itself instead of the runner's
+        package installation.
+    """
+    if elapsed_seconds <= budget_seconds:
+        return None
+    return GuardFailure(
+        guard="require_within_budget",
+        detail=f"the matrix took {elapsed_seconds:.1f}s, over its {budget_seconds:.1f}s budget",
+    )

--- a/backend/tests/scripts/dast/conftest.py
+++ b/backend/tests/scripts/dast/conftest.py
@@ -1,0 +1,552 @@
+"""Throwaway stub applications that give the authorization-matrix harness a real BOLA to find.
+
+A DAST check is only worth having if it can be shown to *catch* something. The
+whole point of this module is therefore a deliberately broken application: a
+genuine ``FastAPI()`` instance whose ``GET /widgets/{widget_id}`` and
+``DELETE /widgets/{widget_id}`` authenticate the caller and then ignore who that
+caller is. Any harness change that stops flagging those two routes turns the
+tests that use these fixtures red, which is the property the whole exercise
+exists to buy.
+
+The apps are real FastAPI apps rather than hand-written OpenAPI dictionaries on
+purpose: discovery then runs against FastAPI's own ``/openapi.json`` generation,
+so a shape change in the framework surfaces here instead of in production.
+
+Alongside the leaky routes sit deliberately *correct* ones —
+``GET /safeitems/{item_id}`` 404s for a foreign owner and
+``GET /widgets/{widget_id}/parts/{part_id}`` 403s — as negative controls. A
+harness that reports those as findings is crying wolf, which is just as useless
+as one that reports nothing.
+
+The second app, built by :func:`build_blind_app`, mints tokens happily and then
+answers 401 to everything else. That is the exact shape of the false pass this
+whole harness exists to forbid: no request ever reaches an ownership check, no
+IDOR is found, and a naive check reports clean.
+
+Containment: these apps live under ``backend/tests/`` and are only ever
+constructed by a test. They are never imported by ``backend/src``, never mounted
+on the production app, and define their own throwaway bearer scheme over an
+in-memory dict. Nothing here imports, touches, or weakens the real auth stack.
+Passwords are generated with ``secrets`` so there is no credential literal at
+all.
+
+``from __future__ import annotations`` is deliberately absent: the route
+handlers below depend on locally-defined dependency callables, and stringised
+annotations would leave FastAPI unable to resolve them from module globals.
+"""
+
+import asyncio
+import secrets
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from typing import Annotated
+
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI, Header, HTTPException
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+from scripts.dast.authz_matrix import HarnessOverrides, main
+from scripts.dast.runner import Identity, MatrixConfig
+from scripts.dast.seeds import SeedSpec
+
+# The stub is driven in-process through ASGITransport, so this URL is never
+# dialled; it exists so the rendered curl repro looks like the real thing.
+STUB_BASE_URL = "http://127.0.0.1:8000"
+
+# Never connected: the injected bootstrap replaces the ORM identity insert, so
+# the CLI builds an engine that is never asked for a connection.
+UNUSED_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+# A list route that requires a token: the harness probes it with and without
+# credentials to prove the auth layer is engaged before trusting any denial.
+STUB_AUTH_PROBE_PATH = "/widgets/"
+
+# Every templated route the stub exposes is object-scoped, so discovery,
+# classification, and probing must all agree on this number.
+STUB_OBJECT_SCOPED_ROUTES = 5
+
+LEAKY_WIDGET_GET = ("GET", "/widgets/{widget_id}")
+LEAKY_WIDGET_DELETE = ("DELETE", "/widgets/{widget_id}")
+SAFE_ITEM_GET = ("GET", "/safeitems/{item_id}")
+SAFE_PART_GET = ("GET", "/widgets/{widget_id}/parts/{part_id}")
+SAFE_PART_POST = ("POST", "/widgets/{widget_id}/parts/")
+
+_BEARER_PREFIX = "Bearer "
+_TOKEN_BYTES = 24
+_PASSWORD_BYTES = 16
+# Row ids start well above zero so a stray ``0``/``1`` in a URL cannot pass for
+# a genuinely seeded object.
+_FIRST_ID = 100
+
+_UNAUTHORIZED = "unauthorized"
+_NOT_FOUND = "not_found"
+_FORBIDDEN = "forbidden"
+
+STUB_SEED_LABEL = "stub"
+STUB_REPLAY_LABEL = "replay"
+
+ActorDependency = Callable[..., Awaitable[str]]
+
+
+class LoginRequest(BaseModel):
+    """Credentials posted to the stub's ``/auth/login``."""
+
+    email: str
+    password: str
+
+
+class TokenOut(BaseModel):
+    """Bearer token minted by the stub's login route."""
+
+    token: str
+
+
+class LabelIn(BaseModel):
+    """The only field any stub create route accepts."""
+
+    label: str
+
+
+class IdOut(BaseModel):
+    """A bare row id, the flat ``id_pointer`` shape."""
+
+    id: int
+
+
+class PartCreated(BaseModel):
+    """A created part, nested one level so the id pointer must traverse."""
+
+    part: IdOut
+
+
+class ItemCreated(BaseModel):
+    """A created safe item, nested one level for the same reason."""
+
+    item: IdOut
+
+
+class WidgetOut(BaseModel):
+    """A widget read, echoing both its owner and the caller who read it.
+
+    ``viewer`` differing from ``owner`` in a 200 response is the leak made
+    visible: the row was served to somebody who does not own it.
+    """
+
+    id: int
+    owner: str
+    viewer: str
+
+
+class PartOut(BaseModel):
+    """A part read, tied back to the widget that owns it."""
+
+    id: int
+    widget_id: int
+
+
+@dataclass
+class StubStore:
+    """In-memory state for one stub deployment: identities, tokens, and owned rows."""
+
+    passwords: dict[str, str] = field(default_factory=dict)
+    tokens: dict[str, str] = field(default_factory=dict)
+    widgets: dict[int, str] = field(default_factory=dict)
+    parts: dict[int, int] = field(default_factory=dict)
+    items: dict[int, str] = field(default_factory=dict)
+    deleted_by: dict[int, str] = field(default_factory=dict)
+    # Labels submitted to create routes: proof that a seed or replay body
+    # arrived intact rather than being rejected as invalid before the handler.
+    labels: list[str] = field(default_factory=list)
+    # Credentials the blind app refused: proof the harness authenticated at all.
+    rejected: list[str] = field(default_factory=list)
+    next_id: int = _FIRST_ID
+
+    def allocate_id(self) -> int:
+        """Return a fresh row id."""
+        self.next_id += 1
+        return self.next_id
+
+
+@dataclass(frozen=True)
+class StubCredentials:
+    """One throwaway identity the harness is expected to log in as."""
+
+    label: str
+    email: str
+    password: str
+
+
+@dataclass(frozen=True)
+class StubDeployment:
+    """A built stub app together with its store and its two pre-registered identities."""
+
+    app: FastAPI
+    store: StubStore
+    owner: StubCredentials
+    intruder: StubCredentials
+
+
+def _unauthorized() -> HTTPException:
+    """Return the stub's uniform 401."""
+    return HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=_UNAUTHORIZED)
+
+
+def _resolve_actor(store: StubStore, authorization: str | None) -> str:
+    """Return the email behind a bearer token, or raise 401.
+
+    Args:
+        store: The deployment's state.
+        authorization: The raw ``Authorization`` header, if any.
+
+    Returns:
+        The authenticated caller's email address.
+
+    Raises:
+        HTTPException: 401 when the header is missing, malformed, or carries a
+            token this deployment never minted (which is what the forged-JWT
+            probe sends).
+    """
+    if authorization is None or not authorization.startswith(_BEARER_PREFIX):
+        raise _unauthorized()
+    email = store.tokens.get(authorization.removeprefix(_BEARER_PREFIX))
+    if email is None:
+        raise _unauthorized()
+    return email
+
+
+def _make_actor_dependency(store: StubStore) -> ActorDependency:
+    """Build the stub's bearer dependency, bound to one store.
+
+    The parameter is named ``authorization`` and declared as a plain header so
+    the generated OpenAPI document carries the same authentication signal the
+    production app emits.
+    """
+
+    async def current_actor(authorization: Annotated[str | None, Header()] = None) -> str:
+        return _resolve_actor(store, authorization)
+
+    return current_actor
+
+
+def _mount_login(app: FastAPI, store: StubStore) -> None:
+    """Mount a minimal ``POST /auth/login`` that mints a bearer token."""
+
+    @app.post("/auth/login")
+    async def login(payload: LoginRequest) -> TokenOut:
+        expected = store.passwords.get(payload.email)
+        if expected is None or not secrets.compare_digest(expected, payload.password):
+            raise _unauthorized()
+        token = secrets.token_urlsafe(_TOKEN_BYTES)
+        store.tokens[token] = payload.email
+        return TokenOut(token=token)
+
+
+def _mount_widgets(app: FastAPI, store: StubStore, actor_dep: ActorDependency) -> None:
+    """Mount the widget routes, two of which are deliberately broken.
+
+    ``list_widgets`` and ``create_widget`` are sound. ``read_widget`` and
+    ``delete_widget`` authenticate and then never consult the owner — the BOLA
+    the harness must find.
+    """
+
+    @app.get(STUB_AUTH_PROBE_PATH)
+    async def list_widgets(actor: Annotated[str, Depends(actor_dep)]) -> list[int]:
+        return [widget_id for widget_id, owner in store.widgets.items() if owner == actor]
+
+    @app.post(STUB_AUTH_PROBE_PATH, status_code=HTTPStatus.CREATED)
+    async def create_widget(
+        actor: Annotated[str, Depends(actor_dep)],
+        payload: LabelIn,
+    ) -> IdOut:
+        widget_id = store.allocate_id()
+        store.widgets[widget_id] = actor
+        store.labels.append(payload.label)
+        return IdOut(id=widget_id)
+
+    @app.get("/widgets/{widget_id}")
+    async def read_widget(
+        widget_id: int,
+        actor: Annotated[str, Depends(actor_dep)],
+    ) -> WidgetOut:
+        owner = store.widgets.get(widget_id)
+        if owner is None:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=_NOT_FOUND)
+        return WidgetOut(id=widget_id, owner=owner, viewer=actor)
+
+    @app.delete("/widgets/{widget_id}", status_code=HTTPStatus.NO_CONTENT)
+    async def delete_widget(
+        widget_id: int,
+        actor: Annotated[str, Depends(actor_dep)],
+    ) -> None:
+        if widget_id not in store.widgets:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=_NOT_FOUND)
+        del store.widgets[widget_id]
+        store.deleted_by[widget_id] = actor
+
+
+def _mount_parts(app: FastAPI, store: StubStore, actor_dep: ActorDependency) -> None:
+    """Mount the two-parameter part routes, both of which enforce ownership.
+
+    These exist for two reasons: they are the negative control for a route whose
+    denial is 403 rather than 404, and they force the seed resolver to fill one
+    parameter from another (a part cannot be created without a widget).
+    """
+
+    @app.post("/widgets/{widget_id}/parts/", status_code=HTTPStatus.CREATED)
+    async def create_part(
+        widget_id: int,
+        actor: Annotated[str, Depends(actor_dep)],
+        payload: LabelIn,
+    ) -> PartCreated:
+        if store.widgets.get(widget_id) != actor:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=_NOT_FOUND)
+        part_id = store.allocate_id()
+        store.parts[part_id] = widget_id
+        store.labels.append(payload.label)
+        return PartCreated(part=IdOut(id=part_id))
+
+    @app.get("/widgets/{widget_id}/parts/{part_id}")
+    async def read_part(
+        widget_id: int,
+        part_id: int,
+        actor: Annotated[str, Depends(actor_dep)],
+    ) -> PartOut:
+        if store.widgets.get(widget_id) != actor:
+            raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail=_FORBIDDEN)
+        if store.parts.get(part_id) != widget_id:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=_NOT_FOUND)
+        return PartOut(id=part_id, widget_id=widget_id)
+
+
+def _mount_safeitems(app: FastAPI, store: StubStore, actor_dep: ActorDependency) -> None:
+    """Mount the correct, enumeration-safe item routes used as the negative control."""
+
+    @app.post("/safeitems/", status_code=HTTPStatus.CREATED)
+    async def create_item(
+        actor: Annotated[str, Depends(actor_dep)],
+        payload: LabelIn,
+    ) -> ItemCreated:
+        item_id = store.allocate_id()
+        store.items[item_id] = actor
+        store.labels.append(payload.label)
+        return ItemCreated(item=IdOut(id=item_id))
+
+    @app.get("/safeitems/{item_id}")
+    async def read_item(
+        item_id: int,
+        actor: Annotated[str, Depends(actor_dep)],
+    ) -> IdOut:
+        if store.items.get(item_id) != actor:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=_NOT_FOUND)
+        return IdOut(id=item_id)
+
+
+def _register_identities(store: StubStore) -> tuple[StubCredentials, StubCredentials]:
+    """Seed two identities into a store and return them, owner first."""
+    owner = StubCredentials(
+        label="A",
+        email="dast-stub-a@example.com",
+        password=secrets.token_urlsafe(_PASSWORD_BYTES),
+    )
+    intruder = StubCredentials(
+        label="B",
+        email="dast-stub-b@example.com",
+        password=secrets.token_urlsafe(_PASSWORD_BYTES),
+    )
+    for credentials in (owner, intruder):
+        store.passwords[credentials.email] = credentials.password
+    return owner, intruder
+
+
+def build_leaky_app() -> StubDeployment:
+    """Build the stub whose two widget-read/delete routes ignore ownership."""
+    store = StubStore()
+    app = FastAPI(title="dast-stub-leaky")
+    actor_dep = _make_actor_dependency(store)
+    _mount_login(app, store)
+    _mount_widgets(app, store, actor_dep)
+    _mount_parts(app, store, actor_dep)
+    _mount_safeitems(app, store, actor_dep)
+    owner, intruder = _register_identities(store)
+    return StubDeployment(app=app, store=store, owner=owner, intruder=intruder)
+
+
+def build_blind_app() -> StubDeployment:
+    """Build the stub that logs anybody in and then answers 401 to everything.
+
+    This is the false pass in its purest form: every probe is denied, so no IDOR
+    can possibly be observed. A harness that reports this as clean has proven
+    nothing at all, so it must instead report a tripped vacuity guard.
+    """
+    store = StubStore()
+    app = FastAPI(title="dast-stub-blind")
+    _mount_login(app, store)
+
+    async def always_unauthorized(
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> None:
+        store.rejected.append(authorization or "")
+        raise _unauthorized()
+
+    blind = [Depends(always_unauthorized)]
+
+    @app.get(STUB_AUTH_PROBE_PATH, dependencies=blind)
+    async def list_widgets() -> list[int]:
+        return []
+
+    @app.post(STUB_AUTH_PROBE_PATH, status_code=HTTPStatus.CREATED, dependencies=blind)
+    async def create_widget(payload: LabelIn) -> IdOut:
+        return IdOut(id=len(payload.label))
+
+    @app.get("/widgets/{widget_id}", dependencies=blind)
+    async def read_widget(widget_id: int) -> IdOut:
+        return IdOut(id=widget_id)
+
+    owner, intruder = _register_identities(store)
+    return StubDeployment(app=app, store=store, owner=owner, intruder=intruder)
+
+
+def make_stub_bootstrap(
+    deployment: StubDeployment,
+) -> Callable[[AsyncClient], Awaitable[tuple[Identity, Identity]]]:
+    """Build the identity-bootstrap seam the runner is handed for a stub.
+
+    In production the runner inserts two user rows through the app's own ORM and
+    then mints both tokens over the real ``POST /auth/login``. Against a stub
+    there is no database, so this substitutes the same two-step shape: the
+    identities already exist in the store, and both tokens come from a genuine
+    login round-trip through the app.
+
+    Args:
+        deployment: The stub whose identities should be logged in.
+
+    Returns:
+        A coroutine function returning ``(owner, intruder)`` identities.
+    """
+
+    async def _login(client: AsyncClient, credentials: StubCredentials) -> Identity:
+        response = await client.post(
+            "/auth/login",
+            json={"email": credentials.email, "password": credentials.password},
+        )
+        assert response.status_code == HTTPStatus.OK, (
+            f"stub login for {credentials.label} failed: {response.status_code} {response.text}"
+        )
+        return Identity(
+            label=credentials.label,
+            email=credentials.email,
+            token=str(response.json()["token"]),
+        )
+
+    async def _bootstrap(client: AsyncClient) -> tuple[Identity, Identity]:
+        return (
+            await _login(client, deployment.owner),
+            await _login(client, deployment.intruder),
+        )
+
+    return _bootstrap
+
+
+STUB_SEED_REGISTRY: dict[str, SeedSpec] = {
+    "widget_id": SeedSpec(
+        create_method="POST",
+        create_path="/widgets/",
+        payload={"label": STUB_SEED_LABEL},
+        id_pointer=("id",),
+    ),
+    "part_id": SeedSpec(
+        create_method="POST",
+        create_path="/widgets/{widget_id}/parts/",
+        payload={"label": STUB_SEED_LABEL},
+        id_pointer=("part", "id"),
+        depends_on=("widget_id",),
+    ),
+    "item_id": SeedSpec(
+        create_method="POST",
+        create_path="/safeitems/",
+        payload={"label": STUB_SEED_LABEL},
+        id_pointer=("item", "id"),
+    ),
+}
+
+STUB_REPLAY_BODIES: dict[tuple[str, str], dict[str, object]] = {
+    SAFE_PART_POST: {"label": STUB_REPLAY_LABEL},
+}
+
+
+@pytest.fixture
+def leaky_deployment() -> StubDeployment:
+    """Provide a freshly built leaky stub, isolated from every other test."""
+    return build_leaky_app()
+
+
+@pytest.fixture
+def blind_deployment() -> StubDeployment:
+    """Provide a freshly built "401s everything" stub."""
+    return build_blind_app()
+
+
+def stub_client(deployment: StubDeployment) -> AsyncClient:
+    """Return an httpx client wired straight into a stub app, no socket involved."""
+    return AsyncClient(
+        transport=ASGITransport(app=deployment.app),
+        base_url=STUB_BASE_URL,
+    )
+
+
+@pytest_asyncio.fixture
+async def leaky_client(leaky_deployment: StubDeployment) -> AsyncIterator[AsyncClient]:
+    """Provide an ASGI-backed client for the leaky stub."""
+    async with stub_client(leaky_deployment) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def blind_client(blind_deployment: StubDeployment) -> AsyncIterator[AsyncClient]:
+    """Provide an ASGI-backed client for the "401s everything" stub."""
+    async with stub_client(blind_deployment) as client:
+        yield client
+
+
+def stub_config(*, min_routes: int = STUB_OBJECT_SCOPED_ROUTES) -> MatrixConfig:
+    """Return the matrix configuration that points the harness at a stub app."""
+    return MatrixConfig(
+        seed_registry=STUB_SEED_REGISTRY,
+        replay_bodies=STUB_REPLAY_BODIES,
+        auth_probe_path=STUB_AUTH_PROBE_PATH,
+        min_routes=min_routes,
+    )
+
+
+def drive_main(deployment: StubDeployment, *, min_routes: int) -> int:
+    """Run the CLI end to end against a stub app and return its exit code.
+
+    ``main`` owns the event loop, so this is deliberately synchronous: an async
+    test could not call it without nesting ``asyncio.run`` inside a running
+    loop. The client is built here and closed afterwards because nothing that
+    injects a client should also be expected to own its lifetime.
+    """
+    client = stub_client(deployment)
+    try:
+        return main(
+            [
+                "--base-url",
+                STUB_BASE_URL,
+                "--database-url",
+                UNUSED_DATABASE_URL,
+                "--min-routes",
+                str(min_routes),
+            ],
+            overrides=HarnessOverrides(
+                client=client,
+                bootstrap=make_stub_bootstrap(deployment),
+                seed_registry=STUB_SEED_REGISTRY,
+                replay_bodies=STUB_REPLAY_BODIES,
+                auth_probe_path=STUB_AUTH_PROBE_PATH,
+            ),
+        )
+    finally:
+        asyncio.run(client.aclose())

--- a/backend/tests/scripts/dast/conftest.py
+++ b/backend/tests/scripts/dast/conftest.py
@@ -49,7 +49,7 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
 
 from scripts.dast.authz_matrix import HarnessOverrides, main
-from scripts.dast.runner import Identity, MatrixConfig
+from scripts.dast.runner import Bootstrap, Identity, MatrixConfig
 from scripts.dast.seeds import SeedSpec
 
 # The stub is driven in-process through ASGITransport, so this URL is never
@@ -521,32 +521,81 @@ def stub_config(*, min_routes: int = STUB_OBJECT_SCOPED_ROUTES) -> MatrixConfig:
     )
 
 
-def drive_main(deployment: StubDeployment, *, min_routes: int) -> int:
-    """Run the CLI end to end against a stub app and return its exit code.
+def stub_overrides(client: AsyncClient, *, bootstrap: Bootstrap | None) -> HarnessOverrides:
+    """Bundle the seams that point the CLI at a stub app.
+
+    Args:
+        client: The client the run should use.
+        bootstrap: The identity bootstrap to inject, or ``None`` to leave the
+            production one in place -- which is how a test drives the real ORM
+            insert against a deliberately unusable database URL.
+    """
+    return HarnessOverrides(
+        client=client,
+        bootstrap=bootstrap,
+        seed_registry=STUB_SEED_REGISTRY,
+        replay_bodies=STUB_REPLAY_BODIES,
+        auth_probe_path=STUB_AUTH_PROBE_PATH,
+    )
+
+
+def close_client(client: AsyncClient) -> None:
+    """Close a client from synchronous test code, which owns no event loop."""
+    asyncio.run(client.aclose())
+
+
+def drive_main_with(
+    overrides: HarnessOverrides,
+    *,
+    min_routes: int,
+    database_url: str = UNUSED_DATABASE_URL,
+) -> int:
+    """Run the CLI end to end with one set of injected seams.
 
     ``main`` owns the event loop, so this is deliberately synchronous: an async
-    test could not call it without nesting ``asyncio.run`` inside a running
-    loop. The client is built here and closed afterwards because nothing that
-    injects a client should also be expected to own its lifetime.
+    test could not call it without nesting ``asyncio.run`` inside a running loop.
     """
-    client = stub_client(deployment)
+    return main(
+        [
+            "--base-url",
+            STUB_BASE_URL,
+            "--database-url",
+            database_url,
+            "--min-routes",
+            str(min_routes),
+        ],
+        overrides=overrides,
+    )
+
+
+def drive_main(
+    deployment: StubDeployment,
+    *,
+    min_routes: int,
+    client: AsyncClient | None = None,
+    bootstrap: Bootstrap | None = None,
+) -> int:
+    """Run the CLI end to end against a stub app and return its exit code.
+
+    Args:
+        deployment: The stub to probe.
+        min_routes: The coverage floor this run is given.
+        client: A client to use instead of a plain one onto the stub, for tests
+            that need one live stage to fail while the others keep working.
+        bootstrap: An identity bootstrap to use instead of the stub's own.
+
+    Returns:
+        The exit code. The client is closed here because nothing that injects a
+        client should also be expected to own its lifetime.
+    """
+    session_client = client if client is not None else stub_client(deployment)
     try:
-        return main(
-            [
-                "--base-url",
-                STUB_BASE_URL,
-                "--database-url",
-                UNUSED_DATABASE_URL,
-                "--min-routes",
-                str(min_routes),
-            ],
-            overrides=HarnessOverrides(
-                client=client,
-                bootstrap=make_stub_bootstrap(deployment),
-                seed_registry=STUB_SEED_REGISTRY,
-                replay_bodies=STUB_REPLAY_BODIES,
-                auth_probe_path=STUB_AUTH_PROBE_PATH,
+        return drive_main_with(
+            stub_overrides(
+                session_client,
+                bootstrap=bootstrap if bootstrap is not None else make_stub_bootstrap(deployment),
             ),
+            min_routes=min_routes,
         )
     finally:
-        asyncio.run(client.aclose())
+        close_client(session_client)

--- a/backend/tests/scripts/dast/test_authz_matrix_cli.py
+++ b/backend/tests/scripts/dast/test_authz_matrix_cli.py
@@ -1,0 +1,291 @@
+"""The CLI: four exit codes, two streams, and no silent defaults.
+
+CI reads exactly one thing from this script — the number it returns — so each of
+the four codes is driven in-process here and asserted directly, with the stream
+split that ``check_dependency_drift`` established: a clean run reports on stdout,
+every failure reports on stderr so a red job's output is unambiguous.
+
+The matrix itself is replaced with a stub for these tests. That is deliberate:
+what is under test is argument handling, wiring, and grading, and none of that
+should need a socket to exercise. The thresholds the flags carry are asserted
+where they land — inside the ``MatrixConfig`` the runner receives — because a
+default that silently stops being applied is how a gate quietly loosens.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from scripts.dast import authz_matrix
+from scripts.dast.discovery import RouteSpec
+from scripts.dast.policy import DEFAULT_ALLOWLIST_PATH, AllowlistEntry, load_allowlist
+from scripts.dast.report import (
+    EXIT_AUTHZ_FINDING,
+    EXIT_CLEAN,
+    EXIT_HARNESS_ERROR,
+    EXIT_UNCOVERED,
+    MatrixReport,
+)
+from scripts.dast.runner import (
+    DEFAULT_BUDGET_SECONDS,
+    DEFAULT_MAX_ALLOWLIST_FRACTION,
+    DEFAULT_MIN_ROUTES,
+    MatrixConfig,
+)
+from scripts.dast.seeds import SEED_REGISTRY
+from scripts.dast.verdict import Cell, CellResult, GuardFailure, Verdict
+
+BASE_URL = "http://127.0.0.1:9999"
+# Never connected: ``run_matrix`` is stubbed out, so the engine the CLI builds
+# is never asked for a session.
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+DISCOVERED_ROUTES = 41
+SEEDED_ROUTES = 37
+ALLOWLISTED_ROUTES = 4
+ELAPSED_SECONDS = 11.5
+
+CUSTOM_MIN_ROUTES = 33
+CUSTOM_BUDGET_SECONDS = 45.0
+CUSTOM_MAX_FRACTION = 0.25
+
+LEAKY_ROUTE = RouteSpec(
+    method="GET",
+    path="/widgets/{widget_id}",
+    params=("widget_id",),
+    requires_auth=True,
+)
+LEAK = CellResult(
+    route=LEAKY_ROUTE,
+    cell=Cell.CROSS_USER,
+    resolved_path="/widgets/7",
+    object_ids=(("widget_id", "7"),),
+    status=200,
+    verdict=Verdict.LEAK,
+)
+PASSING_CELL = CellResult(
+    route=LEAKY_ROUTE,
+    cell=Cell.CROSS_USER,
+    resolved_path="/widgets/7",
+    object_ids=(("widget_id", "7"),),
+    status=404,
+    verdict=Verdict.PASS,
+)
+GUARD_FAILURE = GuardFailure(guard="require_seeded_resources", detail="no objects were created")
+
+
+def build_report(
+    *,
+    results: tuple[CellResult, ...] = (PASSING_CELL,),
+    uncovered: tuple[str, ...] = (),
+    guard_failures: tuple[GuardFailure, ...] = (),
+) -> MatrixReport:
+    """Assemble the report the stubbed matrix will hand back to the CLI."""
+    return MatrixReport(
+        base_url=BASE_URL,
+        discovered=DISCOVERED_ROUTES,
+        seeded=SEEDED_ROUTES,
+        uncovered=uncovered,
+        allowlisted=ALLOWLISTED_ROUTES,
+        results=results,
+        guard_failures=guard_failures,
+        elapsed_seconds=ELAPSED_SECONDS,
+    )
+
+
+def install_stub_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    report: MatrixReport,
+) -> list[tuple[AsyncClient, MatrixConfig]]:
+    """Replace ``run_matrix`` with a recorder and return the list it appends to."""
+    recorded: list[tuple[AsyncClient, MatrixConfig]] = []
+
+    async def _stub_matrix(
+        client: AsyncClient,
+        *,
+        bootstrap: object,
+        config: MatrixConfig,
+    ) -> MatrixReport:
+        assert bootstrap is not None, "the CLI must supply an identity bootstrap"
+        recorded.append((client, config))
+        return report
+
+    monkeypatch.setattr(authz_matrix, "run_matrix", _stub_matrix)
+    return recorded
+
+
+def run_cli(*extra: str) -> int:
+    """Invoke ``main`` with the two required arguments plus ``extra``."""
+    return authz_matrix.main(
+        ["--base-url", BASE_URL, "--database-url", DATABASE_URL, *extra],
+    )
+
+
+def test_the_exit_codes_are_re_exported_unchanged_from_the_report_module() -> None:
+    """One definition of each code; the CLI must not grow a second, drifting copy."""
+    assert authz_matrix.EXIT_CLEAN == EXIT_CLEAN
+    assert authz_matrix.EXIT_AUTHZ_FINDING == EXIT_AUTHZ_FINDING
+    assert authz_matrix.EXIT_UNCOVERED == EXIT_UNCOVERED
+    assert authz_matrix.EXIT_HARNESS_ERROR == EXIT_HARNESS_ERROR
+
+
+def test_a_clean_matrix_exits_zero_and_reports_on_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A passing gate is ordinary output, and it still prints its coverage summary."""
+    install_stub_matrix(monkeypatch, build_report())
+
+    exit_code = run_cli()
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_CLEAN, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert captured.err == ""
+    assert "routes discovered from /openapi.json : 41 object-scoped" in captured.out
+
+
+def test_a_leak_exits_one_and_reports_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Findings go to stderr so a red job's output is unambiguous in the log."""
+    install_stub_matrix(monkeypatch, build_report(results=(LEAK,)))
+
+    exit_code = run_cli()
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_AUTHZ_FINDING, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert captured.out == ""
+    assert "FAIL  GET    /widgets/{widget_id}" in captured.err
+
+
+def test_an_uncovered_route_exits_two(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A route with no seed strategy and no allow-list entry has its own exit code."""
+    install_stub_matrix(monkeypatch, build_report(uncovered=("GET /course/{slug}",)))
+
+    exit_code = run_cli()
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_UNCOVERED, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert captured.out == ""
+    assert "UNCOVERED  GET    /course/{slug}" in captured.err
+
+
+def test_a_tripped_guard_exits_three(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Nothing was proven, so the CLI must not borrow the clean exit code."""
+    install_stub_matrix(monkeypatch, build_report(guard_failures=(GUARD_FAILURE,)))
+
+    exit_code = run_cli()
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert exit_code != EXIT_CLEAN
+    assert captured.out == ""
+    assert "HARNESS ERROR  require_seeded_resources: no objects were created" in captured.err
+
+
+def test_the_documented_defaults_reach_the_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A threshold that stops being applied is how a gate loosens without a diff."""
+    recorded = install_stub_matrix(monkeypatch, build_report())
+
+    run_cli()
+
+    client, config = recorded[0]
+    assert str(client.base_url) == BASE_URL
+    assert config.min_routes == DEFAULT_MIN_ROUTES
+    assert config.budget_seconds == DEFAULT_BUDGET_SECONDS
+    assert config.max_allowlist_fraction == DEFAULT_MAX_ALLOWLIST_FRACTION
+    assert config.seed_registry is SEED_REGISTRY
+    assert config.allowlist == load_allowlist(DEFAULT_ALLOWLIST_PATH)
+
+
+def test_the_default_thresholds_are_the_documented_numbers() -> None:
+    """These three numbers are the acceptance criteria, so they are pinned once."""
+    assert DEFAULT_MIN_ROUTES == 20
+    assert DEFAULT_BUDGET_SECONDS == 120.0
+    assert DEFAULT_MAX_ALLOWLIST_FRACTION == 0.5
+
+
+def test_every_threshold_flag_overrides_its_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tightening a threshold locally must be possible without editing the script."""
+    recorded = install_stub_matrix(monkeypatch, build_report())
+
+    run_cli(
+        "--min-routes",
+        str(CUSTOM_MIN_ROUTES),
+        "--budget-seconds",
+        str(CUSTOM_BUDGET_SECONDS),
+        "--max-allowlist-fraction",
+        str(CUSTOM_MAX_FRACTION),
+    )
+
+    _, config = recorded[0]
+    assert config.min_routes == CUSTOM_MIN_ROUTES
+    assert config.budget_seconds == CUSTOM_BUDGET_SECONDS
+    assert config.max_allowlist_fraction == CUSTOM_MAX_FRACTION
+
+
+def test_an_explicit_allowlist_path_is_loaded_instead_of_the_shipped_one(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The allow-list is data, so a run can be pointed at a different file."""
+    path = tmp_path / "allowlist.toml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            [[route]]
+            method   = "GET"
+            path     = "/widgets/{widget_id}"
+            category = "admin_only"
+            reason   = "covered by the in-process suite instead"
+            """,
+        ).lstrip("\n"),
+        encoding="utf-8",
+    )
+    recorded = install_stub_matrix(monkeypatch, build_report())
+
+    run_cli("--allowlist", str(path))
+
+    _, config = recorded[0]
+    assert config.allowlist == (
+        AllowlistEntry(
+            method="GET",
+            path="/widgets/{widget_id}",
+            category="admin_only",
+            reason="covered by the in-process suite instead",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["--base-url", BASE_URL],
+        ["--database-url", DATABASE_URL],
+    ],
+)
+def test_both_targets_are_required_arguments(argv: list[str]) -> None:
+    """Neither target has a default: guessing one would point the matrix somewhere real.
+
+    A defaulted base URL is how a run silently probes localhost instead of the
+    ephemeral instance the job started, and a defaulted database URL is how it
+    seeds identities into the wrong place.
+    """
+    with pytest.raises(SystemExit):
+        authz_matrix.main(argv)

--- a/backend/tests/scripts/dast/test_bootstrap_identities.py
+++ b/backend/tests/scripts/dast/test_bootstrap_identities.py
@@ -1,0 +1,141 @@
+"""The production identity bootstrap, driven against the real application.
+
+Everything else in this package proves the harness grades correctly. This module
+proves the one step none of it can: that the two identities the matrix rests on
+are real, separate, working accounts of *this* application -- inserted through
+its own ORM and logged in over its own ``POST /auth/login``.
+
+The stakes are asymmetric. If the bootstrap silently misbehaves, every request
+the matrix sends is answered 401, no cross-user access is ever observed, and the
+check goes vacuous while looking healthy. So the assertions here are the two that
+cannot be satisfied by a bootstrap that merely returned something: each token has
+to work on a genuinely authenticated route, and the two identities have to be
+distinct actors -- one's habit must be invisible to the other. Two tokens for the
+same user would make every "denied" in the matrix meaningless.
+
+The application runs in-process over ``ASGITransport`` against a throwaway
+file-backed SQLite database, which is what lets ``_insert_users`` be handed a
+real database URL of its own -- the same shape the production run passes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from conftest import _replace_array_columns
+from database import get_session
+from main import app
+from scripts.dast.authz_matrix import _bootstrap_identities
+from scripts.dast.runner import Identity
+
+HABITS_PATH = "/habits/"
+
+# The minimum a habit needs; the matrix's own seed registry sends the same shape.
+HABIT_BODY: dict[str, object] = {
+    "name": "bootstrap probe habit",
+    "icon": "star",
+    "start_date": "2024-01-01",
+    "energy_cost": 1,
+    "energy_return": 2,
+}
+
+
+@dataclass(frozen=True)
+class BootstrapTarget:
+    """An in-process application together with the database URL it is serving from."""
+
+    client: AsyncClient
+    database_url: str
+
+
+def authorized(identity: Identity) -> dict[str, str]:
+    """Return the header one identity sends."""
+    return {"Authorization": f"Bearer {identity.token}"}
+
+
+@pytest_asyncio.fixture
+async def bootstrap_target(tmp_path: Path) -> AsyncIterator[BootstrapTarget]:
+    """Serve the real application from a throwaway file-backed database.
+
+    File-backed rather than in-memory because the bootstrap opens its own engine
+    against the URL it is handed, exactly as it does in production; two engines
+    onto ``:memory:`` would see two different databases and the login would 401
+    for reasons that have nothing to do with the code under test.
+    """
+    database_url = f"sqlite+aiosqlite:///{tmp_path / 'dast-bootstrap.db'}"
+    engine = create_async_engine(database_url)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    _replace_array_columns()
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    async def _per_request_session() -> AsyncIterator[AsyncSession]:
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _per_request_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield BootstrapTarget(client=client, database_url=database_url)
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_bootstrap_mints_two_tokens_that_actually_authenticate(
+    bootstrap_target: BootstrapTarget,
+) -> None:
+    """A token that does not work turns every later denial into a false pass."""
+    owner, intruder = await _bootstrap_identities(
+        bootstrap_target.client,
+        database_url=bootstrap_target.database_url,
+    )
+
+    # The report names actors by label, so the order they come back in is contractual.
+    assert (owner.label, intruder.label) == ("A", "B")
+    for identity in (owner, intruder):
+        response = await bootstrap_target.client.get(HABITS_PATH, headers=authorized(identity))
+        assert response.status_code == HTTPStatus.OK, (
+            f"identity {identity.label} could not use its own token: {response.text}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_bootstrap_creates_two_genuinely_separate_actors(
+    bootstrap_target: BootstrapTarget,
+) -> None:
+    """The whole matrix rests on this: A's object must be somebody else's object to B.
+
+    Distinct emails and distinct token strings would both be satisfied by two
+    logins as the same user, so the proof is behavioural -- the habit A creates
+    is not in B's listing.
+    """
+    owner, intruder = await _bootstrap_identities(
+        bootstrap_target.client,
+        database_url=bootstrap_target.database_url,
+    )
+    assert owner.email != intruder.email
+
+    created = await bootstrap_target.client.post(
+        HABITS_PATH,
+        json=HABIT_BODY,
+        headers=authorized(owner),
+    )
+    assert created.status_code == HTTPStatus.OK, created.text
+
+    owned = await bootstrap_target.client.get(HABITS_PATH, headers=authorized(owner))
+    intruders = await bootstrap_target.client.get(HABITS_PATH, headers=authorized(intruder))
+
+    assert [habit["id"] for habit in owned.json()] == [created.json()["id"]]
+    assert intruders.json() == [], "the two identities are the same user"

--- a/backend/tests/scripts/dast/test_discovery.py
+++ b/backend/tests/scripts/dast/test_discovery.py
@@ -1,0 +1,275 @@
+"""Discovery reads the live OpenAPI document; it never trusts a hand-written route list.
+
+A hard-coded list of endpoints is the quiet way this check dies: a router lands,
+nobody edits the list, and the matrix keeps reporting clean over a shrinking
+fraction of the app. So the only input is the document the running app serves,
+and the tests below pin the two decisions that document drives — which
+operations exist, and which of them carry an object reference in the path.
+
+The ``_id`` heuristic is deliberately narrow, and everything it declines is
+*kept* rather than dropped. ``{slug}``, ``{token}``, and ``{stage_number}`` are
+still discovered as templated routes so the policy layer can force an explicit
+allow-list entry for each. Silently skipping them would shrink the matrix
+without anybody noticing.
+
+The final test runs against a real ``FastAPI()`` app's own generated document,
+so a change in how the framework spells parameters or header dependencies fails
+here rather than in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.dast.discovery import RouteSpec, discover_routes, is_object_scoped
+from tests.scripts.dast.conftest import (
+    LEAKY_WIDGET_DELETE,
+    LEAKY_WIDGET_GET,
+    SAFE_ITEM_GET,
+    SAFE_PART_GET,
+    SAFE_PART_POST,
+    build_leaky_app,
+)
+
+AUTH_HEADER_PARAMETER: dict[str, object] = {
+    "name": "authorization",
+    "in": "header",
+    "required": False,
+    "schema": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+}
+
+
+def path_parameter(name: str) -> dict[str, object]:
+    """Return an OpenAPI path-parameter object for ``name``."""
+    return {"name": name, "in": "path", "required": True, "schema": {"type": "integer"}}
+
+
+def document(paths: dict[str, object]) -> dict[str, object]:
+    """Wrap a ``paths`` mapping in a minimal OpenAPI envelope."""
+    return {"openapi": "3.1.0", "info": {"title": "t", "version": "1"}, "paths": paths}
+
+
+def authenticated_operation(*params: str) -> dict[str, object]:
+    """Return an operation that takes a bearer header plus the named path params."""
+    return {
+        "parameters": [*(path_parameter(name) for name in params), AUTH_HEADER_PARAMETER],
+        "responses": {"200": {"description": "ok"}},
+    }
+
+
+def test_an_empty_document_discovers_nothing_rather_than_raising() -> None:
+    """A garbled or empty document must produce zero routes, which a guard then catches."""
+    assert discover_routes(document({})) == ()
+
+
+def test_a_missing_paths_key_discovers_nothing() -> None:
+    """A document without ``paths`` at all is the same non-answer, not a crash."""
+    assert discover_routes({"openapi": "3.1.0"}) == ()
+
+
+def test_a_parameterless_operation_is_discovered_with_no_params() -> None:
+    """Collection routes are still discovered; they simply carry no object reference."""
+    routes = discover_routes(document({"/habits/": {"get": authenticated_operation()}}))
+
+    assert routes == (RouteSpec(method="GET", path="/habits/", params=(), requires_auth=True),)
+    assert is_object_scoped(routes[0]) is False
+
+
+def test_a_single_path_parameter_is_captured() -> None:
+    """The common shape: one owned object addressed by id."""
+    routes = discover_routes(
+        document({"/habits/{habit_id}": {"get": authenticated_operation("habit_id")}}),
+    )
+
+    assert routes == (
+        RouteSpec(
+            method="GET",
+            path="/habits/{habit_id}",
+            params=("habit_id",),
+            requires_auth=True,
+        ),
+    )
+    assert is_object_scoped(routes[0]) is True
+
+
+def test_two_path_parameters_are_captured_in_path_order() -> None:
+    """Order matters: each parameter is resolved independently and then substituted."""
+    path = "/practice-recipes/{recipe_id}/apply-to/{user_practice_id}"
+    routes = discover_routes(
+        document({path: {"post": authenticated_operation("recipe_id", "user_practice_id")}}),
+    )
+
+    assert routes == (
+        RouteSpec(
+            method="POST",
+            path=path,
+            params=("recipe_id", "user_practice_id"),
+            requires_auth=True,
+        ),
+    )
+    assert is_object_scoped(routes[0]) is True
+
+
+@pytest.mark.parametrize("param", ["id", "habit_id", "entry_id", "user_practice_id"])
+def test_parameters_ending_in_id_are_object_scoped(param: str) -> None:
+    """Automatic inclusion is driven by the parameter name, so it needs no maintenance."""
+    spec = RouteSpec(method="GET", path=f"/x/{{{param}}}", params=(param,), requires_auth=True)
+
+    assert is_object_scoped(spec) is True
+
+
+@pytest.mark.parametrize("param", ["slug", "token", "stage_number", "identity", "idea"])
+def test_parameters_that_are_not_ids_are_not_object_scoped(param: str) -> None:
+    """``identity`` and ``idea`` merely contain "id"; the heuristic anchors on the suffix."""
+    spec = RouteSpec(method="GET", path=f"/x/{{{param}}}", params=(param,), requires_auth=True)
+
+    assert is_object_scoped(spec) is False
+
+
+def test_a_route_with_one_id_among_other_params_is_object_scoped() -> None:
+    """Any object reference in the path is enough to make the route worth probing."""
+    spec = RouteSpec(
+        method="GET",
+        path="/course/{slug}/entries/{entry_id}",
+        params=("slug", "entry_id"),
+        requires_auth=True,
+    )
+
+    assert is_object_scoped(spec) is True
+
+
+def test_templated_routes_that_are_not_object_scoped_are_still_discovered() -> None:
+    """Not-an-id is a reason to demand an allow-list entry, never a reason to drop the route.
+
+    Dropping them would shrink the matrix silently, which is the failure mode
+    the allow-list exists to make loud.
+    """
+    routes = discover_routes(
+        document(
+            {
+                "/course/{slug}": {"get": authenticated_operation("slug")},
+                "/invitations/{token}": {"get": authenticated_operation("token")},
+            },
+        ),
+    )
+
+    assert tuple(spec.path for spec in routes) == ("/course/{slug}", "/invitations/{token}")
+    assert [is_object_scoped(spec) for spec in routes] == [False, False]
+
+
+def test_an_operation_without_an_authorization_header_is_unauthenticated() -> None:
+    """Login and health are open by design, so the matrix must be able to tell."""
+    routes = discover_routes(
+        document({"/auth/login": {"post": {"responses": {"200": {"description": "ok"}}}}}),
+    )
+
+    assert routes == (RouteSpec(method="POST", path="/auth/login", params=(), requires_auth=False),)
+
+
+def test_an_operation_level_security_requirement_also_marks_the_route_authenticated() -> None:
+    """Some routers declare a security scheme instead of a bare header parameter."""
+    routes = discover_routes(
+        document(
+            {
+                "/widgets/{widget_id}": {
+                    "get": {
+                        "parameters": [path_parameter("widget_id")],
+                        "security": [{"HTTPBearer": []}],
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+            },
+        ),
+    )
+
+    assert routes[0].requires_auth is True
+
+
+def test_parameters_declared_on_the_path_item_are_inherited_by_every_operation() -> None:
+    """OpenAPI lets a path item hoist shared parameters; discovery must merge them."""
+    routes = discover_routes(
+        document(
+            {
+                "/widgets/{widget_id}": {
+                    "parameters": [AUTH_HEADER_PARAMETER],
+                    "get": {
+                        "parameters": [path_parameter("widget_id")],
+                        "responses": {"200": {"description": "ok"}},
+                    },
+                },
+            },
+        ),
+    )
+
+    assert routes == (
+        RouteSpec(
+            method="GET",
+            path="/widgets/{widget_id}",
+            params=("widget_id",),
+            requires_auth=True,
+        ),
+    )
+
+
+def test_non_operation_keys_in_a_path_item_are_not_mistaken_for_methods() -> None:
+    """``summary``, ``description``, and ``parameters`` are metadata, not verbs."""
+    routes = discover_routes(
+        document(
+            {
+                "/widgets/{widget_id}": {
+                    "summary": "widgets",
+                    "description": "a widget",
+                    "parameters": [AUTH_HEADER_PARAMETER],
+                    "get": authenticated_operation("widget_id"),
+                },
+            },
+        ),
+    )
+
+    assert tuple(spec.method for spec in routes) == ("GET",)
+
+
+def test_routes_are_returned_in_a_stable_path_then_method_order() -> None:
+    """Deterministic ordering keeps the report diffable and the probe order predictable."""
+    routes = discover_routes(
+        document(
+            {
+                "/widgets/{widget_id}": {
+                    "put": authenticated_operation("widget_id"),
+                    "get": authenticated_operation("widget_id"),
+                    "delete": authenticated_operation("widget_id"),
+                },
+                "/safeitems/{item_id}": {"get": authenticated_operation("item_id")},
+            },
+        ),
+    )
+
+    assert tuple((spec.method, spec.path) for spec in routes) == (
+        ("GET", "/safeitems/{item_id}"),
+        ("DELETE", "/widgets/{widget_id}"),
+        ("GET", "/widgets/{widget_id}"),
+        ("PUT", "/widgets/{widget_id}"),
+    )
+
+
+def test_discovery_reads_a_real_fastapi_generated_document() -> None:
+    """The genuine article: FastAPI's own ``/openapi.json`` output, not a guess.
+
+    Building the matrix on a hand-written document would let a framework change
+    in how parameters or header dependencies are spelled slip through unnoticed.
+    """
+    deployment = build_leaky_app()
+
+    routes = discover_routes(deployment.app.openapi())
+    object_scoped = {(spec.method, spec.path) for spec in routes if is_object_scoped(spec)}
+
+    assert object_scoped == {
+        LEAKY_WIDGET_GET,
+        LEAKY_WIDGET_DELETE,
+        SAFE_ITEM_GET,
+        SAFE_PART_GET,
+        SAFE_PART_POST,
+    }
+    assert all(spec.requires_auth for spec in routes if is_object_scoped(spec))
+    login = next(spec for spec in routes if spec.path == "/auth/login")
+    assert login.requires_auth is False

--- a/backend/tests/scripts/dast/test_live_failures.py
+++ b/backend/tests/scripts/dast/test_live_failures.py
@@ -1,0 +1,255 @@
+"""An instance that never answered must not be reported as an authorization finding.
+
+Python exits ``1`` on an uncaught exception, and ``1`` is bit-for-bit
+``EXIT_AUTHZ_FINDING``. So a bootstrap whose database refuses it, or an
+``/openapi.json`` fetch that cannot connect, would tell a CI consumer "we found a
+BOLA" when what actually happened is "the harness never authenticated at all" --
+the exact ambiguity this harness exists to eliminate.
+
+Every live-I/O boundary is therefore driven into failure here and asserted to
+produce ``EXIT_HARNESS_ERROR`` with a line naming the stage, the target, and the
+error: the identity bootstrap, the discovery fetch, and a document that arrives
+but is not one. The precedence assertion at the bottom is the point of the
+exercise -- a failed bootstrap reports no findings and no uncovered routes, and
+must still outrank both of them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from http import HTTPStatus
+
+import pytest
+from httpx import ASGITransport, AsyncBaseTransport, AsyncClient, ConnectError, Request, Response
+
+from scripts.dast.report import EXIT_AUTHZ_FINDING, EXIT_CLEAN, EXIT_HARNESS_ERROR
+from scripts.dast.runner import Identity, run_matrix
+from tests.scripts.dast.conftest import (
+    STUB_BASE_URL,
+    STUB_OBJECT_SCOPED_ROUTES,
+    StubDeployment,
+    close_client,
+    drive_main,
+    drive_main_with,
+    stub_client,
+    stub_config,
+    stub_overrides,
+)
+
+LIVE_GUARD = "require_live_stages_completed"
+
+REFUSED_CONNECTION = "All connection attempts failed"
+DATABASE_HOST = "127.0.0.1"
+DATABASE_PORT = 55499
+
+OPENAPI_PATH = "/openapi.json"
+
+# A driver this deployment does not have: ``create_async_engine`` rejects the URL
+# before any socket is opened, which makes the identity database unusable without
+# the test needing one to be up in the first place.
+UNLOADABLE_DRIVER = "nosuchdb+nodriver"
+# Stands in for the deployment credential a real DSN carries. Both URLs below are
+# composed rather than written out, so neither line is a literal userinfo string.
+DSN_USERINFO = "opaque-userinfo-value"
+REDACTION = "***"
+UNLOADABLE_DATABASE_URL = f"{UNLOADABLE_DRIVER}://dast:{DSN_USERINFO}@127.0.0.1:5432/aptitude"
+REDACTED_DATABASE_URL = f"{UNLOADABLE_DRIVER}://dast:{REDACTION}@127.0.0.1:5432/aptitude"
+
+UNPARSEABLE_DATABASE_URL = "this is not a database url"
+UNPARSEABLE_MARKER = "<unparseable database URL>"
+
+
+async def refusing_bootstrap(_client: AsyncClient) -> tuple[Identity, Identity]:
+    """Fail the way the bootstrap fails when the identity database is down.
+
+    Raises:
+        ConnectionRefusedError: Always -- this is what the driver raises through
+            the ORM when nothing is listening on the database's port.
+    """
+    raise ConnectionRefusedError(f"Connect call failed ('{DATABASE_HOST}', {DATABASE_PORT})")
+
+
+class InterceptingTransport(AsyncBaseTransport):
+    """Delegate to a stub app, except for one path handled by a callback.
+
+    The harness talks to its target through exactly one client, so making a
+    single path unreachable -- while login and the probe route keep working --
+    is the only way to drive one live stage into failure without first breaking
+    the stages that run before it.
+    """
+
+    def __init__(
+        self,
+        inner: AsyncBaseTransport,
+        path: str,
+        respond: Callable[[Request], Response],
+    ) -> None:
+        """Wrap ``inner``, routing requests for ``path`` to ``respond`` instead."""
+        self._inner = inner
+        self._path = path
+        self._respond = respond
+
+    async def handle_async_request(self, request: Request) -> Response:
+        """Answer one request: from the callback for ``path``, from the app otherwise."""
+        if request.url.path == self._path:
+            return self._respond(request)
+        return await self._inner.handle_async_request(request)
+
+
+def refuse(request: Request) -> Response:
+    """Fail a request the way an unreachable instance does.
+
+    Raises:
+        ConnectError: Always.
+    """
+    raise ConnectError(REFUSED_CONNECTION, request=request)
+
+
+def serve_a_list(_request: Request) -> Response:
+    """Answer with valid JSON that is not an OpenAPI document."""
+    return Response(HTTPStatus.OK, json=[])
+
+
+def client_with_broken_discovery(
+    deployment: StubDeployment,
+    respond: Callable[[Request], Response],
+) -> AsyncClient:
+    """Return a client onto ``deployment`` whose ``/openapi.json`` is broken."""
+    transport = InterceptingTransport(
+        ASGITransport(app=deployment.app),
+        OPENAPI_PATH,
+        respond,
+    )
+    return AsyncClient(transport=transport, base_url=STUB_BASE_URL)
+
+
+def drive_production_bootstrap(
+    deployment: StubDeployment,
+    *,
+    database_url: str,
+) -> int:
+    """Run the CLI with its own identity bootstrap against a broken database URL."""
+    client = stub_client(deployment)
+    try:
+        return drive_main_with(
+            stub_overrides(client, bootstrap=None),
+            min_routes=STUB_OBJECT_SCOPED_ROUTES,
+            database_url=database_url,
+        )
+    finally:
+        close_client(client)
+
+
+def test_a_bootstrap_that_cannot_reach_its_database_exits_three_not_one(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Exit 1 here would read as a genuine BOLA in the CI log."""
+    exit_code = drive_main(
+        leaky_deployment,
+        min_routes=STUB_OBJECT_SCOPED_ROUTES,
+        bootstrap=refusing_bootstrap,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert exit_code != EXIT_AUTHZ_FINDING
+    assert captured.out == "", f"a harness error must not report on stdout: {captured.out!r}"
+    assert f"HARNESS ERROR  {LIVE_GUARD}" in captured.err, captured.err
+    assert "the identity bootstrap" in captured.err, captured.err
+    assert str(DATABASE_PORT) in captured.err, captured.err
+
+
+def test_an_openapi_fetch_that_cannot_connect_exits_three_not_one(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Discovery is live I/O too, and it fails before a single cell has run."""
+    exit_code = drive_main(
+        leaky_deployment,
+        min_routes=STUB_OBJECT_SCOPED_ROUTES,
+        client=client_with_broken_discovery(leaky_deployment, refuse),
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert exit_code != EXIT_AUTHZ_FINDING
+    assert f"HARNESS ERROR  {LIVE_GUARD}" in captured.err, captured.err
+    assert OPENAPI_PATH in captured.err, captured.err
+    assert REFUSED_CONNECTION in captured.err, captured.err
+
+
+def test_a_document_that_is_not_a_document_is_a_harness_error_not_a_crash(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A proxy answering 200 with something else must not take the run down."""
+    exit_code = drive_main(
+        leaky_deployment,
+        min_routes=STUB_OBJECT_SCOPED_ROUTES,
+        client=client_with_broken_discovery(leaky_deployment, serve_a_list),
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert exit_code != EXIT_AUTHZ_FINDING
+    assert "HARNESS ERROR  require_minimum_coverage" in captured.err, captured.err
+
+
+def test_an_unusable_identity_database_is_named_without_its_credential(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The production bootstrap names the DSN it could not use, credential removed.
+
+    A report is pasted into issues and CI logs, so the URL has to be actionable
+    and the credential in it must not survive the trip.
+    """
+    exit_code = drive_production_bootstrap(
+        leaky_deployment,
+        database_url=UNLOADABLE_DATABASE_URL,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert "the identity bootstrap" in captured.err, captured.err
+    assert REDACTED_DATABASE_URL in captured.err, captured.err
+    assert DSN_USERINFO not in captured.err, "the DSN credential reached the report"
+
+
+def test_an_unparseable_database_url_is_still_a_harness_error(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A DSN that cannot even be parsed must not be echoed back verbatim either."""
+    exit_code = drive_production_bootstrap(
+        leaky_deployment,
+        database_url=UNPARSEABLE_DATABASE_URL,
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert UNPARSEABLE_MARKER in captured.err, captured.err
+    assert UNPARSEABLE_DATABASE_URL not in captured.err, captured.err
+
+
+@pytest.mark.asyncio
+async def test_a_failed_bootstrap_outranks_a_clean_run_with_no_findings(
+    leaky_client: AsyncClient,
+) -> None:
+    """Precedence, at the one point where "nothing was found" would be a lie.
+
+    The run produced no findings and no uncovered routes precisely because it
+    never probed anything, so the guard has to be what decides the exit code.
+    """
+    report = await run_matrix(
+        leaky_client,
+        bootstrap=refusing_bootstrap,
+        config=stub_config(),
+    )
+
+    assert report.findings == ()
+    assert report.uncovered == ()
+    assert [failure.guard for failure in report.guard_failures] == [LIVE_GUARD]
+    assert report.exit_code == EXIT_HARNESS_ERROR
+    assert report.exit_code not in {EXIT_CLEAN, EXIT_AUTHZ_FINDING}

--- a/backend/tests/scripts/dast/test_policy.py
+++ b/backend/tests/scripts/dast/test_policy.py
@@ -1,0 +1,321 @@
+"""The allow-list is an opt-out with a stated reason, not a place to hide routes.
+
+Every route the matrix cannot probe has to be named, categorised, and justified
+in ``allowlist.toml``, and the loader refuses anything less. That refusal is the
+whole value: an entry with a blank reason, an invented category, or a stray key
+is how "we'll come back to this" becomes permanent, and how a shrinking matrix
+keeps reporting clean.
+
+The one carve-out is ``known_leak``, the only category allowed to carry a
+``tracking_issue``. It records a leak we have accepted for now and points at
+where the work is tracked, which is why every other category is forbidden that
+field — nothing may be quietly parked under ``no_seed_strategy``.
+
+The classification tests pin the precedence that follows from all of this: an
+allow-list entry wins over a seed strategy. Removing a route from the allow-list
+must be a deliberate act, so its presence there is the answer even when the
+harness could have probed it.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.dast.discovery import RouteSpec
+from scripts.dast.policy import (
+    ALLOWLIST_CATEGORIES,
+    DEFAULT_ALLOWLIST_PATH,
+    KNOWN_LEAK_CATEGORY,
+    AllowlistEntry,
+    AllowlistError,
+    Coverage,
+    classify_route,
+    classify_routes,
+    load_allowlist,
+)
+from scripts.dast.seeds import SeedSpec
+
+EXPECTED_CATEGORIES = frozenset(
+    {
+        "shared_catalog",
+        "not_object_scoped",
+        "admin_only",
+        "capability_token",
+        "no_seed_strategy",
+        "known_leak",
+    },
+)
+
+TRACKED_ISSUE_NUMBER = 4242
+
+SEEDED_REGISTRY: dict[str, SeedSpec] = {
+    "habit_id": SeedSpec(
+        create_method="POST",
+        create_path="/habits/",
+        payload={"name": "Drink Water"},
+        id_pointer=("id",),
+    ),
+}
+
+HABIT_ROUTE = RouteSpec(
+    method="GET",
+    path="/habits/{habit_id}",
+    params=("habit_id",),
+    requires_auth=True,
+)
+CATALOG_ROUTE = RouteSpec(
+    method="GET",
+    path="/course/content/{content_id}",
+    params=("content_id",),
+    requires_auth=True,
+)
+SLUG_ROUTE = RouteSpec(
+    method="GET",
+    path="/course/{slug}",
+    params=("slug",),
+    requires_auth=True,
+)
+COLLECTION_ROUTE = RouteSpec(method="GET", path="/habits/", params=(), requires_auth=True)
+
+CATALOG_ENTRY = AllowlistEntry(
+    method="GET",
+    path="/course/content/{content_id}",
+    category="shared_catalog",
+    reason="global course catalog; no per-user owner",
+)
+
+
+def write_allowlist(tmp_path: Path, body: str) -> Path:
+    """Write a dedented ``allowlist.toml`` under ``tmp_path`` and return its path."""
+    path = tmp_path / "allowlist.toml"
+    path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return path
+
+
+def test_a_complete_entry_loads_with_every_field_preserved(tmp_path: Path) -> None:
+    """The four required keys are the whole contract for an ordinary opt-out."""
+    path = write_allowlist(
+        tmp_path,
+        """
+        [[route]]
+        method   = "GET"
+        path     = "/course/content/{content_id}"
+        category = "shared_catalog"
+        reason   = "global course catalog; no per-user owner"
+        """,
+    )
+
+    assert load_allowlist(path) == (CATALOG_ENTRY,)
+
+
+def test_an_allowlist_with_no_entries_loads_as_empty(tmp_path: Path) -> None:
+    """Zero opt-outs is the goal state, so it must be expressible without error."""
+    assert load_allowlist(write_allowlist(tmp_path, "\n")) == ()
+
+
+@pytest.mark.parametrize("missing", ["method", "path", "category", "reason"])
+def test_an_entry_missing_a_required_key_is_rejected(tmp_path: Path, missing: str) -> None:
+    """Every key is load-bearing: without all four the entry cannot be reviewed."""
+    fields = {
+        "method": '"GET"',
+        "path": '"/course/content/{content_id}"',
+        "category": '"shared_catalog"',
+        "reason": '"global course catalog"',
+    }
+    del fields[missing]
+    body = "[[route]]\n" + "".join(f"{key} = {value}\n" for key, value in fields.items())
+
+    with pytest.raises(AllowlistError, match=missing):
+        load_allowlist(write_allowlist(tmp_path, body))
+
+
+def test_an_empty_reason_is_rejected(tmp_path: Path) -> None:
+    """A blank justification is worse than none: it looks reviewed and is not."""
+    path = write_allowlist(
+        tmp_path,
+        """
+        [[route]]
+        method   = "GET"
+        path     = "/course/content/{content_id}"
+        category = "shared_catalog"
+        reason   = ""
+        """,
+    )
+
+    with pytest.raises(AllowlistError, match="reason"):
+        load_allowlist(path)
+
+
+def test_an_unrecognised_category_is_rejected_and_named(tmp_path: Path) -> None:
+    """Free-text categories defeat the point; the vocabulary is closed."""
+    path = write_allowlist(
+        tmp_path,
+        """
+        [[route]]
+        method   = "GET"
+        path     = "/course/content/{content_id}"
+        category = "we_will_fix_it_later"
+        reason   = "not now"
+        """,
+    )
+
+    with pytest.raises(AllowlistError, match="we_will_fix_it_later"):
+        load_allowlist(path)
+
+
+def test_an_unknown_key_is_rejected(tmp_path: Path) -> None:
+    """A typo'd key would otherwise be silently ignored and change nothing."""
+    path = write_allowlist(
+        tmp_path,
+        """
+        [[route]]
+        method   = "GET"
+        path     = "/course/content/{content_id}"
+        category = "shared_catalog"
+        reason   = "global course catalog"
+        resaon   = "typo"
+        """,
+    )
+
+    with pytest.raises(AllowlistError, match="resaon"):
+        load_allowlist(path)
+
+
+def test_a_tracking_issue_on_a_non_leak_category_is_rejected(tmp_path: Path) -> None:
+    """Only an accepted leak may cite tracked work; nothing else gets to look tracked."""
+    path = write_allowlist(
+        tmp_path,
+        f"""
+        [[route]]
+        method         = "GET"
+        path           = "/course/content/{{content_id}}"
+        category       = "shared_catalog"
+        reason         = "global course catalog"
+        tracking_issue = {TRACKED_ISSUE_NUMBER}
+        """,
+    )
+
+    with pytest.raises(AllowlistError, match="tracking_issue"):
+        load_allowlist(path)
+
+
+def test_a_known_leak_may_carry_a_tracking_issue(tmp_path: Path) -> None:
+    """An accepted leak is allowed exactly once: named, categorised, and pointed at work."""
+    path = write_allowlist(
+        tmp_path,
+        f"""
+        [[route]]
+        method         = "GET"
+        path           = "/widgets/{{widget_id}}"
+        category       = "known_leak"
+        reason         = "accepted for now; remediation tracked"
+        tracking_issue = {TRACKED_ISSUE_NUMBER}
+        """,
+    )
+
+    entries = load_allowlist(path)
+
+    assert entries == (
+        AllowlistEntry(
+            method="GET",
+            path="/widgets/{widget_id}",
+            category=KNOWN_LEAK_CATEGORY,
+            reason="accepted for now; remediation tracked",
+            tracking_issue=TRACKED_ISSUE_NUMBER,
+        ),
+    )
+
+
+def test_the_category_vocabulary_is_exactly_the_documented_set() -> None:
+    """Adding a category is a design decision, so it has to be made here first."""
+    assert ALLOWLIST_CATEGORIES == EXPECTED_CATEGORIES
+    assert KNOWN_LEAK_CATEGORY in ALLOWLIST_CATEGORIES
+
+
+def test_a_seedable_object_scoped_route_is_covered() -> None:
+    """Every path parameter has a seed strategy, so the route can be probed for real."""
+    coverage = classify_route(HABIT_ROUTE, seed_registry=SEEDED_REGISTRY, allowlist=())
+
+    assert coverage is Coverage.COVERED
+
+
+def test_a_route_whose_parameter_has_no_seed_strategy_is_uncovered() -> None:
+    """A missing seed spec must surface as uncovered rather than as a silent skip."""
+    coverage = classify_route(CATALOG_ROUTE, seed_registry=SEEDED_REGISTRY, allowlist=())
+
+    assert coverage is Coverage.UNCOVERED
+
+
+def test_a_templated_route_that_is_not_object_scoped_is_uncovered() -> None:
+    """``{slug}`` is not an id, so it needs a stated reason rather than a quiet pass."""
+    coverage = classify_route(SLUG_ROUTE, seed_registry=SEEDED_REGISTRY, allowlist=())
+
+    assert coverage is Coverage.UNCOVERED
+
+
+def test_an_allowlist_entry_wins_over_a_working_seed_strategy() -> None:
+    """Opting out is deliberate, so it is never overridden by the harness's ability to probe.
+
+    The inverse precedence would let a route quietly re-enter the matrix and
+    leave a stale entry behind, which the liveness guard would then flag.
+    """
+    entry = AllowlistEntry(
+        method="GET",
+        path="/habits/{habit_id}",
+        category="admin_only",
+        reason="probed by the in-process suite instead",
+    )
+
+    coverage = classify_route(HABIT_ROUTE, seed_registry=SEEDED_REGISTRY, allowlist=(entry,))
+
+    assert coverage is Coverage.ALLOWLISTED
+
+
+def test_classify_routes_splits_the_document_into_three_disjoint_buckets() -> None:
+    """The three counts in the report must add up to the routes considered."""
+    classification = classify_routes(
+        (HABIT_ROUTE, CATALOG_ROUTE, SLUG_ROUTE, COLLECTION_ROUTE),
+        seed_registry=SEEDED_REGISTRY,
+        allowlist=(CATALOG_ENTRY,),
+    )
+
+    assert classification.covered == (HABIT_ROUTE,)
+    assert classification.allowlisted == (CATALOG_ROUTE,)
+    assert classification.uncovered == (SLUG_ROUTE,)
+
+
+def test_routes_with_no_path_parameters_are_not_classified_at_all() -> None:
+    """A collection route carries no object reference, so it is neither probed nor excused."""
+    classification = classify_routes(
+        (COLLECTION_ROUTE,),
+        seed_registry=SEEDED_REGISTRY,
+        allowlist=(),
+    )
+
+    assert classification.covered == ()
+    assert classification.allowlisted == ()
+    assert classification.uncovered == ()
+
+
+def test_the_shipped_allowlist_lives_beside_the_harness_and_loads() -> None:
+    """The file the CLI defaults to must exist and satisfy its own schema."""
+    assert DEFAULT_ALLOWLIST_PATH.name == "allowlist.toml"
+    assert DEFAULT_ALLOWLIST_PATH.parent.name == "dast"
+    assert DEFAULT_ALLOWLIST_PATH.is_file()
+
+    load_allowlist(DEFAULT_ALLOWLIST_PATH)
+
+
+def test_the_shipped_allowlist_accepts_no_known_leaks() -> None:
+    """Landing with an accepted BOLA would make the whole gate advisory.
+
+    The category exists so a deliberate, tracked exception is possible without
+    disabling the check; using it here at landing would defeat the point.
+    """
+    entries = load_allowlist(DEFAULT_ALLOWLIST_PATH)
+
+    accepted = [entry for entry in entries if entry.category == KNOWN_LEAK_CATEGORY]
+    assert accepted == [], f"known leaks are allow-listed: {accepted}"

--- a/backend/tests/scripts/dast/test_registry_covers_real_app.py
+++ b/backend/tests/scripts/dast/test_registry_covers_real_app.py
@@ -1,0 +1,135 @@
+"""A router added today is covered today, enforced in the fast suite with no server.
+
+The way an authorization check like this dies is silent drift: a new router
+lands, nobody adds a seed spec, and the matrix keeps reporting clean over a
+shrinking share of the application. The DAST job itself cannot catch that — it
+would need a database, a live instance, and two minutes — so the coverage
+obligation is enforced here instead, in a plain unit test that reads the real
+app's own OpenAPI document in-process.
+
+The contract is deliberately blunt: every templated route is either seedable or
+carries a written, categorised allow-list entry. There is no third option and no
+implicit skip, so adding an endpoint with an id in its path fails this test until
+somebody makes a decision about it.
+
+The floor assertion below is what stops the test from congratulating itself. If
+the document ever came back empty — a botched import, a lazily-mounted router —
+"nothing uncovered" would be trivially true, so a run that discovers fewer routes
+than the harness's own minimum is treated as a broken test rather than a pass.
+"""
+
+from __future__ import annotations
+
+from main import app
+from scripts.dast.discovery import discover_routes, is_object_scoped
+from scripts.dast.policy import DEFAULT_ALLOWLIST_PATH, classify_routes, load_allowlist
+from scripts.dast.runner import DEFAULT_MAX_ALLOWLIST_FRACTION, DEFAULT_MIN_ROUTES
+from scripts.dast.seeds import REPLAY_BODIES, SEED_REGISTRY
+from scripts.dast.verdict import require_allowlist_bounded, require_allowlist_is_live
+
+MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def test_the_real_document_yields_enough_routes_for_the_assertions_to_mean_anything() -> None:
+    """A floor under discovery, so an empty document cannot read as full coverage."""
+    object_scoped = [spec for spec in discover_routes(app.openapi()) if is_object_scoped(spec)]
+
+    assert len(object_scoped) >= DEFAULT_MIN_ROUTES, (
+        f"only {len(object_scoped)} object-scoped routes were discovered; "
+        "the document is probably not being generated correctly"
+    )
+
+
+def test_every_object_scoped_route_is_either_seeded_or_allowlisted() -> None:
+    """The whole point: a new router is covered the day it is added, or the build stops."""
+    classification = classify_routes(
+        discover_routes(app.openapi()),
+        seed_registry=SEED_REGISTRY,
+        allowlist=load_allowlist(DEFAULT_ALLOWLIST_PATH),
+    )
+
+    uncovered = sorted(f"{spec.method} {spec.path}" for spec in classification.uncovered)
+    assert uncovered == [], (
+        f"these routes have neither a seed strategy nor an allow-list entry: {uncovered}"
+    )
+
+
+def test_no_allowlist_entry_has_outlived_the_route_it_excuses() -> None:
+    """A renamed route must not leave a permanent excuse behind in the allow-list."""
+    failure = require_allowlist_is_live(
+        load_allowlist(DEFAULT_ALLOWLIST_PATH),
+        discover_routes(app.openapi()),
+    )
+
+    assert failure is None, failure
+
+
+def test_the_allowlist_covers_a_minority_of_the_application() -> None:
+    """Excusing most of the app would leave a green check over an unchecked surface."""
+    classification = classify_routes(
+        discover_routes(app.openapi()),
+        seed_registry=SEED_REGISTRY,
+        allowlist=load_allowlist(DEFAULT_ALLOWLIST_PATH),
+    )
+    considered = (
+        len(classification.covered)
+        + len(classification.allowlisted)
+        + len(classification.uncovered)
+    )
+
+    failure = require_allowlist_bounded(
+        len(classification.allowlisted),
+        considered,
+        max_fraction=DEFAULT_MAX_ALLOWLIST_FRACTION,
+    )
+
+    assert failure is None, failure
+
+
+def test_every_seed_spec_is_reachable_from_a_real_path_parameter() -> None:
+    """A seed spec for a parameter no route uses is dead weight that still costs a request.
+
+    It also hides a rename: the old parameter keeps its spec, the new one has
+    none, and the route silently becomes uncovered.
+    """
+    live_params = {param for spec in discover_routes(app.openapi()) for param in spec.params}
+
+    orphans = sorted(set(SEED_REGISTRY) - live_params)
+    assert orphans == [], f"seed specs for parameters no route declares: {orphans}"
+
+
+def test_every_seed_dependency_names_another_seed_spec() -> None:
+    """A dependency the registry cannot satisfy would fail at run time, not at review."""
+    for param, spec in SEED_REGISTRY.items():
+        missing = sorted(set(spec.depends_on) - set(SEED_REGISTRY))
+        assert missing == [], f"{param} depends on unregistered parameters: {missing}"
+
+
+def test_every_templated_create_path_declares_its_dependencies() -> None:
+    """A create path that interpolates a parameter must say so, or ordering is luck."""
+    for param, spec in SEED_REGISTRY.items():
+        interpolated = {piece.split("}")[0] for piece in spec.create_path.split("{")[1:]}
+        undeclared = sorted(interpolated - set(spec.depends_on))
+        assert undeclared == [], (
+            f"{param} interpolates {undeclared} into its create path "
+            "without declaring them in depends_on"
+        )
+
+
+def test_no_seed_spec_depends_on_itself() -> None:
+    """A self-referential spec would deadlock the topological resolution."""
+    for param, spec in SEED_REGISTRY.items():
+        assert param not in spec.depends_on, f"{param} depends on itself"
+
+
+def test_every_replay_body_targets_a_real_mutating_route() -> None:
+    """A body keyed to a route that no longer exists silently stops being sent.
+
+    The replay then goes out empty, gets a 422 before the ownership check runs,
+    and the positive control turns the whole route inconclusive.
+    """
+    live = {(spec.method, spec.path) for spec in discover_routes(app.openapi())}
+
+    for method, path in REPLAY_BODIES:
+        assert method in MUTATING_METHODS, f"{method} {path} takes no request body"
+        assert (method, path) in live, f"{method} {path} is not a route of this app"

--- a/backend/tests/scripts/dast/test_report.py
+++ b/backend/tests/scripts/dast/test_report.py
@@ -1,0 +1,274 @@
+"""A finding is only useful if the reader can act on it without rerunning anything.
+
+Every failure block therefore names the method, the path template, the exact id
+that was sent, whose object it was, and the status the server actually returned
+-- and then hands over a curl line that reproduces it in one paste. "IDOR on
+/journal" is a ticket nobody can close.
+
+Two quieter properties matter as much as the failure format. The summary block
+prints how many routes were discovered, seeded, uncovered, and allow-listed, so
+a green run is readable as "37 routes were genuinely probed" rather than as an
+unqualified thumbs-up. And every report carries a scope note: this check reads
+object references out of the *path*, so a clean result must never be mistaken
+for "no BOLA anywhere in the app".
+
+The exit-code precedence is pinned here too. A tripped vacuity guard outranks a
+finding, because a run that proved nothing cannot also be trusted to have found
+everything.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from scripts.dast.discovery import RouteSpec
+from scripts.dast.report import (
+    EXIT_AUTHZ_FINDING,
+    EXIT_CLEAN,
+    EXIT_HARNESS_ERROR,
+    EXIT_UNCOVERED,
+    PASS_HEADLINE,
+    SCOPE_NOTE,
+    MatrixReport,
+    render_curl,
+    render_report,
+)
+from scripts.dast.verdict import Cell, CellResult, GuardFailure, Verdict
+
+BASE_URL = "http://127.0.0.1:8000"
+
+MARGINALIA_ROUTE = RouteSpec(
+    method="GET",
+    path="/journal/{entry_id}/marginalia",
+    params=("entry_id",),
+    requires_auth=True,
+)
+WIDGET_DELETE_ROUTE = RouteSpec(
+    method="DELETE",
+    path="/widgets/{widget_id}",
+    params=("widget_id",),
+    requires_auth=True,
+)
+WIDGET_GET_ROUTE = RouteSpec(
+    method="GET",
+    path="/widgets/{widget_id}",
+    params=("widget_id",),
+    requires_auth=True,
+)
+SLUG_ROUTE = RouteSpec(method="GET", path="/course/{slug}", params=("slug",), requires_auth=True)
+
+MARGINALIA_LEAK = CellResult(
+    route=MARGINALIA_ROUTE,
+    cell=Cell.CROSS_USER,
+    resolved_path="/journal/14/marginalia",
+    object_ids=(("entry_id", "14"),),
+    status=HTTPStatus.OK,
+    verdict=Verdict.LEAK,
+)
+WIDGET_DELETE_LEAK = CellResult(
+    route=WIDGET_DELETE_ROUTE,
+    cell=Cell.CROSS_USER,
+    resolved_path="/widgets/7",
+    object_ids=(("widget_id", "7"),),
+    status=HTTPStatus.NO_CONTENT,
+    verdict=Verdict.LEAK,
+)
+WIDGET_UNAUTH_LEAK = CellResult(
+    route=WIDGET_GET_ROUTE,
+    cell=Cell.UNAUTH,
+    resolved_path="/widgets/7",
+    object_ids=(("widget_id", "7"),),
+    status=HTTPStatus.OK,
+    verdict=Verdict.LEAK,
+)
+WIDGET_PASS = CellResult(
+    route=WIDGET_GET_ROUTE,
+    cell=Cell.CROSS_USER,
+    resolved_path="/widgets/7",
+    object_ids=(("widget_id", "7"),),
+    status=HTTPStatus.NOT_FOUND,
+    verdict=Verdict.PASS,
+)
+
+THROTTLE_GUARD = GuardFailure(
+    guard="require_no_throttling",
+    detail="3 of 164 responses were 429; results are inconclusive",
+)
+
+SAMPLE_ELAPSED_SECONDS = 12.5
+SAMPLE_DISCOVERED = 5
+SAMPLE_SEEDED = 4
+SAMPLE_ALLOWLISTED = 0
+
+
+def build_report(
+    *,
+    results: tuple[CellResult, ...] = (),
+    uncovered: tuple[str, ...] = (),
+    guard_failures: tuple[GuardFailure, ...] = (),
+) -> MatrixReport:
+    """Assemble a report with everything but the field under test held constant."""
+    return MatrixReport(
+        base_url=BASE_URL,
+        discovered=SAMPLE_DISCOVERED,
+        seeded=SAMPLE_SEEDED,
+        uncovered=uncovered,
+        allowlisted=SAMPLE_ALLOWLISTED,
+        results=results,
+        guard_failures=guard_failures,
+        elapsed_seconds=SAMPLE_ELAPSED_SECONDS,
+    )
+
+
+def test_the_exit_codes_are_the_documented_shell_contract() -> None:
+    """CI reads these numbers, so they are as much a contract as the report text."""
+    assert EXIT_CLEAN == 0
+    assert EXIT_AUTHZ_FINDING == 1
+    assert EXIT_UNCOVERED == 2
+    assert EXIT_HARNESS_ERROR == 3
+
+
+def test_the_summary_block_quantifies_what_was_actually_probed() -> None:
+    """A green run has to state its own coverage, or it is just an unqualified claim."""
+    report = MatrixReport(
+        base_url=BASE_URL,
+        discovered=41,
+        seeded=37,
+        uncovered=(),
+        allowlisted=4,
+        results=(),
+        guard_failures=(),
+        elapsed_seconds=SAMPLE_ELAPSED_SECONDS,
+    )
+
+    assert (
+        "  routes discovered from /openapi.json : 41 object-scoped\n"
+        "  seeded as user A                     : 37\n"
+        "  UNCOVERED (no seed strategy)         : 0\n"
+        "  allow-listed                         : 4\n"
+    ) in render_report(report)
+
+
+def test_a_cross_user_leak_names_the_route_the_id_the_owner_and_the_status() -> None:
+    """Everything needed to triage the finding sits in the block itself."""
+    rendered = render_report(build_report(results=(MARGINALIA_LEAK,)))
+
+    assert (
+        "  FAIL  GET    /journal/{entry_id}/marginalia\n"
+        "        user B token + user A entry_id=14  ->  200 OK   (expected 403/404)\n"
+        '        repro: curl -H "Authorization: Bearer $B_TOKEN" \\\n'
+        "                    http://127.0.0.1:8000/journal/14/marginalia\n"
+    ) in rendered
+
+
+def test_a_mutating_leak_renders_the_verb_in_both_the_headline_and_the_repro() -> None:
+    """A DELETE finding that reproduces as a GET wastes the reader's first attempt."""
+    rendered = render_report(build_report(results=(WIDGET_DELETE_LEAK,)))
+
+    assert (
+        "  FAIL  DELETE /widgets/{widget_id}\n"
+        "        user B token + user A widget_id=7  ->  204 No Content   (expected 403/404)\n"
+        '        repro: curl -X DELETE -H "Authorization: Bearer $B_TOKEN" \\\n'
+        "                    http://127.0.0.1:8000/widgets/7\n"
+    ) in rendered
+
+
+def test_an_unauthenticated_leak_states_that_no_token_was_sent() -> None:
+    """The cell has to be legible from the text; "user B token" here would mislead."""
+    rendered = render_report(build_report(results=(WIDGET_UNAUTH_LEAK,)))
+
+    assert (
+        "  FAIL  GET    /widgets/{widget_id}\n"
+        "        no token + user A widget_id=7  ->  200 OK   (expected 401)\n"
+        "        repro: curl \\\n"
+        "                    http://127.0.0.1:8000/widgets/7\n"
+    ) in rendered
+
+
+def test_render_curl_builds_a_single_pasteable_command() -> None:
+    """The wrapped repro and the one-line command must stay the same command."""
+    assert render_curl(MARGINALIA_LEAK, base_url=BASE_URL) == (
+        'curl -H "Authorization: Bearer $B_TOKEN" http://127.0.0.1:8000/journal/14/marginalia'
+    )
+    assert render_curl(WIDGET_DELETE_LEAK, base_url=BASE_URL) == (
+        'curl -X DELETE -H "Authorization: Bearer $B_TOKEN" http://127.0.0.1:8000/widgets/7'
+    )
+    assert render_curl(WIDGET_UNAUTH_LEAK, base_url=BASE_URL) == (
+        "curl http://127.0.0.1:8000/widgets/7"
+    )
+
+
+def test_every_report_carries_the_scope_note() -> None:
+    """A green must never be read as "no BOLA anywhere"; the check reads paths only."""
+    assert SCOPE_NOTE == (
+        "scope: object references in the path only; ids carried in query params "
+        "or request bodies are not covered"
+    )
+    assert f"  {SCOPE_NOTE}\n" in render_report(build_report())
+    assert f"  {SCOPE_NOTE}\n" in render_report(build_report(results=(MARGINALIA_LEAK,)))
+
+
+def test_a_run_with_only_passing_cells_is_clean_and_says_so() -> None:
+    """The passing report states what was proven rather than staying silent."""
+    report = build_report(results=(WIDGET_PASS,))
+    rendered = render_report(report)
+
+    assert report.findings == ()
+    assert report.exit_code == EXIT_CLEAN
+    assert f"  {PASS_HEADLINE}\n" in rendered
+    assert "FAIL" not in rendered
+
+
+def test_findings_are_exactly_the_cells_that_did_not_pass() -> None:
+    """Passing cells are counted, not printed; findings are the report's payload."""
+    report = build_report(results=(WIDGET_PASS, MARGINALIA_LEAK, WIDGET_DELETE_LEAK))
+
+    assert report.findings == (MARGINALIA_LEAK, WIDGET_DELETE_LEAK)
+    assert report.exit_code == EXIT_AUTHZ_FINDING
+
+
+def test_uncovered_routes_are_listed_and_fail_with_their_own_exit_code() -> None:
+    """A route with no seed strategy and no allow-list entry is unfinished work."""
+    report = build_report(uncovered=(f"{SLUG_ROUTE.method} {SLUG_ROUTE.path}",))
+    rendered = render_report(report)
+
+    assert report.exit_code == EXIT_UNCOVERED
+    assert "  UNCOVERED  GET    /course/{slug}\n" in rendered
+
+
+def test_a_tripped_guard_is_a_harness_error_even_with_nothing_else_wrong() -> None:
+    """Zero findings plus a tripped guard is the false pass, so it must exit 3.
+
+    This is the single most important line in the module: a run that could not
+    prove anything has to be louder than a run that proved everything was fine.
+    """
+    report = build_report(guard_failures=(THROTTLE_GUARD,))
+    rendered = render_report(report)
+
+    assert report.findings == ()
+    assert report.exit_code == EXIT_HARNESS_ERROR
+    assert report.exit_code != EXIT_CLEAN
+    assert (
+        "  HARNESS ERROR  require_no_throttling: "
+        "3 of 164 responses were 429; results are inconclusive\n"
+    ) in rendered
+
+
+def test_a_guard_failure_outranks_a_finding_in_the_exit_code() -> None:
+    """When the run is untrustworthy, "we found one leak" is not the headline."""
+    report = build_report(results=(MARGINALIA_LEAK,), guard_failures=(THROTTLE_GUARD,))
+
+    assert report.exit_code == EXIT_HARNESS_ERROR
+
+
+def test_a_finding_outranks_an_uncovered_route_in_the_exit_code() -> None:
+    """A proven leak is more urgent than a gap in coverage, and both are reported."""
+    report = build_report(
+        results=(MARGINALIA_LEAK,),
+        uncovered=(f"{SLUG_ROUTE.method} {SLUG_ROUTE.path}",),
+    )
+    rendered = render_report(report)
+
+    assert report.exit_code == EXIT_AUTHZ_FINDING
+    assert "  FAIL  GET    /journal/{entry_id}/marginalia\n" in rendered
+    assert "  UNCOVERED  GET    /course/{slug}\n" in rendered

--- a/backend/tests/scripts/dast/test_runner_catches_leak.py
+++ b/backend/tests/scripts/dast/test_runner_catches_leak.py
@@ -1,0 +1,317 @@
+"""The harness must catch a real BOLA, not merely fail to find one.
+
+This is the positive control for the whole check. Every other test in this
+package could pass against a harness that quietly probes nothing; these cannot.
+They drive the matrix at a genuine FastAPI app whose ``GET /widgets/{widget_id}``
+and ``DELETE /widgets/{widget_id}`` authenticate the caller and then serve or
+destroy rows belonging to somebody else, and they assert an explicit expected
+verdict for every single matrix cell — never "no findings were reported", which
+is exactly the sentence a vacuous pass would also satisfy.
+
+Two properties are pinned here that nothing else pins:
+
+* The cross-user cell on each leaky route is ``LEAK``, and the store proves it:
+  the widget the intruder read still belongs to the owner, and the widget the
+  intruder deleted is recorded as deleted *by the intruder*. A harness that
+  merely sends requests without reaching the row cannot make those assertions
+  true.
+* The correct routes stay silent. ``GET /safeitems/{item_id}`` and the part
+  routes deny cross-user access with 404 and 403, and every one of their cells
+  must pass. A checker that cries wolf is discarded within a week, which is a
+  slower path to the same false confidence.
+
+The leaky ``DELETE`` also pins the seeding contract: because its cross-user cell
+destroys the row, its positive control can only be 2xx if the harness seeded a
+*fresh* object for that cell. Sharing one object across a route's four cells
+would turn a genuine mutating leak into an inconclusive run.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from scripts.dast.report import EXIT_AUTHZ_FINDING, MatrixReport
+from scripts.dast.runner import run_matrix
+from scripts.dast.verdict import CELL_ORDER, Cell, CellResult, Verdict
+from tests.scripts.dast.conftest import (
+    LEAKY_WIDGET_DELETE,
+    LEAKY_WIDGET_GET,
+    SAFE_ITEM_GET,
+    SAFE_PART_GET,
+    SAFE_PART_POST,
+    STUB_BASE_URL,
+    STUB_OBJECT_SCOPED_ROUTES,
+    STUB_REPLAY_LABEL,
+    StubDeployment,
+    drive_main,
+    make_stub_bootstrap,
+    stub_config,
+)
+
+EXPECTED_FINDINGS = 2
+NO_UNCOVERED_ROUTES: tuple[str, ...] = ()
+NO_ALLOWLISTED_ROUTES = 0
+
+CURL_REPRO_PREFIX = 'curl -H "Authorization: Bearer $B_TOKEN"'
+
+
+@pytest_asyncio.fixture
+async def leak_report(
+    leaky_deployment: StubDeployment,
+    leaky_client: AsyncClient,
+) -> MatrixReport:
+    """Run the full matrix once against the leaky stub."""
+    return await run_matrix(
+        leaky_client,
+        bootstrap=make_stub_bootstrap(leaky_deployment),
+        config=stub_config(),
+    )
+
+
+def cells_for(report: MatrixReport, route: tuple[str, str]) -> dict[Cell, CellResult]:
+    """Return one route's four cells, keyed by cell, asserting none is missing."""
+    method, path = route
+    found = {
+        result.cell: result
+        for result in report.results
+        if result.route.method == method and result.route.path == path
+    }
+    assert set(found) == set(CELL_ORDER), (
+        f"{method} {path} was probed with cells {sorted(cell.name for cell in found)}; "
+        f"every route needs all of {sorted(cell.name for cell in CELL_ORDER)}"
+    )
+    return found
+
+
+def object_id(result: CellResult, param: str) -> int:
+    """Return the integer id the harness sent for ``param`` on this cell."""
+    sent = dict(result.object_ids)
+    assert param in sent, f"{result.route.method} {result.route.path} sent ids {sent}"
+    return int(sent[param])
+
+
+@pytest.mark.asyncio
+async def test_cross_user_read_of_another_users_widget_is_reported_as_a_leak(
+    leak_report: MatrixReport,
+    leaky_deployment: StubDeployment,
+) -> None:
+    """The intruder reads the owner's widget and the harness names it a LEAK.
+
+    The store assertion is the part that cannot be faked: the id the harness
+    sent still maps to the *owner's* email, so the 200 the intruder received was
+    genuinely somebody else's row rather than one of their own.
+    """
+    cells = cells_for(leak_report, LEAKY_WIDGET_GET)
+    leak = cells[Cell.CROSS_USER]
+
+    assert leak.verdict is Verdict.LEAK
+    assert leak.status == HTTPStatus.OK
+    widget_id = object_id(leak, "widget_id")
+    assert leak.resolved_path == f"/widgets/{widget_id}"
+    assert leaky_deployment.store.widgets[widget_id] == leaky_deployment.owner.email
+
+
+@pytest.mark.asyncio
+async def test_the_leaky_read_still_denies_unauthenticated_and_forged_callers(
+    leak_report: MatrixReport,
+) -> None:
+    """Only the cross-user cell fails; the token-less cells behave correctly.
+
+    This keeps the finding above honest. If every cell on this route failed, the
+    "leak" would be an artefact of a broken probe rather than a broken app.
+    """
+    cells = cells_for(leak_report, LEAKY_WIDGET_GET)
+
+    assert cells[Cell.UNAUTH].status == HTTPStatus.UNAUTHORIZED
+    assert cells[Cell.UNAUTH].verdict is Verdict.PASS
+    assert cells[Cell.FORGED_JWT].status == HTTPStatus.UNAUTHORIZED
+    assert cells[Cell.FORGED_JWT].verdict is Verdict.PASS
+    assert cells[Cell.POSITIVE_CONTROL].status == HTTPStatus.OK
+    assert cells[Cell.POSITIVE_CONTROL].verdict is Verdict.PASS
+
+
+@pytest.mark.asyncio
+async def test_cross_user_delete_of_another_users_widget_is_reported_as_a_leak(
+    leak_report: MatrixReport,
+    leaky_deployment: StubDeployment,
+) -> None:
+    """A mutating verb is caught too, and the row really is gone.
+
+    ``deleted_by`` records the caller the handler saw, so asserting it holds the
+    intruder's email proves the destructive request was executed on the owner's
+    row — not merely sent at it.
+    """
+    cells = cells_for(leak_report, LEAKY_WIDGET_DELETE)
+    leak = cells[Cell.CROSS_USER]
+    store = leaky_deployment.store
+
+    assert leak.verdict is Verdict.LEAK
+    assert leak.status == HTTPStatus.NO_CONTENT
+    widget_id = object_id(leak, "widget_id")
+    assert widget_id not in store.widgets
+    assert store.deleted_by[widget_id] == leaky_deployment.intruder.email
+
+
+@pytest.mark.asyncio
+async def test_the_leaky_delete_gets_its_own_object_for_the_positive_control(
+    leak_report: MatrixReport,
+) -> None:
+    """A destructive cross-user cell must not poison its route's positive control.
+
+    Seeding one object per route and deleting it in the cross-user cell would
+    leave the owner's own delete returning 404, which reads as INCONCLUSIVE and
+    would hide a genuine finding behind a harness error. A fresh object per cell
+    is what keeps a mutating leak reportable, so the two cells must have sent
+    different ids.
+    """
+    cells = cells_for(leak_report, LEAKY_WIDGET_DELETE)
+
+    assert cells[Cell.POSITIVE_CONTROL].status == HTTPStatus.NO_CONTENT
+    assert cells[Cell.POSITIVE_CONTROL].verdict is Verdict.PASS
+    assert object_id(cells[Cell.POSITIVE_CONTROL], "widget_id") != object_id(
+        cells[Cell.CROSS_USER],
+        "widget_id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_correctly_guarded_item_route_produces_no_finding(
+    leak_report: MatrixReport,
+) -> None:
+    """A route that 404s a foreign owner passes every cell — no crying wolf."""
+    cells = cells_for(leak_report, SAFE_ITEM_GET)
+
+    assert cells[Cell.CROSS_USER].status == HTTPStatus.NOT_FOUND
+    assert cells[Cell.CROSS_USER].verdict is Verdict.PASS
+    assert cells[Cell.UNAUTH].status == HTTPStatus.UNAUTHORIZED
+    assert cells[Cell.UNAUTH].verdict is Verdict.PASS
+    assert cells[Cell.FORGED_JWT].status == HTTPStatus.UNAUTHORIZED
+    assert cells[Cell.FORGED_JWT].verdict is Verdict.PASS
+    assert cells[Cell.POSITIVE_CONTROL].status == HTTPStatus.OK
+    assert cells[Cell.POSITIVE_CONTROL].verdict is Verdict.PASS
+
+
+@pytest.mark.asyncio
+async def test_a_403_denial_counts_as_a_pass_on_the_two_parameter_route(
+    leak_report: MatrixReport,
+) -> None:
+    """Ownership denials split 403/404 in this codebase; both are acceptable.
+
+    The route also forces the seed resolver to fill ``part_id`` from a widget it
+    seeded first, so a passing cell here means dependent seeding worked.
+    """
+    cells = cells_for(leak_report, SAFE_PART_GET)
+    cross_user = cells[Cell.CROSS_USER]
+
+    assert cross_user.status == HTTPStatus.FORBIDDEN
+    assert cross_user.verdict is Verdict.PASS
+    assert set(dict(cross_user.object_ids)) == {"widget_id", "part_id"}
+    assert cells[Cell.POSITIVE_CONTROL].status == HTTPStatus.OK
+    assert cells[Cell.POSITIVE_CONTROL].verdict is Verdict.PASS
+
+
+@pytest.mark.asyncio
+async def test_a_mutating_replay_uses_a_valid_body_so_it_reaches_the_owner_check(
+    leak_report: MatrixReport,
+    leaky_deployment: StubDeployment,
+) -> None:
+    """A replayed POST must 404 on ownership, not 422 on schema.
+
+    An invalid body would be rejected before the ownership check ever ran, so a
+    422 here would be a probe that proved nothing while looking like a denial.
+    The label recorded by the handler proves the configured replay body is the
+    one that actually went out.
+    """
+    cells = cells_for(leak_report, SAFE_PART_POST)
+
+    assert cells[Cell.CROSS_USER].status == HTTPStatus.NOT_FOUND
+    assert cells[Cell.CROSS_USER].verdict is Verdict.PASS
+    assert cells[Cell.POSITIVE_CONTROL].status == HTTPStatus.CREATED
+    assert cells[Cell.POSITIVE_CONTROL].verdict is Verdict.PASS
+    assert STUB_REPLAY_LABEL in leaky_deployment.store.labels
+
+
+@pytest.mark.asyncio
+async def test_the_only_findings_are_the_two_planted_leaks(
+    leak_report: MatrixReport,
+) -> None:
+    """Exactly two cells fail, and they are the two the stub was built to leak."""
+    reported = {
+        (finding.route.method, finding.route.path, finding.cell, finding.verdict)
+        for finding in leak_report.findings
+    }
+
+    assert reported == {
+        (*LEAKY_WIDGET_GET, Cell.CROSS_USER, Verdict.LEAK),
+        (*LEAKY_WIDGET_DELETE, Cell.CROSS_USER, Verdict.LEAK),
+    }
+    assert len(leak_report.findings) == EXPECTED_FINDINGS
+
+
+@pytest.mark.asyncio
+async def test_every_route_is_probed_with_the_positive_control_last(
+    leak_report: MatrixReport,
+) -> None:
+    """Cell order is part of the contract: the owner's own call runs after the probes.
+
+    Running the positive control first would let a destructive cross-user cell
+    inherit a still-valid object and let a later 404 read as a correct denial.
+    """
+    for route in (
+        LEAKY_WIDGET_GET,
+        LEAKY_WIDGET_DELETE,
+        SAFE_ITEM_GET,
+        SAFE_PART_GET,
+        SAFE_PART_POST,
+    ):
+        method, path = route
+        ordering = [
+            result.cell
+            for result in leak_report.results
+            if result.route.method == method and result.route.path == path
+        ]
+        assert tuple(ordering) == CELL_ORDER, f"{method} {path} ran cells in {ordering}"
+
+
+@pytest.mark.asyncio
+async def test_the_run_is_graded_as_a_finding_with_no_guard_tripped(
+    leak_report: MatrixReport,
+) -> None:
+    """Every stub route was covered, so the exit code is a finding, not a harness error."""
+    assert leak_report.guard_failures == ()
+    assert leak_report.discovered == STUB_OBJECT_SCOPED_ROUTES
+    assert leak_report.seeded == STUB_OBJECT_SCOPED_ROUTES
+    assert leak_report.uncovered == NO_UNCOVERED_ROUTES
+    assert leak_report.allowlisted == NO_ALLOWLISTED_ROUTES
+    assert leak_report.exit_code == EXIT_AUTHZ_FINDING
+
+
+def test_main_driven_at_the_leaky_stub_exits_with_a_finding(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI turns the two leaks into exit code 1 and writes them to stderr."""
+    exit_code = drive_main(leaky_deployment, min_routes=STUB_OBJECT_SCOPED_ROUTES)
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_AUTHZ_FINDING, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert captured.out == "", f"a failing run must not report on stdout: {captured.out!r}"
+    assert "FAIL  GET    /widgets/{widget_id}" in captured.err, captured.err
+    assert "FAIL  DELETE /widgets/{widget_id}" in captured.err, captured.err
+
+
+def test_the_rendered_report_carries_a_pasteable_curl_repro(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A finding is only actionable if the reader can reproduce it in one paste."""
+    drive_main(leaky_deployment, min_routes=STUB_OBJECT_SCOPED_ROUTES)
+
+    captured = capsys.readouterr()
+    assert CURL_REPRO_PREFIX in captured.err, captured.err
+    assert f"{STUB_BASE_URL}/widgets/" in captured.err, captured.err
+    assert "curl -X DELETE -H" in captured.err, captured.err

--- a/backend/tests/scripts/dast/test_vacuity_guards.py
+++ b/backend/tests/scripts/dast/test_vacuity_guards.py
@@ -1,0 +1,344 @@
+"""The guards that make "no findings" mean something, each proven to actually trip.
+
+A DAST check that cannot authenticate sees every request answered 401, finds no
+IDOR anywhere, and reports clean. That is the failure this whole harness is
+built around, and a guard nobody has watched fire is indistinguishable from no
+guard at all. So every test below drives its guard into the tripped state and
+asserts the failure it produces, then drives it into the healthy state and
+asserts silence — a guard that always trips is as useless as one that never
+does.
+
+The end-to-end tests at the bottom are the ones that matter most. A stub that
+mints tokens and then answers 401 to everything must exit ``EXIT_HARNESS_ERROR``
+and not ``EXIT_CLEAN``; and a run that probed five routes when it was told to
+expect twenty must fail on that basis even though it did find two real leaks,
+because a matrix that shrank without anybody noticing cannot be trusted with the
+"clean" it would otherwise report.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from scripts.dast.discovery import RouteSpec
+from scripts.dast.policy import AllowlistEntry
+from scripts.dast.report import EXIT_CLEAN, EXIT_HARNESS_ERROR
+from scripts.dast.runner import (
+    DEFAULT_BUDGET_SECONDS,
+    DEFAULT_MAX_ALLOWLIST_FRACTION,
+    DEFAULT_MIN_ROUTES,
+    run_matrix,
+)
+from scripts.dast.verdict import (
+    Cell,
+    CellResult,
+    Verdict,
+    require_allowlist_bounded,
+    require_allowlist_is_live,
+    require_auth_established,
+    require_minimum_coverage,
+    require_no_throttling,
+    require_positive_controls,
+    require_seeded_resources,
+    require_within_budget,
+)
+from tests.scripts.dast.conftest import (
+    STUB_OBJECT_SCOPED_ROUTES,
+    StubDeployment,
+    drive_main,
+    make_stub_bootstrap,
+    stub_config,
+)
+
+BLIND_STUB_MIN_ROUTES = 1
+
+PROBED_TOO_FEW = 5
+ALLOWLISTED_MAJORITY = 3
+ALLOWLISTED_MINORITY = 2
+DISCOVERED_ROUTES = 4
+OVER_BUDGET_SECONDS = 130.0
+WITHIN_BUDGET_SECONDS = 42.0
+
+WIDGET_ROUTE = RouteSpec(
+    method="GET",
+    path="/widgets/{widget_id}",
+    params=("widget_id",),
+    requires_auth=True,
+)
+
+RENAMED_ROUTE_ENTRY = AllowlistEntry(
+    method="GET",
+    path="/course/content/{content_id}",
+    category="shared_catalog",
+    reason="global course catalog; no per-user owner",
+)
+LIVE_ENTRY = AllowlistEntry(
+    method="GET",
+    path="/widgets/{widget_id}",
+    category="admin_only",
+    reason="covered by the in-process suite instead",
+)
+
+
+def cell_result(cell: Cell, status: int, verdict: Verdict) -> CellResult:
+    """Build one graded cell for the guards that read a run's results."""
+    return CellResult(
+        route=WIDGET_ROUTE,
+        cell=cell,
+        resolved_path="/widgets/7",
+        object_ids=(("widget_id", "7"),),
+        status=status,
+        verdict=verdict,
+    )
+
+
+def test_auth_established_trips_when_the_credential_does_not_work() -> None:
+    """A token that is refused makes every later denial meaningless."""
+    failure = require_auth_established(
+        authenticated_status=HTTPStatus.UNAUTHORIZED,
+        unauthenticated_status=HTTPStatus.UNAUTHORIZED,
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_auth_established"
+    assert "401" in failure.detail
+
+
+def test_auth_established_trips_when_the_auth_layer_is_not_engaged_at_all() -> None:
+    """The other half: an open endpoint answers 200 without a token.
+
+    Without this branch the guard would pass against an app whose auth was
+    entirely bypassed, which is the worst possible thing to call "clean".
+    """
+    failure = require_auth_established(
+        authenticated_status=HTTPStatus.OK,
+        unauthenticated_status=HTTPStatus.OK,
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_auth_established"
+
+
+def test_auth_established_is_silent_when_both_halves_hold() -> None:
+    """200 with the credential and 401 without it is the only healthy combination."""
+    assert (
+        require_auth_established(
+            authenticated_status=HTTPStatus.OK,
+            unauthenticated_status=HTTPStatus.UNAUTHORIZED,
+        )
+        is None
+    )
+
+
+def test_positive_controls_trip_when_the_owner_cannot_reach_their_own_object() -> None:
+    """If the owner's own call fails, the intruder's denial proves nothing.
+
+    A route whose object was never really created, or whose replay body was
+    rejected as invalid, denies everybody equally — which reads exactly like a
+    correctly guarded route.
+    """
+    failure = require_positive_controls(
+        (
+            cell_result(Cell.CROSS_USER, HTTPStatus.NOT_FOUND, Verdict.PASS),
+            cell_result(Cell.POSITIVE_CONTROL, HTTPStatus.NOT_FOUND, Verdict.INCONCLUSIVE),
+        ),
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_positive_controls"
+    assert "/widgets/{widget_id}" in failure.detail
+
+
+def test_positive_controls_are_silent_when_every_owner_call_succeeded() -> None:
+    """Each probed route proved it could succeed before its denial was believed."""
+    assert (
+        require_positive_controls(
+            (
+                cell_result(Cell.CROSS_USER, HTTPStatus.NOT_FOUND, Verdict.PASS),
+                cell_result(Cell.POSITIVE_CONTROL, HTTPStatus.OK, Verdict.PASS),
+            ),
+        )
+        is None
+    )
+
+
+def test_minimum_coverage_trips_when_nothing_at_all_was_probed() -> None:
+    """An empty or garbled OpenAPI document yields zero routes and a perfect score."""
+    failure = require_minimum_coverage(0, minimum=DEFAULT_MIN_ROUTES)
+
+    assert failure is not None
+    assert failure.guard == "require_minimum_coverage"
+    assert "0" in failure.detail
+
+
+def test_minimum_coverage_trips_when_the_matrix_quietly_shrank() -> None:
+    """Five probed routes where twenty were expected is a regression, not a pass."""
+    failure = require_minimum_coverage(PROBED_TOO_FEW, minimum=DEFAULT_MIN_ROUTES)
+
+    assert failure is not None
+    assert str(PROBED_TOO_FEW) in failure.detail
+    assert str(DEFAULT_MIN_ROUTES) in failure.detail
+
+
+def test_minimum_coverage_is_silent_at_exactly_the_threshold() -> None:
+    """The floor is inclusive, so hitting it exactly is not a failure."""
+    assert require_minimum_coverage(DEFAULT_MIN_ROUTES, minimum=DEFAULT_MIN_ROUTES) is None
+
+
+def test_seeded_resources_trips_when_no_object_was_created() -> None:
+    """With nothing seeded, every probe addresses an id that never existed."""
+    failure = require_seeded_resources(0)
+
+    assert failure is not None
+    assert failure.guard == "require_seeded_resources"
+
+
+def test_seeded_resources_is_silent_once_anything_was_seeded() -> None:
+    """One real object is enough to make the probes address something."""
+    assert require_seeded_resources(1) is None
+
+
+def test_no_throttling_trips_on_a_single_429() -> None:
+    """The rate limiter can turn a whole matrix into uniform, meaningless denials.
+
+    One 429 anywhere is enough: the harness spreads requests across forwarded
+    client keys precisely so this never happens, and a single throttled response
+    means that mechanism stopped working.
+    """
+    failure = require_no_throttling(
+        (HTTPStatus.OK, HTTPStatus.FORBIDDEN, HTTPStatus.TOO_MANY_REQUESTS),
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_no_throttling"
+    assert "429" in failure.detail
+
+
+def test_no_throttling_is_silent_when_no_response_was_throttled() -> None:
+    """Ordinary denials and successes are exactly what the matrix expects to see."""
+    healthy = (HTTPStatus.OK, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND)
+
+    assert require_no_throttling(healthy) is None
+
+
+def test_allowlist_liveness_trips_on_an_entry_that_no_longer_matches_a_route() -> None:
+    """A renamed route leaves its excuse behind, and the excuse keeps excusing nothing.
+
+    Left unchecked the allow-list becomes a graveyard: entries accumulate, none
+    can be shown to still apply, and the bounded-size guard eventually fires for
+    reasons nobody can reconstruct.
+    """
+    failure = require_allowlist_is_live((RENAMED_ROUTE_ENTRY,), (WIDGET_ROUTE,))
+
+    assert failure is not None
+    assert failure.guard == "require_allowlist_is_live"
+    assert "/course/content/{content_id}" in failure.detail
+
+
+def test_allowlist_liveness_is_silent_when_every_entry_matches_a_live_route() -> None:
+    """An entry that still names a real route is doing its job."""
+    assert require_allowlist_is_live((LIVE_ENTRY,), (WIDGET_ROUTE,)) is None
+
+
+def test_allowlist_bounded_trips_when_most_of_the_app_is_excused() -> None:
+    """Excusing the majority of routes turns the gate into decoration."""
+    failure = require_allowlist_bounded(
+        ALLOWLISTED_MAJORITY,
+        DISCOVERED_ROUTES,
+        max_fraction=DEFAULT_MAX_ALLOWLIST_FRACTION,
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_allowlist_bounded"
+
+
+def test_allowlist_bounded_is_silent_at_the_permitted_fraction() -> None:
+    """Half is the documented ceiling, so exactly half still passes."""
+    assert (
+        require_allowlist_bounded(
+            ALLOWLISTED_MINORITY,
+            DISCOVERED_ROUTES,
+            max_fraction=DEFAULT_MAX_ALLOWLIST_FRACTION,
+        )
+        is None
+    )
+
+
+def test_within_budget_trips_when_the_matrix_outran_its_time_box() -> None:
+    """The two-minute acceptance criterion is machine-checked, not aspirational."""
+    failure = require_within_budget(
+        OVER_BUDGET_SECONDS,
+        budget_seconds=DEFAULT_BUDGET_SECONDS,
+    )
+
+    assert failure is not None
+    assert failure.guard == "require_within_budget"
+
+
+def test_within_budget_is_silent_for_a_run_inside_its_time_box() -> None:
+    """A fast run says nothing; only an overrun is worth a line of output."""
+    assert (
+        require_within_budget(WITHIN_BUDGET_SECONDS, budget_seconds=DEFAULT_BUDGET_SECONDS) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_server_that_401s_everything_is_a_harness_error_not_a_clean_run(
+    blind_deployment: StubDeployment,
+    blind_client: AsyncClient,
+) -> None:
+    """The canonical false pass, refused outright.
+
+    This app logs both identities in and then answers 401 to every other
+    request, so no ownership check is ever reached and no IDOR can possibly be
+    observed. Reporting that as clean is the exact outcome the whole design
+    exists to make impossible.
+    """
+    report = await run_matrix(
+        blind_client,
+        bootstrap=make_stub_bootstrap(blind_deployment),
+        config=stub_config(min_routes=BLIND_STUB_MIN_ROUTES),
+    )
+
+    assert report.exit_code == EXIT_HARNESS_ERROR
+    assert report.exit_code != EXIT_CLEAN
+    tripped = {failure.guard for failure in report.guard_failures}
+    assert "require_auth_established" in tripped, f"guards tripped: {sorted(tripped)}"
+    assert blind_deployment.store.rejected, "the harness never sent a credential at all"
+
+
+def test_the_cli_exits_three_against_a_server_that_401s_everything(
+    blind_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End to end, the false pass surfaces as a harness error on stderr."""
+    exit_code = drive_main(blind_deployment, min_routes=BLIND_STUB_MIN_ROUTES)
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert exit_code != EXIT_CLEAN
+    assert captured.out == "", f"a harness error must not report on stdout: {captured.out!r}"
+    assert "HARNESS ERROR  require_auth_established" in captured.err, captured.err
+
+
+def test_a_run_that_probed_too_few_routes_fails_even_though_it_found_leaks(
+    leaky_deployment: StubDeployment,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Coverage collapse outranks the findings it happened to produce.
+
+    The leaky stub exposes five object-scoped routes; asked for the production
+    default of twenty, the run has demonstrably lost most of the application and
+    cannot be trusted to have found everything, so the coverage guard decides
+    the exit code rather than the two genuine leaks.
+    """
+    assert STUB_OBJECT_SCOPED_ROUTES < DEFAULT_MIN_ROUTES
+
+    exit_code = drive_main(leaky_deployment, min_routes=DEFAULT_MIN_ROUTES)
+
+    captured = capsys.readouterr()
+    assert exit_code == EXIT_HARNESS_ERROR, f"stdout={captured.out!r} stderr={captured.err!r}"
+    assert "HARNESS ERROR  require_minimum_coverage" in captured.err, captured.err

--- a/backend/tests/scripts/dast/test_verdict.py
+++ b/backend/tests/scripts/dast/test_verdict.py
@@ -1,0 +1,133 @@
+"""The oracle: every (cell, status) pair has one named verdict, and none of them is a shrug.
+
+The temptation in a check like this is a two-way split — denied or not — which
+collapses "the app correctly refused" together with "the request never reached
+the ownership check". The distinctions below are the difference between a gate
+that means something and one that reports clean when the credentials expired.
+
+Four of them carry the weight:
+
+* ``401`` on the cross-user cell is ``AUTH_BROKEN``, not a pass. The intruder's
+  token is supposed to be valid; if it is not, the run learned nothing about
+  authorization and only looked like it did.
+* ``5xx`` is ``SERVER_ERROR``, not a denial. A handler that blew up mid-request
+  reached the row before it checked who was asking.
+* ``429`` is ``THROTTLED``, never a pass, because the rate limiter can turn an
+  entire matrix into uniform "denials".
+* Anything the table does not recognise — ``410``, ``422`` — is ``INCONCLUSIVE``.
+  A status nobody thought about must never default to "fine".
+
+The whole table is written out rather than derived, because a derivation would
+share its bug with the implementation it is checking.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+
+from scripts.dast.verdict import CELL_ORDER, Cell, Verdict, judge
+
+EXPECTED_VERDICTS = {
+    Verdict.PASS,
+    Verdict.LEAK,
+    Verdict.SERVER_ERROR,
+    Verdict.AUTH_BROKEN,
+    Verdict.THROTTLED,
+    Verdict.INCONCLUSIVE,
+}
+
+ORACLE: list[tuple[Cell, int, Verdict]] = [
+    # The intruder's token against the owner's object: 403 and 404 are the two
+    # acceptable denials this codebase emits; everything else is a finding.
+    (Cell.CROSS_USER, HTTPStatus.OK, Verdict.LEAK),
+    (Cell.CROSS_USER, HTTPStatus.CREATED, Verdict.LEAK),
+    (Cell.CROSS_USER, HTTPStatus.NO_CONTENT, Verdict.LEAK),
+    (Cell.CROSS_USER, HTTPStatus.UNAUTHORIZED, Verdict.AUTH_BROKEN),
+    (Cell.CROSS_USER, HTTPStatus.FORBIDDEN, Verdict.PASS),
+    (Cell.CROSS_USER, HTTPStatus.NOT_FOUND, Verdict.PASS),
+    (Cell.CROSS_USER, HTTPStatus.GONE, Verdict.INCONCLUSIVE),
+    (Cell.CROSS_USER, HTTPStatus.UNPROCESSABLE_ENTITY, Verdict.INCONCLUSIVE),
+    (Cell.CROSS_USER, HTTPStatus.TOO_MANY_REQUESTS, Verdict.THROTTLED),
+    (Cell.CROSS_USER, HTTPStatus.INTERNAL_SERVER_ERROR, Verdict.SERVER_ERROR),
+    (Cell.CROSS_USER, HTTPStatus.SERVICE_UNAVAILABLE, Verdict.SERVER_ERROR),
+    # No token at all: the auth layer must reject before authorization matters.
+    (Cell.UNAUTH, HTTPStatus.OK, Verdict.LEAK),
+    (Cell.UNAUTH, HTTPStatus.CREATED, Verdict.LEAK),
+    (Cell.UNAUTH, HTTPStatus.NO_CONTENT, Verdict.LEAK),
+    (Cell.UNAUTH, HTTPStatus.UNAUTHORIZED, Verdict.PASS),
+    (Cell.UNAUTH, HTTPStatus.FORBIDDEN, Verdict.INCONCLUSIVE),
+    (Cell.UNAUTH, HTTPStatus.NOT_FOUND, Verdict.INCONCLUSIVE),
+    (Cell.UNAUTH, HTTPStatus.GONE, Verdict.INCONCLUSIVE),
+    (Cell.UNAUTH, HTTPStatus.UNPROCESSABLE_ENTITY, Verdict.INCONCLUSIVE),
+    (Cell.UNAUTH, HTTPStatus.TOO_MANY_REQUESTS, Verdict.THROTTLED),
+    (Cell.UNAUTH, HTTPStatus.INTERNAL_SERVER_ERROR, Verdict.SERVER_ERROR),
+    (Cell.UNAUTH, HTTPStatus.SERVICE_UNAVAILABLE, Verdict.SERVER_ERROR),
+    # A well-formed JWT signed with the wrong key: identical expectations.
+    (Cell.FORGED_JWT, HTTPStatus.OK, Verdict.LEAK),
+    (Cell.FORGED_JWT, HTTPStatus.CREATED, Verdict.LEAK),
+    (Cell.FORGED_JWT, HTTPStatus.NO_CONTENT, Verdict.LEAK),
+    (Cell.FORGED_JWT, HTTPStatus.UNAUTHORIZED, Verdict.PASS),
+    (Cell.FORGED_JWT, HTTPStatus.FORBIDDEN, Verdict.INCONCLUSIVE),
+    (Cell.FORGED_JWT, HTTPStatus.NOT_FOUND, Verdict.INCONCLUSIVE),
+    (Cell.FORGED_JWT, HTTPStatus.GONE, Verdict.INCONCLUSIVE),
+    (Cell.FORGED_JWT, HTTPStatus.UNPROCESSABLE_ENTITY, Verdict.INCONCLUSIVE),
+    (Cell.FORGED_JWT, HTTPStatus.TOO_MANY_REQUESTS, Verdict.THROTTLED),
+    (Cell.FORGED_JWT, HTTPStatus.INTERNAL_SERVER_ERROR, Verdict.SERVER_ERROR),
+    (Cell.FORGED_JWT, HTTPStatus.SERVICE_UNAVAILABLE, Verdict.SERVER_ERROR),
+    # The owner against their own object. Only 2xx proves the probe was capable
+    # of succeeding, so every other status is inconclusive by construction --
+    # including the 422 a mutating replay with an invalid body would return.
+    (Cell.POSITIVE_CONTROL, HTTPStatus.OK, Verdict.PASS),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.CREATED, Verdict.PASS),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.NO_CONTENT, Verdict.PASS),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.UNAUTHORIZED, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.FORBIDDEN, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.NOT_FOUND, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.GONE, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.UNPROCESSABLE_ENTITY, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.TOO_MANY_REQUESTS, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.INTERNAL_SERVER_ERROR, Verdict.INCONCLUSIVE),
+    (Cell.POSITIVE_CONTROL, HTTPStatus.SERVICE_UNAVAILABLE, Verdict.INCONCLUSIVE),
+]
+
+
+@pytest.mark.parametrize(("cell", "status", "expected"), ORACLE)
+def test_the_oracle_maps_each_cell_and_status_to_one_verdict(
+    cell: Cell,
+    status: int,
+    expected: Verdict,
+) -> None:
+    """Grading is a total function of the cell and the observed status."""
+    assert judge(cell, status) is expected
+
+
+def test_the_verdict_vocabulary_is_exactly_the_documented_set() -> None:
+    """Each verdict names a distinct cause; adding one is a decision made here."""
+    assert set(Verdict) == EXPECTED_VERDICTS
+
+
+def test_the_cells_run_with_the_positive_control_last() -> None:
+    """The owner's own call must run after the probes that might destroy its object.
+
+    Running it first against a shared object would let a destructive cross-user
+    cell inherit a live row and then read the resulting 404 as a clean denial.
+    """
+    assert CELL_ORDER == (
+        Cell.CROSS_USER,
+        Cell.UNAUTH,
+        Cell.FORGED_JWT,
+        Cell.POSITIVE_CONTROL,
+    )
+
+
+def test_every_cell_is_covered_by_the_oracle_table() -> None:
+    """A new cell without an oracle row would grade as whatever the fallback is."""
+    assert {cell for cell, _, _ in ORACLE} == set(CELL_ORDER)
+
+
+def test_no_cell_treats_a_two_hundred_on_a_foreign_object_as_acceptable() -> None:
+    """The single sentence the whole check exists to enforce, asserted directly."""
+    for cell in (Cell.CROSS_USER, Cell.UNAUTH, Cell.FORGED_JWT):
+        assert judge(cell, HTTPStatus.OK) is Verdict.LEAK


### PR DESCRIPTION
## Summary

Every router's unit tests create a user, create that user's object, and fetch it back
successfully. The negative case — *someone else's* id — is tested per-route at best,
never systematically, and a newly added route starts life untested by construction. A
single missed `WHERE user_id = :current_user` in one of 27 routers is a privacy breach
that a wholly green suite hides.

This adds a PR-blocking check that enumerates every object-scoped route from the live
`/openapi.json`, seeds one object per cell as user A, and replays each route with user
B's token — asserting `403`/`404`, never `2xx`, never `5xx`. It also asserts the
unauthenticated case is `401` and that a structurally valid JWT signed with the wrong key
is rejected. Broken Object Level Authorization is OWASP API Security Top 10 #1.

Against the current codebase the matrix is clean: **41 object-scoped operations
discovered, 30 probed across 120 cells, 0 uncovered, in 1.8s.**

## The thing this check must never do is pass because nothing happened

If the scanner cannot authenticate, every request `401`s, no IDOR is found, and the job
reports clean. That is a false pass. The guards against it are the design, not a
footnote:

- **Per-route positive control.** User A must reach her own object, or the route is a
  harness error. Without it, user B's denial means nothing.
- **Auth probe checks both halves** — `200` with A's token *and* `401` without one. One
  proves the credential works; the other proves the auth layer is engaged at all.
- **Any `429` is an error.** A throttled matrix proves nothing.
- **UNCOVERED routes fail the build**, and a stale allow-list entry — one whose route no
  longer exists — fails too, so the list cannot rot into a blanket suppression.
- Zero routes probed, zero resources seeded, or an over-budget run each fail on their own.
- **A dead target is a harness error, not a finding.** Self-review caught that a
  connection failure escaped as an uncaught traceback and exit `1` — which is
  `EXIT_AUTHZ_FINDING`. All four live stages are now wrapped, and the DSN is redacted
  before it reaches the log.

Objects are seeded **fresh per cell**, not shared per resource. That is not caution, it is
a measured result: a shared-object prototype had `DELETE /habits/{habit_id}` destroy user
A's habit, after which `/completions`, `/goals/units` and `/stats` all answered `404` to
user B — which reads as "correctly denied" and is worth nothing.

## Proof it catches the bug it targets

Gate 1 RED came first. `backend/tests/scripts/dast/conftest.py` mounts a throwaway
`FastAPI()` whose `GET` and `DELETE /widgets/{widget_id}` authenticate the caller and then
never consult the owner. The harness must name that leak — route, method, sent id, owning
actor, actual status, plus a copy-pasteable `curl` — while the ownership-enforcing
negative controls beside it stay quiet, so a harness that cried wolf also goes red. A
check that has never demonstrably caught the bug it targets is not evidence.

## Two identities, without weakening anything

Signup is gated on a live Gumroad license verification against a hard-coded URL, so it
cannot run in CI. The harness inserts two `User` rows through the ORM and mints both
tokens through the **real** `POST /auth/login` over the socket. No production code was
modified, no auth bypass was added, and passwords are generated rather than written down.

The app applies a global `60/minute` limit to every endpoint: measured, 90 rapid requests
from one key produced 30 × `429`, and the same 90 with a rotating `X-Forwarded-For`
produced none. The workflow starts the ephemeral target with
`TRUSTED_PROXY_CIDRS=127.0.0.1/32` — this configures the instance the job started itself,
changes no code, and the `429` guard catches it if the mechanism ever stops working.

## Findings filed, not buried

Mapping the surface turned up two real authorization defects. Both carry the object id in
the **request body**, so this path-scoped harness does not catch either — filed rather
than fixed here, per the issue's constraint against touching router code:

- **#2064** (P0) — `PUT /goals/{goal_id}` lets any user write a goal into another user's
  goal group; the victim then sees the attacker's goal. Reproduced live.
- **#2065** (P1) — `POST /journal/` accepts another user's `user_practice_id` unvalidated.
- **#2066** — follow-up to extend the matrix to body and query object references.

The allow-list has 22 entries and **zero** `known_leak`. Each carries a category and a
reason verified against the router code; the three `/practices/{practice_id}` entries are
there because presets are deliberately world-readable, so probing them would report a
false-positive leak.

## Test plan

- `cd backend && pytest tests/scripts/dast` — **165 passed**, no server required.
- `./scripts/backend/check-all.sh` — **7/7 passed**, 3686 tests, total coverage 97%.
- `pre-commit run mypy --all-files` — passed (the hook covers `backend/scripts/` and
  `backend/tests/`, which `mypy src/` does not).
- `scripts/dast` package coverage **98%**; `authz_matrix.py` 100%.
- Negative matrix run against a live uvicorn + `postgres:16`, exit codes captured
  directly:

  | scenario | exit |
  |---|---|
  | healthy | `0` PASS |
  | unreachable app | `3` `require_live_stages_completed` |
  | bad database | `3` same, DSN password redacted |
  | `--min-routes 999` | `3` `require_minimum_coverage` |
  | `--budget-seconds 0.001` | `3` `require_within_budget` |
  | `--max-allowlist-fraction 0.01` | `3` `require_allowlist_bounded` |

Closes #2020
Refs #2018
