### PR TITLE
test(backend): add a Postgres-backed integration lane with an alembic-built schema

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -256,6 +256,72 @@ jobs:
           # pg_advisory_xact_lock branch that SQLite cannot.
           python -m pytest tests/test_pg_advisory_lock.py -q --no-cov
 
+  backend-integration:
+    # The default suite runs entirely on in-memory SQLite, where
+    # ``backend/conftest.py`` rewrites Postgres ``ARRAY`` columns to ``JSON``
+    # and hand-mirrors the functional / partial unique indexes under
+    # ``..._test`` names. This lane runs the same FastAPI app against a real
+    # Postgres whose schema comes from ``alembic upgrade head``, so array
+    # semantics and index definitions are exercised as production has them
+    # rather than as the fixture approximates them.
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aptitude
+          POSTGRES_PASSWORD: aptitude  # pragma: allowlist secret
+          POSTGRES_DB: aptitude
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U aptitude"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      # Deliberately no job-level DATABASE_URL, unlike migration-drift: the
+      # lane's fixture creates a per-worker database, points alembic at it for
+      # the duration of the upgrade, and restores the variable afterwards. A
+      # job-level value would migrate the service's default database instead.
+      TEST_POSTGRES_URL: postgresql+asyncpg://aptitude:aptitude@localhost:5432/aptitude  # pragma: allowlist secret
+      # Turns "the service container never became healthy" from a green run
+      # full of skips into a job failure.
+      INTEGRATION_LANE_REQUIRE_POSTGRES: "1"
+      SECRET_KEY: ci-only-secret-do-not-use-in-prod  # pragma: allowlist secret
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          # Cache uv's download/build cache, keyed on the requirements files so
+          # a dependency change busts it (audit-ci-05).
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
+
+      - name: Install backend deps
+        run: |
+          uv pip install --system -r backend/requirements-lock.txt
+          uv pip install --system -r backend/requirements-dev.txt
+
+      - name: Run the Postgres integration lane
+        working-directory: backend
+        run: |
+          # Serial on purpose. The lane is a couple of dozen tests and each
+          # extra worker pays for its own database creation plus a full
+          # ``alembic upgrade head``, which costs more than the parallelism
+          # buys back.
+          #
+          # --no-cov: the repo-wide 90% coverage gate belongs to the
+          # backend-quality job, which measures the whole suite.
+          python -m pytest tests/integration -m integration -q --no-cov
+
   content-drift:
     # Issue #397: the vendored backend/content/ must match its pinned
     # CONTENT_VERSION (no silent drift, no hand edits) and the manifest

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -123,6 +123,7 @@ pythonpath = ["."]
 xfail_strict = true
 markers = [
   "real_license_gate: exercise the real Gumroad signup license gate instead of the default test stub-open fixture",
+  "integration: run against a live Postgres 16 whose schema is built by `alembic upgrade head` rather than the SQLite approximation; skipped when TEST_POSTGRES_URL is unset, and hard-failed instead of skipped when INTEGRATION_LANE_REQUIRE_POSTGRES is truthy",
 ]
 
 [tool.coverage.run]

--- a/backend/tests/integration/__init__.py
+++ b/backend/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Tests that run against a live Postgres whose schema is built by alembic."""

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,313 @@
+"""Fixtures binding this package to a live Postgres migrated by alembic.
+
+Run the lane locally against any reachable Postgres 16::
+
+    cd backend
+    export TEST_POSTGRES_URL=postgresql+asyncpg://USER:PASS@HOST/DB  # pragma: allowlist secret
+    pytest -m integration
+
+The account named in that URL needs CREATE DATABASE: the lane never touches the
+database in the URL, only creates and drops one beside it.
+
+With ``TEST_POSTGRES_URL`` unset the whole package skips, so the default SQLite
+suite is unaffected. Setting ``INTEGRATION_LANE_REQUIRE_POSTGRES=1`` (as CI
+does) removes that escape hatch: a missing URL then fails instead of skipping.
+
+Lifecycle, and why it is split the way it is:
+
+* The session-scoped fixture is **synchronous**. ``alembic.command.upgrade``
+  runs ``asyncio.run`` internally via ``migrations/env.py``, which is legal
+  from sync fixture context and illegal from inside a running loop. The admin
+  DDL and the provenance check use ``asyncio.run`` from the same place for
+  consistency.
+* The engine and the HTTP client are **function-scoped**. pytest-asyncio gives
+  each test its own event loop, and a session-scoped async engine would hand
+  later tests connections bound to a loop that has already closed. Only object
+  lifetime moves; the database is still created and migrated once per worker.
+* Each test runs inside an outer transaction that is rolled back at teardown,
+  with the session joined to it via savepoints so the routers' own ``commit``
+  and ``begin_nested`` calls behave normally and still leave nothing behind.
+
+Nothing here skips except the single "no URL configured" branch. A refused
+connection, a non-Postgres dialect, a missing alembic stamp or a failed
+CREATE DATABASE are all defects of the lane itself and must be loud.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import AsyncGenerator, Iterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.pool import NullPool
+from sqlmodel import SQLModel
+
+from database import get_session
+from main import app
+from tests.integration.pg_lane import (
+    URL_ENV,
+    IntegrationLaneMisconfiguredError,
+    integration_database_name,
+    resolve_integration_database_url,
+)
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_ALEMBIC_INI = _BACKEND_ROOT / "alembic.ini"
+_MIGRATIONS_DIR = _BACKEND_ROOT / "migrations"
+
+# ``migrations/env.py`` overrides the config's URL from this variable, so it has
+# to name the per-worker database while the upgrade runs.
+_DATABASE_URL_ENV = "DATABASE_URL"
+
+_POSTGRESQL_DIALECT = "postgresql"
+
+_SKIP_REASON = f"{URL_ENV} is unset -- the Postgres integration lane needs a live server"
+
+# Database names are interpolated into DDL that cannot take bind parameters, so
+# they are constrained to an unambiguous identifier shape first.
+_SAFE_IDENTIFIER = re.compile(r"[a-z0-9_]+")
+
+# ``ARRAY`` columns as the models declare them, captured while the metadata is
+# still pristine. Collection imports every conftest before any test body runs,
+# so nothing has had the chance to rewrite them yet -- see
+# :func:`_assert_array_columns_intact` for what this defends against.
+_DECLARED_ARRAY_COLUMNS: frozenset[tuple[str, str]] = frozenset(
+    (table.name, column.name)
+    for table in SQLModel.metadata.tables.values()
+    for column in table.columns
+    if isinstance(column.type, PG_ARRAY)
+)
+
+
+def _current_array_columns() -> frozenset[tuple[str, str]]:
+    """Return the ``(table, column)`` pairs currently typed as Postgres ARRAY."""
+    return frozenset(
+        (table.name, column.name)
+        for table in SQLModel.metadata.tables.values()
+        for column in table.columns
+        if isinstance(column.type, PG_ARRAY)
+    )
+
+
+def _assert_array_columns_intact() -> None:
+    """Fail if the SQLite fixture's ARRAY-to-JSON rewrite has already run.
+
+    ``backend/conftest._replace_array_columns`` mutates ``SQLModel.metadata``
+    process-globally. Against a real Postgres that would send a JSON string
+    into a ``varchar[]`` column, and the resulting error would point at the
+    model rather than at the fixture that broke it. The lane is selected by
+    marker so no SQLite fixture should ever have run first, but "should" is
+    not a guarantee worth betting a confusing failure on.
+
+    Raises:
+        IntegrationLaneMisconfiguredError: The declared ARRAY columns are
+            missing, either because they were rewritten or because the snapshot
+            itself was taken too late to mean anything.
+    """
+    lost = _DECLARED_ARRAY_COLUMNS - _current_array_columns()
+    if _DECLARED_ARRAY_COLUMNS and not lost:
+        return
+    detail = sorted(f"{table}.{column}" for table, column in lost) or "no ARRAY column at all"
+    msg = (
+        f"SQLModel.metadata no longer declares {detail} as a Postgres ARRAY. A "
+        "SQLite fixture rewrote the type to JSON in this process, which would "
+        "corrupt every write the integration lane makes to a real Postgres."
+    )
+    raise IntegrationLaneMisconfiguredError(msg)
+
+
+def _quoted_database_name(name: str) -> str:
+    """Return ``name`` quoted for DDL, rejecting anything that is not an identifier.
+
+    Raises:
+        IntegrationLaneMisconfiguredError: ``name`` is not a bare lowercase
+            identifier.
+    """
+    if not _SAFE_IDENTIFIER.fullmatch(name):
+        msg = f"refusing to build DDL for the non-identifier database name {name!r}"
+        raise IntegrationLaneMisconfiguredError(msg)
+    return f'"{name}"'
+
+
+async def _run_admin_statements(admin_url: URL, statements: tuple[str, ...]) -> None:
+    """Execute DDL on the URL's own database with autocommit.
+
+    ``CREATE`` / ``DROP DATABASE`` cannot run inside a transaction block, hence
+    the AUTOCOMMIT isolation level and the pool-less engine.
+    """
+    engine = create_async_engine(admin_url, isolation_level="AUTOCOMMIT", poolclass=NullPool)
+    try:
+        async with engine.connect() as connection:
+            for statement in statements:
+                await connection.execute(text(statement))
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config(url: str) -> Config:
+    """Return an alembic config pointed at ``url``.
+
+    ``config_file_name`` is suppressed so ``env.py`` skips its ``fileConfig``
+    call: loading ``alembic.ini``'s ``[loggers]`` section disables every logger
+    created before it, which breaks ``caplog`` assertions in unrelated tests
+    sharing the process.
+    """
+    config = Config(str(_ALEMBIC_INI))
+    config.config_file_name = None
+    config.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    config.set_main_option("sqlalchemy.url", url)
+    return config
+
+
+def _migrate_to_head(url: str) -> set[str]:
+    """Build the schema at ``url`` from zero and return the script head revisions."""
+    config = _alembic_config(url)
+    command.upgrade(config, "head")
+    return set(ScriptDirectory.from_config(config).get_heads())
+
+
+async def _verify_provenance(url: str, heads: set[str]) -> None:
+    """Assert the migrated database is Postgres and stamped at every script head.
+
+    This is the tripwire for the lane silently degrading into something it was
+    built to replace -- a SQLite fallback, or a schema that only partly
+    migrated. The expected revisions come from the script directory, never from
+    a literal, so adding a migration cannot leave this comparison stale.
+
+    Raises:
+        IntegrationLaneMisconfiguredError: The dialect is not Postgres, or the
+            stamped revisions differ from the script heads.
+    """
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as connection:
+            dialect = connection.dialect.name
+            result = await connection.execute(text("SELECT version_num FROM alembic_version"))
+            stamped = set(result.scalars().all())
+    finally:
+        await engine.dispose()
+
+    if dialect != _POSTGRESQL_DIALECT:
+        msg = f"the integration lane connected to a {dialect!r} database, not Postgres"
+        raise IntegrationLaneMisconfiguredError(msg)
+    if stamped != heads:
+        msg = (
+            f"the integration database is stamped at {sorted(stamped)} but the "
+            f"migration scripts head at {sorted(heads)}; the schema did not come "
+            f"from a complete `alembic upgrade head`"
+        )
+        raise IntegrationLaneMisconfiguredError(msg)
+
+
+@pytest.fixture(scope="session")
+def pg_database_url() -> Iterator[str]:
+    """Create, migrate and finally drop this worker's own database.
+
+    Yields the URL of a database whose schema was built by
+    ``alembic upgrade head`` from nothing. Deliberately synchronous: alembic
+    drives its own ``asyncio.run``, which only works outside a running loop.
+
+    The name disambiguates xdist workers within one run, not runs against each
+    other. CI gives every job a private service container, but two concurrent
+    local invocations pointed at one shared server would both claim
+    ``adepthood_it_master`` and race on the CREATE/DROP -- give them distinct
+    ``TEST_POSTGRES_URL`` servers rather than sharing one.
+    """
+    base = resolve_integration_database_url(os.environ)
+    if base is None:
+        pytest.skip(_SKIP_REASON)
+    _assert_array_columns_intact()
+
+    admin_url = make_url(base)
+    name = integration_database_name(os.environ)
+    quoted = _quoted_database_name(name)
+    rendered = admin_url.set(database=name).render_as_string(hide_password=False)
+
+    # FORCE terminates any connection a crashed earlier run left behind, so a
+    # stale backend cannot turn the next run into an unexplained hang.
+    drop = f"DROP DATABASE IF EXISTS {quoted} WITH (FORCE)"
+    asyncio.run(_run_admin_statements(admin_url, (drop, f"CREATE DATABASE {quoted}")))
+    try:
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setenv(_DATABASE_URL_ENV, rendered)
+            heads = _migrate_to_head(rendered)
+        asyncio.run(_verify_provenance(rendered, heads))
+        yield rendered
+    finally:
+        asyncio.run(_run_admin_statements(admin_url, (drop,)))
+
+
+@pytest_asyncio.fixture
+async def pg_engine(pg_database_url: str) -> AsyncGenerator[AsyncEngine, None]:
+    """Yield an engine created inside the current test's event loop.
+
+    Function-scoped because pytest-asyncio closes its loop after every test,
+    and connections checked out under a closed loop raise "attached to a
+    different loop". Creating an engine against a local Postgres costs
+    milliseconds; the expensive part (migrating) already happened once.
+    """
+    engine = create_async_engine(pg_database_url, poolclass=NullPool)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def pg_session(pg_engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    """Yield a session whose every write is rolled back when the test ends.
+
+    The session joins an outer transaction through savepoints, so a router's
+    ``commit()`` or ``begin_nested()`` behaves exactly as it does in production
+    -- constraints fire, ``IntegrityError`` surfaces -- while the outer rollback
+    still leaves the database untouched for the next test.
+
+    ``expire_on_commit=False`` mirrors ``database.async_session_factory``, so
+    handlers can keep reading attributes off an instance after committing it.
+    """
+    async with pg_engine.connect() as connection:
+        transaction = await connection.begin()
+        session = AsyncSession(
+            bind=connection,
+            join_transaction_mode="create_savepoint",
+            expire_on_commit=False,
+        )
+        try:
+            yield session
+        finally:
+            await session.close()
+            await transaction.rollback()
+
+
+@pytest_asyncio.fixture
+async def pg_client(pg_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    """HTTP client driving the real app against the migrated Postgres.
+
+    Handlers are given the *same* session the test holds, so a test can read
+    back rows a request just committed and write rows a request will see.
+    """
+
+    async def _override_get_session() -> AsyncGenerator[AsyncSession, None]:
+        yield pg_session
+
+    app.dependency_overrides[get_session] = _override_get_session
+
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+        assert not app.dependency_overrides, "dependency_overrides leaked between tests"

--- a/backend/tests/integration/pg_lane.py
+++ b/backend/tests/integration/pg_lane.py
@@ -1,0 +1,92 @@
+"""Environment resolution for the Postgres integration lane.
+
+Both helpers are pure functions of the mapping they are handed: nothing here
+reads ``os.environ``. The fixtures pass ``os.environ`` in explicitly, which
+keeps the truth table below testable and stops a developer's shell from
+deciding what CI does.
+
+The asymmetry that matters is in :func:`resolve_integration_database_url`. An
+unset URL means "no Postgres available, skip the lane" when a human runs the
+suite, and "the service container never came up" in CI. Only the second is a
+defect, so CI declares the lane required and the resolver raises instead of
+handing the caller a skip.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from database import normalize_database_url
+
+#: Connection string for the live Postgres the lane runs against.
+URL_ENV = "TEST_POSTGRES_URL"
+
+#: Set truthy where a missing URL is a misconfiguration rather than an opt-out.
+REQUIRE_ENV = "INTEGRATION_LANE_REQUIRE_POSTGRES"
+
+#: pytest-xdist's per-worker identifier, absent outside a distributed run.
+WORKER_ENV = "PYTEST_XDIST_WORKER"
+
+_DATABASE_NAME_PREFIX = "adepthood_it_"
+
+# The worker name a non-distributed run owns, so the database is named the same
+# way whether or not xdist is in play.
+_SERIAL_WORKER = "master"
+
+# Spellings that read as "off". Anything else -- "1", "true", "TRUE", "yes" --
+# arms the require flag, so a typo fails loudly rather than silently disarming.
+_FALSEY = frozenset({"", "0", "false", "no", "off"})
+
+
+class IntegrationLaneMisconfiguredError(RuntimeError):
+    """The lane was declared required but cannot reach a live Postgres."""
+
+
+def _is_truthy(value: str) -> bool:
+    """Return whether an environment value reads as "on"."""
+    return value.strip().casefold() not in _FALSEY
+
+
+def resolve_integration_database_url(env: Mapping[str, str]) -> str | None:
+    """Return the lane's database URL, ``None`` to skip, or raise if required.
+
+    The URL is normalized through the application's own
+    :func:`database.normalize_database_url` rather than re-parsed here, so the
+    lane and the running app can never disagree about which driver a bare
+    ``postgresql://`` URL means.
+
+    Args:
+        env: The environment to read. Never ``os.environ`` implicitly.
+
+    Returns:
+        The normalized URL, or ``None`` when no Postgres is configured and the
+        lane is optional.
+
+    Raises:
+        IntegrationLaneMisconfiguredError: No usable URL while the require flag
+            is set.
+    """
+    raw = env.get(URL_ENV, "").strip()
+    if raw:
+        return normalize_database_url(raw)
+    if _is_truthy(env.get(REQUIRE_ENV, "")):
+        msg = (
+            f"{URL_ENV} is unset or blank while {REQUIRE_ENV} is truthy. "
+            f"The integration lane was declared required, so it fails here "
+            f"rather than skipping past a Postgres that never came up."
+        )
+        raise IntegrationLaneMisconfiguredError(msg)
+    return None
+
+
+def integration_database_name(env: Mapping[str, str]) -> str:
+    """Return the database name this pytest worker owns exclusively.
+
+    Each worker migrates and drops its own database, so two workers can never
+    race on one schema or observe each other's rows.
+
+    Args:
+        env: The environment to read. Never ``os.environ`` implicitly.
+    """
+    worker = env.get(WORKER_ENV, "").strip() or _SERIAL_WORKER
+    return f"{_DATABASE_NAME_PREFIX}{worker}"

--- a/backend/tests/integration/test_pg_array_columns.py
+++ b/backend/tests/integration/test_pg_array_columns.py
@@ -1,0 +1,195 @@
+"""ARRAY-column behaviour that the SQLite lane rewrites to ``JSON`` and loses.
+
+``backend/conftest.py`` swaps every ``ARRAY`` column to ``JSON()`` before
+creating the SQLite schema, so the round-trip tests on the default lane prove
+only that a list survives a JSON encode/decode. The assertions here are the
+ones that JSON cannot satisfy: the server's own report of the stored type, and
+array operators that are a type error against a JSON column.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.stage_progress import StageProgress
+
+pytestmark = pytest.mark.integration
+
+_HABIT_ICON = "🪷"
+_HABIT_START = date(2024, 1, 1)
+_HABIT_ENERGY_COST = 1
+_HABIT_ENERGY_RETURN = 2
+_NOTIFICATION_TIMES = ["08:00", "20:30"]
+_NOTIFICATION_DAYS = ["mon", "wed"]
+_COMPLETED_STAGES = [1, 2, 3]
+_FIRST_STAGE = 1
+_VARCHAR_ARRAY = "character varying[]"
+_INTEGER_ARRAY = "integer[]"
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Create a user and return its authorization headers."""
+    response = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+async def _user_id_for(session: AsyncSession, username: str) -> int:
+    """Return the id of the user :func:`_signup` created for ``username``."""
+    user_id = await session.scalar(
+        text('SELECT id FROM "user" WHERE email = :email'),
+        {"email": f"{username}@example.com"},
+    )
+    assert user_id is not None
+    return int(user_id)
+
+
+async def _create_notifying_habit(client: AsyncClient, headers: dict[str, str]) -> dict[str, Any]:
+    """Create a habit carrying both notification arrays and return the response body."""
+    payload = {
+        "name": "Sit",
+        "icon": _HABIT_ICON,
+        "start_date": _HABIT_START.isoformat(),
+        "energy_cost": _HABIT_ENERGY_COST,
+        "energy_return": _HABIT_ENERGY_RETURN,
+        "notification_times": _NOTIFICATION_TIMES,
+        "notification_frequency": "daily",
+        "notification_days": _NOTIFICATION_DAYS,
+    }
+    response = await client.post("/habits/", json=payload, headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    body: dict[str, Any] = response.json()
+    return body
+
+
+async def _seed_stage_progress(client: AsyncClient, session: AsyncSession, username: str) -> int:
+    """Sign a user up, give them a stage-progress row, and return their id."""
+    await _signup(client, username)
+    user_id = await _user_id_for(session, username)
+    session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=_FIRST_STAGE,
+            completed_stages=_COMPLETED_STAGES,
+        )
+    )
+    await session.flush()
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_notification_arrays_round_trip_unchanged(pg_client: AsyncClient) -> None:
+    """Both notification arrays come back from ``GET`` exactly as they were written."""
+    headers = await _signup(pg_client, "array-roundtrip")
+    created = await _create_notifying_habit(pg_client, headers)
+
+    fetched = await pg_client.get(f"/habits/{created['id']}", headers=headers)
+
+    assert fetched.status_code == HTTPStatus.OK
+    assert fetched.json()["notification_times"] == _NOTIFICATION_TIMES
+    assert fetched.json()["notification_days"] == _NOTIFICATION_DAYS
+
+
+@pytest.mark.asyncio
+async def test_notification_days_is_stored_as_a_varchar_array(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """The server's own type report, not the client's decode, decides this.
+
+    ``pg_typeof`` is answered by Postgres from the stored value, so a column
+    that had silently become ``json`` or ``text`` fails here even though the
+    HTTP round-trip above would still pass.
+    """
+    headers = await _signup(pg_client, "array-typeof")
+    created = await _create_notifying_habit(pg_client, headers)
+
+    column_type = await pg_session.scalar(
+        text("SELECT pg_typeof(notification_days)::text FROM habit WHERE id = :habit_id"),
+        {"habit_id": created["id"]},
+    )
+
+    assert column_type == _VARCHAR_ARRAY
+
+
+@pytest.mark.asyncio
+async def test_notification_days_answers_array_operators(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """``= ANY(...)`` and ``array_length`` run against the column and find the habit.
+
+    Both are the assertions a JSON-backed column can never satisfy: against
+    ``JSON`` they are an operator/type error rather than a wrong answer.
+    """
+    headers = await _signup(pg_client, "array-operators")
+    created = await _create_notifying_habit(pg_client, headers)
+    habit_id = created["id"]
+
+    matched = await pg_session.scalar(
+        text(
+            "SELECT id FROM habit "
+            "WHERE id = :habit_id AND CAST(:day AS varchar) = ANY(notification_days)"
+        ),
+        {"habit_id": habit_id, "day": _NOTIFICATION_DAYS[0]},
+    )
+    length = await pg_session.scalar(
+        text("SELECT array_length(notification_days, 1) FROM habit WHERE id = :habit_id"),
+        {"habit_id": habit_id},
+    )
+
+    assert matched == habit_id
+    assert length == len(_NOTIFICATION_DAYS)
+
+
+@pytest.mark.asyncio
+async def test_completed_stages_is_stored_as_an_integer_array(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """``stageprogress.completed_stages`` is a NOT NULL ``integer[]``, not JSON."""
+    user_id = await _seed_stage_progress(pg_client, pg_session, "array-stage-type")
+
+    column_type = await pg_session.scalar(
+        text(
+            "SELECT pg_typeof(completed_stages)::text FROM stageprogress WHERE user_id = :user_id"
+        ),
+        {"user_id": user_id},
+    )
+
+    assert column_type == _INTEGER_ARRAY
+
+
+@pytest.mark.asyncio
+async def test_completed_stages_answers_array_operators(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """Membership and length hold for the integer array the same way."""
+    user_id = await _seed_stage_progress(pg_client, pg_session, "array-stage-ops")
+
+    matched = await pg_session.scalar(
+        text(
+            "SELECT user_id FROM stageprogress "
+            "WHERE user_id = :user_id AND CAST(:stage AS integer) = ANY(completed_stages)"
+        ),
+        {"user_id": user_id, "stage": _COMPLETED_STAGES[-1]},
+    )
+    length = await pg_session.scalar(
+        text(
+            "SELECT array_length(completed_stages, 1) FROM stageprogress WHERE user_id = :user_id"
+        ),
+        {"user_id": user_id},
+    )
+
+    assert matched == user_id
+    assert length == len(_COMPLETED_STAGES)

--- a/backend/tests/integration/test_pg_unique_indexes.py
+++ b/backend/tests/integration/test_pg_unique_indexes.py
@@ -1,0 +1,196 @@
+"""Unique-index behaviour that only the migrated Postgres schema enforces.
+
+Two of these constraints are functional / partial indexes the SQLite fixture
+either approximates by hand or (for goal completions) deliberately omits from
+``db_session``, so their database-level half runs unexercised on the default
+lane. Each case is asserted twice: once through the HTTP contract, and once by
+inserting straight through the session so the router's pre-check cannot be what
+produces the pass.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import SQLModel
+
+from models.goal_completion import GoalCompletion
+from models.habit import Habit
+
+pytestmark = pytest.mark.integration
+
+_HABIT_ICON = "🪷"
+_HABIT_START = date(2024, 1, 1)
+_HABIT_ENERGY_COST = 1
+_HABIT_ENERGY_RETURN = 2
+_LOW_TIER = "low"
+_COMPLETED_UNITS = 1.0
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Create a user and return its authorization headers."""
+    response = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "secret12345",  # pragma: allowlist secret
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+async def _user_id_for(session: AsyncSession, username: str) -> int:
+    """Return the id of the user :func:`_signup` created for ``username``.
+
+    The habit response schema deliberately omits ``user_id`` -- the server owns
+    it -- so a direct write has to look the owner up rather than echo it back.
+    """
+    user_id = await session.scalar(
+        text('SELECT id FROM "user" WHERE email = :email'),
+        {"email": f"{username}@example.com"},
+    )
+    assert user_id is not None
+    return int(user_id)
+
+
+def _habit_payload(name: str) -> dict[str, object]:
+    """Return a minimal valid habit-creation payload under ``name``."""
+    return {
+        "name": name,
+        "icon": _HABIT_ICON,
+        "start_date": _HABIT_START.isoformat(),
+        "energy_cost": _HABIT_ENERGY_COST,
+        "energy_return": _HABIT_ENERGY_RETURN,
+    }
+
+
+async def _create_habit(client: AsyncClient, headers: dict[str, str], name: str) -> dict[str, Any]:
+    """Create a habit (with its three default goals) and return the response body."""
+    response = await client.post("/habits/", json=_habit_payload(name), headers=headers)
+    assert response.status_code == HTTPStatus.OK
+    body: dict[str, Any] = response.json()
+    return body
+
+
+def _low_tier_goal_id(habit: dict[str, Any]) -> int:
+    """Return the id of the habit's auto-created low-tier goal."""
+    for goal in habit["goals"]:
+        if goal["tier"] == _LOW_TIER:
+            return int(goal["id"])
+    pytest.fail(f"habit {habit['id']} has no {_LOW_TIER}-tier goal")
+
+
+async def _insert_in_savepoint(session: AsyncSession, row: SQLModel) -> None:
+    """Flush ``row`` inside a savepoint so the caller's transaction survives a failure."""
+    async with session.begin_nested():
+        session.add(row)
+        await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_normalized_habit_name_is_rejected_over_http(
+    pg_client: AsyncClient,
+) -> None:
+    """A second habit differing only by case and surrounding space gets a 409."""
+    headers = await _signup(pg_client, "habit-http")
+    await _create_habit(pg_client, headers, "Sit")
+
+    duplicate = await pg_client.post("/habits/", json=_habit_payload("  sit "), headers=headers)
+
+    assert duplicate.status_code == HTTPStatus.CONFLICT
+    assert duplicate.json()["detail"] == "duplicate_habit_name"
+
+
+@pytest.mark.asyncio
+async def test_habit_name_index_rejects_a_duplicate_that_bypasses_the_router(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """The migrated ``lower(trim(name))`` index rejects a direct insert.
+
+    The HTTP test above passes on SQLite too, because ``_ensure_unique_name``
+    catches it before the database is asked. Writing straight through the
+    session removes that pre-check, leaving the index as the only thing that
+    can produce the error -- which is the half the SQLite mirror only
+    approximates.
+    """
+    username = "habit-index"
+    headers = await _signup(pg_client, username)
+    await _create_habit(pg_client, headers, "Sit")
+    duplicate = Habit(
+        user_id=await _user_id_for(pg_session, username),
+        name="  sit ",
+        icon=_HABIT_ICON,
+        start_date=_HABIT_START,
+        energy_cost=_HABIT_ENERGY_COST,
+        energy_return=_HABIT_ENERGY_RETURN,
+    )
+
+    with pytest.raises(IntegrityError):
+        await _insert_in_savepoint(pg_session, duplicate)
+
+
+@pytest.mark.asyncio
+async def test_second_check_in_on_the_same_day_stores_exactly_one_row(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """Re-checking in the same day is idempotent and leaves one completion row.
+
+    The row count is the assertion that has teeth: a 200 with
+    ``already_logged_today`` can be produced by the service's read-before-write
+    fast path alone, whereas exactly one stored row is what the per-day unique
+    index guarantees.
+    """
+    headers = await _signup(pg_client, "goal-idempotent")
+    habit = await _create_habit(pg_client, headers, "Sit")
+    goal_id = _low_tier_goal_id(habit)
+
+    first = await pg_client.post("/goal_completions/", json={"goal_id": goal_id}, headers=headers)
+    second = await pg_client.post("/goal_completions/", json={"goal_id": goal_id}, headers=headers)
+
+    assert first.status_code == HTTPStatus.OK
+    assert first.json()["reason_code"] != "already_logged_today"
+    assert second.status_code == HTTPStatus.OK
+    assert second.json()["reason_code"] == "already_logged_today"
+    stored = await pg_session.scalar(
+        text("SELECT count(*) FROM goalcompletion WHERE goal_id = :goal_id"),
+        {"goal_id": goal_id},
+    )
+    assert stored == 1
+
+
+@pytest.mark.asyncio
+async def test_per_day_index_rejects_a_second_completion_for_the_same_local_day(
+    pg_client: AsyncClient, pg_session: AsyncSession
+) -> None:
+    """``ix_goal_completion_unique_per_day`` rejects a direct duplicate insert.
+
+    ``backend/conftest.py`` omits this index from the default ``db_session``
+    fixture, so on the SQLite lane nothing exercises the database-level half of
+    the ``IntegrityError -> already_logged_today`` path at all.
+    """
+    headers = await _signup(pg_client, "goal-index")
+    habit = await _create_habit(pg_client, headers, "Sit")
+    goal_id = _low_tier_goal_id(habit)
+    await pg_client.post("/goal_completions/", json={"goal_id": goal_id}, headers=headers)
+    result = await pg_session.execute(
+        text("SELECT user_id, local_day FROM goalcompletion WHERE goal_id = :goal_id"),
+        {"goal_id": goal_id},
+    )
+    logged = result.one()
+    duplicate = GoalCompletion(
+        goal_id=goal_id,
+        user_id=logged.user_id,
+        local_day=logged.local_day,
+        completed_units=_COMPLETED_UNITS,
+    )
+
+    with pytest.raises(IntegrityError):
+        await _insert_in_savepoint(pg_session, duplicate)

--- a/backend/tests/integration/test_schema_provenance.py
+++ b/backend/tests/integration/test_schema_provenance.py
@@ -1,0 +1,133 @@
+"""Proof that the lane's schema was built by migrations, not ``create_all``.
+
+Every other assertion in this package is worthless if the database underneath
+it was stood up the way the SQLite fixture does it -- ``metadata.create_all``
+plus hand-written index mirrors -- because that schema is exactly the
+approximation the lane exists to stop trusting. These tests read the schema
+back out of the live server and refuse anything that did not come from
+``alembic upgrade head``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+pytestmark = pytest.mark.integration
+
+_ALEMBIC_INI = Path(__file__).resolve().parents[2] / "alembic.ini"
+
+# Functional / partial unique indexes that only a migration creates. The SQLite
+# fixture mirrors five of these by hand under ``_test``-suffixed names; on a
+# migrated database the real ones must be here under their real names.
+_MIGRATION_OWNED_INDEXES = frozenset(
+    {
+        "ix_habit_user_lower_name_unique",
+        "ix_goal_completion_unique_per_day",
+        "ix_practice_preset_stage_lower_name_unique",
+        "ix_coursestage_stage_number_unique",
+        "ix_stagecontent_stage_content_ref_unique",
+        "ix_user_lower_email_unique",
+    }
+)
+
+# The suffix ``backend/conftest.py`` gives its SQLite stand-ins. Finding one
+# here would mean the lane is running against the fixture's approximation.
+_MIRROR_INDEX_SUFFIX = "_test"
+
+# Columns declared ``ARRAY`` in the models and rewritten to ``JSON`` by the
+# SQLite fixture. On a migrated Postgres they must still be arrays.
+_ARRAY_COLUMNS = [
+    ("habit", "notification_days"),
+    ("habit", "notification_times"),
+    ("goal", "days_of_week"),
+    ("stageprogress", "completed_stages"),
+]
+
+_MINIMUM_SERVER_VERSION_NUM = 160_000
+
+
+async def _public_index_names(session: AsyncSession) -> set[str]:
+    """Return every index name in the live database's ``public`` schema."""
+    result = await session.execute(
+        text("SELECT indexname FROM pg_indexes WHERE schemaname = 'public'")
+    )
+    return set(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_schema_is_stamped_at_the_alembic_script_heads(pg_session: AsyncSession) -> None:
+    """``alembic_version`` must hold exactly the script directory's head set.
+
+    The expected value is read from the migration scripts rather than pinned to
+    a literal revision, so adding a migration cannot leave this test asserting
+    a stale head and a partially-migrated lane cannot pass.
+    """
+    heads = set(ScriptDirectory.from_config(Config(str(_ALEMBIC_INI))).get_heads())
+    assert heads, "the alembic script directory reports no head revisions"
+
+    result = await pg_session.execute(text("SELECT version_num FROM alembic_version"))
+
+    assert set(result.scalars().all()) == heads
+
+
+@pytest.mark.asyncio
+async def test_migration_owned_indexes_are_all_present(pg_session: AsyncSession) -> None:
+    """Every functional / partial unique index a migration creates exists here."""
+    present = await _public_index_names(pg_session)
+
+    assert sorted(_MIGRATION_OWNED_INDEXES - present) == []
+
+
+@pytest.mark.asyncio
+async def test_no_sqlite_mirror_index_exists(pg_session: AsyncSession) -> None:
+    """None of the SQLite fixture's hand-written stand-ins may appear.
+
+    A ``..._test`` index here would mean the lane inherited the approximation
+    it was built to replace.
+    """
+    present = await _public_index_names(pg_session)
+
+    assert sorted(name for name in present if name.endswith(_MIRROR_INDEX_SUFFIX)) == []
+
+
+@pytest.mark.asyncio
+async def test_connection_speaks_the_postgresql_dialect(pg_session: AsyncSession) -> None:
+    """A SQLite fallback in the fixture must fail loudly, right here."""
+    connection = await pg_session.connection()
+
+    assert connection.dialect.name == "postgresql"
+
+
+@pytest.mark.asyncio
+async def test_server_is_a_live_postgres_16(pg_session: AsyncSession) -> None:
+    """The server banner and version number must both report Postgres 16 or newer."""
+    banner = await pg_session.scalar(text("SELECT version()"))
+    version_num = await pg_session.scalar(text("SELECT current_setting('server_version_num')::int"))
+
+    assert isinstance(banner, str)
+    assert banner.startswith("PostgreSQL ")
+    assert version_num >= _MINIMUM_SERVER_VERSION_NUM
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("table_name", "column_name"), _ARRAY_COLUMNS)
+async def test_array_columns_are_declared_as_arrays(
+    pg_session: AsyncSession, table_name: str, column_name: str
+) -> None:
+    """The ARRAY columns the SQLite fixture rewrites to JSON stay arrays here."""
+    data_type = await pg_session.scalar(
+        text(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_schema = 'public' "
+            "AND table_name = :table_name AND column_name = :column_name"
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+
+    assert data_type == "ARRAY"

--- a/backend/tests/test_integration_lane_guard.py
+++ b/backend/tests/test_integration_lane_guard.py
@@ -1,0 +1,318 @@
+"""Tripwires for the Postgres integration lane's resolver and its CI wiring.
+
+This module runs on the default SQLite lane and needs no Postgres. It exists
+because the failure mode of an integration lane is not a red test -- it is a
+green job that never touched Postgres. Two groups of tripwires cover that: a
+truth table over the URL resolver, which must *raise* rather than skip once the
+lane declares itself required, and a static read of ``backend-ci.yml`` asserting
+the job is wired to a real service container and cannot be silently disarmed.
+
+The workflow is parsed as plain text rather than with PyYAML on purpose. PyYAML
+is absent from ``requirements.txt``, ``requirements-lock.txt`` and
+``requirements-dev.txt``, so ``import yaml`` would turn this guard into a
+collection error on the ``backend-compat`` job instead of a passing check.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from database import normalize_database_url
+from tests.integration.pg_lane import (
+    IntegrationLaneMisconfiguredError,
+    integration_database_name,
+    resolve_integration_database_url,
+)
+
+_URL_ENV = "TEST_POSTGRES_URL"
+_REQUIRE_ENV = "INTEGRATION_LANE_REQUIRE_POSTGRES"
+_WORKER_ENV = "PYTEST_XDIST_WORKER"
+
+_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "backend-ci.yml"
+_JOB_NAME = "backend-integration"
+
+_ASYNCPG_SCHEME = "postgresql+asyncpg://"
+_SAMPLE_AUTHORITY = "it:it@localhost:5432/adepthood_it"
+
+# Text fragments that would leave the job structurally present but toothless:
+# a red lane reported as success, a collection-only run, a marker filter that
+# excludes the very tests the lane exists to run, or a shell that swallows
+# pytest's exit code.
+_DISARMING_FRAGMENTS = (
+    "continue-on-error",
+    "--no-strict-markers",
+    "--collect-only",
+    "--deselect",
+    "--ignore",
+    "-k ",
+    "not integration",
+    "set +e",
+    "|| true",
+    "|| exit 0",
+    "if: false",
+    "if: ${{ false }}",
+)
+
+_JOBS_HEADER = re.compile(r"^jobs:[ \t]*$", re.MULTILINE)
+_TOP_LEVEL_JOB = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):[ \t]*$", re.MULTILINE)
+_SWALLOWED_PYTEST = re.compile(r"pytest[^\n]*\|\|")
+_INTEGRATION_MARKER_ARG = re.compile(r"-m\s+[\"']?integration\b")
+
+
+# --- Resolver truth table ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (f"postgresql://{_SAMPLE_AUTHORITY}", f"{_ASYNCPG_SCHEME}{_SAMPLE_AUTHORITY}"),
+        (f"postgres://{_SAMPLE_AUTHORITY}", f"{_ASYNCPG_SCHEME}{_SAMPLE_AUTHORITY}"),
+        (f"{_ASYNCPG_SCHEME}{_SAMPLE_AUTHORITY}", f"{_ASYNCPG_SCHEME}{_SAMPLE_AUTHORITY}"),
+    ],
+)
+def test_configured_url_comes_back_on_the_asyncpg_driver(raw: str, expected: str) -> None:
+    """A configured URL is returned through the app's own scheme normalizer.
+
+    Delegating rather than re-implementing is the point: the lane and the
+    running app can never disagree about which driver a bare ``postgresql://``
+    URL means, so a CI value copied from the ``migration-drift`` job works.
+    """
+    resolved = resolve_integration_database_url({_URL_ENV: raw})
+
+    assert resolved == expected
+    assert resolved == normalize_database_url(raw)
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "TRUE"])
+def test_missing_url_raises_when_the_lane_declares_itself_required(flag: str) -> None:
+    """With the require flag on, an absent URL is a hard error, never a skip.
+
+    This is the single assertion the whole lane rests on: CI sets the flag, so
+    a Postgres service that failed to come up cannot be quietly skipped past
+    while the job still reports success.
+    """
+    with pytest.raises(IntegrationLaneMisconfiguredError) as excinfo:
+        resolve_integration_database_url({_REQUIRE_ENV: flag})
+
+    message = str(excinfo.value)
+    assert _URL_ENV in message
+    assert _REQUIRE_ENV in message
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {},
+        {_REQUIRE_ENV: ""},
+        {_REQUIRE_ENV: "0"},
+        {_REQUIRE_ENV: "false"},
+    ],
+)
+def test_missing_url_returns_none_when_the_lane_is_optional(env: dict[str, str]) -> None:
+    """Without the require flag an absent URL yields ``None`` so the caller skips."""
+    assert resolve_integration_database_url(env) is None
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_url_is_treated_as_unset(blank: str) -> None:
+    """A declared-but-empty URL takes the unset branch instead of building a bad engine."""
+    assert resolve_integration_database_url({_URL_ENV: blank}) is None
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_url_still_raises_when_required(blank: str) -> None:
+    """An empty value in CI is a misconfiguration, not a licence to skip."""
+    with pytest.raises(IntegrationLaneMisconfiguredError):
+        resolve_integration_database_url({_URL_ENV: blank, _REQUIRE_ENV: "1"})
+
+
+def test_resolver_reads_only_its_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolver must not consult ``os.environ`` behind the caller's back.
+
+    An ambient environment that could override the passed mapping would make
+    the truth table above untestable and let a developer's shell decide what
+    CI does.
+    """
+    monkeypatch.setenv(
+        _URL_ENV,
+        "postgresql://ambient:ambient@localhost:5432/ambient",  # pragma: allowlist secret
+    )
+    monkeypatch.setenv(_REQUIRE_ENV, "1")
+
+    assert resolve_integration_database_url({}) is None
+
+
+def test_database_name_defaults_to_the_master_worker() -> None:
+    """Outside xdist the lane owns a single, stably-named database."""
+    assert integration_database_name({}) == "adepthood_it_master"
+
+
+def test_database_name_is_derived_from_the_xdist_worker() -> None:
+    """Under xdist the worker id is what makes the database name unique."""
+    assert integration_database_name({_WORKER_ENV: "gw0"}) == "adepthood_it_gw0"
+
+
+def test_distinct_workers_get_distinct_databases() -> None:
+    """Two workers must never share a database, or their migrations race."""
+    assert integration_database_name({_WORKER_ENV: "gw0"}) != integration_database_name(
+        {_WORKER_ENV: "gw1"}
+    )
+
+
+def test_database_name_reads_only_its_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same purity contract as the URL resolver, for the same reason."""
+    monkeypatch.setenv(_WORKER_ENV, "gw7")
+
+    assert integration_database_name({}) == "adepthood_it_master"
+
+
+# --- Static wiring guard over backend-ci.yml -----------------------------
+
+
+def _split_workflow() -> tuple[str, str]:
+    """Return the workflow's trigger section and its ``jobs:`` section."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    header = _JOBS_HEADER.search(text)
+    if header is None:
+        pytest.fail(f"no top-level `jobs:` key in {_WORKFLOW}")
+    return text[: header.start()], text[header.end() :]
+
+
+def _job_block(name: str) -> str:
+    """Return one top-level job's YAML text, sliced at the next job key."""
+    _, jobs = _split_workflow()
+    matches = list(_TOP_LEVEL_JOB.finditer(jobs))
+    for index, match in enumerate(matches):
+        if match.group("name") != name:
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(jobs)
+        return jobs[match.start() : end]
+    found = sorted(m.group("name") for m in matches)
+    pytest.fail(f"no `{name}:` job in {_WORKFLOW}; found {found}")
+
+
+def _env_value(block: str, key: str) -> str:
+    """Return the scalar assigned to ``key`` by the job, rejecting any shadowing.
+
+    Reading the *first* match anywhere in the block would validate the job-level
+    ``env:`` while a step-scoped ``env:`` further down silently overrode it at
+    runtime -- the guard would stay green describing a value CI no longer uses.
+    So the key is required to appear exactly once: a step-level override fails
+    here rather than drifting past.
+    """
+    pattern = re.compile(rf"^\s*{re.escape(key)}:[ \t]+(?P<value>\S+)", re.MULTILINE)
+    values = [match.group("value") for match in pattern.finditer(block)]
+    if not values:
+        pytest.fail(f"`{key}` is not set in the `{_JOB_NAME}` job block")
+    if len(values) > 1:
+        pytest.fail(
+            f"`{key}` is assigned {len(values)} times in the `{_JOB_NAME}` job "
+            f"block; a step-scoped override would shadow the job-level value at "
+            f"runtime while this guard kept checking the wrong one"
+        )
+    return values[0].strip("\"'")
+
+
+def _pytest_command(block: str) -> str:
+    """Return every non-comment line of a job block that invokes pytest."""
+    lines = [
+        line.strip()
+        for line in block.splitlines()
+        if "pytest" in line and not line.strip().startswith("#")
+    ]
+    if not lines:
+        pytest.fail(f"the `{_JOB_NAME}` job never invokes pytest")
+    return "\n".join(lines)
+
+
+def test_backend_integration_job_exists() -> None:
+    """The lane is only real once a job in backend-ci.yml runs it."""
+    assert _job_block(_JOB_NAME).startswith(f"  {_JOB_NAME}:")
+
+
+def test_job_provisions_a_postgres_16_service() -> None:
+    """The lane must run against the same major version production uses."""
+    assert re.search(r"image:[ \t]*postgres:16\b", _job_block(_JOB_NAME))
+
+
+def test_job_gates_on_the_service_becoming_ready() -> None:
+    """A container that never accepts connections must fail the job, not be raced.
+
+    Without a health check the steps start immediately and the lane's outcome
+    depends on whether Postgres happened to finish booting first.
+    """
+    assert "pg_isready" in _job_block(_JOB_NAME)
+
+
+def test_job_points_the_lane_at_postgres() -> None:
+    """The configured URL must resolve to asyncpg-on-Postgres, not a SQLite fallback.
+
+    Feeding the workflow's literal through the production resolver -- rather
+    than string-matching it here -- means a value like ``sqlite+aiosqlite://``
+    fails this test instead of quietly giving the lane a fake database.
+    """
+    configured = _env_value(_job_block(_JOB_NAME), _URL_ENV)
+
+    resolved = resolve_integration_database_url({_URL_ENV: configured})
+
+    assert resolved is not None
+    assert resolved.startswith(_ASYNCPG_SCHEME)
+
+
+def test_job_declares_the_lane_required() -> None:
+    """The workflow's require-flag literal must read as truthy to the resolver itself.
+
+    Asserting through ``resolve_integration_database_url`` rather than against a
+    restated list of truthy spellings keeps the workflow and the resolver from
+    drifting into a state where CI thinks the lane is required and the code
+    does not.
+    """
+    configured = _env_value(_job_block(_JOB_NAME), _REQUIRE_ENV)
+
+    with pytest.raises(IntegrationLaneMisconfiguredError):
+        resolve_integration_database_url({_REQUIRE_ENV: configured})
+
+
+def test_job_runs_the_integration_marker_with_coverage_off() -> None:
+    """The lane selects by marker and leaves the repo-wide coverage gate alone."""
+    command = _pytest_command(_job_block(_JOB_NAME))
+
+    assert _INTEGRATION_MARKER_ARG.search(command)
+    assert "--no-cov" in command
+
+
+@pytest.mark.parametrize("fragment", _DISARMING_FRAGMENTS)
+def test_job_carries_no_disarming_fragment(fragment: str) -> None:
+    """None of the known ways to make a red lane report success may appear."""
+    assert fragment not in _job_block(_JOB_NAME)
+
+
+def test_job_does_not_swallow_pytests_exit_code() -> None:
+    """A ``pytest ... || <fallback>`` shell chain hides every failure the lane finds."""
+    assert _SWALLOWED_PYTEST.search(_job_block(_JOB_NAME)) is None
+
+
+def test_workflow_keeps_its_concurrency_block() -> None:
+    """Regression guard: cancelling superseded PR runs must survive this change."""
+    triggers, _ = _split_workflow()
+
+    assert re.search(r"^concurrency:[ \t]*$", triggers, re.MULTILINE)
+    assert re.search(r"^  group:[ \t]+\S", triggers, re.MULTILINE)
+    assert re.search(r"^  cancel-in-progress:[ \t]+\S", triggers, re.MULTILINE)
+
+
+def test_workflow_keeps_its_backend_path_filters() -> None:
+    """Regression guard: both triggers stay scoped to backend changes.
+
+    Dropping the filters would run the whole backend suite on every frontend
+    commit; dropping the ``backend/**`` entry would stop running it on the
+    changes that matter.
+    """
+    triggers, _ = _split_workflow()
+    expected_triggers = 2
+
+    assert triggers.count("paths:") == expected_triggers
+    assert triggers.count('- "backend/**"') == expected_triggers


### PR DESCRIPTION
## Summary

The whole backend suite runs on in-memory SQLite while production runs Postgres, and the fixtures bend the schema to fit: `_replace_array_columns` rewrites every Postgres `ARRAY` column to `JSON`, and production functional/partial unique indexes are hand-mirrored under `..._test` names with nothing keeping them in sync with the migrations that create the real ones.

This adds a `pytest -m integration` lane that runs the real FastAPI app against a real Postgres 16 whose schema is built by `alembic upgrade head` — deliberately **not** `SQLModel.metadata.create_all`, which would test the models against themselves and could never catch a migration that had drifted from them. The existing SQLite lane is untouched and remains the fast default; `scripts/backend/test.sh --unit` already filters the new lane out via `-m "not integration and not e2e"`.

### Absence is loud, by construction

The obvious way for a lane like this to rot is to go green because it never actually reached Postgres. Three things prevent that:

- **A required flag.** An unset `TEST_POSTGRES_URL` skips for a human running the suite locally, but CI sets `INTEGRATION_LANE_REQUIRE_POSTGRES=1`, which turns the identical condition into a hard failure. That single branch is the only `pytest.skip` in the change.
- **No fallback path exists.** A refused connection, a non-Postgres dialect, a partially-migrated schema and a failed `CREATE DATABASE` all raise `IntegrationLaneMisconfiguredError`. There is no SQLite fallback to degrade into.
- **Provenance is asserted, not assumed.** Before any test runs, the fixture checks the connection speaks `postgresql` and that `alembic_version` is stamped at the script directory's heads — read from `ScriptDirectory`, never hardcoded, so adding a migration cannot leave the check stale. `test_schema_provenance.py` additionally asserts the real index names are present, that no `..._test` mirror exists, and that the four app `ARRAY` columns are genuinely `ARRAY` rather than `JSON`.

A static wiring guard (`tests/test_integration_lane_guard.py`) runs on the **default** SQLite lane and reads the `backend-integration` job block out of `backend-ci.yml` as plain text, asserting the `postgres:16` service and its `pg_isready` health-check, both environment variables, the `-m integration` marker, and the absence of a dozen ways to silently disarm the job (`continue-on-error`, `--collect-only`, `--deselect`, `-k`, `not integration`, `|| true`, `if: false`, …). It also regression-guards the workflow's `concurrency:` block and `paths:` filters. It parses text rather than importing PyYAML, which is in none of the requirements files and would turn the guard into a collection error on the py3.11/3.13 compat jobs.

### Isolation

Per-test isolation is an outer transaction rolled back at teardown, with the session joined through `join_transaction_mode="create_savepoint"`. The routers' own `commit()` and `begin_nested()` therefore behave exactly as in production — constraints fire, `IntegrityError` surfaces — while the database is left byte-identical for the next test. Each xdist worker creates, migrates and drops its own `adepthood_it_<worker>` database, so workers cannot race on one schema.

### The three ported divergence paths

- the habit `lower(trim(name))` unique index
- the goal-completion per-day unique index — the genuinely untested one, since `backend/conftest.py` deliberately omits it from the default `db_session` fixture
- an `ARRAY` round-trip through the HTTP seam that today runs against `JSON()`, asserting `pg_typeof` returns `character varying[]` / `integer[]` and that array-operator SQL works

## Test plan

- `pytest -m integration` against a live Postgres 16 → **18 passed**; run twice back-to-back and once at `-n 2 --dist loadfile`, with both `adepthood_it_gw0` and `adepthood_it_gw1` observed in `pg_database` mid-run and no survivors afterwards
- `TEST_POSTGRES_URL` unset, no require flag → exit 0, 18 clean skips
- `TEST_POSTGRES_URL` unset + `INTEGRATION_LANE_REQUIRE_POSTGRES=1` → **exit 1**, 18 errors, 0 skips
- dead port (`@localhost:1`) → **exit 1**, 0 skips
- **Mutation evidence:** against a probe fixture mimicking the SQLite one (`create_all` + the `_test` index mirrors + `ARRAY`→`JSON`), **14 of the 18 tests fail** — the lane detects a fallback rather than merely also passing on Postgres. The provenance check was separately proved by stamping a database at an early revision (it raised), and the `ARRAY`-rewrite guard by calling `_replace_array_columns()` in-process (it raised).
- `./scripts/backend/check-all.sh` → **exit 0**, 7/7 stages, 4166 tests, 97% coverage
- pre-commit incl. the 399-file mypy hook, ruff, bandit, detect-secrets → clean
- No new dependency: `asyncpg`, `sqlalchemy` and `alembic` were already pinned. `requirements*.txt` untouched.

### Incidental finding

Migrations **do** apply cleanly from zero on an empty Postgres 16 (all 70 revisions, single head, `alembic check` reports no drift), and the lane exposed **no** Postgres-vs-SQLite behaviour divergence — every assertion agreed on both engines. The value here is that those behaviours are now pinned against the real schema instead of a hand-maintained approximation. The one real hazard surfaced is that `_replace_array_columns` mutates `SQLModel.metadata` process-globally; it is unreachable today given the marker filter, and is now guarded rather than assumed.

Closes #2037
Refs #2035
