### PR TITLE
fix(backend): adapt creek.wheel's {wheel: {F1..F10}} response instead of raising ValidationError

### DIFF
--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -293,8 +293,8 @@ class VaultWheelAspect:
     """One Aspect's fullness at a stage, in a vault-computed wheel read.
 
     A domain-native mirror of the transport's per-Aspect wheel row so the seam's
-    return type stays pure Python; the adapter validates the wire payload against
-    the Pydantic schema and then projects it onto this value.
+    return type stays pure Python; the adapter owns the wire shape and projects
+    it onto this value.
     """
 
     stage_number: int
@@ -308,8 +308,8 @@ class VaultWheelBalance:
 
     The domain-layer return type of :meth:`CreekVaultClient.wheel` -- a plain,
     immutable value carrying no FastAPI/DB/schema dependency, exactly as the rest
-    of this module. The concrete adapter owns the (schema-backed) parse and hands
-    back this value, keeping the domain free of the Pydantic response type.
+    of this module. The concrete adapter owns the parse and hands back this
+    value, keeping the domain free of any wire or response type.
     """
 
     aspects: tuple[VaultWheelAspect, ...]
@@ -351,10 +351,11 @@ class CreekVaultClient(Protocol):
     async def wheel(self) -> VaultWheelBalance:
         """Return a Wheel-of-Wholeness balance read from the vault's corpus.
 
-        Unlike the other capabilities, a wheel payload whose *fields* are
-        malformed is not normalized to :class:`CreekVaultUnavailableError`: the
-        adapter surfaces a parse error so the read/compute path that consumes the
-        wheel owns field-level validation. The wheel is an optional read, never a
-        write, so a caller that cannot obtain it falls back to computing the
+        Degrades exactly like every other capability: a malformed, refused, or
+        otherwise unreadable payload is normalized to
+        :class:`CreekVaultUnavailableError` rather than surfacing a parse error.
+        Domain-range validation of a well-formed balance belongs to the
+        read/compute path that consumes it. The wheel is an optional read, never
+        a write, so a caller that cannot obtain it falls back to computing the
         balance locally.
         """

--- a/backend/src/domain/wheel.py
+++ b/backend/src/domain/wheel.py
@@ -51,10 +51,16 @@ class WheelItem(TypedDict):
     fullness: float
 
 
-async def _aspect_labels_by_stage(
-    session: AsyncSession, stage_numbers: list[int]
-) -> dict[int, str]:
-    """Return ``{stage_number: aspect}`` for the given stages in one query."""
+async def aspect_labels_by_stage(session: AsyncSession, stage_numbers: list[int]) -> dict[int, str]:
+    """Return ``{stage_number: aspect}`` for the given stages in one query.
+
+    Public because the Aspect vocabulary is adepthood's own: any producer of a
+    wheel -- this module's local computation, or a vault-sourced read that
+    carries only counts -- labels its stages from these rows, so the words the
+    user reads have exactly one source. A stage with no ``CourseStage`` row is
+    simply absent from the mapping; deciding what an absent label means belongs
+    to the caller.
+    """
     result = await session.execute(
         select(CourseStage.stage_number, CourseStage.aspect).where(
             col(CourseStage.stage_number).in_(stage_numbers)
@@ -125,7 +131,7 @@ async def compute_wheel_balance(session: AsyncSession, user_id: int) -> list[Whe
     """
     stage_numbers = list(range(1, TOTAL_STAGES + 1))
     batch = await compute_stage_progress_batch(session, user_id, stage_numbers)
-    aspects = await _aspect_labels_by_stage(session, stage_numbers)
+    aspects = await aspect_labels_by_stage(session, stage_numbers)
     weighted_counts = await _chord_tag_weighted_counts(session, user_id)
     return [
         {

--- a/backend/src/schemas/wheel.py
+++ b/backend/src/schemas/wheel.py
@@ -18,11 +18,13 @@ class WheelAspect(BaseModel):
 class WheelBalanceResponse(BaseModel):
     """The ten Aspect fullness values in canonical stage order.
 
-    The Aspect list is capped at ``TOTAL_STAGES`` so a vault-supplied wheel read
-    parsed through this schema cannot materialize an unbounded number of rows;
-    an over-cap payload fails validation and the consumer degrades to the local
-    balance. The local producer always emits exactly ``TOTAL_STAGES`` rows, so
-    the cap never constrains the in-app path.
+    Adepthood's own response shape for the wheel endpoint, never a parse of
+    anything a vault sends: the seam's client owns creek's wire shape and hands
+    the read path a domain value, which is relabelled and rendered through here
+    like any locally-computed balance. The ``TOTAL_STAGES`` cap is therefore
+    purely defensive -- the one producer that fills this model always emits
+    exactly that many rows, and the cap is what keeps a future one from
+    silently serializing more.
     """
 
     aspects: list[WheelAspect] = Field(max_length=TOTAL_STAGES)

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -675,25 +675,44 @@ def _wheel_fullness(raw: object) -> float | None:
     here: the read path's own aspect check owns it, and its chained comparison
     already rejects ``NaN`` and the infinities. That is a division of labor
     between the two halves of the seam, not a gap in either.
+
+    The conversion itself is guarded because JSON has no integer ceiling: a
+    literal past the float range decodes to an arbitrary-precision ``int``, and
+    ``float()`` then raises ``OverflowError`` -- an ``ArithmeticError`` that is in
+    neither this client's transport degrade set nor the read path's
+    ``CreekVaultError`` catch, so it would escape the seam as a crash on the
+    caller's request path. A share no float can hold is simply unreadable, which
+    is what ``None`` already means here.
     """
     if isinstance(raw, bool) or not isinstance(raw, int | float):
         return None
-    return float(raw)
+    try:
+        return float(raw)
+    except OverflowError:
+        return None
 
 
 def _wheel_aspect(entry: object, stage_number: int) -> VaultWheelAspect | None:
     """Project one Frequency entry onto a domain aspect, or drop it whole.
 
     Both halves have to survive on their own terms: a numeric ``share`` and a
-    non-blank ``name`` within :data:`_MAX_WHEEL_ASPECT_NAME_LENGTH`. A partial
-    entry is dropped rather than completed with a default, which would show the
-    user a Frequency reading neither they nor the vault ever produced.
+    non-blank, printable ``name`` within :data:`_MAX_WHEEL_ASPECT_NAME_LENGTH`. A
+    partial entry is dropped rather than completed with a default, which would
+    show the user a Frequency reading neither they nor the vault ever produced.
+
+    Printability is required for the same reason :func:`_is_storable_ref` requires
+    it of a fragment id: a Frequency name is short label text, so a control
+    character in one is never legitimate, and a name carrying CR/LF, an ANSI
+    escape, or a bidirectional override is exactly the payload that forges a log
+    line or misrenders a label. The name is relabelled away before this wheel is
+    rendered, but this helper is the boundary, and a value that is inert wherever
+    it lands does not depend on that.
     """
     if not isinstance(entry, Mapping):
         return None
     fullness = _wheel_fullness(entry.get("share"))
     name = _bounded_text(entry.get("name"), _MAX_WHEEL_ASPECT_NAME_LENGTH)
-    if fullness is None or name is None:
+    if fullness is None or name is None or not name.isprintable():
         return None
     return VaultWheelAspect(stage_number=stage_number, aspect=name, fullness=fullness)
 

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -76,6 +76,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.exceptions import McpError
 from mcp.types import CallToolResult, ErrorData
 
+from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
     CONSUMER_ID,
     CONTRACT_VERSION,
@@ -97,7 +98,6 @@ from domain.creek_vault import (
     VaultWheelBalance,
 )
 from domain.resonance import ANCHOR_TEXT_MAX, NOTE_MAX
-from schemas.wheel import WheelBalanceResponse
 
 # Timeout (seconds) for a single HTTP call to the vault. Bounds how long a slow
 # or hung vault can block a request before adepthood degrades to local.
@@ -233,6 +233,39 @@ _MARGINALIA_KIND_BY_CREEK_KIND: Mapping[str, str] = {
     "tension": "theme",
     "gift": "theme",
 }
+
+# The privacy ceiling adepthood presents when it asks for a wheel. Only
+# aggregate per-Frequency counts and shares cross this seam -- never fragment
+# content -- so the ceiling governs what the vault *counts*, not what it hands
+# back. ``personal`` is the honest maximum: intimate content never reaches the
+# vault from adepthood at all, and creek independently caps a network consumer
+# below intimate. ``open`` would be worse than useless rather than safer,
+# because creek ranks unclassified content with personal: an open ceiling
+# silently excludes every not-yet-classified fragment, so a young corpus reads
+# back as an all-zero wheel.
+_WHEEL_TIER_CEILING = VaultTierCeiling.PERSONAL
+
+# The status a ``creek.wheel`` response reports when it actually computed a
+# wheel. Its own constant rather than a reuse of :data:`_JOURNAL_OK_STATUS` or
+# :data:`_REFLECT_OK_STATUS`, for the reason those two are already kept apart:
+# the capabilities merely happen to spell their success the same way today, and
+# coupling them would let one capability's future rename silently change how
+# another is parsed.
+_WHEEL_OK_STATUS = "ok"
+
+# The Frequency keys adepthood will read out of the vault's wheel map, in
+# canonical order -- one per curriculum stage, so ``F1`` is stage 1. A whitelist
+# rather than an iteration of whatever the vault sent, so a code creek adds
+# later is ignored exactly as an unknown capability string already is.
+_WHEEL_FREQUENCY_CODES: tuple[str, ...] = tuple(f"F{n}" for n in range(1, TOTAL_STAGES + 1))
+
+# Longest Frequency name adepthood will accept from a wheel entry. A *bound*,
+# not a format -- the vault owns what it calls its own Frequencies -- and a
+# generous one, since the longest name either side actually ships is under
+# thirty characters. It exists because that string is carried into a domain
+# value and can reach a log, and without a ceiling a compromised vault could
+# answer with a string of any size at all.
+_MAX_WHEEL_ASPECT_NAME_LENGTH = 128
 
 # Payload-parsing failures. A malformed or wrong-typed handshake response should
 # degrade to unavailable exactly like a transport error, never propagate.
@@ -622,6 +655,85 @@ def _reflect_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, o
     return {"content": body, "privacy_tier_ceiling": tier_ceiling.value}
 
 
+def _wheel_params() -> Mapping[str, object]:
+    """Map a wheel request onto the ``creek.wheel`` wire fields.
+
+    Exactly one: the privacy ceiling the vault's router enforces while it counts.
+    There is no ``consumer`` key -- the vault learns the caller from the MCP
+    session itself, exactly as it already does for ingest and reflect -- and no
+    other caller-supplied parameter exists on this tool.
+    """
+    return {"privacy_tier_ceiling": _WHEEL_TIER_CEILING.value}
+
+
+def _wheel_fullness(raw: object) -> float | None:
+    """Return a Frequency's share as a float, or ``None`` when it is not a number.
+
+    Booleans are rejected *before* the numeric test, because ``isinstance(True,
+    int)`` is ``True`` and a bare numeric check would silently read ``True`` as a
+    completely full Frequency. The ``0.0..1.0`` bound is deliberately not checked
+    here: the read path's own aspect check owns it, and its chained comparison
+    already rejects ``NaN`` and the infinities. That is a division of labor
+    between the two halves of the seam, not a gap in either.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, int | float):
+        return None
+    return float(raw)
+
+
+def _wheel_aspect(entry: object, stage_number: int) -> VaultWheelAspect | None:
+    """Project one Frequency entry onto a domain aspect, or drop it whole.
+
+    Both halves have to survive on their own terms: a numeric ``share`` and a
+    non-blank ``name`` within :data:`_MAX_WHEEL_ASPECT_NAME_LENGTH`. A partial
+    entry is dropped rather than completed with a default, which would show the
+    user a Frequency reading neither they nor the vault ever produced.
+    """
+    if not isinstance(entry, Mapping):
+        return None
+    fullness = _wheel_fullness(entry.get("share"))
+    name = _bounded_text(entry.get("name"), _MAX_WHEEL_ASPECT_NAME_LENGTH)
+    if fullness is None or name is None:
+        return None
+    return VaultWheelAspect(stage_number=stage_number, aspect=name, fullness=fullness)
+
+
+def _wheel_aspects(wheel: Mapping[str, object]) -> tuple[VaultWheelAspect, ...]:
+    """Project the whitelisted Frequency codes onto aspects, dropping the unusable ones.
+
+    Walks :data:`_WHEEL_FREQUENCY_CODES` rather than the mapping's own keys, so
+    the stage number comes from adepthood's canonical order and any code outside
+    the whitelist is ignored. The caller decides what a short result means.
+    """
+    return tuple(
+        aspect
+        for stage_number, code in enumerate(_WHEEL_FREQUENCY_CODES, start=1)
+        if (aspect := _wheel_aspect(wheel.get(code), stage_number)) is not None
+    )
+
+
+def _parse_wheel(payload: Mapping[str, object]) -> VaultWheelBalance | None:
+    """Project a ``creek.wheel`` response onto a domain balance, or ``None`` if unusable.
+
+    Answers ``None`` -- never raises -- so the caller owns the degrade. Three
+    conditions: a literal :data:`_WHEEL_OK_STATUS`, which is the strict equality
+    that makes ``refused``, ``empty``, and any status a future creek adds all
+    degrade rather than be mined for numbers; a ``wheel`` that is a mapping; and
+    a usable entry for *every* Frequency code. That last one is all-or-nothing on
+    purpose: one bad Frequency rejects the whole read rather than yielding a ring
+    with a hole in it.
+    """
+    if payload.get("status") != _WHEEL_OK_STATUS:
+        return None
+    wheel = payload.get("wheel")
+    if not isinstance(wheel, Mapping):
+        return None
+    aspects = _wheel_aspects(wheel)
+    if len(aspects) != len(_WHEEL_FREQUENCY_CODES):
+        return None
+    return VaultWheelBalance(aspects=aspects)
+
+
 def _content_params(body: str, tier_ceiling: VaultTierCeiling) -> Mapping[str, object]:
     """Build the params for a ``creek.classify`` call, whose wire shape is unverified."""
     return {"consumer": CONSUMER_ID, "body": body, "tier_ceiling": tier_ceiling.value}
@@ -762,32 +874,24 @@ class McpCreekVaultClient:
     async def wheel(self) -> VaultWheelBalance:
         """Return a vault-computed Wheel-of-Wholeness read, requiring WHEEL.
 
-        The wire payload is validated against :class:`WheelBalanceResponse` (the
-        schema import is legitimate in this adapter layer) and then projected onto
-        the pure-domain :class:`VaultWheelBalance` the seam contract returns, so
-        the domain module carries no schema dependency.
+        Creek answers with a per-Frequency map keyed ``F1``..``F10``, which
+        :func:`_parse_wheel` projects onto the pure-domain
+        :class:`VaultWheelBalance` the seam contract returns -- so the domain
+        module carries no wire dependency.
 
-        A well-formed mapping whose *fields* do not match the schema still raises
-        ``pydantic.ValidationError`` here rather than degrading to
-        :class:`CreekVaultUnavailableError`. That is the one un-normalized error
-        path in this client and is deliberate: field-level wheel validation and a
-        response-size ceiling belong with the read/compute path that consumes the
-        wheel. It does not weaken the floor guarantee -- the wheel is an optional
-        read, never a write, and a caller that cannot obtain it falls back to
-        computing the balance locally.
+        A malformed or refused wheel degrades exactly like every other
+        capability, to :class:`CreekVaultUnavailableError` carrying the same
+        static, capability-named message, so no payload content can reach a log
+        or a traceback. The wheel is an optional read, never a write, and a
+        caller that cannot obtain it falls back to computing the balance locally.
         """
-        payload = await self._invoke(CreekCapability.WHEEL, {"consumer": CONSUMER_ID})
-        validated = WheelBalanceResponse.model_validate(payload)
-        return VaultWheelBalance(
-            aspects=tuple(
-                VaultWheelAspect(
-                    stage_number=aspect.stage_number,
-                    aspect=aspect.aspect,
-                    fullness=aspect.fullness,
-                )
-                for aspect in validated.aspects
-            ),
-        )
+        payload = await self._invoke(CreekCapability.WHEEL, _wheel_params())
+        balance = _parse_wheel(payload)
+        if balance is None:
+            raise CreekVaultUnavailableError(
+                f"creek vault returned a malformed response: {CreekCapability.WHEEL.value}"
+            )
+        return balance
 
 
 class HandshakeDegradeReason(enum.StrEnum):

--- a/backend/src/services/creek_vault_wheel.py
+++ b/backend/src/services/creek_vault_wheel.py
@@ -125,6 +125,12 @@ async def fetch_vault_wheel(client: CreekVaultClient) -> list[WheelItem] | None:
     usable wheel -- a seam error from the call, a field-level or structural
     violation on the returned balance, or a well-formed but wholly-zero wheel --
     collapses to ``None``, the signal for the caller to compute locally.
+
+    "Validated" is about ranges and structure, not provenance: each item's
+    ``aspect`` is still the *vault's* word for that Frequency, bounded and
+    printable but not adepthood's vocabulary. Every caller must relabel it from
+    the curriculum before rendering or logging it, as
+    :func:`select_wheel_balance` does.
     """
     await client.handshake()
     if not (client.is_available() and client.supports(CreekCapability.WHEEL)):

--- a/backend/src/services/creek_vault_wheel.py
+++ b/backend/src/services/creek_vault_wheel.py
@@ -1,13 +1,14 @@
 """Creek Vault read path: source a Wheel-of-Wholeness balance, degrading safely.
 
-This is the read-path consumer of the seam's ``wheel`` capability. Where the
-seam adapter deliberately defers field-level validation of a wheel payload, this
-module owns it: the adapter validates the wire *shape* against its Pydantic
-schema and, on a malformed field, surfaces a :class:`pydantic.ValidationError`
-rather than normalizing it to :class:`~domain.creek_vault.CreekVaultError`. This
-module catches that error alongside the vault's own error hierarchy and falls
-back, so a malformed-field wheel is indistinguishable from an absent vault to the
-caller.
+This is the read-path consumer of the seam's ``wheel`` capability. The adapter
+underneath it owns creek's wire shape, and degrades a malformed or refused wheel
+payload to :class:`~domain.creek_vault.CreekVaultError` exactly as every other
+capability does; nothing but that one error hierarchy crosses into this module.
+Three jobs are left here, and they are this module's alone: validating the
+*domain ranges* of whatever any client implementation returns, deciding whether
+a well-formed vault wheel is even worth preferring over the locally-computed
+balance, and projecting the vault's counts onto adepthood's own Aspect
+vocabulary.
 
 The governing rule is the same **graceful degradation** as the rest of the seam:
 an absent, unreachable, capability-poor, or malformed-payload vault never raises
@@ -20,7 +21,6 @@ from a trusted local half and an untrusted vault half.
 
 from __future__ import annotations
 
-import pydantic
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from domain.constants import TOTAL_STAGES
@@ -31,7 +31,7 @@ from domain.creek_vault import (
     VaultWheelAspect,
     VaultWheelBalance,
 )
-from domain.wheel import WheelItem, compute_wheel_balance
+from domain.wheel import WheelItem, aspect_labels_by_stage, compute_wheel_balance
 
 # The wheel carries exactly one aspect per curriculum stage; a payload of any
 # other length is rejected outright.
@@ -81,16 +81,38 @@ def _to_items(aspects: tuple[VaultWheelAspect, ...]) -> list[WheelItem]:
     ]
 
 
-async def _read_balance(client: CreekVaultClient) -> VaultWheelBalance | None:
-    """Call the vault's wheel, mapping any seam or field-validation error to ``None``.
+def _carries_signal(items: list[WheelItem]) -> bool:
+    """Return whether any aspect reads above the fullness floor.
 
-    A :class:`~domain.creek_vault.CreekVaultError` (unavailable or unsupported)
-    and a :class:`pydantic.ValidationError` (a malformed field the adapter
-    deliberately did not normalize) both degrade to ``None``.
+    An all-zero wheel is *valid* creek output -- an empty or wholly-unclassified
+    corpus reads exactly that way -- but it says nothing, and rendering it would
+    blank a Map the local balance can fill from the user's own habits, practice,
+    and course progress. The rule is deliberately "no positive value anywhere",
+    never "reject any zero": a real corpus concentrated in one Aspect
+    legitimately reads nine zeros and one number.
+    """
+    return any(item["fullness"] > VAULT_WHEEL_FULLNESS_MIN for item in items)
+
+
+def _usable_items(balance: VaultWheelBalance | None) -> list[WheelItem] | None:
+    """Return a balance's items in canonical order when it both validates and says something."""
+    if balance is None or not _balance_valid(balance.aspects):
+        return None
+    items = _to_items(balance.aspects)
+    return items if _carries_signal(items) else None
+
+
+async def _read_balance(client: CreekVaultClient) -> VaultWheelBalance | None:
+    """Call the vault's wheel, mapping any seam error to ``None``.
+
+    :class:`~domain.creek_vault.CreekVaultError` is the only thing the seam can
+    raise: the adapter normalizes a malformed or refused payload into it exactly
+    as it does an unreachable or unadvertised vault, so one ``except`` covers
+    every way the call can fail to produce a wheel.
     """
     try:
         return await client.wheel()
-    except (CreekVaultError, pydantic.ValidationError):
+    except CreekVaultError:
         return None
 
 
@@ -99,22 +121,48 @@ async def fetch_vault_wheel(client: CreekVaultClient) -> list[WheelItem] | None:
 
     Mirrors the gate order of the reflection read path: a handshake precedes any
     wheel call, and an unavailable vault or one that does not advertise WHEEL
-    degrades before the call is made. A transport/field error from the call, or
-    any field-level or structural validation violation on the returned balance,
-    all collapse to ``None`` -- the signal for the caller to compute locally.
+    degrades before the call is made. Every remaining way to end up without a
+    usable wheel -- a seam error from the call, a field-level or structural
+    violation on the returned balance, or a well-formed but wholly-zero wheel --
+    collapses to ``None``, the signal for the caller to compute locally.
     """
     await client.handshake()
     if not (client.is_available() and client.supports(CreekCapability.WHEEL)):
         return None
-    balance = await _read_balance(client)
-    if balance is None or not _balance_valid(balance.aspects):
-        return None
-    return _to_items(balance.aspects)
+    return _usable_items(await _read_balance(client))
+
+
+async def _relabelled_items(
+    session: AsyncSession, items: list[WheelItem]
+) -> list[WheelItem] | None:
+    """Re-label vault items with adepthood's own Aspect words, or ``None`` if it cannot be done.
+
+    The vault owns the counts; adepthood owns the vocabulary, so a wheel sourced
+    from the vault still reads in the words of the course. Every stage needs a
+    non-blank ``CourseStage`` label: one missing or blank row discards the whole
+    vault wheel, because a ring that is half creek's vocabulary and half a gap is
+    worse than the local balance it would have replaced.
+    """
+    labels = await aspect_labels_by_stage(session, [item["stage_number"] for item in items])
+    relabelled = [
+        WheelItem(stage_number=item["stage_number"], aspect=label, fullness=item["fullness"])
+        for item in items
+        if (label := labels.get(item["stage_number"], "")).strip()
+    ]
+    return relabelled if len(relabelled) == len(items) else None
 
 
 async def select_wheel_balance(
     client: CreekVaultClient, session: AsyncSession, user_id: int
 ) -> list[WheelItem]:
-    """Return the vault's wheel when available and valid, else the locally-computed balance."""
+    """Return the vault's wheel in adepthood's Aspect words, else the locally-computed balance.
+
+    One source per wheel: a vault wheel that cannot be relabelled in full is
+    discarded outright rather than rendered as a hybrid of a vault half and a
+    broken local half.
+    """
     items = await fetch_vault_wheel(client)
-    return items if items is not None else await compute_wheel_balance(session, user_id)
+    relabelled = None if items is None else await _relabelled_items(session, items)
+    if relabelled is not None:
+        return relabelled
+    return await compute_wheel_balance(session, user_id)

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -121,6 +121,15 @@ _WHEEL_ASPECT_NAMES = (
     "Emptiness",
 )
 
+# A JSON integer whose magnitude no float can hold. Every integer literal is
+# valid JSON and Python decodes one to an arbitrary-precision ``int``, so a
+# hostile or buggy vault can put this in a ``share``; ``float()`` on it raises
+# ``OverflowError``, an ``ArithmeticError`` that sits in neither the client's
+# transport degrade set nor the read path's ``CreekVaultError`` catch. The
+# exponent is a decade past the ~1.8e308 float ceiling and far inside CPython's
+# 4300-digit integer-parsing limit, so it is a value that really does arrive.
+_FLOAT_OVERFLOWING_SHARE = 10**400
+
 
 def _wheel_entry(name: object, share: object) -> dict[str, object]:
     """Build one creek.wheel Frequency entry, allowing deliberately malformed field types."""
@@ -937,6 +946,12 @@ _UNUSABLE_WHEEL_PAYLOADS: list[tuple[str, Mapping[str, object]]] = [
         "share_null",
         _wheel_payload(_wheel_map_with("F2", _wheel_entry(_WHEEL_ASPECT_NAMES[1], None))),
     ),
+    (
+        "share_an_int_no_float_can_hold",
+        _wheel_payload(
+            _wheel_map_with("F2", _wheel_entry(_WHEEL_ASPECT_NAMES[1], _FLOAT_OVERFLOWING_SHARE))
+        ),
+    ),
     ("name_missing", _wheel_payload(_wheel_map_with("F5", {"share": 0.5}))),
     ("name_blank", _wheel_payload(_wheel_map_with("F5", _wheel_entry("", 0.5)))),
     ("name_whitespace_only", _wheel_payload(_wheel_map_with("F5", _wheel_entry("   ", 0.5)))),
@@ -946,6 +961,18 @@ _UNUSABLE_WHEEL_PAYLOADS: list[tuple[str, Mapping[str, object]]] = [
         _wheel_payload(
             _wheel_map_with("F5", _wheel_entry("x" * (_MAX_WHEEL_ASPECT_NAME_LENGTH + 1), 0.5))
         ),
+    ),
+    (
+        "name_carrying_a_newline",
+        _wheel_payload(_wheel_map_with("F5", _wheel_entry("Agency\nWARN root: pay up", 0.5))),
+    ),
+    (
+        "name_carrying_an_ansi_escape",
+        _wheel_payload(_wheel_map_with("F5", _wheel_entry("Agency\x1b[31m", 0.5))),
+    ),
+    (
+        "name_carrying_a_bidi_override",
+        _wheel_payload(_wheel_map_with("F5", _wheel_entry("Agency\u202e", 0.5))),
     ),
 ]
 

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -15,7 +15,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.types import CallToolResult, ImageContent, TextContent
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
@@ -36,6 +36,10 @@ from services.creek_vault_client import (
     _MARGINALIA_KIND_BY_CREEK_KIND,
     _MAX_FRAGMENT_ID_LENGTH,
     _MAX_REFLECT_NOTES,
+    _MAX_WHEEL_ASPECT_NAME_LENGTH,
+    _WHEEL_FREQUENCY_CODES,
+    _WHEEL_OK_STATUS,
+    _WHEEL_TIER_CEILING,
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
     _extract_tool_payload,
@@ -44,7 +48,9 @@ from services.creek_vault_client import (
     _McpStreamableHttpTransport,
     _parse_ingest_result,
     _parse_reflection,
+    _parse_wheel,
     _reflect_params,
+    _wheel_params,
     build_creek_vault_client,
 )
 
@@ -97,6 +103,74 @@ def _reflect_payload(notes: object) -> dict[str, object]:
         "notes": notes,
         "essay_grounded": False,
     }
+
+
+# Creek's own Frequency names, in F-code order. Restated as a literal on purpose:
+# these strings arrive from the vault and must survive the parse verbatim, so
+# deriving them from anything adepthood owns would hide a relabelling bug.
+_WHEEL_ASPECT_NAMES = (
+    "Agency",
+    "Receptivity",
+    "Discernment",
+    "Devotion",
+    "Integrity",
+    "Play",
+    "Service",
+    "Sovereignty",
+    "Communion",
+    "Emptiness",
+)
+
+
+def _wheel_entry(name: object, share: object) -> dict[str, object]:
+    """Build one creek.wheel Frequency entry, allowing deliberately malformed field types."""
+    return {"name": name, "share": share}
+
+
+def _creek_wheel_map() -> dict[str, object]:
+    """Build a well-formed creek wheel map: all ten F-codes with distinct shares."""
+    return {
+        f"F{n}": _wheel_entry(_WHEEL_ASPECT_NAMES[n - 1], round(n / 10, 2))
+        for n in range(1, TOTAL_STAGES + 1)
+    }
+
+
+def _wheel_map_with(code: str, entry: object) -> dict[str, object]:
+    """Build the ten-code wheel map with ``code``'s entry replaced by ``entry``."""
+    wheel = _creek_wheel_map()
+    wheel[code] = entry
+    return wheel
+
+
+def _wheel_map_without(code: str) -> dict[str, object]:
+    """Build the ten-code wheel map with ``code`` dropped entirely."""
+    wheel = _creek_wheel_map()
+    del wheel[code]
+    return wheel
+
+
+def _wheel_payload(wheel: object) -> dict[str, object]:
+    """Build a well-formed creek.wheel ok-status response carrying ``wheel``."""
+    return {
+        "status": "ok",
+        "tool": CreekCapability.WHEEL.value,
+        "tier_ceiling": VaultTierCeiling.PERSONAL.value,
+        "total_classified": 20,
+        "unclassified": 3,
+        "wheel": wheel,
+    }
+
+
+def _expected_balance() -> VaultWheelBalance:
+    """Build the domain balance a well-formed creek wheel map projects onto."""
+    return VaultWheelBalance(
+        aspects=tuple(
+            VaultWheelAspect(
+                stage_number=n, aspect=_WHEEL_ASPECT_NAMES[n - 1], fullness=round(n / 10, 2)
+            )
+            for n in range(1, TOTAL_STAGES + 1)
+        )
+    )
 
 
 class ScriptedTransport:
@@ -727,63 +801,209 @@ def test_marginalia_kind_map_covers_creeks_published_kinds() -> None:
     assert set(_MARGINALIA_KIND_BY_CREEK_KIND) == _CREEK_NOTE_KINDS
 
 
+def _wheel_client(payload: Mapping[str, object]) -> McpCreekVaultClient:
+    """Build a client whose transport advertises WHEEL and answers it with ``payload``."""
+    transport = ScriptedTransport(
+        responses={
+            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
+            CreekCapability.WHEEL.value: payload,
+        }
+    )
+    return McpCreekVaultClient(transport=transport)
+
+
+def test_wheel_params_sends_only_the_privacy_tier_ceiling() -> None:
+    """Wheel params carry exactly the one creek.wheel wire field, with no consumer key."""
+    params = _wheel_params()
+    assert params == {"privacy_tier_ceiling": VaultTierCeiling.PERSONAL.value}
+    assert {"consumer", "tier_ceiling"}.isdisjoint(params)
+    assert _WHEEL_TIER_CEILING is VaultTierCeiling.PERSONAL
+
+
+def test_wheel_frequency_codes_cover_every_stage_in_ascending_order() -> None:
+    """The wheel's Frequency codes are F1..F10, one per curriculum stage, in order."""
+    expected_codes = tuple(f"F{n}" for n in range(1, TOTAL_STAGES + 1))
+    assert expected_codes == _WHEEL_FREQUENCY_CODES
+
+
+def test_wheel_wire_constants_match_creeks_published_contract() -> None:
+    """The wheel's success status and its aspect-name ceiling hold their pinned values."""
+    assert _WHEEL_OK_STATUS == "ok"
+    assert _MAX_WHEEL_ASPECT_NAME_LENGTH == 128
+
+
+def test_parse_wheel_projects_a_creek_payload_onto_the_domain_balance() -> None:
+    """_parse_wheel maps each F-code onto its stage number, its name, and its share."""
+    assert _parse_wheel(_wheel_payload(_creek_wheel_map())) == _expected_balance()
+
+
+def test_parse_wheel_returns_none_for_an_unusable_payload() -> None:
+    """_parse_wheel answers None rather than raising, leaving the degrade to its caller."""
+    refusal = {
+        "status": "refused",
+        "tool": CreekCapability.WHEEL.value,
+        "tier_ceiling": VaultTierCeiling.PERSONAL.value,
+        "reason": "requested content exceeds the configured tier ceiling",
+    }
+    assert _parse_wheel(refusal) is None
+
+
 @pytest.mark.asyncio
 async def test_wheel_success_projects_onto_vault_wheel_balance() -> None:
-    """wheel() projects a vault-computed wheel payload onto VaultWheelBalance."""
-    transport = ScriptedTransport(
-        responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
-            CreekCapability.WHEEL.value: {
-                "aspects": [
-                    {"stage_number": 1, "aspect": "courage", "fullness": 0.5},
-                    {"stage_number": 2, "aspect": "shadow", "fullness": 0.75},
-                ]
-            },
-        }
-    )
-    client = McpCreekVaultClient(transport=transport)
+    """wheel() projects creek's F-code wheel map onto ascending VaultWheelBalance aspects."""
+    client = _wheel_client(_wheel_payload(_creek_wheel_map()))
     await client.handshake()
     result = await client.wheel()
-    assert result == VaultWheelBalance(
-        aspects=(
-            VaultWheelAspect(stage_number=1, aspect="courage", fullness=0.5),
-            VaultWheelAspect(stage_number=2, aspect="shadow", fullness=0.75),
-        )
-    )
+    assert result == _expected_balance()
+    assert [aspect.stage_number for aspect in result.aspects] == list(range(1, TOTAL_STAGES + 1))
 
 
 @pytest.mark.asyncio
-async def test_wheel_malformed_fields_raise_validation_error() -> None:
-    """wheel() does not normalize a bad-fields payload; the parse error surfaces."""
-    transport = ScriptedTransport(
-        responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
-            CreekCapability.WHEEL.value: {"aspects": [{"stage_number": "not-an-int"}]},
-        }
-    )
-    client = McpCreekVaultClient(transport=transport)
+async def test_wheel_empty_corpus_parses_as_ten_zero_fullness_aspects() -> None:
+    """An all-zero wheel parses successfully; whether to defer is the read path's call."""
+    wheel = {
+        f"F{n}": _wheel_entry(_WHEEL_ASPECT_NAMES[n - 1], 0.0) for n in range(1, TOTAL_STAGES + 1)
+    }
+    payload = {**_wheel_payload(wheel), "total_classified": 0, "unclassified": 0}
+    client = _wheel_client(payload)
     await client.handshake()
-    with pytest.raises(ValidationError):
+    result = await client.wheel()
+    assert [aspect.stage_number for aspect in result.aspects] == list(range(1, TOTAL_STAGES + 1))
+    assert [aspect.fullness for aspect in result.aspects] == [0.0] * TOTAL_STAGES
+
+
+@pytest.mark.asyncio
+async def test_wheel_ignores_unknown_envelope_and_wheel_keys() -> None:
+    """Envelope fields and wheel codes creek may add are ignored, leaving exactly ten aspects."""
+    wheel = {
+        **_creek_wheel_map(),
+        "F11": _wheel_entry("A Frequency Nobody Has Published Yet", 0.5),
+        "junk": "not an entry at all",
+    }
+    payload = {
+        **_wheel_payload(wheel),
+        "essay": "a grounded essay the wheel contract has no room for",
+        "related": ["eddy-1"],
+    }
+    client = _wheel_client(payload)
+    await client.handshake()
+    result = await client.wheel()
+    assert result == _expected_balance()
+    assert len(result.aspects) == TOTAL_STAGES
+
+
+@pytest.mark.asyncio
+async def test_wheel_accepts_an_integer_share() -> None:
+    """A whole-number share serialized as an int lands as a float fullness."""
+    whole = _wheel_map_with("F4", _wheel_entry(_WHEEL_ASPECT_NAMES[3], 1))
+    client = _wheel_client(_wheel_payload(whole))
+    await client.handshake()
+    result = await client.wheel()
+    stage_four = next(aspect for aspect in result.aspects if aspect.stage_number == 4)
+    assert stage_four.fullness == 1.0
+    assert isinstance(stage_four.fullness, float)
+
+
+_UNUSABLE_WHEEL_PAYLOADS: list[tuple[str, Mapping[str, object]]] = [
+    (
+        "status_refused",
+        {
+            "status": "refused",
+            "tool": CreekCapability.WHEEL.value,
+            "tier_ceiling": VaultTierCeiling.PERSONAL.value,
+            "reason": "requested content exceeds the configured tier ceiling",
+        },
+    ),
+    ("status_missing", {"tool": CreekCapability.WHEEL.value, "wheel": _creek_wheel_map()}),
+    ("status_unknown_future", {**_wheel_payload(_creek_wheel_map()), "status": "empty"}),
+    ("status_wrong_typed", {**_wheel_payload(_creek_wheel_map()), "status": 1}),
+    (
+        "wheel_missing",
+        {key: value for key, value in _wheel_payload(_creek_wheel_map()).items() if key != "wheel"},
+    ),
+    ("wheel_not_a_mapping", _wheel_payload([_creek_wheel_map()])),
+    ("frequency_code_missing", _wheel_payload(_wheel_map_without("F7"))),
+    ("entry_not_a_mapping", _wheel_payload(_wheel_map_with("F3", "nope"))),
+    ("share_missing", _wheel_payload(_wheel_map_with("F2", {"name": _WHEEL_ASPECT_NAMES[1]}))),
+    (
+        "share_a_string",
+        _wheel_payload(_wheel_map_with("F2", _wheel_entry(_WHEEL_ASPECT_NAMES[1], "0.4"))),
+    ),
+    (
+        "share_a_bool",
+        _wheel_payload(_wheel_map_with("F2", _wheel_entry(_WHEEL_ASPECT_NAMES[1], True))),
+    ),
+    (
+        "share_null",
+        _wheel_payload(_wheel_map_with("F2", _wheel_entry(_WHEEL_ASPECT_NAMES[1], None))),
+    ),
+    ("name_missing", _wheel_payload(_wheel_map_with("F5", {"share": 0.5}))),
+    ("name_blank", _wheel_payload(_wheel_map_with("F5", _wheel_entry("", 0.5)))),
+    ("name_whitespace_only", _wheel_payload(_wheel_map_with("F5", _wheel_entry("   ", 0.5)))),
+    ("name_wrong_typed", _wheel_payload(_wheel_map_with("F5", _wheel_entry(42, 0.5)))),
+    (
+        "name_over_length_cap",
+        _wheel_payload(
+            _wheel_map_with("F5", _wheel_entry("x" * (_MAX_WHEEL_ASPECT_NAME_LENGTH + 1), 0.5))
+        ),
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [case[1] for case in _UNUSABLE_WHEEL_PAYLOADS],
+    ids=[case[0] for case in _UNUSABLE_WHEEL_PAYLOADS],
+)
+async def test_wheel_degrades_to_unavailable_on_unusable_payload(
+    payload: Mapping[str, object],
+) -> None:
+    """Any unusable wheel response degrades to CreekVaultUnavailableError, never a parse error."""
+    client = _wheel_client(payload)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
         await client.wheel()
 
 
 @pytest.mark.asyncio
-async def test_wheel_over_cap_aspect_count_raises_validation_error() -> None:
-    """wheel() rejects an aspect list larger than the schema ceiling."""
-    over_cap = [
-        {"stage_number": n, "aspect": f"Aspect-{n}", "fullness": 0.5}
-        for n in range(1, TOTAL_STAGES + 2)
-    ]
-    transport = ScriptedTransport(
-        responses={
-            CreekCapability.HANDSHAKE.value: _handshake_payload([CreekCapability.WHEEL.value]),
-            CreekCapability.WHEEL.value: {"aspects": over_cap},
-        }
-    )
-    client = McpCreekVaultClient(transport=transport)
+async def test_wheel_keeps_a_name_at_the_exact_length_boundary() -> None:
+    """A name of exactly _MAX_WHEEL_ASPECT_NAME_LENGTH characters survives verbatim."""
+    name = "x" * _MAX_WHEEL_ASPECT_NAME_LENGTH
+    client = _wheel_client(_wheel_payload(_wheel_map_with("F5", _wheel_entry(name, 0.5))))
     await client.handshake()
-    with pytest.raises(ValidationError):
+    result = await client.wheel()
+    stage_five = next(aspect for aspect in result.aspects if aspect.stage_number == 5)
+    assert stage_five.aspect == name
+
+
+@pytest.mark.asyncio
+async def test_wheel_adepthood_shaped_payload_degrades_to_unavailable() -> None:
+    """Adepthood's own aspects-list shape is not creek's wire shape, so it degrades."""
+    payload = {
+        "aspects": [
+            {"stage_number": n, "aspect": f"Aspect-{n}", "fullness": 0.5}
+            for n in range(1, TOTAL_STAGES + 1)
+        ]
+    }
+    client = _wheel_client(payload)
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError):
         await client.wheel()
+
+
+@pytest.mark.asyncio
+async def test_wheel_unavailable_error_never_leaks_payload_content() -> None:
+    """The wheel degrade names only the capability, never a string the vault chose."""
+    leak = "SENTINEL-LEAK"
+    oversized = leak + "x" * _MAX_WHEEL_ASPECT_NAME_LENGTH
+    client = _wheel_client(_wheel_payload(_wheel_map_with("F5", _wheel_entry(oversized, 0.5))))
+    await client.handshake()
+    with pytest.raises(CreekVaultUnavailableError) as exc_info:
+        await client.wheel()
+    message = str(exc_info.value)
+    assert leak not in message
+    assert CreekCapability.WHEEL.value in message
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_creek_vault_wheel.py
+++ b/backend/tests/test_creek_vault_wheel.py
@@ -1,16 +1,10 @@
-"""Unit tests for the Creek Vault wheel-of-wholeness seam.
-
-RED: ``services.creek_vault_wheel`` does not exist yet, so every test here
-fails at collection with a ``ModuleNotFoundError`` until ``fetch_vault_wheel``
-and ``select_wheel_balance`` are implemented.
-"""
+"""Unit tests for the Creek Vault wheel-of-wholeness seam."""
 
 from __future__ import annotations
 
 from datetime import date
 
 import pytest
-from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from domain.constants import TOTAL_STAGES
@@ -33,7 +27,6 @@ from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.user import User
-from schemas.wheel import WheelAspect
 from services.creek_vault_wheel import (
     VAULT_WHEEL_EXPECTED_ASPECTS,
     VAULT_WHEEL_FULLNESS_MAX,
@@ -147,15 +140,12 @@ def _override_field(
     return tuple(base)
 
 
-def _malformed_validation_error() -> ValidationError:
-    """Obtain a real pydantic.ValidationError from the wheel adapter's response schema."""
-    try:
-        WheelAspect.model_validate(
-            {"stage_number": "not-a-number", "aspect": "Body", "fullness": 0.5}
-        )
-    except ValidationError as exc:
-        return exc
-    raise AssertionError("expected a ValidationError from a malformed payload")
+def _zero_fullness_aspects() -> tuple[VaultWheelAspect, ...]:
+    """Ten valid aspects whose fullness is zero everywhere, as an unclassified corpus reads."""
+    return tuple(
+        VaultWheelAspect(stage_number=n, aspect=f"Aspect-{n}", fullness=VAULT_WHEEL_FULLNESS_MIN)
+        for n in range(1, VAULT_WHEEL_EXPECTED_ASPECTS + 1)
+    )
 
 
 _INVALID_PAYLOADS: list[tuple[str, tuple[VaultWheelAspect, ...]]] = [
@@ -202,6 +192,24 @@ async def _seed_all_stages(session: AsyncSession) -> None:
     """Insert all ten CourseStage rows."""
     for n in range(1, TOTAL_STAGES + 1):
         session.add(CourseStage(**_stage_data(n)))
+    await session.commit()
+
+
+async def _seed_stages_except(session: AsyncSession, skipped: int) -> None:
+    """Insert every CourseStage row but the one for ``skipped``."""
+    for n in range(1, TOTAL_STAGES + 1):
+        if n != skipped:
+            session.add(CourseStage(**_stage_data(n)))
+    await session.commit()
+
+
+async def _seed_stages_with_blank_aspect(session: AsyncSession, blank_stage: int) -> None:
+    """Insert all ten CourseStage rows, labelling ``blank_stage`` with whitespace only."""
+    for n in range(1, TOTAL_STAGES + 1):
+        data = _stage_data(n)
+        if n == blank_stage:
+            data["aspect"] = "   "
+        session.add(CourseStage(**data))
     await session.commit()
 
 
@@ -324,12 +332,11 @@ async def test_fetch_vault_wheel_returns_none_when_wheel_unsupported() -> None:
     [
         CreekVaultUnavailableError("creek vault call failed: creek.wheel"),
         CreekCapabilityUnsupportedError("capability not advertised: creek.wheel"),
-        _malformed_validation_error(),
     ],
-    ids=["unavailable_error", "capability_unsupported_error", "field_validation_error"],
+    ids=["unavailable_error", "capability_unsupported_error"],
 )
 async def test_fetch_vault_wheel_returns_none_on_wheel_call_error(error: Exception) -> None:
-    """A CreekVaultError or a pydantic ValidationError from wheel() both fall back to None."""
+    """Every CreekVaultError the seam can raise from wheel() falls back to None."""
     client = RecordingWheelVaultClient(wheel_error=error)
 
     result = await fetch_vault_wheel(client)
@@ -356,6 +363,45 @@ async def test_fetch_vault_wheel_returns_none_on_invalid_payload(
     result = await fetch_vault_wheel(client)
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_returns_none_when_no_aspect_is_positive() -> None:
+    """An all-zero wheel is well-formed but carries no signal, so the read path falls back."""
+    client = RecordingWheelVaultClient(
+        wheel_result=VaultWheelBalance(aspects=_zero_fullness_aspects())
+    )
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is None
+    assert client.wheel_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_vault_wheel_accepts_a_single_positive_aspect_among_zeros() -> None:
+    """One positive fullness among nine zeros is signal enough to keep the vault's wheel."""
+    positive_stage = 3
+    positive_fullness = 0.4
+    aspects = tuple(
+        VaultWheelAspect(
+            stage_number=aspect.stage_number,
+            aspect=aspect.aspect,
+            fullness=positive_fullness
+            if aspect.stage_number == positive_stage
+            else VAULT_WHEEL_FULLNESS_MIN,
+        )
+        for aspect in _zero_fullness_aspects()
+    )
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=aspects))
+
+    result = await fetch_vault_wheel(client)
+
+    assert result is not None
+    assert [item["fullness"] for item in result] == [
+        positive_fullness if n == positive_stage else VAULT_WHEEL_FULLNESS_MIN
+        for n in range(1, TOTAL_STAGES + 1)
+    ]
 
 
 @pytest.mark.asyncio
@@ -404,10 +450,10 @@ async def test_select_wheel_balance_falls_back_to_local_when_vault_unavailable(
 
 
 @pytest.mark.asyncio
-async def test_select_wheel_balance_returns_vault_items_when_valid(
+async def test_select_wheel_balance_relabels_vault_items_with_course_stage_aspects(
     db_session: AsyncSession,
 ) -> None:
-    """A valid vault payload wins over the local computation."""
+    """A valid vault wheel keeps its fullness but is relabelled with adepthood's own aspects."""
     await _seed_all_stages(db_session)
     user_id = await _make_user(db_session)
     aspects = _valid_aspects()
@@ -416,7 +462,65 @@ async def test_select_wheel_balance_returns_vault_items_when_valid(
     result = await select_wheel_balance(client, db_session, user_id)
 
     assert result == [
-        {"stage_number": a.stage_number, "aspect": a.aspect, "fullness": a.fullness}
+        {
+            "stage_number": a.stage_number,
+            "aspect": _CANONICAL_ASPECTS[a.stage_number - 1],
+            "fullness": a.fullness,
+        }
         for a in aspects
     ]
+    rendered_labels = {item["aspect"] for item in result}
+    assert rendered_labels.isdisjoint({a.aspect for a in aspects})
+    assert client.wheel_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_select_wheel_balance_falls_back_when_a_course_stage_row_is_missing(
+    db_session: AsyncSession,
+) -> None:
+    """No local label for one stage discards the whole vault wheel, never half of it."""
+    await _seed_stages_except(db_session, skipped=6)
+    user_id = await _make_user(db_session)
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=_valid_aspects()))
+
+    expected = await compute_wheel_balance(db_session, user_id)
+    result = await select_wheel_balance(client, db_session, user_id)
+
+    assert result == expected
+    assert client.wheel_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_select_wheel_balance_falls_back_when_a_course_stage_label_is_blank(
+    db_session: AsyncSession,
+) -> None:
+    """A whitespace-only local label discards the whole vault wheel, never half of it."""
+    await _seed_stages_with_blank_aspect(db_session, blank_stage=6)
+    user_id = await _make_user(db_session)
+    client = RecordingWheelVaultClient(wheel_result=VaultWheelBalance(aspects=_valid_aspects()))
+
+    expected = await compute_wheel_balance(db_session, user_id)
+    result = await select_wheel_balance(client, db_session, user_id)
+
+    assert result == expected
+    assert client.wheel_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_select_wheel_balance_falls_back_on_an_all_zero_vault_wheel(
+    db_session: AsyncSession,
+) -> None:
+    """An all-zero vault wheel is fetched, then discarded for the local computation."""
+    await _seed_all_stages(db_session)
+    user_id = await _make_user(db_session)
+    await _seed_habit_with_completion(db_session, user_id, stage_number=4)
+    client = RecordingWheelVaultClient(
+        wheel_result=VaultWheelBalance(aspects=_zero_fullness_aspects())
+    )
+
+    expected = await compute_wheel_balance(db_session, user_id)
+    result = await select_wheel_balance(client, db_session, user_id)
+
+    assert any(item["fullness"] > VAULT_WHEEL_FULLNESS_MIN for item in expected)
+    assert result == expected
     assert client.wheel_calls == 1

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -342,7 +342,7 @@ async def test_wheel_endpoint_uses_vault_values_when_connected(
     async_client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
-    """A connected, valid vault's fullness values win over local math."""
+    """A connected vault's fullness wins over local math, under adepthood's own labels."""
     await _seed_all_stages(db_session)
     headers, user_id = await _signup(async_client, "wheel_vault_connected")
     # Local computation would give stage 1 fullness == 0.0 (no engagement); the
@@ -360,9 +360,11 @@ async def test_wheel_endpoint_uses_vault_values_when_connected(
     assert resp.status_code == HTTPStatus.OK
     aspects = resp.json()["aspects"]
     assert len(aspects) == _TOTAL_STAGES
+    vault_labels = {aspect.aspect for aspect in vault_aspects}
     for item in aspects:
         assert item["fullness"] == 0.42
-        assert item["aspect"] == f"VaultAspect-{item['stage_number']}"
+        assert item["aspect"] == _CANONICAL_ASPECTS[item["stage_number"] - 1]
+    assert vault_labels.isdisjoint({item["aspect"] for item in aspects})
 
 
 @pytest.mark.asyncio

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -65,15 +65,107 @@ into the vault; it is not something Creek Vault is expected to infer.
 
 Creek's `creek.wheel` computes and owns the Frequency-wheel counts and
 shares — ten buckets, `F1` through `F10`
-(`creek-tools/creek_mcp/tools/wheel.py:95-110`). Adepthood's
-`WheelBalanceResponse` (`backend/src/schemas/wheel.py`) is a *ten-stage
-aspect-fullness* projection, and the projection from one onto the
+(`creek-tools/creek_mcp/tools/wheel.py`, `creek-tools/creek_mcp/server.py`).
+Adepthood's `WheelBalanceResponse` (`backend/src/schemas/wheel.py`) is a
+*ten-stage aspect-fullness* projection, and the projection from one onto the
 other is Adepthood's to own — Creek must not invent our stage/aspect
 vocabulary on our behalf. The fact that both land on ten buckets is a
 numeric coincidence, **not a semantic identity**: `F1..F10` are
 Creek's frequency classification of corpus content, while adepthood's
-ten stages are `CourseStage` rows tied to the APTITUDE program. The
-concrete field-by-field projection is owned by adepthood #1937.
+ten stages are `CourseStage` rows tied to the APTITUDE program.
+
+### The request
+
+`creek.wheel` takes exactly one caller-supplied parameter,
+`privacy_tier_ceiling`; unlike `creek.classify` there is no `consumer`
+parameter — the vault fills that in from its own MCP session
+(`_wheel_params`, `backend/src/services/creek_vault_client.py:658-666`).
+Adepthood always sends `personal`
+(`_WHEEL_TIER_CEILING`, `creek_vault_client.py:237-246`), because only
+aggregate per-Frequency counts and shares cross this seam — never
+fragment content — so the ceiling governs what the vault *counts*, not
+what it hands back. `personal` is the honest maximum here: intimate
+content never reaches the vault from adepthood at all (see
+"Intimate-tier content: pointer only" below), and creek independently
+caps a network consumer below intimate regardless of what adepthood
+asks for. Sending `open` would be worse than useless rather than safer,
+because creek ranks unclassified content with `personal`: an `open`
+ceiling silently excludes every not-yet-classified fragment from the
+count, so a young corpus — most of whose entries have no Frequency yet
+— reads back as an all-zero wheel even though it plainly isn't empty.
+
+### The response projection
+
+The adapter walks a whitelist of the ten `F1..F10` codes rather than
+whatever keys the vault's `wheel` map happens to contain
+(`_wheel_aspects`, `creek_vault_client.py:720-731`), and projects each
+surviving entry as follows:
+
+| Creek `wheel["F<n>"]` field | Adepthood field | Notes |
+| --- | --- | --- |
+| the `F<n>` key itself | `stage_number` = `n` | Canonical order comes from the whitelist, not the map's iteration order |
+| `share` | `fullness` | Read as a float; a boolean is rejected before the numeric test (`_wheel_fullness`, `creek_vault_client.py:669-692`) |
+| `count` | *(not used)* | Adepthood renders proportions, not raw counts |
+| `name` | *(carried, never rendered)* | Validated at the seam but relabelled before it reaches the read path — see below |
+
+The envelope's `total_classified`, `unclassified`, `tool`, and
+`tier_ceiling` fields are read by nothing on adepthood's side. Unknown
+keys — extra envelope fields, and any Frequency code outside
+`F1..F10` — are ignored rather than erroring, the same
+drop-don't-coerce discipline the marginalia mapping below already
+describes for unrecognized kinds.
+
+### The vocabulary decision
+
+Creek's canonical Frequency names are `Agency`, `Receptivity`,
+`Self-Love / Power`, `Community Love / Conformity`, `Achievism`,
+`Pluralism`, `Integration`, `True Self / Transcendence`, `Unity`, and
+`Emptiness`. Adepthood's seeded `CourseStage.aspect` labels for stages
+1–10 (`backend/src/curriculum/archetypal_wavelength.json`) are `Agency`,
+`Receptivity`, `Self-Love`, `Community Love`, `Intellectual
+Understanding`, `Embodied Understanding`, `Systems Wisdom`, `True Self
+Connection`, `Unity`, and `Emptiness`. Same APTITUDE ontology, different
+wording for stages 5 through 8 — Creek's "Achievism" and "Pluralism"
+where adepthood says "Intellectual Understanding" and "Embodied
+Understanding", for instance.
+
+Because of that mismatch, the vault's `name` is validated and carried
+as the faithful wire value at the seam (bounded and non-blank —
+`_wheel_aspect`, `creek_vault_client.py:695-717`), but it is never what
+the user reads. The read path relabels every item from adepthood's own
+`CourseStage` rows before rendering
+(`_relabelled_items`, `backend/src/services/creek_vault_wheel.py:135-152`,
+calling the now-public `aspect_labels_by_stage`,
+`backend/src/domain/wheel.py:54-69`). A wheel that cannot be relabelled
+in full — a missing or blank `CourseStage` row for any of the ten
+stages — is discarded whole rather than rendered as a hybrid of vault
+words and adepthood words
+(`select_wheel_balance`, `creek_vault_wheel.py:155-168`). This is what
+"Creek must not invent our stage/aspect vocabulary on our behalf" means
+concretely: creek's `name` never reaches a screen.
+
+### Bounds on untrusted input
+
+A wheel payload is untrusted input like any other vault response, and
+is bounded accordingly before anything is built from it
+(`creek_vault_client.py:669-731`):
+
+- `name` is length-bounded (`_MAX_WHEEL_ASPECT_NAME_LENGTH`, 128
+  characters), must be non-blank, and must be printable. A Frequency
+  name is short label text, so a control character in one is never
+  legitimate, and CR/LF, an ANSI escape, or a bidirectional override is
+  exactly the payload that forges a log line or misrenders a label —
+  the same rule the seam already applies to a vault-issued fragment id.
+- `share` must be a real number; a boolean is explicitly rejected
+  rather than silently read as a fully-full Frequency, and an integer
+  too large for a float to hold is treated as unreadable rather than
+  raising an `OverflowError` past the seam's degrade set. JSON has no
+  integer ceiling, so that literal really can arrive.
+- A Frequency entry that fails either check drops the *entire* wheel
+  (`_parse_wheel`, `creek_vault_client.py:734-753`) rather than yielding
+  a ring with one bucket missing.
+- Adepthood reads at most the ten whitelisted `F1..F10` codes no matter
+  how large a map the vault sends.
 
 ## Marginalia mapping (adepthood-owned)
 
@@ -154,11 +246,25 @@ capability is still used for the others it supports:
   related-praxis or related-eddies fields — are ignored rather than
   erroring. Content already flagged by the care gate never calls the
   vault for a reflection at all, regardless of vault availability.
-- **WHEEL** — if absent, or if the returned payload fails
-  field-level validation, `fetch_vault_wheel` returns `None`
-  (`backend/src/services/creek_vault_wheel.py:97-113`), and
-  `select_wheel_balance` then falls back to computing the balance
-  locally (`creek_vault_wheel.py:115-120`).
+- **WHEEL** — if absent, or if the vault does not advertise it,
+  `fetch_vault_wheel` returns `None` before any call is made
+  (`backend/src/services/creek_vault_wheel.py:119-132`). A malformed or
+  refused payload degrades exactly like every other capability: the seam
+  adapter now normalizes it to `CreekVaultUnavailableError`
+  (`backend/src/services/creek_vault_client.py:893-913`) rather than
+  surfacing a raw `pydantic.ValidationError` as it once did — the one
+  deliberately un-normalized error path this client used to have — and
+  the read path catches only that error hierarchy
+  (`_read_balance`, `creek_vault_wheel.py:105-116`). A well-formed
+  balance then still has to clear domain-range validation (stage numbers
+  in range, fullness in `0.0..1.0`, all ten stages present with no
+  duplicates) or `fetch_vault_wheel` returns `None` all the same. So does
+  a *valid* all-zero wheel — creek's documented answer for an empty or
+  wholly-unclassified corpus — because it carries no information and
+  would blank a Map the local computation can fill
+  (`_carries_signal`, `creek_vault_wheel.py:84-94`). Any of these causes
+  `select_wheel_balance` to fall back to computing the balance locally
+  (`creek_vault_wheel.py:155-168`).
 - **CLASSIFY** — has **no call site anywhere in `backend/src`**.
   Adepthood does not call Creek's classify capability today; every
   Frequency/Wavelength tag in the app is produced locally.

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -130,17 +130,17 @@ where adepthood says "Intellectual Understanding" and "Embodied
 Understanding", for instance.
 
 Because of that mismatch, the vault's `name` is validated and carried
-as the faithful wire value at the seam (bounded and non-blank —
-`_wheel_aspect`, `creek_vault_client.py:695-717`), but it is never what
-the user reads. The read path relabels every item from adepthood's own
-`CourseStage` rows before rendering
-(`_relabelled_items`, `backend/src/services/creek_vault_wheel.py:135-152`,
+as the faithful wire value at the seam (bounded, non-blank, and
+printable — `_wheel_aspect`, `creek_vault_client.py:695-717`), but it
+is never what the user reads. The read path relabels every item from
+adepthood's own `CourseStage` rows before rendering
+(`_relabelled_items`, `backend/src/services/creek_vault_wheel.py:141-158`,
 calling the now-public `aspect_labels_by_stage`,
 `backend/src/domain/wheel.py:54-69`). A wheel that cannot be relabelled
 in full — a missing or blank `CourseStage` row for any of the ten
 stages — is discarded whole rather than rendered as a hybrid of vault
 words and adepthood words
-(`select_wheel_balance`, `creek_vault_wheel.py:155-168`). This is what
+(`select_wheel_balance`, `creek_vault_wheel.py:161-174`). This is what
 "Creek must not invent our stage/aspect vocabulary on our behalf" means
 concretely: creek's `name` never reaches a screen.
 
@@ -248,7 +248,7 @@ capability is still used for the others it supports:
   vault for a reflection at all, regardless of vault availability.
 - **WHEEL** — if absent, or if the vault does not advertise it,
   `fetch_vault_wheel` returns `None` before any call is made
-  (`backend/src/services/creek_vault_wheel.py:119-132`). A malformed or
+  (`backend/src/services/creek_vault_wheel.py:119-138`). A malformed or
   refused payload degrades exactly like every other capability: the seam
   adapter now normalizes it to `CreekVaultUnavailableError`
   (`backend/src/services/creek_vault_client.py:893-913`) rather than
@@ -264,7 +264,7 @@ capability is still used for the others it supports:
   would blank a Map the local computation can fill
   (`_carries_signal`, `creek_vault_wheel.py:84-94`). Any of these causes
   `select_wheel_balance` to fall back to computing the balance locally
-  (`creek_vault_wheel.py:155-168`).
+  (`creek_vault_wheel.py:161-174`).
 - **CLASSIFY** — has **no call site anywhere in `backend/src`**.
   Adepthood does not call Creek's classify capability today; every
   Frequency/Wavelength tag in the app is produced locally.


### PR DESCRIPTION
## Summary

- **The wheel call could only ever fail against a real vault.** `McpCreekVaultClient.wheel()` sent `{"consumer": CONSUMER_ID}` and then validated the reply with `WheelBalanceResponse.model_validate` — adepthood's own `{aspects: [...]}` response shape. Creek's `creek.wheel` MCP tool accepts exactly one caller-supplied parameter (`privacy_tier_ceiling`; `consumer` is filled server-side from its own env) and answers `{status, tool, tier_ceiling, total_classified, unclassified, wheel: {F1..F10: {name, count, share}}}`. **Both halves of the call were wrong**, so like the sibling `creek.reflect` fix a response-only change would have shipped code that never executes. Verified against `creek-tools/creek_mcp/tools/wheel.py` and `server.py` in `Geoffe-Ga/creek-vault`, not inferred.
- **The adapter now owns creek's wire shape.** A whitelist walk of the ten `F1..F10` codes projects each Frequency's `share` onto a stage's `fullness`, with `name` bounded, non-blank, and printable, and unknown keys — extra envelope fields or a Frequency code outside the whitelist — ignored. Validation is all-or-nothing: one bad Frequency rejects the whole read rather than yielding a ring with a hole in it. A malformed or refused payload degrades to `CreekVaultUnavailableError` exactly like every other capability, which retires the client's one deliberately un-normalized error path and lets `pydantic` leave the read path entirely.
- **Adepthood keeps its own vocabulary.** Creek's Frequency names and adepthood's `CourseStage.aspect` labels agree for stages 1–4 and 9–10 but genuinely differ for 5–8 (creek says *Achievism*, *Pluralism*, *Integration*, *True Self / Transcendence*; adepthood says *Intellectual Understanding*, *Embodied Understanding*, *Systems Wisdom*, *True Self Connection*). A passthrough would have rendered creek's words on the Map. The vault's `name` is carried faithfully at the seam but the rendered label is always adepthood's own `CourseStage` row, and a wheel that cannot be relabelled in full is discarded rather than rendered as a hybrid. This is the projection `docs/creek-vault-mcp-contract.md` reserved for this issue, now written down.

### Decisions worth a reviewer's eye

- **Ceiling `personal`, not `open`.** Only aggregate counts and shares cross this seam — never fragment content — so the ceiling governs what the vault *counts*, not what it hands back. Intimate content never reaches the vault from adepthood at all (`creek_vault_write.py` short-circuits before touching the client), and creek independently caps a network consumer below intimate. `open` would be worse than useless rather than safer: creek ranks unclassified content with `personal`, so an `open` ceiling excludes every not-yet-classified fragment and answers an all-zero wheel for a young corpus.
- **A valid all-zero wheel defers to the local balance.** That is creek's documented empty-corpus answer, and rendering it would blank a Map the local computation can fill from the user's own habits, practice, and course progress. Mirrors the sibling fix's "zero surviving notes defers too". The predicate is "no positive fullness anywhere", never "reject any zero" — a real corpus concentrated in one Frequency legitimately reads nine zeros and one number.
- **Two hardening fixes found by the security pass**, both with their own failing test first. A `share` past the float range decodes from JSON as an arbitrary-precision `int`, passes the numeric type check, and made `float()` raise `OverflowError` — an `ArithmeticError` in neither the client's transport degrade set nor the read path's `CreekVaultError` catch, so one hostile response crashed every wheel read instead of degrading. And a `name` is short label text, so it is now required to be printable: CR/LF, an ANSI escape, or a bidi override in a label is exactly the payload that forges a log line, and the seam already applies this rule to a vault-issued fragment id.

### Found, not fixed here

Two pre-existing seam gaps the security pass surfaced are filed rather than absorbed: **#2078** (a plain `ValueError` from CPython's `sys.int_max_str_digits` guard escapes `_invoke`'s degrade set — all four capabilities) and **#2079** (`_bounded_text` strips before it length-checks). Neither is made materially worse by this change.

## Test plan

- `./scripts/backend/check-all.sh` → exit 0, 7/7 checks. 97% line coverage overall; `creek_vault_wheel.py` 100%, `creek_vault_client.py` 98%.
- `./scripts/backend/complexity.sh` → xenon A/A/A, no module ranks C. `creek_vault_client.py` radon MI 19.12 (rank A) — thin headroom, so the new helpers are deliberately small.
- New tests pin the real wire shape end to end: the request params (`privacy_tier_ceiling` only, no `consumer`), the ten-Frequency happy path, an empty-corpus payload, integer shares, unknown envelope and wheel keys, and the exact `_MAX_WHEEL_ASPECT_NAME_LENGTH` boundary on both sides. Twenty parametrized degrade cases cover refused/missing/unknown/wrong-typed status, a non-mapping wheel, a missing F-code, a non-mapping entry, `share` missing/string/bool/null/float-overflowing, and `name` missing/blank/whitespace/wrong-typed/over-cap/newline/ANSI/bidi. One test asserts a sentinel in the payload never reaches the raised error's message.
- Read-path tests pin the relabelling (vault fullness kept, `CourseStage` labels rendered, vault words absent), the fallback when a `CourseStage` row is missing or blank, the all-zero degrade, and that a single positive value among nine zeros is still accepted.
- `test_wheel_api.py::test_wheel_endpoint_uses_vault_values_when_connected` was respec'd: it asserted the vault's labels reach the API response, which is now the wrong spec.
- Backend-only diff; no frontend files touched and the `/stages/wheel` response shape is unchanged.

Closes #1937
Refs #1932