### PR TITLE
fix(backend): authorize body-carried practice ids on POST /journal/

### DIFF
--- a/backend/scripts/dast/README.md
+++ b/backend/scripts/dast/README.md
@@ -154,3 +154,20 @@ class needs, at minimum: seeding at least one object as the intruder
 identity, templating replay bodies the way create payloads already are, a
 registry describing which body fields carry object references, a matching
 `Cell` variant, and new assertions in `test_registry_covers_real_app.py`.
+
+`POST /journal/` is a second, independent instance of the same class, found
+by hand rather than by the harness. It is even further outside the matrix's
+reach than `goals` was: its path is `/journal/`, with no id in it at all, so
+`is_object_scoped` in `discovery.py` never puts it in the object-scoped set
+to begin with, and `classify_routes` in `policy.py` leaves a route with no
+path parameters out of the count entirely rather than probing or excusing
+it -- there was no cross-user cell to run, clean or otherwise. The two
+foreign-object references, `user_practice_id` and `practice_session_id`,
+were both carried in the request body and are now checked in-app by
+`resolve_owned_user_practice` and `resolve_owned_practice_session` in
+`backend/src/dependencies/ownership.py`. Two instances of this class, found
+by hand in two different routes the matrix has run green on, is what makes
+the gap systemic rather than a one-off in `goals`: a clean matrix report is
+still not a claim that no other route has an unguarded body reference.
+Issue #2124 tracks closing the body-parameter gap described above; nothing
+in this change closes it.

--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -18,6 +18,7 @@ from models.goal_group import GoalGroup
 from models.habit import Habit
 from models.journal_entry import JournalEntry
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
 
@@ -157,19 +158,55 @@ async def require_owned_journal_entry(
     return entry
 
 
+async def resolve_owned_user_practice(
+    session: AsyncSession, user_practice_id: int, user_id: int
+) -> UserPractice:
+    """Resolve ``user_practice_id`` for write access -- owner only -- and audit denials.
+
+    Callers that receive a user-practice id in a request *body* (rather than
+    the path) reuse this directly, so the ownership rule lives in exactly one
+    place regardless of where the id arrived from.
+    """
+    user_practice = await session.get(UserPractice, user_practice_id)
+    if user_practice is None:
+        raise not_found("user_practice")
+    if user_practice.user_id != user_id:
+        log_ownership_denied("user_practice", user_practice_id, user_id)
+        raise forbidden("forbidden")
+    return user_practice
+
+
 async def require_owned_user_practice(
     user_practice_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> UserPractice:
-    """Resolve ``user_practice_id`` and verify the caller owns it."""
-    user_practice = await session.get(UserPractice, user_practice_id)
-    if user_practice is None:
-        raise not_found("user_practice")
-    if user_practice.user_id != current_user:
-        log_ownership_denied("user_practice", user_practice_id, current_user)
+    """Resolve ``user_practice_id`` and verify the caller owns it.
+
+    Delegates to :func:`resolve_owned_user_practice`, which owns the rule and
+    emits the ``resource_access_denied`` audit row on a cross-tenant probe,
+    matching :func:`require_owned_goal_group`.
+    """
+    return await resolve_owned_user_practice(session, user_practice_id, current_user)
+
+
+async def resolve_owned_practice_session(
+    session: AsyncSession, practice_session_id: int, user_id: int
+) -> PracticeSession:
+    """Resolve ``practice_session_id`` for write access -- owner only -- and audit denials.
+
+    Sessions carry ``user_id`` directly, so ownership is a single comparison.
+    There is deliberately no ``require_``-style dependency wrapper: no route
+    takes ``practice_session_id`` as a path parameter, so a wrapper would be
+    dead code.  Body-carried ids call this directly.
+    """
+    practice_session = await session.get(PracticeSession, practice_session_id)
+    if practice_session is None:
+        raise not_found("practice_session")
+    if practice_session.user_id != user_id:
+        log_ownership_denied("practice_session", practice_session_id, user_id)
         raise forbidden("forbidden")
-    return user_practice
+    return practice_session
 
 
 async def require_visible_goal_group(

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,7 +14,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
-from dependencies.ownership import require_owned_journal_entry
+from dependencies.ownership import (
+    require_owned_journal_entry,
+    resolve_owned_practice_session,
+    resolve_owned_user_practice,
+)
 from dependencies.timezone import current_user_timezone
 from domain.care import CarePayload, build_care_payload
 from domain.contraction import build_contraction_invitation, detect_contraction
@@ -249,6 +253,25 @@ async def _record_vault_outcome(
     await session.refresh(entry)
 
 
+async def _authorize_practice_links(
+    session: AsyncSession, payload: JournalMessageCreate, current_user: int
+) -> None:
+    """Verify the caller owns every practice row the new entry links to.
+
+    Both ids arrive in the request *body*, and FastAPI's DI cannot extract
+    body fields into sub-dependencies, so the path-parameter ownership
+    dependencies never see them; the rule has to be invoked by hand here.
+    Each non-null id is checked unconditionally -- there is no "unchanged, so
+    skip" shortcut, because that is precisely the reasoning that lets a forged
+    link through.  Raises 404 for an id that exists for nobody and 403 for one
+    belonging to another user, matching the canonical order elsewhere.
+    """
+    if payload.user_practice_id is not None:
+        await resolve_owned_user_practice(session, payload.user_practice_id, current_user)
+    if payload.practice_session_id is not None:
+        await resolve_owned_practice_session(session, payload.practice_session_id, current_user)
+
+
 @router.post("/", response_model=JournalMessageResponse, status_code=status.HTTP_201_CREATED)
 async def create_journal_entry(
     payload: JournalMessageCreate,
@@ -263,7 +286,13 @@ async def create_journal_entry(
     characters, zero-width, or bidi-override codepoints — defense
     against stored-XSS payloads in journal renderers and Trojan-Source
     smuggling in log viewers.
+
+    ``user_practice_id`` and ``practice_session_id`` are authorized before the
+    row is constructed: an id that exists for nobody is a 404, another user's
+    id is a 403, and neither can reach the session, so no forged link is ever
+    persisted.
     """
+    await _authorize_practice_links(session, payload, current_user)
     data = payload.model_dump()
     # ``entry_date`` is not a column: resolve it to a stored ``timestamp`` (or,
     # when absent, leave it out so the model's default_factory stamps "now").

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -30,11 +30,13 @@ from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select
 
 from models.course_stage import CourseStage
 from models.goal import Goal
+from models.journal_entry import JournalEntry
 from models.practice import Practice
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
@@ -42,6 +44,8 @@ from models.stage_progress import StageProgress
 # Severity: probe attempts use a sentinel id well above any seeded row so
 # the missing-row branch is the same code path as a malicious enumeration.
 _DEFINITELY_MISSING_ID = 999_999
+
+_JOURNAL_PROBE_MESSAGE = "A perfectly ordinary entry."
 
 _HABIT_PAYLOAD: dict[str, object] = {
     "name": "Drink Water",
@@ -114,9 +118,16 @@ async def _create_user_practice(
     db_session: AsyncSession,
     headers: dict[str, str],
     user_id: int,
+    *,
+    practice_name: str | None = None,
 ) -> int:
-    """Seed a practice the user owns (via UserPractice) and return its id."""
-    practice = await _seed_practice(db_session)
+    """Seed a practice the user owns (via UserPractice) and return its id.
+
+    ``practice_name`` must be supplied when one test seeds two of these: the
+    preset catalog is uniquely indexed on (stage_number, normalized name).
+    """
+    overrides: dict[str, object] = {} if practice_name is None else {"name": practice_name}
+    practice = await _seed_practice(db_session, **overrides)
     # Make sure the user is unlocked for stage 1 -- a fresh signup is.
     db_session.add(
         StageProgress(
@@ -150,6 +161,33 @@ def _session_window_payload(user_practice_id: int) -> dict[str, object]:
         "started_at": started.isoformat(),
         "ended_at": ended.isoformat(),
     }
+
+
+def _journal_payload(**foreign_keys: int) -> dict[str, object]:
+    """Build an otherwise-valid ``POST /journal/`` body carrying the given body FKs.
+
+    Everything except the injected id is benign, so a rejection can only be
+    about the id -- never about a malformed message or a missing field.
+    """
+    return {"message": _JOURNAL_PROBE_MESSAGE, **foreign_keys}
+
+
+def _denial_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the ``resource_access_denied`` audit records captured so far."""
+    return [record for record in caplog.records if record.message == "resource_access_denied"]
+
+
+async def _entries_where(
+    db_session: AsyncSession, condition: ColumnElement[bool]
+) -> list[JournalEntry]:
+    """Return every persisted journal entry matching ``condition``.
+
+    Expires the shared test session first so the assertion reads committed
+    state rather than the identity map the request left behind.
+    """
+    db_session.expire_all()
+    result = await db_session.execute(select(JournalEntry).where(condition))
+    return list(result.scalars().all())
 
 
 async def _create_practice_session(
@@ -459,6 +497,117 @@ async def test_idor_practice_session_create_returns_403(
 
 
 @pytest.mark.asyncio
+async def test_idor_journal_create_user_practice_returns_403(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Bob cannot bind a new journal entry to Alice's user-practice.
+
+    ``POST /journal/`` takes ``user_practice_id`` from the request body, so the
+    path-parameter ownership dependencies never see it.  An unguarded write
+    would let an attacker graft rows onto a victim's practice history -- rows
+    that then surface in the victim's practice-scoped views and aggregates.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_j_up_post")
+    bob_headers, bob_id = await _signup(async_client, "bob_j_up_post")
+
+    alice_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id, practice_name="Alice Sit"
+    )
+    bob_practice_id = await _create_user_practice(
+        async_client, db_session, bob_headers, bob_id, practice_name="Bob Sit"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        attack = await async_client.post(
+            "/journal/",
+            json=_journal_payload(user_practice_id=alice_practice_id),
+            headers=bob_headers,
+        )
+
+    assert attack.status_code == HTTPStatus.FORBIDDEN
+    assert attack.json()["detail"] == "forbidden"
+
+    # The identical payload against Bob's own practice is accepted, so the 403
+    # above can only be about ownership -- not a missing row or a bad body.
+    baseline = await async_client.post(
+        "/journal/",
+        json=_journal_payload(user_practice_id=bob_practice_id),
+        headers=bob_headers,
+    )
+    assert baseline.status_code == HTTPStatus.CREATED
+    assert baseline.json()["user_practice_id"] == bob_practice_id
+
+    smuggled = await _entries_where(
+        db_session, col(JournalEntry.user_practice_id) == alice_practice_id
+    )
+    assert smuggled == [], "cross-user journal entry persisted against the victim's user-practice"
+
+    denials = _denial_records(caplog)
+    assert denials, "expected a resource_access_denied audit log entry"
+    assert getattr(denials[0], "resource", None) == "user_practice"
+    assert getattr(denials[0], "resource_id", None) == alice_practice_id
+    assert getattr(denials[0], "user_id", None) == bob_id
+
+
+@pytest.mark.asyncio
+async def test_idor_journal_create_practice_session_returns_403(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Bob cannot bind a new journal entry to Alice's practice session.
+
+    ``practice_session_id`` is the second unguarded body FK on ``POST
+    /journal/``; ``GET /journal/?practice_session_id=`` filters on it, so a
+    forged link is an attacker-controlled write into the victim's session view.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_j_ps_post")
+    bob_headers, bob_id = await _signup(async_client, "bob_j_ps_post")
+
+    alice_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id, practice_name="Alice Sit"
+    )
+    bob_practice_id = await _create_user_practice(
+        async_client, db_session, bob_headers, bob_id, practice_name="Bob Sit"
+    )
+    alice_session_id = await _create_practice_session(
+        async_client, alice_headers, alice_practice_id
+    )
+    bob_session_id = await _create_practice_session(async_client, bob_headers, bob_practice_id)
+
+    with caplog.at_level(logging.WARNING):
+        attack = await async_client.post(
+            "/journal/",
+            json=_journal_payload(practice_session_id=alice_session_id),
+            headers=bob_headers,
+        )
+
+    assert attack.status_code == HTTPStatus.FORBIDDEN
+    assert attack.json()["detail"] == "forbidden"
+
+    baseline = await async_client.post(
+        "/journal/",
+        json=_journal_payload(practice_session_id=bob_session_id),
+        headers=bob_headers,
+    )
+    assert baseline.status_code == HTTPStatus.CREATED
+    assert baseline.json()["practice_session_id"] == bob_session_id
+
+    smuggled = await _entries_where(
+        db_session, col(JournalEntry.practice_session_id) == alice_session_id
+    )
+    assert smuggled == [], "cross-user journal entry persisted against the victim's session"
+
+    denials = _denial_records(caplog)
+    assert denials, "expected a resource_access_denied audit log entry"
+    assert getattr(denials[0], "resource", None) == "practice_session"
+    assert getattr(denials[0], "resource_id", None) == alice_session_id
+    assert getattr(denials[0], "user_id", None) == bob_id
+
+
+@pytest.mark.asyncio
 async def test_idor_practice_session_list_returns_403(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -552,6 +701,35 @@ async def test_missing_row_returns_404(async_client: AsyncClient, method: str, u
     assert resp.status_code == HTTPStatus.NOT_FOUND, (
         f"missing-row regression: {method} {url} must 404, got {resp.status_code}"
     )
+
+
+@pytest.mark.parametrize(
+    ("field", "detail"),
+    [
+        ("user_practice_id", "user_practice_not_found"),
+        ("practice_session_id", "practice_session_not_found"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_journal_create_missing_body_fk_returns_404(
+    async_client: AsyncClient, field: str, detail: str
+) -> None:
+    """A ``POST /journal/`` body FK that exists for nobody 404s, never 403.
+
+    Pins the canonical ordering the IDOR matrix relies on: existence is
+    checked before ownership, so a nonexistent id cannot be mistaken for
+    someone else's.
+    """
+    headers, _ = await _signup(async_client, f"journal_missing_{field}")
+
+    resp = await async_client.post(
+        "/journal/",
+        json=_journal_payload(**{field: _DEFINITELY_MISSING_ID}),
+        headers=headers,
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == detail
 
 
 # ── BUG-COURSE-004: locked course content masks as 404 ──────────────────

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
 from cryptography.fernet import Fernet
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.practice import Practice
+from models.practice_session import PracticeSession
+from models.user_practice import UserPractice
 from services import journal_encryption
+
+# Anchor date for directly-seeded practice rows; the journal assertions never
+# depend on the calendar, only on the ids these rows hand back.
+_SEED_START_DATE = date(2025, 1, 1)
+_SEED_DURATION_MINUTES = 10.0
 
 
 def _message_payload(**overrides: object) -> dict[str, object]:
@@ -33,8 +42,10 @@ def _parse_utc(value: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
-async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
-    """Create a user and return auth headers."""
+async def _signup_with_id(
+    client: AsyncClient, username: str = "alice"
+) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user id)."""
     resp = await client.post(
         "/auth/signup",
         json={
@@ -43,8 +54,55 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
         },
     )
     assert resp.status_code == HTTPStatus.OK
-    token = resp.json()["token"]
-    return {"Authorization": f"Bearer {token}"}
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str]:
+    """Create a user and return auth headers."""
+    headers, _ = await _signup_with_id(client, username)
+    return headers
+
+
+async def _seed_user_practice(session: AsyncSession, user_id: int) -> int:
+    """Insert a Practice plus a UserPractice owned by ``user_id``; return its id."""
+    practice = Practice(
+        stage_number=1,
+        name="Sit",
+        description="A sit.",
+        instructions="Sit and breathe.",
+        default_duration_minutes=_SEED_DURATION_MINUTES,
+        mode="meditation_timer",
+        mode_config={"mode": "meditation_timer", "duration_minutes": 10},
+    )
+    session.add(practice)
+    await session.commit()
+    await session.refresh(practice)
+    user_practice = UserPractice(
+        user_id=user_id,
+        practice_id=practice.id,
+        stage_number=1,
+        start_date=_SEED_START_DATE,
+    )
+    session.add(user_practice)
+    await session.commit()
+    await session.refresh(user_practice)
+    assert user_practice.id is not None
+    return user_practice.id
+
+
+async def _seed_practice_session(session: AsyncSession, user_id: int, user_practice_id: int) -> int:
+    """Insert a PracticeSession owned by ``user_id``; return its id."""
+    practice_session = PracticeSession(
+        user_id=user_id,
+        user_practice_id=user_practice_id,
+        duration_minutes=_SEED_DURATION_MINUTES,
+    )
+    session.add(practice_session)
+    await session.commit()
+    await session.refresh(practice_session)
+    assert practice_session.id is not None
+    return practice_session.id
 
 
 # ── Unauthenticated access ──────────────────────────────────────────────
@@ -127,17 +185,26 @@ async def test_create_journal_entry_invalid_tag_returns_422(async_client: AsyncC
 
 
 @pytest.mark.asyncio
-async def test_create_journal_entry_with_practice_session(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
+async def test_create_journal_entry_with_practice_session(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Body FKs the caller owns are accepted and echoed back on the created entry."""
+    headers, user_id = await _signup_with_id(async_client)
+    user_practice_id = await _seed_user_practice(db_session, user_id)
+    practice_session_id = await _seed_practice_session(db_session, user_id, user_practice_id)
+
     resp = await async_client.post(
         "/journal/",
-        json=_message_payload(practice_session_id=42, user_practice_id=7),
+        json=_message_payload(
+            practice_session_id=practice_session_id,
+            user_practice_id=user_practice_id,
+        ),
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.CREATED
     data = resp.json()
-    assert data["practice_session_id"] == 42
-    assert data["user_practice_id"] == 7
+    assert data["practice_session_id"] == practice_session_id
+    assert data["user_practice_id"] == user_practice_id
 
 
 # ── List & Pagination ───────────────────────────────────────────────────
@@ -457,21 +524,37 @@ async def test_filter_by_invalid_tag_returns_422(async_client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
-async def test_filter_by_practice_session_id(async_client: AsyncClient) -> None:
-    headers = await _signup(async_client)
-    await async_client.post(
+async def test_filter_by_practice_session_id(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Only entries linked to the queried session come back.
+
+    The creating POST is asserted explicitly so a future rejection of the body
+    FK surfaces here instead of silently degrading the filter to ``total == 0``.
+    """
+    headers, user_id = await _signup_with_id(async_client)
+    user_practice_id = await _seed_user_practice(db_session, user_id)
+    practice_session_id = await _seed_practice_session(db_session, user_id, user_practice_id)
+
+    linked = await async_client.post(
         "/journal/",
-        json=_message_payload(message="Session reflection", practice_session_id=10),
+        json=_message_payload(
+            message="Session reflection",
+            practice_session_id=practice_session_id,
+        ),
         headers=headers,
     )
+    assert linked.status_code == HTTPStatus.CREATED
     await async_client.post(
         "/journal/", json=_message_payload(message="Unrelated"), headers=headers
     )
 
-    resp = await async_client.get("/journal/?practice_session_id=10", headers=headers)
+    resp = await async_client.get(
+        f"/journal/?practice_session_id={practice_session_id}", headers=headers
+    )
     data = resp.json()
     assert data["total"] == 1
-    assert data["items"][0]["practice_session_id"] == 10
+    assert data["items"][0]["practice_session_id"] == practice_session_id
 
 
 # ── User isolation ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`POST /journal/` accepted `user_practice_id` and `practice_session_id` from the
request body and splatted them straight onto the new row. Neither was ever
checked against the caller. The issue's live reproduction stands: Alice creates
a user-practice, Bob posts `{"message":"probe","user_practice_id":<alice's>}`,
and gets a **201** whose entry is bound to Alice's row.

This is the same class as #2064 — an object reference travelling in the *body*
escapes the ownership checks that cover path parameters — and it is fixed as
**fail-closed authorization, not validation cleanup**. Both columns are foreign
keys with `NO ACTION`, so a forged reference **pins the victim's row against
deletion**: the day an account-purge or GDPR-erasure path lands, the victim's
delete fails and the attacker chose which of their rows became undeletable.
`JournalEntryUpdate` exposes neither column, so a forged link was also
permanent.

### Reusing the helper rather than inventing a second pattern

The rule already existed for path-carried ids; it had no body-side entry point.
So `require_owned_user_practice` is split exactly the way PR #2120 already split
`require_owned_goal_group`: a plain `resolve_owned_user_practice(session, id,
user_id)` holds the rule, and the dependency becomes a one-line wrapper over it
— signature byte-identical, so its four existing call sites
(`practice_recipes.py:346`, `user_practices.py:604`/`:657`,
`practice_sessions.py:348`) are untouched. `resolve_owned_practice_session`
joins it, deliberately with **no** `require_` wrapper: no route takes that id in
a path, so a wrapper would be dead code — the docstring says so rather than
leaving the asymmetry unexplained.

`_authorize_practice_links` is the **first statement** of the handler, before
`model_dump()` and well before `session.add`, so a denial never reaches the
session. Each non-null id is checked **unconditionally** — no "unchanged, so
skip" branch, per #2120's reasoning that the shortcut is precisely what lets a
forged link through. 404 missing / 403 foreign, and every 403 emits
`resource_access_denied` carrying the *attacker's* id, never the victim's.

### Where the missing check was

`create_journal_entry` (`backend/src/routers/journal.py`) did
`data = payload.model_dump()` then `JournalEntry(sender="user",
user_id=current_user, **data)` — the two body ids rode the splat onto the row
with no resolution of any kind.

### Sweep re-confirmed at HEAD

Every other body-carried FK named in the #2120 snapshot was re-verified against
current code, not trusted: `goal_completions` (→ `resolve_owned_goal_and_habit`),
`practice_sessions` (inline 404→403), `user_practices` (catalog-or-own-draft),
`promotions` (owner-scoped filter), `metta_return` (owner-scoped arc),
`services/energy`; habits routes carry no body FK. **No new unauthorized body FK
was found.** PATCH is structurally closed, not merely currently-correct:
`JournalEntryUpdate` declares neither field and `_apply_entry_update` writes
only enumerated attributes — there is no `model_dump()` splat on that path.

Two report-only findings, neither fixed here (out of scope, worth filing):
`_resolve_user_practice_for_session` (`practice_sessions.py:53-76`) duplicates
this rule but omits `log_ownership_denied`, so `POST /practice-sessions/`
cross-tenant probes still go unaudited — now a near-mechanical consolidation
onto the new plain callable; and `CheckInRequest.goal_id` (`schemas/checkin.py`)
is a dead DTO no route consumes.

### DAST registry

No probing cell added — per #2124 the matrix structurally cannot reach body
references. Verifying the gap note turned up something sharper than assumed:
`POST /journal/` has **no path parameters at all**, so `classify_routes` in
`policy.py` drops it from the coverage count *before* `is_object_scoped` is even
consulted. It was never probed — clean or otherwise. The README's known-gap
section now names it as a second, hand-found instance, which is what makes the
gap systemic rather than a one-off in `goals`. #2124 remains open; nothing here
closes it.

## Test plan

The regression tests are built so a **genuine bypass cannot pass silently**, and
so they cannot pass for an unrelated reason:

- The victim's `user_practice` and `practice_session` are created through the
  real endpoints under the **victim's own headers** — they genuinely exist and
  are genuinely hers, not hand-inserted with a guessed `user_id`.
- A **positive control** asserts the identical payload with the attacker's *own*
  id still returns 201, so the 403 cannot be a false pass from a malformed body,
  a 422, or a row that never existed.
- The **no-persistence assertion queries the database** (`expire_all()` then a
  fresh `select`), not the response.
- A parametrized case pins **404 before 403** with the exact detail strings.

Verified by mutation, each observed red then reverted:

| Mutation | Result |
|---|---|
| Remove the `_authorize_practice_links` call | All 4 tests fail — `assert 201 == 403/404`, reproducing the live defect. Also proves the DB does not backstop this: id `999999` was accepted, so the in-app check is the **only** control. |
| Drop `log_ownership_denied` | Audit assertion fails — the caplog checks are load-bearing, not decorative. |
| Move the check to **after** `session.add` | Every status code stays correct, yet the DB assertions still catch it: `cross-user journal entry persisted against the victim's user-practice`. |

Two tests in `test_journal_api.py` **encoded the bug** — they asserted 201 while
passing ids 42, 7 and 10 that referenced no row at all. They now seed real
owner-held rows, and `test_filter_by_practice_session_id` asserts its creating
POST returned 201 so it can never again degrade silently to `total == 0`.

**Gate 2:** `./scripts/backend/check-all.sh` → **exit 0**, run twice (7/7 stages;
4192 passed / 2 skipped / 1 xfailed, coverage 97%, ruff `select=ALL`, mypy strict
over 423 files including tests, xenon A/A/A, radon MI A, interrogate 96.9%,
bandit + pip-audit clean). The #2108 `database is locked` flake did not appear in
either run. Backend-only diff; no frontend files, no `requirements*.txt`, no
schema change and therefore no Alembic migration.

Closes #2065
Refs #2064, #2120, #2124
