### PR TITLE
chore(deps): land five stale Dependabot bumps and adapt to mcp 2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,6 +108,34 @@ updates:
       # SDK-managed rule — unpin at the SDK 53 upgrade (#885).
       - dependency-name: "expo-keep-awake"
         versions: [">=15.0.0"]
+      # Expo SDK 52 pins expo-web-browser to ~14.0.2; 15.x targets SDK 53+, and
+      # because Expo renumbered its packages to track the SDK number the bot
+      # proposes a jump straight to the 57.x (SDK 57) line. Installing SDK-57
+      # packages against an SDK-52 runtime breaks the native layer. Same
+      # SDK-managed rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-web-browser"
+        versions: [">=15.0.0"]
+      # Expo SDK 52 pins expo-image-manipulator to ~13.0.6; 14.x targets SDK 53+
+      # and the bot proposes the renumbered 57.x line. Expo packages move
+      # together with the SDK via `expo install`, not piecemeal — unpin at the
+      # SDK 53 upgrade (#885).
+      - dependency-name: "expo-image-manipulator"
+        versions: [">=14.0.0"]
+      # Expo SDK 52 pins expo-apple-authentication to ~7.1.3; 8.x targets
+      # SDK 53+ and the bot proposes the renumbered 57.x line. Same SDK-managed
+      # rule — unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-apple-authentication"
+        versions: [">=8.0.0"]
+      # Expo SDK 52 pins expo-auth-session to ~6.0.3; 7.x targets SDK 53+ and
+      # the bot proposes the renumbered 57.x line. Same SDK-managed rule —
+      # unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-auth-session"
+        versions: [">=7.0.0"]
+      # Expo SDK 52 pins expo-file-system to ~18.0.12; 19.x targets SDK 53+ and
+      # the bot proposes the renumbered 57.x line. Same SDK-managed rule —
+      # unpin at the SDK 53 upgrade (#885).
+      - dependency-name: "expo-file-system"
+        versions: [">=19.0.0"]
       # react-native-chart-kit 7.x peer-requires react >=19.1 and
       # react-native >=0.81 — an Expo-SDK-scale pairing, not adaptable in
       # isolation. Same SDK-managed rule — unpin at the SDK upgrade (#885).

--- a/.github/workflows/_claude-scan.yml
+++ b/.github/workflows/_claude-scan.yml
@@ -111,7 +111,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,12 +34,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           # Cache uv's download/build cache, keyed on the requirements files so
           # a dependency change busts it (audit-ci-05).
@@ -128,12 +128,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           # Cache uv's download/build cache, keyed on the requirements files so
           # a dependency change busts it (audit-ci-05).
@@ -180,12 +180,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           # Cache uv's download/build cache, keyed on the requirements files so
           # a dependency change busts it (audit-ci-05).
@@ -266,12 +266,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           # Cache uv's download/build cache, keyed on the requirements files so
           # a dependency change busts it (audit-ci-05).

--- a/.github/workflows/dast-authz.yml
+++ b/.github/workflows/dast-authz.yml
@@ -60,12 +60,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: backend/requirements*.txt

--- a/.github/workflows/deslop.yml
+++ b/.github/workflows/deslop.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Set up Python
         if: matrix.area.stack == 'backend'
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/graph-build.yml
+++ b/.github/workflows/graph-build.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/graph-federate.yml
+++ b/.github/workflows/graph-federate.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/graph-semantic.yml
+++ b/.github/workflows/graph-semantic.yml
@@ -64,7 +64,7 @@ jobs:
           fi
           echo "ANTHROPIC_API_KEY present — proceeding with semantic extraction"
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/graph-tests.yml
+++ b/.github/workflows/graph-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ralph-recap.yml
+++ b/.github/workflows/ralph-recap.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/weekly-playbook.yml
+++ b/.github/workflows/weekly-playbook.yml
@@ -155,7 +155,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python for the lessons digest
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic", "mcp==1.28.1"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic", "mcp==2.0.0", "httpx2==2.9.1"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dev/CI-only tooling. Exact (==) pins matching CI's resolved set so lint,
 # type, and quality gates run identically on every machine. Dependabot's pip
 # ecosystem entry proposes upgrades.
-uvicorn==0.51.0
+uvicorn==0.52.1
 bandit==1.9.4
 interrogate==1.7.0
 isort==8.0.1
@@ -17,7 +17,7 @@ pytest-xdist==3.8.0
 # Type stubs for the runtime jsonschema dependency (issues #389/#390).
 types-jsonschema==4.26.0.20260518
 radon==6.0.1
-ruff==0.16.0
+ruff==0.16.1
 vulture==2.16
 xenon==0.9.3
 pydantic==2.13.4

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -4,16 +4,17 @@ aiosqlite==0.22.1
     # via -r backend/requirements.txt
 alembic==1.18.5
     # via -r backend/requirements.txt
-annotated-doc==0.0.4
+annotated-doc==0.0.5
     # via fastapi
 annotated-types==0.8.0
     # via pydantic
-anthropic==0.120.0
+anthropic==0.120.2
     # via -r backend/requirements.txt
 anyio==4.14.2
     # via
     #   anthropic
     #   httpx
+    #   httpx2
     #   mcp
     #   openai
     #   sse-starlette
@@ -26,13 +27,13 @@ attrs==26.1.0
     #   referencing
 bcrypt==5.0.0
     # via -r backend/requirements.txt
-cachetools==7.1.6
+cachetools==7.1.7
     # via -r backend/requirements.txt
 certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
-cffi==2.1.0
+cffi==2.1.1
     # via cryptography
 click==8.4.2
     # via uvicorn
@@ -52,27 +53,32 @@ docstring-parser==0.18.0
     # via anthropic
 email-validator==2.3.0
     # via -r backend/requirements.txt
-fastapi==0.140.0
+fastapi==0.141.1
     # via -r backend/requirements.txt
 h11==0.16.0
     # via
     #   httpcore
+    #   httpcore2
     #   uvicorn
 httpcore==1.0.9
     # via httpx
+httpcore2==2.9.1
+    # via httpx2
 httpx==0.28.1
     # via
     #   -r backend/requirements.txt
     #   anthropic
-    #   mcp
     #   openai
-httpx-sse==0.4.3
-    # via mcp
+httpx2==2.9.1
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 idna==3.18
     # via
     #   anyio
     #   email-validator
     #   httpx
+    #   httpx2
 iniconfig==2.3.0
     # via pytest
 jiter==0.16.0
@@ -86,15 +92,21 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
     # via jsonschema
 limits==5.8.0
-    # via slowapi
+    # via
+    #   -r backend/requirements.txt
+    #   slowapi
 mako==1.3.12
     # via alembic
 markupsafe==3.0.3
     # via mako
-mcp==1.28.1
+mcp==2.0.0
     # via -r backend/requirements.txt
-openai==2.48.0
+mcp-types==2.0.0
+    # via mcp
+openai==2.53.0
     # via -r backend/requirements.txt
+opentelemetry-api==1.44.0
+    # via mcp
 packaging==26.2
     # via
     #   limits
@@ -109,13 +121,11 @@ pydantic==2.13.4
     #   anthropic
     #   fastapi
     #   mcp
+    #   mcp-types
     #   openai
-    #   pydantic-settings
     #   sqlmodel
 pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.14.2
-    # via mcp
 pygments==2.20.0
     # via pytest
 pyjwt==2.13.0
@@ -128,8 +138,6 @@ pytest==9.1.1
     #   pytest-asyncio
 pytest-asyncio==1.4.0
     # via -r backend/requirements.txt
-python-dotenv==1.2.2
-    # via pydantic-settings
 python-multipart==0.0.32
     # via mcp
 referencing==0.37.0
@@ -160,8 +168,12 @@ starlette==1.3.1
     #   fastapi
     #   mcp
     #   sse-starlette
-tqdm==4.69.1
+tqdm==4.70.0
     # via openai
+truststore==0.10.4
+    # via
+    #   httpcore2
+    #   httpx2
 typing-extensions==4.16.0
     # via
     #   alembic
@@ -169,7 +181,9 @@ typing-extensions==4.16.0
     #   fastapi
     #   limits
     #   mcp
+    #   mcp-types
     #   openai
+    #   opentelemetry-api
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
@@ -180,12 +194,11 @@ typing-inspection==0.4.2
     #   fastapi
     #   mcp
     #   pydantic
-    #   pydantic-settings
 tzdata==2026.3
     # via -r backend/requirements.txt
-uvicorn==0.51.0
+uvicorn==0.52.1
     # via
     #   -r backend/requirements.txt
     #   mcp
-wrapt==2.2.2
+wrapt==2.3.0
     # via deprecated

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,13 +2,13 @@
 # All entries carry exact (==) pins matching CI's resolved set (see
 # requirements-lock.txt) so local dev, the compat matrix, and pip-audit all
 # install one identical set. Dependabot's pip ecosystem entry proposes upgrades.
-cachetools==7.1.6
+cachetools==7.1.7
 # Validates backend/content/manifest.json against the frozen contract at
 # startup (issues #389/#390); the >=4.0 floor (JSON Schema draft 2020-12) is
 # preserved by this pin, which is >= 4.0.
 jsonschema==4.26.0
-fastapi==0.140.0
-uvicorn==0.51.0
+fastapi==0.141.1
+uvicorn==0.52.1
 pydantic==2.13.4
 email-validator==2.3.0
 sqlalchemy==2.0.51
@@ -30,8 +30,13 @@ pytest-asyncio==1.4.0
 httpx==0.28.1
 # MCP SDK powering the Creek Vault streamable-HTTP transport
 # (services/creek_vault_client.py); unconfigured deployments never open it.
-mcp==1.28.1
+mcp==2.0.0
+# The HTTP library the MCP SDK speaks, distinct from the ``httpx`` the plain
+# HTTP vault client uses. Already a transitive mcp dependency; pinned here
+# because the vault client imports it directly to build the MCP transport's
+# timeout budget and to name its errors in the degrade set.
+httpx2==2.9.1
 # LLM provider SDKs for BotMason (issue #402) — the stub provider stays the
 # default; these activate via BOTMASON_PROVIDER + LLM_API_KEY or a BYOK key.
-openai==2.48.0
-anthropic==0.120.0
+openai==2.53.0
+anthropic==0.120.2

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -71,10 +71,10 @@ from typing import NoReturn, Protocol
 from urllib.parse import SplitResult, quote, urlsplit
 
 import httpx
-from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
-from mcp.shared.exceptions import McpError
-from mcp.types import CallToolResult, ErrorData
+import httpx2
+from mcp import Client, MCPError
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import CallToolResult
 
 from domain.creek_vault import (
     CONSUMER_ID,
@@ -131,6 +131,19 @@ _VAULT_DEADLINE_PHASE_BUDGETS = 3
 # worker -- and the journal write path handshakes on every write.
 _VAULT_TOTAL_DEADLINE_SECONDS = _VAULT_TIMEOUT_SECONDS * _VAULT_DEADLINE_PHASE_BUDGETS
 
+# Read budget (seconds) for the MCP session's long-lived server-sent-event
+# stream, which is held open for the life of the session and so cannot share the
+# ten-second budget the request phases use -- a short read timeout would tear the
+# session down while it is merely idle. Mirrors the MCP SDK's own default for
+# that stream, restated here as a named constant because this module builds the
+# transport's HTTP client itself.
+_MCP_SSE_READ_TIMEOUT_SECONDS = 300.0
+
+# The per-phase budget the MCP transport's HTTP client runs under: the same
+# ten-second bound as every other vault call for connect, write, and pool
+# acquisition, and the SSE budget for reads.
+_MCP_HTTP_TIMEOUT = httpx2.Timeout(_VAULT_TIMEOUT_SECONDS, read=_MCP_SSE_READ_TIMEOUT_SECONDS)
+
 # How a "MAJOR.MINOR.PATCH" version string decomposes, and how many of its
 # leading components must match for two contract versions to interoperate. ADR
 # 0004 Decision 4: while the contract is pre-1.0 a minor bump *is* the breaking
@@ -159,28 +172,43 @@ _HTTP_CALL_FAILED_ERRORS: tuple[type[Exception], ...] = (
     httpx.InvalidURL,
 )
 
+# Every way the MCP session's own HTTP layer can fail to land. A separate set
+# from :data:`_HTTP_CALL_FAILED_ERRORS` because the MCP SDK speaks ``httpx2``
+# while :class:`HttpCreekVaultClient` speaks ``httpx``, and the two libraries'
+# exception hierarchies are unrelated -- an ``httpx2.ConnectError`` is not an
+# ``httpx.HTTPError`` and is not an ``OSError``, so without naming it here a
+# vault that is merely unreachable over MCP would raise on the caller's request
+# path instead of degrading. ``InvalidURL`` is named separately for the same
+# reason it is on the httpx side: it sits outside that library's ``HTTPError``
+# hierarchy.
+_MCP_CALL_FAILED_ERRORS: tuple[type[Exception], ...] = (
+    httpx2.HTTPError,
+    httpx2.InvalidURL,
+)
+
 # Transport-layer failures we normalize to a degraded state.
-# :data:`_HTTP_CALL_FAILED_ERRORS` covers the httpx layer underneath the MCP
-# session, ``McpError`` covers an MCP protocol failure or a tool call that
-# returned ``isError`` (raised by :func:`_extract_tool_payload` with a static,
-# content-free message), ``ExceptionGroup`` covers a streamable-HTTP connection
-# failure (anyio task groups wrap the underlying ``httpx.ConnectError`` in a
-# builtins ``ExceptionGroup``; catching the ``Exception``-only group -- never
-# ``BaseExceptionGroup`` -- stays safe under cancellation), and
-# ``json.JSONDecodeError`` covers a content-text block whose body is not JSON.
-# All of these normalize the per-capability path to unavailable exactly as the
-# handshake path already does, keeping one coherent degrade-set
-# (``json.JSONDecodeError`` is a ``ValueError`` subclass, so it is already
-# covered by the handshake's parse-error set).
+# :data:`_HTTP_CALL_FAILED_ERRORS` and :data:`_MCP_CALL_FAILED_ERRORS` cover the
+# httpx layer underneath each transport, ``MCPError`` covers an MCP protocol
+# failure or a tool call that returned ``is_error`` (raised by
+# :func:`_extract_tool_payload` with a static, content-free message),
+# ``ExceptionGroup`` covers a streamable-HTTP connection failure (anyio task
+# groups wrap the underlying connect error in a builtins ``ExceptionGroup``;
+# catching the ``Exception``-only group -- never ``BaseExceptionGroup`` -- stays
+# safe under cancellation), and ``json.JSONDecodeError`` covers a content-text
+# block whose body is not JSON. All of these normalize the per-capability path
+# to unavailable exactly as the handshake path already does, keeping one
+# coherent degrade-set (``json.JSONDecodeError`` is a ``ValueError`` subclass,
+# so it is already covered by the handshake's parse-error set).
 _TRANSPORT_ERROR_TYPES: tuple[type[Exception], ...] = (
     *_HTTP_CALL_FAILED_ERRORS,
-    McpError,
+    *_MCP_CALL_FAILED_ERRORS,
+    MCPError,
     ExceptionGroup,
     json.JSONDecodeError,
 )
 
 # JSON-RPC application-defined server-error code (the -32000..-32099 range) used
-# when a vault tool call reports ``isError``; the paired message is static so it
+# when a vault tool call reports ``is_error``; the paired message is static so it
 # can never echo the entry body or the API key.
 _MCP_TOOL_ERROR_CODE = -32000
 
@@ -1358,22 +1386,43 @@ def _first_text_payload(content: Iterable[object]) -> Mapping[str, object]:
     return {}
 
 
+def _build_mcp_http_client(api_key: str) -> httpx2.AsyncClient:
+    """Build the HTTP client one MCP session runs over: credentialed, bounded, redirect-refusing.
+
+    Built here rather than by the SDK's own ``create_mcp_http_client`` for one
+    reason: that helper hard-codes ``follow_redirects=True`` and exposes no
+    override, and not following a redirect is a security property of this seam
+    rather than a preference -- the same property :func:`_build_pooled_vault_client`
+    pins for the plain-HTTP transport. The journal entry body rides these
+    requests, so a hijacked or compromised vault answering with a redirect could
+    otherwise aim that body at a host the operator never configured. Refusing
+    turns the redirect into a non-2xx, which degrades. Building the client
+    ourselves costs nothing else: the SDK helper only ever set redirects, the
+    timeout, and the headers this function sets explicitly.
+
+    The bearer credential lives on this short-lived, per-call client and never on
+    a shared pool, so it is released with the session that used it.
+    """
+    return httpx2.AsyncClient(
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=_MCP_HTTP_TIMEOUT,
+        follow_redirects=False,
+    )
+
+
 def _extract_tool_payload(result: CallToolResult) -> Mapping[str, object]:
     """Extract the response mapping from an MCP tool-call result.
 
-    A result flagged ``isError`` raises :class:`McpError` with a **static**
+    A result flagged ``is_error`` raises :class:`MCPError` with a **static**
     message -- the error content is deliberately never read, because a vault's
     error text can echo the entry body. Otherwise structured content wins when
     present; a plain-dict tool result rides the content-text channel and is
     JSON-decoded via :func:`_first_text_payload`; anything else yields the
     empty mapping.
     """
-    if result.isError:
-        error_data = ErrorData(
-            code=_MCP_TOOL_ERROR_CODE, message="creek vault tool call returned an error"
-        )
-        raise McpError(error_data)
-    structured = result.structuredContent
+    if result.is_error:
+        raise MCPError(_MCP_TOOL_ERROR_CODE, "creek vault tool call returned an error")
+    structured = result.structured_content
     if isinstance(structured, Mapping):
         return structured
     return _first_text_payload(result.content)
@@ -1383,18 +1432,18 @@ class _McpStreamableHttpTransport:
     """An MCP streamable-HTTP :class:`VaultTransport` for a configured vault.
 
     Each ``call`` opens an MCP session (streamable-HTTP framing with a bearer
-    ``Authorization`` header sourced from ``CREEK_VAULT_API_KEY``), initializes
-    it, invokes the method as an MCP tool, and extracts the response mapping
-    via :func:`_extract_tool_payload`. The key is used only to build that
-    header and is never logged or placed into any exception message (privacy
-    invariant). Construction refuses a plaintext ``http://`` URL to a
+    ``Authorization`` header sourced from ``CREEK_VAULT_API_KEY``), which
+    handshakes on entry, invokes the method as an MCP tool, and extracts the
+    response mapping via :func:`_extract_tool_payload`. The key is used only to
+    build that header and is never logged or placed into any exception message
+    (privacy invariant). Construction refuses a plaintext ``http://`` URL to a
     non-loopback host so the key is never bound to a transport that would send
     it in cleartext.
 
     Every failure branch lands in :data:`_TRANSPORT_ERROR_TYPES`: a connection
-    failure surfaces as an ``ExceptionGroup`` (anyio-wrapped
-    ``httpx.ConnectError``), a protocol failure or ``isError`` tool result as
-    :class:`McpError`, and a non-JSON content-text body as
+    failure surfaces either as an ``httpx2`` error or, when anyio wraps it, as
+    an ``ExceptionGroup``; a protocol failure or ``is_error`` tool result as
+    :class:`MCPError`; and a non-JSON content-text body as
     ``json.JSONDecodeError`` -- so the caller normalizes them to the degraded
     path rather than crashing. The injectable ``connect`` factory lets tests
     drive the full MCP lifecycle against an in-memory server with no network.
@@ -1405,49 +1454,61 @@ class _McpStreamableHttpTransport:
         url: str,
         api_key: str,
         *,
-        connect: Callable[[], AbstractAsyncContextManager[ClientSession]] | None = None,
+        connect: Callable[[], AbstractAsyncContextManager[Client]] | None = None,
     ) -> None:
         """Store the vault URL, bearer key, and connect factory, refusing an insecure URL.
 
         Delegates to :func:`_require_secure_vault_url`, which raises for a
         plaintext ``http://`` URL to a non-loopback host before the key is
         bound. The optional ``connect`` factory defaults to the production
-        streamable-HTTP connection and is supplied as an in-memory session
+        streamable-HTTP connection and is supplied as an in-memory client
         factory under test.
         """
         _require_secure_vault_url(url)
         self._url = url
         self._api_key = api_key
-        self._connect: Callable[[], AbstractAsyncContextManager[ClientSession]] = (
+        self._connect: Callable[[], AbstractAsyncContextManager[Client]] = (
             connect if connect is not None else self._connect_streamable_http
         )
 
     @asynccontextmanager
-    async def _connect_streamable_http(self) -> AsyncIterator[ClientSession]:
+    async def _connect_streamable_http(self) -> AsyncIterator[Client]:
         """Open the production streamable-HTTP MCP session to the vault.
 
         The one untestable-without-a-network seam, kept as small as possible:
-        authenticate with the bearer header, open the streamable-HTTP channel
-        (which yields a read stream, a write stream, and a session-id getter),
-        and wrap the streams in a :class:`ClientSession`.
+        build the HTTP client that carries the bearer header, this module's
+        timeout budget, and its refusal to follow redirects
+        (:func:`_build_mcp_http_client`); open the streamable-HTTP channel over
+        it; and drive that channel with an MCP :class:`Client`. The HTTP client
+        is entered here because the SDK only manages the lifecycle of a client it
+        built itself, so an injected one would otherwise leak its connection
+        pool.
         """
-        headers = {"Authorization": f"Bearer {self._api_key}"}
         async with (
-            streamablehttp_client(self._url, headers=headers, timeout=_VAULT_TIMEOUT_SECONDS) as (
-                read,
-                write,
-                _get_session_id,
-            ),
-            ClientSession(read, write) as session,
+            _build_mcp_http_client(self._api_key) as http_client,
+            Client(streamable_http_client(self._url, http_client=http_client)) as client,
         ):
-            yield session
+            yield client
 
     async def call(self, method: str, params: Mapping[str, object], /) -> Mapping[str, object]:
-        """Run one MCP tool call over a fresh session and return its payload mapping."""
-        async with self._connect() as session:
-            await session.initialize()
-            result = await session.call_tool(method, dict(params))
-        return _extract_tool_payload(result)
+        """Run one MCP tool call over a fresh session, under the whole-call deadline.
+
+        The deadline covers the session as a whole -- connect, MCP handshake, and
+        ``tools/call`` -- for the same reason :meth:`HttpCreekVaultClient._authorized_request`
+        carries one: the per-phase budgets are not a request deadline, since the
+        read budget restarts on every socket read. Without it a vault that
+        accepts the session and then trickles would hold this coroutine and its
+        connection open indefinitely, and the journal write path handshakes on
+        every write. Expiry raises ``TimeoutError``, an ``OSError`` subclass, so
+        it lands in the caller's existing transport branch and degrades. The
+        module constant is read at call time rather than captured, so a
+        redeployment (or a test) can move the ceiling without rebuilding the
+        transport.
+        """
+        async with asyncio.timeout(_VAULT_TOTAL_DEADLINE_SECONDS):
+            async with self._connect() as client:
+                result = await client.call_tool(method, dict(params))
+            return _extract_tool_payload(result)
 
 
 def build_creek_vault_client(transport: VaultTransport | None = None) -> CreekVaultClient:

--- a/backend/tests/test_creek_vault_client.py
+++ b/backend/tests/test_creek_vault_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager
@@ -9,11 +10,11 @@ from datetime import UTC, datetime
 from typing import cast
 
 import httpx
+import httpx2
 import pytest
-from mcp import ClientSession
-from mcp.server.fastmcp import FastMCP
-from mcp.shared.exceptions import McpError
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp import Client, MCPError
+from mcp.client.client import InMemoryTransport
+from mcp.server.mcpserver import MCPServer
 from mcp.types import CallToolResult, ImageContent, TextContent
 from pydantic import BaseModel, ValidationError
 
@@ -36,8 +37,12 @@ from services.creek_vault_client import (
     _MARGINALIA_KIND_BY_CREEK_KIND,
     _MAX_FRAGMENT_ID_LENGTH,
     _MAX_REFLECT_NOTES,
+    _MCP_SSE_READ_TIMEOUT_SECONDS,
+    _MCP_TOOL_ERROR_CODE,
+    _VAULT_TIMEOUT_SECONDS,
     LocalFallbackCreekVaultClient,
     McpCreekVaultClient,
+    _build_mcp_http_client,
     _extract_tool_payload,
     _handshake_params,
     _ingest_params,
@@ -51,6 +56,17 @@ from services.creek_vault_client import (
 _VAULT_URL = "https://vault.example.test"
 
 _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+
+# Where the whole-call ceiling lives, so a test can shorten it in place. Read at
+# call time rather than captured, exactly as the HTTP transport's deadline is.
+_DEADLINE_ATTR = "services.creek_vault_client._VAULT_TOTAL_DEADLINE_SECONDS"
+
+# A whole-call deadline short enough to expire during a test, paired with a tool
+# that sleeps two orders of magnitude longer so the deadline -- never the sleep
+# -- is what ends the call. The sleep is cancelled the moment the deadline
+# fires, so the test costs milliseconds, not seconds.
+_TINY_DEADLINE_SECONDS = 0.02
+_HUNG_TOOL_SLEEP_SECONDS = 5.0
 
 # One well-formed creek note's quote and note text, reused so the hygiene matrix
 # can pair exactly one malformed item against a known-good sibling.
@@ -953,23 +969,29 @@ async def test_unavailable_error_never_leaks_body_or_api_key(
 
 # --- Real MCP streamable-HTTP transport driven against an in-memory vault ---
 # These tests exercise _McpStreamableHttpTransport end to end by injecting an
-# in-memory FastMCP server through its connect seam, so the real MCP lifecycle
-# (initialize -> tools/call -> result) runs with no network.
+# in-memory MCP server through its connect seam, so the real MCP lifecycle
+# (handshake -> tools/call -> result) runs with no network.
 
 
 class _IngestOut(BaseModel):
-    """Typed ingest result used to exercise the structuredContent branch."""
+    """Typed ingest result used to exercise the structured-content branch."""
 
     status: str
     fragment_id: str
     action: str
 
 
-def _mem_connect(server: FastMCP) -> Callable[[], AbstractAsyncContextManager[ClientSession]]:
-    """Return a connect factory yielding an in-memory session bound to ``server``."""
+def _mem_connect(server: MCPServer) -> Callable[[], AbstractAsyncContextManager[Client]]:
+    """Return a connect factory yielding an in-memory client bound to ``server``.
 
-    def _factory() -> AbstractAsyncContextManager[ClientSession]:
-        return create_connected_server_and_client_session(server)
+    The server is wrapped in an :class:`InMemoryTransport` rather than handed to
+    :class:`Client` directly so the client drives the same JSON-RPC framing and
+    negotiated handshake the production streamable-HTTP transport does; passing
+    the server itself would take the SDK's in-process shortcut and skip both.
+    """
+
+    def _factory() -> AbstractAsyncContextManager[Client]:
+        return Client(InMemoryTransport(server))
 
     return _factory
 
@@ -981,8 +1003,8 @@ class _RaisingConnect:
         """Store the exception raised on context entry."""
         self._exc = exc
 
-    async def __aenter__(self) -> ClientSession:
-        """Raise the stored exception instead of yielding a session."""
+    async def __aenter__(self) -> Client:
+        """Raise the stored exception instead of yielding a client."""
         raise self._exc
 
     async def __aexit__(self, *_exc_info: object) -> bool:
@@ -990,7 +1012,7 @@ class _RaisingConnect:
         return False
 
 
-def _serve_handshake(server: FastMCP, capabilities: Sequence[str]) -> None:
+def _serve_handshake(server: MCPServer, capabilities: Sequence[str]) -> None:
     """Register a creek.handshake tool advertising ``capabilities`` on ``server``."""
     advertised = list(capabilities)
 
@@ -1004,7 +1026,7 @@ def _serve_handshake(server: FastMCP, capabilities: Sequence[str]) -> None:
 @pytest.mark.asyncio
 async def test_real_transport_handshake_populates_result() -> None:
     """The real MCP transport completes a handshake against an in-memory server."""
-    server = FastMCP("fake-creek-vault")
+    server = MCPServer("fake-creek-vault")
     _serve_handshake(server, [CreekCapability.JOURNAL.value])
     transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
     client = McpCreekVaultClient(transport=transport)
@@ -1017,7 +1039,7 @@ async def test_real_transport_handshake_populates_result() -> None:
 async def test_real_transport_handshake_sends_privacy_tier_ceiling() -> None:
     """The real transport passes only privacy_tier_ceiling to the handshake tool."""
     received: dict[str, object] = {}
-    server = FastMCP("fake-creek-vault")
+    server = MCPServer("fake-creek-vault")
 
     @server.tool(name=CreekCapability.HANDSHAKE.value)
     def _handshake(privacy_tier_ceiling: str = "sentinel") -> dict[str, object]:
@@ -1045,16 +1067,145 @@ async def test_real_transport_degrades_on_connection_exception_group() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_http_client_refuses_redirects_and_carries_the_vault_budget() -> None:
+    """The MCP transport's own HTTP client refuses redirects and bounds every phase.
+
+    Refusing is the security property: the journal entry body rides these
+    requests, so a hijacked vault answering a redirect must not be able to aim
+    that body at a host the operator never configured. The SDK's own client
+    factory hard-codes redirect-following with no override, which is why this
+    module builds the client itself.
+    """
+    client = _build_mcp_http_client("api-key")
+    try:
+        assert client.follow_redirects is False
+        assert client.timeout.connect == _VAULT_TIMEOUT_SECONDS
+        assert client.timeout.write == _VAULT_TIMEOUT_SECONDS
+        assert client.timeout.pool == _VAULT_TIMEOUT_SECONDS
+        assert client.timeout.read == _MCP_SSE_READ_TIMEOUT_SECONDS
+        assert client.headers["Authorization"] == "Bearer api-key"
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_transport_bounds_a_hung_vault_with_the_whole_call_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vault that accepts the session and then goes quiet is ended, not waited on.
+
+    The per-phase budgets cannot do this on their own: the read budget restarts
+    on every socket read, so a vault that answers the MCP handshake and then
+    trickles stays inside all four indefinitely while holding a worker. Only the
+    whole-call ceiling ends it, and it degrades like any other timeout because
+    ``TimeoutError`` is an ``OSError``.
+    """
+    monkeypatch.setattr(_DEADLINE_ATTR, _TINY_DEADLINE_SECONDS)
+    server = MCPServer("fake-creek-vault")
+
+    @server.tool(name=CreekCapability.HANDSHAKE.value)
+    async def _hang(privacy_tier_ceiling: str = VaultTierCeiling.OPEN.value) -> dict[str, object]:
+        """Never answer, so the whole-call deadline is what ends the call."""
+        del privacy_tier_ceiling
+        await asyncio.sleep(_HUNG_TOOL_SLEEP_SECONDS)
+        return _handshake_payload([CreekCapability.JOURNAL.value])
+
+    transport = _McpStreamableHttpTransport(_VAULT_URL, "api-key", connect=_mem_connect(server))
+    client = McpCreekVaultClient(transport=transport)
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param(httpx2.ConnectError("unreachable"), id="connect-error"),
+        pytest.param(httpx2.ReadTimeout("timed out"), id="read-timeout"),
+        pytest.param(httpx2.InvalidURL("unbuildable"), id="invalid-url"),
+    ],
+)
+async def test_real_transport_degrades_on_unwrapped_mcp_http_error(
+    failure: Exception,
+) -> None:
+    """An MCP transport failure raised bare -- not inside a group -- still degrades.
+
+    The MCP SDK speaks ``httpx2``, whose exceptions share no base class with the
+    ``httpx`` ones :class:`HttpCreekVaultClient` raises and are not ``OSError``
+    either, so nothing but an explicit entry in the degrade set catches them.
+    Without one an unreachable vault would raise on the caller's request path
+    instead of degrading -- the exact failure this module exists to prevent --
+    and ``InvalidURL`` needs naming twice over, since it sits outside its own
+    library's ``HTTPError`` hierarchy.
+    """
+    transport = _McpStreamableHttpTransport(
+        _VAULT_URL, "api-key", connect=lambda: _RaisingConnect(failure)
+    )
+    client = McpCreekVaultClient(transport=transport)
+    result = await client.handshake()
+    assert result == HandshakeResult.unavailable()
+
+
+class _ConnectThenFail:
+    """Connect factory that serves one live session, then fails every later attempt.
+
+    Lets a test advertise a capability through a real handshake and then land the
+    transport failure on the gated capability call itself, which is the branch
+    that has to stay content-free.
+    """
+
+    def __init__(self, server: MCPServer, exc: Exception) -> None:
+        """Store the server to serve once and the exception to raise thereafter."""
+        self._server = server
+        self._exc = exc
+        self._served = False
+
+    def __call__(self) -> AbstractAsyncContextManager[Client]:
+        """Return a live in-memory client the first time, a raising one after."""
+        if self._served:
+            return _RaisingConnect(self._exc)
+        self._served = True
+        return Client(InMemoryTransport(self._server))
+
+
+@pytest.mark.asyncio
+async def test_real_transport_capability_call_degrades_on_mcp_http_error() -> None:
+    """A per-capability MCP call degrades without leaking the body or the API key."""
+    body_sentinel = "SENTINEL_BODY_MCP_HTTP_ERROR_DO_NOT_LEAK"
+    key_sentinel = "SENTINEL_KEY_MCP_HTTP_ERROR_DO_NOT_LEAK"
+    server = MCPServer("fake-creek-vault")
+    _serve_handshake(server, [CreekCapability.JOURNAL.value])
+    connect = _ConnectThenFail(server, httpx2.ConnectError(f"{body_sentinel} {key_sentinel}"))
+    transport = _McpStreamableHttpTransport(_VAULT_URL, key_sentinel, connect=connect)
+    client = McpCreekVaultClient(transport=transport)
+    await client.handshake()
+    request = VaultIngestRequest(
+        entry_id=7,
+        body=body_sentinel,
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
+    )
+    with pytest.raises(CreekVaultUnavailableError) as exc_info:
+        await client.ingest(request)
+    message = str(exc_info.value)
+    assert body_sentinel not in message
+    assert key_sentinel not in message
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+
+
+@pytest.mark.asyncio
 async def test_real_transport_reads_structured_content() -> None:
-    """A tool with a typed result is read from structuredContent."""
-    server = FastMCP("fake-creek-vault")
+    """A tool with a typed result is read from structured content."""
+    server = MCPServer("fake-creek-vault")
     _serve_handshake(server, [CreekCapability.JOURNAL.value])
 
     @server.tool(name=CreekCapability.JOURNAL.value)
     def _ingest(
         content: str, external_id: str, timestamp: str, tier: str, privacy_tier_ceiling: str
     ) -> _IngestOut:
-        """Return a typed ingest result so structuredContent is populated."""
+        """Return a typed ingest result so structured content is populated."""
         del content, external_id, timestamp, tier, privacy_tier_ceiling
         return _IngestOut(status="ok", fragment_id="vault-ref-structured", action="created")
 
@@ -1066,7 +1217,7 @@ async def test_real_transport_reads_structured_content() -> None:
 
 
 def test_extract_tool_payload_reads_content_text() -> None:
-    """A result with no structuredContent is JSON-decoded from its content text."""
+    """A result with no structured content is JSON-decoded from its content text."""
     result = CallToolResult(
         content=[TextContent(type="text", text='{"stored": true, "vault_ref": "vault-ref-text"}')]
     )
@@ -1093,19 +1244,20 @@ def test_extract_tool_payload_skips_non_text_block_before_text() -> None:
 
 
 def test_extract_tool_payload_error_result_raises_without_reading_content() -> None:
-    """An isError result raises rather than surfacing its (possibly sensitive) content text."""
+    """An is_error result raises rather than surfacing its (possibly sensitive) content text."""
     leak = "SENTINEL_ERROR_CONTENT_DO_NOT_LEAK"
-    result = CallToolResult(content=[TextContent(type="text", text=leak)], isError=True)
-    with pytest.raises(McpError) as exc_info:
+    result = CallToolResult(content=[TextContent(type="text", text=leak)], is_error=True)
+    with pytest.raises(MCPError) as exc_info:
         _extract_tool_payload(result)
     assert leak not in str(exc_info.value)
+    assert exc_info.value.code == _MCP_TOOL_ERROR_CODE
 
 
 @pytest.mark.asyncio
 async def test_real_transport_tool_error_degrades_without_leaking_body() -> None:
     """A tool that raises degrades to CreekVaultUnavailableError without leaking the body."""
     body_sentinel = "SENTINEL_BODY_REAL_TRANSPORT_DO_NOT_LEAK"
-    server = FastMCP("fake-creek-vault")
+    server = MCPServer("fake-creek-vault")
     _serve_handshake(server, [CreekCapability.JOURNAL.value])
 
     @server.tool(name=CreekCapability.JOURNAL.value)

--- a/scripts/graph/requirements.txt
+++ b/scripts/graph/requirements.txt
@@ -1,8 +1,8 @@
-graphifyy==0.9.26
+graphifyy==0.9.29
 # Anthropic SDK for the `--backend claude` semantic pass (graph-semantic.yml).
 # graphifyy treats it as an optional extra, so it must be pinned explicitly —
 # without it every semantic chunk fails with "the 'anthropic' package is
 # required for this backend". Kept on its own line (not the [anthropic]
 # extra) because the workflows parse the graphifyy pin with
 # `sed -n 's/^graphifyy==//p'`. Version matches backend/requirements.txt.
-anthropic==0.120.0
+anthropic==0.120.2


### PR DESCRIPTION
## Summary

Lands five stale Dependabot bumps as one PR rather than five CI cycles. Each
dependency file was edited directly to the target version and
`backend/requirements-lock.txt` regenerated with its own documented command
(`uv pip compile backend/requirements.txt -o backend/requirements-lock.txt`), so
no bot branch's stale base rode along.

| Bump | Where |
|---|---|
| `actions/setup-python` 6.3.0 → **7.0.0** | 11 workflow files |
| `astral-sh/setup-uv` 8.3.2 → **9.0.0** | `backend-ci.yml`, `dast-authz.yml` |
| `graphifyy` 0.9.26 → 0.9.29 | `scripts/graph/requirements.txt` |
| `anthropic` 0.120.0 → 0.120.2 | backend + graph tooling (kept consistent) |
| `cachetools` 7.1.6 → 7.1.7, `fastapi` 0.140.0 → 0.141.1, `uvicorn` 0.51.0 → 0.52.1, `openai` 2.48.0 → 2.53.0, `ruff` 0.16.0 → 0.16.1 | `backend/requirements*.txt` |
| `annotated-doc` 0.0.5, `cffi` 2.1.1, `tqdm` 4.70.0, `wrapt` 2.3.0 | lock-only transitives |
| `mcp` 1.28.1 → **2.0.0** | `backend/requirements*.txt` + source (below) |

The pip group is #2106's ten-update set, not the numbers from the superseded
#2092. Neither major action bump needed a workflow change beyond the pin:
`setup-python` v7 removed the `pip-install` input we never set and dropped EOL
Python versions we do not run, and `setup-uv` v9's one breaking change is
`prune-cache` defaulting to `false`, which we never set either. The `ruff`
0.16.1 bump surfaced no new findings — the lint gate is green with no
suppression, no pin-back, and no config change.

### What `mcp` 2.0.0 required

The SDK renamed most of the surface `services/creek_vault_client.py` calls, so
the vault transport was adapted rather than pinned back:

- `streamablehttp_client` → `streamable_http_client`, which no longer takes
  `headers=` or `timeout=` and yields a two-tuple. The bearer `Authorization`
  header and this module's timeout budget now ride an `httpx2.AsyncClient` this
  module builds itself (see the redirect item below), entered by our own context
  manager because the SDK only closes a client it built itself. The per-phase budget is
  unchanged (10s connect/write/pool); the long-lived SSE stream keeps the 300s
  read budget the 1.x transport applied, now spelled out as a named constant.
- The session seam moved from `ClientSession` to the high-level `Client`, which
  handshakes on context entry — so the explicit `await session.initialize()` is
  gone rather than lost.
- `McpError` → `MCPError`, and it now takes `(code, message)` directly instead of
  an `ErrorData`. The static, content-free message is unchanged, so a tool error
  still cannot echo the entry body.
- `CallToolResult` fields are snake_case: `isError` → `is_error`,
  `structuredContent` → `structured_content`.
- **`httpx2` is now pinned directly.** The SDK moved off `httpx` onto `httpx2`,
  whose exception hierarchy is unrelated — an `httpx2.ConnectError` is neither an
  `httpx.HTTPError` nor an `OSError`. Without naming those types in the degrade
  set, an unreachable MCP vault would have raised on the caller's request path
  instead of degrading, breaking this module's "degrade, never crash" invariant.
  The new `_MCP_CALL_FAILED_ERRORS` set closes that hole, and four new tests
  cover it — they fail on this branch if that entry is removed.
- **The MCP transport now refuses redirects.** The SDK's `create_mcp_http_client`
  hard-codes `follow_redirects=True` with no override, so the client is built
  here instead (`_build_mcp_http_client`). The journal entry body rides these
  requests, and a hijacked vault answering with a redirect could otherwise aim
  it at a host the operator never configured — the same reasoning that already
  pins `follow_redirects=False` on the plain-HTTP vault client.
- **`_McpStreamableHttpTransport.call` gains the whole-call deadline** the HTTP
  transport has always carried, for the reason stated there: the per-phase
  budgets are not a request deadline, since the read budget restarts on every
  socket read. Expiry raises `TimeoutError`, an `OSError`, so it degrades like
  any other timeout.
- Tests: `mcp.server.fastmcp.FastMCP` → `mcp.server.mcpserver.MCPServer`, and
  `create_connected_server_and_client_session` is gone. The in-memory seam is now
  `Client(InMemoryTransport(server))` — wrapping the server in a transport rather
  than passing it to `Client` directly, so the tests keep driving the same
  JSON-RPC framing and negotiated handshake production uses instead of taking the
  SDK's in-process shortcut.
- `.pre-commit-config.yaml` had to move the mypy hook's `additional_dependencies`
  to `mcp==2.0.0` (+ `httpx2==2.9.1`); left alone, the type gate would have kept
  checking against the 1.x API and passed on code that no longer exists.

Also pins five SDK-52-managed Expo packages out of Dependabot's range
(expo-web-browser, expo-image-manipulator, expo-apple-authentication,
expo-auth-session, expo-file-system), deferring them to the Expo SDK epic #885
along with the SDK-tied ignores already listed there. Supersedes #2086, #2088,
#2089, #2090, #2091.

## Test plan

- `./scripts/backend/check-all.sh` — all 7 stages green (dependency drift, lint,
  format, mypy, bandit + pip-audit, complexity, 3795 tests, coverage).
- `pre-commit run --hook-stage pre-commit --files $(git diff --name-only ...)` —
  all hooks pass, including the mypy hook re-resolved against mcp 2.0.
- `pytest tests/test_creek_vault_client.py` — 104 tests green against the 2.0
  SDK, with no test deleted, skipped, or weakened; six are new. Four cover the
  `httpx2` degrade path the SDK's HTTP-library switch opened up, and two pin the
  redirect refusal and the whole-call deadline. Each was verified by mutation:
  restoring `follow_redirects=True`, dropping the `asyncio.timeout`, or removing
  `_MCP_CALL_FAILED_ERRORS` from the degrade set turns the matching tests red, so
  they pin behavior rather than merely passing.
- Every bump was installed and exercised in a throwaway virtualenv inside the
  worktree; the shared `.venv` was never modified.
- Frontend is untouched, so its suite was not run.

Closes #2084, closes #2101, closes #2087, closes #2096, closes #2107, closes #2095.

Supersedes #2082, #2085, #2083, #2106, #2093.
