### PR TITLE
test(backend): vendor Creek's published /v1 contract bundle and fail CI when the two repos drift

### DIFF
--- a/.github/workflows/creek-contract-drift.yml
+++ b/.github/workflows/creek-contract-drift.yml
@@ -1,0 +1,63 @@
+name: Creek contract drift
+
+# Ask Creek, once a week, whether it still publishes the /v1 contract bytes this
+# repo vendored under backend/tests/fixtures/creek_v1/. The conformance suite
+# reads every wire shape it asserts out of that vendored copy, so upstream can
+# move without a single test going red -- the copy silently stops describing the
+# server and the divergence surfaces in production instead of in review. This
+# job is the only thing that looks.
+#
+# Scheduled and manual only, deliberately: no push and no pull_request trigger.
+# A PR check that reached out to the live network would make every build depend
+# on a third party's availability, would let a PR author's branch decide what
+# gets fetched, and would turn an upstream outage into a merge blocker. The
+# offline half of the same script (`verify`) runs in the normal test suite on
+# every PR, and that is where the fast feedback belongs.
+#
+# creek-vault is a public repository, so the raw fetch is unauthenticated and
+# this workflow references no secret at all. There is nothing here for a
+# compromised step to exfiltrate.
+#
+# Exit 1 (drift) and exit 2 (could not verify) both fail the job, and neither is
+# swallowed. Exit 2 is not a softer outcome than exit 1: a run that could not
+# reach Creek, or that was served something it refused to parse, has proven
+# nothing about the pin. Letting it pass would turn this gate into a weekly
+# green checkmark that means "nobody looked".
+
+on:
+  schedule:
+    # Saturdays 08:30 UTC -- the weekday 08:00 slots are taken by the scan
+    # workflows, and a weekend run leaves the whole week to act on a finding.
+    - cron: "30 8 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: creek-contract-drift
+  cancel-in-progress: false
+
+jobs:
+  compare-upstream:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install the drift check's only dependency
+        # The check imports httpx and nothing else from the app, so installing
+        # the whole backend requirement set would only widen the surface of a
+        # job that talks to the network. The version comes from the repo's own
+        # pins as a constraint rather than being restated here, so this job can
+        # never quietly fetch with a different httpx than the app ships.
+        run: pip install -c backend/requirements.txt httpx
+
+      - name: Compare the vendored bundle against what Creek publishes today
+        working-directory: backend
+        run: python -m scripts.creek_contract_drift compare

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -454,6 +454,330 @@
         "line_number": 317
       }
     ],
+    "backend/tests/fixtures/creek_v1/vendor.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0c559037d21e4407c4b8e1d09c269fb8e345f21b",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0568568126bc49285f6320e968d82f0877ddd5d9",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0beffbf9df6254b3b34edd4e82cf65c85ebd3273",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "61232af5e0fac26b3e50feabaf0389a2d26bdff8",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "9e97f0d3d0d8b74679d3bbe5d044f1286cd614ec",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "73275626ecfb9f99b991585e538de06f8402293c",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "e3fc1f4c4e7912d9c57ed7a5721c069ad86e51df",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "54991807deb694c3a4ee6c84077c21bdb70252bb",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "91826e2422b410d3c197d9d86f35ee04dd401066",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "a4129dde0758aa67505d19cb0e5b5e1e40b75c56",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "fa18ede47a282653671ae3180158856a306aab32",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "effebd18385b059a27af09e7ab4dca6f801d016e",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "e9fbaa556a8cafa9b1f6cd364155b8b61549f116",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "5fac56111267781fa7f5fda516993d614402369d",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "a976db01a068156ddb5062737c610b35a2036591",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "785a0b64e4741efc088205589b2632b8898933a6",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "39b9679e0e33db16fdd2c8263168c568da135754",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "9bf08eed7a572773aba1afa0586d281219fc32ac",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "6598a7f2684184a683ad99acce6a7955479ab9fb",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "6b59d3263726ed4aa4c96b585182df3eea53f824",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "fc4ad40801e13d8016432e866cab352fcaaab9b8",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "c2c85f2c142f22c2c2847cc1fbf6b0cbc72066c3",
+        "is_verified": false,
+        "line_number": 99
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "a29d2df507cce91c6a6656cdb375156ba00fa4b1",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0f71297fd0fbb88414735366e6eb551677a65804",
+        "is_verified": false,
+        "line_number": 107
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "f1f0befa5d11f5674c10095f08d29bb475e8d816",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "7cd1fe6247f29a064f91ee6cf3f70271de0247f6",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "14c9cdf5623a63179e244e5db6d0543afde74696",
+        "is_verified": false,
+        "line_number": 119
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "f2df62804f5e30de6647189f46f32c208b54e8d3",
+        "is_verified": false,
+        "line_number": 123
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "c88dc42e013ef993ae53215df13ebaf68791f252",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "201e1ead17b4e148acdb973f0b3afd07594340ec",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "357533bc7b59b0877f022f548116a4117f5945ff",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "77d99fdb98e123bc3067d9d27dfc42ddc7171da9",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "2f459628c2fea89a1eef0f1f7d897bb6bfe7b7a9",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "764f160c9021000d251bc025f232f9d01f6963c9",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "2e5ee195a222febb13419ab1b0b60f4013bc19d5",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "848e003618b3e227cdcc2d60bb470bd8125d0396",
+        "is_verified": false,
+        "line_number": 155
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "99d2de98c79c7f3153d25c3d01170a194c116b1e",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "14cb11dc43d68d6e3793cb29733b1072bd2e9086",
+        "is_verified": false,
+        "line_number": 163
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "fe1ec8a737e040db2fbd8b469b8dbfc4be34cf4c",
+        "is_verified": false,
+        "line_number": 167
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "9066a92d0f246a7d3ede1eb7104de79bf70ecc6f",
+        "is_verified": false,
+        "line_number": 171
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "2d33eaaeed25e67e5028595c33fb7b1302bc9b7b",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "110a747f61580381251f235835e1ce9d0cd3159f",
+        "is_verified": false,
+        "line_number": 179
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0be773b0f6021b13a72e84b9cadacee4aa71818b",
+        "is_verified": false,
+        "line_number": 183
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "f92ac9f67a94ea2c27eb07c7adb8c689c84a606e",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "0341dff256fa66a2bbac660259a44a6e2f444b9a",
+        "is_verified": false,
+        "line_number": 191
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/vendor.json",
+        "hashed_secret": "9c62bebccea30bffa2ecce9cd544baafaecea0e6",
+        "is_verified": false,
+        "line_number": 196
+      }
+    ],
     "backend/tests/test_database.py": [
       {
         "type": "Basic Auth Credentials",
@@ -473,5 +797,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-01T05:12:50Z"
+  "generated_at": "2026-08-01T05:59:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,6 +124,12 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^backend/content/"
+      ]
     }
   ],
   "results": {
@@ -145,6 +151,309 @@
         "line_number": 28
       }
     ],
+    "backend/tests/fixtures/creek_v1/manifest.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "0568568126bc49285f6320e968d82f0877ddd5d9",
+        "is_verified": false,
+        "line_number": 9
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "0beffbf9df6254b3b34edd4e82cf65c85ebd3273",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "61232af5e0fac26b3e50feabaf0389a2d26bdff8",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "9e97f0d3d0d8b74679d3bbe5d044f1286cd614ec",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "73275626ecfb9f99b991585e538de06f8402293c",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "e3fc1f4c4e7912d9c57ed7a5721c069ad86e51df",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "54991807deb694c3a4ee6c84077c21bdb70252bb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "91826e2422b410d3c197d9d86f35ee04dd401066",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "a4129dde0758aa67505d19cb0e5b5e1e40b75c56",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "fa18ede47a282653671ae3180158856a306aab32",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "effebd18385b059a27af09e7ab4dca6f801d016e",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "e9fbaa556a8cafa9b1f6cd364155b8b61549f116",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "5fac56111267781fa7f5fda516993d614402369d",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "a976db01a068156ddb5062737c610b35a2036591",
+        "is_verified": false,
+        "line_number": 107
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "785a0b64e4741efc088205589b2632b8898933a6",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "39b9679e0e33db16fdd2c8263168c568da135754",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "9bf08eed7a572773aba1afa0586d281219fc32ac",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "6598a7f2684184a683ad99acce6a7955479ab9fb",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "6b59d3263726ed4aa4c96b585182df3eea53f824",
+        "is_verified": false,
+        "line_number": 142
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "fc4ad40801e13d8016432e866cab352fcaaab9b8",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "c2c85f2c142f22c2c2847cc1fbf6b0cbc72066c3",
+        "is_verified": false,
+        "line_number": 163
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "a29d2df507cce91c6a6656cdb375156ba00fa4b1",
+        "is_verified": false,
+        "line_number": 170
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "0f71297fd0fbb88414735366e6eb551677a65804",
+        "is_verified": false,
+        "line_number": 177
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "f1f0befa5d11f5674c10095f08d29bb475e8d816",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "7cd1fe6247f29a064f91ee6cf3f70271de0247f6",
+        "is_verified": false,
+        "line_number": 191
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "14c9cdf5623a63179e244e5db6d0543afde74696",
+        "is_verified": false,
+        "line_number": 198
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "c88dc42e013ef993ae53215df13ebaf68791f252",
+        "is_verified": false,
+        "line_number": 205
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "201e1ead17b4e148acdb973f0b3afd07594340ec",
+        "is_verified": false,
+        "line_number": 212
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "357533bc7b59b0877f022f548116a4117f5945ff",
+        "is_verified": false,
+        "line_number": 219
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "77d99fdb98e123bc3067d9d27dfc42ddc7171da9",
+        "is_verified": false,
+        "line_number": 226
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "2f459628c2fea89a1eef0f1f7d897bb6bfe7b7a9",
+        "is_verified": false,
+        "line_number": 233
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "764f160c9021000d251bc025f232f9d01f6963c9",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "2e5ee195a222febb13419ab1b0b60f4013bc19d5",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "848e003618b3e227cdcc2d60bb470bd8125d0396",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "99d2de98c79c7f3153d25c3d01170a194c116b1e",
+        "is_verified": false,
+        "line_number": 261
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "14cb11dc43d68d6e3793cb29733b1072bd2e9086",
+        "is_verified": false,
+        "line_number": 268
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "fe1ec8a737e040db2fbd8b469b8dbfc4be34cf4c",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "9066a92d0f246a7d3ede1eb7104de79bf70ecc6f",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "2d33eaaeed25e67e5028595c33fb7b1302bc9b7b",
+        "is_verified": false,
+        "line_number": 289
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "110a747f61580381251f235835e1ce9d0cd3159f",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "0be773b0f6021b13a72e84b9cadacee4aa71818b",
+        "is_verified": false,
+        "line_number": 303
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "f92ac9f67a94ea2c27eb07c7adb8c689c84a606e",
+        "is_verified": false,
+        "line_number": 310
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/fixtures/creek_v1/manifest.json",
+        "hashed_secret": "0341dff256fa66a2bbac660259a44a6e2f444b9a",
+        "is_verified": false,
+        "line_number": 317
+      }
+    ],
     "backend/tests/test_database.py": [
       {
         "type": "Basic Auth Credentials",
@@ -164,5 +473,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-02T18:24:27Z"
+  "generated_at": "2026-08-01T05:12:50Z"
 }

--- a/backend/scripts/creek_contract_drift.py
+++ b/backend/scripts/creek_contract_drift.py
@@ -609,6 +609,20 @@ def fetch_upstream_file(url: str) -> bytes:
     Returns:
         The response body.
 
+    The body is streamed and the running total is checked against
+    :data:`MAX_FILE_BYTES` after each chunk, so the cap stops the download
+    rather than merely refusing what has already been buffered. Reading the
+    whole response first would let a compromised or malfunctioning publisher
+    decide how much memory this process holds, with only the timeout as a
+    bound -- and a cap that reports its refusal after paying the full cost is
+    not really a cap.
+
+    Args:
+        url: The URL to fetch, as built by :func:`upstream_url`.
+
+    Returns:
+        The response body.
+
     Raises:
         UpstreamFetchError: When the URL is not HTTPS, or when the body exceeds
             :data:`MAX_FILE_BYTES`. Redirects are not followed, because a
@@ -618,12 +632,18 @@ def fetch_upstream_file(url: str) -> bytes:
     """
     if not url.startswith(_HTTPS_SCHEME):
         raise UpstreamFetchError(_INSECURE_URL_REASON)
-    response = httpx.get(url, follow_redirects=False, timeout=FETCH_TIMEOUT_SECONDS)
-    response.raise_for_status()
-    content = response.content
-    if len(content) > MAX_FILE_BYTES:
-        raise UpstreamFetchError(_OVERSIZED_REASON)
-    return content
+    chunks: list[bytes] = []
+    received = 0
+    with httpx.stream(
+        "GET", url, follow_redirects=False, timeout=FETCH_TIMEOUT_SECONDS
+    ) as response:
+        response.raise_for_status()
+        for chunk in response.iter_bytes():
+            received += len(chunk)
+            if received > MAX_FILE_BYTES:
+                raise UpstreamFetchError(_OVERSIZED_REASON)
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _fetch_body(name: str, fetch: Fetcher) -> bytes | Unverifiable:

--- a/backend/scripts/creek_contract_drift.py
+++ b/backend/scripts/creek_contract_drift.py
@@ -1,0 +1,911 @@
+"""Fail the gate when Adepthood's vendored copy of Creek's /v1 contract stops matching.
+
+Creek publishes its ``/v1`` contract as a directory of generated files plus a
+``manifest.json`` recording a sha256 for each of them. Adepthood vendors that
+directory by copy, pinned to one upstream commit, and the conformance suite in
+``tests/test_creek_contract_conformance.py`` reads every wire shape it asserts
+out of that copy. A copy-and-pin integration has exactly one failure mode worth
+automating against: the copy silently stops describing the server. The suite
+stays green, the client goes on agreeing with a document nobody serves any
+more, and the divergence surfaces in production instead of in review.
+
+Two questions are asked separately, because they fail for different reasons and
+have different remedies. :func:`verify_local` asks whether our own vendored
+bytes still hash to the digests recorded in ``vendor.json`` -- an offline,
+network-free integrity check that catches a hand-edit, a bad merge, or a
+truncating checkout. :func:`compare_upstream` asks whether Creek still publishes
+the bytes we vendored, which is the actual drift question and the only one that
+needs a remote answer.
+
+The constraint that shapes every branch below is that this check must never
+fail open. Upstream is untrusted input that turns into filesystem reads and log
+lines, so a fetch that raised, a body that is not JSON, a body larger than
+:data:`MAX_FILE_BYTES`, a manifest with no entries, an entry whose path or
+digest cannot be trusted, and a run that ended up comparing nothing are each
+reported as "cannot verify" rather than as "clean". Reporting success for a run
+that proved nothing is the one outcome worse than reporting drift, because it
+manufactures confidence in a pin that may no longer be a pin.
+
+Usage:
+
+    python -m scripts.creek_contract_drift verify                  # offline
+    python -m scripts.creek_contract_drift compare                 # fetches upstream
+    python -m scripts.creek_contract_drift snapshot --commit <sha>  # re-cut the sidecar
+
+Exit codes:
+    0 -- every compared file matched the digest recorded for it.
+    1 -- at least one file's bytes moved, upstream or on disk.
+    2 -- the comparison could not be completed: an unreachable or untrustworthy
+        upstream, a manifest that could not be parsed, or nothing to compare at
+        all. No drift was proven, but none was ruled out either.
+    Both non-zero codes fail the gate; the split exists only to tell an operator
+    whether to re-vendor the bundle or to go and find out why the check could
+    not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+EXIT_CLEAN = 0
+EXIT_DRIFT = 1
+EXIT_UNVERIFIABLE = 2
+
+MANIFEST_NAME = "manifest.json"
+README_NAME = "README.md"
+VENDOR_NAME = "vendor.json"
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+BUNDLE_ROOT = _BACKEND_ROOT / "tests" / "fixtures" / "creek_v1"
+
+UPSTREAM_REPO = "Geoffe-Ga/creek-vault"
+UPSTREAM_PATH = "docs/contracts/adepthood-v1"
+UPSTREAM_REF = "main"
+_RAW_CONTENT_HOST = "https://raw.githubusercontent.com"
+
+# Bounds on untrusted upstream input. Both are ten-times headroom over the
+# published bundle (47 files, largest ~11 KiB), which is wide enough that a
+# clean fetch never trips them and narrow enough that a hostile or broken
+# upstream cannot decide how much memory this gate spends.
+MAX_BUNDLE_FILES = 512
+MAX_FILE_BYTES = 1024 * 1024
+
+# Generous enough for a cold CDN edge, finite enough that a hung connection
+# fails the scheduled job rather than occupying a runner until it is killed.
+FETCH_TIMEOUT_SECONDS = 30.0
+
+# Creek's manifest covers neither itself nor the hand-written README, so those
+# two are the only files a comparison has to fetch by name; the manifest's own
+# entries cover the other 45.
+_DIRECTLY_FETCHED = (MANIFEST_NAME, README_NAME)
+
+# ``examples/<capability>/<state>.json`` is the only path shape that names a
+# capability. Schemas, the retry policy, the manifest and the README do not.
+_EXAMPLES_DIRECTORY = "examples"
+_EXAMPLE_PATH_SEGMENTS = 3
+_CAPABILITY_SEGMENT = 1
+_PATH_SEPARATOR = "/"
+
+_HEX_DIGEST = re.compile(r"[0-9a-f]{64}")
+_PARENT_SEGMENT = ".."
+_WINDOWS_SEPARATOR = "\\"
+_HTTPS_SCHEME = "https://"
+
+_ABSENT_DIGEST = "(absent)"
+_NO_CAPABILITY = "no capability"
+
+_EMPTY_REASON = "the manifest was empty"
+_NOT_JSON_REASON = "the manifest was not JSON"
+_NOT_AN_OBJECT_REASON = "the manifest was not a JSON object"
+_NO_FILE_LIST_REASON = "the manifest carried no file list"
+_EMPTY_FILE_LIST_REASON = "the manifest listed no files, so it can only agree vacuously"
+_TOO_MANY_FILES_REASON = f"the manifest listed more than {MAX_BUNDLE_FILES} files"
+_NOT_AN_ENTRY_REASON = "is not an object"
+_UNTRUSTED_PATH_REASON = "carries a path this checker will not turn into a read"
+_NOT_A_DIGEST_REASON = "carries something that is not a 64-character lowercase sha256"
+
+_FETCH_FAILED_REASON = "the fetch failed, so nothing about this file was proven"
+_OVERSIZED_REASON = f"the body exceeded {MAX_FILE_BYTES} bytes and was refused before being parsed"
+_INSECURE_URL_REASON = "refusing to fetch a contract file over anything but HTTPS"
+
+_REMEDIATION_COMMAND = "python -m scripts.creek_contract_drift snapshot --commit <sha>"
+_REMEDIATION = (
+    "Fix: re-vendor the bundle at the new upstream commit, regenerate the "
+    f"sidecar with `{_REMEDIATION_COMMAND}`, and re-run the conformance suite."
+)
+_NOTHING_VERIFIED = (
+    "Cannot verify the Creek contract bundle: nothing was compared, so no drift "
+    "was found and none was ruled out.\n"
+)
+
+_VERIFY_COMMAND = "verify"
+_COMPARE_COMMAND = "compare"
+_SNAPSHOT_COMMAND = "snapshot"
+
+# Everything a fetcher is allowed to fail with. A fetch that failed for any
+# reason has proven nothing about upstream, so every one of these lands in the
+# same "cannot verify" bucket; the tuple is spelled out rather than caught
+# blindly so an unexpected failure still surfaces as a traceback.
+_FETCH_FAILURES = (OSError, RuntimeError, ValueError, httpx.HTTPError)
+
+Fetcher = Callable[[str], bytes]
+
+
+class ManifestError(ValueError):
+    """A manifest could not be trusted enough to compare anything against."""
+
+
+class UpstreamFetchError(RuntimeError):
+    """One upstream file could not be fetched under this checker's own rules."""
+
+
+@dataclass(frozen=True)
+class VendoredFile:
+    """One file a manifest records, by bundle-relative path and sha256 digest."""
+
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class BundleManifest:
+    """A parsed manifest: the versions it names and the files it records.
+
+    ``source_commit`` is populated only by our own ``vendor.json`` sidecar,
+    which is what makes the vendored copy a pin; Creek's ``manifest.json``
+    describes a directory rather than a revision and leaves it ``None``. The two
+    version strings are carried for the operator's benefit and are optional for
+    the same reason -- only the digest set is load-bearing here.
+    """
+
+    contract_version: str | None
+    ontology_version: str | None
+    source_commit: str | None
+    files: tuple[VendoredFile, ...]
+
+
+@dataclass(frozen=True)
+class Change:
+    """One file whose digest disagrees with the digest we recorded for it.
+
+    ``vendored`` is always the digest *we* recorded in ``vendor.json`` and
+    ``upstream`` is always the digest observed on the other side of the
+    comparison -- which is the on-disk bytes for :func:`verify_local` and
+    Creek's published bytes for :func:`compare_upstream`. The naming follows the
+    question being asked ("does the other side still agree with our record?")
+    rather than the source of the bytes, so a local verification does put an
+    on-disk digest in ``upstream``.
+
+    ``vendored is None`` means a file exists that nobody recorded; ``upstream is
+    None`` means a recorded file is gone. Both are drift: a vendored bundle is a
+    pin only while its file set is exactly the set that was pinned.
+    """
+
+    capability: str | None
+    path: str
+    vendored: str | None
+    upstream: str | None
+
+
+@dataclass(frozen=True)
+class Unverifiable:
+    """A file the checker could not compare at all, and why.
+
+    The reason never quotes bytes that came from upstream. A rejected path is
+    described by its position in the manifest instead, so a hostile manifest
+    cannot choose what this gate writes into a CI log.
+    """
+
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """The full outcome of one run: what was compared, what moved, what could not be read."""
+
+    compared: int
+    changes: tuple[Change, ...]
+    unverifiable: tuple[Unverifiable, ...]
+
+    @property
+    def exit_code(self) -> int:
+        """Return the process exit code for this report."""
+        return _grade(self)
+
+
+def _grade(report: DriftReport) -> int:
+    """Decide a report's exit code, with proven drift outranking uncertainty.
+
+    Args:
+        report: The report to grade.
+
+    Returns:
+        ``EXIT_DRIFT`` when any file moved, ``EXIT_UNVERIFIABLE`` when anything
+        could not be read -- including when nothing was compared at all, since
+        having checked nothing must never be reported the same way as having
+        checked everything and found it sound -- and ``EXIT_CLEAN`` only when
+        real files were compared and every one of them held.
+    """
+    if report.changes:
+        return EXIT_DRIFT
+    if report.unverifiable or not report.compared:
+        return EXIT_UNVERIFIABLE
+    return EXIT_CLEAN
+
+
+def _sha256(data: bytes) -> str:
+    """Return the lowercase hex sha256 of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _capability_of(path: str) -> str | None:
+    """Return the capability a bundle path names, or ``None`` when it names none.
+
+    Args:
+        path: A bundle-relative path.
+
+    Returns:
+        The ``<capability>`` segment of ``examples/<capability>/<state>.json``.
+        Schemas, the retry policy, the manifest and the README describe the
+        contract as a whole rather than one capability, so they yield ``None``.
+    """
+    segments = path.split(_PATH_SEPARATOR)
+    if len(segments) == _EXAMPLE_PATH_SEGMENTS and segments[0] == _EXAMPLES_DIRECTORY:
+        return segments[_CAPABILITY_SEGMENT]
+    return None
+
+
+def _is_printable_ascii(text: str) -> bool:
+    """Return whether a string is non-empty printable ASCII.
+
+    A generated bundle emits neither a non-ASCII nor a non-printable name, so
+    anything else is either a mistake or an attempt to smuggle a control
+    character through a path that becomes a log line.
+    """
+    return bool(text) and text.isascii() and text.isprintable()
+
+
+def _is_contained_path(path: str) -> bool:
+    """Return whether a path stays inside the bundle on every platform we run on.
+
+    Absolute paths and parent-directory references climb out of the bundle, and
+    a backslash is a directory separator on one of those platforms even though
+    it is an ordinary character on the others.
+    """
+    return (
+        _WINDOWS_SEPARATOR not in path
+        and _PARENT_SEGMENT not in path
+        and not path.startswith(_PATH_SEPARATOR)
+    )
+
+
+def _is_safe_relative_path(path: str) -> bool:
+    """Return whether a manifest path is safe to turn into a filesystem read.
+
+    Args:
+        path: A path string taken straight out of an untrusted manifest.
+
+    Returns:
+        ``True`` only for a printable-ASCII path that stays inside the bundle.
+    """
+    return _is_printable_ascii(path) and _is_contained_path(path)
+
+
+def _entry_reason(index: int, problem: str) -> str:
+    """Describe a refused manifest entry by position rather than by content.
+
+    Args:
+        index: The zero-based position of the entry within the file list.
+        problem: What was wrong with it.
+
+    Returns:
+        A message naming the position and the problem. The entry's own bytes are
+        deliberately not interpolated: they are untrusted, and this string ends
+        up in a CI log.
+    """
+    return f"manifest entry {index} {problem}"
+
+
+def _optional_text(value: object) -> str | None:
+    """Return ``value`` when it is a string, otherwise ``None``."""
+    return value if isinstance(value, str) else None
+
+
+def _source_commit(source: object) -> str | None:
+    """Return the pinned commit a manifest's ``source`` block records, if any.
+
+    Args:
+        source: The manifest's ``source`` value, of whatever shape it had.
+
+    Returns:
+        The recorded commit sha for our sidecar; ``None`` for Creek's manifest,
+        which carries no source block at all.
+    """
+    if isinstance(source, dict):
+        return _optional_text(source.get("commit"))
+    return None
+
+
+def _decode_object(raw: bytes) -> dict[str, object]:
+    """Decode manifest bytes into a JSON object, refusing anything else.
+
+    Args:
+        raw: The manifest bytes, from disk or from an untrusted fetch.
+
+    Returns:
+        The decoded object, with string keys.
+
+    Raises:
+        ManifestError: When the bytes are empty, are not JSON, or decode to
+            anything other than an object -- an array, a bare string and a proxy
+            error page are all refused rather than guessed at.
+    """
+    if not raw:
+        raise ManifestError(_EMPTY_REASON)
+    try:
+        document: object = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise ManifestError(_NOT_JSON_REASON) from error
+    if not isinstance(document, dict):
+        raise ManifestError(_NOT_AN_OBJECT_REASON)
+    return {str(key): value for key, value in document.items()}
+
+
+def _entry_path(index: int, entry: Mapping[str, object]) -> str:
+    """Return one entry's path, refusing anything this checker will not read.
+
+    Raises:
+        ManifestError: When the path is absent, is not a string, or is not a
+            contained printable-ASCII relative path.
+    """
+    path = _optional_text(entry.get("path"))
+    if path is None or not _is_safe_relative_path(path):
+        raise ManifestError(_entry_reason(index, _UNTRUSTED_PATH_REASON))
+    return path
+
+
+def _entry_digest(index: int, entry: Mapping[str, object]) -> str:
+    """Return one entry's sha256, refusing anything that is not one.
+
+    Raises:
+        ManifestError: When the digest is absent, is not a string, or is not
+            exactly 64 lowercase hex characters. A digest that is not a digest
+            can only ever compare unequal or crash, so it is refused up front.
+    """
+    digest = _optional_text(entry.get("sha256"))
+    if digest is None or not _HEX_DIGEST.fullmatch(digest):
+        raise ManifestError(_entry_reason(index, _NOT_A_DIGEST_REASON))
+    return digest
+
+
+def _parse_entry(index: int, entry: object) -> VendoredFile:
+    """Validate one manifest entry into a path and a digest.
+
+    Args:
+        index: The entry's zero-based position, used to describe a refusal.
+        entry: The raw entry, of whatever shape the manifest carried.
+
+    Returns:
+        The validated :class:`VendoredFile`.
+
+    Raises:
+        ManifestError: When the entry is not an object, or when either of its
+            two fields is one this checker declines to trust.
+    """
+    if not isinstance(entry, dict):
+        raise ManifestError(_entry_reason(index, _NOT_AN_ENTRY_REASON))
+    return VendoredFile(path=_entry_path(index, entry), sha256=_entry_digest(index, entry))
+
+
+def _parse_files(value: object) -> tuple[VendoredFile, ...]:
+    """Validate a manifest's ``files`` list into vendored-file entries.
+
+    Args:
+        value: The manifest's ``files`` value, of whatever shape it had.
+
+    Returns:
+        One :class:`VendoredFile` per entry, in manifest order.
+
+    Raises:
+        ManifestError: When the file list is absent, is not a list, is empty --
+            an emptied manifest would otherwise "match" by having nothing to
+            disagree with -- or lists more files than a bundle can hold.
+    """
+    if not isinstance(value, list):
+        raise ManifestError(_NO_FILE_LIST_REASON)
+    if not value:
+        raise ManifestError(_EMPTY_FILE_LIST_REASON)
+    if len(value) > MAX_BUNDLE_FILES:
+        raise ManifestError(_TOO_MANY_FILES_REASON)
+    return tuple(_parse_entry(index, entry) for index, entry in enumerate(value))
+
+
+def parse_manifest(raw: bytes) -> BundleManifest:
+    """Parse manifest bytes into a manifest this checker is willing to trust.
+
+    The same parser reads Creek's published ``manifest.json``, our own
+    ``vendor.json`` sidecar, and whatever an upstream fetch happened to return,
+    so every validation rule applies to all three. That is deliberate: the
+    untrusted case is the one that matters, and giving it a separate, laxer path
+    is how a hostile manifest gets read by accident.
+
+    Args:
+        raw: The manifest bytes.
+
+    Returns:
+        The parsed :class:`BundleManifest`.
+
+    Raises:
+        ManifestError: When the bytes are not a JSON object carrying a non-empty,
+            bounded list of entries whose paths and digests are all trustworthy.
+    """
+    document = _decode_object(raw)
+    return BundleManifest(
+        contract_version=_optional_text(document.get("contract_version")),
+        ontology_version=_optional_text(document.get("ontology_version")),
+        source_commit=_source_commit(document.get("source")),
+        files=_parse_files(document.get("files")),
+    )
+
+
+def load_vendor_manifest(root: Path = BUNDLE_ROOT) -> BundleManifest:
+    """Read the sidecar recording what was vendored, and from which commit.
+
+    Args:
+        root: The vendored bundle directory.
+
+    Returns:
+        The parsed sidecar, covering all 47 vendored files.
+
+    Raises:
+        ManifestError: When the sidecar is unreadable as a manifest. This one is
+            a committed file of ours rather than untrusted input, so a broken
+            sidecar is a broken checkout and raises instead of degrading into a
+            finding.
+    """
+    return parse_manifest((root / VENDOR_NAME).read_bytes())
+
+
+def load_upstream_manifest(root: Path = BUNDLE_ROOT) -> BundleManifest:
+    """Read the vendored copy of Creek's own manifest, without touching a network.
+
+    Args:
+        root: The vendored bundle directory.
+
+    Returns:
+        The parsed manifest, covering the 45 generated files it records -- it
+        covers neither itself nor the hand-written README.
+
+    Raises:
+        ManifestError: When the vendored manifest is unreadable as a manifest.
+    """
+    return parse_manifest((root / MANIFEST_NAME).read_bytes())
+
+
+def _recorded_digests(root: Path) -> dict[str, str]:
+    """Return the ``path -> sha256`` mapping our sidecar recorded."""
+    return {item.path: item.sha256 for item in load_vendor_manifest(root).files}
+
+
+def _disk_digests(root: Path) -> dict[str, str]:
+    """Return the ``path -> sha256`` mapping of every bundle file on disk.
+
+    Args:
+        root: The bundle directory to walk.
+
+    Returns:
+        A mapping keyed by bundle-relative POSIX path. The sidecar excludes
+        itself: it is the record, not the record's subject.
+    """
+    return {
+        path.relative_to(root).as_posix(): _sha256(path.read_bytes())
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and path.name != VENDOR_NAME
+    }
+
+
+def _compare_digests(
+    recorded: Mapping[str, str],
+    observed: Mapping[str, str],
+    unobtainable: frozenset[str],
+) -> tuple[int, tuple[Change, ...]]:
+    """Compare what we recorded against what the other side actually has.
+
+    Args:
+        recorded: The ``path -> sha256`` mapping from our sidecar.
+        observed: The ``path -> sha256`` mapping observed on the other side.
+        unobtainable: Paths that could not be observed at all. They are excluded
+            from the "recorded but gone" set, because a file we failed to read
+            is unverified rather than deleted, and calling it deleted would turn
+            an outage into a false drift alarm.
+
+    Returns:
+        A ``(compared, changes)`` pair. Every observed path counts as compared,
+        as does every recorded path the other side no longer has -- a shrinking
+        comparison is exactly the silent failure this gate exists to catch.
+    """
+    changes = [
+        Change(
+            capability=_capability_of(path),
+            path=path,
+            vendored=recorded.get(path),
+            upstream=digest,
+        )
+        for path, digest in sorted(observed.items())
+        if recorded.get(path) != digest
+    ]
+    gone = sorted(recorded.keys() - observed.keys() - unobtainable)
+    changes.extend(
+        Change(
+            capability=_capability_of(path),
+            path=path,
+            vendored=recorded[path],
+            upstream=None,
+        )
+        for path in gone
+    )
+    return len(observed) + len(gone), tuple(changes)
+
+
+def verify_local(root: Path = BUNDLE_ROOT) -> DriftReport:
+    """Check the vendored bytes on disk against the digests we recorded for them.
+
+    Offline and network-free: this is the half of the gate that catches a
+    hand-edit, a bad merge, or a truncating checkout, and it is cheap enough to
+    run unconditionally.
+
+    Args:
+        root: The vendored bundle directory.
+
+    Returns:
+        A report comparing every recorded path against disk *and* every on-disk
+        file against the record, so an unlisted file is drift just as much as a
+        changed one.
+    """
+    compared, changes = _compare_digests(
+        _recorded_digests(root),
+        _disk_digests(root),
+        frozenset(),
+    )
+    return DriftReport(compared=compared, changes=changes, unverifiable=())
+
+
+def upstream_url(name: str) -> str:
+    """Return the raw-content URL Creek publishes one bundle file at.
+
+    Args:
+        name: A bundle-relative path.
+
+    Returns:
+        The ``raw.githubusercontent.com`` URL for that file at
+        :data:`UPSTREAM_REF`. The comparison deliberately reads the branch and
+        not the pinned commit: asking whether the pin still matches what Creek
+        publishes *today* is the whole question.
+    """
+    return f"{_RAW_CONTENT_HOST}/{UPSTREAM_REPO}/{UPSTREAM_REF}/{UPSTREAM_PATH}/{name}"
+
+
+def fetch_upstream_file(url: str) -> bytes:
+    """Fetch one file from Creek's public repository over HTTPS.
+
+    Kept as a module-level function rather than inlined into
+    :func:`compare_upstream` so the CLI's network seam has a name that tests can
+    substitute; an inline request would make the compare subcommand untestable
+    offline. creek-vault is public, so the request carries no credential.
+
+    Args:
+        url: The URL to fetch, as built by :func:`upstream_url`.
+
+    Returns:
+        The response body.
+
+    Raises:
+        UpstreamFetchError: When the URL is not HTTPS, or when the body exceeds
+            :data:`MAX_FILE_BYTES`. Redirects are not followed, because a
+            redirect away from the raw-content host is a change of publisher
+            rather than a detail of transport.
+        httpx.HTTPError: When the request fails or the status is not a success.
+    """
+    if not url.startswith(_HTTPS_SCHEME):
+        raise UpstreamFetchError(_INSECURE_URL_REASON)
+    response = httpx.get(url, follow_redirects=False, timeout=FETCH_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    content = response.content
+    if len(content) > MAX_FILE_BYTES:
+        raise UpstreamFetchError(_OVERSIZED_REASON)
+    return content
+
+
+def _fetch_body(name: str, fetch: Fetcher) -> bytes | Unverifiable:
+    """Fetch one upstream file, turning any failure into an unverifiable finding.
+
+    Args:
+        name: The bundle-relative path to fetch.
+        fetch: The injected fetcher.
+
+    Returns:
+        The body, or an :class:`Unverifiable` naming why it could not be used.
+        The size bound is applied here as well as inside the real fetcher, so an
+        injected fetcher cannot hand this checker an unbounded body either. Only
+        the exception's type is reported: the message may carry bytes chosen by
+        whatever answered, and this text ends up in a CI log.
+    """
+    try:
+        body = fetch(upstream_url(name))
+    except _FETCH_FAILURES as error:
+        return Unverifiable(path=name, reason=f"{_FETCH_FAILED_REASON} ({type(error).__name__})")
+    if len(body) > MAX_FILE_BYTES:
+        return Unverifiable(path=name, reason=_OVERSIZED_REASON)
+    return body
+
+
+def _fetch_directly(fetch: Fetcher) -> dict[str, bytes | Unverifiable]:
+    """Fetch the two files Creek's manifest cannot cover, one outcome each."""
+    return {name: _fetch_body(name, fetch) for name in _DIRECTLY_FETCHED}
+
+
+def _findings(bodies: Mapping[str, bytes | Unverifiable]) -> list[Unverifiable]:
+    """Return the fetch outcomes that produced a finding rather than bytes."""
+    return [item for item in bodies.values() if isinstance(item, Unverifiable)]
+
+
+def _observed_upstream(
+    bodies: Mapping[str, bytes | Unverifiable],
+    manifest: BundleManifest,
+) -> dict[str, str]:
+    """Build the upstream ``path -> sha256`` mapping a comparison can be run against.
+
+    Args:
+        bodies: The directly fetched files, keyed by name.
+        manifest: The parsed upstream manifest.
+
+    Returns:
+        A digest per observed path: the two directly fetched files hashed from
+        their own bytes, plus the 45 digests the manifest records for everything
+        else. Creek's manifest covers neither itself nor the README, which is
+        exactly why those two have to be fetched and hashed here.
+    """
+    observed = {name: _sha256(body) for name, body in bodies.items() if isinstance(body, bytes)}
+    observed.update({item.path: item.sha256 for item in manifest.files})
+    return observed
+
+
+def compare_upstream(root: Path = BUNDLE_ROOT, *, fetch: Fetcher) -> DriftReport:
+    """Check what Creek publishes today against the digests we vendored.
+
+    Args:
+        root: The vendored bundle directory.
+        fetch: The seam that produces upstream bytes for a URL. Injected so the
+            whole comparison can be exercised over in-memory bodies.
+
+    Returns:
+        A report over all 47 vendored files. When the upstream manifest itself
+        cannot be obtained or parsed, the comparison is abandoned rather than
+        run against a partial picture: the report then says nothing was compared
+        instead of reporting the manifest's own mismatch as if it were the
+        finding, because an unreadable manifest leaves 45 files unexamined.
+    """
+    recorded = _recorded_digests(root)
+    bodies = _fetch_directly(fetch)
+    unverifiable = _findings(bodies)
+
+    manifest = _parse_fetched_manifest(bodies[MANIFEST_NAME], unverifiable)
+    if manifest is None:
+        return DriftReport(compared=0, changes=(), unverifiable=tuple(unverifiable))
+
+    compared, changes = _compare_digests(
+        recorded,
+        _observed_upstream(bodies, manifest),
+        frozenset(item.path for item in unverifiable),
+    )
+    return DriftReport(compared=compared, changes=changes, unverifiable=tuple(unverifiable))
+
+
+def _parse_fetched_manifest(
+    body: bytes | Unverifiable,
+    unverifiable: list[Unverifiable],
+) -> BundleManifest | None:
+    """Parse the fetched manifest, recording a finding instead of raising.
+
+    Args:
+        body: The fetched manifest body, or the finding explaining its absence.
+        unverifiable: The findings list, appended to in place when the body is
+            present but cannot be parsed.
+
+    Returns:
+        The parsed manifest, or ``None`` when the comparison cannot proceed.
+    """
+    if not isinstance(body, bytes):
+        return None
+    try:
+        return parse_manifest(body)
+    except ManifestError as error:
+        unverifiable.append(Unverifiable(path=MANIFEST_NAME, reason=str(error)))
+        return None
+
+
+def snapshot(root: Path = BUNDLE_ROOT, *, commit: str) -> str:
+    """Render the sidecar that records what was vendored, without writing anything.
+
+    The bundle name and both version strings are read out of Creek's own
+    manifest rather than retyped, so the sidecar cannot claim a version the
+    bundle does not carry.
+
+    Args:
+        root: The vendored bundle directory.
+        commit: The upstream commit sha the bundle was fetched at. A branch name
+            would let the "pinned" copy move underneath the digests that are the
+            only thing making it a pin, so the caller must supply a sha.
+
+    Returns:
+        The sidecar's exact text, for the operator to commit verbatim. Writing
+        is left to the caller: snapshotting is a pure read, and a checker that
+        silently rewrites the record it checks against is no longer a checker.
+    """
+    document = _decode_object((root / MANIFEST_NAME).read_bytes())
+    payload = {
+        "bundle": document.get("bundle"),
+        "contract_version": document.get("contract_version"),
+        "ontology_version": document.get("ontology_version"),
+        "source": {"repo": UPSTREAM_REPO, "commit": commit, "path": UPSTREAM_PATH},
+        "files": [
+            {"path": path, "sha256": digest} for path, digest in sorted(_disk_digests(root).items())
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _digest_text(value: str | None) -> str:
+    """Render a digest, naming its absence rather than printing ``None``."""
+    return value if value is not None else _ABSENT_DIGEST
+
+
+def _capability_text(value: str | None) -> str:
+    """Render a capability name, naming its absence rather than printing ``None``."""
+    return value if value is not None else _NO_CAPABILITY
+
+
+def _change_lines(changes: tuple[Change, ...]) -> list[str]:
+    """Render the drift section, naming each file's capability and both digests.
+
+    Args:
+        changes: The files whose digests disagree.
+
+    Returns:
+        The rendered lines, without trailing newlines.
+    """
+    verb = "file does" if len(changes) == 1 else "files do"
+    lines = [f"Creek contract drift: {len(changes)} vendored {verb} not match the record."]
+    lines.extend(
+        f"  {item.path} ({_capability_text(item.capability)}): "
+        f"recorded {_digest_text(item.vendored)} / observed {_digest_text(item.upstream)}"
+        for item in changes
+    )
+    lines.append(_REMEDIATION)
+    return lines
+
+
+def _unverifiable_lines(unverifiable: tuple[Unverifiable, ...]) -> list[str]:
+    """Render the could-not-verify section, naming each file and its reason.
+
+    Args:
+        unverifiable: The files that could not be compared.
+
+    Returns:
+        The rendered lines, without trailing newlines.
+    """
+    count = len(unverifiable)
+    lines = [f"Cannot verify the Creek contract bundle: {count} file(s) were not compared."]
+    lines.extend(f"  {item.path}: {item.reason}" for item in unverifiable)
+    return lines
+
+
+def _finding_lines(report: DriftReport) -> list[str]:
+    """Render every non-empty finding section, in severity order.
+
+    Args:
+        report: The report to render.
+
+    Returns:
+        The rendered lines, empty when the run found nothing at all.
+    """
+    lines: list[str] = []
+    if report.changes:
+        lines.extend(_change_lines(report.changes))
+    if report.unverifiable:
+        lines.extend(_unverifiable_lines(report.unverifiable))
+    return lines
+
+
+def render_report(report: DriftReport) -> str:
+    """Render a report as the operator-facing text the gate prints.
+
+    Args:
+        report: The report to render.
+
+    Returns:
+        A newline-terminated block. A clean run names how many files were
+        actually compared, so "compared nothing" can never read the same as
+        "compared everything and found it sound" -- and a run with nothing to
+        compare says exactly that instead of borrowing the clean wording.
+    """
+    lines = _finding_lines(report)
+    if lines:
+        return "\n".join(lines) + "\n"
+    if not report.compared:
+        return _NOTHING_VERIFIED
+    return (
+        f"Creek contract drift: none. {report.compared} vendored file(s) "
+        "match the recorded digests.\n"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the subcommand parser.
+
+    Returns:
+        A parser whose subcommand is required, so an unrecognised or missing
+        one fails the gate rather than defaulting into a check the operator did
+        not ask for.
+    """
+    parser = argparse.ArgumentParser(description="Check the vendored Creek /v1 contract bundle.")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser(_VERIFY_COMMAND, help="check the vendored bytes against vendor.json")
+    subcommands.add_parser(
+        _COMPARE_COMMAND, help="check Creek's published bytes against vendor.json"
+    )
+    cut = subcommands.add_parser(_SNAPSHOT_COMMAND, help="render a fresh vendor.json on stdout")
+    cut.add_argument("--commit", required=True, help="the upstream commit sha being vendored")
+    return parser
+
+
+def _check(command: str) -> DriftReport:
+    """Run the drift check the subcommand names.
+
+    Args:
+        command: The parsed subcommand.
+
+    Returns:
+        The resulting report. ``fetch_upstream_file`` is resolved as a module
+        global here rather than bound as a default argument, so substituting the
+        module attribute redirects the CLI's only network call.
+    """
+    if command == _COMPARE_COMMAND:
+        return compare_upstream(BUNDLE_ROOT, fetch=fetch_upstream_file)
+    return verify_local(BUNDLE_ROOT)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one subcommand and return its process exit code.
+
+    Args:
+        argv: The command-line arguments after the program name. ``None`` reads
+            ``sys.argv``.
+
+    Returns:
+        ``EXIT_CLEAN`` for the snapshot subcommand, which only renders text,
+        otherwise the report's exit code. The report goes to stdout when clean
+        and to stderr otherwise, so a failing gate's output is unambiguous.
+    """
+    args = _build_parser().parse_args(argv)
+    if args.command == _SNAPSHOT_COMMAND:
+        sys.stdout.write(snapshot(BUNDLE_ROOT, commit=args.commit))
+        return EXIT_CLEAN
+    report = _check(args.command)
+    stream = sys.stdout if report.exit_code == EXIT_CLEAN else sys.stderr
+    stream.write(render_report(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via tests/CLI
+    sys.exit(main(sys.argv[1:]))

--- a/backend/tests/fixtures/creek_v1/README.md
+++ b/backend/tests/fixtures/creek_v1/README.md
@@ -1,0 +1,151 @@
+# Adepthood `/v1` contract bundle
+
+This directory is the published, machine-checkable contract for the
+Adepthood HTTP application API. It exists so a consumer — chiefly the
+Adepthood client — can validate against Creek's actual wire shapes without
+running Creek's own test suite. The decision behind this surface, including
+the versioning rule, the error taxonomy, and the oracle-avoidance reasoning
+that shapes several fixtures, is
+[`../../decisions/2026-07-31-adepthood-http-application-api.md`](../../decisions/2026-07-31-adepthood-http-application-api.md).
+Read that document first; this README is the manual for the *bundle*, not a
+restatement of the contract it documents.
+
+## This file is the one hand-written thing in this directory
+
+Every other file under `docs/contracts/adepthood-v1/` is **generated** by
+`build_bundle()` in
+[`creek_mcp/api/bundle.py`](../../../creek-tools/creek_mcp/api/bundle.py)
+from the Pydantic models in
+[`creek_mcp/api/models.py`](../../../creek-tools/creek_mcp/api/models.py).
+`tests/test_adepthood_contract_models.py::test_committed_bundle_equals_a_fresh_build`
+asserts the committed bytes are byte-identical to a fresh `build_bundle()`
+call. If you find yourself about to hand-edit a `schemas/*.json`, an
+`examples/**/*.json`, `retry-policy.json`, or `manifest.json`: don't — edit
+the model or the fixture payload in `creek_mcp/api/bundle.py` instead and
+regenerate. A hand-edited generated file will fail that round-trip test the
+next time it runs.
+
+## Layout
+
+```
+adepthood-v1/
+├── README.md                          # this file — hand-written, not covered by the round-trip test
+├── manifest.json                      # contract_version, ontology_version, and a sha256 per generated file
+├── retry-policy.json                  # {code: disposition} — the whole answer to "should I retry this error?"
+├── schemas/
+│   └── <ModelName>.schema.json        # one JSON Schema per CONTRACT_MODELS entry (16 files)
+└── examples/
+    └── <capability>/
+        └── <state>.json               # one fixture per (capability, state) cell (4 × 7 = 28 files)
+```
+
+## The two axes of the example matrix
+
+**Capabilities** (four): `capabilities`, `journal-upsert`, `reflections`,
+`wheel` — read directly off the `Capability` enum, so this directory's
+subdirectory names can never name a different set of capabilities than the
+server actually advertises through `GET /v1/capabilities`.
+
+**States** (seven), in the order a consumer meets them:
+
+| State | Meaning | Response is |
+|---|---|---|
+| `success` | The canonical happy response | 200, the capability's own model |
+| `empty` | The legitimately-empty answer — **never an error** | 200 |
+| `refusal` | An above-ceiling / unresolvable vault-object refusal | 403, `ErrorEnvelope` |
+| `care-escalation` | The acute-distress guard fired | 200, `CareEscalationResponse` (reflections only — see below) |
+| `malformed-input` | The request does not satisfy the published schema | 422, `ErrorEnvelope` |
+| `incompatible-version` | The requested contract minor is not served here | 409, `ErrorEnvelope` |
+| `unavailable-service` | The vault is absent or unreadable | 503, `ErrorEnvelope` |
+
+## Reading a fixture as a client engineer
+
+1. Look up your capability's directory under `examples/`.
+2. Pick the state you're building a handler for.
+3. Read `manifest.json`'s matching entry for the `model` name that governs
+   that cell, and validate the fixture against
+   `schemas/<model>.schema.json`.
+4. If you land on `capabilities/care-escalation.json`,
+   `journal-upsert/care-escalation.json`, or `wheel/care-escalation.json`,
+   you have found one of the three `NotApplicableExample` cells — see
+   below. Do not write a handler for a care-escalation response on any
+   capability except `reflections`; the server can never emit one.
+
+## Why three cells are `NotApplicableExample`
+
+The acute-distress care guard runs only inside `reflect_tool`. `capabilities`,
+`journal-upsert`, and `wheel` therefore have **no reachable
+care-escalation response shape at all** — not "rare," structurally
+impossible. Those three cells hold an explicit, schema-validated
+`NotApplicableExample` (`{"unreachable": true, "reason": "..."}`) rather than
+either a fabricated response (which would document a shape the server can
+never send) or an absent file (which would read as "undocumented" rather
+than "cannot happen"). If you are generating client code from this matrix
+mechanically, treat `NotApplicableExample` as "skip — this branch does not
+exist," not as a normal response variant to handle.
+
+## JSON key order is *not* the contract's ordering guarantee
+
+Every file here is serialised with `sort_keys=True`, because byte-determinism
+is what makes the `sha256` manifest and the regeneration test meaningful. So
+`examples/wheel/success.json` lists `F1`, `F10`, `F2`, `F3`… — alphabetical,
+not canonical. **Do not read that as the frequency order.**
+
+The wheel's deterministic ordering is pinned in the two places that are
+actually normative: `WheelFrequencies` declares ten separate fields in the
+canonical `F1`…`F10` order of
+`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`, and
+`schemas/WheelFrequencies.schema.json`'s `required` array reproduces that
+order. JSON objects are unordered by specification, so a client must key the
+ten frequencies by name — never by position in the serialised example.
+
+## Integrity: pin the manifest hash, not the files
+
+`manifest.json` records the `contract_version`, the `ontology_version`, and
+a `sha256` for every other generated file in this directory, sorted by
+path. Adepthood's recommended integration is:
+
+1. Vendor this directory into the Adepthood repository by copy, fetched from
+   a `raw.githubusercontent.com` URL pinned to a specific commit sha (not a
+   branch).
+2. Pin `manifest.json`'s own bytes — or its hash — in Adepthood's CI, and
+   fail the build if a re-fetch produces a different manifest without a
+   corresponding, reviewed update on the Adepthood side.
+3. At runtime, a stale vendored copy is not silently wrong: `/v1` refuses a
+   contract-minor mismatch with `409 incompatible_version` (see the ADR's
+   [Versioning](../../decisions/2026-07-31-adepthood-http-application-api.md#versioning)
+   section), so drift surfaces as a loud, typed error rather than a shape
+   mismatch discovered in production.
+
+This is copy-and-pin, not a package. Nothing mechanically stops a vendored
+copy from drifting between fetches beyond the manifest-hash check described
+above; Creek-side, CI enforces that the bundle can never itself drift from
+the models that generate it. Publishing this directory as a GitHub Release
+asset (the existing rolling `knowledge-graph` release is the precedent) is
+the natural next step and is deliberately not done as part of this bundle's
+first publication.
+
+## Security invariants held across every fixture in this bundle
+
+- No fixture contains a real journal body, a credential, or a token.
+- No fixture contains `"tier": "intimate"` or `"routed_tier": "intimate"`
+  anywhere — this is not merely a convention: `WireTierCeiling` has exactly
+  two members (`open`, `personal`), so `intimate` is not a constructible
+  value on this wire at all.
+- Every `examples/*/refusal.json` fixture is the **intimate example** for
+  its capability: the closest this bundle comes to showing you above-ceiling
+  content is showing you the refusal it produces instead. That is the point
+  of publishing them, not an accident of the state axis's naming.
+- Every payload is built from the runtime constants it documents
+  (`CONTRACT_VERSION`, `ONTOLOGY_VERSION`, `CANONICAL_FREQUENCY_NAMES`,
+  `CARE_SIGNAL`, `ERROR_MESSAGES`) rather than from hand-copied duplicates,
+  so this bundle cannot describe a server that does not exist.
+
+## Regenerating this bundle
+
+This directory is written by `write_bundle()` in
+`creek_mcp/api/bundle.py`, called against the repository's `docs/contracts/`
+path. Regenerate it whenever a model in `creek_mcp/api/models.py` or a
+fixture payload in `creek_mcp/api/bundle.py` changes; the committed
+round-trip test will fail the build until you do. This README is excluded
+from that generation and from the round-trip check — edit it directly.

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/care-escalation.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/care-escalation.json
@@ -1,0 +1,4 @@
+{
+  "reason": "the acute-distress guard runs only inside reflect_tool, so this capability has no care-escalation response shape",
+  "unreachable": true
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/empty.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/empty.json
@@ -1,0 +1,21 @@
+{
+  "capabilities": [],
+  "contract_minor": "0.2",
+  "contract_version": "0.2.0",
+  "ontology_version": "aptitude-wavelength/2026-05-23",
+  "status": "uninitialized",
+  "supported_contract_minors": [
+    "0.2"
+  ],
+  "tier_model": {
+    "ceilings": [
+      "open",
+      "personal"
+    ],
+    "default": "open",
+    "intimate_never_egresses": true
+  },
+  "vault": {
+    "available": false
+  }
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/incompatible-version.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/incompatible-version.json
@@ -1,0 +1,5 @@
+{
+  "code": "incompatible_version",
+  "message": "the requested contract minor is not served here",
+  "request_id": "req-example-capabilities-incompatible-version"
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/malformed-input.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/malformed-input.json
@@ -1,0 +1,5 @@
+{
+  "code": "invalid_request",
+  "message": "the request does not satisfy the published schema",
+  "request_id": "req-example-capabilities-malformed-input"
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/refusal.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/refusal.json
@@ -1,0 +1,5 @@
+{
+  "code": "privacy_refused",
+  "message": "resolved content exceeds the declared tier ceiling",
+  "request_id": "req-example-capabilities-refusal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/success.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/success.json
@@ -1,0 +1,26 @@
+{
+  "capabilities": [
+    "capabilities",
+    "journal-upsert",
+    "reflections",
+    "wheel"
+  ],
+  "contract_minor": "0.2",
+  "contract_version": "0.2.0",
+  "ontology_version": "aptitude-wavelength/2026-05-23",
+  "status": "ok",
+  "supported_contract_minors": [
+    "0.2"
+  ],
+  "tier_model": {
+    "ceilings": [
+      "open",
+      "personal"
+    ],
+    "default": "open",
+    "intimate_never_egresses": true
+  },
+  "vault": {
+    "available": true
+  }
+}

--- a/backend/tests/fixtures/creek_v1/examples/capabilities/unavailable-service.json
+++ b/backend/tests/fixtures/creek_v1/examples/capabilities/unavailable-service.json
@@ -1,0 +1,5 @@
+{
+  "code": "unavailable",
+  "message": "the vault is not available to serve this request",
+  "request_id": "req-example-capabilities-unavailable-service"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/care-escalation.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/care-escalation.json
@@ -1,0 +1,4 @@
+{
+  "reason": "the acute-distress guard runs only inside reflect_tool, so this capability has no care-escalation response shape",
+  "unreachable": true
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/empty.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/empty.json
@@ -1,0 +1,8 @@
+{
+  "action": "unchanged",
+  "external_id": "adepthood:entry:2026-07-31T06:12:00Z",
+  "fragment_id": "frag-3f9a1c7e40b2",
+  "status": "ok",
+  "tier": "personal",
+  "tier_ceiling": "personal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/incompatible-version.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/incompatible-version.json
@@ -1,0 +1,5 @@
+{
+  "code": "incompatible_version",
+  "message": "the requested contract minor is not served here",
+  "request_id": "req-example-journal-upsert-incompatible-version"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/malformed-input.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/malformed-input.json
@@ -1,0 +1,5 @@
+{
+  "code": "invalid_request",
+  "message": "the request does not satisfy the published schema",
+  "request_id": "req-example-journal-upsert-malformed-input"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/refusal.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/refusal.json
@@ -1,0 +1,5 @@
+{
+  "code": "privacy_refused",
+  "message": "resolved content exceeds the declared tier ceiling",
+  "request_id": "req-example-journal-upsert-refusal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/success.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/success.json
@@ -1,0 +1,8 @@
+{
+  "action": "created",
+  "external_id": "adepthood:entry:2026-07-31T06:12:00Z",
+  "fragment_id": "frag-3f9a1c7e40b2",
+  "status": "ok",
+  "tier": "personal",
+  "tier_ceiling": "personal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/journal-upsert/unavailable-service.json
+++ b/backend/tests/fixtures/creek_v1/examples/journal-upsert/unavailable-service.json
@@ -1,0 +1,5 @@
+{
+  "code": "unavailable",
+  "message": "the vault is not available to serve this request",
+  "request_id": "req-example-journal-upsert-unavailable-service"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/care-escalation.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/care-escalation.json
@@ -1,0 +1,19 @@
+{
+  "care_signal": {
+    "kind": "acute_distress",
+    "message": "This sounds urgent and heavy, and you deserve real human support right now \u2014 more than a chatbot can give. Please reach out to someone you trust, or contact a crisis service. You are not alone in this.",
+    "resources": [
+      {
+        "contact": "Call or text 988",
+        "name": "988 Suicide & Crisis Lifeline (US)"
+      },
+      {
+        "contact": "https://findahelpline.com",
+        "name": "Find a Helpline (international directory)"
+      }
+    ]
+  },
+  "reason": "acute_distress",
+  "status": "escalate",
+  "tier_ceiling": "personal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/empty.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/empty.json
@@ -1,0 +1,8 @@
+{
+  "essay": null,
+  "essay_grounded": false,
+  "notes": [],
+  "routed_tier": "personal",
+  "status": "empty",
+  "tier_ceiling": "personal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/incompatible-version.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/incompatible-version.json
@@ -1,0 +1,5 @@
+{
+  "code": "incompatible_version",
+  "message": "the requested contract minor is not served here",
+  "request_id": "req-example-reflections-incompatible-version"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/malformed-input.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/malformed-input.json
@@ -1,0 +1,5 @@
+{
+  "code": "invalid_request",
+  "message": "the request does not satisfy the published schema",
+  "request_id": "req-example-reflections-malformed-input"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/refusal.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/refusal.json
@@ -1,0 +1,5 @@
+{
+  "code": "privacy_refused",
+  "message": "resolved content exceeds the declared tier ceiling",
+  "request_id": "req-example-reflections-refusal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/success.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/success.json
@@ -1,0 +1,14 @@
+{
+  "essay": null,
+  "essay_grounded": false,
+  "notes": [
+    {
+      "kind": "pattern",
+      "note": "Synthetic example prose. A real note mirrors the writer's own words back to them and never advises.",
+      "quote": "I keep saying yes to things I do not want"
+    }
+  ],
+  "routed_tier": "personal",
+  "status": "ok",
+  "tier_ceiling": "personal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/reflections/unavailable-service.json
+++ b/backend/tests/fixtures/creek_v1/examples/reflections/unavailable-service.json
@@ -1,0 +1,5 @@
+{
+  "code": "unavailable",
+  "message": "the vault is not available to serve this request",
+  "request_id": "req-example-reflections-unavailable-service"
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/care-escalation.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/care-escalation.json
@@ -1,0 +1,4 @@
+{
+  "reason": "the acute-distress guard runs only inside reflect_tool, so this capability has no care-escalation response shape",
+  "unreachable": true
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/empty.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/empty.json
@@ -1,0 +1,58 @@
+{
+  "status": "ok",
+  "tier_ceiling": "open",
+  "total_classified": 0,
+  "unclassified": 0,
+  "wheel": {
+    "F1": {
+      "count": 0,
+      "name": "Agency",
+      "share": 0.0
+    },
+    "F10": {
+      "count": 0,
+      "name": "Emptiness",
+      "share": 0.0
+    },
+    "F2": {
+      "count": 0,
+      "name": "Receptivity",
+      "share": 0.0
+    },
+    "F3": {
+      "count": 0,
+      "name": "Self-Love / Power",
+      "share": 0.0
+    },
+    "F4": {
+      "count": 0,
+      "name": "Community Love / Conformity",
+      "share": 0.0
+    },
+    "F5": {
+      "count": 0,
+      "name": "Achievism",
+      "share": 0.0
+    },
+    "F6": {
+      "count": 0,
+      "name": "Pluralism",
+      "share": 0.0
+    },
+    "F7": {
+      "count": 0,
+      "name": "Integration",
+      "share": 0.0
+    },
+    "F8": {
+      "count": 0,
+      "name": "True Self / Transcendence",
+      "share": 0.0
+    },
+    "F9": {
+      "count": 0,
+      "name": "Unity",
+      "share": 0.0
+    }
+  }
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/incompatible-version.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/incompatible-version.json
@@ -1,0 +1,5 @@
+{
+  "code": "incompatible_version",
+  "message": "the requested contract minor is not served here",
+  "request_id": "req-example-wheel-incompatible-version"
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/malformed-input.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/malformed-input.json
@@ -1,0 +1,5 @@
+{
+  "code": "invalid_request",
+  "message": "the request does not satisfy the published schema",
+  "request_id": "req-example-wheel-malformed-input"
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/refusal.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/refusal.json
@@ -1,0 +1,5 @@
+{
+  "code": "privacy_refused",
+  "message": "resolved content exceeds the declared tier ceiling",
+  "request_id": "req-example-wheel-refusal"
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/success.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/success.json
@@ -1,0 +1,58 @@
+{
+  "status": "ok",
+  "tier_ceiling": "open",
+  "total_classified": 10,
+  "unclassified": 0,
+  "wheel": {
+    "F1": {
+      "count": 1,
+      "name": "Agency",
+      "share": 0.1
+    },
+    "F10": {
+      "count": 1,
+      "name": "Emptiness",
+      "share": 0.1
+    },
+    "F2": {
+      "count": 1,
+      "name": "Receptivity",
+      "share": 0.1
+    },
+    "F3": {
+      "count": 1,
+      "name": "Self-Love / Power",
+      "share": 0.1
+    },
+    "F4": {
+      "count": 1,
+      "name": "Community Love / Conformity",
+      "share": 0.1
+    },
+    "F5": {
+      "count": 1,
+      "name": "Achievism",
+      "share": 0.1
+    },
+    "F6": {
+      "count": 1,
+      "name": "Pluralism",
+      "share": 0.1
+    },
+    "F7": {
+      "count": 1,
+      "name": "Integration",
+      "share": 0.1
+    },
+    "F8": {
+      "count": 1,
+      "name": "True Self / Transcendence",
+      "share": 0.1
+    },
+    "F9": {
+      "count": 1,
+      "name": "Unity",
+      "share": 0.1
+    }
+  }
+}

--- a/backend/tests/fixtures/creek_v1/examples/wheel/unavailable-service.json
+++ b/backend/tests/fixtures/creek_v1/examples/wheel/unavailable-service.json
@@ -1,0 +1,5 @@
+{
+  "code": "unavailable",
+  "message": "the vault is not available to serve this request",
+  "request_id": "req-example-wheel-unavailable-service"
+}

--- a/backend/tests/fixtures/creek_v1/manifest.json
+++ b/backend/tests/fixtures/creek_v1/manifest.json
@@ -1,0 +1,322 @@
+{
+  "bundle": "adepthood-v1",
+  "contract_version": "0.2.0",
+  "files": [
+    {
+      "capability": "capabilities",
+      "model": "NotApplicableExample",
+      "path": "examples/capabilities/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97",
+      "state": "care-escalation"
+    },
+    {
+      "capability": "capabilities",
+      "model": "CapabilitiesResponse",
+      "path": "examples/capabilities/empty.json",
+      "sha256": "abff9182a8c5fe4f4a32ad1d96118dfd14d85dbf7b1a48406ff2c34be3145426",
+      "state": "empty"
+    },
+    {
+      "capability": "capabilities",
+      "model": "ErrorEnvelope",
+      "path": "examples/capabilities/incompatible-version.json",
+      "sha256": "31ec5c80d575fff4c4ef489e86bddbe7e3bcf2efa6e4ca0b9cb4ed727d93b210",
+      "state": "incompatible-version"
+    },
+    {
+      "capability": "capabilities",
+      "model": "ErrorEnvelope",
+      "path": "examples/capabilities/malformed-input.json",
+      "sha256": "0c7e796525f90bb81cac9f5f04173b2d1471733eb3606e807feea3dcac3fbfa7",
+      "state": "malformed-input"
+    },
+    {
+      "capability": "capabilities",
+      "model": "ErrorEnvelope",
+      "path": "examples/capabilities/refusal.json",
+      "sha256": "a27761795b0af5acb873c400b81a9e35f073c629d390f77ae762605436c6a5ac",
+      "state": "refusal"
+    },
+    {
+      "capability": "capabilities",
+      "model": "CapabilitiesResponse",
+      "path": "examples/capabilities/success.json",
+      "sha256": "5c4618983b0196b4484b2604fedd6b9bbb02c54b6e414223b4c879fed689e7a1",
+      "state": "success"
+    },
+    {
+      "capability": "capabilities",
+      "model": "ErrorEnvelope",
+      "path": "examples/capabilities/unavailable-service.json",
+      "sha256": "89a0b5295b63a7c84f76da28bc556abf281afefa7993a3b5701ddd01baf9294d",
+      "state": "unavailable-service"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "NotApplicableExample",
+      "path": "examples/journal-upsert/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97",
+      "state": "care-escalation"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "JournalUpsertResponse",
+      "path": "examples/journal-upsert/empty.json",
+      "sha256": "66498f2275528fb22151d8441c3cab5d3fa60d089100b3d39d35cdbd2f2b59ba",
+      "state": "empty"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "ErrorEnvelope",
+      "path": "examples/journal-upsert/incompatible-version.json",
+      "sha256": "11f79c2f713c309b0e7ef5d426950b1325f649e0ee353c96092d13d99b892432",
+      "state": "incompatible-version"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "ErrorEnvelope",
+      "path": "examples/journal-upsert/malformed-input.json",
+      "sha256": "16c1542153a2d53b3203107d4d299dc8fa819bbeb9666279301b18371bfa7e9a",
+      "state": "malformed-input"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "ErrorEnvelope",
+      "path": "examples/journal-upsert/refusal.json",
+      "sha256": "ae3f45dcfef37cf4d7aea5ce53a9d26b52db376e15c62f2e0773c53b3199643c",
+      "state": "refusal"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "JournalUpsertResponse",
+      "path": "examples/journal-upsert/success.json",
+      "sha256": "a1d405aa236bc6ea4c7f6e8f93354a5fbee2e631b4020299eb3208170a554411",
+      "state": "success"
+    },
+    {
+      "capability": "journal-upsert",
+      "model": "ErrorEnvelope",
+      "path": "examples/journal-upsert/unavailable-service.json",
+      "sha256": "a29004223b68de26c66e2dfaa64ff3fde4495e0b3bee0c21c3aae8c56be6a6a6",
+      "state": "unavailable-service"
+    },
+    {
+      "capability": "reflections",
+      "model": "CareEscalationResponse",
+      "path": "examples/reflections/care-escalation.json",
+      "sha256": "8558c3fa48b4be421fed76e7116f48568ce9eb4fba9ebe9f274e1c5e385b9b91",
+      "state": "care-escalation"
+    },
+    {
+      "capability": "reflections",
+      "model": "ReflectionResponse",
+      "path": "examples/reflections/empty.json",
+      "sha256": "acbc52f5a0d4928138cc2e2a83e8d71676951ca5b639c143ab588e63b397845f",
+      "state": "empty"
+    },
+    {
+      "capability": "reflections",
+      "model": "ErrorEnvelope",
+      "path": "examples/reflections/incompatible-version.json",
+      "sha256": "4c7b3c4625d963299263022c73a76ec98f8dbf7139211ca4e77446b27994de0a",
+      "state": "incompatible-version"
+    },
+    {
+      "capability": "reflections",
+      "model": "ErrorEnvelope",
+      "path": "examples/reflections/malformed-input.json",
+      "sha256": "8c38d1d2895086249a6d0f3a036b91ff647ecf2dfaf754854da19b04d1025240",
+      "state": "malformed-input"
+    },
+    {
+      "capability": "reflections",
+      "model": "ErrorEnvelope",
+      "path": "examples/reflections/refusal.json",
+      "sha256": "550679693ae83fea294a953e0df211d998d98901131c37500db986896b8131bc",
+      "state": "refusal"
+    },
+    {
+      "capability": "reflections",
+      "model": "ReflectionResponse",
+      "path": "examples/reflections/success.json",
+      "sha256": "250fd9c41d702ffcae5e2e29ba38147785a1eb74b6d9ec96b38b834b44812deb",
+      "state": "success"
+    },
+    {
+      "capability": "reflections",
+      "model": "ErrorEnvelope",
+      "path": "examples/reflections/unavailable-service.json",
+      "sha256": "7102f95c0f3e31cae0aa55b9b73a17b4ba3c32aa3548ee7df4ba79962577c524",
+      "state": "unavailable-service"
+    },
+    {
+      "capability": "wheel",
+      "model": "NotApplicableExample",
+      "path": "examples/wheel/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97",
+      "state": "care-escalation"
+    },
+    {
+      "capability": "wheel",
+      "model": "WheelResponse",
+      "path": "examples/wheel/empty.json",
+      "sha256": "6cb4819a51ef6b46d21d09b823ed5a2c54fc9531aa400355eb9effcb8fccc3e5",
+      "state": "empty"
+    },
+    {
+      "capability": "wheel",
+      "model": "ErrorEnvelope",
+      "path": "examples/wheel/incompatible-version.json",
+      "sha256": "490109a3068923a32f76df6ca4225ba5d851df7fac1f636a529d85bbeb780deb",
+      "state": "incompatible-version"
+    },
+    {
+      "capability": "wheel",
+      "model": "ErrorEnvelope",
+      "path": "examples/wheel/malformed-input.json",
+      "sha256": "27211ed75a39694528f23582127bd29adeb6ae0e015bbef0932e78c37cc29532",
+      "state": "malformed-input"
+    },
+    {
+      "capability": "wheel",
+      "model": "ErrorEnvelope",
+      "path": "examples/wheel/refusal.json",
+      "sha256": "e2fdd19cb5f8071c6397dd5a3c3e789b9ee4ecc8d145ca78e534433182d92631",
+      "state": "refusal"
+    },
+    {
+      "capability": "wheel",
+      "model": "WheelResponse",
+      "path": "examples/wheel/success.json",
+      "sha256": "c92e80eb28c198926cb2ad07c8de2c55a36a0aeda037496242ed5ba340f05ad8",
+      "state": "success"
+    },
+    {
+      "capability": "wheel",
+      "model": "ErrorEnvelope",
+      "path": "examples/wheel/unavailable-service.json",
+      "sha256": "06708a8b5a4e5544927d1615fc35da42fb57de2b64e3ff554945236a2fd2a22b",
+      "state": "unavailable-service"
+    },
+    {
+      "capability": null,
+      "model": null,
+      "path": "retry-policy.json",
+      "sha256": "62f9e85767f6a0a1c23577ef076b7f731b9078d6284306e7c5803118a6e72b6a",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "CapabilitiesResponse",
+      "path": "schemas/CapabilitiesResponse.schema.json",
+      "sha256": "6858b7e7646166bc2ae3870edc3d31516d9a5acaba28fea3d353a838773443ef",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "CareEscalationResponse",
+      "path": "schemas/CareEscalationResponse.schema.json",
+      "sha256": "1f4a89716c036acde720419f708925c814cbe222c58b795642f54682f4514f4a",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "CareResource",
+      "path": "schemas/CareResource.schema.json",
+      "sha256": "ae8893d6366f2a39d294721de29a0dad3140b04198991b2578292be7f60a41fd",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "CareSignal",
+      "path": "schemas/CareSignal.schema.json",
+      "sha256": "fc09e8583eca62438b9a4b4074da5fcb1f31c694a059d11e7efca5db9b60ce90",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "ErrorEnvelope",
+      "path": "schemas/ErrorEnvelope.schema.json",
+      "sha256": "c1bb9eacb78da59fe790ba3df123bda365c62e3ddbcb89ca2bc0f9a7507414af",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "JournalUpsertRequest",
+      "path": "schemas/JournalUpsertRequest.schema.json",
+      "sha256": "76137d5fe64f4b3ced1866d9d50e2d0e66e9fb59b85359ab0971b1b9ce5d1b1c",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "JournalUpsertResponse",
+      "path": "schemas/JournalUpsertResponse.schema.json",
+      "sha256": "acbcdc550fe2e7aa46ed8e2d692c06f1a153b508b953d6b98345ef1bd2477b1e",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "NotApplicableExample",
+      "path": "schemas/NotApplicableExample.schema.json",
+      "sha256": "b85a807991582faa458995db5c56ff3c6810f89d2bf345aa79d180be8ab508ae",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "ReflectionNote",
+      "path": "schemas/ReflectionNote.schema.json",
+      "sha256": "a8c4e2163c65c664711fbfde82ea67eeeb274cfd3128e3610679d4600f30328e",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "ReflectionRequest",
+      "path": "schemas/ReflectionRequest.schema.json",
+      "sha256": "7e2b2db6842cd14beaeeea08fea5217065ddb9cf578a213a118098a25ae96658",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "ReflectionResponse",
+      "path": "schemas/ReflectionResponse.schema.json",
+      "sha256": "678194d72f6384f60985eedbc92d71342ac1213ce2cd17dfc09edf00526ea1a1",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "TierModel",
+      "path": "schemas/TierModel.schema.json",
+      "sha256": "2936160c5beb8595c47f61c9f1b4dea94f4dbf6074cd2f7805ee496c6359ff9d",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "VaultState",
+      "path": "schemas/VaultState.schema.json",
+      "sha256": "6cd84f27aa18111ab4a9c50da4d192ee2fe58d8d9b371ec5ce7b2c474820c8c9",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "WheelFrequencies",
+      "path": "schemas/WheelFrequencies.schema.json",
+      "sha256": "05262b931e2ecbfcbcf532af32c4ac99c90a8e54b763fa1f8f0dfbf64c1dad98",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "WheelFrequency",
+      "path": "schemas/WheelFrequency.schema.json",
+      "sha256": "3841faae5d27a54dae95d8ab24294bc670d3f4db428705643e3a9071a831e24e",
+      "state": null
+    },
+    {
+      "capability": null,
+      "model": "WheelResponse",
+      "path": "schemas/WheelResponse.schema.json",
+      "sha256": "d0e80808e2559503d58149cffccac3efca52b055002e2e79e0aed5b9a4274a3d",
+      "state": null
+    }
+  ],
+  "ontology_version": "aptitude-wavelength/2026-05-23"
+}

--- a/backend/tests/fixtures/creek_v1/retry-policy.json
+++ b/backend/tests/fixtures/creek_v1/retry-policy.json
@@ -1,0 +1,11 @@
+{
+  "incompatible_version": "terminal",
+  "internal_error": "retry_with_backoff",
+  "invalid_request": "terminal",
+  "not_found": "terminal",
+  "privacy_refused": "terminal",
+  "temporarily_unavailable": "retry_with_backoff",
+  "unauthenticated": "terminal",
+  "unavailable": "retry_after_operator_action",
+  "unsupported_capability": "terminal"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/CapabilitiesResponse.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/CapabilitiesResponse.schema.json
@@ -1,0 +1,142 @@
+{
+  "$defs": {
+    "CapabilitiesStatus": {
+      "description": "Overall readiness reported by the capabilities handshake.\n\nAttributes:\n    OK: The vault is present and this server can serve the contract.\n    UNINITIALIZED: No vault has been scaffolded yet. Both version strings\n        are still reported, so a client can always negotiate versions\n        against a server whose vault does not exist.\n    INCOMPATIBLE: The client's requested contract minor is not in\n        :data:`SUPPORTED_CONTRACT_MINORS`.",
+      "enum": [
+        "ok",
+        "uninitialized",
+        "incompatible"
+      ],
+      "title": "CapabilitiesStatus",
+      "type": "string"
+    },
+    "Capability": {
+      "description": "The four capabilities ``/v1`` publishes at contract 0.2.\n\nThe values are also the directory names of the example matrix in\n:mod:`creek_mcp.api.bundle`, so the advertised capability list and the\ndocumented fixtures cannot name different things.\n\nAttributes:\n    CAPABILITIES: Version and feature handshake; safe before any read.\n    JOURNAL_UPSERT: Idempotent journal entry create/update.\n    REFLECTIONS: Margin notes on an entry, care-guarded.\n    WHEEL: Aggregate APTITUDE frequency distribution.",
+      "enum": [
+        "capabilities",
+        "journal-upsert",
+        "reflections",
+        "wheel"
+      ],
+      "title": "Capability",
+      "type": "string"
+    },
+    "TierModel": {
+      "additionalProperties": false,
+      "description": "What the server promises about privacy tiers, advertised up front.\n\nAttributes:\n    ceilings: Every ceiling this surface admits \u2014 the two members of\n        :class:`WireTierCeiling`, in ascending breadth.\n    default: The ceiling applied when a caller declares none. Pinned to\n        ``open``, the most restrictive value, so an omitted ceiling can\n        only ever fail closed.\n    intimate_never_egresses: ``Literal[True]``. A promise, not a flag: the\n        schema admits no other value, so a server cannot advertise the\n        opposite and a client need not branch on it.",
+      "properties": {
+        "ceilings": {
+          "description": "Tier ceilings this surface admits.",
+          "items": {
+            "$ref": "#/$defs/WireTierCeiling"
+          },
+          "title": "Ceilings",
+          "type": "array"
+        },
+        "default": {
+          "const": "open",
+          "description": "Ceiling applied when the caller declares none.",
+          "title": "Default",
+          "type": "string"
+        },
+        "intimate_never_egresses": {
+          "const": true,
+          "description": "Standing promise that intimate content never egresses.",
+          "title": "Intimate Never Egresses",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ceilings",
+        "default",
+        "intimate_never_egresses"
+      ],
+      "title": "TierModel",
+      "type": "object"
+    },
+    "VaultState": {
+      "additionalProperties": false,
+      "description": "Whether a vault exists behind this server.\n\nDeliberately one boolean. Anything richer \u2014 fragment counts, last-write\ntimestamps, initialisation progress \u2014 is a measurement of the corpus, and\nthe handshake is reachable before any tier gate has run.\n\nAttributes:\n    available: ``True`` when a scaffolded vault is readable.",
+      "properties": {
+        "available": {
+          "description": "True when a scaffolded vault is readable.",
+          "title": "Available",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "available"
+      ],
+      "title": "VaultState",
+      "type": "object"
+    },
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The handshake: versions, vault readiness and the capability list.\n\nSafe to call before anything else, including against an uninitialised vault\n\u2014 which is why both version strings are required regardless of\n:attr:`status`. A client must always be able to read the version off a\nserver whose vault does not exist yet, or version negotiation would need a\nvault to negotiate about.\n\nAttributes:\n    status: Overall readiness.\n    contract_version: :data:`creek_mcp.contract.CONTRACT_VERSION`.\n    contract_minor: The ``major.minor`` this response speaks.\n    supported_contract_minors: Every minor still served here.\n    ontology_version: :data:`creek_mcp.contract.ONTOLOGY_VERSION` \u2014 the\n        shared frequency/phase vocabulary. A mismatch means \"renegotiate\".\n    vault: Vault readiness.\n    tier_model: The standing tier promise.\n    capabilities: The capabilities actually served. Empty on an\n        uninitialised vault.",
+  "properties": {
+    "capabilities": {
+      "description": "Capabilities served; empty on an uninitialised vault.",
+      "items": {
+        "$ref": "#/$defs/Capability"
+      },
+      "title": "Capabilities",
+      "type": "array"
+    },
+    "contract_minor": {
+      "description": "The major.minor spoken here.",
+      "title": "Contract Minor",
+      "type": "string"
+    },
+    "contract_version": {
+      "description": "Full semantic contract version.",
+      "title": "Contract Version",
+      "type": "string"
+    },
+    "ontology_version": {
+      "description": "Shared APTITUDE frequency / Wavelength phase vocabulary.",
+      "title": "Ontology Version",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/CapabilitiesStatus",
+      "description": "Overall server readiness."
+    },
+    "supported_contract_minors": {
+      "description": "Every contract minor this server still serves.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Supported Contract Minors",
+      "type": "array"
+    },
+    "tier_model": {
+      "$ref": "#/$defs/TierModel",
+      "description": "Standing privacy-tier promise."
+    },
+    "vault": {
+      "$ref": "#/$defs/VaultState",
+      "description": "Vault readiness."
+    }
+  },
+  "required": [
+    "status",
+    "contract_version",
+    "contract_minor",
+    "supported_contract_minors",
+    "ontology_version",
+    "vault",
+    "tier_model",
+    "capabilities"
+  ],
+  "title": "CapabilitiesResponse",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/CareEscalationResponse.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/CareEscalationResponse.schema.json
@@ -1,0 +1,98 @@
+{
+  "$defs": {
+    "CareResource": {
+      "additionalProperties": false,
+      "description": "A way to reach a human, named and contactable.\n\nAttributes:\n    name: What the resource is called.\n    contact: How to reach it. Required \u2014 a resource without a contact\n        dead-ends the person reading it at the worst possible moment.",
+      "properties": {
+        "contact": {
+          "description": "How to reach it; required.",
+          "title": "Contact",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the care resource.",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "contact"
+      ],
+      "title": "CareResource",
+      "type": "object"
+    },
+    "CareSignal": {
+      "additionalProperties": false,
+      "description": "The structured \"reach a human\" envelope, mirroring the runtime constant.\n\nValidates :data:`creek.care.guardrail.CARE_SIGNAL` itself rather than an\nabridged copy of it, so the wire shape cannot fall behind the guardrail.\n\nAttributes:\n    kind: The care guard that fired.\n    message: Prose addressed to the person, not to the client.\n    resources: At least one contactable resource. The signal never\n        dead-ends.",
+      "properties": {
+        "kind": {
+          "description": "The care guard that fired.",
+          "title": "Kind",
+          "type": "string"
+        },
+        "message": {
+          "description": "Prose addressed to the person.",
+          "title": "Message",
+          "type": "string"
+        },
+        "resources": {
+          "description": "At least one contactable resource.",
+          "items": {
+            "$ref": "#/$defs/CareResource"
+          },
+          "minItems": 1,
+          "title": "Resources",
+          "type": "array"
+        }
+      },
+      "required": [
+        "kind",
+        "message",
+        "resources"
+      ],
+      "title": "CareSignal",
+      "type": "object"
+    },
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "A 200-shaped escalation: the care signal instead of model prose.\n\nNot an error, and there is no ``care_escalation`` member of\n:class:`ErrorCode`, because a person in acute distress must not have their\nresponse swallowed by a client's error path.\n\nAttributes:\n    status: Pinned to :attr:`ReflectionStatus.ESCALATE`.\n    tier_ceiling: The caller's own declared ceiling, echoed.\n    reason: Which care guard fired.\n    care_signal: The runtime :data:`creek.care.guardrail.CARE_SIGNAL`,\n        whole.",
+  "properties": {
+    "care_signal": {
+      "$ref": "#/$defs/CareSignal",
+      "description": "The runtime care signal, whole."
+    },
+    "reason": {
+      "description": "Which care guard fired.",
+      "title": "Reason",
+      "type": "string"
+    },
+    "status": {
+      "const": "escalate",
+      "description": "Always escalate.",
+      "title": "Status",
+      "type": "string"
+    },
+    "tier_ceiling": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Caller's declared ceiling."
+    }
+  },
+  "required": [
+    "status",
+    "tier_ceiling",
+    "reason",
+    "care_signal"
+  ],
+  "title": "CareEscalationResponse",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/CareResource.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/CareResource.schema.json
@@ -1,0 +1,22 @@
+{
+  "additionalProperties": false,
+  "description": "A way to reach a human, named and contactable.\n\nAttributes:\n    name: What the resource is called.\n    contact: How to reach it. Required \u2014 a resource without a contact\n        dead-ends the person reading it at the worst possible moment.",
+  "properties": {
+    "contact": {
+      "description": "How to reach it; required.",
+      "title": "Contact",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of the care resource.",
+      "title": "Name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "contact"
+  ],
+  "title": "CareResource",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/CareSignal.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/CareSignal.schema.json
@@ -1,0 +1,56 @@
+{
+  "$defs": {
+    "CareResource": {
+      "additionalProperties": false,
+      "description": "A way to reach a human, named and contactable.\n\nAttributes:\n    name: What the resource is called.\n    contact: How to reach it. Required \u2014 a resource without a contact\n        dead-ends the person reading it at the worst possible moment.",
+      "properties": {
+        "contact": {
+          "description": "How to reach it; required.",
+          "title": "Contact",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the care resource.",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "contact"
+      ],
+      "title": "CareResource",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The structured \"reach a human\" envelope, mirroring the runtime constant.\n\nValidates :data:`creek.care.guardrail.CARE_SIGNAL` itself rather than an\nabridged copy of it, so the wire shape cannot fall behind the guardrail.\n\nAttributes:\n    kind: The care guard that fired.\n    message: Prose addressed to the person, not to the client.\n    resources: At least one contactable resource. The signal never\n        dead-ends.",
+  "properties": {
+    "kind": {
+      "description": "The care guard that fired.",
+      "title": "Kind",
+      "type": "string"
+    },
+    "message": {
+      "description": "Prose addressed to the person.",
+      "title": "Message",
+      "type": "string"
+    },
+    "resources": {
+      "description": "At least one contactable resource.",
+      "items": {
+        "$ref": "#/$defs/CareResource"
+      },
+      "minItems": 1,
+      "title": "Resources",
+      "type": "array"
+    }
+  },
+  "required": [
+    "kind",
+    "message",
+    "resources"
+  ],
+  "title": "CareSignal",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/ErrorEnvelope.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/ErrorEnvelope.schema.json
@@ -1,0 +1,45 @@
+{
+  "$defs": {
+    "ErrorCode": {
+      "description": "The nine wire error codes, closed at contract 0.2.\n\nThere is deliberately **no** ``care_escalation`` member: an escalation is a\nsuccessful, 200-shaped :class:`CareEscalationResponse`, because a person in\nacute distress must not have their response swallowed by a client's error\npath.\n\nAttributes:\n    UNAUTHENTICATED: No valid consumer credential accompanied the request.\n    INVALID_REQUEST: The body does not satisfy the published schema.\n    INCOMPATIBLE_VERSION: The requested contract minor is not served here.\n    PRIVACY_REFUSED: The single answer for every vault-object non-answer.\n        Above the ceiling, purged, orphaned, schema-invalid and deleted out\n        of band all collapse to this one code with this one message.\n    NOT_FOUND: A **routing** code only \u2014 no such endpoint or path on this\n        server. Never emitted for a vault object. Emitting it for a\n        fragment would reintroduce the existence oracle that #846 / #970 /\n        #972 / #1090 collapsed: the difference between \"no such id\" and\n        \"not for you\" is a corpus enumeration primitive.\n    UNSUPPORTED_CAPABILITY: A published capability this server does not\n        implement.\n    UNAVAILABLE: The vault is absent or unreadable; a human must act.\n    TEMPORARILY_UNAVAILABLE: A transient condition; backoff will clear it.\n    INTERNAL_ERROR: An unexpected server fault.",
+      "enum": [
+        "unauthenticated",
+        "invalid_request",
+        "incompatible_version",
+        "privacy_refused",
+        "not_found",
+        "unsupported_capability",
+        "unavailable",
+        "temporarily_unavailable",
+        "internal_error"
+      ],
+      "title": "ErrorCode",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The one error shape on ``/v1``: three fields, and never a fourth.\n\nIt echoes nothing. Not the request body, not the resolved tier, not the\nidentifier that was probed. Everything a caller needs in order to act is in\n:data:`ERROR_STATUS` and :data:`RETRY_POLICY`, both keyed on :attr:`code`\nalone; everything else they might want is something this server must not\ntell them.\n\nAttributes:\n    code: The closed wire code. Look up HTTP status, human message and\n        retry disposition from it.\n    message: A constant drawn from :data:`ERROR_MESSAGES`. Never composed\n        from request or vault material.\n    request_id: A server-generated correlation id for the operator's logs.\n        Opaque to the client, and derived from nothing the caller sent.",
+  "properties": {
+    "code": {
+      "$ref": "#/$defs/ErrorCode",
+      "description": "Closed wire error code."
+    },
+    "message": {
+      "description": "Constant message from ERROR_MESSAGES.",
+      "title": "Message",
+      "type": "string"
+    },
+    "request_id": {
+      "description": "Server-generated correlation id.",
+      "title": "Request Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "code",
+    "message",
+    "request_id"
+  ],
+  "title": "ErrorEnvelope",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/JournalUpsertRequest.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/JournalUpsertRequest.schema.json
@@ -1,0 +1,45 @@
+{
+  "$defs": {
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "An idempotent journal write from a remote consumer.\n\nAttributes:\n    content: The entry body. Whitespace-only is refused rather than\n        written: an empty fragment is indistinguishable from a corrupted\n        one once it is in the vault, and it would still consume an\n        ``external_id``.\n    timestamp: Optional client-supplied entry time. Omitted means \"the\n        server stamps it\", so a client with no reliable clock is still a\n        valid client.\n    tier: The tier to create the entry at. Typed\n        :class:`WireTierCeiling`, so ``intimate`` is not expressible \u2014 a\n        remote consumer cannot even *ask* for an intimate write.",
+  "properties": {
+    "content": {
+      "description": "Entry body; must not be blank.",
+      "title": "Content",
+      "type": "string"
+    },
+    "tier": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Tier to create the entry at."
+    },
+    "timestamp": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional client-supplied entry time.",
+      "title": "Timestamp"
+    }
+  },
+  "required": [
+    "content",
+    "tier"
+  ],
+  "title": "JournalUpsertRequest",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/JournalUpsertResponse.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/JournalUpsertResponse.schema.json
@@ -1,0 +1,65 @@
+{
+  "$defs": {
+    "JournalAction": {
+      "description": "What an idempotent journal upsert actually did.\n\n``UNCHANGED`` is a success, not an error: re-sending an unmodified entry is\nthe steady state of a continuous sync, and a client must be able to tell it\napart from a write without diffing content itself.\n\nAttributes:\n    CREATED: A new fragment was written.\n    UPDATED: An existing fragment was updated in place.\n    UNCHANGED: The content hash matched; nothing was written.",
+      "enum": [
+        "created",
+        "updated",
+        "unchanged"
+      ],
+      "title": "JournalAction",
+      "type": "string"
+    },
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The result of an idempotent journal write.\n\nAttributes:\n    status: Always ``\"ok\"``. Failure is an :class:`ErrorEnvelope`.\n    tier_ceiling: The ceiling the call was served under \u2014 the caller's own\n        declared value, echoed for correlation.\n    external_id: The consumer-side identity of the entry, unchanged.\n    fragment_id: The vault-side identity now backing it.\n    action: Whether the write created, updated, or changed nothing.\n    tier: The tier the entry was created at. Not expressible as\n        ``intimate``, for the same reason as on the request.",
+  "properties": {
+    "action": {
+      "$ref": "#/$defs/JournalAction",
+      "description": "Created, updated, or unchanged."
+    },
+    "external_id": {
+      "description": "Consumer-side entry identity.",
+      "title": "External Id",
+      "type": "string"
+    },
+    "fragment_id": {
+      "description": "Vault-side fragment identity.",
+      "title": "Fragment Id",
+      "type": "string"
+    },
+    "status": {
+      "const": "ok",
+      "description": "Always ok; failure is an error.",
+      "title": "Status",
+      "type": "string"
+    },
+    "tier": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Tier the entry was created at."
+    },
+    "tier_ceiling": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Ceiling the call ran at."
+    }
+  },
+  "required": [
+    "status",
+    "tier_ceiling",
+    "external_id",
+    "fragment_id",
+    "action",
+    "tier"
+  ],
+  "title": "JournalUpsertResponse",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/NotApplicableExample.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/NotApplicableExample.schema.json
@@ -1,0 +1,23 @@
+{
+  "additionalProperties": false,
+  "description": "Marks a fixture-matrix cell that has no response shape to document.\n\nThe published example matrix is 4 capabilities x 7 states. Three of those\ncells \u2014 care escalation for ``capabilities``, ``journal-upsert`` and\n``wheel`` \u2014 are *structurally* unreachable: the acute-distress guard runs\nonly inside :func:`creek_mcp.tools.reflect.reflect_tool`, so no other\ncapability can ever escalate.\n\nBoth alternatives were worse. Fabricating a care-escalation response for\nthose cells would publish a shape the server can never emit, and a consumer\nwould write handling code for a branch that cannot be taken. Omitting the\ncells would break the rectangular matrix, and a hole in a matrix reads as\n\"not documented yet\" rather than \"cannot happen\" \u2014 which is exactly the\ndistinction a cross-repo consumer needs.\n\nSo the cell is filled with an explicit, machine-checkable statement of\nunreachability that says *why*.\n\nAttributes:\n    unreachable: ``Literal[True]``. The claim is the whole point of the\n        model, so the schema admits no other value.\n    reason: Why this cell cannot occur.",
+  "properties": {
+    "reason": {
+      "description": "Why this cell is structurally unreachable.",
+      "title": "Reason",
+      "type": "string"
+    },
+    "unreachable": {
+      "const": true,
+      "description": "Always true; this cell has no reachable response shape.",
+      "title": "Unreachable",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "unreachable",
+    "reason"
+  ],
+  "title": "NotApplicableExample",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/ReflectionNote.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/ReflectionNote.schema.json
@@ -1,0 +1,43 @@
+{
+  "$defs": {
+    "NoteKind": {
+      "description": "The seven margin-note kinds, mirroring the reflect tool's vocabulary.\n\nKept in lock-step with :data:`creek_mcp.tools.reflect._ALLOWED_KINDS`,\nwhich is what the produced notes are actually constrained to; a wire enum\nthat drifted from it would let a legitimate note fail validation on the way\nout.\n\nAttributes:\n    FEAR: A named fear surfacing in the entry.\n    GIFT: Something the writer is giving or has been given.\n    LONGING: An unmet want the writing circles.\n    PATTERN: A recurrence the writer has not named yet.\n    REFRAME: The same material seen from another angle.\n    TENSION: Two things the entry holds at once.\n    VALUE: A commitment the entry reveals.",
+      "enum": [
+        "fear",
+        "gift",
+        "longing",
+        "pattern",
+        "reframe",
+        "tension",
+        "value"
+      ],
+      "title": "NoteKind",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "One margin note: a verbatim span, a kind, and the reflection itself.\n\nAttributes:\n    quote: A span copied verbatim from the entry. The producing tool\n        verifies this; a note whose quote is not verbatim is dropped rather\n        than returned.\n    kind: One of the seven :class:`NoteKind` values.\n    note: The reflection, addressed to the writer in second person.",
+  "properties": {
+    "kind": {
+      "$ref": "#/$defs/NoteKind",
+      "description": "Margin-note kind."
+    },
+    "note": {
+      "description": "The reflection itself.",
+      "title": "Note",
+      "type": "string"
+    },
+    "quote": {
+      "description": "Verbatim span copied from the entry.",
+      "title": "Quote",
+      "type": "string"
+    }
+  },
+  "required": [
+    "quote",
+    "kind",
+    "note"
+  ],
+  "title": "ReflectionNote",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/ReflectionRequest.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/ReflectionRequest.schema.json
@@ -1,0 +1,42 @@
+{
+  "additionalProperties": false,
+  "description": "A request for margin notes on exactly one source.\n\nAttributes:\n    content: Inline text supplied by the caller \u2014 their own words, so no\n        vault tier applies to it.\n    entry_ref: A vault fragment reference instead. Resolving it is a read,\n        so it is subject to the ceiling gate.\n    max_notes: How many notes at most, bounded to ``[1, 10]`` inclusive.",
+  "properties": {
+    "content": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Inline text to reflect on.",
+      "title": "Content"
+    },
+    "entry_ref": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Vault fragment reference to reflect on.",
+      "title": "Entry Ref"
+    },
+    "max_notes": {
+      "default": 3,
+      "description": "Maximum margin notes to return.",
+      "maximum": 10,
+      "minimum": 1,
+      "title": "Max Notes",
+      "type": "integer"
+    }
+  },
+  "title": "ReflectionRequest",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/ReflectionResponse.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/ReflectionResponse.schema.json
@@ -1,0 +1,111 @@
+{
+  "$defs": {
+    "NoteKind": {
+      "description": "The seven margin-note kinds, mirroring the reflect tool's vocabulary.\n\nKept in lock-step with :data:`creek_mcp.tools.reflect._ALLOWED_KINDS`,\nwhich is what the produced notes are actually constrained to; a wire enum\nthat drifted from it would let a legitimate note fail validation on the way\nout.\n\nAttributes:\n    FEAR: A named fear surfacing in the entry.\n    GIFT: Something the writer is giving or has been given.\n    LONGING: An unmet want the writing circles.\n    PATTERN: A recurrence the writer has not named yet.\n    REFRAME: The same material seen from another angle.\n    TENSION: Two things the entry holds at once.\n    VALUE: A commitment the entry reveals.",
+      "enum": [
+        "fear",
+        "gift",
+        "longing",
+        "pattern",
+        "reframe",
+        "tension",
+        "value"
+      ],
+      "title": "NoteKind",
+      "type": "string"
+    },
+    "ReflectionNote": {
+      "additionalProperties": false,
+      "description": "One margin note: a verbatim span, a kind, and the reflection itself.\n\nAttributes:\n    quote: A span copied verbatim from the entry. The producing tool\n        verifies this; a note whose quote is not verbatim is dropped rather\n        than returned.\n    kind: One of the seven :class:`NoteKind` values.\n    note: The reflection, addressed to the writer in second person.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/NoteKind",
+          "description": "Margin-note kind."
+        },
+        "note": {
+          "description": "The reflection itself.",
+          "title": "Note",
+          "type": "string"
+        },
+        "quote": {
+          "description": "Verbatim span copied from the entry.",
+          "title": "Quote",
+          "type": "string"
+        }
+      },
+      "required": [
+        "quote",
+        "kind",
+        "note"
+      ],
+      "title": "ReflectionNote",
+      "type": "object"
+    },
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Margin notes for one entry.\n\nAttributes:\n    status: ``ok`` or ``empty``. ``escalate`` arrives as a\n        :class:`CareEscalationResponse` instead.\n    tier_ceiling: The caller's own declared ceiling, echoed.\n    routed_tier: The tier the model call was keyed with. **Safe to expose,\n        and provably so:** for every ceiling ``/v1`` permits and every\n        :class:`~creek.models.PrivacyTier` that ceiling admits,\n        ``routing_tier(ceiling, tier)`` equals\n        ``CEILING_ROUTING_TIER[ceiling]``. It is a constant function of the\n        caller's *own declared ceiling*, so it carries zero bits about the\n        content's tier \u2014 the caller learns only what they themselves\n        supplied. The invariant holds because ``routing_tier`` takes the\n        more sensitive of the ceiling-derived tier and the content tier,\n        and an admitted tier is by definition no more sensitive than its\n        ceiling. It is pinned by\n        ``test_routed_tier_is_a_constant_function_of_the_declared_ceiling``\n        in ``tests/test_adepthood_contract_models.py``. **If that test ever\n        fails, remove this field \u2014 do not relax the test.** A\n        ``routed_tier`` that varies with content is a one-bit tier oracle\n        over the whole corpus.\n    notes: The margin notes; empty when ``status`` is ``empty``.\n    essay: Optional free prose. Ungrounded by construction.\n    essay_grounded: Required, and only ``False`` is admissible at 0.2.",
+  "properties": {
+    "essay": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional free prose.",
+      "title": "Essay"
+    },
+    "essay_grounded": {
+      "const": false,
+      "description": "Required; only False is admissible at contract 0.2.",
+      "title": "Essay Grounded",
+      "type": "boolean"
+    },
+    "notes": {
+      "description": "Margin notes; may be empty.",
+      "items": {
+        "$ref": "#/$defs/ReflectionNote"
+      },
+      "title": "Notes",
+      "type": "array"
+    },
+    "routed_tier": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Tier the call was keyed with; a function of tier_ceiling."
+    },
+    "status": {
+      "description": "ok or empty; escalate is CareEscalationResponse instead.",
+      "enum": [
+        "ok",
+        "empty"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "tier_ceiling": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Caller's declared ceiling."
+    }
+  },
+  "required": [
+    "status",
+    "tier_ceiling",
+    "routed_tier",
+    "notes",
+    "essay_grounded"
+  ],
+  "title": "ReflectionResponse",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/TierModel.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/TierModel.schema.json
@@ -1,0 +1,44 @@
+{
+  "$defs": {
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "What the server promises about privacy tiers, advertised up front.\n\nAttributes:\n    ceilings: Every ceiling this surface admits \u2014 the two members of\n        :class:`WireTierCeiling`, in ascending breadth.\n    default: The ceiling applied when a caller declares none. Pinned to\n        ``open``, the most restrictive value, so an omitted ceiling can\n        only ever fail closed.\n    intimate_never_egresses: ``Literal[True]``. A promise, not a flag: the\n        schema admits no other value, so a server cannot advertise the\n        opposite and a client need not branch on it.",
+  "properties": {
+    "ceilings": {
+      "description": "Tier ceilings this surface admits.",
+      "items": {
+        "$ref": "#/$defs/WireTierCeiling"
+      },
+      "title": "Ceilings",
+      "type": "array"
+    },
+    "default": {
+      "const": "open",
+      "description": "Ceiling applied when the caller declares none.",
+      "title": "Default",
+      "type": "string"
+    },
+    "intimate_never_egresses": {
+      "const": true,
+      "description": "Standing promise that intimate content never egresses.",
+      "title": "Intimate Never Egresses",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "ceilings",
+    "default",
+    "intimate_never_egresses"
+  ],
+  "title": "TierModel",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/VaultState.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/VaultState.schema.json
@@ -1,0 +1,16 @@
+{
+  "additionalProperties": false,
+  "description": "Whether a vault exists behind this server.\n\nDeliberately one boolean. Anything richer \u2014 fragment counts, last-write\ntimestamps, initialisation progress \u2014 is a measurement of the corpus, and\nthe handshake is reachable before any tier gate has run.\n\nAttributes:\n    available: ``True`` when a scaffolded vault is readable.",
+  "properties": {
+    "available": {
+      "description": "True when a scaffolded vault is readable.",
+      "title": "Available",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "available"
+  ],
+  "title": "VaultState",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/WheelFrequencies.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/WheelFrequencies.schema.json
@@ -1,0 +1,83 @@
+{
+  "$defs": {
+    "WheelFrequency": {
+      "additionalProperties": false,
+      "description": "One APTITUDE frequency's slice of the wheel.\n\nAttributes:\n    name: The canonical frequency name from\n        :data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`.\n    count: Classified fragments at this frequency. A tally, so never\n        negative.\n    share: Fraction of *classified* fragments at this frequency, bounded to\n        ``[0.0, 1.0]``.",
+      "properties": {
+        "count": {
+          "description": "Classified fragments here.",
+          "minimum": 0,
+          "title": "Count",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Canonical APTITUDE frequency name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "share": {
+          "description": "Fraction of classified fragments at this frequency.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Share",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "count",
+        "share"
+      ],
+      "title": "WheelFrequency",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "All ten frequencies, as ten separate required fields.\n\nTen declared fields rather than a mapping, on purpose. It is what makes the\npublished JSON Schema say ``required: [F1 .. F10]`` \u2014 a consumer generating\ncode from the schema gets ten guaranteed members instead of an open\ndictionary it has to defend against \u2014 and it fixes the emission order at\nthe canonical one, so a diff of two wheels is a diff of numbers rather than\nof key ordering.\n\nFields are declared in the order of\n:data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`. An eleventh\nfrequency is a change to the shared ontology vocabulary \u2014 a contract change\nwith a version bump \u2014 which is why ``extra=\"forbid\"`` rejects one rather\nthan passing it through.\n\nAttributes:\n    F1: Agency.\n    F2: Receptivity.\n    F3: Self-Love / Power.\n    F4: Community Love / Conformity.\n    F5: Achievism.\n    F6: Pluralism.\n    F7: Integration.\n    F8: True Self / Transcendence.\n    F9: Unity.\n    F10: Emptiness.",
+  "properties": {
+    "F1": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F10": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F2": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F3": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F4": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F5": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F6": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F7": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F8": {
+      "$ref": "#/$defs/WheelFrequency"
+    },
+    "F9": {
+      "$ref": "#/$defs/WheelFrequency"
+    }
+  },
+  "required": [
+    "F1",
+    "F2",
+    "F3",
+    "F4",
+    "F5",
+    "F6",
+    "F7",
+    "F8",
+    "F9",
+    "F10"
+  ],
+  "title": "WheelFrequencies",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/WheelFrequency.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/WheelFrequency.schema.json
@@ -1,0 +1,31 @@
+{
+  "additionalProperties": false,
+  "description": "One APTITUDE frequency's slice of the wheel.\n\nAttributes:\n    name: The canonical frequency name from\n        :data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`.\n    count: Classified fragments at this frequency. A tally, so never\n        negative.\n    share: Fraction of *classified* fragments at this frequency, bounded to\n        ``[0.0, 1.0]``.",
+  "properties": {
+    "count": {
+      "description": "Classified fragments here.",
+      "minimum": 0,
+      "title": "Count",
+      "type": "integer"
+    },
+    "name": {
+      "description": "Canonical APTITUDE frequency name.",
+      "title": "Name",
+      "type": "string"
+    },
+    "share": {
+      "description": "Fraction of classified fragments at this frequency.",
+      "maximum": 1.0,
+      "minimum": 0.0,
+      "title": "Share",
+      "type": "number"
+    }
+  },
+  "required": [
+    "name",
+    "count",
+    "share"
+  ],
+  "title": "WheelFrequency",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/schemas/WheelResponse.schema.json
+++ b/backend/tests/fixtures/creek_v1/schemas/WheelResponse.schema.json
@@ -1,0 +1,133 @@
+{
+  "$defs": {
+    "WheelFrequencies": {
+      "additionalProperties": false,
+      "description": "All ten frequencies, as ten separate required fields.\n\nTen declared fields rather than a mapping, on purpose. It is what makes the\npublished JSON Schema say ``required: [F1 .. F10]`` \u2014 a consumer generating\ncode from the schema gets ten guaranteed members instead of an open\ndictionary it has to defend against \u2014 and it fixes the emission order at\nthe canonical one, so a diff of two wheels is a diff of numbers rather than\nof key ordering.\n\nFields are declared in the order of\n:data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`. An eleventh\nfrequency is a change to the shared ontology vocabulary \u2014 a contract change\nwith a version bump \u2014 which is why ``extra=\"forbid\"`` rejects one rather\nthan passing it through.\n\nAttributes:\n    F1: Agency.\n    F2: Receptivity.\n    F3: Self-Love / Power.\n    F4: Community Love / Conformity.\n    F5: Achievism.\n    F6: Pluralism.\n    F7: Integration.\n    F8: True Self / Transcendence.\n    F9: Unity.\n    F10: Emptiness.",
+      "properties": {
+        "F1": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F10": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F2": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F3": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F4": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F5": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F6": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F7": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F8": {
+          "$ref": "#/$defs/WheelFrequency"
+        },
+        "F9": {
+          "$ref": "#/$defs/WheelFrequency"
+        }
+      },
+      "required": [
+        "F1",
+        "F2",
+        "F3",
+        "F4",
+        "F5",
+        "F6",
+        "F7",
+        "F8",
+        "F9",
+        "F10"
+      ],
+      "title": "WheelFrequencies",
+      "type": "object"
+    },
+    "WheelFrequency": {
+      "additionalProperties": false,
+      "description": "One APTITUDE frequency's slice of the wheel.\n\nAttributes:\n    name: The canonical frequency name from\n        :data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`.\n    count: Classified fragments at this frequency. A tally, so never\n        negative.\n    share: Fraction of *classified* fragments at this frequency, bounded to\n        ``[0.0, 1.0]``.",
+      "properties": {
+        "count": {
+          "description": "Classified fragments here.",
+          "minimum": 0,
+          "title": "Count",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Canonical APTITUDE frequency name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "share": {
+          "description": "Fraction of classified fragments at this frequency.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Share",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "count",
+        "share"
+      ],
+      "title": "WheelFrequency",
+      "type": "object"
+    },
+    "WireTierCeiling": {
+      "description": "The only two tier ceilings expressible on ``/v1``.\n\n``/v1`` is remote by construction, and\n:func:`creek_mcp.policy.admitted_ceiling` refuses any remote call declaring\na ceiling outside :data:`creek_mcp.policy.REMOTE_ADMITTED_CEILINGS` *before\ndispatch*. Since #1073 that decision is transport-neutral, so every adapter\nis meant to reach it the same way; the MCP surface does so today through\n:meth:`creek_mcp.server._BoundedFastMCP.call_tool`, and #1074 mounts the\n``/v1`` handlers that will. This enum mirrors that frozenset, so\n``intimate`` and ``all`` are not merely refused at runtime \u2014 they cannot be\nconstructed at all, which is the half of the guarantee that does not depend\non a handler remembering to ask.\n\nThe same two values double as the wire's *tier* vocabulary (see\n:class:`JournalUpsertRequest`, :class:`JournalUpsertResponse` and\n:class:`ReflectionResponse`). The two vocabularies coincide by\nconstruction: the set of tiers a remote caller may name is exactly the set\nof ceilings a remote caller may declare, because a tier above the remote\ncap is one no remote request can reach in either direction.\n\nAttributes:\n    OPEN: Openly publishable content only (ontology \u00a713.2).\n    PERSONAL: Adds personal \u2014 and, per #961, ``unclassified`` \u2014 content.",
+      "enum": [
+        "open",
+        "personal"
+      ],
+      "title": "WireTierCeiling",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The aggregate APTITUDE frequency distribution of the admitted corpus.\n\nAn empty corpus is an all-zero wheel with ``total_classified == 0``, not an\nerror: a freshly-initialised vault is a legitimate state, and answering it\nwith an error would make a client treat \"new\" as \"broken\".\n\nAttributes:\n    status: Always ``\"ok\"``. Failure is an :class:`ErrorEnvelope`.\n    tier_ceiling: The caller's own declared ceiling, echoed. Fragments\n        above it were excluded from the tally.\n    total_classified: Admitted fragments carrying a frequency.\n    unclassified: Admitted fragments carrying no frequency yet.\n    wheel: The ten frequency slices.",
+  "properties": {
+    "status": {
+      "const": "ok",
+      "description": "Always ok; failure is an error.",
+      "title": "Status",
+      "type": "string"
+    },
+    "tier_ceiling": {
+      "$ref": "#/$defs/WireTierCeiling",
+      "description": "Caller's declared ceiling."
+    },
+    "total_classified": {
+      "description": "Admitted fragments carrying a frequency.",
+      "minimum": 0,
+      "title": "Total Classified",
+      "type": "integer"
+    },
+    "unclassified": {
+      "description": "Admitted fragments with no frequency yet.",
+      "minimum": 0,
+      "title": "Unclassified",
+      "type": "integer"
+    },
+    "wheel": {
+      "$ref": "#/$defs/WheelFrequencies",
+      "description": "The ten frequency slices."
+    }
+  },
+  "required": [
+    "status",
+    "tier_ceiling",
+    "total_classified",
+    "unclassified",
+    "wheel"
+  ],
+  "title": "WheelResponse",
+  "type": "object"
+}

--- a/backend/tests/fixtures/creek_v1/vendor.json
+++ b/backend/tests/fixtures/creek_v1/vendor.json
@@ -1,0 +1,200 @@
+{
+  "bundle": "adepthood-v1",
+  "contract_version": "0.2.0",
+  "files": [
+    {
+      "path": "README.md",
+      "sha256": "52679890bcc46f87f5467becc6c33fcb62867cd50c839de75a30b2832886d66c"
+    },
+    {
+      "path": "examples/capabilities/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97"
+    },
+    {
+      "path": "examples/capabilities/empty.json",
+      "sha256": "abff9182a8c5fe4f4a32ad1d96118dfd14d85dbf7b1a48406ff2c34be3145426"
+    },
+    {
+      "path": "examples/capabilities/incompatible-version.json",
+      "sha256": "31ec5c80d575fff4c4ef489e86bddbe7e3bcf2efa6e4ca0b9cb4ed727d93b210"
+    },
+    {
+      "path": "examples/capabilities/malformed-input.json",
+      "sha256": "0c7e796525f90bb81cac9f5f04173b2d1471733eb3606e807feea3dcac3fbfa7"
+    },
+    {
+      "path": "examples/capabilities/refusal.json",
+      "sha256": "a27761795b0af5acb873c400b81a9e35f073c629d390f77ae762605436c6a5ac"
+    },
+    {
+      "path": "examples/capabilities/success.json",
+      "sha256": "5c4618983b0196b4484b2604fedd6b9bbb02c54b6e414223b4c879fed689e7a1"
+    },
+    {
+      "path": "examples/capabilities/unavailable-service.json",
+      "sha256": "89a0b5295b63a7c84f76da28bc556abf281afefa7993a3b5701ddd01baf9294d"
+    },
+    {
+      "path": "examples/journal-upsert/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97"
+    },
+    {
+      "path": "examples/journal-upsert/empty.json",
+      "sha256": "66498f2275528fb22151d8441c3cab5d3fa60d089100b3d39d35cdbd2f2b59ba"
+    },
+    {
+      "path": "examples/journal-upsert/incompatible-version.json",
+      "sha256": "11f79c2f713c309b0e7ef5d426950b1325f649e0ee353c96092d13d99b892432"
+    },
+    {
+      "path": "examples/journal-upsert/malformed-input.json",
+      "sha256": "16c1542153a2d53b3203107d4d299dc8fa819bbeb9666279301b18371bfa7e9a"
+    },
+    {
+      "path": "examples/journal-upsert/refusal.json",
+      "sha256": "ae3f45dcfef37cf4d7aea5ce53a9d26b52db376e15c62f2e0773c53b3199643c"
+    },
+    {
+      "path": "examples/journal-upsert/success.json",
+      "sha256": "a1d405aa236bc6ea4c7f6e8f93354a5fbee2e631b4020299eb3208170a554411"
+    },
+    {
+      "path": "examples/journal-upsert/unavailable-service.json",
+      "sha256": "a29004223b68de26c66e2dfaa64ff3fde4495e0b3bee0c21c3aae8c56be6a6a6"
+    },
+    {
+      "path": "examples/reflections/care-escalation.json",
+      "sha256": "8558c3fa48b4be421fed76e7116f48568ce9eb4fba9ebe9f274e1c5e385b9b91"
+    },
+    {
+      "path": "examples/reflections/empty.json",
+      "sha256": "acbc52f5a0d4928138cc2e2a83e8d71676951ca5b639c143ab588e63b397845f"
+    },
+    {
+      "path": "examples/reflections/incompatible-version.json",
+      "sha256": "4c7b3c4625d963299263022c73a76ec98f8dbf7139211ca4e77446b27994de0a"
+    },
+    {
+      "path": "examples/reflections/malformed-input.json",
+      "sha256": "8c38d1d2895086249a6d0f3a036b91ff647ecf2dfaf754854da19b04d1025240"
+    },
+    {
+      "path": "examples/reflections/refusal.json",
+      "sha256": "550679693ae83fea294a953e0df211d998d98901131c37500db986896b8131bc"
+    },
+    {
+      "path": "examples/reflections/success.json",
+      "sha256": "250fd9c41d702ffcae5e2e29ba38147785a1eb74b6d9ec96b38b834b44812deb"
+    },
+    {
+      "path": "examples/reflections/unavailable-service.json",
+      "sha256": "7102f95c0f3e31cae0aa55b9b73a17b4ba3c32aa3548ee7df4ba79962577c524"
+    },
+    {
+      "path": "examples/wheel/care-escalation.json",
+      "sha256": "a5d2d2bfcd3b274cfe9d191a22b419fbceb1ade75b8ae1326004d4ca2ac58f97"
+    },
+    {
+      "path": "examples/wheel/empty.json",
+      "sha256": "6cb4819a51ef6b46d21d09b823ed5a2c54fc9531aa400355eb9effcb8fccc3e5"
+    },
+    {
+      "path": "examples/wheel/incompatible-version.json",
+      "sha256": "490109a3068923a32f76df6ca4225ba5d851df7fac1f636a529d85bbeb780deb"
+    },
+    {
+      "path": "examples/wheel/malformed-input.json",
+      "sha256": "27211ed75a39694528f23582127bd29adeb6ae0e015bbef0932e78c37cc29532"
+    },
+    {
+      "path": "examples/wheel/refusal.json",
+      "sha256": "e2fdd19cb5f8071c6397dd5a3c3e789b9ee4ecc8d145ca78e534433182d92631"
+    },
+    {
+      "path": "examples/wheel/success.json",
+      "sha256": "c92e80eb28c198926cb2ad07c8de2c55a36a0aeda037496242ed5ba340f05ad8"
+    },
+    {
+      "path": "examples/wheel/unavailable-service.json",
+      "sha256": "06708a8b5a4e5544927d1615fc35da42fb57de2b64e3ff554945236a2fd2a22b"
+    },
+    {
+      "path": "manifest.json",
+      "sha256": "75517971c71557e47e68fa92780421dbc27a351897878eb4588eb2f26226295f"
+    },
+    {
+      "path": "retry-policy.json",
+      "sha256": "62f9e85767f6a0a1c23577ef076b7f731b9078d6284306e7c5803118a6e72b6a"
+    },
+    {
+      "path": "schemas/CapabilitiesResponse.schema.json",
+      "sha256": "6858b7e7646166bc2ae3870edc3d31516d9a5acaba28fea3d353a838773443ef"
+    },
+    {
+      "path": "schemas/CareEscalationResponse.schema.json",
+      "sha256": "1f4a89716c036acde720419f708925c814cbe222c58b795642f54682f4514f4a"
+    },
+    {
+      "path": "schemas/CareResource.schema.json",
+      "sha256": "ae8893d6366f2a39d294721de29a0dad3140b04198991b2578292be7f60a41fd"
+    },
+    {
+      "path": "schemas/CareSignal.schema.json",
+      "sha256": "fc09e8583eca62438b9a4b4074da5fcb1f31c694a059d11e7efca5db9b60ce90"
+    },
+    {
+      "path": "schemas/ErrorEnvelope.schema.json",
+      "sha256": "c1bb9eacb78da59fe790ba3df123bda365c62e3ddbcb89ca2bc0f9a7507414af"
+    },
+    {
+      "path": "schemas/JournalUpsertRequest.schema.json",
+      "sha256": "76137d5fe64f4b3ced1866d9d50e2d0e66e9fb59b85359ab0971b1b9ce5d1b1c"
+    },
+    {
+      "path": "schemas/JournalUpsertResponse.schema.json",
+      "sha256": "acbcdc550fe2e7aa46ed8e2d692c06f1a153b508b953d6b98345ef1bd2477b1e"
+    },
+    {
+      "path": "schemas/NotApplicableExample.schema.json",
+      "sha256": "b85a807991582faa458995db5c56ff3c6810f89d2bf345aa79d180be8ab508ae"
+    },
+    {
+      "path": "schemas/ReflectionNote.schema.json",
+      "sha256": "a8c4e2163c65c664711fbfde82ea67eeeb274cfd3128e3610679d4600f30328e"
+    },
+    {
+      "path": "schemas/ReflectionRequest.schema.json",
+      "sha256": "7e2b2db6842cd14beaeeea08fea5217065ddb9cf578a213a118098a25ae96658"
+    },
+    {
+      "path": "schemas/ReflectionResponse.schema.json",
+      "sha256": "678194d72f6384f60985eedbc92d71342ac1213ce2cd17dfc09edf00526ea1a1"
+    },
+    {
+      "path": "schemas/TierModel.schema.json",
+      "sha256": "2936160c5beb8595c47f61c9f1b4dea94f4dbf6074cd2f7805ee496c6359ff9d"
+    },
+    {
+      "path": "schemas/VaultState.schema.json",
+      "sha256": "6cd84f27aa18111ab4a9c50da4d192ee2fe58d8d9b371ec5ce7b2c474820c8c9"
+    },
+    {
+      "path": "schemas/WheelFrequencies.schema.json",
+      "sha256": "05262b931e2ecbfcbcf532af32c4ac99c90a8e54b763fa1f8f0dfbf64c1dad98"
+    },
+    {
+      "path": "schemas/WheelFrequency.schema.json",
+      "sha256": "3841faae5d27a54dae95d8ab24294bc670d3f4db428705643e3a9071a831e24e"
+    },
+    {
+      "path": "schemas/WheelResponse.schema.json",
+      "sha256": "d0e80808e2559503d58149cffccac3efca52b055002e2e79e0aed5b9a4274a3d"
+    }
+  ],
+  "ontology_version": "aptitude-wavelength/2026-05-23",
+  "source": {
+    "commit": "879d9611cb4c3b5599578f39772b906c8c170e02",
+    "path": "docs/contracts/adepthood-v1",
+    "repo": "Geoffe-Ga/creek-vault"
+  }
+}

--- a/backend/tests/scripts/test_creek_contract_drift.py
+++ b/backend/tests/scripts/test_creek_contract_drift.py
@@ -34,7 +34,8 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import AbstractContextManager, contextmanager
 from http import HTTPStatus
 from pathlib import Path
 
@@ -192,18 +193,51 @@ def _constant_fetcher(body: bytes) -> Fetcher:
     return _fetch
 
 
-def _stub_get(status: int, body: bytes) -> Callable[..., httpx.Response]:
-    """Build a stand-in for ``httpx.get`` answering every URL with one response."""
+class _ScriptedStream:
+    """A stand-in for the streaming response ``httpx.stream`` yields.
 
-    def _get(url: str, **_options: object) -> httpx.Response:
-        """Answer with the fixed status and body."""
-        return httpx.Response(status, content=body, request=httpx.Request("GET", url))
+    Records how many chunks were actually pulled, which is what lets a test
+    assert the size cap *stopped* a download rather than merely refusing a body
+    it had already paid to receive in full.
+    """
 
-    return _get
+    def __init__(self, status: int, chunks: Sequence[bytes], url: str) -> None:
+        """Store the scripted response and the URL it answers for."""
+        self._status = status
+        self._chunks = tuple(chunks)
+        self._url = url
+        self.pulled = 0
+
+    def raise_for_status(self) -> None:
+        """Raise the same error httpx would for a non-success status."""
+        if self._status >= HTTPStatus.BAD_REQUEST:
+            request = httpx.Request("GET", self._url)
+            raise httpx.HTTPStatusError(
+                f"status {self._status}",
+                request=request,
+                response=httpx.Response(self._status, request=request),
+            )
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        """Yield the scripted chunks, counting each one as it is consumed."""
+        for chunk in self._chunks:
+            self.pulled += 1
+            yield chunk
 
 
-def _forbidden_get(url: str, **_options: object) -> httpx.Response:
-    """Stand in for ``httpx.get`` where no request may be made at all."""
+def _stub_stream(stream: _ScriptedStream) -> Callable[..., AbstractContextManager[_ScriptedStream]]:
+    """Build a stand-in for ``httpx.stream`` that yields one scripted response."""
+
+    @contextmanager
+    def _stream(_method: str, _url: str, **_options: object) -> Iterator[_ScriptedStream]:
+        """Yield the scripted response for the duration of the block."""
+        yield stream
+
+    return _stream
+
+
+def _forbidden_stream(_method: str, url: str, **_options: object) -> AbstractContextManager[object]:
+    """Stand in for ``httpx.stream`` where no request may be made at all."""
     raise _FetchNotScriptedError(url)
 
 
@@ -674,10 +708,17 @@ def test_upstream_url_addresses_the_public_raw_content_host() -> None:
 def test_fetch_upstream_file_returns_the_body_the_raw_host_served(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real fetcher is a thin read, exercised here against a stubbed transport."""
-    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.OK, CHANGED_BODY))
+    """The real fetcher is a thin read, exercised here against a stubbed transport.
 
-    assert fetch_upstream_file(upstream_url(MANIFEST_NAME)) == CHANGED_BODY
+    The body arrives as several chunks so the reassembly is exercised rather
+    than assumed: a fetcher that returned only the first chunk would still hash
+    to something, and that something would compare unequal for the wrong reason.
+    """
+    url = upstream_url(MANIFEST_NAME)
+    chunks = [CHANGED_BODY[:4], CHANGED_BODY[4:9], CHANGED_BODY[9:]]
+    monkeypatch.setattr(httpx, "stream", _stub_stream(_ScriptedStream(HTTPStatus.OK, chunks, url)))
+
+    assert fetch_upstream_file(url) == CHANGED_BODY
 
 
 def test_fetch_upstream_file_refuses_a_plaintext_url_before_requesting_it(
@@ -688,7 +729,7 @@ def test_fetch_upstream_file_refuses_a_plaintext_url_before_requesting_it(
     The stub raises on any call at all, so the refusal is proven to happen
     before the request rather than after it.
     """
-    monkeypatch.setattr(httpx, "get", _forbidden_get)
+    monkeypatch.setattr(httpx, "stream", _forbidden_stream)
 
     with pytest.raises(UpstreamFetchError):
         fetch_upstream_file("http://raw.githubusercontent.com/Geoffe-Ga/creek-vault/main/x.json")
@@ -696,18 +737,37 @@ def test_fetch_upstream_file_refuses_a_plaintext_url_before_requesting_it(
 
 def test_fetch_upstream_file_raises_on_an_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
     """A 404 body is not a contract file, so it must not be handed on as one."""
-    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.NOT_FOUND, CHANGED_BODY))
+    url = upstream_url(MANIFEST_NAME)
+    stream = _ScriptedStream(HTTPStatus.NOT_FOUND, [CHANGED_BODY], url)
+    monkeypatch.setattr(httpx, "stream", _stub_stream(stream))
 
     with pytest.raises(httpx.HTTPStatusError):
-        fetch_upstream_file(upstream_url(MANIFEST_NAME))
+        fetch_upstream_file(url)
+
+    assert stream.pulled == 0, "the status must be refused before any body is read"
 
 
-def test_fetch_upstream_file_refuses_an_oversized_body(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The size bound lives in the fetcher too, so no caller can be handed an unbounded body."""
-    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.OK, b"x" * (MAX_FILE_BYTES + 1)))
+def test_fetch_upstream_file_stops_an_oversized_download_instead_of_buffering_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The size bound must end the transfer, not merely refuse what already arrived.
+
+    A cap checked only after the whole body is in memory lets a compromised or
+    malfunctioning publisher decide how much this process holds, with nothing
+    but the timeout to stop it -- so the assertion here is not just that the
+    fetcher raised, but that it stopped pulling chunks partway through. The
+    scripted body is twice the cap, delivered in eighths.
+    """
+    url = upstream_url(MANIFEST_NAME)
+    chunk_count = 16
+    chunk_size = MAX_FILE_BYTES // (chunk_count // 2)
+    stream = _ScriptedStream(HTTPStatus.OK, [b"x" * chunk_size] * chunk_count, url)
+    monkeypatch.setattr(httpx, "stream", _stub_stream(stream))
 
     with pytest.raises(UpstreamFetchError):
-        fetch_upstream_file(upstream_url(MANIFEST_NAME))
+        fetch_upstream_file(url)
+
+    assert stream.pulled < chunk_count, "the download must be abandoned, not merely rejected"
 
 
 def test_main_verify_returns_clean_on_the_vendored_bundle(

--- a/backend/tests/scripts/test_creek_contract_drift.py
+++ b/backend/tests/scripts/test_creek_contract_drift.py
@@ -1,0 +1,757 @@
+"""Tests for ``backend/scripts/creek_contract_drift.py``.
+
+Creek publishes the ``/v1`` contract as a directory of generated files plus a
+``manifest.json`` that records a sha256 for each of them. Adepthood vendors that
+directory by copy, pinned to one upstream commit. A copy-and-pin integration has
+exactly one failure mode worth automating against: the copy silently stops
+describing the server. This checker exists to make that loud, and these tests
+pin its contract.
+
+Two questions are asked separately, because they fail for different reasons and
+have different remedies. ``verify_local`` asks whether our own vendored bytes
+still match the digests we recorded when we vendored them -- an offline,
+network-free integrity check that catches a hand-edit, a bad merge, or a
+truncating checkout. ``compare_upstream`` asks whether Creek still publishes the
+bytes we vendored, which is the actual drift question and the one that needs a
+remote answer.
+
+Every fetch in this suite is an injected callable over in-memory bytes, so no
+test touches a network, and every mutation happens in a ``tmp_path`` copy of the
+bundle, so no test edits the vendored fixtures. The remaining contact with real
+data is deliberate and is the positive control the whole suite rests on: the
+clean cases assert *how many* files were compared, so "clean" can never be
+reported by a run that compared nothing.
+
+The checker must never fail open. A fetcher that raises, a body that is not
+JSON, a manifest with no entries, an entry whose path or digest cannot be
+trusted, and a comparison that ended up comparing nothing are each unverifiable
+rather than clean -- reporting success for a run that proved nothing is the one
+outcome worse than reporting drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from http import HTTPStatus
+from pathlib import Path
+
+import httpx
+import pytest
+
+from scripts import creek_contract_drift as drift_module
+from scripts.creek_contract_drift import (
+    BUNDLE_ROOT,
+    EXIT_CLEAN,
+    EXIT_DRIFT,
+    EXIT_UNVERIFIABLE,
+    MAX_BUNDLE_FILES,
+    MAX_FILE_BYTES,
+    UPSTREAM_PATH,
+    UPSTREAM_REF,
+    UPSTREAM_REPO,
+    Change,
+    DriftReport,
+    Fetcher,
+    ManifestError,
+    UpstreamFetchError,
+    compare_upstream,
+    fetch_upstream_file,
+    load_upstream_manifest,
+    load_vendor_manifest,
+    main,
+    parse_manifest,
+    render_report,
+    snapshot,
+    upstream_url,
+    verify_local,
+)
+
+MANIFEST_NAME = "manifest.json"
+README_NAME = "README.md"
+VENDOR_NAME = "vendor.json"
+
+BUNDLE_NAME = "adepthood-v1"
+CONTRACT_VERSION = "0.2.0"
+ONTOLOGY_VERSION = "aptitude-wavelength/2026-05-23"
+
+# The upstream commit the vendored bundle was fetched at. It is the whole point
+# of the sidecar: a branch name would let the "pinned" copy move underneath us.
+PINNED_COMMIT = "879d9611cb4c3b5599578f39772b906c8c170e02"  # pragma: allowlist secret
+
+# 45 generated files are listed inside Creek's manifest; the manifest and the
+# hand-written README are the two it cannot cover, and our sidecar covers all 47.
+CREEK_MANIFEST_ENTRIES = 45
+VENDORED_FILES = 47
+
+# Two example paths whose drift must name two different capabilities in the
+# rendered report, so "a capability is named" cannot pass by naming a constant.
+JOURNAL_SUCCESS = "examples/journal-upsert/success.json"
+WHEEL_SUCCESS = "examples/wheel/success.json"
+
+# A body no upstream would serve, used to prove a changed byte is detected
+# rather than a changed length.
+CHANGED_BODY = b'{"changed": true}\n'
+
+# An upper bound on a sane input bound: wide enough for anything Creek would
+# publish, narrow enough that an unbounded fetch is still a bug.
+SANE_MAX_BUNDLE_FILES = 10_000
+SANE_MAX_FILE_BYTES = 16 * 1024 * 1024
+
+
+class _FetchNotScriptedError(RuntimeError):
+    """A fetcher was asked for a URL the test did not script."""
+
+
+def _sha256(data: bytes) -> str:
+    """Return the lowercase hex sha256 of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _vendored_bytes(relative: str) -> bytes:
+    """Return the on-disk bytes of one vendored bundle file."""
+    return (BUNDLE_ROOT / relative).read_bytes()
+
+
+def _copy_bundle(tmp_path: Path) -> Path:
+    """Copy the vendored bundle into ``tmp_path`` so a test may mutate it freely."""
+    destination = tmp_path / "creek_v1"
+    shutil.copytree(BUNDLE_ROOT, destination)
+    return destination
+
+
+def _rewrite(root: Path, relative: str, body: bytes) -> None:
+    """Overwrite one file inside a bundle copy."""
+    (root / relative).write_bytes(body)
+
+
+def _fetcher(manifest: bytes, readme: bytes) -> Fetcher:
+    """Build an offline fetcher answering only the two URLs a comparison needs.
+
+    ``compare_upstream`` needs the upstream manifest and the upstream README;
+    the 45 digests inside the fetched manifest cover everything else. Matching on
+    the trailing filename keeps this independent of however the module spells the
+    raw-content URL, and an unscripted URL raises rather than answering, so a
+    comparison that fetched something unexpected cannot look clean.
+    """
+
+    def _fetch(url: str) -> bytes:
+        """Answer one scripted URL, refusing anything else."""
+        if url.endswith(MANIFEST_NAME):
+            return manifest
+        if url.endswith(README_NAME):
+            return readme
+        raise _FetchNotScriptedError(url)
+
+    return _fetch
+
+
+def _vendored_fetcher() -> Fetcher:
+    """Build the fetcher that answers with exactly the bytes we vendored."""
+    return _fetcher(_vendored_bytes(MANIFEST_NAME), _vendored_bytes(README_NAME))
+
+
+def _serialise(payload: object) -> bytes:
+    """Serialise a manifest exactly as Creek's generator does, trailing newline included.
+
+    Byte-for-byte fidelity matters here: a test that rebuilds the manifest to
+    change one digest must leave the manifest's own digest untouched, or every
+    such test would report two changes instead of the one it is about.
+    """
+    return json.dumps(payload, indent=2, sort_keys=True).encode() + b"\n"
+
+
+def _changed_upstream_fetcher(relative: str) -> Fetcher:
+    """Build a fetcher whose manifest reports a different digest for ``relative``."""
+    payload = json.loads(_vendored_bytes(MANIFEST_NAME))
+    for entry in payload["files"]:
+        if entry["path"] == relative:
+            entry["sha256"] = _sha256(CHANGED_BODY)
+    return _fetcher(_serialise(payload), _vendored_bytes(README_NAME))
+
+
+def _raising_fetcher() -> Fetcher:
+    """Build a fetcher that fails instead of answering, as an offline runner would."""
+
+    def _fetch(url: str) -> bytes:
+        """Refuse every URL."""
+        raise _FetchNotScriptedError(url)
+
+    return _fetch
+
+
+def _constant_fetcher(body: bytes) -> Fetcher:
+    """Build a fetcher answering every URL with one fixed body."""
+
+    def _fetch(_url: str) -> bytes:
+        """Answer with the fixed body."""
+        return body
+
+    return _fetch
+
+
+def _stub_get(status: int, body: bytes) -> Callable[..., httpx.Response]:
+    """Build a stand-in for ``httpx.get`` answering every URL with one response."""
+
+    def _get(url: str, **_options: object) -> httpx.Response:
+        """Answer with the fixed status and body."""
+        return httpx.Response(status, content=body, request=httpx.Request("GET", url))
+
+    return _get
+
+
+def _forbidden_get(url: str, **_options: object) -> httpx.Response:
+    """Stand in for ``httpx.get`` where no request may be made at all."""
+    raise _FetchNotScriptedError(url)
+
+
+def _entry(path: str, sha256: str) -> dict[str, object]:
+    """Build one upstream manifest entry."""
+    return {"capability": None, "model": None, "path": path, "sha256": sha256, "state": None}
+
+
+def _manifest_bytes(files: Sequence[Mapping[str, object]]) -> bytes:
+    """Serialise an upstream-shaped manifest carrying ``files``."""
+    payload = {
+        "bundle": BUNDLE_NAME,
+        "contract_version": CONTRACT_VERSION,
+        "files": list(files),
+        "ontology_version": ONTOLOGY_VERSION,
+    }
+    return _serialise(payload)
+
+
+def _only_change(report: DriftReport) -> Change:
+    """Return the report's single change, asserting there is exactly one."""
+    assert report.unverifiable == (), report.unverifiable
+    assert len(report.changes) == 1, report.changes
+    return report.changes[0]
+
+
+def _change_for(report: DriftReport, path: str) -> Change:
+    """Return the report's change for ``path``, asserting there is exactly one."""
+    assert report.unverifiable == (), report.unverifiable
+    matching = [change for change in report.changes if change.path == path]
+    assert len(matching) == 1, report.changes
+    return matching[0]
+
+
+def test_exit_code_constants_are_the_documented_shell_codes() -> None:
+    """The three codes are the contract between this script and the gate that runs it."""
+    assert EXIT_CLEAN == 0
+    assert EXIT_DRIFT == 1
+    assert EXIT_UNVERIFIABLE == 2
+
+
+def test_upstream_coordinates_name_the_published_bundle() -> None:
+    """A comparison must look where Creek actually publishes the contract."""
+    assert UPSTREAM_REPO == "Geoffe-Ga/creek-vault"
+    assert UPSTREAM_PATH == "docs/contracts/adepthood-v1"
+    assert UPSTREAM_REF == "main"
+
+
+def test_bundle_root_is_the_vendored_creek_directory() -> None:
+    """The default root is the committed bundle, not a path assembled at call time."""
+    assert BUNDLE_ROOT.is_dir()
+    assert (BUNDLE_ROOT / MANIFEST_NAME).is_file()
+    assert (BUNDLE_ROOT / README_NAME).is_file()
+    assert BUNDLE_ROOT.name == "creek_v1"
+
+
+def test_input_bounds_admit_the_real_bundle_and_still_bound_a_hostile_one() -> None:
+    """Upstream is untrusted input, so both bounds must be real and both must fit.
+
+    A bound below the published bundle would reject a clean fetch; an unbounded
+    one would let a hostile or broken upstream decide how much memory this gate
+    spends. The assertions pin both directions rather than the exact numbers.
+    """
+    largest = max(path.stat().st_size for path in BUNDLE_ROOT.rglob("*") if path.is_file())
+
+    assert VENDORED_FILES <= MAX_BUNDLE_FILES <= SANE_MAX_BUNDLE_FILES
+    assert largest <= MAX_FILE_BYTES <= SANE_MAX_FILE_BYTES
+
+
+def test_verify_local_compares_every_vendored_file_and_finds_no_drift() -> None:
+    """The committed bundle matches its own recorded digests, and 47 files prove it.
+
+    The count is the positive control: without it, a run that found no files at
+    all would render exactly like a run that verified the whole bundle.
+    """
+    report = verify_local(BUNDLE_ROOT)
+
+    assert report.compared == VENDORED_FILES
+    assert report.changes == ()
+    assert report.unverifiable == ()
+    assert report.exit_code == EXIT_CLEAN
+
+    rendered = render_report(report)
+    assert str(VENDORED_FILES) in rendered
+    assert "cannot verify" not in rendered.lower()
+
+
+def test_verify_local_reports_one_mutated_fixture_and_names_its_capability(
+    tmp_path: Path,
+) -> None:
+    """A single changed byte in one example is drift, attributed to its capability."""
+    root = _copy_bundle(tmp_path)
+    recorded = _sha256(_vendored_bytes(JOURNAL_SUCCESS))
+    _rewrite(root, JOURNAL_SUCCESS, CHANGED_BODY)
+
+    report = verify_local(root)
+    change = _only_change(report)
+
+    assert change.path == JOURNAL_SUCCESS
+    assert change.capability == "journal-upsert"
+    assert change.vendored == recorded
+    assert change.upstream == _sha256(CHANGED_BODY)
+    assert report.exit_code == EXIT_DRIFT
+    assert JOURNAL_SUCCESS in render_report(report)
+    assert "journal-upsert" in render_report(report)
+
+
+def test_verify_local_reports_a_file_nobody_recorded(tmp_path: Path) -> None:
+    """An unlisted file is drift too: the vendored set must be exactly what we pinned."""
+    root = _copy_bundle(tmp_path)
+    added = "examples/journal-upsert/surprise.json"
+    _rewrite(root, added, CHANGED_BODY)
+
+    report = verify_local(root)
+    change = _only_change(report)
+
+    assert change.path == added
+    assert change.vendored is None
+    assert change.upstream == _sha256(CHANGED_BODY)
+    assert report.exit_code == EXIT_DRIFT
+    assert added in render_report(report)
+
+
+def test_verify_local_reports_a_recorded_file_that_is_gone(tmp_path: Path) -> None:
+    """A deleted fixture must fail loudly rather than shrink the comparison silently."""
+    root = _copy_bundle(tmp_path)
+    recorded = _sha256(_vendored_bytes(WHEEL_SUCCESS))
+    (root / WHEEL_SUCCESS).unlink()
+
+    report = verify_local(root)
+    change = _only_change(report)
+
+    assert change.path == WHEEL_SUCCESS
+    assert change.capability == "wheel"
+    assert change.vendored == recorded
+    assert change.upstream is None
+    assert report.exit_code == EXIT_DRIFT
+    assert "wheel" in render_report(report)
+
+
+def test_compare_upstream_is_clean_when_upstream_serves_the_vendored_bytes() -> None:
+    """Two fetches plus the 45 digests inside them cover all 47 vendored files."""
+    report = compare_upstream(BUNDLE_ROOT, fetch=_vendored_fetcher())
+
+    assert report.compared == VENDORED_FILES
+    assert report.changes == ()
+    assert report.unverifiable == ()
+    assert report.exit_code == EXIT_CLEAN
+    assert str(VENDORED_FILES) in render_report(report)
+
+
+@pytest.mark.parametrize(
+    ("relative", "capability"),
+    [(JOURNAL_SUCCESS, "journal-upsert"), (WHEEL_SUCCESS, "wheel")],
+)
+def test_compare_upstream_names_the_changed_capability(relative: str, capability: str) -> None:
+    """A republished example is drift, and the report says which capability moved.
+
+    Two capabilities are exercised so the rendered name cannot be a constant that
+    happens to match one of them. Upstream's manifest is reported alongside the
+    example, because a real republication moves the manifest's own bytes too --
+    that is a second true finding, not noise, and the report must carry both.
+    """
+    report = compare_upstream(BUNDLE_ROOT, fetch=_changed_upstream_fetcher(relative))
+    change = _change_for(report, relative)
+
+    assert {item.path for item in report.changes} == {relative, MANIFEST_NAME}
+    assert change.capability == capability
+    assert change.vendored == _sha256(_vendored_bytes(relative))
+    assert change.upstream == _sha256(CHANGED_BODY)
+    assert report.compared == VENDORED_FILES
+    assert report.exit_code == EXIT_DRIFT
+
+    rendered = render_report(report)
+    assert capability in rendered
+    assert relative in rendered
+
+
+def test_compare_upstream_detects_a_rewritten_upstream_readme() -> None:
+    """The README is outside Creek's manifest, so only a direct fetch can catch it."""
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_fetcher(_vendored_bytes(MANIFEST_NAME), CHANGED_BODY),
+    )
+    change = _only_change(report)
+
+    assert change.path == README_NAME
+    assert change.capability is None
+    assert change.vendored == _sha256(_vendored_bytes(README_NAME))
+    assert change.upstream == _sha256(CHANGED_BODY)
+    assert report.exit_code == EXIT_DRIFT
+
+
+def test_compare_upstream_detects_a_reserialised_upstream_manifest() -> None:
+    """The manifest's own bytes are compared, not just the digests it carries.
+
+    Upstream is reserialised with different indentation, so all 45 listed digests
+    still agree and only the manifest itself moved. Nothing else in the bundle
+    can catch that, because nothing else records the manifest's digest.
+    """
+    reindented = json.dumps(json.loads(_vendored_bytes(MANIFEST_NAME)), indent=4, sort_keys=True)
+    reserialised = reindented.encode() + b"\n"
+
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_fetcher(reserialised, _vendored_bytes(README_NAME)),
+    )
+    change = _only_change(report)
+
+    assert change.path == MANIFEST_NAME
+    assert change.vendored == _sha256(_vendored_bytes(MANIFEST_NAME))
+    assert change.upstream == _sha256(reserialised)
+    assert report.compared == VENDORED_FILES
+    assert report.exit_code == EXIT_DRIFT
+
+
+def test_compare_upstream_reports_a_file_creek_no_longer_publishes() -> None:
+    """A path dropped from Creek's manifest is drift, not a smaller clean run.
+
+    Two changes are expected, not one: dropping an entry also moves the
+    manifest's own bytes. The second is the point -- a recorded file that
+    upstream stopped listing must be named rather than quietly left out of the
+    comparison, which is how a shrinking check reports clean.
+    """
+    payload = json.loads(_vendored_bytes(MANIFEST_NAME))
+    payload["files"] = [entry for entry in payload["files"] if entry["path"] != WHEEL_SUCCESS]
+
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_fetcher(_serialise(payload), _vendored_bytes(README_NAME)),
+    )
+    dropped = report.changes[-1]
+
+    assert [change.path for change in report.changes] == [MANIFEST_NAME, WHEEL_SUCCESS]
+    assert dropped.capability == "wheel"
+    assert dropped.vendored == _sha256(_vendored_bytes(WHEEL_SUCCESS))
+    assert dropped.upstream is None
+    assert report.unverifiable == ()
+    assert report.compared == VENDORED_FILES
+    assert report.exit_code == EXIT_DRIFT
+
+
+def test_a_file_that_could_not_be_fetched_is_unverified_rather_than_deleted() -> None:
+    """An unreachable file is unproven, and calling it deleted would be a false alarm.
+
+    Only the README fails here, so the manifest still covers 45 of the 47. The
+    missing one must be reported as unverifiable and subtracted from the
+    compared count, never reported as drift -- an upstream outage and an
+    upstream deletion are different events with different remedies.
+    """
+
+    def _fetch(url: str) -> bytes:
+        """Answer only the manifest, as a partial outage would."""
+        if url.endswith(MANIFEST_NAME):
+            return _vendored_bytes(MANIFEST_NAME)
+        raise _FetchNotScriptedError(url)
+
+    report = compare_upstream(BUNDLE_ROOT, fetch=_fetch)
+
+    assert report.changes == ()
+    assert [item.path for item in report.unverifiable] == [README_NAME]
+    assert report.compared == VENDORED_FILES - 1
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_a_fetcher_that_raises_is_unverifiable_not_clean() -> None:
+    """An offline runner proves nothing about upstream, so it must not report clean."""
+    report = compare_upstream(BUNDLE_ROOT, fetch=_raising_fetcher())
+
+    assert report.changes == ()
+    assert report.unverifiable != ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert report.exit_code != EXIT_CLEAN
+    assert "cannot verify" in render_report(report).lower()
+
+
+def test_a_non_json_upstream_body_is_unverifiable_not_clean() -> None:
+    """A proxy error page served as the manifest is an unread comparison, not a pass."""
+    report = compare_upstream(BUNDLE_ROOT, fetch=_constant_fetcher(b"<html>not json</html>"))
+
+    assert report.changes == ()
+    assert report.unverifiable != ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert report.exit_code != EXIT_CLEAN
+
+
+def test_an_upstream_manifest_with_no_entries_is_unverifiable_not_clean() -> None:
+    """An emptied manifest would otherwise "match" by having nothing to disagree with."""
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_fetcher(_manifest_bytes([]), _vendored_bytes(README_NAME)),
+    )
+
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert report.exit_code != EXIT_CLEAN
+
+
+def test_an_oversized_upstream_body_is_rejected_rather_than_read() -> None:
+    """Upstream is untrusted, so an unbounded body is refused before it is parsed."""
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_constant_fetcher(b"x" * (MAX_FILE_BYTES + 1)),
+    )
+
+    assert report.changes == ()
+    assert report.unverifiable != ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert report.exit_code != EXIT_CLEAN
+
+
+def test_a_comparison_that_compared_nothing_is_unverifiable_not_clean() -> None:
+    """Zero compared files proves nothing; reporting it as clean is the fail-open."""
+    report = DriftReport(compared=0, changes=(), unverifiable=())
+
+    assert report.exit_code == EXIT_UNVERIFIABLE
+    assert report.exit_code != EXIT_CLEAN
+
+
+def test_render_report_says_nothing_was_verified_rather_than_borrowing_clean_wording() -> None:
+    """The empty report must name its own cause, never read like a verified bundle."""
+    nothing = render_report(DriftReport(compared=0, changes=(), unverifiable=()))
+    clean = render_report(verify_local(BUNDLE_ROOT))
+
+    assert nothing != clean
+    assert "nothing" in nothing.lower() or "cannot verify" in nothing.lower()
+
+
+def test_parse_manifest_reads_creeks_published_manifest() -> None:
+    """The vendored manifest parses into its 45 entries and its two version strings."""
+    manifest = parse_manifest(_vendored_bytes(MANIFEST_NAME))
+
+    assert manifest.contract_version == CONTRACT_VERSION
+    assert manifest.ontology_version == ONTOLOGY_VERSION
+    assert manifest.source_commit is None
+    assert len(manifest.files) == CREEK_MANIFEST_ENTRIES
+    assert {item.path for item in manifest.files} >= {JOURNAL_SUCCESS, WHEEL_SUCCESS}
+    assert all(len(item.sha256) == 64 for item in manifest.files)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/absolute/success.json",
+        "../escape.json",
+        "examples/../../escape.json",
+        "examples\\wheel\\success.json",
+        "examples/wheel/succ\u00e9ss.json",
+        "examples/wheel/su\x00ccess.json",
+        "examples/wheel/succ\tess.json",
+    ],
+)
+def test_parse_manifest_refuses_a_path_it_will_not_trust(path: str) -> None:
+    """A manifest path becomes a filesystem read, so anything unusual is refused.
+
+    Absolute paths and dot segments climb out of the bundle, a backslash is a
+    separator on one of the platforms this runs on, and a non-printable or
+    non-ASCII path is not something a generated bundle emits.
+    """
+    raw = _manifest_bytes([_entry(path, _sha256(CHANGED_BODY))])
+
+    with pytest.raises(ManifestError):
+        parse_manifest(raw)
+
+
+@pytest.mark.parametrize(
+    "sha256",
+    ["", "not-hex", "A" * 64, "a" * 63, "a" * 65, "a" * 63 + "g"],
+)
+def test_parse_manifest_refuses_a_digest_that_is_not_64_lowercase_hex(sha256: str) -> None:
+    """A digest that is not a digest can only ever compare unequal or crash."""
+    raw = _manifest_bytes([_entry("examples/wheel/success.json", sha256)])
+
+    with pytest.raises(ManifestError):
+        parse_manifest(raw)
+
+
+def test_parse_manifest_refuses_more_entries_than_the_bundle_bound() -> None:
+    """A manifest listing more files than a bundle can hold is a hostile input."""
+    files = [
+        _entry(f"schemas/Generated{index}.schema.json", _sha256(CHANGED_BODY))
+        for index in range(MAX_BUNDLE_FILES + 1)
+    ]
+
+    with pytest.raises(ManifestError):
+        parse_manifest(_manifest_bytes(files))
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [b"", b"<html>not json</html>", b"[]", b'"a string"', b"{}", b'{"files": {}}'],
+)
+def test_parse_manifest_refuses_bytes_it_cannot_interpret(raw: bytes) -> None:
+    """Anything that is not a manifest object with a file list is refused, not guessed."""
+    with pytest.raises(ManifestError):
+        parse_manifest(raw)
+
+
+def test_parse_manifest_refuses_an_entry_that_is_not_an_object() -> None:
+    """A file list of scalars is refused outright rather than silently skipped."""
+    with pytest.raises(ManifestError):
+        parse_manifest(b'{"files": [42]}')
+
+
+def test_a_refused_manifest_entry_leaves_nothing_compared() -> None:
+    """A rejected path must be reported, never used to read a file off disk."""
+    raw = _manifest_bytes([_entry("../escape.json", _sha256(CHANGED_BODY))])
+
+    report = compare_upstream(
+        BUNDLE_ROOT,
+        fetch=_fetcher(raw, _vendored_bytes(README_NAME)),
+    )
+
+    assert report.compared == 0
+    assert report.changes == ()
+    assert report.unverifiable != ()
+    assert report.exit_code == EXIT_UNVERIFIABLE
+
+
+def test_load_vendor_manifest_records_the_pinned_source_commit() -> None:
+    """Our sidecar pins a commit sha, which is what makes the vendored copy a pin."""
+    manifest = load_vendor_manifest(BUNDLE_ROOT)
+
+    assert manifest.source_commit == PINNED_COMMIT
+    assert manifest.contract_version == CONTRACT_VERSION
+    assert manifest.ontology_version == ONTOLOGY_VERSION
+    assert len(manifest.files) == VENDORED_FILES
+
+
+def test_load_upstream_manifest_reads_the_vendored_copy_of_creeks_manifest() -> None:
+    """Creek's own manifest is read from disk, not refetched, so it stays offline."""
+    manifest = load_upstream_manifest(BUNDLE_ROOT)
+
+    assert len(manifest.files) == CREEK_MANIFEST_ENTRIES
+    assert manifest.source_commit is None
+    assert MANIFEST_NAME not in {item.path for item in manifest.files}
+    assert README_NAME not in {item.path for item in manifest.files}
+
+
+def test_snapshot_round_trips_the_committed_sidecar_exactly() -> None:
+    """Regenerating the sidecar at the pinned commit must reproduce it byte for byte.
+
+    This is what makes the re-vendor procedure mechanical: the operator runs the
+    snapshot subcommand and commits its output, and this test proves the file in
+    the tree is what that command produces rather than something hand-edited.
+    """
+    assert snapshot(BUNDLE_ROOT, commit=PINNED_COMMIT) == (BUNDLE_ROOT / VENDOR_NAME).read_text()
+
+
+def test_snapshot_does_not_write_a_file(tmp_path: Path) -> None:
+    """Snapshotting is a pure read: the caller decides where the text lands."""
+    root = _copy_bundle(tmp_path)
+    (root / VENDOR_NAME).unlink()
+
+    text = snapshot(root, commit=PINNED_COMMIT)
+
+    assert not (root / VENDOR_NAME).exists()
+    assert json.loads(text)["source"]["commit"] == PINNED_COMMIT
+
+
+def test_upstream_url_addresses_the_public_raw_content_host() -> None:
+    """The comparison reads the branch, because "what does Creek publish now" is the question."""
+    assert upstream_url(MANIFEST_NAME) == (
+        f"https://raw.githubusercontent.com/{UPSTREAM_REPO}/"
+        f"{UPSTREAM_REF}/{UPSTREAM_PATH}/{MANIFEST_NAME}"
+    )
+
+
+def test_fetch_upstream_file_returns_the_body_the_raw_host_served(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real fetcher is a thin read, exercised here against a stubbed transport."""
+    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.OK, CHANGED_BODY))
+
+    assert fetch_upstream_file(upstream_url(MANIFEST_NAME)) == CHANGED_BODY
+
+
+def test_fetch_upstream_file_refuses_a_plaintext_url_before_requesting_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A contract document must not be read off a channel anyone can rewrite.
+
+    The stub raises on any call at all, so the refusal is proven to happen
+    before the request rather than after it.
+    """
+    monkeypatch.setattr(httpx, "get", _forbidden_get)
+
+    with pytest.raises(UpstreamFetchError):
+        fetch_upstream_file("http://raw.githubusercontent.com/Geoffe-Ga/creek-vault/main/x.json")
+
+
+def test_fetch_upstream_file_raises_on_an_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 body is not a contract file, so it must not be handed on as one."""
+    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.NOT_FOUND, CHANGED_BODY))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_upstream_file(upstream_url(MANIFEST_NAME))
+
+
+def test_fetch_upstream_file_refuses_an_oversized_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The size bound lives in the fetcher too, so no caller can be handed an unbounded body."""
+    monkeypatch.setattr(httpx, "get", _stub_get(HTTPStatus.OK, b"x" * (MAX_FILE_BYTES + 1)))
+
+    with pytest.raises(UpstreamFetchError):
+        fetch_upstream_file(upstream_url(MANIFEST_NAME))
+
+
+def test_main_verify_returns_clean_on_the_vendored_bundle(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The verify subcommand is the offline gate check-all can run unconditionally."""
+    exit_code = main(["verify"])
+
+    assert exit_code == EXIT_CLEAN
+    assert str(VENDORED_FILES) in capsys.readouterr().out
+
+
+def test_main_compare_drives_the_module_fetch_seam(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The compare subcommand's network call is a named module attribute, not inline.
+
+    Keeping it patchable is what lets the CLI path be exercised without a
+    network; an inline request would make this subcommand untestable offline.
+    """
+    monkeypatch.setattr(drift_module, "fetch_upstream_file", _vendored_fetcher())
+
+    exit_code = main(["compare"])
+
+    assert exit_code == EXIT_CLEAN
+    assert str(VENDORED_FILES) in capsys.readouterr().out
+
+
+def test_main_snapshot_prints_the_sidecar_the_operator_is_to_commit(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The re-vendor procedure is one command whose stdout is the file, verbatim."""
+    exit_code = main(["snapshot", "--commit", PINNED_COMMIT])
+
+    assert exit_code == EXIT_CLEAN
+    assert capsys.readouterr().out == (BUNDLE_ROOT / VENDOR_NAME).read_text()
+
+
+def test_main_rejects_an_unknown_subcommand() -> None:
+    """An unrecognised subcommand must fail the gate rather than default to a check."""
+    try:
+        exit_code: object = main(["reticulate"])
+    except SystemExit as exit_signal:
+        exit_code = exit_signal.code
+
+    assert exit_code != EXIT_CLEAN

--- a/backend/tests/test_creek_contract_conformance.py
+++ b/backend/tests/test_creek_contract_conformance.py
@@ -1,0 +1,876 @@
+"""Conformance of the Creek Vault client against Creek's own published bundle.
+
+The fixtures under ``tests/fixtures/creek_v1/`` are Creek's ratified ``/v1``
+contract bundle, vendored byte-for-byte from ``Geoffe-Ga/creek-vault`` at one
+pinned commit. Every wire shape asserted below is read from those files. Nothing
+here invents a payload: if a shape is not in the bundle it is not tested, and if
+the bundle changes these tests change with it rather than the other way round.
+
+Re-vendoring the bundle
+-----------------------
+
+1. Fetch each file from ``raw.githubusercontent.com`` at a **pinned commit sha**,
+   never a branch. A branch would let the "pinned" copy move underneath the
+   checksums that are the only thing making it a pin.
+2. Verify every fetched file against Creek's own ``manifest.json``, which records
+   a sha256 for the 45 files it covers -- it covers neither itself nor the
+   hand-written ``README.md``.
+3. Regenerate ``vendor.json`` with the drift script's ``snapshot`` subcommand and
+   commit its output verbatim. ``tests/scripts/test_creek_contract_drift.py``
+   asserts the committed sidecar is exactly what that command produces.
+4. Re-run ``detect-secrets scan --baseline .secrets.baseline``: every digest
+   changes, and a high-entropy hex string is precisely what that scanner flags.
+5. Re-run this suite and the drift-script suite.
+6. A change to Creek's ``contract_version`` is a **human decision**, not a
+   mechanical update. Moving it means moving ``domain.creek_vault``'s
+   ``CONTRACT_VERSION``, the pinned-version bullet in ADR 0004, and the contract
+   document's version bullet together, in one reviewed change.
+
+The strict-xfail tripwire
+-------------------------
+
+Three divergences separate today's client from Creek's ratified documents. The
+client reads a top-level ``available`` where Creek nests ``vault.available``. It
+maps advertised capability names through ``CreekCapability``, whose ``creek.*``
+values share no member with Creek's published names. And its error vocabulary
+has no ``privacy_refused`` and no ``unavailable``, so it drops both. Fixing any
+of them belongs to the client, not to this suite.
+
+Until they are fixed, the ratified outcome is asserted under
+``@pytest.mark.xfail(strict=True)``. Repo-wide ``xfail_strict`` means that
+assertion executes on every run and becomes a **hard failure the moment it starts
+passing** -- which is exactly when the client is fixed and the marker must be
+deleted. That is the intent: the tripwire reports the divergence closing in the
+same run that closes it. It is paired with plainly-asserted, today-green
+observations of what the client actually does, so the current behaviour is
+recorded rather than merely known.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from collections.abc import AsyncGenerator, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from http import HTTPStatus
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
+    CreekVaultContractError,
+    CreekVaultUnavailableError,
+    VaultIngestAction,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultTierCeiling,
+)
+from scripts.creek_contract_drift import BUNDLE_ROOT, EXIT_DRIFT, verify_local
+from services.creek_vault_client import HandshakeDegradeReason, HttpCreekVaultClient
+
+MANIFEST_NAME = "manifest.json"
+README_NAME = "README.md"
+VENDOR_NAME = "vendor.json"
+RETRY_POLICY_NAME = "retry-policy.json"
+
+PINNED_REPO = "Geoffe-Ga/creek-vault"
+PINNED_COMMIT = "879d9611cb4c3b5599578f39772b906c8c170e02"  # pragma: allowlist secret
+PINNED_PATH = "docs/contracts/adepthood-v1"
+ONTOLOGY_VERSION = "aptitude-wavelength/2026-05-23"
+
+CREEK_MANIFEST_ENTRIES = 45
+VENDORED_FILES = 47
+EXAMPLE_CELLS = 28
+CAPABILITY_COUNT = 4
+STATE_COUNT = 7
+UNREACHABLE_CELLS = 3
+REACHABLE_CELLS = EXAMPLE_CELLS - UNREACHABLE_CELLS
+
+_VAULT_URL = "https://vault.example.test"
+_API_KEY = "creek-vault-conformance-key"  # pragma: allowlist secret
+_CAPABILITIES_PATH = "/v1/capabilities"
+
+_ENTRY_ID = 7
+_ENTRY_BODY = "a floor-level journal entry"
+_CREATED_AT = datetime(2026, 7, 31, 6, 12, tzinfo=UTC)
+
+# The vault-issued fragment id Creek's two ratified journal bodies answer with.
+_FRAGMENT_ID = "frag-3f9a1c7e40b2"
+
+# The longest string any vendored example carries is Creek's 201-character care
+# message. A real journal body would not fit, which is what makes "no real
+# writing was published in these fixtures" a checkable claim rather than a hope.
+_MAX_EXAMPLE_STRING = 256
+
+# Credential shapes that must appear in no vendored file. The key spellings are
+# quoted so the README's prose about not carrying a token cannot match; the
+# bearer prefix is what a captured header value would start with.
+_CREDENTIAL_MARKERS = ('"api_key"', '"password"', '"token"', '"secret"', "Bearer ")
+
+# The tier that must never egress, and the three fields it could travel in.
+_FORBIDDEN_TIER = "intimate"
+_TIER_FIELDS = ("tier", "tier_ceiling", "routed_tier")
+
+# The two keys a journal body would travel under if one had been published.
+_BODY_KEYS = ("content", "body")
+
+# HAND-MAINTAINED TABLE. The seven per-state HTTP statuses appear only as prose in
+# the bundle's hand-written README; no generated file carries them, so this
+# restates that published state table and is the one mapping in this suite that is
+# not read from machine-readable data. ``test_state_status_table_matches_the_manifest``
+# keeps its key set honest against the manifest.
+_STATUS_BY_STATE: Mapping[str, int] = {
+    "success": HTTPStatus.OK,
+    "empty": HTTPStatus.OK,
+    "care-escalation": HTTPStatus.OK,
+    "refusal": HTTPStatus.FORBIDDEN,
+    "malformed-input": HTTPStatus.UNPROCESSABLE_ENTITY,
+    "incompatible-version": HTTPStatus.CONFLICT,
+    "unavailable-service": HTTPStatus.SERVICE_UNAVAILABLE,
+}
+
+# The states served at a non-200 status, derived from the table above rather than
+# written out a second time, so the two can never disagree about which cells are
+# errors.
+_ERROR_STATES = frozenset(
+    state for state, status in _STATUS_BY_STATE.items() if status != HTTPStatus.OK
+)
+
+# TRANSLATION THAT EXISTS ONLY BECAUSE OF TWO DIVERGENCES. Creek advertises its
+# capabilities by their published names; ``CreekCapability`` spells the same four
+# ideas as ``creek.*`` values, and the two sets share no member. This table, plus
+# the lifting of ``vault.available`` in :func:`_client_readable_capabilities`, is
+# the entire difference between Creek's ratified capability document and a
+# document today's client can complete a handshake against. Both must be deleted
+# the moment the client reads Creek's document natively: they are scaffolding
+# around a bug, not part of the contract.
+_CAPABILITY_BY_CREEK_NAME: Mapping[str, CreekCapability] = {
+    "capabilities": CreekCapability.HANDSHAKE,
+    "journal-upsert": CreekCapability.JOURNAL,
+    "reflections": CreekCapability.REFLECT,
+    "wheel": CreekCapability.WHEEL,
+}
+
+Handler = Callable[[httpx.Request], httpx.Response]
+ClientFactory = Callable[[Handler], HttpCreekVaultClient]
+
+
+@dataclass(frozen=True)
+class _Cell:
+    """One ``(capability, state)`` cell of Creek's published example matrix."""
+
+    capability: str
+    state: str
+    path: str
+    model: str
+
+
+def _read_bytes(relative: str) -> bytes:
+    """Return the raw bytes of one vendored bundle file."""
+    return (BUNDLE_ROOT / relative).read_bytes()
+
+
+def _read_json(relative: str) -> dict[str, object]:
+    """Return one vendored JSON file decoded as an object."""
+    decoded = json.loads(_read_bytes(relative))
+    assert isinstance(decoded, dict), relative
+    return decoded
+
+
+def _sha256(data: bytes) -> str:
+    """Return the lowercase hex sha256 of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _entries(relative: str) -> tuple[Mapping[str, object], ...]:
+    """Return a manifest's ``files`` list as mappings."""
+    files = _read_json(relative)["files"]
+    assert isinstance(files, list), relative
+    return tuple(entry for entry in files if isinstance(entry, dict))
+
+
+def _digests(relative: str) -> dict[str, str]:
+    """Return a manifest's ``path -> sha256`` mapping."""
+    return {str(entry["path"]): str(entry["sha256"]) for entry in _entries(relative)}
+
+
+def _example_cells(entries: tuple[Mapping[str, object], ...]) -> tuple[_Cell, ...]:
+    """Build the example matrix from manifest entries rather than a written list."""
+    return tuple(
+        _Cell(
+            capability=str(entry["capability"]),
+            state=str(entry["state"]),
+            path=str(entry["path"]),
+            model=str(entry["model"]),
+        )
+        for entry in entries
+        if entry["capability"] is not None
+    )
+
+
+def _is_unreachable(cell: _Cell) -> bool:
+    """Return whether a cell holds Creek's "this branch does not exist" sentinel.
+
+    Read from the payload's own ``unreachable`` marker, so the three sentinel
+    cells drop out of every client-driving parametrisation as data rather than as
+    a skip.
+    """
+    return _read_json(cell.path).get("unreachable") is True
+
+
+def _cell_id(cell: _Cell) -> str:
+    """Name a parametrised case after the matrix cell it drives."""
+    return f"{cell.capability}-{cell.state}"
+
+
+_CELLS = _example_cells(_entries(MANIFEST_NAME))
+_REACHABLE = tuple(cell for cell in _CELLS if not _is_unreachable(cell))
+_UNREACHABLE = tuple(cell for cell in _CELLS if _is_unreachable(cell))
+_CAPABILITIES = frozenset(cell.capability for cell in _CELLS)
+_STATES = frozenset(cell.state for cell in _CELLS)
+_CAPABILITY_ERROR_CELLS = tuple(
+    cell for cell in _REACHABLE if cell.capability == "capabilities" and cell.state in _ERROR_STATES
+)
+
+
+def _client_readable_capabilities() -> dict[str, object]:
+    """Derive a handshake document today's client can complete, from Creek's own.
+
+    Exactly two edits to ``examples/capabilities/success.json``, each undoing one
+    known divergence: ``vault.available`` is lifted to the top-level key the
+    client reads, and Creek's published capability names are translated through
+    :data:`_CAPABILITY_BY_CREEK_NAME`. Every other field is Creek's, unmodified.
+
+    This is scaffolding around a bug. When the client reads Creek's document
+    natively it must be deleted rather than generalised -- keeping it would let
+    the journal conformance cells go on passing against a document Creek does not
+    publish.
+    """
+    published = _read_json("examples/capabilities/success.json")
+    vault = published["vault"]
+    assert isinstance(vault, dict)
+    advertised = published["capabilities"]
+    assert isinstance(advertised, list)
+    return {
+        **published,
+        "available": vault["available"],
+        "capabilities": [_CAPABILITY_BY_CREEK_NAME[str(name)].value for name in advertised],
+    }
+
+
+@dataclass
+class _Recorder:
+    """A route-aware ``MockTransport`` handler that records every request it sees.
+
+    The capability path answers the derived handshake document; every other path
+    answers the journal exchange. Recording is load-bearing for the
+    read-capability tests, which assert that no request left the process at all.
+    """
+
+    journal_payload: object = None
+    journal_status: int = HTTPStatus.OK
+    calls: list[str] = field(default_factory=list)
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        """Answer one request, recording the method and path it arrived on."""
+        self.calls.append(f"{request.method} {request.url.path}")
+        if request.url.path == _CAPABILITIES_PATH:
+            return httpx.Response(HTTPStatus.OK, json=_client_readable_capabilities())
+        return httpx.Response(self.journal_status, json=self.journal_payload)
+
+
+def _static_handler(payload: object, status: int) -> Handler:
+    """Return a handler answering every request with one vendored document."""
+
+    def _handle(_request: httpx.Request) -> httpx.Response:
+        """Answer with the fixed payload and status."""
+        return httpx.Response(status, json=payload)
+
+    return _handle
+
+
+def _ingest_request() -> VaultIngestRequest:
+    """Build the one ingest request every journal cell is driven with."""
+    return VaultIngestRequest(
+        entry_id=_ENTRY_ID,
+        body=_ENTRY_BODY,
+        tier=VaultTierCeiling.PERSONAL,
+        tier_ceiling=VaultTierCeiling.PERSONAL,
+        created_at=_CREATED_AT,
+    )
+
+
+@pytest_asyncio.fixture
+async def vault_clients() -> AsyncGenerator[ClientFactory, None]:
+    """Yield a factory for MockTransport-backed vault clients, closing each after."""
+    created: list[httpx.AsyncClient] = []
+
+    def _build(handler: Handler) -> HttpCreekVaultClient:
+        """Build one in-memory client and register its transport for teardown."""
+        http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        created.append(http)
+        return HttpCreekVaultClient(_VAULT_URL, _API_KEY, http_client=http)
+
+    yield _build
+    for http in created:
+        await http.aclose()
+
+
+async def _call_read_capability(client: HttpCreekVaultClient, capability: str) -> object:
+    """Invoke the client method implementing one of the unratified read capabilities."""
+    if capability == "reflections":
+        return await client.reflect(_ENTRY_BODY, VaultTierCeiling.OPEN)
+    return await client.wheel()
+
+
+async def _handshaken(clients: ClientFactory, recorder: _Recorder) -> HttpCreekVaultClient:
+    """Return a client that has completed a handshake against the derived document."""
+    client = clients(recorder)
+    result = await client.handshake()
+    assert result.available, "the derived capability document must complete a handshake"
+    return client
+
+
+async def _assert_ingest_result(
+    clients: ClientFactory,
+    payload: object,
+    expected: VaultIngestResult,
+) -> None:
+    """Drive one journal upsert against ``payload`` and assert the exact result.
+
+    Shared by the parametrised conformance cells and by the drift-sensitivity
+    test, which feeds it a mutated payload and requires it to raise. That reuse is
+    the point: it proves these assertions read the fields they claim to, rather
+    than accepting whatever the vault happened to answer.
+    """
+    recorder = _Recorder(journal_payload=payload, journal_status=HTTPStatus.OK)
+    client = await _handshaken(clients, recorder)
+
+    assert await client.ingest(_ingest_request()) == expected
+
+
+def _walk_strings(value: object) -> Iterable[str]:
+    """Yield every string appearing as a key or a value anywhere in ``value``."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            yield key
+            yield from _walk_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_strings(item)
+
+
+def _tier_values(value: object) -> Iterable[str]:
+    """Yield every value carried by a tier-bearing field anywhere in ``value``."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key in _TIER_FIELDS and isinstance(item, str):
+                yield item
+            yield from _tier_values(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _tier_values(item)
+
+
+def _vendored_paths() -> frozenset[str]:
+    """Return every vendored path on disk except our own sidecar."""
+    return frozenset(
+        str(path.relative_to(BUNDLE_ROOT))
+        for path in BUNDLE_ROOT.rglob("*")
+        if path.is_file() and path.name != VENDOR_NAME
+    )
+
+
+def _mutated_copy(tmp_path: Path, relative: str, old: str, new: str) -> Path:
+    """Copy the bundle into ``tmp_path`` and rename one field inside one file."""
+    root = tmp_path / "creek_v1"
+    shutil.copytree(BUNDLE_ROOT, root)
+    target = root / relative
+    text = target.read_text(encoding="utf-8")
+    assert old in text, f"{relative} must contain {old} for this mutation to mean anything"
+    target.write_text(text.replace(old, new), encoding="utf-8")
+    return root
+
+
+# --------------------------------------------------------------------------
+# (a) Bundle integrity and provenance
+# --------------------------------------------------------------------------
+
+
+def test_vendor_sidecar_records_the_pinned_provenance() -> None:
+    """The sidecar names the repo, commit, path, and both versions it was cut from."""
+    sidecar = _read_json(VENDOR_NAME)
+    source = sidecar["source"]
+    assert isinstance(source, dict)
+
+    assert sidecar["bundle"] == "adepthood-v1"
+    assert sidecar["contract_version"] == CONTRACT_VERSION
+    assert sidecar["ontology_version"] == ONTOLOGY_VERSION
+    assert source["repo"] == PINNED_REPO
+    assert source["commit"] == PINNED_COMMIT
+    assert source["path"] == PINNED_PATH
+
+
+def test_every_vendored_file_matches_its_recorded_digest() -> None:
+    """A vendored copy is a pin only while its bytes still hash to what we recorded."""
+    recorded = _digests(VENDOR_NAME)
+
+    assert len(recorded) == VENDORED_FILES
+    for path, digest in sorted(recorded.items()):
+        assert _sha256(_read_bytes(path)) == digest, path
+
+
+def test_the_on_disk_file_set_is_exactly_the_recorded_file_set() -> None:
+    """An unrecorded file on disk is as much drift as a changed one."""
+    assert _vendored_paths() == frozenset(_digests(VENDOR_NAME))
+
+
+def test_the_two_manifests_agree_on_every_shared_digest() -> None:
+    """Our sidecar and Creek's manifest must never disagree about the same bytes."""
+    sidecar = _digests(VENDOR_NAME)
+    creek = _digests(MANIFEST_NAME)
+
+    assert len(creek) == CREEK_MANIFEST_ENTRIES
+    assert creek.keys() <= sidecar.keys()
+    for path, digest in sorted(creek.items()):
+        assert sidecar[path] == digest, path
+
+
+def test_the_two_manifests_jointly_cover_every_vendored_path_once() -> None:
+    """Creek's 45 plus the two files it cannot cover are exactly the 47 on disk."""
+    creek = frozenset(_digests(MANIFEST_NAME))
+    uncovered = frozenset({MANIFEST_NAME, README_NAME})
+
+    assert not creek & uncovered
+    assert creek | uncovered == _vendored_paths()
+    assert len(creek) + len(uncovered) == VENDORED_FILES
+
+
+# --------------------------------------------------------------------------
+# (b) Version agreement
+# --------------------------------------------------------------------------
+
+
+def test_contract_version_agrees_across_both_manifests_and_the_domain_pin() -> None:
+    """One version string in three places; any two of them disagreeing is the bug."""
+    assert _read_json(VENDOR_NAME)["contract_version"] == CONTRACT_VERSION
+    assert _read_json(MANIFEST_NAME)["contract_version"] == CONTRACT_VERSION
+    assert CONTRACT_VERSION == "0.2.0"
+
+
+def test_ontology_version_agrees_across_both_manifests() -> None:
+    """The ontology the wire vocabulary is drawn from is pinned the same way."""
+    assert _read_json(VENDOR_NAME)["ontology_version"] == ONTOLOGY_VERSION
+    assert _read_json(MANIFEST_NAME)["ontology_version"] == ONTOLOGY_VERSION
+
+
+# --------------------------------------------------------------------------
+# (c) Conformance, parametrised from the vendored manifest
+# --------------------------------------------------------------------------
+
+
+def test_the_example_matrix_is_the_published_four_by_seven_grid() -> None:
+    """Non-vacuity first: an emptied bundle fails here rather than passing silently."""
+    assert len(_CELLS) == EXAMPLE_CELLS
+    assert len(_CAPABILITIES) == CAPABILITY_COUNT
+    assert len(_STATES) == STATE_COUNT
+    assert len(_CELLS) == CAPABILITY_COUNT * STATE_COUNT
+    assert len(_REACHABLE) == REACHABLE_CELLS
+    assert len(_UNREACHABLE) == UNREACHABLE_CELLS
+
+
+def test_the_parametrised_case_list_covers_every_capability() -> None:
+    """The cases that drive the client must span all four capabilities, not one."""
+    assert _REACHABLE != ()
+    assert frozenset(cell.capability for cell in _REACHABLE) == _CAPABILITIES
+    assert frozenset(cell.state for cell in _REACHABLE) == _STATES
+    assert len(_CAPABILITY_ERROR_CELLS) == len(_ERROR_STATES)
+
+
+def test_only_reflections_publishes_a_reachable_care_escalation() -> None:
+    """The care guard runs in one capability, so the other three cells are sentinels."""
+    assert {cell.capability for cell in _UNREACHABLE} == {
+        "capabilities",
+        "journal-upsert",
+        "wheel",
+    }
+    assert {cell.state for cell in _UNREACHABLE} == {"care-escalation"}
+    assert {cell.model for cell in _UNREACHABLE} == {"NotApplicableExample"}
+
+
+def test_state_status_table_matches_the_manifest() -> None:
+    """The one hand-maintained table must cover exactly the published state axis."""
+    assert frozenset(_STATUS_BY_STATE) == _STATES
+
+
+def test_capability_translation_table_matches_the_manifest() -> None:
+    """The divergence-bridging table must name exactly Creek's four capabilities."""
+    assert frozenset(_CAPABILITY_BY_CREEK_NAME) == _CAPABILITIES
+    assert len(frozenset(_CAPABILITY_BY_CREEK_NAME.values())) == CAPABILITY_COUNT
+
+
+def test_every_published_error_code_has_a_status_and_a_retry_disposition() -> None:
+    """A newly published code must not default silently into an existing branch."""
+    status_by_code: dict[str, int] = {}
+    for cell in _REACHABLE:
+        code = _read_json(cell.path).get("code")
+        if isinstance(code, str):
+            status_by_code.setdefault(code, _STATUS_BY_STATE[cell.state])
+            assert status_by_code[code] == _STATUS_BY_STATE[cell.state], code
+
+    assert status_by_code == {
+        "privacy_refused": HTTPStatus.FORBIDDEN,
+        "invalid_request": HTTPStatus.UNPROCESSABLE_ENTITY,
+        "incompatible_version": HTTPStatus.CONFLICT,
+        "unavailable": HTTPStatus.SERVICE_UNAVAILABLE,
+    }
+    assert frozenset(status_by_code) <= frozenset(_read_json(RETRY_POLICY_NAME))
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "the client reads a top-level 'available' where Creek nests 'vault.available', "
+        "and maps advertised names through CreekCapability, whose creek.* values share "
+        "no member with Creek's published capabilities/journal-upsert/reflections/wheel"
+    ),
+)
+async def test_ratified_capability_documents_are_understood(
+    vault_clients: ClientFactory,
+) -> None:
+    """Creek's own capability documents must handshake to their ratified outcome.
+
+    Both 200 documents are asserted in one test because the two divergences are
+    one behaviour: a client that reads Creek's document natively gets both cells
+    right, and today's client gets the success cell wrong. The empty document
+    happens to reach the ratified answer today, but only because the client never
+    looks at the field that says so.
+    """
+    success = vault_clients(
+        _static_handler(_read_json("examples/capabilities/success.json"), HTTPStatus.OK),
+    )
+    result = await success.handshake()
+
+    assert result.available is True
+    assert result.capabilities == frozenset(_CAPABILITY_BY_CREEK_NAME.values())
+    assert success.supports(CreekCapability.JOURNAL) is True
+    assert success.last_degrade_reason is None
+
+    empty = vault_clients(
+        _static_handler(_read_json("examples/capabilities/empty.json"), HTTPStatus.OK),
+    )
+    empty_result = await empty.handshake()
+
+    assert empty_result.available is False
+    assert empty.last_degrade_reason == HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_observed_capability_success_degrades_to_vault_reported_unavailable(
+    vault_clients: ClientFactory,
+) -> None:
+    """The observed outcome is the divergence, not the contract.
+
+    Creek's ratified success document advertises an available vault and four
+    capabilities. Today's client reports the vault unavailable and supports
+    nothing, and the reason it records is the maximally misleading one: it never
+    reaches the capability list, because the top-level ``available`` key it looks
+    for is absent, so it concludes the vault reported itself unavailable.
+    """
+    client = vault_clients(
+        _static_handler(_read_json("examples/capabilities/success.json"), HTTPStatus.OK),
+    )
+
+    result = await client.handshake()
+
+    assert result.available is False
+    assert result.capabilities == frozenset()
+    assert client.last_degrade_reason == HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
+    assert client.supports(CreekCapability.JOURNAL) is False
+
+
+@pytest.mark.asyncio
+async def test_observed_capability_empty_degrades_to_vault_reported_unavailable(
+    vault_clients: ClientFactory,
+) -> None:
+    """The empty document's observed outcome coincides with its ratified one.
+
+    Creek's uninitialized vault reports ``vault.available`` false and advertises
+    nothing, and the client reports exactly that -- but for the wrong reason,
+    reaching the same conclusion from the absence of a top-level key it would not
+    have read either way.
+    """
+    client = vault_clients(
+        _static_handler(_read_json("examples/capabilities/empty.json"), HTTPStatus.OK),
+    )
+
+    result = await client.handshake()
+
+    assert result.available is False
+    assert result.capabilities == frozenset()
+    assert client.last_degrade_reason == HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cell", _CAPABILITY_ERROR_CELLS, ids=_cell_id)
+async def test_capability_error_states_degrade_as_unreachable(
+    cell: _Cell,
+    vault_clients: ClientFactory,
+) -> None:
+    """Every non-200 capability document degrades the handshake rather than raising.
+
+    All four land on ``UNREACHABLE`` because the client raises for status before
+    reading the body, so Creek's typed error envelope is never consulted. That is
+    the observed behaviour; the envelope is what a fixed client would read.
+    """
+    client = vault_clients(_static_handler(_read_json(cell.path), _STATUS_BY_STATE[cell.state]))
+
+    result = await client.handshake()
+
+    assert result.available is False
+    assert client.last_degrade_reason == HandshakeDegradeReason.UNREACHABLE
+
+
+@pytest.mark.asyncio
+async def test_journal_upsert_success_is_a_created_write(vault_clients: ClientFactory) -> None:
+    """Creek's ratified success body is read as a durable, newly created fragment."""
+    await _assert_ingest_result(
+        vault_clients,
+        _read_json("examples/journal-upsert/success.json"),
+        VaultIngestResult(stored=True, vault_ref=_FRAGMENT_ID, action=VaultIngestAction.CREATED),
+    )
+
+
+@pytest.mark.asyncio
+async def test_journal_upsert_empty_is_an_unchanged_write(vault_clients: ClientFactory) -> None:
+    """Creek's empty state is a stored no-op re-send, not an error and not a loss."""
+    await _assert_ingest_result(
+        vault_clients,
+        _read_json("examples/journal-upsert/empty.json"),
+        VaultIngestResult(stored=True, vault_ref=_FRAGMENT_ID, action=VaultIngestAction.UNCHANGED),
+    )
+
+
+@pytest.mark.asyncio
+async def test_journal_upsert_refusal_is_misreported_as_a_rejected_credential(
+    vault_clients: ClientFactory,
+) -> None:
+    """Creek ratifies this cell as a privacy refusal; the client has no such error.
+
+    ``examples/journal-upsert/refusal.json`` carries ``privacy_refused`` at 403.
+    ``VaultErrorCode`` has no ``privacy_refused`` member, and 403 is in the
+    credential-rejected status set, so the refusal is classified on status alone
+    and surfaces as an auth failure. An operator reading that would go and rotate
+    a credential that was never refused.
+    """
+    recorder = _Recorder(
+        journal_payload=_read_json("examples/journal-upsert/refusal.json"),
+        journal_status=HTTPStatus.FORBIDDEN,
+    )
+    client = await _handshaken(vault_clients, recorder)
+
+    with pytest.raises(CreekVaultAuthError):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("malformed-input", CreekVaultContractError),
+        ("incompatible-version", CreekVaultContractError),
+        ("unavailable-service", CreekVaultUnavailableError),
+    ],
+)
+async def test_journal_upsert_error_states_raise_their_classified_failure(
+    state: str,
+    expected: type[Exception],
+    vault_clients: ClientFactory,
+) -> None:
+    """Each ratified error body is classified into a failure an operator can act on.
+
+    ``unavailable`` is not a ``VaultErrorCode`` member, so the 503 cell is
+    classified from its status class rather than from the code Creek published.
+    """
+    recorder = _Recorder(
+        journal_payload=_read_json(f"examples/journal-upsert/{state}.json"),
+        journal_status=_STATUS_BY_STATE[state],
+    )
+    client = await _handshaken(vault_clients, recorder)
+
+    with pytest.raises(expected):
+        await client.ingest(_ingest_request())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capability", ["reflections", "wheel"])
+async def test_read_capabilities_are_refused_without_any_egress(
+    capability: str,
+    vault_clients: ClientFactory,
+) -> None:
+    """The unratified read capabilities refuse locally, so no request leaves at all.
+
+    The no-egress half is the load-bearing one: refusing after sending would have
+    already put a body on a wire toward a shape nobody has agreed on.
+    """
+    recorder = _Recorder()
+    client = vault_clients(recorder)
+
+    with pytest.raises(CreekCapabilityUnsupportedError):
+        await _call_read_capability(client, capability)
+
+    assert recorder.calls == []
+
+
+def test_reflections_refusal_is_a_privacy_refusal_envelope() -> None:
+    """A refusal is an error envelope carrying a code and no care signal."""
+    refusal = _read_json("examples/reflections/refusal.json")
+
+    assert refusal["code"] == "privacy_refused"
+    assert "care_signal" not in refusal
+    assert "status" not in refusal
+    assert refusal["request_id"] == "req-example-reflections-refusal"
+
+
+def test_reflections_care_escalation_is_a_distinct_escalation_shape() -> None:
+    """An escalation is a 200 care handoff with resources and no error code at all.
+
+    Refusal and escalation are different published shapes at different statuses,
+    which is what stops a client from collapsing "we will not answer this" and
+    "you deserve human support right now" into one degraded path.
+    """
+    escalation = _read_json("examples/reflections/care-escalation.json")
+    signal = escalation["care_signal"]
+    assert isinstance(signal, dict)
+    resources = signal["resources"]
+    assert isinstance(resources, list)
+
+    assert escalation["status"] == "escalate"
+    assert signal["kind"] == "acute_distress"
+    assert resources != []
+    assert "code" not in escalation
+    assert _STATUS_BY_STATE["care-escalation"] != _STATUS_BY_STATE["refusal"]
+
+
+# --------------------------------------------------------------------------
+# (d) Test-of-the-tests: provable drift sensitivity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_renamed_response_field_is_caught_by_checksum_and_by_assertion(
+    tmp_path: Path,
+    vault_clients: ClientFactory,
+) -> None:
+    """Renaming one response field must fail both halves of this gate, not one.
+
+    The checksum half proves the vendored bytes are watched; the assertion half
+    proves the conformance assertions read the fields they claim to. A suite that
+    only checksummed would notice the rename without knowing it mattered, and one
+    that only asserted would never notice upstream moving underneath it.
+    """
+    relative = "examples/journal-upsert/success.json"
+    root = _mutated_copy(tmp_path, relative, '"fragment_id"', '"fragmentId"')
+
+    report = verify_local(root)
+
+    assert [change.path for change in report.changes] == [relative]
+    assert report.changes[0].capability == "journal-upsert"
+    assert report.exit_code == EXIT_DRIFT
+
+    mutated = json.loads((root / relative).read_text(encoding="utf-8"))
+    with pytest.raises(AssertionError, match="stored"):
+        await _assert_ingest_result(
+            vault_clients,
+            mutated,
+            VaultIngestResult(
+                stored=True,
+                vault_ref=_FRAGMENT_ID,
+                action=VaultIngestAction.CREATED,
+            ),
+        )
+
+
+def test_a_renamed_request_parameter_is_caught_by_the_checksum(tmp_path: Path) -> None:
+    """A request-shape change has no response to assert on, so the digest must catch it."""
+    relative = "schemas/JournalUpsertRequest.schema.json"
+    root = _mutated_copy(tmp_path, relative, '"content"', '"entry_content"')
+
+    report = verify_local(root)
+
+    assert [change.path for change in report.changes] == [relative]
+    assert report.changes[0].capability is None
+    assert report.exit_code == EXIT_DRIFT
+
+
+# --------------------------------------------------------------------------
+# (e) Privacy invariants
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cell", _CELLS, ids=_cell_id)
+def test_no_example_names_the_intimate_tier_in_any_tier_field(cell: _Cell) -> None:
+    """Intimate content never egresses, so no published example may route at it."""
+    assert _FORBIDDEN_TIER not in set(_tier_values(_read_json(cell.path)))
+
+
+def test_the_capability_document_publishes_the_two_ceiling_tier_model() -> None:
+    """The tier model is advertised up front, and it admits exactly two ceilings."""
+    tier_model = _read_json("examples/capabilities/success.json")["tier_model"]
+    assert isinstance(tier_model, dict)
+
+    assert tier_model["ceilings"] == ["open", "personal"]
+    assert tier_model["intimate_never_egresses"] is True
+    assert tier_model["default"] == "open"
+
+
+@pytest.mark.parametrize("relative", sorted(_vendored_paths()))
+def test_no_vendored_file_carries_a_credential_shaped_value(relative: str) -> None:
+    """A published contract bundle must contain no key, token, or bearer header."""
+    text = _read_bytes(relative).decode("utf-8")
+
+    for marker in _CREDENTIAL_MARKERS:
+        assert marker not in text, f"{relative} carries {marker}"
+
+
+@pytest.mark.parametrize("cell", _CELLS, ids=_cell_id)
+def test_example_prose_is_bounded_synthetic_text_not_a_journal_body(cell: _Cell) -> None:
+    """No example may carry real writing, expressed as two checkable bounds.
+
+    A journal body would travel under a ``content`` or ``body`` key, and would be
+    longer than any string Creek actually publishes -- the longest is its
+    201-character care message.
+    """
+    payload = _read_json(cell.path)
+    longest = max(len(item) for item in _walk_strings(payload))
+
+    assert not any(key in payload for key in _BODY_KEYS)
+    assert longest <= _MAX_EXAMPLE_STRING
+
+
+def test_the_reflection_example_is_labelled_synthetic_prose() -> None:
+    """The one example carrying note text says in the text itself that it is synthetic."""
+    notes = _read_json("examples/reflections/success.json")["notes"]
+    assert isinstance(notes, list)
+    note = notes[0]
+    assert isinstance(note, dict)
+
+    assert str(note["note"]).startswith("Synthetic example prose.")
+    assert note["quote"] == "I keep saying yes to things I do not want"
+    assert note["kind"] == "pattern"
+
+
+def test_the_bundle_root_is_this_directorys_vendored_fixture_tree() -> None:
+    """The drift script and this suite must read the same vendored bundle."""
+    assert BUNDLE_ROOT.resolve() == (Path(__file__).parent / "fixtures" / "creek_v1").resolve()

--- a/docs/adr/0004-creek-vault-http-application-boundary.md
+++ b/docs/adr/0004-creek-vault-http-application-boundary.md
@@ -5,7 +5,9 @@
 - **Issue:** [#2044](https://github.com/Geoffe-Ga/adepthood/issues/2044)
   (epic [#2043](https://github.com/Geoffe-Ga/adepthood/issues/2043))
 - **Pinned contract version:** 0.2.0 (tracks Creek's published
-  constant; /v1 PENDING creek-vault#1072)
+  constant; see the 2026-07-31 note at the end of this document — the
+  `/v1` bundle creek-vault#1072 tracked has since shipped and is now
+  vendored, and it publishes this same 0.2.0)
 
 ## Context
 
@@ -336,3 +338,58 @@ change without the other two.
 - No confidential-compute work is unblocked, advanced, or implied by
   this ADR (Decision 6); #958 and creek-vault#757 remain exactly where
   they were.
+
+## Note, 2026-07-31 — creek-vault#1072 shipped; the bundle is vendored
+
+This ADR was written while creek-vault#1072 was open and had published
+nothing, which is why every `/v1` shape above is marked **PENDING
+creek-vault#1072**. That issue has since closed. Creek now publishes a
+generated, byte-deterministic contract bundle at
+`docs/contracts/adepthood-v1/` — 16 JSON Schemas, a
+`retry-policy.json` disposition table over nine error codes, a
+four-capability by seven-state example matrix, and a `manifest.json`
+recording a sha256 per generated file — behind its own ADR,
+`docs/decisions/2026-07-31-adepthood-http-application-api.md`.
+
+Three facts this ADR asserted are therefore now out of date, and are
+recorded here rather than edited in place so the reasoning above stays
+readable as what was known at the time:
+
+1. "creek-vault#1072 is open and has shipped nothing" (Context) is no
+   longer true, and neither is Decision 5's forward-looking phrasing
+   about the ratified document arriving later. It has arrived.
+2. The published bundle advertises `contract_version` **0.2.0** — the
+   same value Decision 3 pins, and the same value
+   `domain/creek_vault.py` carries. The pin needs no change. Decision
+   3's refusal to guess a number is vindicated rather than overtaken.
+3. Every "PENDING creek-vault#1072" resolution in the divergence table
+   now has a real ratified shape to resolve against. Replacing those
+   cells is deliberately **not** done in this note: the owning issues
+   named in that table's last column own both the shape and the client
+   change, and a resolution written here ahead of the code would be
+   the same mirroring this ADR exists to end.
+
+The bundle is vendored byte-for-byte at a pinned upstream commit under
+`backend/tests/fixtures/creek_v1/`, with a `vendor.json` sidecar
+recording the source repository, commit, path, versions and a sha256
+per file. An offline test asserts the vendored bytes still hash to
+their recorded digests and that the vendored set is exactly the
+recorded set; a scheduled workflow re-fetches the bundle and fails when
+upstream no longer matches, naming the capability that moved. Neither
+check may report success for a run that compared nothing.
+
+Vendoring the bundle does **not** by itself close any divergence. The
+conformance suite that reads it records, as executable assertions, that
+today's HTTP client cannot complete a handshake against Creek's own
+ratified capability document at all: it reads a top-level `available`
+where Creek nests `vault.available`, and it maps advertised capability
+names through an enum whose `creek.*` values share no member with
+Creek's published `capabilities`/`journal-upsert`/`reflections`/`wheel`.
+A third divergence sits in the error vocabulary — Creek's
+`privacy_refused` is not a `VaultErrorCode` member, so a privacy
+refusal served at 403 is classified on status alone and surfaces as a
+rejected credential. Fixing all three belongs to the issues named in
+the divergence table.
+
+Nothing in Decision 6 changes. This note is a factual correction and a
+pointer to the vendored bundle; it revises no decision.

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -30,19 +30,41 @@ Do not restate Creek's request/response shapes here — that mirroring
 is what let this document and Creek's real server drift apart, which
 ADR 0004's Context section documents in detail. Instead:
 
-- Creek's ratified, canonical `/v1` contract is tracked in
-  creek-vault#1072. As of this writing that issue is **open and has
-  shipped nothing** — treat any `/v1` shape as **PENDING
-  creek-vault#1072** until it ships.
-- Until `/v1` ships, Creek's own published reference is
-  `docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md` in the
-  `Geoffe-Ga/creek-vault` repository. Read that document, and Creek's
-  actual server code (`creek-tools/creek_mcp/contract.py`,
-  `server.py`, `tools/reflect.py`, `tools/wheel.py`), for the
-  authoritative shapes — not this file.
-- The version this document pins against is Creek's currently
-  published `CONTRACT_VERSION` constant (`creek-tools/creek_mcp/contract.py:18`),
-  not a guess at what `/v1` will eventually say.
+- Creek's ratified, canonical `/v1` contract **has shipped**
+  (creek-vault#1072, closed). It is published as a generated bundle at
+  `docs/contracts/adepthood-v1/` in the `Geoffe-Ga/creek-vault`
+  repository: 16 JSON Schemas, a `retry-policy.json` disposition
+  table, a four-capability by seven-state example matrix, and a
+  `manifest.json` recording a sha256 per generated file. Creek's ADR
+  `docs/decisions/2026-07-31-adepthood-http-application-api.md` is the
+  decision behind it. That bundle — not this file, and no longer
+  Creek's server code read by hand — is the authoritative source for
+  every `/v1` request and response shape.
+- Adepthood **vendors** that bundle byte-for-byte at a pinned upstream
+  commit, under `backend/tests/fixtures/creek_v1/`, alongside a
+  `vendor.json` sidecar recording the source repository, commit, path,
+  contract version, ontology version, and a sha256 per vendored file.
+  Copy-and-pin is upstream's own prescribed integration, and it is
+  what lets adepthood's tests assert against Creek's real bytes
+  instead of against a second, independently-editable mirror — the
+  mirroring that produced the divergences ADR 0004's Context section
+  documents.
+- Two checks keep the copy honest, and both fail loudly rather than
+  quietly: an offline test asserts every vendored file still hashes to
+  its recorded digest and that the vendored set is exactly the
+  recorded set, and a scheduled workflow re-fetches the bundle from
+  upstream and fails when it no longer matches, naming the capability
+  that moved. Neither is allowed to report success for a run that
+  compared nothing. The re-vendor procedure lives in the module
+  docstring of `backend/tests/test_creek_contract_conformance.py`.
+- The MCP surface is unaffected: Creek's `creek-tools/creek_mcp/`
+  server remains the agent-facing adapter and remains what adepthood's
+  shipped MCP client talks to. The bundle describes `/v1` only.
+- The version this document pins against is Creek's published
+  `CONTRACT_VERSION`, which the vendored bundle's `manifest.json`
+  restates and which
+  `backend/tests/test_creek_contract_conformance.py` asserts equal to
+  `domain/creek_vault.py`'s constant.
 
 ## Shared ontology and tier mapping (adepthood-owned)
 


### PR DESCRIPTION
## Summary

The two repos each tested against their own idea of the shared contract, so both CI suites stayed green while the integration was completely non-functional. This vendors Creek's published `/v1` contract bundle and builds the machinery that turns that class of silent divergence into a red build.

**Upstream has shipped.** `creek-vault#1072` is closed. `docs/contracts/adepthood-v1/` exists and is a generated, byte-deterministic bundle: 16 JSON Schemas, a `retry-policy.json` disposition table over nine error codes, a four-capability by seven-state example matrix, and a `manifest.json` recording a sha256 per generated file. **Nothing vendored here is PENDING** — every wire shape asserted in this PR is read out of bytes Creek actually publishes, and the pinned `contract_version` the bundle advertises is `0.2.0`, exactly what `domain/creek_vault.py` already carries.

- **Vendored** all 47 files byte-for-byte at creek-vault commit `879d9611`, the commit that last wrote the bundle path, plus a generated `vendor.json` sidecar recording source repo, commit, path, both versions, and a sha256 per file. Copy-and-pin is upstream's own prescribed integration, not an invention here.
- **`backend/scripts/creek_contract_drift.py`** owns bundle semantics. `verify_local` hashes the bytes on disk against `vendor.json` and flags any file nobody recorded — offline, network-free, and it runs in the normal suite on every PR. `compare_upstream` asks whether Creek still publishes those bytes.
- **`backend/tests/test_creek_contract_conformance.py`** drives the real `HttpCreekVaultClient` through `httpx.MockTransport` against every published example, with the 28-cell matrix built from the manifest rather than a written list.
- **`.github/workflows/creek-contract-drift.yml`** re-fetches weekly. Scheduled and manual only — a PR check on the live network would make every build depend on a third party and turn an upstream outage into a merge blocker.

### What the conformance suite found

Against Creek's own ratified `capabilities/success.json`, today's HTTP adapter reports `available=False` with an empty capability set, so `ingest`, `reflect` and `wheel` all refuse. The adapter cannot talk to Creek at all. Three causes, none of them fixed here:

1. The client reads a top-level `available`; Creek nests it as `vault: {"available": true}`. It short-circuits before reading capabilities, so the degrade reason it records is the maximally misleading `vault_reported_unavailable` — it says the vault reported itself down when the vault said the opposite.
2. `CreekCapability`'s values are `creek.*`; Creek advertises `capabilities`/`journal-upsert`/`reflections`/`wheel`. **Zero overlap**, so the capability set parses empty.
3. `VaultErrorCode` has no `privacy_refused`, and 403 is in the credential-rejected status set — so a privacy refusal surfaces as an auth failure and would send an operator to rotate a key that was never refused.

A sibling lane owns `services/creek_vault_client.py` and every `test_creek_vault_*` module, so fixing these is out of scope. (1) and (2) are asserted under a strict xfail; `xfail_strict` is repo-wide, so it executes every run and **turns hard-red the moment it starts passing** — which is exactly when the client is fixed and the marker must be deleted. Each is paired with a plainly-asserted, today-green observation of the actual behaviour. (3) is asserted outright.

For the same reason this PR does **not** touch the issue's "replace hand-written fixtures in existing vault test modules" task, per its own budget escape hatch.

### The failure mode this was designed against

A gate that passes because it did nothing. Exit `0` clean / `1` drift / `2` unverifiable, and a fetch that raised, a body that is not JSON, a body over the size cap, a manifest listing no files, and a run that compared nothing are **all exit 2**, never exit 0. The clean report names how many files it compared, so "checked nothing" cannot render like "checked everything". `render_report` on an empty report names its own cause instead of borrowing the clean wording. The conformance parametrisation asserts 4 capabilities x 7 states = 28 cells before anything else runs.

Creek's manifest is untrusted input that becomes filesystem reads and CI log lines, so every entry is validated before use — printable ASCII, no parent segment or backslash, not absolute, digest exactly 64 lowercase hex — with file-count and per-body caps, and a refused entry is reported by position rather than by echoing its own bytes. The body is streamed and the cap checked per chunk, so it ends the transfer rather than refusing what already arrived. `snapshot` writes no file at all, so there is no manifest-driven write path to traverse.

## Test plan

- `./scripts/backend/check-all.sh` — exit 0, 7 passed / 0 failed.
- Full backend suite: **3980 passed, 2 skipped, 1 xfailed**, total coverage 97.16%.
- New suites: **194 passed, 1 xfailed, zero xpass** (the one xfail is the tripwire).
- `backend/scripts/creek_contract_drift.py`: **100% line and branch** coverage; xenon A/A/A; radon MI **A (39.04)**.
- `pre-commit run` clean on every touched file; `detect-secrets` re-baselined over the two generated digest manifests rather than suppressed inline.

**Live end-to-end evidence, not just unit tests.** Run against the real upstream today:

```
$ python -m scripts.creek_contract_drift compare
Creek contract drift: none. 47 vendored file(s) match the recorded digests.
exit=0
```

And the negative control, pointed at creek-vault's pre-regeneration commit `f9d62ee2`:

```
Creek contract drift: 8 vendored files do not match the record.
  manifest.json (no capability): recorded 75517971... / observed 829bf3f4...
  schemas/CapabilitiesResponse.schema.json ...
  [6 more]
Fix: re-vendor the bundle at the new upstream commit, regenerate the sidecar ...
exit_code = 1
```

Those are exactly the files upstream's own commit message says it changed ("Descriptions and sha256s only"). The gate detects real drift against real upstream bytes.

Drift sensitivity is also demonstrated in-suite: renaming a response field in a copied bundle must fail **both** the checksum and the very assertion helper the conformance cells use, and renaming a request parameter in a schema must fail the checksum. A gate never shown to catch its target is not evidence.

## Notes for the reviewer

- The strict xfail is deliberate and will **detonate** when the sibling lane fixes the client. That is the design, not flakiness: the fixing PR deletes the marker, `_CAPABILITY_BY_CREEK_NAME` and `_client_readable_capabilities` together. All three carry ALL-CAPS delete-don't-generalise labels at their definition sites.
- `compare_upstream` trusts the digests inside Creek's fetched manifest for 45 of 47 files, independently fetching and hashing only `manifest.json` and `README.md`. This is upstream's explicitly documented recommended integration ("Integrity: pin the manifest hash, not the files"), backed by Creek CI enforcing that its bundle cannot drift from the models that generate it.
- ADR 0004 gets an **appended dated note** rather than an in-place rewrite, following the change-control rule the ADR sets for itself. It deliberately does not resolve the divergence table — the issues named in that table's last column own both the ratified shape and the client change.
- The `.secrets.baseline` diff includes a `^backend/content/` filter entry. That is not scope creep: `.pre-commit-config.yaml` already carries that exact exclusion on the hook, and the regeneration merely caught the baseline's metadata up to it.

## Graph

skipped: `graphify-out` absent in this fresh worktree.

Closes #2048
Refs #2043
