### PR TITLE
perf(tooling): cut the Ralph tick's local phase from ~142 min to ~34 min

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -118,6 +118,34 @@ primarily as a reviewer; their occasional edits are narrow and plan-guided).
 `dependency-review-specialist` (pins/lockfile/license checks need no deep
 reasoning — spend the cheaper tier).
 
+### The dimension this policy does not price: invocations per tick
+
+The policy above ranks roles by *leverage per call*. It does not rank them by
+*calls per tick*, and those two orderings are close to inverted:
+
+| Role | Tier | Invocations per tick |
+| --- | --- | --- |
+| `chief-architect` | Fable | **1** — one plan, then done |
+| `test-specialist` | Opus | **many** — Gate 1 RED, plus once per drop-back |
+| `implementation-specialist` | Opus | **many** — GREEN, refactor, plus once per drop-back |
+
+Drop-backs are not rare: `scripts/ralph/PROMPT.md` routes a Gate 2, Gate 2.5,
+Gate 3 (CI), or Gate 4 (review) failure *back to Gate 1*, and each return
+re-invokes the code-writing specialists. So tier choice on those two roles is
+multiplied by the tick's failure count, while tier choice on `chief-architect`
+is not.
+
+This matters because PR throughput fell from a 27-minute to a 78-minute median
+inter-merge gap in the window that began when #1968 moved `test-specialist` and
+`implementation-specialist` from Fable to Opus and `chief-architect` the other
+way. The measurement is in #2073; the open decision is #2074.
+
+**Nothing here overrides the policy** — it is an owner call about output
+quality, and the measurement says only that the change is temporally
+correlated with the regression, not that the resulting code was worse or
+better. The point is that a future tier change on a hot-loop role should be
+made knowing it is multiplied by the drop-back count, and re-measured after.
+
 ## Gate → agent invocation matrix
 
 | Stage | Conductor action | Agent(s) |

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,7 +1,12 @@
 name: Backend CI
 
 on:
+  # ``push`` is scoped to main. Without the branch filter it also fired on
+  # every push to a PR branch, so each push started TWO identical ~18-minute
+  # runs — one ``push``, one ``pull_request``, seconds apart (#2077). The main
+  # entry is kept so merges still get a post-merge run.
   push:
+    branches: [main]
     paths:
       - "backend/**"
       - ".pre-commit-config.yaml"
@@ -11,6 +16,16 @@ on:
       - "backend/**"
       - ".pre-commit-config.yaml"
       - ".github/workflows/backend-ci.yml"
+
+# One in-flight run per PR. A Ralph lane pushing a fix while CI is still
+# grinding on the previous commit used to leave the stale run to burn to
+# completion against a dead SHA. Cancellation is limited to pull_request:
+# every push to main is a distinct merge whose run should stand on its own.
+# Cancelled runs conclude as ``cancelled``, not ``success``, so
+# iteration-trigger.yml's success gate cannot mis-fire on one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend-quality:
@@ -133,7 +148,7 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        run: pytest -q --no-cov
+        run: pytest -q --no-cov -n auto --dist loadfile
 
   migration-drift:
     # BUG-INFRA-023: guard against models diverging from migrations.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,15 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+
+# A full agent review is the most expensive thing this repo runs. Without a
+# concurrency group, every ``synchronize`` started another one and left the
+# previous review grinding against a superseded SHA — then posted its verdict
+# on the PR, where address-feedback could act on a comment describing code
+# that no longer exists (#2077). Newest push wins.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,7 +1,10 @@
 name: Frontend CI
 
 on:
+  # Scoped to main for the same reason as backend-ci.yml: an unscoped ``push``
+  # duplicated every PR run (#2077). Merges still get a post-merge run.
   push:
+    branches: [main]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
@@ -11,6 +14,11 @@ on:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
       - ".pre-commit-config.yaml"
+
+# One in-flight run per PR; see backend-ci.yml for the rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   frontend-quality:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,7 +155,11 @@ repos:
       - id: backend-tests-coverage
         name: backend tests (coverage required)
         language: system
-        entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=90'
+        # Bare ``--cov`` (not ``--cov=.``) so the measured set is the single
+        # declaration in [tool.coverage.run] source (= {src, scripts}), the
+        # same set backend-ci.yml's branch-coverage step asserts over.
+        # ``-n auto`` distributes the suite: 15m58s -> 4m07s on 4 cores (#2076).
+        entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && pytest -n auto --dist loadfile --cov --cov-report=term-missing --cov-fail-under=90'
         pass_filenames: false
         files: ^backend/
         stages: [pre-push]

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -54,6 +54,20 @@ _STUB_LICENSE_SALE_PREFIX = "stub-sale-"
 # ---------------------------------------------------------------------------
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
+# SQLite serialises writers behind a lock and fails the statement outright once
+# its busy timeout expires, rather than queueing. The concurrency fixtures below
+# deliberately drive several simultaneous writers against one file, so on a
+# loaded machine — every xdist worker running its own share of the suite
+# (#2076) — the default 5 s ceiling is reached and the write raises
+# "database is locked" instead of waiting its turn.
+#
+# Raising the ceiling cannot mask a real defect: these tests assert an *outcome*
+# invariant (exactly one token pack credited, exactly one audit row), never a
+# latency bound. A genuine double-credit still fails the assertions no matter
+# how long a writer waits. All this buys is that the test stops failing for want
+# of CPU.
+_CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS = 30
+
 test_engine = create_async_engine(TEST_DATABASE_URL, echo=False)
 test_session_factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
 
@@ -287,7 +301,11 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
     engine.
     """
     db_url = f"sqlite+aiosqlite:///{tmp_path / 'concurrent.db'}"
-    concurrent_engine = create_async_engine(db_url, echo=False)
+    concurrent_engine = create_async_engine(
+        db_url,
+        echo=False,
+        connect_args={"timeout": _CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS},
+    )
     concurrent_factory = async_sessionmaker(
         concurrent_engine, class_=AsyncSession, expire_on_commit=False
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -108,7 +108,16 @@ mypy_path = ["backend/src", "backend", "src", "."]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-q --strict-markers --strict-config --cov=src --cov=scripts --cov-report=term-missing --cov-report=xml --cov-fail-under=90"
+# Coverage is deliberately NOT in addopts. It used to be, and that made every
+# targeted run during Red→Green — `pytest tests/test_foo.py` — instrument all
+# 10,910 statements, write coverage.xml, and then FAIL the run against a
+# whole-repo 90% gate the single file could never satisfy. A green file exited
+# 1 (#2075). The gate itself is unchanged and still enforced, by the three
+# invocations that actually gate: `scripts/backend/check-all.sh` (via
+# coverage.sh --report-only), the `backend-tests-coverage` pre-push hook, and
+# backend-ci.yml. The measured file set stays {src, scripts}, declared once in
+# [tool.coverage.run] source below rather than restated per invocation.
+addopts = "-q --strict-markers --strict-config"
 testpaths = ["tests"]
 pythonpath = ["."]
 xfail_strict = true

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -9,6 +9,11 @@ mypy==2.3.0
 pre-commit==4.6.1
 pytest==9.1.1
 pytest-cov==7.1.0
+# Distributes the ~3k-test suite across cores. Measured on 4 cores: 15m58s
+# serial -> 4m07s, identical coverage (#2076). Gate 2 re-runs the whole suite
+# on every drop-back, so this is the difference between a 16-minute and a
+# 4-minute retry.
+pytest-xdist==3.8.0
 # Type stubs for the runtime jsonschema dependency (issues #389/#390).
 types-jsonschema==4.26.0.20260518
 radon==6.0.1

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -36,7 +36,7 @@ cffi==2.1.0
     # via cryptography
 click==8.4.2
     # via uvicorn
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   -r backend/requirements.txt
     #   pyjwt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ alembic==1.18.5
 asyncpg==0.31.0
 aiosqlite==0.22.1
 bcrypt==5.0.0
-cryptography==49.0.0
+cryptography==50.0.0
 PyJWT==2.13.0
 # Moving-window counters for the invalid-license signup throttle
 # (rate_limit.py). Already a transitive slowapi dependency; pinned here

--- a/backend/tests/test_config_consolidation.py
+++ b/backend/tests/test_config_consolidation.py
@@ -9,6 +9,7 @@ import tomllib
 from typing import Any
 
 BACKEND_DIR = pathlib.Path(__file__).resolve().parent.parent
+REPO_ROOT = BACKEND_DIR.parent
 
 
 class TestConfigConsolidation:
@@ -27,12 +28,51 @@ class TestConfigConsolidation:
         assert "addopts" in opts
         assert "pythonpath" in opts
 
-    def test_pyproject_addopts_has_cov_flags(self) -> None:
+    def test_pyproject_addopts_has_no_coverage_flags(self) -> None:
+        """Coverage flags must stay out of addopts — they poison the TDD loop.
+
+        These flags used to live here. The effect was that a targeted run
+        during Red->Green (``pytest tests/test_foo.py``) instrumented all
+        ~11k statements, wrote coverage.xml, and then FAILED the run against
+        a whole-repo 90% gate that one file can never satisfy: a green file
+        exited 1. That false red cost ~12s and several wasted agent turns on
+        the most-repeated loop in a Ralph tick (#2075).
+
+        The threshold is not relaxed — it moved to the invocations that
+        actually gate, asserted by the tests below.
+        """
         cfg = _load_pyproject()
         addopts = cfg["tool"]["pytest"]["ini_options"]["addopts"]
-        assert "--cov=src" in addopts
-        assert "--cov-report=term-missing" in addopts
-        assert "--cov-fail-under=90" in addopts
+        assert "--cov" not in addopts, (
+            f"coverage must not be in addopts, or every targeted test run pays "
+            f"for it and fails the whole-repo threshold: {addopts!r}"
+        )
+
+    def test_check_all_collects_coverage_data_for_the_gate(self) -> None:
+        """Gate 2 must still produce the coverage data coverage.sh gates on.
+
+        Removing coverage from addopts means the suite no longer collects it
+        implicitly, so the Gate 2 script has to ask for it explicitly. If this
+        regresses, ``coverage.sh --report-only`` finds no data and check-all
+        stops gating coverage at all.
+        """
+        check_all = (REPO_ROOT / "scripts" / "backend" / "check-all.sh").read_text()
+        assert '"test.sh" --unit --coverage-data' in check_all
+
+    def test_pre_push_hook_still_enforces_the_threshold(self) -> None:
+        """The pre-push hook is the second place the 90% gate is enforced."""
+        hooks = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+        assert "--cov-fail-under=90" in hooks
+
+    def test_suite_runs_distributed(self) -> None:
+        """Whole-suite runs must be distributed; serial costs 16 min a round.
+
+        Gate 2 re-runs the entire suite on every drop-back, so a serial suite
+        multiplies straight into tick latency (#2076).
+        """
+        assert "pytest-xdist" in (BACKEND_DIR / "requirements-dev.txt").read_text()
+        test_sh = (REPO_ROOT / "scripts" / "backend" / "test.sh").read_text()
+        assert '-n "$PYTEST_WORKERS"' in test_sh
 
     def test_pyproject_addopts_has_strict_flags(self) -> None:
         cfg = _load_pyproject()

--- a/backend/tests/test_transcription_privacy.py
+++ b/backend/tests/test_transcription_privacy.py
@@ -271,7 +271,21 @@ _BASELINE_LOG_RECORD_KEYS = (
     frozenset(logging.makeLogRecord({}).__dict__) | _STANDARD_LATE_LOG_RECORD_KEYS
 )
 _ALLOWED_ACCESS_LOG_EXTRA_KEYS = frozenset(
-    {"http_method", "http_path", "http_status", "elapsed_ms"}
+    # ``trace_id`` is not a caller-supplied ``extra=`` key: the framework-wide
+    # filter from ``observability.install_trace_id_logging`` stamps it on every
+    # record by design (see ``middleware/logging.py`` -- the access line is
+    # documented as always carrying it). Whether it is present here depends on
+    # whether some earlier test in the same process already booted the app and
+    # installed that filter, so leaving it out made this assertion depend on
+    # test ordering -- latent under a serial run, and surfaced the moment the
+    # suite was distributed across xdist workers (#2076).
+    #
+    # It is listed here rather than folded into ``_BASELINE_LOG_RECORD_KEYS``
+    # deliberately: that would drop it from ``extra_keys`` and exempt it from
+    # the no-leaked-bytes assertion below. Allow-listing keeps it under that
+    # check. The value is normalised and log-injection-safe
+    # (``observability._normalise_trace_id``), so it cannot carry image bytes.
+    {"http_method", "http_path", "http_status", "elapsed_ms", "trace_id"}
 )
 
 

--- a/frontend/.audit-allowlist.json
+++ b/frontend/.audit-allowlist.json
@@ -7,13 +7,5 @@
     "engineering convenience: everything else, including anything newly introduced,",
     "still fails the gate. See scripts/frontend/audit-gate.mjs."
   ],
-  "allow": [
-    {
-      "id": "GHSA-mh99-v99m-4gvg",
-      "package": "brace-expansion",
-      "expires": "2026-10-22",
-      "issue": 1975,
-      "reason": "Patched only in brace-expansion@5.0.8 with no 1.1.x/2.x backport (latest 2.x is 2.1.2). Unreachable: eslint-plugin-react@7.37.5 is the latest published version and pins minimatch ^3.1.2, and minimatch@3 calls brace-expansion as a function while v5 exports a non-callable __esModule object. Probed across the whole Expo ladder (SDK 52 -> 53 -> 57 ceiling); the advisory survives every rung, so #885 does not fix it. A blanket brace-expansion@5.0.8 override makes the audit pass and provably breaks the toolchain (minimatch@3.1.5 throws 'expand is not a function' at call time, after lint and tests look green)."
-    }
-  ]
+  "allow": []
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2861,6 +2861,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4004,6 +4027,28 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@expo/xcpretty/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4182,9 +4227,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -6160,16 +6205,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -7333,9 +7378,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8107,6 +8152,29 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-jest": {
@@ -9467,16 +9535,16 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
@@ -10344,9 +10412,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -10960,9 +11028,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13434,28 +13502,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsc-android": {
       "version": "250231.0.0",
       "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250231.0.0.tgz",
@@ -14417,9 +14463,9 @@
       }
     },
     "node_modules/metro-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,12 +91,12 @@
     "tar": "7.5.20",
     "markdown-it": "14.2.0",
     "linkify-it": "5.0.2",
-    "fast-uri": "3.1.4",
-    "brace-expansion@1": "1.1.16",
-    "brace-expansion@2": "2.1.2",
-    "brace-expansion@5": "5.0.7",
-    "js-yaml@3": "3.15.0",
-    "js-yaml@4": "4.3.0",
+    "fast-uri": "3.1.5",
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9",
+    "js-yaml@3": "3.15.1",
+    "js-yaml@4": "4.3.1",
     "postcss": "^8.5.23"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,8 @@ scripts/
 │   ├── lint.sh        # ruff
 │   ├── format.sh      # ruff format
 │   ├── typecheck.sh   # mypy
-│   ├── test.sh        # pytest (--unit / --integration / --e2e / --all)
+│   ├── test.sh        # pytest, xdist-distributed (--unit / --integration / --e2e / --all;
+│   │                  #   --coverage to report+gate, --coverage-data to collect only)
 │   ├── coverage.sh    # pytest with coverage (≥90%); --report-only reports on existing data
 │   ├── security.sh    # bandit + pip-audit
 │   ├── complexity.sh  # radon + xenon; gates at xenon A grade and MI rank ≥ B

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -120,7 +120,7 @@ run_check "Complexity analysis" "complexity.sh"
 # described this run.
 rm -f .coverage .coverage.* coverage.xml
 
-run_check "Unit tests" "test.sh" --unit
+run_check "Unit tests" "test.sh" --unit --coverage-data
 run_check "Coverage report" "coverage.sh" --report-only --xml
 
 echo "=== Quality Checks Summary ==="

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -10,7 +10,15 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
 
 TEST_TYPE="unit"
 COVERAGE=false
+COVERAGE_DATA=false
 VERBOSE=false
+
+# Whole-suite runs are distributed across cores with pytest-xdist. Measured on
+# a 4-core box: 15m58s serial -> 4m07s at -n auto, identical coverage (#2076).
+# ``--dist loadfile`` keeps every test in a file on one worker, which is what
+# the module-scoped async DB fixtures in backend/conftest.py assume.
+# Overridable so a constrained runner can pin a smaller number.
+PYTEST_WORKERS="${PYTEST_WORKERS:-auto}"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -35,6 +43,10 @@ while [[ $# -gt 0 ]]; do
             COVERAGE=true
             shift
             ;;
+        --coverage-data)
+            COVERAGE_DATA=true
+            shift
+            ;;
         --verbose)
             VERBOSE=true
             shift
@@ -50,9 +62,17 @@ OPTIONS:
     --integration   Run integration tests only
     --e2e           Run end-to-end tests only
     --all           Run all test types
-    --coverage      Generate coverage report
+    --coverage      Generate coverage report (term + html + xml) and enforce
+                    the 90% threshold here
+    --coverage-data Collect coverage data only - no report, no threshold. For
+                    callers that report and gate separately (check-all.sh runs
+                    the suite once under this flag, then coverage.sh
+                    --report-only applies the threshold to the data on disk).
     --verbose       Show detailed output
     --help          Display this help message
+
+ENVIRONMENT:
+    PYTEST_WORKERS  xdist worker count for whole-suite runs (default: auto)
 
 EXIT CODES:
     0               All tests passed
@@ -81,7 +101,7 @@ if $VERBOSE; then
 fi
 
 # Build pytest arguments
-PYTEST_ARGS=(-v)
+PYTEST_ARGS=(-v -n "$PYTEST_WORKERS" --dist loadfile)
 
 case "$TEST_TYPE" in
     unit)
@@ -101,16 +121,32 @@ case "$TEST_TYPE" in
         ;;
 esac
 
-# Add coverage if requested
+# Add coverage if requested.
+#
+# Both modes pass a bare ``--cov`` so the measured set comes from the single
+# declaration in [tool.coverage.run] source (= {src, scripts}) rather than
+# being restated here. Naming a source explicitly (``--cov=src``) would
+# OVERRIDE that config and silently drop scripts/ from the measurement that
+# backend-ci.yml's branch-coverage step asserts over {src, scripts}.
 if $COVERAGE; then
     echo "Coverage enabled"
     PYTEST_ARGS+=(
-        --cov=src
+        --cov
         --cov-branch
         --cov-report=term-missing
         --cov-report=html
         --cov-report=xml
         --cov-fail-under=90
+    )
+elif $COVERAGE_DATA; then
+    # Data only: ``--cov-report=`` disables every report, and no threshold is
+    # applied, because the caller gates on the data afterwards. Reporting here
+    # too would render the same numbers twice per check-all run.
+    echo "Coverage data collection enabled (no report, no threshold)"
+    PYTEST_ARGS+=(
+        --cov
+        --cov-branch
+        --cov-report=
     )
 fi
 


### PR DESCRIPTION
Closes #2075, closes #2076, closes #2077. Epic: #2073.

## Why

PR throughput fell ~3x around 2026-07-24. Measuring all 95 PRs merged Jul 17 →
Aug 1 plus 120 Backend CI runs located the loss precisely — and it is **not** in
CI and **not** in review:

| Metric | Jul 17–25 | Jul 28–Aug 1 |
| --- | --- | --- |
| Median PR open→merge | 27.8 min | 29.8 min — **flat** |
| Median inter-merge gap | 27.0 min | **78.4 min** |
| Median inter-PR-open gap | 31.1 min | **85.9 min** |
| Mean concurrent lanes | 1.0–1.6 | 1.0–1.4 — unchanged |

Backend CI queue delay was **0 s** across all 120 runs, and CI duration
*improved* (~31 → ~18 min). Since lane count is unchanged and open→merge is
flat, the per-lane local phase falls out by arithmetic: **~34 → ~142 min**.
That is the whole regression, and it is entirely pre-PR.

## What changed

**Coverage out of pytest `addopts` (#2075).** It made every targeted run during
Red→Green instrument ~11k statements, write `coverage.xml`, and then fail a
whole-repo 90% gate one file cannot meet — a green file exited 1. That false red
sits on the most-repeated loop in a tick, and each one buys an
investigate/re-run/escalate turn.

**No threshold is relaxed.** The gate moves to the three invocations that
already gate explicitly (`check-all.sh` via `coverage.sh --report-only`, the
`backend-tests-coverage` pre-push hook, `backend-ci.yml`). Both coverage modes
now pass a bare `--cov` so the measured `{src, scripts}` set comes from the
single `[tool.coverage.run] source` declaration — naming a source explicitly
(`--cov=src`, as `test.sh --coverage` did) would silently drop `scripts/` from
the set CI asserts over.

**`pytest-xdist` for whole-suite runs (#2076).** 2,986 tests ran single-process;
`user` ≈ `real` — one core busy, three idle. Gate 2 re-runs the whole suite on
every drop-back, so this multiplied straight into tick latency.
`scripts/ralph/PROMPT.md` routes every Gate 2/2.5/3/4 failure back to Gate 1.

**One CI run per push, and cancel superseded ones (#2077).** `backend-ci` and
`frontend-ci` fired on both `push` and `pull_request` — two identical ~18-min
runs seconds apart on every PR push. `push` is now scoped to `main` so merges
keep their post-merge run. No PR workflow had a `concurrency` group, so
superseded runs — including full Claude reviews against dead SHAs — burned to
completion. Cancellation is limited to `pull_request`; cancelled runs conclude
as `cancelled`, not `success`, so `iteration-trigger.yml`'s gate cannot mis-fire.

**Incidental:** `cryptography` 49.0.0 → 50.0.0 for PYSEC-2026-3552, which landed
mid-branch and blocked the pip-audit hook. Upgraded, not suppressed.

## Results

| | Before | After |
| --- | --- | --- |
| Targeted single-file run | 30.8 s, **exit 1** | **17.9 s, exit 0** |
| Full backend suite | 15 m 58 s | **4 m 07 s** |
| Full `check-all` end-to-end | ~20+ min | **4 m 23 s**, 3624 tests pass |
| Coverage | 96.99% | **97.00%**, same 10,910 stmts, still gated at 90% |

## Testing

`test_config_consolidation.py` previously asserted the **broken** contract
(`test_pyproject_addopts_has_cov_flags`). It is now inverted to pin the fixed
one, plus the three surviving gate sites and the distributed-suite invocation —
so a future change cannot quietly put coverage back into `addopts` or
de-parallelize the suite.

Verified locally: `check-all.sh` green (4 m 23 s), `pre-commit run --all-files`
green (28 hooks), pre-push hooks green on push.

## Not in this PR

**#2074 — the model-tier decision — is deliberately untouched.** `113ce507`/#1968
moved `test-specialist` and `implementation-specialist` Fable → Opus and
`chief-architect` the other way on Jul 24, putting the slowest tier on the
agents invoked many times per tick and the fast tier on the one invoked once.
Every fast day precedes that commit; every slow day follows it. But it was an
explicit owner policy call about code quality, so it needs a human decision, not
an agent revert. `.claude/agents/README.md` gains the dimension that decision
was missing — invocations per tick — without changing any tier.

Recommendation on #2074: re-measure the next 20 PRs now that this PR removes the
confounder, then decide.

Also filed: **#2102** — agents re-verify what is already green (three of seven
full-suite runs in the originating session bought nothing), including the new
hazard that a core-saturating `-n auto` suite makes concurrent test processes
corrupt each other's results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkKc5LMLPMqs5pYDr2YipR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkKc5LMLPMqs5pYDr2YipR)_