### PR TITLE
test(full-stack): add static wiring guards for screens, routers and API wrappers

### DIFF
--- a/backend/tests/test_router_wiring.py
+++ b/backend/tests/test_router_wiring.py
@@ -1,0 +1,152 @@
+"""Static guard: every router module is actually mounted on the app.
+
+A router module can be written, tested in isolation, and shipped without ever
+being passed to ``app.include_router`` -- its endpoints then answer 404 in
+production while its own unit tests stay green.  This guard derives both sides
+mechanically: the expected set from ``pkgutil.iter_modules`` over the
+``routers`` package, and the mounted set by walking the app's live route tree.
+Neither side is hand-written, so deleting an ``include_router`` call turns this
+red.
+
+The tree walk follows two shapes on purpose.  Older FastAPI flattened included
+routers into ``app.routes`` as ``APIRoute`` objects; 0.141 includes them lazily,
+so ``app.routes`` holds wrapper objects that keep the source router under
+``original_router``.  Reading that attribute with ``getattr`` rather than
+importing the private wrapper class keeps the guard working across an upgrade in
+either direction.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter
+
+import routers
+from main import app
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from types import ModuleType
+
+    from starlette.routing import BaseRoute
+
+# Justifications are DATA, not comments: an inert ``# because ...`` next to an
+# entry cannot fail anything, so the excuse is a required non-empty string that
+# the self-lint test below asserts on.  Entries are also checked for staleness,
+# which makes this allowlist a ratchet that can only shrink.
+ROUTER_ALLOWLIST: dict[str, str] = {}
+
+MIN_JUSTIFICATION_LENGTH = 20
+
+
+def _child_routes(route: object) -> list[object]:
+    """Return the nested routes of ``route`` across both FastAPI shapes."""
+    original = getattr(route, "original_router", None)
+    nested: list[object] = list(getattr(original, "routes", None) or [])
+    nested.extend(getattr(route, "routes", None) or [])
+    return nested
+
+
+def _walk_routes(
+    routes: Iterable[object],
+    visited: set[int],
+    endpoints: set[object],
+) -> None:
+    """Collect every endpoint callable reachable from ``routes``."""
+    for route in routes:
+        if id(route) in visited:
+            continue
+        visited.add(id(route))
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is not None:
+            endpoints.add(endpoint)
+        _walk_routes(_child_routes(route), visited, endpoints)
+
+
+def _mounted_endpoints() -> set[object]:
+    """Return the endpoint callables the running app serves."""
+    endpoints: set[object] = set()
+    _walk_routes(app.routes, set(), endpoints)
+    return endpoints
+
+
+def _router_module_names() -> list[str]:
+    """List the router modules on disk (``__init__`` is excluded by pkgutil)."""
+    return sorted(info.name for info in pkgutil.iter_modules(routers.__path__))
+
+
+def _module_routers(module: ModuleType) -> list[APIRouter]:
+    """Return the module-level ``APIRouter`` values a router module exports."""
+    return [value for value in vars(module).values() if isinstance(value, APIRouter)]
+
+
+def _declared_routes(module_routers: Sequence[APIRouter]) -> list[BaseRoute]:
+    """Flatten the routes declared across a module's routers."""
+    return [route for router in module_routers for route in router.routes]
+
+
+def _any_mounted(routes: Sequence[BaseRoute], mounted: set[object]) -> bool:
+    """Report whether any declared route's endpoint is served by the app."""
+    return any(getattr(route, "endpoint", None) in mounted for route in routes)
+
+
+def _wiring_violation(name: str, mounted: set[object]) -> str | None:
+    """Explain why router module ``name`` is unwired, or ``None`` if it is wired."""
+    module = importlib.import_module(f"routers.{name}")
+    module_routers = _module_routers(module)
+    if not module_routers:
+        return f"{name}: module exports no APIRouter"
+    routes = _declared_routes(module_routers)
+    if not routes:
+        return f"{name}: its APIRouter declares no routes"
+    if _any_mounted(routes, mounted):
+        return None
+    return f"{name}: routes are not mounted (missing app.include_router)"
+
+
+def _unwired_modules() -> dict[str, str]:
+    """Map each unwired router module name to the reason it is unwired."""
+    mounted = _mounted_endpoints()
+    unwired: dict[str, str] = {}
+    for name in _router_module_names():
+        reason = _wiring_violation(name, mounted)
+        if reason is not None:
+            unwired[name] = reason
+    return unwired
+
+
+def _allowlist_problems(name: str, justification: str, unwired: dict[str, str]) -> list[str]:
+    """Report what is wrong with one allowlist entry, if anything."""
+    problems: list[str] = []
+    if len(justification.strip()) < MIN_JUSTIFICATION_LENGTH:
+        problems.append(
+            f"allowlist entry '{name}' needs a justification of at least "
+            f"{MIN_JUSTIFICATION_LENGTH} characters"
+        )
+    if name not in unwired:
+        problems.append(f"stale allowlist entry '{name}' -- remove it")
+    return problems
+
+
+def test_every_router_module_is_mounted() -> None:
+    """Every module under ``routers`` contributes a route the app serves."""
+    # Non-emptiness first: an enumeration that finds nothing would report zero
+    # violations forever, and the guard would pass by doing nothing.
+    assert _router_module_names(), "no router modules discovered under routers/"
+    unwired = _unwired_modules()
+    violations = [reason for name, reason in unwired.items() if name not in ROUTER_ALLOWLIST]
+    assert not violations, "Unmounted router modules: " + "; ".join(violations)
+
+
+def test_router_allowlist_entries_are_justified_and_current() -> None:
+    """Allowlist entries carry a real justification and never outlive their cause."""
+    unwired = _unwired_modules()
+    problems = [
+        problem
+        for name, justification in ROUTER_ALLOWLIST.items()
+        for problem in _allowlist_problems(name, justification, unwired)
+    ]
+    assert not problems, "; ".join(problems)

--- a/frontend/src/__tests__/wiring/apiCallers.test.ts
+++ b/frontend/src/__tests__/wiring/apiCallers.test.ts
@@ -1,0 +1,398 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+import * as ts from 'typescript';
+
+const SRC = path.resolve(__dirname, '..', '..');
+const API_DIR = path.join(SRC, 'api');
+const API_INDEX = path.join(API_DIR, 'index.ts');
+
+const IGNORED_DIRS = new Set(['__tests__', '__mocks__', 'node_modules']);
+const MODULE_SUFFIXES = ['.tsx', '.ts', '/index.tsx', '/index.ts'];
+const MIN_JUSTIFICATION_LENGTH = 20;
+
+/**
+ * Endpoint wrappers knowingly without a production reference, keyed by
+ * ``symbol`` or ``namespace.method``. The justification is DATA, not a comment:
+ * an inert code comment cannot fail a test, so the excuse is a required
+ * non-empty string that the self-lint below asserts on, and stale entries fail
+ * too -- the allowlist is a ratchet that can only shrink.
+ */
+const CALLER_ALLOWLIST: Record<string, string> = {
+  classifyUnauthorizedDetail:
+    'Called inside the API layer by the 401 handler; exported only so its detail-string parsing can be unit tested directly.',
+  fetchAllPages:
+    'Called inside the API layer by listAll and the other Page-envelope readers; exported only for direct unit coverage of the pagination loop.',
+  'habits.list':
+    'Deliberately retained beside listAll as the request-machinery test vehicle and bare-array wire-contract guard, per its own docstring in src/api/index.ts.',
+  idempotencyKey:
+    'Called inside the API layer to key suggestion-accept, invitation-dismiss and return-start; exported for unit coverage, and its caller-supplied seam on the habit check-in wrapper is still unadopted by any screen.',
+  'journal.delete':
+    'Wraps the live DELETE /journal/{entry_id} route, for which no journal screen offers an affordance yet; tracked for adoption or removal.',
+  'practiceTags.remove':
+    'Wraps the live DELETE /practice-tags/{tag_id} route; the tag library UI can list and create tags but not delete one, so this is tracked for adoption or removal.',
+  'practiceTags.update':
+    'Wraps the live PATCH /practice-tags/{tag_id} route; the tag library UI can list and create tags but not rename one, so this is tracked for adoption or removal.',
+  'prompts.history':
+    'Wraps the live GET /prompts/history route, for which no prompt screen offers an affordance yet; tracked for adoption or removal.',
+};
+
+const sourceCache = new Map<string, ts.SourceFile>();
+
+function parseFile(file: string): ts.SourceFile {
+  const cached = sourceCache.get(file);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const parsed = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf-8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  sourceCache.set(file, parsed);
+  return parsed;
+}
+
+function walk(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && !IGNORED_DIRS.has(entry.name)) {
+      found.push(...walk(full));
+    } else if (
+      entry.isFile() &&
+      /\.tsx?$/.test(entry.name) &&
+      !/\.(test|spec)\./.test(entry.name)
+    ) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+// --- Side one: the endpoint wrappers the API module exposes -----------------
+
+function isFunctionValued(node: ts.Node | undefined): boolean {
+  return node !== undefined && (ts.isArrowFunction(node) || ts.isFunctionExpression(node));
+}
+
+function isExported(node: ts.Statement): boolean {
+  return ts.canHaveModifiers(node)
+    ? (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    : false;
+}
+
+/** Every function-valued member of an exported namespace object, as ``X.method``. */
+function objectMembers(namespace: string, object: ts.ObjectLiteralExpression): string[] {
+  const members: string[] = [];
+  for (const property of object.properties) {
+    if (ts.isMethodDeclaration(property) && ts.isIdentifier(property.name)) {
+      members.push(`${namespace}.${property.name.text}`);
+    } else if (
+      ts.isPropertyAssignment(property) &&
+      ts.isIdentifier(property.name) &&
+      isFunctionValued(property.initializer)
+    ) {
+      members.push(`${namespace}.${property.name.text}`);
+    }
+  }
+  return members;
+}
+
+function declarationSymbols(declaration: ts.VariableDeclaration): string[] {
+  if (!ts.isIdentifier(declaration.name)) {
+    return [];
+  }
+  const name = declaration.name.text;
+  const initializer = declaration.initializer;
+  if (isFunctionValued(initializer)) {
+    return [name];
+  }
+  if (initializer !== undefined && ts.isObjectLiteralExpression(initializer)) {
+    return objectMembers(name, initializer);
+  }
+  return [];
+}
+
+/**
+ * Endpoint wrappers, selected by SHAPE rather than by name so the list cannot
+ * drift: exported function declarations, exported function-valued consts, and
+ * every function-valued member of an exported object-literal const.
+ *
+ * Enumerating namespace objects member by member is the point. Treating
+ * ``habits`` as one symbol would pass all eight of its methods the moment any
+ * one of them is referenced, which is nearly no guard at all.
+ *
+ * Falling out by shape, deliberately: ``export class`` (ApiError and friends
+ * are error types, not wrappers), ``interface`` / ``type`` aliases, re-exports,
+ * and consts whose initializer is a primitive (the timeout and header
+ * constants). No name list is maintained anywhere.
+ */
+function exportedWrappers(): string[] {
+  const symbols: string[] = [];
+  for (const statement of parseFile(API_INDEX).statements) {
+    if (!isExported(statement)) {
+      continue;
+    }
+    if (ts.isFunctionDeclaration(statement) && statement.name !== undefined) {
+      symbols.push(statement.name.text);
+    } else if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        symbols.push(...declarationSymbols(declaration));
+      }
+    }
+  }
+  return symbols.sort();
+}
+
+// --- Side two: what production code actually references ---------------------
+
+interface ApiBindings {
+  /** local name -> exported name, so ``import { auth as authApi }`` resolves. */
+  named: Map<string, string>;
+  /** locals bound by ``import * as api from '@/api'``. */
+  namespaces: Set<string>;
+}
+
+function resolveSpecifier(specifier: string, importerDir: string): string | null {
+  let base: string | null = null;
+  if (specifier.startsWith('@/')) {
+    base = path.join(SRC, specifier.slice(2));
+  } else if (specifier.startsWith('.')) {
+    base = path.resolve(importerDir, specifier);
+  }
+  if (base === null) {
+    return null;
+  }
+  for (const suffix of MODULE_SUFFIXES) {
+    const candidate = base + suffix;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function reExportsFromApiIndex(statement: ts.Statement, file: string): ts.NamedExports | null {
+  if (!ts.isExportDeclaration(statement) || statement.isTypeOnly) {
+    return null;
+  }
+  const specifier = statement.moduleSpecifier;
+  if (specifier === undefined || !ts.isStringLiteral(specifier)) {
+    return null;
+  }
+  if (resolveSpecifier(specifier.text, path.dirname(file)) !== API_INDEX) {
+    return null;
+  }
+  const clause = statement.exportClause;
+  return clause !== undefined && ts.isNamedExports(clause) ? clause : null;
+}
+
+/**
+ * Names a module under ``src/api`` forwards out of ``index.ts``, mapped back to
+ * their ``index.ts`` name. ``@/api/practiceShare`` is exactly such a barrel and
+ * is the only path its consumers use, so binding solely on ``@/api`` would
+ * report all five share wrappers as dead.
+ */
+function forwardedNames(file: string): Map<string, string> {
+  const forwarded = new Map<string, string>();
+  if (file === API_INDEX || !file.startsWith(API_DIR + path.sep)) {
+    return forwarded;
+  }
+  for (const statement of parseFile(file).statements) {
+    const clause = reExportsFromApiIndex(statement, file);
+    for (const element of clause?.elements ?? []) {
+      if (!element.isTypeOnly) {
+        forwarded.set(element.name.text, (element.propertyName ?? element.name).text);
+      }
+    }
+  }
+  return forwarded;
+}
+
+interface ApiImportLink {
+  clause: ts.ImportClause;
+  /** null for a direct ``src/api`` import; otherwise a barrel's name mapping. */
+  translation: Map<string, string> | null;
+}
+
+/** Resolve, never string-match: ``@/api``, ``../api`` and ``@/api/practiceShare``
+ * all reach the same surface, and only resolution can tell. */
+function apiImportLink(statement: ts.Statement, file: string): ApiImportLink | null {
+  if (!ts.isImportDeclaration(statement) || statement.importClause === undefined) {
+    return null;
+  }
+  const specifier = statement.moduleSpecifier;
+  if (!ts.isStringLiteral(specifier)) {
+    return null;
+  }
+  const resolved = resolveSpecifier(specifier.text, path.dirname(file));
+  if (resolved === null) {
+    return null;
+  }
+  const clause = statement.importClause;
+  if (resolved === API_INDEX) {
+    return { clause, translation: null };
+  }
+  const forwarded = forwardedNames(resolved);
+  return forwarded.size > 0 ? { clause, translation: forwarded } : null;
+}
+
+function boundExportName(
+  element: ts.ImportSpecifier,
+  translation: Map<string, string> | null,
+): string | undefined {
+  if (element.isTypeOnly) {
+    return undefined;
+  }
+  const exported = (element.propertyName ?? element.name).text;
+  return translation === null ? exported : translation.get(exported);
+}
+
+function addClauseBindings(link: ApiImportLink, bindings: ApiBindings): void {
+  const { clause, translation } = link;
+  if (clause.isTypeOnly) {
+    return;
+  }
+  const named = clause.namedBindings;
+  if (named === undefined) {
+    return;
+  }
+  if (ts.isNamespaceImport(named)) {
+    if (translation === null) {
+      bindings.namespaces.add(named.name.text);
+    }
+    return;
+  }
+  for (const element of named.elements) {
+    const exported = boundExportName(element, translation);
+    if (exported !== undefined) {
+      bindings.named.set(element.name.text, exported);
+    }
+  }
+}
+
+/** Local bindings a consumer holds on the API surface. */
+function apiBindings(source: ts.SourceFile, file: string): ApiBindings {
+  const bindings: ApiBindings = { named: new Map(), namespaces: new Set() };
+  for (const statement of source.statements) {
+    const link = apiImportLink(statement, file);
+    if (link !== null) {
+      addClauseBindings(link, bindings);
+    }
+  }
+  return bindings;
+}
+
+function recordPropertyAccess(
+  node: ts.PropertyAccessExpression,
+  bindings: ApiBindings,
+  reached: Set<string>,
+): void {
+  const object = node.expression;
+  if (ts.isIdentifier(object)) {
+    const exported = bindings.named.get(object.text);
+    if (exported !== undefined) {
+      reached.add(`${exported}.${node.name.text}`);
+    } else if (bindings.namespaces.has(object.text)) {
+      reached.add(node.name.text);
+    }
+    return;
+  }
+  if (
+    ts.isPropertyAccessExpression(object) &&
+    ts.isIdentifier(object.expression) &&
+    bindings.namespaces.has(object.expression.text)
+  ) {
+    reached.add(`${object.name.text}.${node.name.text}`);
+  }
+}
+
+function recordReference(node: ts.Node, bindings: ApiBindings, reached: Set<string>): void {
+  if (ts.isPropertyAccessExpression(node)) {
+    recordPropertyAccess(node, bindings, reached);
+    return;
+  }
+  if (ts.isIdentifier(node)) {
+    const exported = bindings.named.get(node.text);
+    if (exported !== undefined) {
+      reached.add(exported);
+    }
+  }
+}
+
+/**
+ * Reference-based, not call-based. Wrappers are injected as values here (a
+ * screen passes ``practiceRecipes.list`` down as a prop default), so demanding
+ * a following ``(`` would report those as dead.
+ *
+ * ``import`` declarations are not walked -- importing a symbol is not using it
+ * -- and ``ts.TypeQueryNode`` subtrees are skipped, so ``typeof
+ * practiceRecipes.list`` in a prop type does not count as a value reference.
+ */
+function collectReferences(file: string, reached: Set<string>): void {
+  const source = parseFile(file);
+  const bindings = apiBindings(source, file);
+  if (bindings.named.size === 0 && bindings.namespaces.size === 0) {
+    return;
+  }
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) || ts.isTypeQueryNode(node)) {
+      return;
+    }
+    recordReference(node, bindings, reached);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(source, visit);
+}
+
+/** Production consumers: all of ``src`` except the API module and test scaffolding. */
+function consumerFiles(): string[] {
+  return walk(SRC).filter((file) => !file.startsWith(API_DIR + path.sep));
+}
+
+function referencedSymbols(): Set<string> {
+  const reached = new Set<string>();
+  for (const file of consumerFiles()) {
+    collectReferences(file, reached);
+  }
+  return reached;
+}
+
+function unreferencedWrappers(): string[] {
+  const reached = referencedSymbols();
+  return exportedWrappers().filter((symbol) => !reached.has(symbol));
+}
+
+function allowlistProblems(key: string, justification: string, violations: Set<string>): string[] {
+  const problems: string[] = [];
+  if (justification.trim().length < MIN_JUSTIFICATION_LENGTH) {
+    problems.push(
+      `allowlist entry '${key}' needs a justification of at least ${MIN_JUSTIFICATION_LENGTH} characters`,
+    );
+  }
+  if (!violations.has(key)) {
+    problems.push(`stale allowlist entry '${key}' -- remove it`);
+  }
+  return problems;
+}
+
+describe('wiring: every API endpoint wrapper has a production reference', () => {
+  it('has no endpoint wrapper unreachable from production code', () => {
+    // Non-emptiness first: an enumeration that finds nothing would report zero
+    // violations forever, and the guard would pass by doing nothing.
+    expect(exportedWrappers().length).toBeGreaterThan(0);
+    const violations = unreferencedWrappers().filter((symbol) => !(symbol in CALLER_ALLOWLIST));
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps allowlist entries justified and current', () => {
+    const unreferenced = new Set(unreferencedWrappers());
+    const problems = Object.entries(CALLER_ALLOWLIST).flatMap(([symbol, justification]) =>
+      allowlistProblems(symbol, justification, unreferenced),
+    );
+    expect(problems).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/wiring/screensMounted.test.ts
+++ b/frontend/src/__tests__/wiring/screensMounted.test.ts
@@ -1,0 +1,220 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+import * as ts from 'typescript';
+
+const SRC = path.resolve(__dirname, '..', '..');
+const FEATURES_DIR = path.join(SRC, 'features');
+const NAVIGATION_DIR = path.join(SRC, 'navigation');
+// App.tsx is a navigator root, not just the entry point: the six Auth screens
+// and WelcomeScreen are mounted by ``AuthNavigator`` / ``WelcomeGate`` there and
+// are never imported from ``navigation/``. Omitting it would blind the guard to
+// seven screens.
+const APP_ENTRY = path.join(SRC, 'App.tsx');
+
+const IGNORED_DIRS = new Set(['__tests__', '__mocks__', 'node_modules']);
+const MODULE_SUFFIXES = ['.tsx', '.ts', '/index.tsx', '/index.ts'];
+const MIN_JUSTIFICATION_LENGTH = 20;
+
+/**
+ * Screens knowingly absent from every navigator, keyed by their path relative
+ * to ``src``. The justification is DATA, not a comment: an inert code comment
+ * cannot fail a test, so the excuse is a required non-empty string that the
+ * self-lint below asserts on, and stale entries fail too -- the allowlist is a
+ * ratchet that can only shrink.
+ */
+const SCREEN_ALLOWLIST: Record<string, string> = {};
+
+const sourceCache = new Map<string, ts.SourceFile>();
+
+function parseFile(file: string): ts.SourceFile {
+  const cached = sourceCache.get(file);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const parsed = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf-8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  sourceCache.set(file, parsed);
+  return parsed;
+}
+
+function walk(dir: string, matches: (name: string) => boolean): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && !IGNORED_DIRS.has(entry.name)) {
+      found.push(...walk(full, matches));
+    } else if (entry.isFile() && matches(entry.name)) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+const isScreenFile = (name: string): boolean =>
+  /Screen\.tsx$/.test(name) && !/\.(test|spec)\.tsx$/.test(name);
+
+const isSourceFile = (name: string): boolean =>
+  /\.tsx?$/.test(name) && !/\.(test|spec)\.tsx?$/.test(name);
+
+/** A named import binding is a mount only if it carries a runtime value. */
+function isTypeOnlyClause(clause: ts.ImportClause | undefined): boolean {
+  if (clause === undefined || clause.name !== undefined) {
+    return false;
+  }
+  if (clause.isTypeOnly) {
+    return true;
+  }
+  const bindings = clause.namedBindings;
+  if (bindings === undefined || !ts.isNamedImports(bindings)) {
+    return false;
+  }
+  return bindings.elements.length > 0 && bindings.elements.every((el) => el.isTypeOnly);
+}
+
+function literalSpecifier(node: ts.Expression | undefined): string | null {
+  return node !== undefined && ts.isStringLiteral(node) ? node.text : null;
+}
+
+/** The module specifier of a value-carrying import/export, else null. */
+function valueModuleSpecifier(node: ts.Statement): string | null {
+  if (ts.isImportDeclaration(node)) {
+    return isTypeOnlyClause(node.importClause) ? null : literalSpecifier(node.moduleSpecifier);
+  }
+  if (ts.isExportDeclaration(node) && !node.isTypeOnly) {
+    return literalSpecifier(node.moduleSpecifier);
+  }
+  return null;
+}
+
+function valueImports(file: string): string[] {
+  const specifiers: string[] = [];
+  for (const statement of parseFile(file).statements) {
+    const specifier = valueModuleSpecifier(statement);
+    if (specifier !== null) {
+      specifiers.push(specifier);
+    }
+  }
+  return specifiers;
+}
+
+/** ``@/x`` mirrors the jest ``moduleNameMapper``; bare packages are not ours. */
+function basePath(specifier: string, importerDir: string): string | null {
+  if (specifier.startsWith('@/')) {
+    return path.join(SRC, specifier.slice(2));
+  }
+  return specifier.startsWith('.') ? path.resolve(importerDir, specifier) : null;
+}
+
+function resolveModule(specifier: string, importerDir: string): string | null {
+  const base = basePath(specifier, importerDir);
+  if (base === null) {
+    return null;
+  }
+  for (const suffix of MODULE_SUFFIXES) {
+    const candidate = base + suffix;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** A pure re-export hub: nothing but imports and exports, at least one of which
+ * forwards another module. Screens reached through one still count as mounted. */
+function isBarrel(file: string): boolean {
+  const { statements } = parseFile(file);
+  const forwards = statements.some(
+    (s) => ts.isExportDeclaration(s) && s.moduleSpecifier !== undefined,
+  );
+  return (
+    forwards && statements.every((s) => ts.isImportDeclaration(s) || ts.isExportDeclaration(s))
+  );
+}
+
+function noteReference(
+  resolved: string,
+  referenced: Set<string>,
+  visited: Set<string>,
+  queue: string[],
+): void {
+  referenced.add(resolved);
+  if (!visited.has(resolved) && isBarrel(resolved)) {
+    visited.add(resolved);
+    queue.push(resolved);
+  }
+}
+
+function referencedModules(roots: string[]): Set<string> {
+  const referenced = new Set<string>();
+  const visited = new Set<string>(roots);
+  const queue = [...roots];
+  let file = queue.pop();
+  while (file !== undefined) {
+    for (const specifier of valueImports(file)) {
+      const resolved = resolveModule(specifier, path.dirname(file));
+      if (resolved !== null) {
+        noteReference(resolved, referenced, visited, queue);
+      }
+    }
+    file = queue.pop();
+  }
+  return referenced;
+}
+
+function allowlistProblems(key: string, justification: string, violations: Set<string>): string[] {
+  const problems: string[] = [];
+  if (justification.trim().length < MIN_JUSTIFICATION_LENGTH) {
+    problems.push(
+      `allowlist entry '${key}' needs a justification of at least ${MIN_JUSTIFICATION_LENGTH} characters`,
+    );
+  }
+  if (!violations.has(key)) {
+    problems.push(`stale allowlist entry '${key}' -- remove it`);
+  }
+  return problems;
+}
+
+function unmountedScreens(): string[] {
+  const roots = [APP_ENTRY, ...walk(NAVIGATION_DIR, isSourceFile)];
+  const referenced = referencedModules(roots);
+  return walk(FEATURES_DIR, isScreenFile)
+    .filter((screen) => !referenced.has(screen))
+    .map((screen) => path.relative(SRC, screen))
+    .sort();
+}
+
+/**
+ * Static reachability guard: every ``*Screen.tsx`` under ``src/features`` is
+ * imported by a navigator root (``src/navigation/**`` or ``src/App.tsx``).
+ *
+ * Limitation, stated honestly: "mounted" here means "statically imported by a
+ * navigator". A screen that is imported but never rendered in a
+ * ``<Stack.Screen component={...}>`` would slip past. That hole is closed by a
+ * different gate -- ESLint runs at zero warnings with ``no-unused-vars``, so an
+ * import nothing renders fails lint. JSX-level verification is deliberately not
+ * attempted: it would require resolving component identifiers through the type
+ * checker for no coverage the composed gates do not already give.
+ */
+describe('wiring: every feature screen is mounted in a navigator', () => {
+  it('has no screen missing from every navigator root', () => {
+    // Non-emptiness first: a walk that finds nothing would otherwise report
+    // zero violations forever, and the guard would pass by doing nothing.
+    expect(walk(FEATURES_DIR, isScreenFile).length).toBeGreaterThan(0);
+    const violations = unmountedScreens().filter((screen) => !(screen in SCREEN_ALLOWLIST));
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps allowlist entries justified and current', () => {
+    const unmounted = new Set(unmountedScreens());
+    const problems = Object.entries(SCREEN_ALLOWLIST).flatMap(([screen, justification]) =>
+      allowlistProblems(screen, justification, unmounted),
+    );
+    expect(problems).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Three static reachability guards that fail the existing suites the moment a
screen, a router, or an API endpoint wrapper stops being reachable. Test-only:
**zero production files changed**, 770 lines added.

The epic's premise (#2035) is that both halves of this stack are tested
exhaustively in isolation and nothing asserts they are connected, so a feature
can ship "wired to nothing" with every suite green — six merged issues are
instances of that one root cause. The de-slop detector finds such code weeks
later by noticing it is orphaned; nothing catches it before merge.

The design constraint that mattered: **a guard whose expected set is a
hand-maintained list buys nothing**, because deleting a screen and its list
entry together still passes. So each guard derives both sides mechanically and
restates neither. Nothing is hand-maintained except the allowlists.

| Guard | Expected set | Actual set |
|---|---|---|
| `screensMounted.test.ts` | filesystem walk of `features/**/*Screen.tsx` (21) | TS-AST value imports of the navigator roots, followed through barrels to resolved paths |
| `apiCallers.test.ts` | AST shape scan of `api/index.ts` — 11 exported functions **plus each function-valued member of the 26 namespace objects** (104 symbols) | TS-AST value references across 357 production files |
| `test_router_wiring.py` | `pkgutil.iter_modules` over `routers` (27) | endpoint identities from a walk of the mounted `main.app` route tree (120) |

### Three findings worth calling out

**Searching `navigation/` alone would blind the screens guard to a third of the
app.** The six Auth screens and `WelcomeScreen` are mounted only in `App.tsx`.
Proven by mutation against both root kinds independently.

**Treating an API namespace as one symbol makes that guard nearly worthless.**
`habits` is referenced somewhere, so all eight of its methods would pass even
if seven were dead. The guard enumerates members individually. Detection is
alias-aware (`AuthContext` imports `auth as authApi`; a naive scan reports 29
spurious violations) and reference-based rather than call-based (screens inject
wrappers as prop defaults, e.g. `props.list ?? practiceRecipes.list`; requiring
a following `(` reports 11 more). Type-query positions do not count.

**The obvious backend implementation is wrong on this repo's FastAPI.** 0.141
includes routers lazily, so `app.routes` holds wrapper objects rather than
flattened `APIRoute`s — the natural
`{r.endpoint for r in app.routes if isinstance(r, APIRoute)}` sees only the
three health endpoints and reports all 27 routers unmounted. The walk reads
`original_router` through `getattr` rather than naming the private class, so it
holds across a FastAPI upgrade in either direction.

### Allowlists

Justifications are **data, not comments** — an inert comment cannot fail
anything, so each entry is a required string that a second self-lint test
asserts on (>= 20 chars). That test also fails **stale** entries, so an
allowlist can only ever shrink. Each main test asserts its derived set is
non-empty first, so a renamed directory turns a guard red rather than quietly
into a permanent pass.

Screens and routers ship with **empty** allowlists. Eight API wrappers are
allowlisted, in two honest categories:

- **Permanent, correct as they stand** — `classifyUnauthorizedDetail`,
  `fetchAllPages` and `idempotencyKey` are called inside `src/api/index.ts`
  itself and exported only for direct unit coverage; `habits.list` carries its
  own rationale at `api/index.ts:1070`.
- **Debt, filed as #2128** — `journal.delete`, `prompts.history`,
  `practiceTags.update` and `practiceTags.remove` each wrap a **live backend
  route** that no UI ever calls. Per this issue's scope rule they are
  allowlisted with justifications rather than wired up here.

### Known limitation, stated in the code

"Mounted" means "statically imported by a navigator". A screen imported but
never rendered would slip this guard — closed by a different gate, since ESLint
runs at zero warnings and an unused import fails lint. JSX-level verification
was deliberately not attempted.

## Test plan

`./scripts/frontend/check-all.sh` -> exit 0 (5/5; 448 suites, 5183 tests).
`./scripts/backend/check-all.sh` -> exit 0 (7/7; coverage 97%).
All 28 pre-commit hooks pass.

**Every guard was proven to fail by deleting the wiring it protects**, then
reverted (worktree verified clean after each):

| Mutation | Result |
|---|---|
| Unmount `JournalPhotographScreen` from `RootStack.tsx` | `+ "features/Journal/JournalPhotographScreen.tsx"` |
| Unmount `CancelResetScreen` from `App.tsx` | `+ "features/Auth/CancelResetScreen.tsx"` |
| Remove the sole *value* reference to `practiceRecipes.apply`, leaving three `typeof` uses | `+ "practiceRecipes.apply"` |
| Remove the sole value reference to `practiceTags.create`, leaving two `typeof` uses | `+ "practiceTags.create"` |
| Comment out `app.include_router(metta_return_router)` | `AssertionError: Unmounted router modules: metta_return: routes are not mounted (missing app.include_router)` |
| Comment out `app.include_router(ui_flags_router)` | `AssertionError: Unmounted router modules: ui_flags: routes are not mounted (missing app.include_router)` |
| Allowlist entry with an empty justification | `+ "allowlist entry 'habits.list' needs a justification of at least 20 characters"` |
| Justified allowlist entry for a symbol that *is* referenced | `+ "stale allowlist entry 'habits.listAll' -- remove it"` |

The last two API mutations are the load-bearing ones: they show the member-level
enumeration has teeth where a namespace-level guard would stay green, and that
the `TypeQueryNode` exclusion is real work — surviving `typeof` references did
not mask either deletion.

Closes #2036
Refs #2035
Refs #2128