### PR TITLE
fix(backend): authorize the goal group named in a goal update's body

### DIFF
--- a/backend/scripts/dast/README.md
+++ b/backend/scripts/dast/README.md
@@ -129,3 +129,28 @@ fails that test until somebody decides whether it is seedable or excused.
 Object references in the **path** only. Ids carried in query parameters or
 request bodies are not covered, so a green run must never be read as "no BOLA
 anywhere". The report prints that note on every run for the same reason.
+
+## Known coverage gap
+
+The path-only scope above is structural, not an oversight in the registry.
+`RouteSpec` and `is_object_scoped` in `discovery.py` derive object-scoping
+purely from templated path-parameter names, so a body field is invisible to
+the matrix from the start. `replay_body()` in `seeds.py` then returns the
+configured `REPLAY_BODIES` entry verbatim -- only *create* payloads are run
+through `render_payload`, so a replay body is never rewritten to reference an
+id the harness seeded. Seeding itself always runs as the owner identity
+(every create in `runner.py` sends `session.owner.token`), so there is no
+object seeded as the intruder for a forged body to point at. And denial
+grading is global rather than per-route -- `_ACCEPTABLE_DENIALS` in
+`verdict.py` accepts both 403 and 404 for every route alike -- so no
+per-endpoint expectation exists to get wrong either.
+
+`PUT /goals/{goal_id}` shows the gap without any registry bug: it is
+registered, seeded, and probed like every other route, and its cross-user
+cell against `goal_id` in the path is a clean denial. The leak was in
+`goal_group_id`, a field of the replay *body*, which the matrix has no
+mechanism to vary per credential or point at a foreign object. Closing this
+class needs, at minimum: seeding at least one object as the intruder
+identity, templating replay bodies the way create payloads already are, a
+registry describing which body fields carry object references, a matching
+`Cell` variant, and new assertions in `test_registry_covers_real_app.py`.

--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -188,18 +188,37 @@ async def require_visible_goal_group(
     return group
 
 
+async def resolve_owned_goal_group(session: AsyncSession, group_id: int, user_id: int) -> GoalGroup:
+    """Resolve ``group_id`` for write access -- owner only -- and audit denials.
+
+    Shared templates need no branch of their own: the CHECK constraint on
+    ``goalgroup`` keeps them ownerless (``user_id IS NULL``), so they fail
+    the ownership comparison and land on the same 403 as another user's
+    private group.  Callers that receive a group id in a request *body*
+    (rather than the path) reuse this directly, so the write rule lives in
+    exactly one place.
+    """
+    group = await session.get(GoalGroup, group_id)
+    if group is None:
+        raise not_found("goal_group")
+    if group.user_id != user_id:
+        log_ownership_denied("goal_group", group_id, user_id)
+        raise forbidden("forbidden")
+    return group
+
+
 async def require_owned_goal_group(
     group_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> GoalGroup:
-    """Resolve ``group_id`` for write access -- owner only."""
-    group = await session.get(GoalGroup, group_id)
-    if group is None:
-        raise not_found("goal_group")
-    if group.user_id != current_user:
-        raise forbidden("forbidden")
-    return group
+    """Resolve ``group_id`` for write access -- owner only.
+
+    Delegates to :func:`resolve_owned_goal_group`, which owns the rule and
+    emits the ``resource_access_denied`` audit row on a cross-tenant probe,
+    matching :func:`require_owned_habit` and :func:`require_owned_user_practice`.
+    """
+    return await resolve_owned_goal_group(session, group_id, current_user)
 
 
 async def require_visible_practice(

--- a/backend/src/routers/goals.py
+++ b/backend/src/routers/goals.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database import get_session
-from dependencies.ownership import require_owned_goal
+from dependencies.ownership import require_owned_goal, resolve_owned_goal_group
 from models.goal import Goal
 from routers.auth import get_current_user
 from schemas.goal import Goal as GoalSchema
@@ -39,7 +39,17 @@ async def update_goal(
     ``habit_id`` is intentionally not part of ``GoalUpdate`` so the parent
     habit cannot be swapped via this endpoint -- a goal is bound to its
     habit for life.
+
+    ``goal_group_id`` *is* editable, and it names a second object that
+    ``require_owned_goal`` says nothing about: that dependency authorises the
+    goal in the path, not the group in the body.  Without its own object-level
+    check, a caller could file their goal under someone else's group and have
+    the owner read it back.  So every non-null group is authorised here as a
+    write target.  Shared templates are rejected too -- they are ownerless and
+    world-readable, so a goal parked in one is published to every user.
     """
+    if payload.goal_group_id is not None:
+        await resolve_owned_goal_group(session, payload.goal_group_id, current_user)
     for key, value in payload.model_dump().items():
         setattr(goal, key, value)
     session.add(goal)

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -24,14 +24,17 @@ Also asserts that no owned-resource response DTO echoes ``user_id``.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from models.course_stage import CourseStage
+from models.goal import Goal
 from models.practice import Practice
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
@@ -78,6 +81,22 @@ async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], i
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+def _goal_put_payload(goal: dict[str, object]) -> dict[str, object]:
+    """Rebuild the full-replace ``PUT /goals/{id}`` body from an API-returned goal."""
+    return {
+        field: goal[field]
+        for field in (
+            "title",
+            "tier",
+            "target",
+            "target_unit",
+            "frequency",
+            "frequency_unit",
+            "is_additive",
+        )
+    }
 
 
 async def _seed_practice(db_session: AsyncSession, **overrides: object) -> Practice:
@@ -330,6 +349,78 @@ async def test_idor_shared_template_get_is_visible(async_client: AsyncClient) ->
     resp = await async_client.get(f"/goal-groups/{group_id}", headers=bob_headers)
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["name"] == "Community Yoga"
+
+
+@pytest.mark.asyncio
+async def test_idor_goal_update_cannot_write_into_another_users_group(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alice cannot smuggle her goal into Bob's private group via ``PUT /goals/{id}``.
+
+    ``require_owned_goal`` authorises the goal but not the ``goal_group_id``
+    in the body, so an unguarded full-replace write would publish Alice's
+    goal (title, target, units, parent habit) into Bob's group, which Bob
+    then reads through ``GET /goal-groups/{id}``.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_goal_xgroup")
+    bob_headers, _bob_id = await _signup(async_client, "bob_goal_xgroup")
+
+    habit = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    assert habit.status_code == HTTPStatus.OK
+    alice_goals = habit.json()["goals"]
+    assert alice_goals, "habit creation must embed its default tier goals"
+    goal_id = alice_goals[0]["id"]
+    payload = _goal_put_payload(alice_goals[0])
+
+    create_group = await async_client.post(
+        "/goal-groups/", json={"name": "Bob Private"}, headers=bob_headers
+    )
+    assert create_group.status_code == HTTPStatus.CREATED
+    bob_group_id = create_group.json()["id"]
+
+    # The victim group really exists and its owner can read it, so a 403 below
+    # cannot be an artefact of a missing target row.
+    owner_read = await async_client.get(f"/goal-groups/{bob_group_id}", headers=bob_headers)
+    assert owner_read.status_code == HTTPStatus.OK
+    assert owner_read.json()["name"] == "Bob Private"
+
+    # The identical payload with a benign group is accepted, so a 403 below
+    # cannot be an artefact of an unrelated validation failure.
+    baseline = await async_client.put(
+        f"/goals/{goal_id}",
+        json={**payload, "goal_group_id": None},
+        headers=alice_headers,
+    )
+    assert baseline.status_code == HTTPStatus.OK
+    assert baseline.json()["goal_group_id"] is None
+
+    with caplog.at_level(logging.WARNING):
+        attack = await async_client.put(
+            f"/goals/{goal_id}",
+            json={**payload, "goal_group_id": bob_group_id},
+            headers=alice_headers,
+        )
+
+    assert attack.status_code == HTTPStatus.FORBIDDEN
+    assert attack.json()["detail"] == "forbidden"
+
+    db_session.expire_all()
+    stored = (await db_session.execute(select(Goal).where(Goal.id == goal_id))).scalars().one()
+    assert stored.goal_group_id is None, (
+        "cross-user goal-group write persisted; the goal moved into the victim's group"
+    )
+
+    victim_view = await async_client.get(f"/goal-groups/{bob_group_id}", headers=bob_headers)
+    assert victim_view.status_code == HTTPStatus.OK
+    assert victim_view.json()["goals"] == [], "attacker's goal surfaced inside the victim's group"
+
+    denials = [r for r in caplog.records if r.message == "resource_access_denied"]
+    assert denials, "expected a resource_access_denied audit log entry"
+    assert getattr(denials[0], "resource", None) == "goal_group"
+    assert getattr(denials[0], "resource_id", None) == bob_group_id
+    assert getattr(denials[0], "user_id", None) == alice_id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -20,6 +20,9 @@ from sqlmodel import select
 from models.goal import Goal
 from models.habit import Habit
 
+# Sentinel well above any seeded row, matching the security suite's probe id.
+_DEFINITELY_MISSING_ID = 999_999
+
 
 async def _signup(client: AsyncClient, username: str = "goaluser") -> tuple[dict[str, str], int]:
     """Create a user and return ``(auth headers, user_id)``."""
@@ -68,6 +71,30 @@ async def _seed_goal(
     await db_session.commit()
     await db_session.refresh(goal)
     return goal
+
+
+async def _create_goal_group(
+    client: AsyncClient,
+    headers: dict[str, str],
+    name: str,
+    *,
+    shared_template: bool = False,
+) -> int:
+    """Create a goal group through the API and return its id."""
+    body: dict[str, object] = {"name": name}
+    if shared_template:
+        body["shared_template"] = True
+        body["source"] = "community"
+    resp = await client.post("/goal-groups/", json=body, headers=headers)
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _stored_goal_group_id(db_session: AsyncSession, goal_id: int | None) -> int | None:
+    """Re-read ``goal_id`` from the DB, bypassing the session identity map."""
+    db_session.expire_all()
+    result = await db_session.execute(select(Goal).where(Goal.id == goal_id))
+    return result.scalars().one().goal_group_id
 
 
 def _update_payload(**overrides: object) -> dict[str, object]:
@@ -264,6 +291,131 @@ async def test_update_goal_rejects_forged_habit_id(
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+# ── goal_group_id assignment ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_goal_assigns_own_goal_group(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The caller's own group is a valid assignment target."""
+    headers, user_id = await _signup(async_client, "groupowner")
+    goal = await _seed_goal(db_session, user_id)
+    group_id = await _create_goal_group(async_client, headers, "My Group")
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(goal_group_id=group_id),
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["goal_group_id"] == group_id
+    assert await _stored_goal_group_id(db_session, goal.id) == group_id
+
+
+@pytest.mark.asyncio
+async def test_update_goal_clears_goal_group_when_null(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An explicit null unassigns a goal from the caller's own group."""
+    headers, user_id = await _signup(async_client, "groupclearer")
+    goal = await _seed_goal(db_session, user_id)
+    group_id = await _create_goal_group(async_client, headers, "Temporary Group")
+
+    assigned = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(goal_group_id=group_id),
+        headers=headers,
+    )
+    assert assigned.status_code == HTTPStatus.OK
+    assert assigned.json()["goal_group_id"] == group_id
+
+    cleared = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(goal_group_id=None),
+        headers=headers,
+    )
+
+    assert cleared.status_code == HTTPStatus.OK
+    assert cleared.json()["goal_group_id"] is None
+    assert await _stored_goal_group_id(db_session, goal.id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_goal_omitting_goal_group_id_leaves_it_null(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Full-replace PUT semantics hold: an omitted goal_group_id is not an error."""
+    headers, user_id = await _signup(async_client, "groupomitter")
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(),
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["goal_group_id"] is None
+    assert await _stored_goal_group_id(db_session, goal.id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_goal_404_when_goal_group_missing(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-existent target group 404s with a detail distinct from a missing goal."""
+    headers, user_id = await _signup(async_client, "groupghost")
+    goal = await _seed_goal(db_session, user_id)
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(goal_group_id=_DEFINITELY_MISSING_ID),
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "goal_group_not_found"
+    assert await _stored_goal_group_id(db_session, goal.id) is None
+
+
+@pytest.mark.asyncio
+async def test_update_goal_rejects_shared_template_group(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A shared template is not an assignment target, so a goal cannot be published.
+
+    Templates are ownerless and every authenticated user reads them with
+    their goals eagerly embedded, so parking a goal in one would broadcast
+    its author's title and description to the entire user base — a wider
+    leak than the cross-user write this guard exists to stop.
+    """
+    headers, user_id = await _signup(async_client, "templateconsumer")
+    author_headers, _author_id = await _signup(async_client, "templateauthor")
+    goal = await _seed_goal(db_session, user_id)
+    template_id = await _create_goal_group(
+        async_client, author_headers, "Community Meditation", shared_template=True
+    )
+
+    # The template is readable by the caller, so the rejection below is the
+    # write guard rather than an artefact of an unreachable row.
+    visible = await async_client.get(f"/goal-groups/{template_id}", headers=headers)
+    assert visible.status_code == HTTPStatus.OK
+
+    resp = await async_client.put(
+        f"/goals/{goal.id}",
+        json=_update_payload(goal_group_id=template_id),
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert resp.json()["detail"] == "forbidden"
+    assert await _stored_goal_group_id(db_session, goal.id) is None
+    published = await async_client.get(f"/goal-groups/{template_id}", headers=author_headers)
+    assert published.json()["goals"] == []
 
 
 # ── Batch unit update (issue #289) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

`PUT /goals/{goal_id}` full-replace-copies its `GoalUpdate` payload onto the goal row, and `goal_group_id` names a **second** object that nothing authorized. `require_owned_goal` covers the goal in the path; the group in the body had no object-level check at all. Any authenticated user could set `goal_group_id` to another user's private group, and the victim then read the attacker's goal — title, description, target, units, parent `habit_id` — inside their own group via `GET /goal-groups/{id}` and the list endpoint. OWASP API Security Top 10 #1 (BOLA).

The fix extracts the rule that already existed one file away rather than restating it: `resolve_owned_goal_group` holds the owner-only predicate, `require_owned_goal_group` becomes a delegate over it (mirroring the `resolve_owned_goal_and_habit` / `require_owned_goal` pair directly above), and the router authorizes any non-null group before the `setattr` loop.

### Decisions a reviewer should not "correct" without reading these

- **404 missing / 403 not-yours**, following the goal-group family rather than the goals family's enumeration-safe collapse-to-404. `GET /goal-groups/{id}` already discriminates those two cases identically, so the body path opens no oracle the path surface has not opened already; and the client needs `goal_group_not_found` distinguishable from `goal_not_found`. The body path's partition is in fact strictly *coarser* than the path surface's, and reaching it at all requires already owning a goal.
- **Shared templates are rejected**, which falls out of the owner-only predicate for free (the CHECK constraint keeps templates ownerless, so `user_id IS NULL` never matches a caller). Admitting them would have been the wider hole: every authenticated user reads every template with its `goals` eagerly embedded, so a goal parked in one is published to the entire user base rather than leaked to one victim. Nothing regresses — the only `goalsApi.update` call site replays server-cached values inside a per-goal try/catch, and the onboarding template picker's selection is dropped before the wire (`toApiPayload` omits the field and `HabitCreate` has none).
- **The check is unconditional whenever the value is non-null** — deliberately not skipped when the id already equals the goal's current group. An authorization check conditioned on prior row state is how the next one of these gets written, and the only rows it refuses are rows the bug itself planted.
- **Denials now emit the `resource_access_denied` audit row**, which also newly covers the existing `PUT`/`DELETE /goal-groups/{id}` path, bringing goal groups in line with `require_owned_habit` and `require_owned_user_practice`. The record carries a resource name and two ints — no PII.

### Sibling sweep — fix the class, not the instance

Two orthogonal passes (every `payload.model_dump()` full-copy in `src/routers/` + `src/services/`, and every `*_id` field across `src/schemas/`) converge: `goals.py` was the only live cross-tenant body-FK write. `goal_completions.py`, `practice_sessions.py`, `user_practices.py`, `promotions.py`, `metta_return.py` and `services/energy.py` all already authorize their body-supplied FKs; `POST`/`PUT /habits/` and `PUT /habits/{habit_id}/goals/units` carry no FK in the body. Only two writers of `Goal.goal_group_id` exist at all: the handler fixed here and the owner-gated unlink in `delete_goal_group`.

### DAST registry

`PUT /goals/{goal_id}` **was** registered and probed correctly — the registry was not wrong. The harness derives object scoping from **path** parameters only, never templates a replay body, seeds solely as the owner, and varies only the credential per cell, so a body-carried object reference is structurally unprobeable. `backend/scripts/dast/README.md` now records that gap so the next reader does not mistake the `authz-matrix` gate for coverage of this class.

## Test plan

- **RED first, and verified for the right reason.** With the patch reverted, `test_idor_goal_update_cannot_write_into_another_users_group` fails `assert 200 == 403`, and a throwaway probe dumped the live leak end to end — Alice's `ALICE-CONFIDENTIAL-TITLE` and its description appearing in Bob's `GET /goal-groups/{id}` and `GET /goal-groups/`. Patched, the attack is `403 {"detail":"forbidden"}` and both victim views show `"goals":[]`.
- The regression test is built so it cannot pass for the wrong reason: the victim's group is proven to exist and be owner-readable *before* the attack, the attacker's payload is proven otherwise valid via an identical baseline PUT that succeeds, and the assertions pin the rejection **plus** DB non-mutation **plus** the victim's group staying empty **plus** the audit record's `resource` / `resource_id` / `user_id`.
- Endpoint contract in `backend/tests/test_goals_api.py`: own-group assignment (200), unassign via explicit null (200 → `None`), omitted key (200), missing group (404 + `goal_group_not_found`, distinct from `goal_not_found`), shared template (403 + row unchanged + template still goal-free).
- `./scripts/backend/check-all.sh` → exit 0, 7/7 stages, **4146 passed / 2 skipped / 1 xfailed**, coverage 97%. bandit and pip-audit clean; xenon A-grade and radon MI clean; the ~399-file pre-commit mypy hook passes. Backend-only diff — no frontend files touched, no migration, no dependency changes.

## Follow-ups this PR deliberately does not do

1. **Remediate rows planted before the fix** (data migration: null `goal.goal_group_id` where the group's owner differs from the parent habit's owner). Until then those rows keep leaking on read, so this issue should not be considered fully remediated without it.
2. **`POST /journal/` accepts `practice_session_id` / `user_practice_id` from the body unchecked.** Not a live cross-tenant read — the foreign id lands on the attacker's own row and nothing in `src/` dereferences those columns beyond a caller-scoped filter — but they are FKs with NO ACTION, so a foreign id **pins the victim's row against deletion**. That becomes a live cross-tenant DoS the day an account purge lands, so it should be scoped "authorize and fail closed", not "cosmetic cleanup".
3. **DAST body-parameter authorization cells** — intruder-side seeding, templated replay bodies, a registry of body fields carrying object references, and matching coverage assertions.
4. Any authenticated user can mint a `shared_template` goal group that is broadcast to every user and is then irreversible (templates 403 on both PUT and DELETE, so not even the author can remove it).

Closes #2064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
