### PR TITLE
fix(backend): parse creek.reflect's {notes: [...]} response instead of a "reflection" string

### DIFF
--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -96,6 +96,7 @@ from domain.creek_vault import (
     VaultWheelAspect,
     VaultWheelBalance,
 )
+from domain.resonance import ANCHOR_TEXT_MAX, NOTE_MAX
 from schemas.wheel import WheelBalanceResponse
 
 # Timeout (seconds) for a single HTTP call to the vault. Bounds how long a slow
@@ -195,6 +196,43 @@ _JOURNAL_OK_STATUS = "ok"
 # column on every save, which without a ceiling lets a compromised vault grow
 # the operator's database by as much as it cares to answer with.
 _MAX_FRAGMENT_ID_LENGTH = 256
+
+# The status a ``creek.reflect`` response reports when it actually produced
+# notes. Deliberately its own constant rather than a reuse of
+# :data:`_JOURNAL_OK_STATUS`: the two capabilities merely happen to spell their
+# success the same way today, and coupling them would let either one's future
+# rename silently change how the other is parsed.
+_REFLECT_OK_STATUS = "ok"
+
+# How many notes of a reflect response adepthood will even look at. Double
+# Creek's own shipped cap of six, so a vault that modestly raises its cap still
+# lands whole, while a buggy or hostile one is bounded to roughly twelve times
+# (:data:`~domain.resonance.ANCHOR_TEXT_MAX` + :data:`~domain.resonance.NOTE_MAX`)
+# plus JSON overhead -- about 12 KB serialized -- instead of however much it
+# cares to answer with. This is a bound on *untrusted vault output before
+# serialization*, independent of the separate anchoring cap
+# :mod:`domain.resonance` applies to how many of these notes survive onto the
+# entry; neither one substitutes for the other.
+_MAX_REFLECT_NOTES = 12
+
+# How Creek's seven published note kinds render in adepthood's marginalia
+# vocabulary. ``pattern`` is the one that speaks across entries -- Creek grounds
+# its notes in the surrounding corpus, so a recurrence note is exactly what
+# adepthood calls a ``connection`` -- while the other six each observe something
+# about this one entry and so render as a ``theme``. Adepthood's third kind,
+# ``symbol``, is deliberately unused: nothing in Creek's vocabulary denotes an
+# image standing for something else, and forcing a non-symbol onto it would
+# render the note as something it is not. A kind absent from this table is
+# dropped, never coerced onto a nearest neighbor.
+_MARGINALIA_KIND_BY_CREEK_KIND: Mapping[str, str] = {
+    "pattern": "connection",
+    "reframe": "theme",
+    "fear": "theme",
+    "longing": "theme",
+    "value": "theme",
+    "tension": "theme",
+    "gift": "theme",
+}
 
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
@@ -484,8 +522,108 @@ def _parse_classification(payload: Mapping[str, object]) -> VaultClassification:
     return VaultClassification(tags=tuple(item for item in raw if isinstance(item, str)))
 
 
+def _bounded_text(raw: object, limit: int) -> str | None:
+    """Return a vault-supplied string when it is usable text within ``limit``, else ``None``.
+
+    Three conditions, each of which a note cannot do without: it is a string at
+    all (a number or a nested object is not text), it carries something other
+    than whitespace (a blank quote anchors to nothing and a blank note says
+    nothing), and it fits the marginalia field it is bound for, so no vault can
+    answer with an unbounded string. The value is returned **verbatim** rather
+    than stripped, because adepthood anchors a quote by matching it
+    character-for-character against the entry body -- trimming here would
+    silently break the very anchor this check exists to protect.
+    """
+    if not isinstance(raw, str) or not raw.strip() or len(raw) > limit:
+        return None
+    return raw
+
+
+def _marginalia_kind(raw: object) -> str | None:
+    """Map one Creek note kind onto adepthood's, or ``None`` when we do not know it.
+
+    Mirrors :func:`_coerce_capability` and :func:`_coerce_ingest_action`: an
+    unknown or wrong-typed kind is dropped rather than raising or being coerced
+    onto a neighbor, so a vault that invents a kind loses that one note instead
+    of having it rendered as something the user never wrote.
+    """
+    if not isinstance(raw, str):
+        return None
+    return _MARGINALIA_KIND_BY_CREEK_KIND.get(raw)
+
+
+def _reflection_note(item: object) -> dict[str, str] | None:
+    """Project one Creek note onto the marginalia contract, or drop it whole.
+
+    This is the boundary where an untrusted vault's output becomes something
+    adepthood renders back to the user, so every field has to survive on its own
+    terms: a mappable kind, a quote within
+    :data:`~domain.resonance.ANCHOR_TEXT_MAX`, a note within
+    :data:`~domain.resonance.NOTE_MAX`. A partial note is dropped rather than
+    completed with a default, which would put words in the user's Higher Self
+    that neither they nor the vault ever wrote.
+    """
+    if not isinstance(item, Mapping):
+        return None
+    kind = _marginalia_kind(item.get("kind"))
+    quote = _bounded_text(item.get("quote"), ANCHOR_TEXT_MAX)
+    note = _bounded_text(item.get("note"), NOTE_MAX)
+    if kind is None or quote is None or note is None:
+        return None
+    return {"kind": kind, "quote": quote, "note": note}
+
+
+def _reflection_notes(raw: object) -> list[dict[str, str]]:
+    """Narrow a vault's note list to the ones adepthood can actually render.
+
+    Answers with an empty list -- never raises -- for anything that is not a
+    list, since a malformed reflection must defer to the cloud rather than break
+    the resonance pass. Only the leading :data:`_MAX_REFLECT_NOTES` items are
+    considered, order preserved, so an over-eager or hostile vault cannot grow
+    this work (or the JSON it feeds) without bound; inside that prefix each item
+    stands or falls alone, so one malformed note never costs its siblings.
+    """
+    if not isinstance(raw, list):
+        return []
+    return [
+        note for item in raw[:_MAX_REFLECT_NOTES] if (note := _reflection_note(item)) is not None
+    ]
+
+
+def _parse_reflection(payload: Mapping[str, object]) -> str:
+    """Render a ``creek.reflect`` response as the strict marginalia JSON contract.
+
+    Answers with the empty string -- which the caller reads as "no vault
+    reflection", deferring to the cloud -- in every case but one: a literal
+    ``ok`` status carrying at least one renderable note. The strict equality is
+    what makes ``empty``, ``escalate`` (Creek's care handoff), ``refused``, and
+    any status a future Creek adds all defer rather than be mined for notes.
+    Zero surviving notes defers too, deliberately: rendering ``{"notes": []}``
+    would suppress the fallback and leave the user with a Higher Self that said
+    nothing at all, which is worse than a cloud answer.
+    """
+    if payload.get("status") != _REFLECT_OK_STATUS:
+        return ""
+    notes = _reflection_notes(payload.get("notes"))
+    if not notes:
+        return ""
+    return json.dumps({"notes": notes})
+
+
+def _reflect_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, object]:
+    """Map a reflection request onto the ``creek.reflect`` wire fields.
+
+    Exactly two: the body to reflect on, and the privacy ceiling the vault's
+    router enforces. No ``consumer`` key -- the vault learns the caller from the
+    MCP session itself, as it already does for ingest -- and no ``entry_ref``,
+    since adepthood reflects on an ad-hoc body rather than on a fragment the
+    vault has already stored.
+    """
+    return {"content": body, "privacy_tier_ceiling": tier_ceiling.value}
+
+
 def _content_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, object]:
-    """Build the shared params for a content-bearing call (classify/reflect)."""
+    """Build the params for a ``creek.classify`` call, whose wire shape is unverified."""
     return {"consumer": CONSUMER_ID, "body": body, "tier_ceiling": tier_ceiling.value}
 
 
@@ -611,10 +749,15 @@ class McpCreekVaultClient:
         return _parse_classification(payload)
 
     async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> str:
-        """Produce a Higher Self reflection over the corpus, requiring REFLECT."""
-        payload = await self._invoke(CreekCapability.REFLECT, _content_params(body, tier_ceiling))
-        reflection = payload.get("reflection")
-        return reflection if isinstance(reflection, str) else ""
+        """Produce a Higher Self reflection over the corpus, requiring REFLECT.
+
+        Returns the vault's own notes translated into the marginalia JSON
+        contract the resonance pass anchors against (:func:`_parse_reflection`),
+        or the empty string when the vault declined, escalated, or answered with
+        nothing renderable -- which the caller reads as "defer to the cloud".
+        """
+        payload = await self._invoke(CreekCapability.REFLECT, _reflect_params(body, tier_ceiling))
+        return _parse_reflection(payload)
 
     async def wheel(self) -> VaultWheelBalance:
         """Return a vault-computed Wheel-of-Wholeness read, requiring WHEEL.

--- a/backend/src/services/creek_vault_reflect.py
+++ b/backend/src/services/creek_vault_reflect.py
@@ -17,10 +17,13 @@ handshake, so the vault is provably untouched for those entries.
 The vault's ``reflect`` output is fed straight into
 :func:`~domain.resonance.generate_marginalia`, which anchors verbatim quotes on
 adepthood's side and expects the same strict ``{"notes": [...]}`` JSON the cloud
-LLM returns. Because the cloud-shaped prompt is *not* forwarded across the seam
-(the vault builds its own enclave-side prompt), the vault is responsible for
-emitting that contract; a non-conforming reflection simply anchors to zero notes,
-exactly as a malformed cloud completion already does.
+LLM returns. The cloud-shaped prompt is *not* forwarded across the seam (the
+vault builds its own enclave-side prompt), and the vault answers in its own reply
+shape rather than adepthood's -- so translating that shape into this contract
+belongs to the client adapter (:mod:`services.creek_vault_client`), not to the
+vault. A reflection the adapter cannot render, because the vault declined,
+escalated, or answered with nothing usable, arrives here as a blank string and
+defers to the cloud ``fallback`` rather than anchoring to zero notes.
 
 Intimate content is out of scope here by construction: the router's privacy floor
 returns for an intimate entry before this module is ever reached, so

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
@@ -30,8 +31,11 @@ from domain.creek_vault import (
     VaultWheelAspect,
     VaultWheelBalance,
 )
+from domain.resonance import ANCHOR_TEXT_MAX, NOTE_MAX, VALID_KINDS
 from services.creek_vault_client import (
+    _MARGINALIA_KIND_BY_CREEK_KIND,
     _MAX_FRAGMENT_ID_LENGTH,
+    _MAX_REFLECT_NOTES,
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
     _extract_tool_payload,
@@ -39,12 +43,25 @@ from services.creek_vault_client import (
     _ingest_params,
     _McpStreamableHttpTransport,
     _parse_ingest_result,
+    _parse_reflection,
+    _reflect_params,
     build_creek_vault_client,
 )
 
 _VAULT_URL = "https://vault.example.test"
 
 _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+
+# One well-formed creek note's quote and note text, reused so the hygiene matrix
+# can pair exactly one malformed item against a known-good sibling.
+_REFLECT_QUOTE = "the river kept moving"
+_REFLECT_NOTE = "You keep reaching for motion when you write about rest."
+
+# Creek's seven published note kinds, restated here on purpose: this literal is
+# the pin against the vocabulary drifting out from under the mapping table.
+_CREEK_NOTE_KINDS = frozenset(
+    {"reframe", "fear", "longing", "value", "pattern", "tension", "gift"},
+)
 
 
 def _handshake_payload(
@@ -62,6 +79,23 @@ def _handshake_payload(
         "contract_version": contract_version,
         "ontology_version": ontology_version,
         "attestation": attestation,
+    }
+
+
+def _creek_note(kind: object, quote: object, note: object) -> dict[str, object]:
+    """Build one creek.reflect note item, allowing deliberately malformed field types."""
+    return {"kind": kind, "quote": quote, "note": note}
+
+
+def _reflect_payload(notes: object) -> dict[str, object]:
+    """Build a well-formed creek.reflect ok-status response carrying ``notes``."""
+    return {
+        "status": "ok",
+        "tool": CreekCapability.REFLECT.value,
+        "tier_ceiling": VaultTierCeiling.OPEN.value,
+        "routed_tier": VaultTierCeiling.OPEN.value,
+        "notes": notes,
+        "essay_grounded": False,
     }
 
 
@@ -460,8 +494,37 @@ async def test_classify_missing_tags_returns_empty_classification() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reflect_success_returns_reflection_text() -> None:
-    """reflect() returns the reflection string from a successful vault response."""
+async def test_reflect_renders_creek_notes_as_the_marginalia_contract() -> None:
+    """reflect() turns creek's own note shape into the strict marginalia JSON contract."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.REFLECT.value]),
+            CreekCapability.REFLECT.value: _reflect_payload(
+                [
+                    _creek_note("pattern", _REFLECT_QUOTE, _REFLECT_NOTE),
+                    _creek_note("fear", "I stalled again", "The stall gets named plainly here."),
+                ]
+            ),
+        }
+    )
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    result = await client.reflect("body text", VaultTierCeiling.OPEN)
+    assert json.loads(result) == {
+        "notes": [
+            {"kind": "connection", "quote": _REFLECT_QUOTE, "note": _REFLECT_NOTE},
+            {
+                "kind": "theme",
+                "quote": "I stalled again",
+                "note": "The stall gets named plainly here.",
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_reflect_legacy_reflection_shaped_payload_yields_no_reflection() -> None:
+    """A payload carrying only the old reflection key has no ok status, so the caller falls back."""
     transport = ScriptedTransport(
         responses={
             CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.REFLECT.value]),
@@ -471,22 +534,197 @@ async def test_reflect_success_returns_reflection_text() -> None:
     client = McpCreekVaultClient(transport=transport)
     await client.handshake()
     result = await client.reflect("body text", VaultTierCeiling.OPEN)
-    assert result == "a warm note"
-
-
-@pytest.mark.asyncio
-async def test_reflect_missing_reflection_returns_empty_string() -> None:
-    """reflect() returns the empty string when the response reflection is absent or wrong-typed."""
-    transport = ScriptedTransport(
-        responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.REFLECT.value]),
-            CreekCapability.REFLECT.value: {"reflection": 123},
-        }
-    )
-    client = McpCreekVaultClient(transport=transport)
-    await client.handshake()
-    result = await client.reflect("body text", VaultTierCeiling.OPEN)
     assert result == ""
+
+
+def test_reflect_params_sends_only_content_and_privacy_tier_ceiling() -> None:
+    """Reflect params carry exactly the creek.reflect wire fields, with no consumer key."""
+    params = _reflect_params("some body", VaultTierCeiling.PERSONAL)
+    assert params == {"content": "some body", "privacy_tier_ceiling": "personal"}
+    assert {"consumer", "body", "tier_ceiling"}.isdisjoint(params)
+
+
+@pytest.mark.parametrize(
+    ("creek_kind", "marginalia_kind"),
+    [
+        pytest.param("pattern", "connection", id="pattern"),
+        pytest.param("reframe", "theme", id="reframe"),
+        pytest.param("fear", "theme", id="fear"),
+        pytest.param("longing", "theme", id="longing"),
+        pytest.param("value", "theme", id="value"),
+        pytest.param("tension", "theme", id="tension"),
+        pytest.param("gift", "theme", id="gift"),
+    ],
+)
+def test_parse_reflection_maps_each_creek_kind(creek_kind: str, marginalia_kind: str) -> None:
+    """Each of creek's seven note kinds renders as its ratified marginalia kind."""
+    payload = _reflect_payload([_creek_note(creek_kind, _REFLECT_QUOTE, _REFLECT_NOTE)])
+    assert json.loads(_parse_reflection(payload)) == {
+        "notes": [{"kind": marginalia_kind, "quote": _REFLECT_QUOTE, "note": _REFLECT_NOTE}]
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {
+                "status": "empty",
+                "tool": CreekCapability.REFLECT.value,
+                "tier_ceiling": VaultTierCeiling.OPEN.value,
+                "routed_tier": VaultTierCeiling.OPEN.value,
+                "notes": [],
+                "essay_grounded": False,
+            },
+            id="empty",
+        ),
+        pytest.param(
+            {
+                "status": "escalate",
+                "tool": CreekCapability.REFLECT.value,
+                "tier_ceiling": VaultTierCeiling.PERSONAL.value,
+                "reason": "care signal detected in the submitted content",
+                "care_signal": {"severity": "high", "category": "self_harm"},
+            },
+            id="escalate",
+        ),
+        pytest.param(
+            {
+                "status": "refused",
+                "tool": CreekCapability.REFLECT.value,
+                "tier_ceiling": VaultTierCeiling.OPEN.value,
+                "reason": "requested content exceeds the configured tier ceiling",
+            },
+            id="refused",
+        ),
+        pytest.param(
+            {"notes": [_creek_note("gift", _REFLECT_QUOTE, _REFLECT_NOTE)]},
+            id="status_missing",
+        ),
+        pytest.param(
+            {"status": "partial", "notes": [_creek_note("gift", _REFLECT_QUOTE, _REFLECT_NOTE)]},
+            id="status_unknown_future",
+        ),
+        pytest.param(
+            {"status": 123, "notes": [_creek_note("gift", _REFLECT_QUOTE, _REFLECT_NOTE)]},
+            id="status_wrong_typed",
+        ),
+    ],
+)
+def test_parse_reflection_non_ok_status_yields_no_reflection(payload: Mapping[str, object]) -> None:
+    """Any status other than the literal ok yields no reflection, even carrying usable notes."""
+    assert _parse_reflection(payload) == ""
+
+
+@pytest.mark.parametrize(
+    "notes",
+    [
+        pytest.param([], id="empty_list"),
+        pytest.param("not-a-list", id="string"),
+        pytest.param({}, id="mapping"),
+        pytest.param(
+            ["not-a-mapping", _creek_note("prophecy", _REFLECT_QUOTE, _REFLECT_NOTE), 7],
+            id="every_item_malformed",
+        ),
+    ],
+)
+def test_parse_reflection_ok_without_usable_notes_yields_no_reflection(notes: object) -> None:
+    """An ok status with nothing usable yields no reflection rather than an empty notes list."""
+    assert _parse_reflection(_reflect_payload(notes)) == ""
+
+
+def test_parse_reflection_ok_without_a_notes_key_yields_no_reflection() -> None:
+    """An ok payload with no notes key at all yields no reflection, never a bare notes list."""
+    payload = {"status": "ok", "tool": CreekCapability.REFLECT.value}
+    assert _parse_reflection(payload) == ""
+
+
+@pytest.mark.parametrize(
+    "bad_note",
+    [
+        pytest.param("not-a-mapping", id="non_mapping_item"),
+        pytest.param(_creek_note("prophecy", _REFLECT_QUOTE, _REFLECT_NOTE), id="unknown_kind"),
+        pytest.param(_creek_note(7, _REFLECT_QUOTE, _REFLECT_NOTE), id="non_string_kind"),
+        pytest.param({"kind": "gift", "note": _REFLECT_NOTE}, id="missing_quote"),
+        pytest.param({"kind": "gift", "quote": _REFLECT_QUOTE}, id="missing_note"),
+        pytest.param(_creek_note("gift", 7, _REFLECT_NOTE), id="non_string_quote"),
+        pytest.param(_creek_note("gift", _REFLECT_QUOTE, 7), id="non_string_note"),
+        pytest.param(_creek_note("gift", "", _REFLECT_NOTE), id="empty_quote"),
+        pytest.param(_creek_note("gift", " \n\t ", _REFLECT_NOTE), id="whitespace_quote"),
+        pytest.param(_creek_note("gift", _REFLECT_QUOTE, ""), id="empty_note"),
+        pytest.param(_creek_note("gift", _REFLECT_QUOTE, " \n\t "), id="whitespace_note"),
+        pytest.param(
+            _creek_note("gift", "q" * (ANCHOR_TEXT_MAX + 1), _REFLECT_NOTE), id="oversized_quote"
+        ),
+        pytest.param(
+            _creek_note("gift", _REFLECT_QUOTE, "n" * (NOTE_MAX + 1)), id="oversized_note"
+        ),
+    ],
+)
+def test_parse_reflection_drops_a_malformed_note_keeping_its_sibling(bad_note: object) -> None:
+    """A malformed note is dropped item by item, never taking its well-formed sibling with it."""
+    payload = _reflect_payload([bad_note, _creek_note("gift", _REFLECT_QUOTE, _REFLECT_NOTE)])
+    assert json.loads(_parse_reflection(payload)) == {
+        "notes": [{"kind": "theme", "quote": _REFLECT_QUOTE, "note": _REFLECT_NOTE}]
+    }
+
+
+def test_parse_reflection_keeps_notes_at_the_exact_length_boundaries() -> None:
+    """A quote of exactly ANCHOR_TEXT_MAX and a note of exactly NOTE_MAX both survive."""
+    quote = "q" * ANCHOR_TEXT_MAX
+    note = "n" * NOTE_MAX
+    payload = _reflect_payload([_creek_note("value", quote, note)])
+    assert json.loads(_parse_reflection(payload)) == {
+        "notes": [{"kind": "theme", "quote": quote, "note": note}]
+    }
+
+
+def test_parse_reflection_passes_the_quote_through_verbatim() -> None:
+    """A quote keeps its exact surrounding whitespace, since adepthood anchors it verbatim."""
+    quote = f"  {_REFLECT_QUOTE}  "
+    payload = _reflect_payload([_creek_note("pattern", quote, _REFLECT_NOTE)])
+    assert json.loads(_parse_reflection(payload)) == {
+        "notes": [{"kind": "connection", "quote": quote, "note": _REFLECT_NOTE}]
+    }
+
+
+def test_parse_reflection_caps_the_note_count_keeping_the_leading_prefix() -> None:
+    """Only the first _MAX_REFLECT_NOTES notes are rendered, in the order the vault sent them."""
+    over_cap = [
+        _creek_note("gift", _REFLECT_QUOTE, f"note number {index}")
+        for index in range(_MAX_REFLECT_NOTES + 3)
+    ]
+    rendered = json.loads(_parse_reflection(_reflect_payload(over_cap)))
+    assert [note["note"] for note in rendered["notes"]] == [
+        f"note number {index}" for index in range(_MAX_REFLECT_NOTES)
+    ]
+
+
+def test_parse_reflection_ignores_additive_response_fields() -> None:
+    """Essay and relation fields creek may add do not change the rendered marginalia."""
+    notes = [_creek_note("longing", _REFLECT_QUOTE, _REFLECT_NOTE)]
+    bare: Mapping[str, object] = {"status": "ok", "notes": notes}
+    enriched: Mapping[str, object] = {
+        **_reflect_payload(notes),
+        "essay": "a grounded essay the strict marginalia contract has no room for",
+        "essay_grounded": True,
+        "related_praxis": ["morning-sit"],
+        "related_eddies": [{"id": "eddy-1"}],
+    }
+    assert json.loads(_parse_reflection(enriched)) == json.loads(_parse_reflection(bare))
+    assert json.loads(_parse_reflection(enriched)) == {
+        "notes": [{"kind": "theme", "quote": _REFLECT_QUOTE, "note": _REFLECT_NOTE}]
+    }
+
+
+def test_marginalia_kind_map_targets_only_anchorable_kinds() -> None:
+    """Every mapped kind is one domain.resonance will actually anchor."""
+    assert set(_MARGINALIA_KIND_BY_CREEK_KIND.values()) <= VALID_KINDS
+
+
+def test_marginalia_kind_map_covers_creeks_published_kinds() -> None:
+    """The mapping's keys are exactly creek's seven published note kinds."""
+    assert set(_MARGINALIA_KIND_BY_CREEK_KIND) == _CREEK_NOTE_KINDS
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_creek_vault_reflect.py
+++ b/backend/tests/test_creek_vault_reflect.py
@@ -7,6 +7,8 @@ and ``select_reflection_llm`` are implemented.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pytest
 
 from domain.creek_vault import (
@@ -21,10 +23,17 @@ from domain.creek_vault import (
     VaultTierCeiling,
     VaultWheelBalance,
 )
-from domain.resonance import ResonanceLLM
+from domain.resonance import ResonanceLLM, generate_marginalia
+from services.creek_vault_client import McpCreekVaultClient
 from services.creek_vault_reflect import VaultResonanceLLM, select_reflection_llm
 
 _BODY = "the body under reflection"
+
+# A body plus two verbatim substrings of it, so the vault's quotes anchor for
+# real rather than being paraphrases the resonance pass would drop.
+_LOOP_STALL_QUOTE = "I stalled again"
+_LOOP_RIVER_QUOTE = "the river kept moving"
+_LOOP_BODY = f"{_LOOP_STALL_QUOTE} this week, and yet {_LOOP_RIVER_QUOTE} without me."
 
 
 class RecordingVaultClient:
@@ -97,6 +106,64 @@ class RecordingFallbackLLM:
         """Record ``prompt`` and return the sentinel completion."""
         self.prompts.append(prompt)
         return self._result
+
+
+class ScriptedReflectTransport:
+    """A minimal vault transport: a REFLECT-capable handshake, then one scripted reflect payload."""
+
+    def __init__(self, reflect_payload: Mapping[str, object]) -> None:
+        """Store the creek.reflect response this fake answers every reflect call with."""
+        self._reflect_payload = reflect_payload
+
+    async def call(self, method: str, _params: Mapping[str, object]) -> Mapping[str, object]:
+        """Answer creek.handshake as a REFLECT-capable vault, anything else with the payload."""
+        if method == CreekCapability.HANDSHAKE.value:
+            return {
+                "available": True,
+                "capabilities": [CreekCapability.REFLECT.value],
+                "contract_version": CONTRACT_VERSION,
+                "ontology_version": "1.0.0",
+                "attestation": None,
+            }
+        return self._reflect_payload
+
+
+@pytest.mark.asyncio
+async def test_vault_reflection_reaches_marginalia_instead_of_the_cloud_fallback() -> None:
+    """A creek-shaped vault reflection anchors as marginalia without deferring to the cloud."""
+    payload: Mapping[str, object] = {
+        "status": "ok",
+        "tool": CreekCapability.REFLECT.value,
+        "tier_ceiling": VaultTierCeiling.PERSONAL.value,
+        "routed_tier": VaultTierCeiling.PERSONAL.value,
+        "essay_grounded": False,
+        "notes": [
+            {
+                "kind": "pattern",
+                "quote": _LOOP_RIVER_QUOTE,
+                "note": "Motion keeps answering the weeks you call stalled.",
+            },
+            {
+                "kind": "fear",
+                "quote": _LOOP_STALL_QUOTE,
+                "note": "You name the stall plainly before anything else.",
+            },
+        ],
+    }
+    client = McpCreekVaultClient(transport=ScriptedReflectTransport(payload))
+    await client.handshake()
+    fallback = RecordingFallbackLLM()
+    llm = VaultResonanceLLM(
+        client, body=_LOOP_BODY, tier_ceiling=VaultTierCeiling.PERSONAL, fallback=fallback
+    )
+
+    anchored = await generate_marginalia(_LOOP_BODY, llm=llm)
+
+    assert [(note.kind, note.anchor_text) for note in anchored] == [
+        ("connection", _LOOP_RIVER_QUOTE),
+        ("theme", _LOOP_STALL_QUOTE),
+    ]
+    assert fallback.prompts == []
 
 
 @pytest.mark.asyncio

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -75,7 +75,7 @@ Creek's frequency classification of corpus content, while adepthood's
 ten stages are `CourseStage` rows tied to the APTITUDE program. The
 concrete field-by-field projection is owned by adepthood #1937.
 
-## Marginalia mapping (adepthood-owned, vocabulary gap)
+## Marginalia mapping (adepthood-owned)
 
 Creek's `creek.reflect` emits margin notes with a `kind` drawn from
 seven values: `{reframe, fear, longing, value, pattern, tension,
@@ -84,12 +84,30 @@ gift}` (`creek-tools/creek_mcp/tools/reflect.py:85`). Adepthood's
 (`backend/src/models/marginalia.py:23-28`), enforced by a database
 `CHECK` constraint (`marginalia.py:42-45`) and mirrored in
 `domain/resonance.py:21`'s `VALID_KINDS`. A raw passthrough of Creek's
-`kind` would be rejected by that constraint outright — the two
-vocabularies are not aligned and there is no trivial one-to-one
-mapping. The concrete kind-by-kind mapping (which of Creek's seven
-kinds maps to which of adepthood's three, and what happens to the ones
-that don't fit cleanly) is owned by adepthood #1936 and is
-deliberately **not** invented in this document.
+`kind` would be rejected by that constraint outright, so the
+translation below happens in adepthood's client adapter, not in
+Creek — Creek owns its own vocabulary and must not be asked to learn
+adepthood's:
+
+| Creek kind | Adepthood kind | Why |
+| --- | --- | --- |
+| `pattern` | `connection` | Creek grounds its notes in the surrounding corpus, so a recurrence note is exactly adepthood's cross-entry "connection" |
+| `reframe` | `theme` | A reinterpretation of this one entry, not a cross-entry link |
+| `fear` | `theme` | An affective reading of the entry's own content |
+| `longing` | `theme` | Same: affect surfaced from the entry itself |
+| `value` | `theme` | A value the entry expresses is a theme of the entry |
+| `tension` | `theme` | An intra-entry tension is thematic, not relational across entries |
+| `gift` | `theme` | A quality observed in the entry — thematic |
+
+Unrecognized kinds are dropped, not coerced: a `kind` adepthood does
+not know is never stored or rendered — the same drop-don't-coerce
+discipline the client already applies to unknown capability and
+error-code strings. Dropping one note does not discard its siblings.
+
+`symbol` is deliberately unused. Nothing in Creek's vocabulary denotes
+an image standing for something else, and forcing a non-symbol note
+onto that kind would misrender it. `symbol` remains reachable only
+from adepthood's own cloud reflection path.
 
 ## Per-capability fallback rules (as shipped)
 
@@ -104,7 +122,7 @@ capability is still used for the others it supports:
   advertised `creek.journal` — an unadvertised capability is refused
   locally, with no request sent — before issuing a `PUT` to the
   entry's own `/v1/journal-entries/{entry_id}` URL
-  (`backend/src/services/creek_vault_client.py:1095-1121`). Either
+  (`backend/src/services/creek_vault_client.py:1238-1264`). Either
   way, if the vault is absent or otherwise unavailable at handshake
   time, the write path reports `UNAVAILABLE`
   (`backend/src/services/creek_vault_write.py:266-267`); if the
@@ -122,9 +140,20 @@ capability is still used for the others it supports:
   once and forgotten, and the operator's own Postgres remains the
   sole system of record for that content either way.
 - **REFLECT** — if absent, adepthood falls back to its existing cloud
-  LLM reflection path (`backend/src/services/creek_vault_reflect.py:105-120`).
-  Content already flagged by the care gate never calls the vault for a
-  reflection at all, regardless of vault availability.
+  LLM reflection path (`backend/src/services/creek_vault_reflect.py:108-123`).
+  The same fallback fires for a response whose `status` is anything
+  other than `ok` — Creek's `empty`, its `escalate` care-signal
+  envelope, and its `refused` envelope all yield no vault reflection,
+  exactly as an absent capability does. An `ok` response none of whose
+  notes survive the marginalia-kind translation above also falls
+  back, rather than rendering an empty note set. A vault response is
+  untrusted input: the number of notes adepthood will accept from one
+  response is bounded, and each note's quote and body are
+  length-bounded, before anything is built from them. Additive fields
+  Creek may add later — its optional `essay`, and any future
+  related-praxis or related-eddies fields — are ignored rather than
+  erroring. Content already flagged by the care gate never calls the
+  vault for a reflection at all, regardless of vault availability.
 - **WHEEL** — if absent, or if the returned payload fails
   field-level validation, `fetch_vault_wheel` returns `None`
   (`backend/src/services/creek_vault_wheel.py:97-113`), and

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -122,7 +122,7 @@ capability is still used for the others it supports:
   advertised `creek.journal` — an unadvertised capability is refused
   locally, with no request sent — before issuing a `PUT` to the
   entry's own `/v1/journal-entries/{entry_id}` URL
-  (`backend/src/services/creek_vault_client.py:1238-1264`). Either
+  (`backend/src/services/creek_vault_client.py:1241-1288`). Either
   way, if the vault is absent or otherwise unavailable at handshake
   time, the write path reports `UNAVAILABLE`
   (`backend/src/services/creek_vault_write.py:266-267`); if the
@@ -148,7 +148,7 @@ capability is still used for the others it supports:
   notes survive the marginalia-kind translation above also falls
   back, rather than rendering an empty note set. A vault response is
   untrusted input: the number of notes adepthood will accept from one
-  response is bounded, and each note's quote and body are
+  response is bounded, and each note's quote and note text are
   length-bounded, before anything is built from them. Additive fields
   Creek may add later — its optional `essay`, and any future
   related-praxis or related-eddies fields — are ignored rather than


### PR DESCRIPTION
## Summary

`McpCreekVaultClient.reflect` read `payload.get("reflection")` — a key creek-vault's shipped `creek.reflect` tool does not emit — so it always returned `""`, `VaultResonanceLLM` always read that as "no answer", and the cloud fallback answered every resonance pass. The vault-grounded Higher Self never fired, which defeats the point of connecting a vault. The request was wrong too: `_content_params` sent `{consumer, body, tier_ceiling}` while creek's registered tool signature is `creek.reflect(content, entry_ref, privacy_tier_ceiling)` — all three names wrong, so the call would have been rejected before any response parsing mattered.

This parses creek's **actual** shipped shapes (read from `creek-tools/creek_mcp/tools/reflect.py`, `tier_ceiling.py`, and `server.py` in `Geoffe-Ga/creek-vault` — nothing here is guessed):

- `{"status": "ok"|"empty", "tool", "tier_ceiling", "routed_tier", "notes": [{"quote","kind","note"}], "essay_grounded", "essay"?}`
- care escalation: `{"status": "escalate", ..., "reason", "care_signal"}`
- refusal: `{"status": "refused", ..., "reason"}`

and translates it into the strict `{"notes": [...]}` marginalia contract `domain.resonance.generate_marginalia` already consumes.

### The vocabulary gap, now decided

Creek emits seven note kinds; adepthood's `MarginaliaKind` permits three, enforced by a DB `CHECK` constraint. A raw passthrough anchors **zero** notes. `docs/creek-vault-mcp-contract.md` explicitly deferred this mapping to this issue; the PR ratifies it and replaces that placeholder section:

| Creek kind | Adepthood kind | Why |
| --- | --- | --- |
| `pattern` | `connection` | Creek grounds notes in the surrounding corpus, so a recurrence note is exactly adepthood's cross-entry "connection" |
| `reframe`, `fear`, `longing`, `value`, `tension`, `gift` | `theme` | Each observes something about this one entry — not a cross-entry link, not an image |

`symbol` is deliberately **unused**: nothing in creek's vocabulary denotes an image standing for something else, and forcing a non-symbol onto it would render the note as something it is not. Unknown kinds are **dropped, never coerced** onto a nearest neighbour, and dropping one note never costs its siblings.

### Degrade rules

Anything but a literal `ok` status yields `""` so the existing cloud fallback engages — that covers `empty`, creek's `escalate` care handoff, `refused`, a missing status, and any status a future creek adds. An `ok` whose notes all fail translation also yields `""` rather than `{"notes": []}`: rendering an empty note set would suppress the fallback and leave the user with a Higher Self that said nothing at all.

### Bounding untrusted input

A vault response is untrusted network input that ends up persisted and rendered, so it is bounded **before** anything is built from it: at most `_MAX_REFLECT_NOTES = 12` items are considered (double creek's own cap of 6), each `quote` within `ANCHOR_TEXT_MAX` and each `note` within `NOTE_MAX` — roughly 12 KB serialized worst case, verified empirically at 11,159 chars against a 10,000-note input. Additive fields creek may add later (`essay`, and the `related_praxis`/`related_eddies` of #1930) are ignored by construction, since parsing reads only `status` and `notes`.

### Which adapter this touches, and why

**MCP only.** `HttpCreekVaultClient.reflect` deliberately keeps refusing with `CreekCapabilityUnsupportedError`: creek's `/v1` reflect shape is still PENDING upstream (creek-vault#1072 has shipped nothing), and guessing an unratified wire format is worse than staying local — the standing rule for this epic. MCP is the default transport (`CREEK_VAULT_PROTOCOL`) and is where `creek.reflect` actually runs today. The new helpers are **module-level pure functions** precisely so the HTTP adapter can adopt them unchanged when `/v1` ships (#2047). `LocalFallbackCreekVaultClient` and `_content_params` (which still serves `classify`, whose creek-side shape is unverified) are behaviourally untouched.

## Test plan

RED first: the new tests failed with `ImportError` on the absent names, and the end-to-end test failed with `assert [] == [('connection', ...)]` — i.e. the vault reflection producing zero marginalia, exactly the defect.

- **Loop-closer** (`test_creek_vault_reflect.py`): drives a real `McpCreekVaultClient` through a real handshake and `reflect()` parse, into a real `VaultResonanceLLM`, into the real `generate_marginalia`, and asserts both the anchored `(kind, anchor_text)` pairs **and** `fallback.prompts == []`. This is the issue's Goal asserted end to end; it fails against the pre-fix code.
- **Regression pin:** a payload shaped like the old `{"reflection": ...}` key now yields `""`.
- **Request shape:** `_reflect_params` carries exactly `{content, privacy_tier_ceiling}`, asserted disjoint from `{consumer, body, tier_ceiling}`.
- **Mapping:** all seven creek kinds parametrized; two drift guards — every mapped value is in `domain.resonance.VALID_KINDS` (imported, not restated), and the key set is exactly creek's seven (restated deliberately, as the pin against creek's vocabulary drifting).
- **Status matrix:** `empty`, `escalate` (with a `care_signal` payload), `refused`, missing, unknown-future, wrong-typed — the last three carrying *usable* notes, so the gate cannot be faked by the empty-notes path.
- **Item hygiene:** 13 parametrized cases (non-mapping item, unknown/non-string kind, missing/non-string/empty/whitespace quote and note, oversized quote, oversized note), each paired with a good sibling that must survive.
- **Boundaries:** a quote of exactly `ANCHOR_TEXT_MAX` and a note of exactly `NOTE_MAX` survive (pins `>`, not `>=`); a quote keeps its exact surrounding whitespace, since anchoring is verbatim.
- **Cap and additive fields:** order-preserving prefix at `_MAX_REFLECT_NOTES`; enriched and bare payloads render identically.

Gates: `./scripts/backend/check-all.sh` 7 passed / 0 failed, total coverage 97% (`creek_vault_client.py` 98%, `creek_vault_reflect.py` 100%); `./scripts/backend/complexity.sh` exit 0 (max new-function cyclomatic 5; radon MI on `creek_vault_client.py` 27.44 → 23.26, still rank A); `pre-commit run --all-files` green except the four `frontend/*` hooks, which fail only because this worktree has no `frontend/node_modules` (backend-only diff). A dedicated security review and a Gate 2.5 code review both returned **no defects introduced**.

## Pre-existing issues surfaced, deliberately not fixed here

The security pass found nothing wrong with this diff, but flagged four pre-existing surfaces. Each predates this change, each needs its own tests, and folding them in would turn a scoped parsing fix into four unrelated ones. Recording them so they are not lost:

1. **Vault corpus is deployment-scoped, not per-user.** `get_creek_vault_client()` takes no user and builds from one `CREEK_VAULT_URL`/`CREEK_VAULT_API_KEY`, and `CONSUMER_ID` is deployment-wide. Since creek grounds notes in the surrounding corpus, a `connection` note returned for user A could in principle be grounded in user B's material. Inert on `main` (reflect never returned anything) — **this commit is what makes that path live**, though it still requires `CREEK_VAULT_URL` to be set, which `.env.example` leaves empty. Worth an architect decision (per-user scoping vs. documenting that a connected vault implies a single-user deployment) **before** any multi-tenant instance sets that variable.
2. **`RecursionError` from deeply-nested JSON escapes every degrade set.** It subclasses `RuntimeError`, so it is in neither `_TRANSPORT_ERROR_TYPES` nor `_HANDSHAKE_DEGRADE_ERRORS`, and 500s a request whose wallet was already charged instead of falling back. One-line fix, but it touches all five capabilities.
3. **No response-size cap at the MCP transport** — `_first_text_payload`'s bare `json.loads` materializes the whole payload before any of our bounds apply. Bounds here cap the *stored* string and our *work*, not peak memory.
4. **`sanitize_user_text` gaps** — C1 controls (incl. 8-bit CSI `U+009B`), `U+061C`, `U+2028`/`U+2029`, and lone surrogates survive. Equally reachable from user-typed text and the cloud LLM path, so not vault-specific.

Also unchanged and deliberately out of scope: `select_reflection_llm`'s gate order is untouched — a care-flagged entry still returns the fallback with **zero** vault calls and no handshake, and an intimate classification still short-circuits in the router before this seam is reached.

Closes #1936
Refs #1932, #2043
