### PR TITLE
test(full-stack): drive the unmocked API client against a live backend through three journeys

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,93 @@
+name: E2E
+
+# The one job in this repository where the frontend and the backend meet. Both
+# suites are exhaustive in isolation and neither can tell whether the wire
+# between them is connected, so this lane drives the production API client --
+# unmocked, over a real socket -- against the real app on a real Postgres.
+#
+# It watches both halves: a route renamed in the backend and a path edited in
+# the client are equally capable of severing the seam, so either tree triggers
+# the run.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - "backend/**"
+      - ".github/workflows/e2e.yml"
+  pull_request:
+    paths:
+      - "frontend/**"
+      - "backend/**"
+      - ".github/workflows/e2e.yml"
+
+# One in-flight run per PR, mirroring the sibling workflows.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-journeys:
+    runs-on: ubuntu-latest
+    # A slow gate gets skipped and a skipped gate is worse than none, so the
+    # budget is explicit: the lane boots a server, migrates a schema and runs
+    # three journeys in well under a minute of work.
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: aptitude
+          POSTGRES_PASSWORD: aptitude  # pragma: allowlist secret
+          POSTGRES_DB: aptitude
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U aptitude"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      # The lane creates and drops its own database beside this one; it never
+      # writes to the database named here. An unset value is a hard failure in
+      # globalSetup rather than a skip -- a lane that silently tests nothing is
+      # the defect this whole job exists to remove.
+      TEST_POSTGRES_URL: postgresql+asyncpg://aptitude:aptitude@localhost:5432/aptitude  # pragma: allowlist secret
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/requirements*.txt
+
+      - name: Install backend runtime deps
+        # Runtime only: the launcher boots the app and runs alembic, neither of
+        # which needs the dev toolchain.
+        run: uv pip install --system -r backend/requirements-lock.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version-file: "frontend/.nvmrc"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run the journeys against a live backend
+        working-directory: frontend
+        env:
+          E2E_PYTHON: python
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ scripts/ralph/state.json
 
 # Knowledge-graph build artifacts (rebuilt locally / via release; see scripts/graph/)
 graphify-out/
+
+# Coordinates of the server one e2e run booted — a dead port from a previous run
+# would be worse than no file at all, so it is never shared and never committed.
+frontend/e2e/.e2e-state.json

--- a/backend/tests/e2e/__init__.py
+++ b/backend/tests/e2e/__init__.py
@@ -1,0 +1,6 @@
+"""Launcher for the live server the frontend end-to-end lane drives.
+
+Nothing here is collected by pytest: the package holds a runnable module, not
+tests. It lives under ``tests/`` so the repo's Python gates (ruff, mypy, bandit)
+still apply to it while the coverage source set (``src``, ``scripts``) does not.
+"""

--- a/backend/tests/e2e/server.py
+++ b/backend/tests/e2e/server.py
@@ -1,0 +1,345 @@
+"""Boot the real FastAPI app on an ephemeral, alembic-built Postgres.
+
+Run it the way the frontend lane's ``globalSetup`` does, from ``backend`` with
+``PYTHONPATH=src``, having exported ``DATABASE_URL`` (the throwaway database),
+``E2E_ADMIN_DATABASE_URL`` (a database that already exists on the same server)
+and a per-run ``SECRET_KEY``::
+
+    python -m tests.e2e.server
+
+Everything arrives through the environment rather than argv, so no password ever
+reaches a process listing, and ``SECRET_KEY`` in particular has to be set by the
+caller because ``routers.auth`` reads it at import time. ``DATABASE_URL`` names a
+database that does not exist yet: this module creates it, builds its schema with
+``alembic upgrade head`` (never ``SQLModel.metadata.create_all``, which would
+test the models against themselves), serves the app on a loopback port, and
+drops the database again on shutdown. The bound port is announced on stdout as
+``E2E_READY port=<n>`` once the application has finished starting, which is what
+the caller waits for -- a sleep would either be too short on a cold machine or
+waste the budget on a warm one. Because uvicorn re-raises the signal that stopped
+it, the caller runs ``--drop-only`` after reaping this process rather than
+trusting a ``finally`` that a SIGTERM never reaches.
+
+Exactly one thing is substituted, and it is the only third-party call on the
+signup path: ``routers.auth.verify_aptitude_license``, whose real implementation
+POSTs to Gumroad over the internet. The lane forbids third-party network, and
+``backend/conftest.py`` stubs the same seam for the same reason. Nothing on the
+frontend-to-backend request path is faked: the routers, middleware, session
+handling, schemas and migrations are the production ones, and the journeys reach
+them over a real socket.
+
+Failure is loud everywhere. A missing variable, a refused connection, a database
+that did not migrate to every script head, or a dialect that is not Postgres all
+raise before the server starts serving. There is no fallback and no skip: a lane
+that quietly tests nothing is the defect this whole exercise exists to remove.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import socket
+import sys
+from pathlib import Path
+
+import uvicorn
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+import routers.auth as auth_router
+from database import normalize_database_url
+from domain.entitlements import AptitudeLicenseCheck, LicenseOutcome
+from main import app
+from rate_limit import limiter
+from schemas.gumroad import GumroadPurchase
+
+#: URL of the throwaway database this process owns for its whole lifetime.
+DATABASE_URL_ENV = "DATABASE_URL"
+
+#: URL of an existing database on the same server, used only to CREATE/DROP.
+ADMIN_URL_ENV = "E2E_ADMIN_DATABASE_URL"
+
+#: Signing key for the session JWTs, generated per run by the caller.
+SECRET_KEY_ENV = "SECRET_KEY"  # pragma: allowlist secret -- a variable name, not a value
+
+#: Line the caller waits for; the port is chosen by the kernel, not guessed.
+READY_PREFIX = "E2E_READY port="
+
+_LOOPBACK_HOST = "127.0.0.1"
+_POSTGRESQL_DIALECT = "postgresql"
+
+# Database names are interpolated into DDL, which cannot take bind parameters,
+# so the name is constrained to an unambiguous identifier shape first.
+_SAFE_IDENTIFIER = re.compile(r"[a-z0-9_]+")
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_ALEMBIC_INI = _BACKEND_ROOT / "alembic.ini"
+_MIGRATIONS_DIR = _BACKEND_ROOT / "migrations"
+
+_STUB_LICENSE_PRODUCT_ID = "prod_e2e_aptitude"
+_STUB_LICENSE_SALE_PREFIX = "e2e-sale-"
+
+
+class E2EServerError(RuntimeError):
+    """The lane cannot be brought up as specified."""
+
+
+def _require_env(name: str) -> str:
+    """Return the value of ``name``, or raise naming what to set.
+
+    Raises:
+        E2EServerError: The variable is unset or blank.
+    """
+    value = os.environ.get(name, "").strip()
+    if not value:
+        msg = f"{name} is unset or blank; the e2e lane cannot start without it"
+        raise E2EServerError(msg)
+    return value
+
+
+def _require_database_url(name: str) -> str:
+    """Return a database URL from the environment, normalized to the app's driver."""
+    return normalize_database_url(_require_env(name))
+
+
+def _quoted_database_name(name: str) -> str:
+    """Return ``name`` quoted for DDL, rejecting anything but a bare identifier.
+
+    Raises:
+        E2EServerError: ``name`` is not a lowercase identifier.
+    """
+    if not _SAFE_IDENTIFIER.fullmatch(name):
+        msg = f"refusing to build DDL for the non-identifier database name {name!r}"
+        raise E2EServerError(msg)
+    return f'"{name}"'
+
+
+def _database_name(url: str) -> str:
+    """Return the database component of ``url``.
+
+    Raises:
+        E2EServerError: The URL names no database.
+    """
+    name = make_url(url).database
+    if not name:
+        msg = f"{DATABASE_URL_ENV} names no database, so there is nothing to create"
+        raise E2EServerError(msg)
+    return name
+
+
+async def _run_admin_statements(admin_url: URL, statements: tuple[str, ...]) -> None:
+    """Execute DDL against the admin URL's own database with autocommit.
+
+    ``CREATE`` / ``DROP DATABASE`` cannot run inside a transaction block, hence
+    the AUTOCOMMIT isolation level and the pool-less engine.
+    """
+    engine = create_async_engine(admin_url, isolation_level="AUTOCOMMIT", poolclass=NullPool)
+    try:
+        async with engine.connect() as connection:
+            for statement in statements:
+                await connection.execute(text(statement))
+    finally:
+        await engine.dispose()
+
+
+def _alembic_config(url: str) -> Config:
+    """Return an alembic config pointed at ``url``.
+
+    ``config_file_name`` is suppressed so ``env.py`` skips its ``fileConfig``
+    call, which would otherwise disable every logger configured before it --
+    including the app's own, whose startup lines are the boot evidence.
+    """
+    config = Config(str(_ALEMBIC_INI))
+    config.config_file_name = None
+    config.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    config.set_main_option("sqlalchemy.url", url)
+    return config
+
+
+def _migrate_to_head(url: str) -> set[str]:
+    """Build the schema at ``url`` from zero and return the script head revisions."""
+    config = _alembic_config(url)
+    command.upgrade(config, "head")
+    return set(ScriptDirectory.from_config(config).get_heads())
+
+
+async def _read_provenance(url: str) -> tuple[str, set[str]]:
+    """Return the dialect name and stamped revisions of the database at ``url``."""
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as connection:
+            dialect = connection.dialect.name
+            result = await connection.execute(text("SELECT version_num FROM alembic_version"))
+            return dialect, set(result.scalars().all())
+    finally:
+        await engine.dispose()
+
+
+def _assert_provenance(dialect: str, stamped: set[str], heads: set[str]) -> None:
+    """Assert the schema came from a complete upgrade of a real Postgres.
+
+    This is the tripwire for the lane degrading into something it exists to
+    replace. The expected revisions come from the script directory, so adding a
+    migration cannot leave the comparison stale.
+
+    Raises:
+        E2EServerError: The dialect is not Postgres, or the stamp is not at head.
+    """
+    if dialect != _POSTGRESQL_DIALECT:
+        msg = f"the e2e lane connected to a {dialect!r} database, not Postgres"
+        raise E2EServerError(msg)
+    if stamped != heads:
+        msg = (
+            f"the e2e database is stamped at {sorted(stamped)} but the migration "
+            f"scripts head at {sorted(heads)}; the schema did not come from a "
+            f"complete `alembic upgrade head`"
+        )
+        raise E2EServerError(msg)
+
+
+async def _stub_license_check(
+    email: str,
+    *_args: object,
+    **_kwargs: object,
+) -> AptitudeLicenseCheck:
+    """Verify any license, echoing the submitted email so the match check passes.
+
+    Stands in for the live Gumroad call the real gate makes. Everything the gate
+    does with the answer -- the duplicate-email refusal, password hashing, the
+    entitlement grant -- still runs for real. The signature swallows the license
+    key and the optional client the real function takes, because the stub's
+    answer does not depend on either.
+    """
+    purchase = GumroadPurchase(
+        email=email,
+        product_id=_STUB_LICENSE_PRODUCT_ID,
+        sale_id=f"{_STUB_LICENSE_SALE_PREFIX}{email}",
+        refunded=False,
+        chargebacked=False,
+    )
+    return AptitudeLicenseCheck(LicenseOutcome.VERIFIED, purchase)
+
+
+def _prepare_app() -> None:
+    """Apply the two lane-local adjustments to the imported app.
+
+    The license stub replaces the only third-party network call on the signup
+    path. The limiter is disarmed because this lane exercises wiring, not abuse
+    controls: every journey shares one loopback address, so the 3/minute signup
+    cap would make "how many journeys exist" a hidden global constraint and turn
+    a fourth journey into a flake. Rate limiting keeps its own tests.
+    """
+    auth_router.verify_aptitude_license = _stub_license_check
+    limiter.enabled = False
+
+
+class _AnnouncingServer(uvicorn.Server):
+    """Uvicorn server that names its port once startup has actually completed.
+
+    Announcing from inside ``startup`` rather than polling a flag means the
+    caller's first request cannot arrive before the lifespan has run: the line
+    is written after the routers are mounted, the seeders have run and the
+    socket is listening.
+    """
+
+    def __init__(self, config: uvicorn.Config, port: int) -> None:
+        """Store the port to announce alongside the usual server config."""
+        super().__init__(config)
+        self._announced_port = port
+
+    async def startup(self, sockets: list[socket.socket] | None = None) -> None:
+        """Start serving, then write the ready line to stdout."""
+        await super().startup(sockets=sockets)
+        sys.stdout.write(f"{READY_PREFIX}{self._announced_port}\n")
+        sys.stdout.flush()
+
+
+async def _serve(port: int) -> None:
+    """Serve the app on ``port`` until the process is asked to stop."""
+    config = uvicorn.Config(app, host=_LOOPBACK_HOST, port=port, log_level="info")
+    await _AnnouncingServer(config, port).serve()
+
+
+def _reserve_port() -> int:
+    """Return a free loopback port the kernel picked."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind((_LOOPBACK_HOST, 0))
+        return int(probe.getsockname()[1])
+
+
+def _drop_statement(quoted: str) -> str:
+    """Return the DROP that also evicts connections a crashed run left behind."""
+    return f"DROP DATABASE IF EXISTS {quoted} WITH (FORCE)"
+
+
+def _provision(database_url: str, admin_url: URL, quoted: str) -> None:
+    """Create the database and build its schema, verifying what was built."""
+    create = (_drop_statement(quoted), f"CREATE DATABASE {quoted}")
+    asyncio.run(_run_admin_statements(admin_url, create))
+    heads = _migrate_to_head(database_url)
+    dialect, stamped = asyncio.run(_read_provenance(database_url))
+    _assert_provenance(dialect, stamped, heads)
+
+
+def run() -> None:
+    """Provision, serve, and drop the database again on the way out.
+
+    The drop here covers the paths this process controls -- a boot failure, a
+    crash inside ``serve`` -- but not a signal: uvicorn re-raises the SIGTERM it
+    captured once ``serve`` returns, which ends the process before any ``finally``
+    of ours runs. The caller therefore owns the ordinary drop and invokes
+    ``--drop-only`` after reaping this process. Both paths issue the same
+    ``DROP DATABASE IF EXISTS``, so running them both is harmless.
+    """
+    database_url = _require_database_url(DATABASE_URL_ENV)
+    admin_url = make_url(_require_database_url(ADMIN_URL_ENV))
+    quoted = _quoted_database_name(_database_name(database_url))
+    _require_env(SECRET_KEY_ENV)
+
+    # The try opens before provisioning, not after: a migration that throws or a
+    # stamp that does not match leaves a created-but-unusable database behind
+    # otherwise, and that path dies before the ready line, so the caller has no
+    # lane state to recover from either.
+    try:
+        _provision(database_url, admin_url, quoted)
+        _prepare_app()
+        asyncio.run(_serve(_reserve_port()))
+    finally:
+        asyncio.run(_run_admin_statements(admin_url, (_drop_statement(quoted),)))
+
+
+def drop() -> None:
+    """Drop the lane's database without starting a server.
+
+    The teardown fallback for a run whose server process died before its own
+    cleanup could run.
+    """
+    database_url = _require_database_url(DATABASE_URL_ENV)
+    admin_url = make_url(_require_database_url(ADMIN_URL_ENV))
+    quoted = _quoted_database_name(_database_name(database_url))
+    asyncio.run(_run_admin_statements(admin_url, (_drop_statement(quoted),)))
+
+
+def main() -> None:
+    """Dispatch between serving the lane and dropping its leftovers."""
+    parser = argparse.ArgumentParser(description="Live server for the frontend e2e lane.")
+    parser.add_argument(
+        "--drop-only",
+        action="store_true",
+        help="drop the database named by DATABASE_URL and exit",
+    )
+    if parser.parse_args().drop_only:
+        drop()
+        return
+    run()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/__tests__/e2eLaneGuard.test.ts
+++ b/frontend/__tests__/e2eLaneGuard.test.ts
@@ -1,0 +1,299 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Tripwires for the real-wire e2e lane, modelled on the backend's
+ * `tests/test_integration_lane_guard.py`.
+ *
+ * The failure mode of an e2e lane is not a red test -- it is a green job that
+ * never reached the server, or a spec that quietly mocked the very client it
+ * claims to exercise. This file runs on the DEFAULT frontend suite (no server,
+ * no database), reads the lane's files as plain text, and asserts both that the
+ * wiring is present and that none of the known ways to disarm it are.
+ */
+
+const FRONTEND_ROOT = resolve(__dirname, '..');
+const REPO_ROOT = resolve(FRONTEND_ROOT, '..');
+
+const WORKFLOW = join(REPO_ROOT, '.github', 'workflows', 'e2e.yml');
+const PACKAGE_JSON = join(FRONTEND_ROOT, 'package.json');
+const E2E_CONFIG = join(FRONTEND_ROOT, 'jest.e2e.config.js');
+const E2E_DIR = join(FRONTEND_ROOT, 'e2e');
+const SERVER_LAUNCHER = join(REPO_ROOT, 'backend', 'tests', 'e2e', 'server.py');
+
+const E2E_SCRIPT = 'test:e2e';
+const LICENSE_STUB = 'verify_aptitude_license';
+const EXPECTED_JOURNEYS = ['auth.e2e.test.ts', 'habits.e2e.test.ts', 'journal.e2e.test.ts'];
+const ONLY_MODULE_ALIAS = ['^@/(.*)$'];
+
+/**
+ * Text fragments that would leave the job structurally present but toothless:
+ * a red lane reported as success, a shell that swallows the exit code, a run
+ * that passes because it found no tests, or a disabled job.
+ */
+const DISARMING_FRAGMENTS = [
+  'continue-on-error',
+  '|| true',
+  '|| exit 0',
+  'set +e',
+  'if: false',
+  '--passWithNoTests',
+  '--onlyFailures',
+  '.skip',
+];
+
+/** Ways a spec could stop driving the real client while still looking like a test. */
+const FORBIDDEN_IN_SPECS: Array<[string, RegExp]> = [
+  ['jest.mock(', /\bjest\.mock\s*\(/],
+  ['jest.spyOn(...fetch...)', /\bjest\.spyOn\s*\([^)]*fetch/i],
+  ['global.fetch =', /\bglobal\.fetch\s*=/],
+  ['globalThis.fetch =', /\bglobalThis\.fetch\s*=/],
+];
+
+/** Ways any file in the lane could turn an absent backend into a silent pass. */
+const FORBIDDEN_SKIP_PATHS: Array<[string, RegExp]> = [
+  ['describe.skip', /\bdescribe\.skip\b/],
+  ['it.skip', /\bit\.skip\b/],
+  ['test.skip', /\btest\.skip\b/],
+  ['describe.only', /\bdescribe\.only\b/],
+  ['it.only', /\bit\.only\b/],
+  ['test.only', /\btest\.only\b/],
+  ['xit(', /\bxit\s*\(/],
+  ['xdescribe(', /\bxdescribe\s*\(/],
+  ['bare early return', /^[ \t]*return;[ \t]*$/m],
+];
+
+/** Mocking machinery that has no business on the e2e request path. */
+const FORBIDDEN_IN_LAUNCHER = [
+  'monkeypatch',
+  'unittest.mock',
+  'mock.patch',
+  'MagicMock',
+  'AsyncMock',
+  'dependency_overrides',
+  '@patch',
+];
+
+const JOBS_HEADER = /^jobs:[ \t]*$/m;
+const PYTHON_ATTRIBUTE_ASSIGNMENT = /^[ \t]*([A-Za-z_]\w*(?:\.\w+)+)[ \t]*=(?!=)[ \t]*(\S+)/gm;
+const PYTHON_DEF = /^[ \t]*(?:async[ \t]+)?def[ \t]+(\w+)/gm;
+// Anchored on the key itself: `indexOf('moduleNameMapper')` also finds the word
+// inside this config's own header comment and slices the wrong block.
+const MAPPER_BLOCK = /moduleNameMapper\s*:\s*\{([^}]*)\}/;
+const MAPPER_KEY = /'([^']+)'\s*:/g;
+
+function read(path: string, why: string): string {
+  if (!existsSync(path)) {
+    throw new Error(`${path} does not exist. ${why}`);
+  }
+  return readFileSync(path, 'utf8');
+}
+
+/** Split the workflow into its trigger preamble and its `jobs:` body. */
+function splitWorkflow(): [string, string] {
+  const text = read(WORKFLOW, 'The e2e lane only runs once a workflow invokes it.');
+  const header = JOBS_HEADER.exec(text);
+  if (header === null) {
+    throw new Error(`${WORKFLOW} has no top-level "jobs:" key.`);
+  }
+  return [text.slice(0, header.index), text.slice(header.index)];
+}
+
+function workflowText(): string {
+  return read(WORKFLOW, 'The e2e lane only runs once a workflow invokes it.');
+}
+
+function packageScripts(): Record<string, string> {
+  const raw: unknown = JSON.parse(read(PACKAGE_JSON, 'The frontend package manifest is missing.'));
+  const scripts = (raw as { scripts?: Record<string, string> }).scripts;
+  if (scripts === undefined) {
+    throw new Error(`${PACKAGE_JSON} declares no "scripts" block.`);
+  }
+  return scripts;
+}
+
+function e2eScript(): string {
+  const script = packageScripts()[E2E_SCRIPT];
+  if (script === undefined) {
+    throw new Error(
+      `${PACKAGE_JSON} has no "${E2E_SCRIPT}" script, so nothing runs jest.e2e.config.js.`,
+    );
+  }
+  return script;
+}
+
+/** The literal keys declared in jest.e2e.config.js's `moduleNameMapper`. */
+function mapperKeys(): string[] {
+  const text = read(E2E_CONFIG, 'The e2e jest project config is missing.');
+  const block = MAPPER_BLOCK.exec(text);
+  if (block === null) {
+    throw new Error(`${E2E_CONFIG} declares no moduleNameMapper block.`);
+  }
+  return [...(block[1] ?? '').matchAll(MAPPER_KEY)].map((match) => match[1] ?? '');
+}
+
+function e2eFiles(suffix: string): string[] {
+  if (!existsSync(E2E_DIR)) {
+    throw new Error(`${E2E_DIR} does not exist; the e2e lane has no specs.`);
+  }
+  return readdirSync(E2E_DIR).filter((name) => name.endsWith(suffix));
+}
+
+function launcherText(): string {
+  return read(
+    SERVER_LAUNCHER,
+    'The lane needs a launcher that boots the real FastAPI app on ephemeral Postgres.',
+  );
+}
+
+/**
+ * Attribute assignments in the launcher whose value is a callable.
+ *
+ * Rebinding a module attribute to a function (or a lambda, or a Mock) is what
+ * "stubbing" means here, and it is the only thing worth forbidding: the launcher
+ * legitimately assigns scalars to configure alembic and uvicorn, so a blanket
+ * ban on attribute assignment would flag ordinary setup as a fake.
+ */
+function launcherStubTargets(): string[] {
+  const text = launcherText();
+  const defined = new Set([...text.matchAll(PYTHON_DEF)].map((match) => match[1] ?? ''));
+  const targets: string[] = [];
+  for (const assignment of text.matchAll(PYTHON_ATTRIBUTE_ASSIGNMENT)) {
+    const value = (assignment[2] ?? '').replace(/\(.*$/, '');
+    if (defined.has(value) || value === 'lambda' || value.endsWith('Mock')) {
+      targets.push(assignment[1] ?? '');
+    }
+  }
+  return targets;
+}
+
+describe('e2e workflow is wired and cannot be silently disarmed', () => {
+  it('exists and triggers on pull_request', () => {
+    const [triggers] = splitWorkflow();
+
+    expect(triggers).toMatch(/^\s{2}pull_request:/m);
+  });
+
+  it('provisions a postgres:16 service container', () => {
+    expect(workflowText()).toMatch(/image:[ \t]*["']?postgres:16\b/);
+  });
+
+  it('points the lane at that database via TEST_POSTGRES_URL', () => {
+    expect(workflowText()).toMatch(/^[ \t]*TEST_POSTGRES_URL:[ \t]+\S/m);
+  });
+
+  it(`runs the ${E2E_SCRIPT} script`, () => {
+    expect(workflowText()).toContain(E2E_SCRIPT);
+  });
+
+  it.each(DISARMING_FRAGMENTS)('carries no "%s" escape hatch', (fragment) => {
+    const text = workflowText();
+
+    if (text.includes(fragment)) {
+      throw new Error(`${WORKFLOW} contains the disarming fragment "${fragment}".`);
+    }
+    expect(text).not.toContain(fragment);
+  });
+});
+
+describe('package.json exposes the lane as its own script', () => {
+  it(`declares ${E2E_SCRIPT} against jest.e2e.config.js`, () => {
+    expect(e2eScript()).toContain('jest.e2e.config.js');
+  });
+
+  it.each(['--passWithNoTests', '--coverage', '.skip'])(
+    `keeps "%s" out of the ${E2E_SCRIPT} script`,
+    (fragment) => {
+      expect(e2eScript()).not.toContain(fragment);
+    },
+  );
+});
+
+describe('jest.e2e.config.js isolates the lane without weakening anything', () => {
+  it('declares no coverage gate of its own', () => {
+    const text = read(E2E_CONFIG, 'The e2e jest project config is missing.');
+
+    expect(text).not.toContain('coverageThreshold');
+    expect(text).not.toContain('collectCoverage');
+  });
+
+  it('maps the @/ alias and nothing else', () => {
+    expect(mapperKeys()).toEqual(ONLY_MODULE_ALIAS);
+  });
+
+  it.each(['api', 'fetch', 'expo'])('maps no module matching "%s"', (needle) => {
+    const offenders = mapperKeys().filter((key) => key.toLowerCase().includes(needle));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('e2e specs drive the unmocked production client', () => {
+  it('ships the three journeys the lane is built around', () => {
+    expect(e2eFiles('.e2e.test.ts').sort()).toEqual(EXPECTED_JOURNEYS);
+  });
+
+  it('imports the real API client in every journey', () => {
+    for (const name of e2eFiles('.e2e.test.ts')) {
+      const text = readFileSync(join(E2E_DIR, name), 'utf8');
+      if (!/from '@\/api'/.test(text)) {
+        throw new Error(`e2e/${name} never imports from "@/api"; it exercises nothing real.`);
+      }
+    }
+  });
+
+  it.each(FORBIDDEN_IN_SPECS)('contains no %s in any journey', (label, pattern) => {
+    const offenders = e2eFiles('.e2e.test.ts').filter((name) =>
+      pattern.test(readFileSync(join(E2E_DIR, name), 'utf8')),
+    );
+
+    if (offenders.length > 0) {
+      throw new Error(`${offenders.join()} use "${label}", which fakes the request path.`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it.each(FORBIDDEN_SKIP_PATHS)('offers no %s skip path anywhere in e2e/', (label, pattern) => {
+    const offenders = e2eFiles('.ts').filter((name) =>
+      pattern.test(readFileSync(join(E2E_DIR, name), 'utf8')),
+    );
+
+    if (offenders.length > 0) {
+      throw new Error(
+        `e2e/${offenders.join()} contains "${label}". An absent backend must fail the ` +
+          `lane, never skip it -- throw instead.`,
+      );
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('the server launcher stubs exactly one third-party call', () => {
+  it('exists', () => {
+    expect(launcherText().length).toBeGreaterThan(0);
+  });
+
+  it(`stubs ${LICENSE_STUB} exactly once`, () => {
+    const stubs = launcherStubTargets().filter((lhs) => lhs.endsWith(LICENSE_STUB));
+
+    expect(stubs).toHaveLength(1);
+  });
+
+  it('stubs nothing else on the request path', () => {
+    const others = launcherStubTargets().filter((lhs) => !lhs.endsWith(LICENSE_STUB));
+
+    if (others.length > 0) {
+      throw new Error(
+        `${SERVER_LAUNCHER} rebinds ${others.join()} to a callable; the Gumroad license ` +
+          `check is the only stub the lane permits on the request path.`,
+      );
+    }
+    expect(others).toEqual([]);
+  });
+
+  it.each(FORBIDDEN_IN_LAUNCHER)('uses no "%s" mocking machinery', (fragment) => {
+    expect(launcherText()).not.toContain(fragment);
+  });
+});

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,78 @@
+# End-to-end lane: the real client against a real server
+
+Every other test in this repository runs on one side of the wire. The backend
+suite drives routes with an in-process client against SQLite; dozens of frontend
+test files mock `src/api` outright and the rest never reach the network.
+Both can be green while the two halves have never met — which is how six
+shipped features turned out to be wired to nothing.
+
+This lane is the one place they meet. It imports the production API client from
+`src/api/index.ts` — unmocked, with its real Zod response validation, its real
+retry and refresh loop, and a real `fetch` over a real socket — and drives it
+through three journeys against a live FastAPI app on a real Postgres whose
+schema was built by `alembic upgrade head`.
+
+## Running it locally
+
+```bash
+docker run -d --name adepthood-e2e-pg \
+  -e POSTGRES_USER=aptitude -e POSTGRES_PASSWORD=aptitude -e POSTGRES_DB=aptitude \
+  -p 5432:5432 postgres:16
+
+cd frontend
+TEST_POSTGRES_URL=postgresql+asyncpg://aptitude:aptitude@localhost:5432/aptitude npm run test:e2e  # pragma: allowlist secret
+```
+
+The account in `TEST_POSTGRES_URL` needs `CREATE DATABASE`. The lane never
+touches the database that URL names: it creates a randomly-suffixed one beside
+it, migrates it, and drops it at teardown.
+
+Python has to be able to import the backend. The lane uses `E2E_PYTHON` if set,
+falls back to the repo's `.venv/bin/python`, and finally to `python3`. Inside a
+git worktree the virtualenv is one level up and will not be found, so point at
+it explicitly:
+
+```bash
+E2E_PYTHON=/path/to/adepthood/.venv/bin/python npm run test:e2e
+```
+
+## What is real, and the one thing that is not
+
+Real: the routers, the middleware stack, CORS, session handling, the Pydantic
+schemas, the migrations, the startup seeders, the JWTs, bcrypt password hashing,
+Postgres constraints — and, on the client side, every wrapper, header, query
+string and Zod schema in `src/api/index.ts`.
+
+Stubbed: exactly one function, `routers.auth.verify_aptitude_license`. Signup is
+gated on a live HTTPS call to Gumroad's license API, and an e2e lane that
+depended on a third party's uptime would be a flake generator. `backend/conftest.py`
+stubs the same seam for the same reason. Everything the gate does with the
+answer — the duplicate-email refusal, the password hashing, the entitlement
+grant — still runs for real.
+
+The launcher also disarms the rate limiter. Signup is capped at three per minute
+per client address and every journey here shares `127.0.0.1`, so leaving it
+armed would make "how many journeys exist" a hidden global constraint: a fourth
+journey, or one retry, would start failing on a cap rather than on a defect.
+Rate limiting keeps its own tests in the backend suite.
+
+`frontend/__tests__/e2eLaneGuard.test.ts` enforces both of those boundaries
+mechanically. It runs in the ordinary frontend suite and fails if a journey ever
+mocks the API module or `fetch`, if the launcher stubs anything besides the
+license check, or if the CI job acquires a way to be disarmed.
+
+## No skips, ever
+
+An absent Postgres, a server that will not boot, or a health probe that answers
+wrong all throw. There is no conditional skip anywhere in the lane, because a
+lane that quietly passes without making a request is precisely the gap it was
+built to close.
+
+## Teardown
+
+`globalTeardown` SIGTERMs the server's process group, escalates to SIGKILL after
+ten seconds, and then drops the database. The server cannot reliably drop its
+own: uvicorn re-raises the signal that stopped it, ending the process before any
+`finally` of its own runs. If the whole jest process is itself SIGKILLed, one
+randomly-named database survives — it can never collide with a later run, and
+`DROP DATABASE IF EXISTS adepthood_e2e_<suffix>` cleans it up.

--- a/frontend/e2e/auth.e2e.test.ts
+++ b/frontend/e2e/auth.e2e.test.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+
+import { describe, afterAll, expect, it } from '@jest/globals';
+
+import { ApiError, auth, journal, setTokenGetter } from '@/api';
+
+// `@example.test` is a reserved TLD the signup validator rejects with 422.
+const EMAIL_DOMAIN = '@example.com';
+const PASSWORD = 'correct horse battery staple'; // pragma: allowlist secret
+const TIMEZONE = 'UTC';
+const LICENSE_KEY = 'e2e-license';
+const JWT_SEGMENTS = 3;
+const HTTP_UNAUTHORIZED = 401;
+
+const email = `e2e-auth-${randomUUID()}${EMAIL_DOMAIN}`;
+
+/** Resolve with whatever a request rejected with; fail if it resolved instead. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error('expected the request to reject, but it resolved');
+}
+
+describe('auth journey against a live server', () => {
+  let sessionToken: string | null = null;
+  let signupUserId = 0;
+
+  afterAll(() => {
+    setTokenGetter(null);
+  });
+
+  it('signs up a fresh account and returns a usable session', async () => {
+    const response = await auth.signup({
+      email,
+      password: PASSWORD,
+      timezone: TIMEZONE,
+      license_key: LICENSE_KEY,
+    });
+
+    expect(response.token.split('.')).toHaveLength(JWT_SEGMENTS);
+    expect(response.user_id).toBeGreaterThan(0);
+    expect(response.timezone).toBe(TIMEZONE);
+
+    signupUserId = response.user_id;
+  });
+
+  it('logs the same account back in and hands the token to the client', async () => {
+    const response = await auth.login({ email, password: PASSWORD });
+
+    expect(response.user_id).toBe(signupUserId);
+    expect(response.token.split('.')).toHaveLength(JWT_SEGMENTS);
+    expect(response.timezone).toBe(TIMEZONE);
+
+    sessionToken = response.token;
+    setTokenGetter(() => sessionToken);
+  });
+
+  it('reads the new account state through the authenticated client', async () => {
+    const page = await journal.list();
+
+    // A brand-new account owns nothing: exact envelope, no bare status check.
+    expect(page).toEqual({ items: [], total: 0, has_more: false });
+  });
+
+  it('rejects the same call with a 401 once the token getter yields null', async () => {
+    setTokenGetter(() => null);
+
+    const failure = await rejection(journal.list());
+
+    expect(failure).toBeInstanceOf(ApiError);
+    expect((failure as ApiError).status).toBe(HTTP_UNAUTHORIZED);
+  });
+
+  it('rejects a wrong password with the backend invalid_credentials detail', async () => {
+    const wrong = 'not-the-password'; // pragma: allowlist secret
+    const failure = await rejection(auth.login({ email, password: wrong }));
+
+    expect(failure).toBeInstanceOf(ApiError);
+    expect((failure as ApiError).status).toBe(HTTP_UNAUTHORIZED);
+    expect((failure as ApiError).detail).toBe('invalid_credentials');
+  });
+});

--- a/frontend/e2e/globalSetup.ts
+++ b/frontend/e2e/globalSetup.ts
@@ -1,0 +1,143 @@
+import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+import globalTeardown from './globalTeardown';
+import {
+  BACKEND_DIR,
+  clearLaneState,
+  pythonExecutable,
+  writeLaneState,
+  type LaneState,
+} from './laneState';
+
+/**
+ * Bring up the server the journeys drive: an ephemeral Postgres database built
+ * by `alembic upgrade head`, and the real FastAPI app serving it on a loopback
+ * port. Nothing here degrades gracefully. A missing Postgres, a server that
+ * fails to boot, or a health probe that answers wrong all throw, because the
+ * only thing worse than a red e2e lane is a green one that never made a
+ * request.
+ */
+
+const POSTGRES_URL_ENV = 'TEST_POSTGRES_URL';
+const READY_PREFIX = 'E2E_READY port=';
+const BOOT_TIMEOUT_MS = 180_000;
+const SECRET_KEY_BYTES = 32;
+const DATABASE_SUFFIX_BYTES = 6;
+
+const POSTGRES_HELP =
+  `${POSTGRES_URL_ENV} is unset, so there is no database to build the schema in. ` +
+  'Start one with: docker run -d --name adepthood-e2e-pg -e POSTGRES_USER=aptitude ' +
+  '-e POSTGRES_PASSWORD=aptitude -e POSTGRES_DB=aptitude -p 5432:5432 postgres:16 ' +
+  `then point ${POSTGRES_URL_ENV} at it (see frontend/e2e/README.md for the full recipe). ` +
+  'The lane never skips on an absent server: that is the gap it exists to close.';
+
+/** Replace the database component of a connection URL, preserving any query. */
+function withDatabase(url: string, name: string): string {
+  // Split on the FIRST '?' only, keeping the whole query: split(url, 2) would
+  // silently drop everything after a second '?'.
+  const queryStart = url.indexOf('?');
+  const base = queryStart === -1 ? url : url.slice(0, queryStart);
+  const query = queryStart === -1 ? undefined : url.slice(queryStart + 1);
+  if (!base.includes('://')) {
+    throw new Error(`${POSTGRES_URL_ENV} is not a connection URL: "${url}"`);
+  }
+  const authorityEnd = base.indexOf('/', base.indexOf('://') + '://'.length);
+  const authority = authorityEnd === -1 ? base : base.slice(0, authorityEnd);
+  return `${authority}/${name}${query === undefined ? '' : `?${query}`}`;
+}
+
+/** Confirm the app is actually answering, not merely listening. */
+async function assertHealthy(baseUrl: string): Promise<void> {
+  const response = await fetch(`${baseUrl}/health`);
+  const body: unknown = await response.json();
+  const { status, database } = body as { status?: unknown; database?: unknown };
+  if (response.status !== 200 || status !== 'healthy' || database !== 'connected') {
+    throw new Error(
+      `the e2e server answered GET /health with ${response.status} ${JSON.stringify(body)}; ` +
+        'the lane needs a server that is up and connected to its database',
+    );
+  }
+}
+
+interface Launch {
+  pid: number;
+  port: number;
+}
+
+/** Spawn the server and resolve once it announces the port it bound. */
+function launchServer(databaseUrl: string, adminUrl: string): Promise<Launch> {
+  const child = spawn(pythonExecutable(), ['-m', 'tests.e2e.server'], {
+    cwd: BACKEND_DIR,
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      PYTHONPATH: 'src',
+      DATABASE_URL: databaseUrl,
+      E2E_ADMIN_DATABASE_URL: adminUrl,
+      SECRET_KEY: randomBytes(SECRET_KEY_BYTES).toString('base64url'),
+    },
+  });
+
+  return new Promise<Launch>((resolvePort, reject) => {
+    let log = '';
+    const fail = (reason: string): void => {
+      reject(new Error(`${reason}\n--- server output ---\n${log}`));
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      fail(`the e2e server did not report readiness within ${BOOT_TIMEOUT_MS}ms`);
+    }, BOOT_TIMEOUT_MS);
+
+    const onChunk = (chunk: Buffer): void => {
+      log += chunk.toString();
+      const match = /E2E_READY port=(\d+)/.exec(log);
+      if (match?.[1] === undefined) return;
+      clearTimeout(timer);
+      resolvePort({ pid: child.pid ?? 0, port: Number(match[1]) });
+    };
+    child.stdout.on('data', onChunk);
+    child.stderr.on('data', onChunk);
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      fail(
+        `the e2e server exited (code ${String(code)}, signal ${String(signal)}) before ${READY_PREFIX}`,
+      );
+    });
+    child.on('error', (error: Error) => {
+      clearTimeout(timer);
+      fail(`could not start the e2e server: ${error.message}`);
+    });
+  });
+}
+
+export default async function globalSetup(): Promise<void> {
+  const adminUrl = process.env[POSTGRES_URL_ENV]?.trim();
+  if (!adminUrl) throw new Error(POSTGRES_HELP);
+
+  clearLaneState();
+  const databaseUrl = withDatabase(
+    adminUrl,
+    `adepthood_e2e_${randomBytes(DATABASE_SUFFIX_BYTES).toString('hex')}`,
+  );
+
+  const { pid, port } = await launchServer(databaseUrl, adminUrl);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const state: LaneState = { pid, baseUrl, databaseUrl, adminUrl };
+  writeLaneState(state);
+
+  try {
+    await assertHealthy(baseUrl);
+  } catch (error: unknown) {
+    // Jest runs globalTeardown only after a globalSetup that returned, so a
+    // server that booted but answers wrong would otherwise outlive the run.
+    await globalTeardown();
+    throw error;
+  }
+
+  // Read by `src/config.ts` at import time, and inlined into the compiled module
+  // by babel-preset-expo -- which is why the lane disables Jest's transform
+  // cache. Workers are forked after this runs, so they inherit the value.
+  process.env.EXPO_PUBLIC_API_BASE_URL = baseUrl;
+}

--- a/frontend/e2e/globalTeardown.ts
+++ b/frontend/e2e/globalTeardown.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from 'node:child_process';
+
+import {
+  BACKEND_DIR,
+  clearLaneState,
+  pythonExecutable,
+  readLaneState,
+  type LaneState,
+} from './laneState';
+
+/**
+ * Take the lane back down deterministically: no server left listening, no
+ * database left behind, and a loud failure if either cannot be guaranteed.
+ *
+ * The drop runs here rather than in the server's own `finally` because uvicorn
+ * re-raises the signal that stopped it, ending the process before any cleanup
+ * of its own could run. Both paths issue `DROP DATABASE IF EXISTS`, so a server
+ * that did manage to clean up after itself costs this one a no-op.
+ */
+
+const SIGTERM_GRACE_MS = 10_000;
+const EXIT_POLL_MS = 50;
+
+/** Whether the process group leader is still around. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The two signals teardown sends, in escalation order. */
+type StopSignal = 'SIGTERM' | 'SIGKILL';
+
+/** Signal the whole process group, tolerating a leader that already exited. */
+function signalGroup(pid: number, signal: StopSignal): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    // ESRCH: the group is already gone, which is the state we wanted anyway.
+  }
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolveWait) => {
+    setTimeout(resolveWait, ms);
+  });
+
+/** SIGTERM the group, escalating to SIGKILL if it outstays the grace period. */
+async function stopServer(pid: number): Promise<void> {
+  if (pid <= 0) return;
+  signalGroup(pid, 'SIGTERM');
+  const deadline = Date.now() + SIGTERM_GRACE_MS;
+  while (isAlive(pid) && Date.now() < deadline) {
+    await wait(EXIT_POLL_MS);
+  }
+  if (isAlive(pid)) signalGroup(pid, 'SIGKILL');
+}
+
+/** Drop the run's database, failing loudly rather than leaking it silently. */
+function dropDatabase(state: LaneState): void {
+  const result = spawnSync(pythonExecutable(), ['-m', 'tests.e2e.server', '--drop-only'], {
+    cwd: BACKEND_DIR,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PYTHONPATH: 'src',
+      DATABASE_URL: state.databaseUrl,
+      E2E_ADMIN_DATABASE_URL: state.adminUrl,
+    },
+  });
+  if (result.status === 0) return;
+  throw new Error(
+    `could not drop the e2e database (exit ${String(result.status)}): ${result.stderr || result.stdout}`,
+  );
+}
+
+export default async function globalTeardown(): Promise<void> {
+  const state = readLaneState();
+  if (state === null) return;
+  try {
+    await stopServer(state.pid);
+    dropDatabase(state);
+  } finally {
+    clearLaneState();
+  }
+}

--- a/frontend/e2e/habits.e2e.test.ts
+++ b/frontend/e2e/habits.e2e.test.ts
@@ -1,0 +1,142 @@
+import { randomUUID } from 'node:crypto';
+
+import { describe, afterAll, expect, it } from '@jest/globals';
+
+import { auth, goalCompletions, habits, setTokenGetter } from '@/api';
+import type { ApiGoal, ApiHabitWithGoals } from '@/api';
+
+// `@example.test` is a reserved TLD the signup validator rejects with 422.
+const EMAIL_DOMAIN = '@example.com';
+const PASSWORD = 'correct horse battery staple'; // pragma: allowlist secret
+const TIMEZONE = 'UTC';
+const LICENSE_KEY = 'e2e-license';
+const ISO_DATE_LENGTH = 10;
+
+const ENERGY_COST = 2;
+const ENERGY_RETURN = 5;
+const HABIT_ICON = 'candle';
+const CLEAR_TIER = 'clear';
+// The three tiers the server seeds with every habit, sorted for comparison.
+const EXPECTED_TIERS = ['clear', 'low', 'stretch'];
+
+const email = `e2e-habits-${randomUUID()}${EMAIL_DOMAIN}`;
+const habitName = `E2E Habit ${randomUUID()}`;
+// The account's timezone is UTC, so the server's "today" is this calendar day.
+const today = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
+
+/** Unwrap a collection the journey requires to hold exactly one element. */
+function exactlyOne<T>(items: readonly T[], what: string): T {
+  const [first] = items;
+  if (items.length !== 1 || first === undefined) {
+    throw new Error(`expected exactly one ${what}, got ${items.length}`);
+  }
+  return first;
+}
+
+function goalForTier(goals: readonly ApiGoal[], tier: string): ApiGoal {
+  const match = goals.find((goal) => goal.tier === tier);
+  if (match === undefined) {
+    throw new Error(
+      `no "${tier}" goal on the habit; tiers were ${goals.map((g) => g.tier).join()}`,
+    );
+  }
+  return match;
+}
+
+describe('habits journey against a live server', () => {
+  let sessionToken: string | null = null;
+  let habitId = 0;
+  let clearGoalId = 0;
+
+  afterAll(() => {
+    setTokenGetter(null);
+  });
+
+  it('registers its own account so no other journey can perturb it', async () => {
+    const response = await auth.signup({
+      email,
+      password: PASSWORD,
+      timezone: TIMEZONE,
+      license_key: LICENSE_KEY,
+    });
+
+    expect(response.user_id).toBeGreaterThan(0);
+
+    sessionToken = response.token;
+    setTokenGetter(() => sessionToken);
+  });
+
+  it('creates a habit and echoes back every field it was given', async () => {
+    const created = await habits.create({
+      name: habitName,
+      icon: HABIT_ICON,
+      start_date: today,
+      energy_cost: ENERGY_COST,
+      energy_return: ENERGY_RETURN,
+    });
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.name).toBe(habitName);
+    expect(created.icon).toBe(HABIT_ICON);
+    expect(created.start_date).toBe(today);
+    expect(created.energy_cost).toBe(ENERGY_COST);
+    expect(created.energy_return).toBe(ENERGY_RETURN);
+
+    habitId = created.id;
+  });
+
+  it('lists the habit back through the Page envelope with its three default goals', async () => {
+    const listed: ApiHabitWithGoals[] = await habits.listAll();
+
+    const habit = exactlyOne(listed, 'habit on the fresh account');
+    expect(habit.id).toBe(habitId);
+    expect(habit.name).toBe(habitName);
+    expect(habit.streak).toBe(0);
+    expect(habit.goals.map((goal) => goal.tier).sort()).toEqual(EXPECTED_TIERS);
+    for (const goal of habit.goals) {
+      expect(goal.habit_id).toBe(habitId);
+      expect(goal.completions ?? []).toHaveLength(0);
+    }
+
+    clearGoalId = goalForTier(habit.goals, CLEAR_TIER).id;
+  });
+
+  it('records a check-in on the clear goal and starts the streak', async () => {
+    const result = await goalCompletions.create({ goal_id: clearGoalId, did_complete: true });
+
+    expect(result.streak).toBe(1);
+    expect(result.reason_code).toBe('streak_incremented');
+    expect(result.milestones.map((milestone) => milestone.threshold)).toEqual([1]);
+  });
+
+  it('reports the check-in in the habit stats', async () => {
+    const stats = await habits.getStats(habitId);
+
+    expect(stats.current_streak).toBe(1);
+    expect(stats.longest_streak).toBe(1);
+    expect(stats.total_completions).toBe(1);
+    expect(stats.completion_rate).toBe(1);
+    expect(stats.completion_dates).toEqual([today]);
+    // The three series are one chart: a drift between them is a wire bug.
+    expect(stats.day_labels.length).toBeGreaterThan(0);
+    expect(stats.values).toHaveLength(stats.day_labels.length);
+    expect(stats.completions_by_day).toHaveLength(stats.day_labels.length);
+  });
+
+  it('shows the streak and the embedded completion on a fresh list', async () => {
+    const listed = await habits.listAll();
+
+    const habit = exactlyOne(listed, 'habit on the fresh account');
+    expect(habit.streak).toBe(1);
+
+    const clearGoal = goalForTier(habit.goals, CLEAR_TIER);
+    const completion = exactlyOne(clearGoal.completions ?? [], 'completion on the clear goal');
+    expect(completion.id).toBeGreaterThan(0);
+    expect(Number.isNaN(Date.parse(completion.timestamp))).toBe(false);
+
+    // Only the tier that was checked in carries a completion.
+    for (const goal of habit.goals.filter((candidate) => candidate.id !== clearGoalId)) {
+      expect(goal.completions ?? []).toHaveLength(0);
+    }
+  });
+});

--- a/frontend/e2e/journal.e2e.test.ts
+++ b/frontend/e2e/journal.e2e.test.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto';
+
+import { describe, afterAll, expect, it } from '@jest/globals';
+
+import { auth, journal, setTokenGetter } from '@/api';
+
+// `@example.test` is a reserved TLD the signup validator rejects with 422.
+const EMAIL_DOMAIN = '@example.com';
+const PASSWORD = 'correct horse battery staple'; // pragma: allowlist secret
+const TIMEZONE = 'UTC';
+const LICENSE_KEY = 'e2e-license';
+
+const email = `e2e-journal-${randomUUID()}${EMAIL_DOMAIN}`;
+// Non-ASCII on purpose: a UTF-8 mishandling anywhere on the wire (request
+// encoding, column collation, response encoding) breaks the round-trip below.
+const body = `Reflexión sobre la vela 灯 y el río — ${randomUUID()}`;
+
+describe('journal journey against a live server', () => {
+  let sessionToken: string | null = null;
+  let entryId = 0;
+
+  afterAll(() => {
+    setTokenGetter(null);
+  });
+
+  it('registers its own account so no other journey can perturb it', async () => {
+    const response = await auth.signup({
+      email,
+      password: PASSWORD,
+      timezone: TIMEZONE,
+      license_key: LICENSE_KEY,
+    });
+
+    expect(response.user_id).toBeGreaterThan(0);
+
+    sessionToken = response.token;
+    setTokenGetter(() => sessionToken);
+  });
+
+  it('creates an entry and returns it fully materialised', async () => {
+    const created = await journal.create({ message: body });
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.message).toBe(body);
+    expect(created.sender).toBe('user');
+    expect(created.tag).toBe('freeform');
+    expect(created.classification).toBe('personal');
+    expect(created.status).toBe('draft');
+    expect(Number.isNaN(Date.parse(created.timestamp))).toBe(false);
+
+    entryId = created.id;
+  });
+
+  it('lists exactly the one entry the account owns', async () => {
+    const page = await journal.list();
+
+    expect(page.total).toBe(1);
+    expect(page.has_more).toBe(false);
+    expect(page.items).toHaveLength(1);
+
+    const [entry] = page.items;
+    expect(entry?.id).toBe(entryId);
+    expect(entry?.message).toBe(body);
+    expect(entry?.sender).toBe('user');
+  });
+
+  it('round-trips the body byte-for-byte on a single-entry read', async () => {
+    const entry = await journal.get(entryId);
+
+    expect(entry.id).toBe(entryId);
+    expect(entry.message).toBe(body);
+    expect([...entry.message]).toEqual([...body]);
+  });
+});

--- a/frontend/e2e/laneState.ts
+++ b/frontend/e2e/laneState.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * The handshake between `globalSetup` and `globalTeardown`, which run in the
+ * same process but cannot share a closure across Jest's module boundary, and
+ * between both of them and `setupEnv`, which runs in the worker.
+ */
+export interface LaneState {
+  /** Process group leader of the server, killed as a group at teardown. */
+  pid: number;
+  /** Loopback origin the production client is pointed at. */
+  baseUrl: string;
+  /** URL of the throwaway database the run owns. */
+  databaseUrl: string;
+  /** URL of a database that already exists, used only to drop the throwaway one. */
+  adminUrl: string;
+}
+
+/** Repository root, three levels up from `frontend/e2e`. */
+export const REPO_ROOT = resolve(__dirname, '..', '..');
+
+/** Working directory the server module must be launched from. */
+export const BACKEND_DIR = join(REPO_ROOT, 'backend');
+
+/** Where the run records itself; `.gitignore`d, and removed at teardown. */
+export const STATE_FILE = join(__dirname, '.e2e-state.json');
+
+/** Write the run's coordinates so teardown can reach them. */
+export function writeLaneState(state: LaneState): void {
+  writeFileSync(STATE_FILE, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+/** Read the run's coordinates, or null when setup never got far enough. */
+export function readLaneState(): LaneState | null {
+  if (!existsSync(STATE_FILE)) return null;
+  return JSON.parse(readFileSync(STATE_FILE, 'utf8')) as LaneState;
+}
+
+/** Forget the run, so a later invocation cannot inherit a dead server's port. */
+export function clearLaneState(): void {
+  rmSync(STATE_FILE, { force: true });
+}
+
+/**
+ * The interpreter that can import the backend. `E2E_PYTHON` wins; otherwise the
+ * repo's virtualenv if it exists (the local case), else whatever `python3` is on
+ * PATH (the CI case, where dependencies are installed system-wide).
+ *
+ * Shared rather than duplicated: setup spawns the server with it and teardown
+ * drops the database with it, and an interpreter that differed between the two
+ * would leave the database behind while looking like it had cleaned up.
+ */
+export function pythonExecutable(): string {
+  const override = process.env.E2E_PYTHON?.trim();
+  if (override) return override;
+  const venv = join(REPO_ROOT, '.venv', 'bin', 'python');
+  return existsSync(venv) ? venv : 'python3';
+}

--- a/frontend/e2e/setupEnv.ts
+++ b/frontend/e2e/setupEnv.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+// The path comes from the module that writes it, so a rename cannot silently
+// turn this cross-check into a no-op: a missing file reads as "setup has not
+// run", which is exactly what a drifted path would look like.
+import { STATE_FILE } from './laneState';
+
+/**
+ * Fail-fast preflight for the e2e lane. There is no skip path anywhere here:
+ * an absent or misaddressed backend must turn the lane red, because a lane
+ * that quietly reports success without touching the server is the exact
+ * failure this suite exists to prevent.
+ */
+
+const BASE_URL_ENV = 'EXPO_PUBLIC_API_BASE_URL';
+const LOOPBACK_BASE_URL = /^http:\/\/127\.0\.0\.1:\d+$/;
+
+const REMEDY =
+  `Run the lane through "npm run test:e2e", which boots a FastAPI server on an ` +
+  `ephemeral port, records it in ${STATE_FILE}, and exports ${BASE_URL_ENV}. ` +
+  `Never skip on an absent backend -- fix the backend.`;
+
+/** The base URL globalSetup recorded, or null when it has not run yet. */
+function recordedBaseUrl(): string | null {
+  if (!existsSync(STATE_FILE)) return null;
+  const raw: unknown = JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+  if (typeof raw !== 'object' || raw === null || !('baseUrl' in raw)) {
+    throw new Error(
+      `${STATE_FILE} has no "baseUrl" key; the server launcher wrote a bad state file.`,
+    );
+  }
+  const { baseUrl } = raw as { baseUrl: unknown };
+  if (typeof baseUrl !== 'string') {
+    throw new Error(`${STATE_FILE} "baseUrl" is ${typeof baseUrl}, expected a string.`);
+  }
+  return baseUrl;
+}
+
+const configured = process.env[BASE_URL_ENV];
+
+if (configured === undefined || configured.trim() === '') {
+  throw new Error(
+    `${BASE_URL_ENV} is unset or blank, so the e2e lane has no server to talk to. ${REMEDY}`,
+  );
+}
+
+if (!LOOPBACK_BASE_URL.test(configured)) {
+  throw new Error(
+    `${BASE_URL_ENV} is "${configured}", which is not a loopback server of the form ` +
+      `http://127.0.0.1:<port>. The e2e lane must never address a shared or remote ` +
+      `environment. ${REMEDY}`,
+  );
+}
+
+const recorded = recordedBaseUrl();
+
+if (recorded !== null && recorded !== configured) {
+  throw new Error(
+    `${BASE_URL_ENV} is "${configured}" but the launcher recorded "${recorded}" in ` +
+      `${STATE_FILE}. The tests would drive a different server than the one under ` +
+      `test (a stale transform cache or a leaked env var). ${REMEDY}`,
+  );
+}

--- a/frontend/jest.e2e.config.js
+++ b/frontend/jest.e2e.config.js
@@ -1,0 +1,36 @@
+// Real-wire end-to-end lane.
+//
+// Everything on the request path is real: the production API client in
+// `src/api/index.ts`, its Zod response validation, its retry/refresh loop, a
+// real `fetch` over a real socket, and a live FastAPI server on ephemeral
+// Postgres. Nothing here is mocked.
+//
+// The lane is deliberately unreachable from `npx jest`: the default config's
+// `roots` are `src` and `__tests__`, so a top-level `e2e/` folder is invisible
+// to it. That isolation is what lets this project drop the unit suite's expo
+// `moduleNameMapper` shims and its 90% coverage thresholds without weakening
+// either of them for the suite that actually needs them.
+
+/** @type {import('jest').Config} */
+module.exports = {
+  rootDir: __dirname,
+  roots: ['<rootDir>/e2e'],
+  testMatch: ['<rootDir>/e2e/**/*.e2e.test.ts'],
+  testEnvironment: 'node',
+  // One server, one database, journeys that read back what they wrote.
+  maxWorkers: 1,
+  // babel-preset-expo inlines `process.env.EXPO_PUBLIC_API_BASE_URL` at
+  // transform time, so a warm transform cache would bake a previous run's
+  // ephemeral port into the compiled `@/config`.
+  cache: false,
+  // `src/config.ts` reads `__DEV__`, which only the react-native preset defines.
+  globals: { __DEV__: true },
+  // The alias and nothing else: no expo module mocks, no fetch shim.
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  globalSetup: '<rootDir>/e2e/globalSetup.ts',
+  globalTeardown: '<rootDir>/e2e/globalTeardown.ts',
+  setupFiles: ['<rootDir>/e2e/setupEnv.ts'],
+  testTimeout: 60000,
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
     "web": "expo start --web",
     "web:build": "expo export --platform web",
     "test": "jest --passWithNoTests",
+    "test:e2e": "jest --config jest.e2e.config.js",
     "complexity": "eslint . --format json | node -e \"const r=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));const msgs=r.flatMap(f=>f.messages.filter(m=>['complexity','sonarjs/cognitive-complexity'].includes(m.ruleId)).map(m=>({file:f.filePath,line:m.line,rule:m.ruleId,msg:m.message})));console.table(msgs);console.log('Total complexity warnings:',msgs.length)\""
   },
   "version": "1.0.0",

--- a/frontend/tsconfig.eslint.json
+++ b/frontend/tsconfig.eslint.json
@@ -10,9 +10,11 @@
     "src/**/*.js",
     "__tests__/**/*.ts",
     "__tests__/**/*.tsx",
+    "e2e/**/*.ts",
     "@types/**/*.d.ts",
     "eslint.config.cjs",
     "jest.config.js",
+    "jest.e2e.config.js",
     "jest.setup.js"
   ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,6 +21,6 @@
     "types": ["jest", "react", "react-native", "expo"]
   },
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"],
-  "include": ["src", "__tests__", "@types"],
+  "include": ["src", "__tests__", "e2e", "@types"],
   "extends": "expo/tsconfig.base"
 }


### PR DESCRIPTION
## Summary

Both suites in this repo are exhaustive on their own side of the wire, and
neither can tell whether the wire is connected. The backend drives its routes
in-process against SQLite; dozens of frontend test files mock `src/api` outright
and the rest never reach the network. Six shipped features turned out to be
wired to nothing, and every one of them tested green the whole time.

This adds the one place the two halves meet: a Jest lane that imports the
production client from `frontend/src/api/index.ts` — unmocked, with its real Zod
response validation, its retry/refresh loop, and a real `fetch` over a real
socket — and drives it against a live FastAPI app on an ephemeral Postgres whose
schema comes from `alembic upgrade head`.

**The three journeys**, each registering its own account so none can perturb
another:

- **auth** — signup → login → an authenticated read succeeds → the token getter
  yields null → the same call rejects with `ApiError.status === 401`; plus a
  wrong password surfacing the backend's own `invalid_credentials` detail.
- **habits** — create → the `Page` envelope lists it with its three default
  goals → check in on the clear-tier goal → `streak: 1` /
  `reason_code: 'streak_incremented'` → stats report the completion → a fresh
  list shows the streak and the embedded completion on that tier only.
- **journal** — create → the list holds exactly that entry → fetch by id
  round-trips a non-ASCII body code point for code point.

Every assertion is on response content or on state the server can be asked about
afterwards, never on a bare status code: a 200 with an empty body is the failure
mode being hunted.

**Isolation rather than dilution.** The lane is a separate Jest project under a
top-level `frontend/e2e/`, which the default config's `roots` cannot see. That is
what lets it drop the unit suite's expo `moduleNameMapper` shims and its 90%
coverage thresholds without weakening either for the suite that needs them. No
threshold anywhere is changed, and the diff contains no suppression of any kind.

**Exactly one stub, and it is not on the request path.** Signup is gated on a
live HTTPS call to Gumroad's license API, which the issue's "no third-party
network" rule forbids; `backend/tests/e2e/server.py` substitutes
`routers.auth.verify_aptitude_license`, the same seam `backend/conftest.py`
stubs for the same reason. Everything the gate does with the answer — the
duplicate-email refusal, bcrypt hashing, the entitlement grant — still runs for
real, as do the routers, middleware, migrations and startup seeders.

**One deliberate liberty, flagged for your call:** the launcher also sets
`limiter.enabled = False` (the repo's existing `disable_rate_limit` pattern).
Signup is capped at 3/minute per client address and all three journeys share
`127.0.0.1`, so an armed limiter puts the lane exactly on the cap with zero
headroom — I confirmed by hand that a fourth signup within the minute returns
`rate_limit_exceeded`. Leaving it armed would make "how many journeys exist" a
hidden global constraint and turn the next journey the epic plans into a flake.
Rate limiting keeps its own tests in the backend suite.

**Nothing skips.** An unset `TEST_POSTGRES_URL`, a server that will not boot, and
a health probe that answers wrong all throw. `frontend/__tests__/e2eLaneGuard.test.ts`
runs in the ordinary frontend suite (46 assertions) and fails if a journey ever
mocks the API module or `fetch`, if the launcher stubs anything but the license
check, if the lane grows a skip path, or if `e2e.yml` acquires `continue-on-error`,
`|| true`, `if: false`, `--passWithNoTests` or friends. It is modelled on the
`test_integration_lane_guard.py` precedent from #2037.

Builds directly on #2037 (the Postgres/alembic integration lane, whose
create-migrate-verify recipe and fail-loudly-never-skip posture this reuses).

## Test plan

- `npm run test:e2e` — **15/15 across 3 suites**, 6.4s total wall clock
  including boot, migration, seeding and teardown (budget was ~5 minutes).
- `frontend/__tests__/e2eLaneGuard.test.ts` — **46/46** in the default suite.
- `./scripts/backend/check-all.sh` — **7/7 stages green**, coverage 97%.
- `./scripts/frontend/check-all.sh` — audit, lint, format and typecheck green;
  full suite **449 suites / 5229 tests green** on a re-run (the first pass had 7
  five-second-timeout flakes while the backend suite was saturating the CPU).

**Mutation proof — each break observed red for the right reason, then reverted
(`frontend/src/api/index.ts` and `backend/src/main.py` are byte-identical to
`main` in this PR):**

| Mutation | Result |
|---|---|
| Client route path `/journal/` → `/journals/` | journal journey red, `ApiError 404`; auth + habits still green |
| Query key casing `paginate` → `Paginate` | habits journey red via the client's own Zod contract check — the server answers a bare array instead of the `Page` envelope, `ApiValidationError` |
| Unmounted `journal_router` in `main.py` | journal journey **and** the auth journey's authenticated read red — the exact "feature wired to nothing" defect this epic exists for |

Absence proven loud, not silent: with `TEST_POSTGRES_URL` unset the run dies in
`globalSetup` with an actionable message naming the docker one-liner; with
`EXPO_PUBLIC_API_BASE_URL` unset every suite fails to run. Teardown verified to
leave zero orphaned processes and zero leftover databases.

No dependency changes on either side.

Closes #2039
Refs #2035
