### PR TITLE
fix(ralph): reach the do-not-auto-merge hold through the bridge issue's marker

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -120,9 +120,13 @@ merge a pending/failing PR). The helper keys CI off the `gh pr checks` **exit
 code** (`0`=green, `8`=pending, else=failed) and only honours an LGTM verdict
 posted **after** the PR's HEAD commit (stale-verdict guard). It also proves
 freshness against `main` with the compare API rather than trusting
-`mergeStateStatus`, and honours the `do-not-auto-merge` human hold. Capture the
-exit code alongside the token — the helper exits non-zero when it cannot classify
-a lane, and an unchecked `$STATUS` would just come back empty:
+`mergeStateStatus`, and honours the `do-not-auto-merge` human hold — reaching a
+Dependabot PR's bridge issue through the `<!-- dependabot-pr:<N> -->` marker on
+that issue when the bot has regenerated its PR body and taken the `Closes #N`
+link with it. Capture the exit code alongside the token — the helper exits
+non-zero when it cannot classify a lane (including when a bot PR about to merge
+has a hold it can neither find nor rule out), and an unchecked `$STATUS` would
+just come back empty:
 ```bash
 STATUS=$(scripts/ralph/pr-ready.sh "$PR_NUM") && RC=0 || RC=$?   # ready | ready-unreviewed | behind | pending | ci-failed | changes-requested | awaiting-review | optout
 ```
@@ -157,8 +161,11 @@ Then act on `$STATUS`:
   before merging anything.
   What replaces Gate 4 here is green CI **verified against current `main`**
   (`behind_by == 0`, so the green is today's `main`, not a stale base) plus the
-  `do-not-auto-merge` hold, which is checked first and would have printed
-  `optout`. That substitution is only honest when CI actually ran, so the helper
+  `do-not-auto-merge` hold, which is checked first — before any CI probe, on
+  every route including the bridge issue's marker — and would have printed
+  `optout`. A hold this token's own PR class can neither find nor rule out is
+  likewise never merged: the helper exits non-zero with no token at all rather
+  than reading that silence as consent. That substitution is only honest when CI actually ran, so the helper
   also requires a real non-review check to have SUCCEEDED: every test workflow is
   `paths:`-filtered to its own sources, so a `github-actions` ecosystem bump
   touches only `.github/workflows/*.yml`, matches none of them, and would
@@ -204,7 +211,9 @@ Then act on `$STATUS`:
   conflict (`fleet.sh sync` → conflict-fix worker → push); the post-resolution
   push triggers the PR's real CI + review.
 - **`ci-failed`** — a check failed. Advance it via Step 2 (`ci-debugging`).
-- **`optout`** — the PR, or the issue it closes, carries `do-not-auto-merge`.
+- **`optout`** — the PR, the issue it closes, or (on a Dependabot PR whose body
+  links no issue) the bridge issue whose `<!-- dependabot-pr:<N> -->` marker names
+  it, carries `do-not-auto-merge`.
   **Leave it entirely alone**: do not merge it, do not sync it, do not dispatch a
   `ci-debugging` or `address-feedback` worker at it. A human owns this PR. Do not
   `assign`/`adopt` a worktree for it either, and skip it when refilling in Step 4.

--- a/scripts/ralph/FLEET.md
+++ b/scripts/ralph/FLEET.md
@@ -155,7 +155,7 @@ One token per lane, exactly one action. This table, `pr-ready.sh`'s header, and
 | `ci-failed` | a check failed or errored. | Dispatch a `ci-debugging` worker into the lane. |
 | `changes-requested` | a fresh verdict (posted after HEAD) that is not `LGTM` — `CHANGES_REQUESTED` or `COMMENTS`. Gate 4 failed. | Dispatch an `address-feedback` worker into the lane. Terminal for `watch-pr.sh` — the watcher exits on it, so the verdict is a wake, never a timeout. |
 | `awaiting-review` | no verdict yet, or only a stale one that predates HEAD (a fresh non-LGTM is `changes-requested` instead). | Wait for the review or re-review; `watch-pr.sh` counts this as in-flight. |
-| `optout` | `do-not-auto-merge` on the PR or on the issue it closes. | Leave the lane entirely alone — no merge, no sync, no worker, and never `assign`/`adopt` a new one. A worktree it already holds **stays held** (`reconcile` releases only on `MERGED`/`CLOSED`): releasing it would discard work a human paused. Run `fleet.sh release <N>` by hand to take the slot back. |
+| `optout` | `do-not-auto-merge` on the PR, on the issue its body closes, or — when a Dependabot PR's body links nothing — on the bridge issue carrying that PR's `<!-- dependabot-pr:<N> -->` marker. | Leave the lane entirely alone — no merge, no sync, no worker, and never `assign`/`adopt` a new one. A worktree it already holds **stays held** (`reconcile` releases only on `MERGED`/`CLOSED`): releasing it would discard work a human paused. Run `fleet.sh release <N>` by hand to take the slot back. |
 | *non-zero exit* | could not classify (API failure, expired token). | Leave the lane alone this wake; the next wake retries. |
 
 **Gate 4 on a bot PR.** `claude-code-review.yml` skips runs whose `github.actor`
@@ -185,8 +185,19 @@ current `main`**, and `pr-ready.sh` pins each word of that:
 explicit OK — is *replaced* by that evidence, not silently dropped. The per-PR
 human hold is the `do-not-auto-merge` label on the PR or on its bridge issue: its
 **absence** is what lets a lane merge, and its presence stops the loop dead
-(`optout`). An *undeterminable* hold (the label lookup failed) is a tooling error
-that stalls the lane, never a silent "no hold". The label must exist in the repo
+(`optout`). Two routes reach that bridge issue, because Dependabot regenerates
+its PR body from its own template on every rebase and group recomputation and
+takes the bridge's appended `Closes #N` with it: the body link, and — only on a
+Dependabot PR whose body links nothing — the `<!-- dependabot-pr:<N> -->` marker
+the bridge stamped into the ISSUE body, which the PR rewrite cannot reach. An
+*undeterminable* hold (the label lookup failed) is a tooling error that stalls
+the lane, never a silent "no hold"; so is an *unprovable* one, where neither
+route resolves — that scan is filtered by the `dependencies` label, which has
+been watched to fail to stick (hence `ensure-issue-label.sh`), so a matchless
+scan is silence, not proof. Such a lane still classifies normally and is refused
+(exit 2, no token) only where it would otherwise print `ready`/`ready-unreviewed`
+— `behind` still prints `behind`, since a sync is always safe and often re-links
+the body. The label must exist in the repo
 for a human to apply it — `scripts/setup-scan-labels.sh` creates it idempotently,
 run via `.github/workflows/labels-bootstrap.yml` (`workflow_dispatch`).
 
@@ -255,8 +266,11 @@ Seven offline suites cover the fleet — six shell, one Python — all run in CI
 - `scripts/ralph/test_pr_ready.sh` stubs `gh` and pins every status token: CI
   classification from the **exit code** (8 ⇒ `pending`, never `ready`), the
   stale-verdict guard, the `do-not-auto-merge` hold — including that it resolves
-  the *last* issue link in the body and that an unreadable label answer fails
-  closed (exit 2, not "no hold") — the freshness guard (`CLEAN` is not proof of
+  the *last* issue link in the body, that it falls back to the bridge issue's
+  `<!-- dependabot-pr:<N> -->` marker (whole-marker match, every match checked,
+  bot lanes only) when Dependabot has rewritten that link away, and that an
+  unreadable label answer or an unprovable hold fails closed (exit 2, not "no
+  hold") — the freshness guard (`CLEAN` is not proof of
   being current) and its laziness (only a would-be-`ready` lane pays for the
   compare probe), the `ready-unreviewed` path, and the `changes-requested`
   split (a fresh non-LGTM verdict is actionable; missing/stale keeps waiting).

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -17,14 +17,34 @@
 #                    is not LGTM (CHANGES_REQUESTED/COMMENTS) → Step 2
 #                    (address-feedback): Gate 4 has spoken and wants changes
 #   awaiting-review  no verdict yet, or only a stale one (predates HEAD) → wait
-#   optout           `do-not-auto-merge` on the PR or on the issue it closes → the
+#   optout           `do-not-auto-merge` on the PR, on the issue its body closes,
+#                    or on the bridge issue whose marker names this PR → the
 #                    loop does not act on this PR AT ALL (no merge, no sync, no
 #                    ci-debugging worker); a human owns it. Checked first, and an
 #                    unreadable label answer exits 2 rather than assuming no hold.
 #
-# An UNDETERMINABLE opt-out (the label or body lookup failed) is deliberately one of
-# those tooling errors: reading a failed lookup as "unlabelled" would let a rate limit
-# or an expired token silently defeat the one control a human retains over this loop.
+# An UNDETERMINABLE opt-out (the label, body, or marker lookup failed) is deliberately
+# one of those tooling errors: reading a failed lookup as "unlabelled" would let a rate
+# limit or an expired token silently defeat the one control a human retains over this
+# loop. So is an UNPROVABLE one on a bot PR about to be merged (see below).
+#
+# WHY THE MARKER FALLBACK EXISTS: the body-link route to the hold vanishes on exactly
+# the PRs the hold exists for. Dependabot regenerates its PR body from its own template
+# on every rebase and group recomputation, taking the bridge's appended `Closes #N` with
+# it — so `linked_issue` comes back empty and "no link" would be read as "no hold", a
+# fail-OPEN on the one PR class this loop merges with no review verdict. The bridge also
+# stamps `<!-- dependabot-pr:<N> -->` into the ISSUE body, which that rewrite cannot
+# reach because it lives on another object; that is the durable route. It is scanned only
+# on a Dependabot-authored PR whose body links nothing (human PRs routinely link nothing
+# and must classify normally, and an empty author reads as human), so in steady state the
+# extra `gh issue list` costs no lane anything. A scan that matches NOTHING is silence,
+# not proof: it is filtered by the `dependencies` label, which this repo has watched fail
+# to stick — hence `ensure-issue-label.sh`. Such a lane therefore classifies normally and
+# is refused only at the point of merge, so `behind` still prints `behind` (a sync is
+# always safe, and re-linking the body is often what makes the hold provable again).
+#
+# An unresolvable hold on a bot PR that would otherwise merge is likewise one of those
+# exit-2 tooling errors: no token, and the next wake retries.
 #
 # WHY THIS EXISTS: the previous all-lanes Monitor grepped `gh pr checks` output
 # for ': pending'. That output is TAB-delimited (name<TAB>pending<TAB>...), so the
@@ -102,6 +122,12 @@ readonly OPTOUT_LABEL="do-not-auto-merge"
 # The issue-link vocabulary the rest of the loop uses (pick-next.sh's in-flight
 # scan, the Dependabot bridge). Case-insensitive via `grep -i`.
 readonly ISSUE_LINK_RE='(closes|fixes|resolves)[[:space:]]+#[0-9]+'
+
+# The only label the Dependabot bridge puts on the issues it files, and the page
+# size it scans them with. Both mirror the bridge's own query so the two sides
+# see the same set; the label is what keeps the fallback scan cheap.
+readonly BRIDGE_ISSUE_LABEL="dependencies"
+readonly BRIDGE_SCAN_LIMIT=200
 
 # Placeholder slug `gh` substitutes from the current repo when no --repo is given.
 readonly CURRENT_REPO_SLUG='{owner}/{repo}'
@@ -184,6 +210,40 @@ linked_issue() {
   { printf '%s' "$body" | grep -oiE "$ISSUE_LINK_RE" || true; } | tail -n 1 | tr -dc '0-9'
 }
 
+# The bridge's durable link, in the one shape both sides agree on — copied
+# verbatim from `dependabot-to-ralph-issue.yml`, which writes it. Inventing a
+# second linking convention here would be a second thing to drift silently, and
+# a drift restores the fail-open with nothing anywhere to report it.
+marker_for() { printf '<!-- dependabot-pr:%s -->' "$1"; }
+PR_MARKER="$(marker_for "$pr")"
+readonly PR_MARKER
+
+# Every open bridge issue whose body carries THIS PR's marker, one number per
+# line; empty when none does. Non-zero on API failure, like `labels_of`, so the
+# caller refuses to classify rather than inferring "no hold". The match is on the
+# whole marker including its closing `-->`: a bare number is a substring of every
+# longer one, so a looser test would inherit an unrelated bump's hold. Splicing
+# $pr into the jq string is safe because arg parsing already proved it matches
+# ^[0-9]+$ — nothing else here reaches the query.
+bridge_issues_for_pr() {
+  gh issue list ${repo_args[@]+"${repo_args[@]}"} \
+    --label "$BRIDGE_ISSUE_LABEL" --state open --limit "$BRIDGE_SCAN_LIMIT" \
+    --json number,body \
+    --jq ".[] | select((.body // \"\") | contains(\"$PR_MARKER\")) | .number"
+}
+
+# Stops the WHOLE script when one candidate issue carries the hold, so a hold
+# found on any route wins outright. A failed lookup stops it too: "unreadable"
+# must never collapse into "no hold". Safe to `exit` from because every caller
+# below invokes it directly, never in a pipeline or a command substitution.
+exit_if_issue_holds() { # exit_if_issue_holds <issue number> <how it links this PR>
+  local labels
+  labels="$(labels_of issue "$1")" ||
+    die "could not read labels of issue #$1 ($2 PR #$pr); refusing to guess whether $OPTOUT_LABEL is set"
+  has_optout_label "$labels" || return 0
+  echo "optout"; exit 0
+}
+
 # An undeterminable hold is a TOOLING error, never "no hold". Reading a failed
 # lookup as unlabelled would let a rate limit, a 5xx, or an expired token
 # silently defeat the one control a human has over this loop and auto-merge the
@@ -196,14 +256,40 @@ if has_optout_label "$pr_labels"; then
   echo "optout"; exit 0
 fi
 
-pr_body="$(gh pr view "${gh_args[@]}" --json body --jq '.body')" ||
-  die "could not read the body of PR #$pr; refusing to guess whether a linked issue carries $OPTOUT_LABEL"
+# The author rides along on the body call rather than costing a round trip of its
+# own; it gates the marker fallback below. Author FIRST because a login cannot
+# contain `|` and a body freely can, so the split has to be on the first
+# separator — and by parameter expansion, never `read`, which would truncate a
+# multi-line body at its first newline.
+body_line="$(gh pr view "${gh_args[@]}" --json body,author \
+  --jq '(.author.login // "") + "|" + (.body // "")')" ||
+  die "could not read the body and author of PR #$pr; refusing to guess whether a linked issue carries $OPTOUT_LABEL"
+pr_author="${body_line%%|*}"
+pr_body="${body_line#*|}"
+
+# Set when a bot lane's hold could be neither found nor ruled out. It is NOT
+# "no hold" — the scan is label-filtered — so it defers rather than decides: the
+# lane classifies normally and is refused only where it would otherwise merge.
+hold_unproven=""
+
 issue_n="$(linked_issue "$pr_body")"
 if [[ -n "$issue_n" ]]; then
-  issue_labels="$(labels_of issue "$issue_n")" ||
-    die "could not read labels of issue #$issue_n (linked by PR #$pr); refusing to guess whether $OPTOUT_LABEL is set"
-  if has_optout_label "$issue_labels"; then
-    echo "optout"; exit 0
+  exit_if_issue_holds "$issue_n" "linked by"
+elif [[ "$pr_author" == "$DEPENDABOT_AUTHOR" ]]; then
+  # Only Dependabot rewrites its own body, so only Dependabot can have lost the
+  # link. An empty author reads as human here, which is safe: the sole
+  # merge-without-review path re-verifies the author itself and fails closed on
+  # empty. A failed scan dies at once — unlike a matchless one, no later answer
+  # can arrive to settle it.
+  bridge_issues="$(bridge_issues_for_pr)" ||
+    die "could not scan for the bridge issue of PR #$pr; refusing to guess whether $OPTOUT_LABEL is set"
+  if [[ -z "$bridge_issues" ]]; then
+    hold_unproven="yes"
+  else
+    while IFS= read -r bridge_n; do
+      [[ -n "$bridge_n" ]] || continue
+      exit_if_issue_holds "$bridge_n" "marker-linked to"
+    done <<<"$bridge_issues"
   fi
 fi
 
@@ -334,6 +420,12 @@ branch_is_current() {
 # DIRTY/CONFLICTING/BLOCKED/DRAFT/UNKNOWN, and short-circuiting on it keeps the
 # probe off every lane that is not already one step from merging.
 if [[ "$merge_state" == "CLEAN" ]] && branch_is_current; then
+  # The deferred refusal sits HERE, at the only point where an unprovable hold
+  # could do harm: every token above is a wait or a remedy no human reserving the
+  # PR would object to, while these two merge it. Refusing earlier would wedge
+  # lanes that were never about to merge.
+  [[ -z "$hold_unproven" ]] ||
+    die "PR #$pr is Dependabot's, its body links no issue, and no open $BRIDGE_ISSUE_LABEL issue carries $PR_MARKER, so $OPTOUT_LABEL can be neither found nor ruled out; re-run the Dependabot-to-Ralph bridge reconciler (gh workflow run dependabot-to-ralph-issue.yml) to re-link the PR body, then retry"
   echo "$ready_token"
 else
   echo "behind"

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -20,6 +20,13 @@
 # HEAD (a force-push must not re-clear our commits), and both `gh` answers are
 # parsed by field count so a stray `|` fails closed.
 #
+# A fifth dimension guards the hold itself against the bot erasing it: Dependabot
+# regenerates its PR body from its own template on rebase, taking the bridge's
+# appended `Closes #N` with it, so the body-link route vanishes on exactly the PRs
+# the hold exists for. The bridge's `<!-- dependabot-pr:<N> -->` marker lives on
+# the ISSUE, which that rewrite cannot reach, so it is the durable route — and a
+# bot lane where NEITHER route resolves may still classify, but may never merge.
+#
 # Run:  bash scripts/ralph/test_pr_ready.sh
 set -euo pipefail
 
@@ -67,7 +74,18 @@ mkdir -p "$BIN"
 #                   every other issue reads as unlabelled, so a test can pin
 #                   WHICH of several linked issues the hold lookup resolved
 #   ISSUE_LABELS_EC — exit code that same call returns (non-0 = API failure)
-#   PR_BODY       — the body `pr view --json body` returns
+#   ISSUE_LIST_JSON — raw `--json number,body` payload for the `issue list` scan
+#                   that finds the bridge issue by its durable marker; when the
+#                   caller passes `--jq` the stub runs the REAL jq against it, so a
+#                   containment match loose enough to hit a longer PR number is
+#                   caught here rather than masked by a scalar stub. An empty list
+#                   by default, so unrelated cases stay deterministic
+#   ISSUE_LIST_EC — exit code that same call returns (non-0 = API failure)
+#   ISSUE_LIST_SENTINEL — file the stub touches when the issue-list endpoint is hit,
+#                   so a test can prove that scan stays off human lanes entirely
+#   PR_BODY       — the body `pr view --json body,author` returns, emitted AFTER
+#                   PR_AUTHOR as "<author>|<body>": the author leads because a login
+#                   can never contain `|` and a multi-line body can
 #   PR_BODY_EC    — exit code that same call returns (non-0 = API failure)
 #   BASE_REF / HEAD_OID — the "<baseRefName>|<headRefOid>" compare inputs
 #   BEHIND_BY     — `.behind_by` from `gh api .../compare/<base>...<head>`; set it
@@ -75,9 +93,10 @@ mkdir -p "$BIN"
 #   COMPARE_EC    — exit code that same compare call returns (non-0 = API failure)
 #   COMPARE_SENTINEL — file the stub touches when the compare endpoint is hit, so
 #                   a test can prove the freshness probe stayed lazy
-#   PR_AUTHOR     — `.author.login` for `pr view --json author,statusCheckRollup`;
-#                   `app/dependabot` is the one value that can clear the review
-#                   gate, and the empty default fails closed to awaiting-review
+#   PR_AUTHOR     — `.author.login`, answered on BOTH the early body call and
+#                   `pr view --json author,statusCheckRollup`; `app/dependabot` is
+#                   the one value that can clear the review gate or reach the marker
+#                   fallback, and the empty default reads as a human on both
 #   REVIEW_CONCLUSIONS — comma-joined `claude-review` conclusions from that same
 #                   rollup (the real shape repeats one entry per triggering
 #                   event, e.g. `SKIPPED,SKIPPED`); empty = no such check
@@ -116,8 +135,20 @@ case "$args" in
       printf '%s' "${ISSUE_LABELS:-}" | tr ',' '\n'
     fi
     exit "${ISSUE_LABELS_EC:-0}" ;;
+  *"issue list"*)
+    [[ -n "${ISSUE_LIST_SENTINEL:-}" ]] && : > "$ISSUE_LIST_SENTINEL"
+    expr="" prev=""
+    for a in "$@"; do [[ "$prev" == "--jq" ]] && expr="$a"; prev="$a"; done
+    # Real jq when the caller filters server-side, raw payload when it filters its
+    # own — either way the containment match is exercised, never simulated.
+    if [[ -n "$expr" ]]; then
+      printf '%s' "${ISSUE_LIST_JSON:-[]}" | jq -rc "$expr"
+    else
+      printf '%s\n' "${ISSUE_LIST_JSON:-[]}"
+    fi
+    exit "${ISSUE_LIST_EC:-0}" ;;
   *"pr view"*"--json body"*)
-    printf '%s\n' "${PR_BODY:-}"
+    printf '%s|%s\n' "${PR_AUTHOR:-}" "${PR_BODY:-}"
     exit "${PR_BODY_EC:-0}" ;;
   *"pr view"*"--json baseRefName"*) printf '%s|%s\n' "${BASE_REF:-main}" "${HEAD_OID:-c0ffee1}" ;;
   *"pr view"*"--json author"*)
@@ -416,20 +447,27 @@ DEPENDABOT_COMMIT="dependabot[bot]"
 SKIPPED="SKIPPED"
 NO_VERDICT="|false"
 
+# A bot PR whose body carries no issue link reaches its hold only through the
+# bridge issue's durable marker, so every bot lane below that expects a MERGE token
+# has to be given a resolvable, hold-free bridge issue — that is the realistic
+# rewritten-body world. Without it these are the fail-closed case pinned at the end
+# of this file, not the token they are here to test. Do not drop it.
+BRIDGED='[{"number":1982,"body":"<!-- dependabot-pr:100 -->"}]'
+
 check "reviewless dependabot bump + green + CLEAN + behind_by 0 → ready-unreviewed" "ready-unreviewed" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
 
 # The rollup carries one entry per triggering event (push + pull_request), so a
 # repeated SKIPPED is the ordinary live shape, not an anomaly.
 check "duplicate SKIPPED rollup entries → ready-unreviewed" "ready-unreviewed" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED,$SKIPPED" BEHIND_BY=0 run 100)"
 
 # `ready` keeps its full four-part meaning: a reviewed PR is never downgraded to
 # the token that asks the orchestrator to decide.
 check "reviewless setup but WITH a fresh LGTM → plain ready" "ready" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" BEHIND_BY=0 run 100)"
 
 # With the review gate gone the freshness guard carries the whole safety burden,
@@ -482,7 +520,7 @@ check "reviewless bump where NO non-review check succeeded → awaiting-review" 
 # The positive twin: one non-review check that actually passed is the whole claim
 # behind the token, so the guard discriminates rather than refusing every bump.
 check "same bump with one non-review SUCCESS → ready-unreviewed" "ready-unreviewed" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" NON_REVIEW_SUCCESSES=1 \
      BEHIND_BY=0 run 100)"
 
@@ -550,6 +588,7 @@ check "opt-out on a would-be ready-unreviewed PR → optout" "optout" \
 S_GATE_LGTM="$WORK/gate-fresh-lgtm"
 check "fresh LGTM still classifies as ready" "ready" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" REVIEW_SENTINEL="$S_GATE_LGTM" run 100)"
 probed "a fresh verdict never probes the review gate" "no" "$S_GATE_LGTM"
 
@@ -584,9 +623,142 @@ probed "opt-out lane never probes the review gate" "no" "$S_GATE_OPTOUT"
 S_GATE_NONE="$WORK/gate-no-verdict"
 check "no-verdict lane classifies as ready-unreviewed" "ready-unreviewed" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+     ISSUE_LIST_JSON="$BRIDGED" \
      PR_AUTHOR="$DEPENDABOT" REVIEW_CONCLUSIONS="$SKIPPED" \
      REVIEW_SENTINEL="$S_GATE_NONE" run 100)"
 probed "no-verdict lane does probe the review gate" "yes" "$S_GATE_NONE"
+
+# --- the hold must outlive Dependabot rewriting its own PR body -------------
+# A rebase or group recomputation regenerates that body from the bot's template,
+# taking the bridge's appended `Closes #N` with it — so on exactly the bot PRs a
+# human reserves, the body-link route to the hold silently disappears and reading
+# "no link" as "no hold" fails OPEN. The bridge also stamps a marker into the
+# ISSUE body, which the PR rewrite cannot reach because it lives on another
+# object; that is the durable route. A rewritten body still carries the upstream
+# changelog's bare "Fixes" headings, so detection has to key on the reference
+# form, never the keyword alone.
+REWRITTEN_BODY="Bumps ruff from 0.15.0 to 0.16.0.
+
+<h3>Bug fixes</h3>
+<h3>Fixes</h3>
+Dependabot will resolve any conflicts with this PR."
+
+check "hold reached through the issue marker when the body link is gone → optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON="$BRIDGED" \
+     ISSUE_LABELS_FOR=1982 ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# The marker route is checked as EARLY as the body route, so the hold outranks
+# every other token. Lazier placement would let a held bot PR still be synced or
+# handed a ci-debugging worker that pushes commits onto a branch a human owns.
+check "the marker hold short-circuits pending CI" "optout" \
+  "$(CHECKS_EC=8 PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" \
+     ISSUE_LIST_JSON="$BRIDGED" ISSUE_LABELS_FOR=1982 \
+     ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# Marker matching is on the WHOLE marker: a bare `100` also occurs inside `1002`,
+# so a loose containment test would inherit a hold from an unrelated bump.
+NEAR_MISS='[{"number":1002,"body":"<!-- dependabot-pr:1002 -->"},{"number":1982,"body":"<!-- dependabot-pr:100 -->"}]'
+
+check "a hold on a longer PR number is not this PR's hold" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON="$NEAR_MISS" \
+     ISSUE_LABELS_FOR=1002 ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# The twin: with only the longer number present nothing matches, which is silence
+# about a hold, not proof of none — so the merge is refused, not granted.
+NEAR_MISS_ONLY='[{"number":1002,"body":"<!-- dependabot-pr:1002 -->"}]'
+
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON="$NEAR_MISS_ONLY" run 100)" || rc=$?
+check "a near-miss marker leaves the hold unproven and exits 2" "2" "$rc"
+check "a near-miss marker prints no verdict" "" "$out"
+
+# The bridge can leave more than one issue pointing at a bump (a re-run, a manual
+# duplicate), and a hold on ANY of them is still a human saying no.
+TWO_BRIDGES='[{"number":1982,"body":"<!-- dependabot-pr:100 -->"},{"number":1990,"body":"superseded\n<!-- dependabot-pr:100 -->"}]'
+
+check "a hold on the second marker match still wins → optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON="$TWO_BRIDGES" \
+     ISSUE_LABELS_FOR=1990 ISSUE_LABELS="dependencies,$OPTOUT" run 100)"
+
+# Neither route resolving does not mean there is no hold: the scan is filtered by
+# the `dependencies` label, which this repo has watched fail to stick (hence
+# ensure-issue-label.sh). Merging on that silence is the fail-open being fixed.
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=0 \
+   PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" REVIEW_CONCLUSIONS="$SKIPPED" \
+   ISSUE_LIST_JSON='[]' run 100)" || rc=$?
+check "an unprovable hold blocks ready-unreviewed with exit 2" "2" "$rc"
+check "an unprovable hold prints no ready-unreviewed verdict" "" "$out"
+
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON='[]' run 100)" || rc=$?
+check "an unprovable hold blocks ready with exit 2" "2" "$rc"
+check "an unprovable hold prints no ready verdict" "" "$out"
+
+# A failed scan is a tooling error like every other lookup here, and dies at once
+# rather than deferring: there is nothing to defer, no answer can arrive later.
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+   PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_EC=1 run 100)" || rc=$?
+check "marker scan failure exits 2" "2" "$rc"
+check "marker scan failure prints no verdict" "" "$out"
+
+# --- the fallback stays off every lane that cannot need it ------------------
+# Only Dependabot rewrites its own bodies, so a human PR without a link must not
+# pay an API call for it — and must never be held by a scan that cannot apply.
+S_ISSUE_HUMAN="$WORK/issue-list-human"
+check "a human PR with no issue link still classifies as ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     ISSUE_LIST_SENTINEL="$S_ISSUE_HUMAN" run 100)"
+probed "a human PR never scans for a marker" "no" "$S_ISSUE_HUMAN"
+
+S_ISSUE_LINKED="$WORK/issue-list-linked"
+check "a bot PR whose body still links an issue classifies from the link" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LABELS="dependencies" \
+     ISSUE_LIST_SENTINEL="$S_ISSUE_LINKED" run 100)"
+probed "an intact body link never scans for a marker" "no" "$S_ISSUE_LINKED"
+
+# The knowing cost of checking the hold FIRST, pinned rather than hidden: an
+# unlinked bot lane pays for the scan even while CI is still running. That is the
+# price of a hold that outranks every other token, and it is worth it.
+S_ISSUE_PENDING="$WORK/issue-list-pending"
+check "an unlinked bot lane with pending CI still classifies as pending" "pending" \
+  "$(CHECKS_EC=8 PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" \
+     ISSUE_LIST_SENTINEL="$S_ISSUE_PENDING" run 100)"
+probed "an unlinked bot lane scans for a marker before CI settles" "yes" "$S_ISSUE_PENDING"
+
+# An unproven hold refuses only the MERGE. Wedging a lane that is not about to
+# merge would strand it: `behind`'s remedy (a sync) is safe and, by re-linking the
+# body or re-labelling the issue, is often what makes the hold provable again.
+rc=0
+out="$(CHECKS_EC=1 PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" \
+   ISSUE_LIST_JSON='[]' run 100)" || rc=$?
+check "an unprovable hold still reports ci-failed" "ci-failed" "$out"
+check "an unprovable hold does not fail a red lane" "0" "$rc"
+
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=17 \
+   PR_AUTHOR="$DEPENDABOT" PR_BODY="$REWRITTEN_BODY" ISSUE_LIST_JSON='[]' run 100)" || rc=$?
+check "an unprovable hold still reports behind" "behind" "$out"
+check "an unprovable hold does not fail a stale lane" "0" "$rc"
+
+# --- cross-file coupling: the bridge marker ---------------------------------
+# The marker shape exists twice — the bridge writes it, pr-ready.sh reads it — and
+# a silent drift between the two copies restores the exact fail-open being fixed,
+# with nothing anywhere to report that the hold stopped being found.
+MARKER_PREFIX='<!-- dependabot-pr:'
+BRIDGE_WORKFLOW="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/dependabot-to-ralph-issue.yml"
+
+check "the bridge still stamps the marker onto the issue" "yes" \
+  "$(grep -qF "$MARKER_PREFIX" "$BRIDGE_WORKFLOW" 2>/dev/null && echo yes || echo no)"
+check "pr-ready.sh still looks for that same marker" "yes" \
+  "$(grep -qF "$MARKER_PREFIX" "$READY" 2>/dev/null && echo yes || echo no)"
 
 # --- cross-file coupling: the review check's NAME ---------------------------
 # pr-ready.sh matches the review check by the literal string `claude-review`, which


### PR DESCRIPTION
## Summary

The `do-not-auto-merge` human hold was reachable only through text Dependabot
owns and rewrites, so it could evaporate silently on the one PR class this loop
merges with no review verdict.

`pr-ready.sh` looked for the hold on the PR's own labels, or on the issue the PR
body links via `Closes|Fixes|Resolves #N`. The bridge appends that link to the
bot's body — but Dependabot **regenerates that body from its own template** on
every rebase and group recomputation, taking the appended line with it.
`linked_issue()` then returned empty and the script read "no link" as "no hold",
skipping the issue-label check entirely. A hold placed on the bridge issue — the
object a human actually sees in the backlog — was ignored, and the PR could
classify `ready`/`ready-unreviewed` and merge. That is a fail-**open** on the
control that stands in for the repo owner's explicit OK, and it contradicted the
same file's handling of a failed label lookup, which deliberately exits 2 rather
than guessing.

**Confirmed live, not inferred.** Merged bot PRs #2112 and #2114 both carry zero
`(closes|fixes|resolves)\s+#[0-9]+` matches in their bodies after a
`@dependabot rebase`, while their bridge issues #2113 and #2115 still carry
`<!-- dependabot-pr:2112 -->` / `<!-- dependabot-pr:2114 -->`. Both merges
therefore closed nothing and both issues had to be closed by hand. The marker is
the durable route precisely because it lives on the **issue**, which the PR-body
rewrite cannot reach.

Note #2114's body does contain six bare `fixes` hits — all
`<h3>🐛 Bug fixes</h3>` changelog headings — so detection here stays on the
reference pattern and never a bare keyword.

### What changed

A Dependabot-authored PR whose body links nothing now falls back to that marker:
scan open `dependencies` issues for one whose body contains this PR's **whole**
marker, and honour a hold on **any** match. The full-marker match matters —
a bare number is a substring of every longer one, so a looser test would inherit
an unrelated bump's hold (`100` inside `1002`). The shape is copied verbatim from
`dependabot-to-ralph-issue.yml` rather than restated, and a cross-file test pins
the literal in both files so the two copies cannot drift apart in silence.

Three outcomes, each failing closed in the right direction:

- **Scan fails** → `die` (exit 2, no token), exactly like the existing label and
  body lookup failures.
- **Matches found** → every match's labels are checked; a hold on any wins.
- **No match** → this is *silence, not proof*. The scan is filtered by the
  `dependencies` label, which this repo has watched fail to stick (the reason
  `ensure-issue-label.sh` exists). So the lane **defers rather than decides**:
  it classifies normally through `pending`, `ci-failed`, `behind`,
  `awaiting-review` and `changes-requested`, and is refused only where it would
  otherwise print `ready` or `ready-unreviewed`. `behind` still prints `behind`,
  since a sync is always safe and is often what makes the hold provable again by
  re-linking the body.

The fallback fires inside the **opt-out block, before any CI probe**, so a hold
found through the marker outranks every other token exactly as one found through
the body link already does. Placing it at the merge threshold would have been
cheaper and wrong: this file's contract is that the loop does not act on a held
PR *at all*, and a lazy check would still have let a held bot PR be synced, or
handed it a `ci-debugging` worker pushing commits onto a branch a human reserved.
It is gated on the Dependabot author, so ordinary lanes — which routinely link no
issue — make exactly the calls they made before; the author rides along on the
existing body call rather than costing a round trip.

`FLEET.md`, `pr-ready.sh`'s header and `ralph-tick.md` Step 1 are contractually
required to agree, so all three are updated together.

## Test plan

`scripts/ralph/test_pr_ready.sh`: **85 → 109 passing, 0 failing.** 24 new
assertions, 13 of which were RED before the implementation and failed for the
right reason (the script printed a merge token where `optout` or exit 2 was
required — the bug itself, e.g. `expected 'optout', got 'ready'`).

Covering, per acceptance criterion:

- Hold honoured via the marker when the body link is gone → `optout`.
- The same world with `CHECKS_EC=8` still → `optout`, pinning the early
  placement (the marker route short-circuits pending CI as the body route does).
- Full-marker precision: PR 100 does not match an issue marked
  `dependabot-pr:1002`; a near-miss-only list on a would-be-merge exits 2.
- A hold on the **second** marker match still wins.
- Neither route resolvable on a would-be `ready` **and** a would-be
  `ready-unreviewed` → rc 2 with empty stdout (both asserted).
- A failed scan → rc 2, empty stdout (tooling error, never "no hold").
- An ordinary human PR with no link → `ready`, with a sentinel proving **no**
  `gh issue list` call is made.
- Call-profile pins for the laziness trade: no scan when a bot PR's body does
  link an issue; a scan *does* happen on an unlinked bot lane even while pending
  (the knowing trade, documented in the suite rather than hidden).
- An unproven hold never wedges a lane that is not about to merge: `ci-failed`
  and `behind` both still exit 0.
- Cross-file tripwire on the marker literal in both files.

Six pre-existing cases gained one env var (`ISSUE_LIST_JSON="$BRIDGED"`, a
resolvable hold-free bridge issue — the realistic rewritten-body world). They set
a Dependabot author with no body link and expect a merge token; under the new
behaviour that exact world is by design the exit-2 case. **No expected token
changed and no assertion was weakened** — verified by re-running at HEAD with the
additions in place: still 85 passed, 0 failed, nothing flipped.

Also verified:

- 109/0 under **stock `/bin/bash` 3.2.57** (the script must stay bash-3.2-safe);
  `/bin/bash -n` clean.
- `shellcheck --severity=warning` clean (the pre-commit hook's exact args).
- Sibling suites unaffected: `test_fleet` 63/0, `test_pick_next` 23/0,
  `test_watch_pr` 25/0, `test_exec_bits` 12/0, `test_ensure_issue_label` 111/0,
  `pytest scripts/ralph` 82 passed.
- `pre-commit` green on every applicable hook (frontend hooks skip — shell/docs
  only, no `backend/` or `frontend/` sources touched).

## Scope

Deliberately **out**, to be filed as follow-ups rather than silently widened:

1. **`pick-next.sh` mis-scoping.** Its in-flight scan reads open PR *bodies* for
   the same link pattern, so a `dependencies` issue whose link was erased reads
   as *available* and a build lane can be assigned to an issue that must only
   ever be **adopted**. Same root cause, but the direction inverts (issue marker
   → open PR), so it needs its own scan and its own tests.
2. **A narrow residual fail-open.** The fallback fires only when the body links
   *nothing*. A bot body that happened to contain a plain-text changelog
   `Fixes #456` would resolve that unrelated issue and never reach the marker.
   Empirically absent today (Dependabot renders release notes as HTML anchors;
   #2112/#2114 had zero reference-pattern matches), and the acceptance criteria
   scope the fallback to "body link absent" — but it is real. The fix would be to
   consult the marker *in addition to* any body link on a bot lane.

Not changed: `dependabot-to-ralph-issue.yml`. A `pull_request_target` trigger on
`edited`/`synchronize` to re-assert the link would multiply the trigger surface
of a write-token job, and a rebase rewrite arrives as a force-push whose event
timing races the rewrite anyway. The tolerate-fix makes the hold safe regardless.

No `permissions:` block was widened. No gate was weakened.

Closes #2027
