### PR TITLE
security(backend): bind a configured Creek Vault to the one user it belongs to

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -164,6 +164,22 @@ CREEK_VAULT_API_KEY=  # bearer credential; used only to build the Authorization 
 # with a URL configured and the selector wrong, the vault is silently unused, and
 # that warning is the only place it says so.
 CREEK_VAULT_PROTOCOL=http
+# The numeric id of the single adepthood user the configured vault belongs to.
+# Read plainly: Creek Vault's corpus is NOT partitioned per user -- everything
+# adepthood replicates into it can ground a reflection, or be counted into a
+# wheel, for whoever queries it next. There is no tenant field anywhere in the
+# ratified /v1 contract to ask Creek to keep users apart, so adepthood has to,
+# and the only way it can is by only ever putting one user's material in. That
+# is the whole reason exactly one user may be bound here -- see ADR 0004,
+# Decision 7 (docs/adr/0004-creek-vault-http-application-boundary.md) for the
+# full reasoning and the tracked path to a real per-user vault (#2134).
+# Leaving this unset with a vault otherwise configured does not fail the
+# deploy, but it is inert for EVERY user: no journal entry replicates, no
+# reflection consults the vault, no wheel reads from it -- and every request
+# logs a WARNING naming this variable so the gap is not silent forever. A
+# value that is not a positive integer (non-numeric, 0, or negative) is
+# treated exactly the same as unset and fails closed the same way.
+CREEK_VAULT_OWNER_USER_ID=  # e.g. 42 -- the one adepthood user id the vault belongs to
 
 # Railway auto-injected (do not set manually)
 # RAILWAY_ENVIRONMENT=production

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -179,6 +179,13 @@ CREEK_VAULT_PROTOCOL=http
 # logs a WARNING naming this variable so the gap is not silent forever. A
 # value that is not a positive integer (non-numeric, 0, or negative) is
 # treated exactly the same as unset and fails closed the same way.
+# One thing this CANNOT fix: a corpus that is already mixed. Binding an owner
+# governs what goes in from now on; it does not partition what a previous
+# configuration already replicated. If this vault ran with more than one active
+# user before you set this, its corpus still holds their writing and the bound
+# owner's reflections can still be grounded in it. Adepthood cannot clean that
+# up -- /v1 has no delete capability at all -- so re-scaffold or purge the vault
+# on Creek's side before trusting the binding on a vault that predates it.
 CREEK_VAULT_OWNER_USER_ID=  # e.g. 42 -- the one adepthood user id the vault belongs to
 
 # Railway auto-injected (do not set manually)

--- a/backend/src/dependencies/creek_vault.py
+++ b/backend/src/dependencies/creek_vault.py
@@ -1,0 +1,148 @@
+"""The gate that binds a configured Creek Vault to the one user it belongs to.
+
+Adepthood reaches a vault with a single deployment-wide identity. There is no
+per-user credential to present and no tenant field anywhere in the ratified
+``/v1`` contract -- ingest and reflect both refuse unknown properties, and the
+wheel read is parameterless -- so everything adepthood replicates lands in one
+corpus, every reflection is grounded in that whole corpus, and the wheel is its
+whole-corpus aggregate. Per-user scoping therefore cannot be built from this
+side at all; it can only be *declined*, which is what this module does.
+
+The binding is one environment variable naming one adepthood user
+(:data:`OWNER_ENV_VAR`). That user reaches the configured vault; every other
+user is served the local fallback, which is exactly the path a deployment with
+no vault has always run on -- their entries never enter the corpus, so no
+stranger's reflection can quote them, and nothing they are answered with is
+drawn from it. Nothing about their experience degrades beyond what an
+unconfigured deployment already offers: the local pipeline is the floor the
+whole seam is built on.
+
+Fail closed, and never raise. An unset or unreadable binding leaves the vault
+nobody's, since the alternative -- picking a user -- would pick the wrong one.
+And this runs as a per-request dependency, where a raise means the handler body
+never executes: a mis-typed variable would turn every journal save into a 500
+and cost the writer their entry. That is the loss the whole seam promises can
+never happen for a vault's sake, so this degrades for the same reason and in the
+same way :func:`~services.creek_vault_client.build_creek_vault_client` degrades
+for a stale protocol selector.
+
+Kept apart from :mod:`dependencies.ownership` deliberately. That module audits
+denied cross-tenant *probes*: someone reached for a row that is not theirs and
+was refused with a 403 or an enumeration-safe 404. Nothing of the sort happens
+here. A non-owner asked for nothing they should not have, is refused nothing,
+and is answered in full -- what they lose is an optional capability they were
+never told about. Borrowing that vocabulary would file a routine capability
+degrade as an access-control incident and put a blameless user in an audit log.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated
+
+from fastapi import Depends
+
+from domain.creek_vault import CreekVaultClient, resolve_vault_owner
+from routers.auth import get_current_user
+from services.creek_vault_client import LocalFallbackCreekVaultClient, build_creek_vault_client
+from services.creek_vault_telemetry import VaultTelemetryOutcome
+
+logger = logging.getLogger(__name__)
+
+# The variable naming the single adepthood user a configured vault belongs to,
+# and the one naming the vault itself. Read at request time rather than captured
+# at import, matching ``build_creek_vault_client``: a redeployed configuration
+# takes effect on the next request instead of the next restart, and a test can
+# set one without reloading a module.
+OWNER_ENV_VAR = "CREEK_VAULT_OWNER_USER_ID"
+_VAULT_URL_ENV_VAR = "CREEK_VAULT_URL"
+
+# The two ways a configured vault ends up belonging to nobody, and the two static
+# messages that say so. Both name the variable that fixes it, because a record
+# describing only the symptom leaves an operator to rediscover which of a dozen
+# ``CREEK_VAULT_*`` settings is missing. They are separate messages because they
+# are separate news: nobody has set the binding yet, versus somebody set it to
+# something that is not a user id -- the first is a step not taken, the second is
+# a value to go and look at.
+_UNSET_OWNER_EVENT = (
+    "creek vault is configured but bound to no user; every user gets the local "
+    "fallback -- set CREEK_VAULT_OWNER_USER_ID to the id of the user it belongs to"
+)
+_UNREADABLE_OWNER_EVENT = (
+    "creek vault owner binding is not a user id; every user gets the local "
+    "fallback -- set CREEK_VAULT_OWNER_USER_ID to the id of the user it belongs to"
+)
+
+# What the variable was found to be, in a closed vocabulary of this module's own
+# words. The raw value is deliberately absent: it is whatever an operator typed,
+# and a variable filled in by hand next to ``CREEK_VAULT_API_KEY`` is one paste
+# away from being a credential. "Unreadable" is the whole of what a reader needs,
+# and it is the most a record can safely say.
+_BINDING_UNSET = "unset"
+_BINDING_UNREADABLE = "unreadable"
+
+
+def _log_unowned_vault(raw_owner: str | None) -> None:
+    """Warn that a configured vault is inert for everybody, without echoing the value.
+
+    Only ever called once the vault is known to be configured, which is the whole
+    condition that makes this worth waking someone for: a deployment carrying a
+    vault URL, a credential, and no owner is one variable away from working, and
+    silence would leave an operator reading a vault-shaped configuration whose
+    replication simply never happens.
+    """
+    unset = raw_owner is None or not raw_owner.strip()
+    event = _UNSET_OWNER_EVENT if unset else _UNREADABLE_OWNER_EVENT
+    binding = _BINDING_UNSET if unset else _BINDING_UNREADABLE
+    logger.warning(event, extra={"env_var": OWNER_ENV_VAR, "binding": binding})
+
+
+def get_creek_vault_client(
+    current_user: Annotated[int, Depends(get_current_user)],
+) -> CreekVaultClient:
+    """Return the vault client this caller may hold: the real one only for its owner.
+
+    The bound owner gets whatever
+    :func:`~services.creek_vault_client.build_creek_vault_client` makes of the
+    deployment's configuration. Everyone else -- and everyone, when the binding
+    is missing or unreadable -- gets :class:`LocalFallbackCreekVaultClient`, so
+    their writing never reaches the shared corpus and no answer of theirs is ever
+    drawn from it.
+
+    The two silent paths are counted apart, by whether a vault exists at all. A
+    deployment with none keeps counting
+    :attr:`~VaultTelemetryOutcome.FALLBACK_UNCONFIGURED`, exactly as it did
+    before this gate existed; a user held back from a vault that *is* there
+    counts :attr:`~VaultTelemetryOutcome.FALLBACK_NOT_OWNER`. Both are DEBUG,
+    because neither is a fault -- one operator chose no vault, and the other is
+    watching the binding do its job. Only the misconfiguration in between, a
+    vault configured and inert for everyone, is worth a WARNING, and it is the
+    only thing logged here.
+    """
+    raw_owner = os.getenv(OWNER_ENV_VAR)
+    owner = resolve_vault_owner(raw_owner)
+    # ``owner`` is ``None`` when the binding is missing or unreadable, and no
+    # user id equals ``None``, so an unbound vault falls through to the fallback
+    # for everybody without a branch of its own.
+    if owner == current_user:
+        return build_creek_vault_client()
+    vault_configured = bool(os.getenv(_VAULT_URL_ENV_VAR, ""))
+    if owner is None and vault_configured:
+        _log_unowned_vault(raw_owner)
+    return LocalFallbackCreekVaultClient(_degrade_outcome(vault_configured=vault_configured))
+
+
+def _degrade_outcome(*, vault_configured: bool) -> VaultTelemetryOutcome:
+    """Name a local-fallback degrade after what is actually true of the deployment.
+
+    With a vault present, the user is being kept out of one that exists -- whether
+    because it belongs to someone else or because it belongs to nobody yet -- and
+    that is what :attr:`~VaultTelemetryOutcome.FALLBACK_NOT_OWNER` says. With no
+    vault at all there is no owner to not be, so the honest label is the one this
+    path has always carried, and every counter predating this gate keeps its
+    meaning.
+    """
+    if vault_configured:
+        return VaultTelemetryOutcome.FALLBACK_NOT_OWNER
+    return VaultTelemetryOutcome.FALLBACK_UNCONFIGURED

--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -31,6 +31,7 @@ published contract, which that document points at, owns the wire shapes.
 from __future__ import annotations
 
 import enum
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -40,10 +41,6 @@ from typing import Protocol
 # what a vault advertises. A major-version mismatch degrades to unavailable
 # rather than risking a call under an incompatible surface.
 CONTRACT_VERSION = "0.2.0"
-
-# The identifier adepthood presents to Creek Vault so the vault's router can
-# scope capabilities and attestation to this consumer.
-CONSUMER_ID = "CREEK_MCP_CONSUMER"
 
 
 class CreekCapability(enum.StrEnum):
@@ -104,6 +101,69 @@ def tier_ceiling_for(classification: str) -> VaultTierCeiling:
         return TIER_CEILING_BY_CLASSIFICATION[classification]
     except KeyError:
         raise ValueError(f"unknown journal classification: {classification!r}") from None
+
+
+# The smallest value that can name a person. User ids are assigned from a
+# positive sequence, so anything at or below this floor names nobody -- which is
+# what lets :func:`resolve_vault_owner` refuse ``0`` without special-casing it.
+_LOWEST_USER_ID = 1
+
+# The only spelling of a user id this binding accepts: ASCII digits, nothing
+# else. ``int`` is considerably more generous -- it reads ``1_0`` as ten, ``+7``
+# as seven, and every Unicode decimal digit as its numeric value, so an
+# ARABIC-INDIC or FULLWIDTH seven is just as much a seven to it. None of that is
+# wrong arithmetic; it is the wrong *contract* for a value an operator reads back
+# to confirm. A binding whose rendered text and parsed meaning can disagree is
+# one nobody can audit by looking at it, and this is the setting that decides
+# whose journal a shared corpus accumulates. Narrowing here only ever rejects
+# spellings no operator meant to type. (The confusables themselves are named
+# rather than shown: the lint that forbids them in source is the same instinct
+# this pattern encodes.)
+_ASCII_USER_ID = re.compile(r"\A[0-9]+\Z")
+
+
+def resolve_vault_owner(raw: str | None) -> int | None:
+    """Read the single adepthood user a configured vault belongs to, or nobody.
+
+    Adepthood reaches a vault with one deployment-wide identity, so everything it
+    replicates lands in one corpus and every answer the vault grounds is drawn
+    from that same corpus. The contract carries no tenant of any kind, so the
+    only way that corpus can stay one person's is for the deployment to name the
+    person: this parses that binding, and ``None`` means the vault is nobody's
+    and therefore no one's to write into or read from.
+
+    It fails closed for the same reason :func:`tier_ceiling_for` does, with a
+    higher price for guessing. An unparseable ceiling would widen one entry's
+    tier; an unparseable owner would decide *whose* journal a shared corpus
+    accumulates, so anything that is not plainly a user id resolves to nobody and
+    the whole deployment degrades to its local pipeline.
+
+    ``0`` is refused explicitly rather than by accident. It parses, so a check
+    that only rejected unreadable text would admit it -- and ``0`` is the
+    commonest way an unset numeric variable is spelled, by a default in a
+    template, by an integer cast of an empty string, by an orchestrator filling a
+    blank. Ids are assigned from a positive sequence (:data:`_LOWEST_USER_ID`),
+    so no user is ever ``0`` and admitting it could only ever bind a vault to a
+    person who does not exist -- or, worse, to whoever a future sequence hands
+    that id to. Negatives are refused on the same reasoning.
+
+    The digits themselves are matched before they are converted
+    (:data:`_ASCII_USER_ID`), rather than left to ``int``, whose generosity is
+    the wrong contract here: it would silently read ``1_0`` as ten and any
+    Unicode decimal digit as its value, so a binding could parse as a user
+    nobody would guess from reading it. Surrounding whitespace is still
+    forgiven, since it survives a copy-paste and changes nothing about which id
+    is named.
+    """
+    if raw is None:
+        return None
+    candidate = raw.strip()
+    if not _ASCII_USER_ID.match(candidate):
+        return None
+    owner = int(candidate)
+    if owner < _LOWEST_USER_ID:
+        return None
+    return owner
 
 
 class VaultErrorCode(enum.StrEnum):

--- a/backend/src/routers/invitations.py
+++ b/backend/src/routers/invitations.py
@@ -25,13 +25,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from dependencies.creek_vault import get_creek_vault_client
 from dependencies.timezone import current_user_timezone
 from domain.creek_vault import CreekVaultClient
 from errors import not_found
 from models.invitation_signal import InvitationSignal
 from routers.auth import get_current_user
 from schemas.invitations import InvitationResponse
-from services.creek_vault_write import get_creek_vault_client
 from services.invitations import generate_invitation_signals
 
 router = APIRouter(prefix="/invitations", tags=["invitations"])

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
 from database import get_session
+from dependencies.creek_vault import get_creek_vault_client
 from dependencies.ownership import (
     require_owned_journal_entry,
     resolve_owned_practice_session,
@@ -81,7 +82,6 @@ from services.creek_vault_reflect import select_reflection_llm
 from services.creek_vault_write import (
     VaultWriteOutcome,
     VaultWriteStatus,
-    get_creek_vault_client,
     store_and_classify,
 )
 from services.llm_usage import record_llm_usage

--- a/backend/src/routers/stages.py
+++ b/backend/src/routers/stages.py
@@ -13,6 +13,7 @@ from sqlmodel import col, select
 
 from curriculum import CurriculumDataError, stage_curriculum
 from database import get_session
+from dependencies.creek_vault import get_creek_vault_client
 from dependencies.timezone import current_user_timezone
 from domain.constants import TOTAL_STAGES
 from domain.creek_vault import CreekVaultClient
@@ -47,7 +48,6 @@ from schemas.stage import (
 )
 from schemas.wheel import WheelAspect, WheelBalanceResponse
 from services.creek_vault_wheel import select_wheel_balance
-from services.creek_vault_write import get_creek_vault_client
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -43,7 +43,10 @@ guessing a transport would send vault traffic somewhere the operator did not
 choose -- but the retired ``mcp`` selector degrades to the local fallback with a
 warning rather than raising, because this factory runs per request and a raise
 there would cost the writer their entry, while an unrecognized selector still
-raises, having no knowable intent to honour.
+raises, having no knowable intent to honour. It answers that question and no
+other: *who* may hold a configured client is settled one layer up, in
+:mod:`dependencies.creek_vault`, because a vault reached under a single
+deployment-wide identity is one shared corpus rather than any user's.
 
 Transport security: the configured transport refuses a plaintext ``http://`` URL
 to any non-loopback host, because every request carries the
@@ -1658,19 +1661,37 @@ class LocalFallbackCreekVaultClient:
     them. Unused parameters are underscore-prefixed to match the protocol
     positionally without pretending to consume them.
 
-    Every capability records :attr:`~VaultTelemetryOutcome.FALLBACK_UNCONFIGURED`
-    under its own name before answering. It is not a fault -- it is a deployment
-    exercising its choice not to have a vault, which is why it is the one outcome
-    logged at DEBUG -- but it is still worth counting per capability, because a
-    single unlabelled tally would say a deployment has no vault without saying
-    what it kept asking one for. :meth:`is_available` and :meth:`supports` record
-    nothing: they are cache reads rather than attempts, and counting them would
-    inflate the tallies with questions no vault was ever asked.
+    Every capability records an outcome under its own name before answering,
+    defaulting to :attr:`~VaultTelemetryOutcome.FALLBACK_UNCONFIGURED`. That is
+    not a fault -- it is a deployment exercising its choice not to have a vault,
+    which is why it is one of the outcomes logged at DEBUG -- but it is still
+    worth counting per capability, because a single unlabelled tally would say a
+    deployment has no vault without saying what it kept asking one for.
+    :meth:`is_available` and :meth:`supports` record nothing: they are cache
+    reads rather than attempts, and counting them would inflate the tallies with
+    questions no vault was ever asked.
+
+    The outcome is a constructor argument because "no vault here" is true of more
+    than one situation, and they are not the same news. A deployment with a vault
+    bound to one user serves this same client to everybody else
+    (:mod:`dependencies.creek_vault` passes
+    :attr:`~VaultTelemetryOutcome.FALLBACK_NOT_OWNER` for them), and counting
+    those under the unconfigured name would report a choice nobody made. The
+    behaviour is identical either way -- there is nothing behind this client in
+    any case -- so what varies is only the name the degrade is counted under.
+    The default keeps every existing construction, and every counter read off
+    one, meaning exactly what it did before.
     """
+
+    def __init__(
+        self, outcome: VaultTelemetryOutcome = VaultTelemetryOutcome.FALLBACK_UNCONFIGURED
+    ) -> None:
+        """Bind the outcome every capability of this client will be counted under."""
+        self._outcome = outcome
 
     async def handshake(self) -> HandshakeResult:
         """Report no usable vault."""
-        record_vault_outcome(VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.HANDSHAKE)
+        record_vault_outcome(self._outcome, CreekCapability.HANDSHAKE)
         return HandshakeResult.unavailable()
 
     def is_available(self) -> bool:
@@ -1683,27 +1704,38 @@ class LocalFallbackCreekVaultClient:
 
     async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
         """No-op ingest: report not stored without raising (Postgres is authoritative)."""
-        record_vault_outcome(VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.JOURNAL)
+        record_vault_outcome(self._outcome, CreekCapability.JOURNAL)
         return VaultIngestResult(stored=False, vault_ref=None)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Raise: classification has no local vault to serve it."""
-        record_vault_outcome(VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.CLASSIFY)
+        record_vault_outcome(self._outcome, CreekCapability.CLASSIFY)
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.CLASSIFY))
 
     async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultReflection:
         """Raise: reflection has no local vault to serve it."""
-        record_vault_outcome(VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.REFLECT)
+        record_vault_outcome(self._outcome, CreekCapability.REFLECT)
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.REFLECT))
 
     async def wheel(self) -> VaultWheelBalance:
         """Raise: a vault wheel read has no local vault to serve it."""
-        record_vault_outcome(VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.WHEEL)
+        record_vault_outcome(self._outcome, CreekCapability.WHEEL)
         raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.WHEEL))
 
 
 def build_creek_vault_client() -> CreekVaultClient:
     """Return the vault client appropriate for the current configuration.
+
+    **Tenancy-unaware by construction, and reached only through
+    :func:`dependencies.creek_vault.get_creek_vault_client`.** This factory
+    answers one question -- what transport, if any, this deployment's
+    configuration describes -- and knows nothing about who is asking. It cannot:
+    adepthood presents a single deployment-wide identity to a vault, and the
+    contract carries no tenant field, so a client built here is a handle on one
+    shared corpus rather than on any user's. Which user may hold that handle is
+    the dependency's decision, and wiring this function into a request path
+    directly would hand the same corpus to everybody -- so if a route needs a
+    vault client, it depends on the dependency, never on this.
 
     When ``CREEK_VAULT_URL`` is unset or empty, no vault is configured and a
     :class:`LocalFallbackCreekVaultClient` is returned so the app runs fully on

--- a/backend/src/services/creek_vault_telemetry.py
+++ b/backend/src/services/creek_vault_telemetry.py
@@ -79,7 +79,7 @@ VAULT_OUTCOME_EVENT = "creek vault outcome"
 class VaultTelemetryOutcome(enum.StrEnum):
     """How one attempt at one vault capability ended.
 
-    Eleven members rather than "worked" and "did not", because the failures have
+    Twelve members rather than "worked" and "did not", because the failures have
     different owners and different remedies: ``UNAVAILABLE`` is infrastructure to
     restore, ``TIMEOUT`` is a vault that is up and too slow, ``AUTH_FAILED`` is a
     credential to rotate, ``INCOMPATIBLE_VERSION`` is two pins to align,
@@ -92,6 +92,18 @@ class VaultTelemetryOutcome(enum.StrEnum):
     person in acute distress, which is a successful outcome that happens to
     arrive as an exception.
 
+    ``FALLBACK_NOT_OWNER`` is the twelfth, and it sits next to
+    ``FALLBACK_UNCONFIGURED`` because it is the other half of the same sentence
+    and emphatically not the same fact. This deployment *has* a vault; it is
+    being asked for by a user it does not belong to. Adepthood reaches a vault
+    with one deployment-wide identity, so one vault is one corpus, and a corpus
+    stays one person's only if exactly one person is served from it -- everyone
+    else is answered locally, and lands here. Folding the two together would
+    report "the operator chose no vault" for a deployment that chose one, hiding
+    both the operational question (is the binding pointed at the right person?)
+    and the ordinary steady state (most users of a bound vault are not its
+    owner), which have nothing to do with each other.
+
     Values are the wire strings a dashboard counts by, so they are this module's
     contract and must not be reworded casually; the member order is pinned by a
     test for the same reason.
@@ -99,6 +111,7 @@ class VaultTelemetryOutcome(enum.StrEnum):
 
     SUCCESS = "vault_success"
     FALLBACK_UNCONFIGURED = "vault_fallback_unconfigured"
+    FALLBACK_NOT_OWNER = "vault_fallback_not_owner"
     UNAVAILABLE = "vault_unavailable"
     TIMEOUT = "vault_timeout"
     AUTH_FAILED = "vault_auth_failed"
@@ -160,6 +173,14 @@ _OUTCOME_BY_ERROR_TYPE: tuple[tuple[type[BaseException], VaultTelemetryOutcome],
 # news worth one INFO line. Everything else is a fault somebody may need to act
 # on.
 #
+# ``FALLBACK_NOT_OWNER`` joins the unconfigured path at DEBUG on that same
+# reasoning: a user who is not the bound owner being served locally is the
+# design working, once per request of theirs forever, so warning on it would bury
+# the real faults under the loudest steady state the seam has. The one genuine
+# misconfiguration in this neighbourhood -- a vault configured with no readable
+# owner, and therefore inert for everybody -- is not this event: it is warned
+# about once, where it is discovered, by :mod:`dependencies.creek_vault`.
+#
 # ``ESCALATED`` is the one entry here that is tiered for privacy rather than for
 # noise, and it is a deliberate product decision rather than an oversight. Its
 # fields are as content-free as every other outcome's -- but *that this line was
@@ -178,6 +199,7 @@ _OUTCOME_BY_ERROR_TYPE: tuple[tuple[type[BaseException], VaultTelemetryOutcome],
 # with nobody's identity anywhere in them.
 _SEVERITY_BY_OUTCOME: Mapping[VaultTelemetryOutcome, int] = {
     VaultTelemetryOutcome.FALLBACK_UNCONFIGURED: logging.DEBUG,
+    VaultTelemetryOutcome.FALLBACK_NOT_OWNER: logging.DEBUG,
     VaultTelemetryOutcome.SUCCESS: logging.INFO,
     VaultTelemetryOutcome.ESCALATED: logging.DEBUG,
 }

--- a/backend/src/services/creek_vault_write.py
+++ b/backend/src/services/creek_vault_write.py
@@ -1,11 +1,18 @@
 """Creek Vault write path: store a journal entry durably, degrading safely.
 
 This is the thin orchestration layer the journal router calls after an entry is
-committed. It sits atop the pure :mod:`domain.creek_vault` seam and the concrete
-adapters in :mod:`services.creek_vault_client`, and its whole job is to turn the
-seam's fine-grained handshake/ingest surface into one best-effort call that
-*never raises a vault error* -- so the user's entry is saved regardless of
-whether a vault is present, reachable, or capable.
+committed. It sits atop the pure :mod:`domain.creek_vault` seam, and its whole
+job is to turn the seam's fine-grained handshake/ingest surface into one
+best-effort call that *never raises a vault error* -- so the user's entry is
+saved regardless of whether a vault is present, reachable, or capable.
+
+Every function here takes the client as a parameter and constructs none, which
+is what keeps this module out of the tenancy decision entirely. Choosing whether
+a caller may hold a real vault client at all belongs to
+:func:`dependencies.creek_vault.get_creek_vault_client`, since a vault reached
+under adepthood's one deployment-wide identity is a single shared corpus rather
+than any one user's; a provider living here would be reachable from a router
+without passing that gate.
 
 The governing rule is **graceful degradation**: a missing, unreachable, or
 capability-poor vault collapses to a well-defined :class:`VaultWriteStatus`
@@ -55,7 +62,6 @@ from domain.creek_vault import (
     tier_ceiling_for,
 )
 from models.journal_entry import JournalClassification
-from services.creek_vault_client import build_creek_vault_client
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -276,13 +282,3 @@ async def store_and_classify(
     if vault_ref is None:
         return _DEGRADED_OUTCOME
     return VaultWriteOutcome(status=VaultWriteStatus.INGESTED, vault_ref=vault_ref, tags=())
-
-
-def get_creek_vault_client() -> CreekVaultClient:
-    """Return a per-request Creek Vault client for FastAPI dependency injection.
-
-    A thin wrapper over :func:`~services.creek_vault_client.build_creek_vault_client`
-    with no module-level cache, so a test can override this provider and a
-    reconfigured deployment picks up the change on the next request.
-    """
-    return build_creek_vault_client()

--- a/backend/tests/routers/test_invitations.py
+++ b/backend/tests/routers/test_invitations.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from dependencies.creek_vault import get_creek_vault_client
 from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
     CONTRACT_VERSION,
@@ -29,7 +30,6 @@ from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.invitation_signal import InvitationSignal
 from models.user import User
-from services.creek_vault_write import get_creek_vault_client
 
 _LIST_URL = "/invitations"
 _SUSTAINED_STREAK = 21  # mirrors SUSTAINED_HABIT_STREAK_DAYS in the domain

--- a/backend/tests/test_contract_version_docs.py
+++ b/backend/tests/test_contract_version_docs.py
@@ -1,6 +1,7 @@
 """Drift guards between the Creek Vault contract in code and the docs that pin it.
 
-Two kinds of restatement rot silently without a guard, and both are covered here.
+Three kinds of restatement rot silently without a guard, and all three are
+covered here.
 
 *Version restatements.* ``CONTRACT_VERSION`` in ``domain.creek_vault`` is the
 single source of truth for the version adepthood advertises at handshake.  The
@@ -13,10 +14,18 @@ pointer to the ADR.
 *Ownership pointers.* The intimate-transit sub-decisions live in the boundary
 ADR's Decision 6; the contract doc explicitly disclaims owning them.  A docstring
 that cites the contract doc as the source of those decisions therefore points at
-a document that denies holding the rule.  The remaining meta-tests pin that
+a document that denies holding the rule.  The next meta-tests pin that
 ownership from both ends: the docs must keep saying where the rule lives, and no
 ``backend/src`` module docstring may cite the contract doc as a decision's owner
 or discuss intimate transit without naming the ADR that owns it.
+
+*Tenancy restatements.* The vault's single-tenant binding is the same shape of
+rule one document further on: Decision 7 of the same ADR owns it, the contract
+doc disclaims it exactly as it disclaims intimate transit, and the operator meets
+it as one environment variable.  That variable is the whole rule as far as a
+deployment is concerned, so an ``.env.example`` that does not mention it is a
+deployment configured to hand a vault to nobody without saying why -- which makes
+documenting it a guard rather than a courtesy.
 """
 
 from __future__ import annotations
@@ -31,6 +40,7 @@ from domain.creek_vault import CONTRACT_VERSION
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ADR_DOC = _REPO_ROOT / "docs" / "adr" / "0004-creek-vault-http-application-boundary.md"
 _CONTRACT_DOC = _REPO_ROOT / "docs" / "creek-vault-mcp-contract.md"
+_ENV_EXAMPLE = _REPO_ROOT / "backend" / ".env.example"
 _BACKEND_SRC = _REPO_ROOT / "backend" / "src"
 
 _STRICT_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
@@ -78,6 +88,24 @@ _CONTRACT_DOC_AS_DECISION_OWNER = re.compile(
 # A module docstring mentioning both of these is discussing the intimate-transit
 # rule and must therefore name the ADR that records it.
 _INTIMATE_TRANSIT_MARKERS = ("intimate", "transit")
+
+# The sentence the contract doc uses to hand the vault-tenancy rule to the ADR,
+# mirroring the intimate-transit disclaimer above and pinned for the same reason:
+# a reworded hand-off leaves the docstrings that cite the ADR resting on a
+# document that no longer says where the rule lives.
+_CONTRACT_DOC_TENANCY_DISCLAIMER = "Decision 7, not in this document"
+
+# The ADR section that owns the single-tenant binding, and its four sub-decisions.
+_TENANCY_DECISION_HEADING = "## Decision 7"
+_TENANCY_SUB_DECISIONS = (
+    "**(a) Identity scope",
+    "**(b) Owner binding",
+    "**(c) Fail-closed default",
+    "**(d) Per-user end-state",
+)
+
+# The one environment variable the tenancy rule reaches an operator through.
+_VAULT_OWNER_ENV_VAR = "CREEK_VAULT_OWNER_USER_ID"
 
 
 def _module_docstrings() -> Iterator[tuple[Path, str]]:
@@ -155,6 +183,37 @@ def test_boundary_adr_owns_the_intimate_transit_sub_decisions() -> None:
     )
     missing = [marker for marker in _INTIMATE_SUB_DECISIONS if marker not in text]
     assert not missing, f"ADR Decision 6 is missing sub-decisions: {missing}."
+
+
+def test_contract_doc_disclaims_the_vault_tenancy_rule() -> None:
+    """The contract doc still hands the single-tenant binding to the ADR by name."""
+    assert _CONTRACT_DOC_TENANCY_DISCLAIMER in _CONTRACT_DOC.read_text(encoding="utf-8"), (
+        f"Contract doc must keep saying the vault-tenancy rule lives in the ADR "
+        f"({_CONTRACT_DOC_TENANCY_DISCLAIMER!r}); source docstrings cite the ADR on that basis."
+    )
+
+
+def test_boundary_adr_owns_the_vault_tenancy_sub_decisions() -> None:
+    """ADR 0004's Decision 7 still carries all four single-tenant sub-decisions."""
+    text = _ADR_DOC.read_text(encoding="utf-8")
+    assert _TENANCY_DECISION_HEADING in text, (
+        f"ADR must keep the {_TENANCY_DECISION_HEADING!r} heading that docstrings cite."
+    )
+    missing = [marker for marker in _TENANCY_SUB_DECISIONS if marker not in text]
+    assert not missing, f"ADR Decision 7 is missing sub-decisions: {missing}."
+
+
+def test_env_example_documents_the_vault_owner_variable() -> None:
+    """The env template names the variable a vault is bound to one user by.
+
+    Undocumented, the fail-closed default reads as a broken vault: replication
+    silently stops for everyone and the only clue is one WARNING an operator has
+    no reason to expect.
+    """
+    assert _VAULT_OWNER_ENV_VAR in _ENV_EXAMPLE.read_text(encoding="utf-8"), (
+        f"{_ENV_EXAMPLE} must document {_VAULT_OWNER_ENV_VAR}: without it, a configured "
+        f"vault belongs to nobody and nothing in the template says why."
+    )
 
 
 def test_no_backend_source_cites_the_contract_doc_as_a_decision_owner() -> None:

--- a/backend/tests/test_creek_vault_domain.py
+++ b/backend/tests/test_creek_vault_domain.py
@@ -10,7 +10,6 @@ import pytest
 
 from domain import creek_vault
 from domain.creek_vault import (
-    CONSUMER_ID,
     CONTRACT_VERSION,
     TIER_CEILING_BY_CLASSIFICATION,
     CreekCapability,
@@ -361,8 +360,3 @@ def test_contract_version_constant() -> None:
     It tracks Creek's published contract constant, and the docs restate it.
     """
     assert CONTRACT_VERSION == "0.2.0"
-
-
-def test_consumer_id_constant() -> None:
-    """CONSUMER_ID matches the identifier adepthood presents at handshake."""
-    assert CONSUMER_ID == "CREEK_MCP_CONSUMER"

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -28,6 +28,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from conftest import test_engine
+from dependencies import creek_vault as vault_dependency
 from domain.constants import TOTAL_STAGES
 from domain.creek_vault import (
     CONTRACT_VERSION,
@@ -101,6 +102,12 @@ _REFLECTIONS_PATH = "/v1/reflections"
 _REFLECTIONS_URL = f"{_VAULT_URL}{_REFLECTIONS_PATH}"
 
 _API_KEY = "creek-vault-test-key"  # pragma: allowlist secret
+
+# A configured vault's single bound owner, and somebody who is not them. Two ids
+# that are never equal, so "owner" and "everyone else" cannot be satisfied by the
+# same comparison.
+_VAULT_OWNER_ID = 11
+_NON_OWNER_ID = 12
 
 _SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"
 
@@ -2796,6 +2803,22 @@ async def _drive_fallback_unconfigured(
     assert (await LocalFallbackCreekVaultClient().ingest(_ingest_request())).stored is False
 
 
+async def _drive_fallback_not_owner(
+    _http_clients: ClientFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive a user who is not the bound owner of a configured vault.
+
+    Through the real gate rather than by constructing the fallback with the
+    outcome by hand: that gate is the only thing in adepthood that ever chooses
+    this outcome, so driving anything else would count a path production does not
+    have.
+    """
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv(vault_dependency.OWNER_ENV_VAR, str(_VAULT_OWNER_ID))
+    client = vault_dependency.get_creek_vault_client(_NON_OWNER_ID)
+    assert (await client.ingest(_ingest_request())).stored is False
+
+
 _OUTCOME_DRIVERS: tuple[tuple[VaultTelemetryOutcome, CreekCapability, OutcomeDriver], ...] = (
     (VaultTelemetryOutcome.SUCCESS, CreekCapability.JOURNAL, _drive_ingest_success),
     (VaultTelemetryOutcome.SCHEMA_FAILURE, CreekCapability.JOURNAL, _drive_ingest_not_stored),
@@ -2823,6 +2846,11 @@ _OUTCOME_DRIVERS: tuple[tuple[VaultTelemetryOutcome, CreekCapability, OutcomeDri
         VaultTelemetryOutcome.FALLBACK_UNCONFIGURED,
         CreekCapability.JOURNAL,
         _drive_fallback_unconfigured,
+    ),
+    (
+        VaultTelemetryOutcome.FALLBACK_NOT_OWNER,
+        CreekCapability.JOURNAL,
+        _drive_fallback_not_owner,
     ),
 )
 

--- a/backend/tests/test_creek_vault_telemetry.py
+++ b/backend/tests/test_creek_vault_telemetry.py
@@ -306,6 +306,7 @@ def test_outcome_wire_values_are_stable() -> None:
     assert [outcome.value for outcome in VaultTelemetryOutcome] == [
         "vault_success",
         "vault_fallback_unconfigured",
+        "vault_fallback_not_owner",
         "vault_unavailable",
         "vault_timeout",
         "vault_auth_failed",
@@ -486,12 +487,15 @@ def test_the_code_field_carries_the_vaults_own_reason_when_it_named_one(
 
 
 # The severity each outcome is expected to log at. A deployment that never had a
-# vault is a choice rather than a fault, so it stays at DEBUG; a healthy answer is
-# news worth one INFO line; a care escalation is deliberately DEBUG for privacy
-# rather than for noise (see the escalation tests below); everything else is a
-# fault an operator may need to act on.
+# vault is a choice rather than a fault, so it stays at DEBUG; a user held back
+# from a vault that belongs to someone else stays there with it, being the design
+# working rather than failing; a healthy answer is news worth one INFO line; a
+# care escalation is deliberately DEBUG for privacy rather than for noise (see
+# the escalation tests below); everything else is a fault an operator may need to
+# act on.
 _SEVERITY_BY_OUTCOME: Mapping[VaultTelemetryOutcome, int] = {
     VaultTelemetryOutcome.FALLBACK_UNCONFIGURED: logging.DEBUG,
+    VaultTelemetryOutcome.FALLBACK_NOT_OWNER: logging.DEBUG,
     VaultTelemetryOutcome.SUCCESS: logging.INFO,
     VaultTelemetryOutcome.ESCALATED: logging.DEBUG,
     VaultTelemetryOutcome.UNAVAILABLE: logging.WARNING,

--- a/backend/tests/test_creek_vault_tenancy.py
+++ b/backend/tests/test_creek_vault_tenancy.py
@@ -1,0 +1,497 @@
+"""Single-tenant binding tests for the Creek Vault seam.
+
+Adepthood reaches a vault with one deployment-wide identity, so the corpus a
+vault grounds its answers in is whatever adepthood has replicated into it.  That
+is safe only while exactly one person writes into it, which is what these tests
+pin: a configured vault belongs to the single user named by
+``CREEK_VAULT_OWNER_USER_ID``, and everyone else is served the local fallback, so
+no other user's writing enters the corpus and no other user ever queries it.
+
+Three families.  The first is the pure parse of the owner variable, which fails
+closed on everything that is not a positive user id.  The second is the
+dependency gate itself, driven directly against an environment rather than
+through FastAPI, including what it logs when the binding is missing or
+unreadable and what it must never echo.  The third drives the real app end to end
+with two registered users and one shared fake vault standing in for the single
+corpus, asserting the leak cannot travel in either direction: the non-owner's
+writing never reaches the corpus, and nothing the non-owner is answered with is
+drawn from it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dependencies import creek_vault as vault_dependency
+from domain.constants import TOTAL_STAGES
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultClient,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultReflection,
+    VaultReflectionNote,
+    VaultReflectionStatus,
+    VaultTierCeiling,
+    VaultWheelAspect,
+    VaultWheelBalance,
+    resolve_vault_owner,
+)
+from models.course_stage import CourseStage
+from services import marginalia as marginalia_service
+from services.botmason import STUB_MODEL_NAME, LLMResponse
+from services.creek_vault_client import HttpCreekVaultClient, LocalFallbackCreekVaultClient
+from services.creek_vault_telemetry import (
+    VAULT_OUTCOME_EVENT,
+    VaultTelemetryOutcome,
+    reset_vault_telemetry_for_tests,
+    vault_outcome_counts,
+)
+
+# The environment variable that binds a configured vault to one adepthood user.
+_OWNER_ENV_VAR = "CREEK_VAULT_OWNER_USER_ID"
+
+_VAULT_URL = "https://vault.example.test"
+_API_KEY = "creek-vault-tenancy-key"  # pragma: allowlist secret
+
+# Two ids that are never equal, so "owner" and "everyone else" cannot be
+# satisfied by the same comparison.
+_OWNER_ID = 7
+_OTHER_ID = 8
+
+# A mis-pasted owner value.  It stands in for a credential fat-fingered into the
+# wrong variable, which is why no record may echo it back.
+_UNPARSEABLE_OWNER = "not-an-int"
+
+_SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
+
+# The owner's writing, and the unmistakable substring by which it is recognized
+# anywhere it must not appear.
+_ALPHA_SENTINEL = "alpha-corpus-sentinel-never-leaves-its-owner"
+_ALPHA_BODY = f"The willow bent without breaking. {_ALPHA_SENTINEL}"
+
+# The non-owner's writing, plus the verbatim fragment their locally generated
+# reflection anchors against.
+_BETA_SENTINEL = "beta-corpus-sentinel-never-enters-the-vault"
+_BETA_QUOTE = "the rain kept walking with me"
+_BETA_BODY = f"I noticed {_BETA_QUOTE}. {_BETA_SENTINEL}"
+
+_CLOUD_NOTE = "The cloud reads: you return to water."
+_VAULT_NOTE = "The vault reads: this is written in the corpus."
+
+# The fullness the shared fake vault reports for every Aspect.  Distinct from the
+# 0.0 a fresh user's locally computed balance produces, so which source answered
+# a wheel request is decidable from the response alone.
+_VAULT_FULLNESS = 0.42
+
+_VAULT_WHEEL_ASPECTS = tuple(
+    VaultWheelAspect(stage_number=n, aspect=f"creek-frequency-{n}", fullness=_VAULT_FULLNESS)
+    for n in range(1, TOTAL_STAGES + 1)
+)
+
+# One synthetic Aspect label per seeded stage: the wheel read is discarded whole
+# unless every stage carries a non-blank label.
+_STAGE_ASPECTS = (
+    "Body",
+    "Body",
+    "Emotion",
+    "Emotion",
+    "Mind",
+    "Mind",
+    "Spirit",
+    "Spirit",
+    "Nondual",
+    "Nondual",
+)
+
+_CREATED_AT = datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _reset_vault_telemetry() -> Iterator[None]:
+    """Empty the process-wide outcome counters around every test in this module."""
+    reset_vault_telemetry_for_tests()
+    yield
+    reset_vault_telemetry_for_tests()
+
+
+@pytest.fixture
+def configured_vault(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure a reachable vault with a credential and no owner bound yet.
+
+    The protocol selector is cleared rather than set so a stale value in the
+    developer's own environment cannot degrade the real client out from under the
+    tests that assert one is built.
+    """
+    monkeypatch.setenv("CREEK_VAULT_URL", _VAULT_URL)
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _API_KEY)
+    monkeypatch.delenv("CREEK_VAULT_PROTOCOL", raising=False)
+    monkeypatch.delenv(_OWNER_ENV_VAR, raising=False)
+
+
+def _client_for(user_id: int) -> CreekVaultClient:
+    """Resolve the vault client the request-time gate hands to ``user_id``."""
+    return vault_dependency.get_creek_vault_client(user_id)
+
+
+def _record_text(record: logging.LogRecord) -> str:
+    """Render every string one record could carry: its message plus its own attributes."""
+    attributes = " ".join(f"{key}={value}" for key, value in vars(record).items())
+    return f"{record.getMessage()} {attributes}"
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the captured records an operator would actually be paged by."""
+    return [record for record in caplog.records if record.levelno >= logging.WARNING]
+
+
+def _ingest_request(body: str) -> VaultIngestRequest:
+    """Build an open-tier ingest request carrying ``body``."""
+    return VaultIngestRequest(
+        entry_id=1,
+        body=body,
+        tier=VaultTierCeiling.OPEN,
+        tier_ceiling=VaultTierCeiling.OPEN,
+        created_at=_CREATED_AT,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("abc", None),
+        ("1.5", None),
+        ("0", None),
+        ("-3", None),
+        ("7", 7),
+        ("  7  ", 7),
+    ],
+)
+def test_resolve_vault_owner_admits_only_a_positive_user_id(
+    raw: str | None, expected: int | None
+) -> None:
+    """Only a whitespace-tolerant positive integer names an owner; everything else is nobody.
+
+    ``0`` and negatives are refused alongside the unparseable values, and that is
+    the load-bearing half: a user id is positive, so admitting ``0`` would let the
+    commonest "unset" sentinel silently own a deployment's vault.
+    """
+    assert resolve_vault_owner(raw) == expected
+
+
+@pytest.mark.usefixtures("configured_vault")
+def test_the_bound_owner_gets_the_vault_and_every_other_user_gets_the_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With an owner bound, exactly that user reaches the configured vault."""
+    monkeypatch.setenv(_OWNER_ENV_VAR, str(_OWNER_ID))
+
+    assert isinstance(_client_for(_OWNER_ID), HttpCreekVaultClient)
+    assert isinstance(_client_for(_OTHER_ID), LocalFallbackCreekVaultClient)
+
+
+@pytest.mark.usefixtures("configured_vault")
+def test_a_configured_vault_with_no_owner_is_nobodys_and_says_so(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A vault URL without an owner binding falls closed for everyone, loudly.
+
+    Loudly because this is a live deployment one variable away from working:
+    silence would leave an operator reading a vault-shaped configuration whose
+    replication never happens, with nothing anywhere to say why.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    assert isinstance(_client_for(_OWNER_ID), LocalFallbackCreekVaultClient)
+    assert isinstance(_client_for(_OTHER_ID), LocalFallbackCreekVaultClient)
+
+    warnings = _warnings(caplog)
+    assert warnings, "an unbound vault must warn rather than degrade in silence"
+    assert all(_OWNER_ENV_VAR in _record_text(record) for record in warnings), (
+        f"every warning must name {_OWNER_ENV_VAR}, the variable that fixes it"
+    )
+
+
+@pytest.mark.usefixtures("configured_vault")
+def test_an_unreadable_owner_falls_closed_without_echoing_the_value(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A garbage owner binding degrades everyone and keeps the raw value out of the log.
+
+    The value is the operator's own text and could as easily be a credential
+    pasted into the wrong variable, so the record names the variable and never
+    what was found in it.
+    """
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setenv(_OWNER_ENV_VAR, _UNPARSEABLE_OWNER)
+
+    assert isinstance(_client_for(_OWNER_ID), LocalFallbackCreekVaultClient)
+    assert isinstance(_client_for(_OTHER_ID), LocalFallbackCreekVaultClient)
+
+    warnings = _warnings(caplog)
+    assert warnings, "an unreadable owner binding must warn rather than degrade in silence"
+    assert all(_OWNER_ENV_VAR in _record_text(record) for record in warnings)
+    leaked = [record for record in caplog.records if _UNPARSEABLE_OWNER in _record_text(record)]
+    assert not leaked, "the raw owner value must reach no log record, message or field"
+
+
+def test_no_vault_configured_stays_silent_for_everyone(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployment that chose no vault is not a fault and earns no warning."""
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
+    monkeypatch.delenv(_OWNER_ENV_VAR, raising=False)
+
+    assert isinstance(_client_for(_OWNER_ID), LocalFallbackCreekVaultClient)
+    assert isinstance(_client_for(_OTHER_ID), LocalFallbackCreekVaultClient)
+    assert _warnings(caplog) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configured_vault")
+async def test_a_non_owner_degrade_counts_under_its_own_outcome(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user who is not the owner is counted apart from a deployment with no vault.
+
+    Two different facts with two different remedies: one deployment never wanted
+    a vault, the other has one that this user is deliberately kept out of. The
+    records stay at DEBUG like the unconfigured path, because neither is a fault.
+    """
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setenv(_OWNER_ENV_VAR, str(_OWNER_ID))
+    client = _client_for(_OTHER_ID)
+
+    await client.handshake()
+    await client.ingest(_ingest_request(_BETA_BODY))
+
+    assert vault_outcome_counts() == {
+        (VaultTelemetryOutcome.FALLBACK_NOT_OWNER, CreekCapability.HANDSHAKE): 1,
+        (VaultTelemetryOutcome.FALLBACK_NOT_OWNER, CreekCapability.JOURNAL): 1,
+    }
+    levels = [
+        record.levelno for record in caplog.records if record.getMessage() == VAULT_OUTCOME_EVENT
+    ]
+    assert levels == [logging.DEBUG, logging.DEBUG]
+
+
+def test_the_not_owner_outcome_carries_its_own_wire_string() -> None:
+    """The new outcome is countable under a name of its own on a dashboard."""
+    assert VaultTelemetryOutcome.FALLBACK_NOT_OWNER.value == "vault_fallback_not_owner"
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_client_still_counts_as_unconfigured_by_default() -> None:
+    """The no-vault client's own outcome is unchanged, so existing counters keep their meaning."""
+    await LocalFallbackCreekVaultClient().handshake()
+
+    assert vault_outcome_counts() == {
+        (VaultTelemetryOutcome.FALLBACK_UNCONFIGURED, CreekCapability.HANDSHAKE): 1,
+    }
+
+
+class _SharedCorpusVaultClient:
+    """One deployment-wide vault: whatever it is given, it may hand back to anyone.
+
+    The fake is deliberately a *single instance* shared across both users'
+    requests, because that is the real risk this issue exists to close -- there
+    is one vault, one identity, and therefore one corpus. Its ``reflect``
+    grounds in what it was previously given, exactly as the real capability
+    does, so a note quoting another user's writing is what a leak would look
+    like rather than something this fake has to be told to fabricate.
+    """
+
+    def __init__(self) -> None:
+        """Start with an empty corpus and no recorded reads."""
+        self.ingested_bodies: list[str] = []
+        self.reflect_calls: list[str] = []
+        self.wheel_calls = 0
+
+    async def handshake(self) -> HandshakeResult:
+        """Report a vault that can ingest, reflect, and answer a wheel."""
+        return HandshakeResult(
+            available=True,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=frozenset(
+                {CreekCapability.JOURNAL, CreekCapability.REFLECT, CreekCapability.WHEEL}
+            ),
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Report available -- this fake never degrades."""
+        return True
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Report every capability but classify as supported."""
+        return capability is not CreekCapability.CLASSIFY
+
+    async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Add the body to the one shared corpus and answer with a stored ref."""
+        self.ingested_bodies.append(request.body)
+        return VaultIngestResult(stored=True, vault_ref=f"vault-ref-{len(self.ingested_bodies)}")
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Raise: adepthood never calls classify, and a fake that answered would hide that."""
+        raise CreekCapabilityUnsupportedError("creek vault capability unsupported: creek.classify")
+
+    async def reflect(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultReflection:
+        """Record the read and answer a note quoting the earliest body in the corpus."""
+        del tier_ceiling
+        self.reflect_calls.append(body)
+        grounded = self.ingested_bodies[0] if self.ingested_bodies else body
+        return VaultReflection(
+            status=VaultReflectionStatus.OK,
+            notes=(VaultReflectionNote(kind="theme", quote=grounded, note=_VAULT_NOTE),),
+            essay=None,
+            essay_grounded=False,
+            routed_tier=VaultTierCeiling.PERSONAL,
+        )
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Record the read and answer the whole-corpus aggregate, recognizable by its fullness."""
+        self.wheel_calls += 1
+        return VaultWheelBalance(aspects=_VAULT_WHEEL_ASPECTS)
+
+
+def _stage_row(stage_number: int) -> CourseStage:
+    """Build one CourseStage row carrying the Aspect label a wheel read is relabelled with."""
+    return CourseStage(
+        title=f"Stage {stage_number}",
+        subtitle="sub",
+        stage_number=stage_number,
+        overview_url="",
+        category="test",
+        aspect=_STAGE_ASPECTS[stage_number - 1],
+        spiral_dynamics_color="beige",
+        growing_up_stage="archaic",
+        divine_gender_polarity="masculine",
+        relationship_to_free_will="active",
+        free_will_description="desc",
+    )
+
+
+async def _seed_all_stages(db_session: AsyncSession) -> None:
+    """Insert every CourseStage row, so a wheel read has a full label set to land on."""
+    for stage_number in range(1, TOTAL_STAGES + 1):
+        db_session.add(_stage_row(stage_number))
+    await db_session.commit()
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Sign up a fresh user and return its auth header and DB-assigned id."""
+    resp = await client.post(
+        "/auth/signup",
+        json={"email": f"{username}@example.com", "password": _SIGNUP_PASSWORD},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    return {"Authorization": f"Bearer {data['token']}"}, int(data["user_id"])
+
+
+async def _create_entry(client: AsyncClient, headers: dict[str, str], body: str) -> int:
+    """Create a personal journal entry and return its id."""
+    resp = await client.post(
+        "/journal/",
+        json={"message": body, "classification": "personal"},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+def _fake_cloud_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the cloud resonance seam so the non-owner's reflection is locally generated."""
+    payload = json.dumps({"notes": [{"kind": "theme", "quote": _BETA_QUOTE, "note": _CLOUD_NOTE}]})
+
+    async def _complete(
+        prompt: str, history: object, *, system_prompt: object, api_key: object
+    ) -> LLMResponse:
+        del prompt, history, system_prompt, api_key
+        return LLMResponse(
+            text=payload,
+            provider="stub",
+            model=STUB_MODEL_NAME,
+            prompt_tokens=0,
+            completion_tokens=0,
+        )
+
+    monkeypatch.setattr(marginalia_service, "generate_response", _complete)
+
+
+def _fullness_values(payload: object) -> list[float]:
+    """Return each Aspect's fullness from a wheel response body, in the order served."""
+    assert isinstance(payload, dict)
+    aspects = payload["aspects"]
+    assert isinstance(aspects, list)
+    return [float(item["fullness"]) for item in aspects]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configured_vault")
+async def test_reflection_is_never_grounded_in_another_users_corpus(
+    async_client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One shared corpus, two users: only the bound owner writes to it or reads from it.
+
+    Every leg is asserted in both directions. The owner's entry must reach the
+    corpus, or the whole test would pass on broken wiring that simply never
+    called a vault; the other user's entry must not, or their writing becomes
+    material a stranger's reflection can quote; the other user's resonance must
+    not touch the vault at all, since a corpus holding one person's journal can
+    only ground an answer in it; and their wheel must be the balance computed
+    from their own progress rather than the whole-corpus aggregate.
+    """
+    shared = _SharedCorpusVaultClient()
+
+    def _build_shared() -> CreekVaultClient:
+        """Return the one shared corpus, whoever asked for a vault."""
+        return shared
+
+    # Patch the builder, not the dependency: overriding the dependency bypasses the gate under test.
+    monkeypatch.setattr(vault_dependency, "build_creek_vault_client", _build_shared)
+    _fake_cloud_llm(monkeypatch)
+    await _seed_all_stages(db_session)
+
+    owner_headers, owner_id = await _signup(async_client, "vault_owner")
+    other_headers, _other_id = await _signup(async_client, "vault_other")
+    monkeypatch.setenv(_OWNER_ENV_VAR, str(owner_id))
+
+    await _create_entry(async_client, owner_headers, _ALPHA_BODY)
+    assert shared.ingested_bodies == [_ALPHA_BODY], "the owner's own writing must reach the vault"
+
+    other_entry = await _create_entry(async_client, other_headers, _BETA_BODY)
+    assert shared.ingested_bodies == [_ALPHA_BODY]
+    assert _BETA_SENTINEL not in "\n".join(shared.ingested_bodies)
+
+    resonance = await async_client.post(f"/journal/{other_entry}/resonance", headers=other_headers)
+    assert resonance.status_code == HTTPStatus.OK
+    notes = resonance.json()["marginalia"]
+    assert notes, "the non-owner still gets a reflection, generated locally"
+    assert shared.reflect_calls == []
+    assert _ALPHA_SENTINEL not in json.dumps(notes)
+
+    other_wheel = await async_client.get("/stages/wheel", headers=other_headers)
+    assert other_wheel.status_code == HTTPStatus.OK
+    assert _fullness_values(other_wheel.json()) == [0.0] * TOTAL_STAGES
+
+    owner_wheel = await async_client.get("/stages/wheel", headers=owner_headers)
+    assert owner_wheel.status_code == HTTPStatus.OK
+    assert _fullness_values(owner_wheel.json()) == [_VAULT_FULLNESS] * TOTAL_STAGES

--- a/backend/tests/test_creek_vault_tenancy.py
+++ b/backend/tests/test_creek_vault_tenancy.py
@@ -194,6 +194,35 @@ def test_resolve_vault_owner_admits_only_a_positive_user_id(
     assert resolve_vault_owner(raw) == expected
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "1_0",
+        "+7",
+        "\u0667",
+        "\uff17",
+        "7\u200b",
+    ],
+)
+def test_resolve_vault_owner_refuses_every_spelling_int_would_have_widened(raw: str) -> None:
+    """A binding is only a user id if it reads as one; ``int``'s generosity is refused.
+
+    Each of these is something ``int`` accepts and an operator would not
+    recognize as the id they typed: underscore grouping turns ``1_0`` into ten, a
+    leading sign parses away, and every Unicode decimal digit converts to its
+    numeric value, so an ARABIC-INDIC or FULLWIDTH seven is a seven. A
+    zero-width space is the case whitespace-stripping alone would miss. All of
+    them are written here as escapes rather than glyphs so this file cannot
+    itself smuggle a confusable past a reader.
+
+    This is the setting that decides whose journal a shared corpus accumulates,
+    so the value an operator reads back must be the value that binds. Refusing
+    these costs nothing -- no one means to type them -- and each one admitted
+    would be a binding nobody could audit by looking at it.
+    """
+    assert resolve_vault_owner(raw) is None
+
+
 @pytest.mark.usefixtures("configured_vault")
 def test_the_bound_owner_gets_the_vault_and_every_other_user_gets_the_fallback(
     monkeypatch: pytest.MonkeyPatch,
@@ -483,10 +512,15 @@ async def test_reflection_is_never_grounded_in_another_users_corpus(
 
     resonance = await async_client.post(f"/journal/{other_entry}/resonance", headers=other_headers)
     assert resonance.status_code == HTTPStatus.OK
+    # Ordered so a regression fails on the tenancy property itself rather than on a
+    # downstream symptom.  Anchoring drops a note whose quote is absent from the
+    # reader's own entry, so a cross-grounded note tends to arrive as *empty*
+    # marginalia -- a real safety net, but a narrower one than this test is about:
+    # it constrains the quote field only, never the note prose or the wheel.
+    assert shared.reflect_calls == [], "a non-owner's reflection must never consult the corpus"
     notes = resonance.json()["marginalia"]
+    assert _ALPHA_SENTINEL not in json.dumps(notes), "no answer may carry the owner's writing"
     assert notes, "the non-owner still gets a reflection, generated locally"
-    assert shared.reflect_calls == []
-    assert _ALPHA_SENTINEL not in json.dumps(notes)
 
     other_wheel = await async_client.get("/stages/wheel", headers=other_headers)
     assert other_wheel.status_code == HTTPStatus.OK

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from dependencies.creek_vault import get_creek_vault_client
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
@@ -41,7 +42,6 @@ from services.creek_vault_write import (
     VaultDegradeReason,
     VaultWriteOutcome,
     VaultWriteStatus,
-    get_creek_vault_client,
     store_and_classify,
 )
 
@@ -49,6 +49,10 @@ _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
 _BODY = "A quiet entry about the week's practice."
 
 _ENTRY_ID = 101
+
+# Any authenticated caller: the paths exercised here have no vault to belong to
+# anyone, so which user asks makes no difference to what they are handed.
+_ANY_USER_ID = 1
 
 # A body and an error text distinctive enough to spot in any log record. The
 # degrade log must be a static message with content-free structured fields, so
@@ -345,9 +349,14 @@ async def test_local_fallback_client_returns_unavailable_for_non_intimate_entry(
 def test_get_creek_vault_client_returns_local_fallback_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With no CREEK_VAULT_URL configured, the FastAPI provider yields the local fallback."""
+    """With no CREEK_VAULT_URL configured, the FastAPI provider yields the local fallback.
+
+    The provider now takes the caller's user id, since a configured vault belongs
+    to exactly one user; with no vault configured there is nobody it could belong
+    to, so the id chosen here is immaterial.
+    """
     monkeypatch.delenv("CREEK_VAULT_URL", raising=False)
-    client = get_creek_vault_client()
+    client = get_creek_vault_client(_ANY_USER_ID)
     assert isinstance(client, LocalFallbackCreekVaultClient)
 
 

--- a/backend/tests/test_journal_vault_read.py
+++ b/backend/tests/test_journal_vault_read.py
@@ -22,6 +22,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
+from dependencies.creek_vault import get_creek_vault_client
 from domain.care import build_care_payload
 from domain.creek_vault import (
     CONTRACT_VERSION,
@@ -45,7 +46,6 @@ from scripts.creek_contract_drift import BUNDLE_ROOT
 from services import marginalia as marginalia_service
 from services.botmason import STUB_MODEL_NAME, LLMResponse
 from services.creek_vault_client import HttpCreekVaultClient
-from services.creek_vault_write import get_creek_vault_client
 from services.usage import get_monthly_cap
 
 _SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -18,6 +18,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
+from dependencies.creek_vault import get_creek_vault_client
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
@@ -37,7 +38,6 @@ from domain.creek_vault import (
 from main import app
 from models.journal_entry import JournalEntry
 from routers.journal import _record_vault_outcome
-from services.creek_vault_write import get_creek_vault_client
 
 _SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
 

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -9,6 +9,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dependencies.creek_vault import get_creek_vault_client
 from domain.creek_vault import (
     CONTRACT_VERSION,
     CreekCapability,
@@ -26,7 +27,6 @@ from models.course_stage import CourseStage
 from models.goal import Goal
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
-from services.creek_vault_write import get_creek_vault_client
 
 _TOTAL_STAGES = 10
 

--- a/docs/adr/0004-creek-vault-http-application-boundary.md
+++ b/docs/adr/0004-creek-vault-http-application-boundary.md
@@ -669,6 +669,28 @@ pinning the fail-closed parse (missing, blank, non-integer, `0`, and
 negative all resolve to no owner) and the WARNING behavior — logged
 once per request, naming the variable, never echoing the raw value.
 
+**What this does not reach: a corpus that is already mixed.** The
+binding governs what enters the corpus from the moment it ships. It
+cannot touch what a previous configuration already replicated. Any
+deployment that ran with a vault configured and more than one active
+user before this shipped has a corpus that *already* holds several
+people's writing, and binding an owner does not retroactively
+partition it — every reflection the bound owner is served can still
+ground itself in material that was never theirs. The gate closes the
+inflow; it does not undo the past, and nobody should read a green
+tenancy suite as saying otherwise.
+
+Remediation for that case is operational and sits on Creek's side,
+not adepthood's: the corpus has to be re-scaffolded, or purged of
+everyone but the bound owner, by whoever administers the vault.
+Adepthood cannot do it from here even in principle — the ratified
+`/v1` capability list is exactly `capabilities`, `journal-upsert`,
+`reflections`, `wheel` (`CapabilitiesResponse.schema.json`), and none
+of those removes a fragment; journal writes are upsert-only. An
+operator turning this binding on for a vault that predates it should
+treat the existing corpus as compromised for tenancy purposes and
+decide deliberately whether to keep it.
+
 What is deliberately **not** claimed. Nothing here says anything about
 how Creek partitions, or fails to partition, a corpus on its own side
 — no such guarantee is published, per Decision 7(a), and this ADR has

--- a/docs/adr/0004-creek-vault-http-application-boundary.md
+++ b/docs/adr/0004-creek-vault-http-application-boundary.md
@@ -285,15 +285,113 @@ stands unchanged in substance** — this ADR relocates where the
 intimate-transit sub-decisions are recorded; it does not revise any of
 them.
 
+## Decision 7 — Creek Vault is bound to exactly one adepthood user per deployment
+
+**(a) Identity scope.** Adepthood reaches a configured vault with a
+single deployment-wide bearer credential, `CREEK_VAULT_API_KEY`, and
+nothing else on the wire says who is asking. Verified directly
+against the vendored `/v1` schemas: `ReflectionRequest.schema.json`
+is `additionalProperties: false` and admits only `content`,
+`entry_ref`, `max_notes`; `JournalUpsertRequest.schema.json` is
+`additionalProperties: false` and admits only `content`, `tier`,
+`timestamp`; `/v1/wheel` is a parameterless `GET`; and
+`CapabilitiesResponse.schema.json` advertises `status`,
+`contract_version`, `contract_minor`,
+`supported_contract_minors`, `ontology_version`, `vault.available`,
+`tier_model`, and `capabilities` — nothing about tenancy or
+partitioning anywhere in that list. No request shape has anywhere to
+carry a tenant, and no response shape says the corpus is split by
+one. Per-user scoping is therefore not a feature adepthood chose to
+skip; it is not buildable from adepthood's side of this contract at
+all. Nor is any creek-side partitioning guarantee assumed in its
+place — none is published, and Decision 6's discipline about not
+inferring a guarantee the wire does not state applies here with equal
+force.
+
+**(b) Owner binding.** `CREEK_VAULT_OWNER_USER_ID` names the one
+adepthood user a configured vault belongs to. It is enforced once, at
+the client-provider seam (`backend/src/dependencies/creek_vault.py`),
+which every router reaches through — journal writes, reflections, and
+the wheel read all resolve their `CreekVaultClient` through this one
+dependency, so the binding covers ingest, reflect, and wheel
+together rather than needing three separate gates that could drift
+apart. Gating only the read path was considered and rejected: if
+every user's entries still reached the corpus, the bound owner's own
+reflections and wheel would be grounded in everyone else's journals —
+the identical leak this ADR exists to close, just pointed at a single
+victim instead of the whole user base. The write side has to be
+gated for the read side's guarantee to mean anything.
+
+**(c) Fail-closed default.** An unset or unreadable
+`CREEK_VAULT_OWNER_USER_ID` — missing, blank, non-integer, `0`, or
+negative — resolves to no owner at all
+(`domain.creek_vault.resolve_vault_owner`), and no user id ever
+equals `None`, so every user, including whoever might have been
+intended as the owner, gets `LocalFallbackCreekVaultClient`. A
+deployment in that state is not broken; it behaves exactly like a
+deployment with no vault configured at all, which is the floor the
+whole seam is already built on. The one difference an operator is
+owed is a signal: a vault that is configured (URL and credential
+both present) but carries no readable owner logs one WARNING per
+request naming the variable to set, and never echoes the raw value —
+the same discipline `build_creek_vault_client` already applies to a
+stale protocol selector. The gate degrades instead of raising for the
+same reason that selector does: it runs inside a per-request FastAPI
+dependency, so a raise there means the handler body never executes —
+every journal save would 500 and the writer's entry would exist
+nowhere. That is exactly the loss this seam promises can never happen
+for a vault's sake, so an unreadable binding costs a user an optional
+capability, never their journal entry.
+
+**(d) Per-user end-state.** This binding is an interim floor, not
+the destination — a deployment with real multi-user vault-backed
+reflections is still future work. Lifting it needs a change on
+Creek's side of the contract, not adepthood's: either a tenant or
+consumer field admitted by `ReflectionRequest` and
+`JournalUpsertRequest`, paired with a `/v1/wheel` scoped to that same
+tenant, or per-consumer credentials backed by a partitioning
+guarantee that is itself *advertised in `CapabilitiesResponse`* so
+adepthood can verify it at handshake time rather than assume it
+holds. A guarantee this ADR cannot observe at handshake is not one it
+may act on — that is the same reasoning (a) applies to the absence of
+any tenancy claim today, run forward to what would have to change for
+the claim to exist. Tracked as adepthood #2134, blocked on
+`Geoffe-Ga/creek-vault` shipping either shape.
+
+What this costs, recorded honestly rather than rounded up: on a
+genuinely multi-user deployment that configures a vault, only the
+one bound user gets vault-backed reflections and a vault-backed
+wheel. Every other user runs the local pipeline — local reflection,
+locally computed wheel — which is not a degraded experience relative
+to some richer default; it is the same floor every vault-less
+deployment already runs on today, for every one of its users.
+
+**Rejected — shipping the leak and calling it a known limitation:**
+the alternative to (b) and (c) above was not "no vault feature" but
+"a vault feature that silently mixes users' journals in the corpus it
+grounds reflections in" — a privacy defect, not a limitation, and one
+this ADR will not document as though it were a tradeoff.
+
+**Rejected — inferring a per-consumer partitioning guarantee from
+Creek's behavior:** even if today's Creek deployment happened to
+partition by credential in practice, nothing in the ratified contract
+promises it, and `CapabilitiesResponse` has a `tier_model` field for
+exactly this kind of standing promise yet says nothing about tenancy
+there. Building on unpublished behavior is the same mistake Decision
+6 already refuses to make for confidential compute, and (d) names the
+one place such a promise would have to appear before adepthood could
+rely on it.
+
 ## Divergence table
 
 | What adepthood ships | What Creek publishes | Resolution | Owning repo / issue |
 | --- | --- | --- | --- |
-| `reflect` params `{consumer, body, tier_ceiling}` (`backend/src/services/creek_vault_client.py:277-279`) | `reflect(content, entry_ref, privacy_tier_ceiling)` (`creek-tools/creek_mcp/server.py:332-346`) | PENDING creek-vault#1072 for the ratified `/v1` shape | adepthood #2047 |
-| `wheel` params `{"consumer": CONSUMER_ID}` (`creek_vault_client.py:426`) | `wheel(privacy_tier_ceiling)` only (`server.py:349-358`) | PENDING creek-vault#1072 for the ratified `/v1` shape | adepthood #2047 |
+| `reflect` params `{consumer, body, tier_ceiling}` (`backend/src/services/creek_vault_client.py:277-279`) | `reflect(content, entry_ref, privacy_tier_ceiling)` (`creek-tools/creek_mcp/server.py:332-346`) | RESOLVED by the `/v1` cutover (#2047); the client this row describes is retired — archaeology only, per the 2026-08-07 note | adepthood #2047 |
+| `wheel` params `{"consumer": CONSUMER_ID}` (`creek_vault_client.py:426`) | `wheel(privacy_tier_ceiling)` only (`server.py:349-358`) | RESOLVED by the `/v1` cutover (#2047); `CONSUMER_ID` no longer exists in the codebase — archaeology only, per the 2026-08-07 note | adepthood #2047 |
 | `reflect` result read as scalar `payload.get("reflection")` (`creek_vault_client.py:406-407`) | `{status, tool, tier_ceiling, routed_tier, notes[{quote, kind, note}], essay_grounded, essay?}` (`creek-tools/creek_mcp/tools/reflect.py:479-490`) | PENDING creek-vault#1072 for the ratified `/v1` shape | adepthood #1936 |
 | `wheel` result validated as `WheelBalanceResponse{aspects:[{stage_number, aspect, fullness}]}` (`backend/src/schemas/wheel.py`) | `{status, tool, tier_ceiling, total_classified, unclassified, wheel:{F1..F10:{name, count, share}}}` (`creek-tools/creek_mcp/tools/wheel.py:95-110`) | PENDING creek-vault#1072 for the ratified `/v1` shape; the stage/aspect projection is Adepthood's to own — Creek must not invent our vocabulary, and the F1-F10-to-ten-stage numeric coincidence is NOT a semantic identity | adepthood #1937 |
 | Major-only version gate, a no-op pre-1.0 (`_CONTRACT_MAJOR`, `creek_vault_client.py:79,242`) | `CONTRACT_VERSION = "0.2.0"` (`creek-tools/creek_mcp/contract.py:18`) | Exact-minor comparison per Decision 4; pin lives here, comparison code lands in #2045 | both repos |
+| Single deployment-wide bearer credential; no tenant field on any `/v1` request or response (`backend/src/dependencies/creek_vault.py`) | No tenancy or partitioning of any kind published in `/v1` — verified against every schema in `backend/tests/fixtures/creek_v1/schemas/` | PENDING a creek-side contract change (tenant field, or advertised per-consumer partitioning); interim single-tenant binding shipped per Decision 7 | `creek-vault` / adepthood #2134 |
 
 ## Deprecation and change control
 
@@ -539,9 +637,47 @@ at `:277-279`, `_CONTRACT_MAJOR` at `:79,242`, the scalar
 `payload.get("reflection")` read at `:406-407`, the `wheel` params at
 `:426` — describes the **pre-cutover MCP client**, and none of those
 symbols or line numbers resolves to anything today: the code they
-point at was deleted by this issue. They are left exactly as written,
+point at was deleted by this issue. The `CONSUMER_ID` constant those
+citations name is gone too — it carried no tenancy meaning even while
+it existed (Decision 7(a)), and Decision 7's binding replaces it with
+a real one. They are left exactly as written,
 per this ADR's append-only convention, because the argument they
 support is an argument about what was true when the decision was made,
 and rewriting the evidence under a decision is how a decision record
 stops being a record. Read them as archaeology, not as a map of the
 current file.
+
+## Note, 2026-08-07 — the vault-tenancy binding ships
+
+Issue #2072, whose bug report is the one that surfaced Decision 7 in
+the first place: a deployment-wide vault identity meant every user's
+replicated journal material landed in one corpus, so a reflection
+returned to one user could ground itself in another user's writing,
+and `/v1/wheel`'s whole-corpus aggregate was being served to every
+user as though it were theirs. `CREEK_VAULT_OWNER_USER_ID` and its
+enforcement at `backend/src/dependencies/creek_vault.py`, described
+in full in Decision 7 above, are the fix that shipped for it.
+
+What is proven, and how: `backend/tests/test_creek_vault_tenancy.py`
+drives the real app end to end with two registered users and one
+shared fake vault standing in for the single corpus, and asserts the
+leak cannot travel in either direction — the non-owner's journal entry
+never reaches the corpus at all, and nothing the non-owner is answered
+with (reflection or wheel) is drawn from it. A second family in the
+same suite drives the dependency directly against a bare environment,
+pinning the fail-closed parse (missing, blank, non-integer, `0`, and
+negative all resolve to no owner) and the WARNING behavior — logged
+once per request, naming the variable, never echoing the raw value.
+
+What is deliberately **not** claimed. Nothing here says anything about
+how Creek partitions, or fails to partition, a corpus on its own side
+— no such guarantee is published, per Decision 7(a), and this ADR has
+not gone looking for one. The single-tenant property this deployment
+actually gets holds for exactly one reason: adepthood refuses to put
+a second user's material into a corpus it already knows is shared and
+unpartitioned. That is an adepthood-side refusal, not a Creek-side
+promise, and reads exactly that way at every place this ADR touches
+it — Decision 7(a)'s citation of the schemas that carry no tenant
+field, and (d)'s naming of the specific creek-side change (a tenant
+field, or an advertised partitioning guarantee) that would be needed
+before adepthood could ever claim otherwise.

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -347,3 +347,13 @@ Today's actual behavior is the skip-only mode from
 classification short-circuits before any vault call at all, not even a
 handshake. No intimate journal content is transmitted to any vault
 today, in any form.
+
+## Vault tenancy: pointer only
+
+Tenancy is not part of Creek's `/v1` wire contract at all — none of
+`ReflectionRequest`, `JournalUpsertRequest`, `/v1/wheel`, or
+`CapabilitiesResponse` carries a tenant field to document here. The
+rule governing how adepthood copes with that absence — binding a
+configured vault to exactly one adepthood user — is recorded in
+[ADR 0004](adr/0004-creek-vault-http-application-boundary.md),
+Decision 7, not in this document.


### PR DESCRIPTION
## Summary

Creek Vault's corpus was **deployment-scoped**. Adepthood reaches a vault with a
single deployment-wide bearer credential, so everything it replicated landed in
**one corpus** — and creek's `reflect` grounds its notes in the surrounding
corpus. A reflection returned to user A could therefore be grounded in, and
quote from, user B's journal.

The leak was wider than `reflect`. Three capabilities shared that one corpus:

- **`reflect`** — notes grounded in the whole corpus.
- **`wheel`** — `GET /v1/wheel` is a *whole-corpus aggregate*, and it was served
  to every user as **their** Wheel-of-Wholeness balance and fed **their**
  invitations (`services/creek_vault_wheel.py`, `services/invitations.py`).
- **`ingest`** — the capability that put everyone's entries in the shared corpus
  to begin with.

For a product whose floor is a private journal, this is the wrong property to
get wrong. Latent on `main` until #2071 fixed `reflect` in both directions;
that commit is what made the path live.

### Which of the three directions, and why

The issue offered three. **This is Direction 3 — the interim single-tenant gate
— because Directions 1 and 2 are not honestly available from this repository**,
and I verified that rather than assuming it:

- **Direction 1 (per-user consumer identity) is unbuildable here.** The ratified
  `/v1` contract has **no tenant field anywhere**:
  `ReflectionRequest.schema.json` is `additionalProperties: false` admitting only
  `content`/`entry_ref`/`max_notes`; `JournalUpsertRequest.schema.json` is
  `additionalProperties: false` admitting only `content`/`tier`/`timestamp`;
  `/v1/wheel` is a parameterless `GET`. Inventing a field would be rejected on
  the wire *and* would violate the discipline this codebase already states in
  `_reflection_request_body` and `_journal_entry_body` — never guess at an
  unratified contract.
- **Direction 2 (vault-side scoping) has nothing to verify.**
  `CapabilitiesResponse.schema.json` advertises status, versions,
  `vault.available`, `tier_model` and the capability list, and says **nothing**
  about tenancy or partitioning. There is no published guarantee, so none is
  claimed. **No creek-side guarantee was assumed anywhere in this change.**

So the corpus is kept one person's the only way it can be from this side: the
deployment names the person.

### What actually enforces it

`CREEK_VAULT_OWNER_USER_ID` binds a configured vault to exactly one adepthood
user, enforced **once, at the client-provider seam**
(`backend/src/dependencies/creek_vault.py`). Every other user is served
`LocalFallbackCreekVaultClient` — the same path a vault-less deployment has
always run on.

**A multi-tenant deployment is refused, not merely documented as unsupported.**
A second user does not get a warning and proceed; they get the local-fallback
client, so their entry never reaches `ingest`, their resonance never calls
`reflect`, and their wheel is computed locally. The gate sits at the provider
rather than per-capability precisely so it covers all three at once and cannot
drift apart.

Gating only the *read* path would have been dishonest: if every user's entries
still reached the corpus, the bound owner's own reflections and wheel would be
grounded in everyone else's journals — the identical leak, pointed at one victim
instead of the whole user base.

**Fails closed.** Unset, blank, non-integer, `0` or negative binds *nobody* and
the vault goes inert for **everyone**, including whoever was intended as owner.
Note what is deliberately *not* treated as a control: neither the empty
`CREEK_VAULT_URL` in `.env.example` nor any client-side refusal is enforcement —
those are circumstances. The gate is the control.

The owner id is matched as **ASCII digits** before conversion rather than handed
to `int`, which reads `1_0` as ten, parses a leading sign away, and converts any
Unicode decimal digit to its value (an ARABIC-INDIC or FULLWIDTH seven is a seven
to it). A binding whose rendered text and parsed meaning can disagree is one
nobody can audit by reading it — and this is the setting that decides whose
journal a shared corpus accumulates.

The gate **degrades rather than raising**: it runs in a per-request dependency,
where a raise means the handler body never executes and every journal save 500s.
That is the one loss this seam promises can never happen for a vault's sake.

### What this does NOT protect against

**A corpus that is already mixed.** The gate governs inflow from the moment it
ships; it cannot partition what a previous configuration already replicated. A
deployment that ran with a vault and several active users still holds their
writing, and the bound owner's reflections can still ground themselves in it.
Adepthood cannot remediate that from here even in principle — the ratified `/v1`
capability list is exactly `capabilities`, `journal-upsert`, `reflections`,
`wheel`, and **none of those removes a fragment**; journal writes are
upsert-only. Remediation is operational, on Creek's side: re-scaffold or purge
the corpus. This is recorded in ADR 0004's dated note and in `.env.example`
where an operator will actually meet it.

Also unchanged: this is an interim floor, not per-user scoping. Lifting it needs
a creek-side change — a tenant field on the two request shapes plus a scoped
wheel, **or** per-consumer credentials with a partitioning guarantee *advertised
in `CapabilitiesResponse`* so adepthood can verify it at handshake rather than
assume it. Tracked as #2134, blocked on `Geoffe-Ga/creek-vault`.

### Telemetry stays content-safe

`FALLBACK_NOT_OWNER` joins the closed vocabulary at DEBUG, so a user held back
from a vault that *exists* stays countable apart from a deployment that has
none — folding them together would report "the operator chose no vault" when the
truth is "this vault is not yours". #2117's property is preserved: no journal
content in any log or counter. The WARNING for a configured-but-unbound vault
names the variable and **never echoes its value** — one typed next to
`CREEK_VAULT_API_KEY` is one paste from being a credential.

Known tradeoff, accepted deliberately: that WARNING fires per request while the
deployment is misconfigured. The state is meant to be transient and silence
would hide an inert vault; a once-per-process latch is the follow-up if it ever
proves noisy, not a threshold change.

Also removes the dead `CONSUMER_ID` constant, whose docstring claimed the vault
"scopes capabilities and attestation to this consumer" — precisely the guarantee
this change records as nonexistent.

## Test plan

The property is pinned by `backend/tests/test_creek_vault_tenancy.py` (22 tests).
The central one is `test_reflection_is_never_grounded_in_another_users_corpus`,
which pins the **property, not the configuration**:

- A **single shared fake vault instance** serves both users' requests — it models
  the one deployment-wide corpus, records every ingested body, and answers
  `reflect` by quoting from what it has recorded, exactly as the real capability
  grounds in the surrounding corpus.
- It patches **`dependencies.creek_vault.build_creek_vault_client`** — the
  builder, where it is used — so the **real gate stays in the call path**. It
  deliberately does *not* use `app.dependency_overrides`, which would bypass the
  very gate under test; a comment says so, because a future reader will be
  tempted to "simplify" it.
- Both users are registered through the real API and the owner's **DB-assigned**
  id is read back before binding, so nothing hardcodes `1`.

Asserted in **both directions**, so no leg can pass vacuously:

| Leg | Assertion |
|---|---|
| Control (owner) | The owner's entry **does** reach the corpus, and the owner's wheel **is** the fake's `0.42` aggregate |
| Ingest | The non-owner's body never enters the corpus, and their sentinel appears nowhere in it |
| Reflect | `reflect_calls == []` for the non-owner, and no note returned to them carries the owner's sentinel |
| Wheel | The non-owner's wheel is the locally-computed all-zero balance, not the aggregate |

**Verified by mutation.** I neutered the gate (forced it to always return the
real client) and re-ran: **5 tests failed**, the property test failing exactly at
the leak — the non-owner's body appearing in the shared corpus. Restored and
hash-verified.

That experiment also surfaced something worth stating plainly: with the gate
removed, the reflect leg first failed on *empty marginalia*, because quote
anchoring independently drops a note whose quote is absent from the reader's own
entry. That is a real safety net but a **narrower one than the property** — it
constrains the `quote` field only, never the note prose and never the wheel
aggregate. It is not a tenancy control and must not be mistaken for one. The
assertions are now ordered so a regression fails on the tenancy claim itself, and
the comment says why.

Supporting coverage: the fail-closed parse matrix (including `1_0`, `+7`, Unicode
decimal digits and a zero-width space, each written as escapes so the suite
cannot itself smuggle a confusable past a reader); the gate's client selection;
the WARNING's content-safety (asserting the raw value appears in **no** record's
message or attributes); silence when no vault is configured; and the telemetry
outcome, including that the fallback client's **default** outcome is unchanged so
every pre-existing counter keeps its meaning.

Drift guards in `backend/tests/test_contract_version_docs.py` were extended so
the docs cannot rot: ADR 0004 must keep `## Decision 7` and its four
sub-decisions, the contract doc must keep handing tenancy to the ADR, and
`.env.example` must document the variable — making the operator-facing half of
AC4 a test rather than a hope.

**Gate 2:** `./scripts/backend/check-all.sh` → **exit 0** (7/7 stages; 4219
passed / 2 skipped / 1 xfailed / 0 failed, coverage 97%, ruff `select=ALL`, mypy
strict, xenon A, radon MI no module ranks C, bandit + pip-audit clean).
`src/dependencies/creek_vault.py` is at 100% line and branch coverage. The
strict-xfail tripwire `test_ratified_capability_documents_are_understood` **still
XFAILs** — it did not flip. The #2108 `database is locked` flake did not appear.

**Gate 2.5:** `code-review-orchestrator` → **CLEAN**, no blockers. Its
blast-radius sweep independently confirmed `build_creek_vault_client` has exactly
one caller in `backend/src` (the gate) and found no bypass path — no background
task, lifespan hook, seeder or script constructs a vault client outside a
request. That sweep was a manual import search rather than a `graphify affected`
run, as the reviewer had no graphify access.

Backend + docs only; no frontend files, no `requirements*.txt`, no schema change
and therefore no Alembic migration.

Closes #2072
Refs #2134, #2071, #2117
