### PR TITLE
perf(backend): length-check a vault string before stripping it in _bounded_text

### DIFF
--- a/backend/src/services/creek_vault_payload.py
+++ b/backend/src/services/creek_vault_payload.py
@@ -155,8 +155,18 @@ def _bounded_text(raw: object, limit: int) -> str | None:
     than stripped, because adepthood anchors a quote by matching it
     character-for-character against the entry body -- trimming here would
     silently break the very anchor this check exists to protect.
+
+    The three are asked in cheapest-first order, so an oversized vault-supplied
+    string is refused on its length alone rather than after ``strip`` has
+    allocated a full-size transient copy of it. The waste was real only for
+    whitespace-padded input -- CPython answers with the receiver itself when an
+    exact :class:`str` has nothing to remove, so an oversized value with no
+    surrounding whitespace was never copied -- but a padded one was, and a vault
+    that chooses its own payload chooses the padding too. It is defence in depth
+    on an untrusted response rather than the primary control, which remains the
+    bound itself.
     """
-    if not isinstance(raw, str) or not raw.strip() or len(raw) > limit:
+    if not isinstance(raw, str) or len(raw) > limit or not raw.strip():
         return None
     return raw
 

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -74,7 +74,11 @@ from services.creek_vault_client import (
     build_creek_vault_client,
     close_creek_vault_http_pool,
 )
-from services.creek_vault_payload import _MARGINALIA_KIND_BY_CREEK_KIND, _MAX_REFLECT_NOTES
+from services.creek_vault_payload import (
+    _MARGINALIA_KIND_BY_CREEK_KIND,
+    _MAX_REFLECT_NOTES,
+    _bounded_text,
+)
 from services.creek_vault_telemetry import (
     VaultCallTimedOutError,
     VaultTelemetryOutcome,
@@ -3321,6 +3325,93 @@ def test_marginalia_kind_map_targets_only_anchorable_kinds() -> None:
 def test_marginalia_kind_map_covers_creeks_published_kinds() -> None:
     """The mapping's keys are exactly Creek's seven published note kinds."""
     assert set(_MARGINALIA_KIND_BY_CREEK_KIND) == _CREEK_NOTE_KINDS
+
+
+def _strip_spy_text(value: str) -> tuple[str, list[str | None]]:
+    """Build a string that logs every ``strip`` asked of it, and return both.
+
+    ``_bounded_text`` admits a value on ``isinstance(raw, str)``, which a subclass
+    satisfies, so this walks the helper down exactly the path a vault-supplied
+    string walks while leaving a record of which guards were consulted along the
+    way. The log lives in this closure rather than on the instance because a
+    ``str`` subclass may only carry an empty ``__slots__``, and keeping it here
+    rather than on the class also keeps one call's record out of the next one's.
+    The override still delegates, so the value behaves as its own text to anything
+    else that touches it.
+    """
+    strip_calls: list[str | None] = []
+
+    class _StripSpyText(str):
+        """A string that answers as itself while recording each ``strip``."""
+
+        __slots__ = ()
+
+        def strip(self, chars: str | None = None, /) -> str:
+            """Record the consultation, then answer as the underlying string would."""
+            strip_calls.append(chars)
+            return super().strip(chars)
+
+    return _StripSpyText(value), strip_calls
+
+
+def test_bounded_text_rejects_an_over_limit_value_without_consulting_strip() -> None:
+    """An over-limit value is refused on its length alone, before anything copies it.
+
+    A vault answers with untrusted text, and the cheap check on that text is its
+    length: an oversized value is going to be dropped whatever its contents, so
+    asking it to ``strip`` first buys nothing and costs a transient copy of the
+    whole oversized string. The copy is real only for whitespace-padded input --
+    CPython hands back the receiver itself when an exact ``str`` has nothing to
+    remove -- so the value here is padded and exactly one character over, the
+    smallest shape in which the wasted work actually happens.
+
+    Reordering side-effect-free guards behind ``or`` cannot change what the helper
+    returns for any input, so no input/output assertion can pin it. Observing
+    whether ``strip`` was consulted at all is the only way to hold the ordering in
+    place against a later edit that quietly restores the expensive check to the
+    front.
+    """
+    oversized, strip_calls = _strip_spy_text(" " + "x" * ANCHOR_TEXT_MAX)
+
+    assert _bounded_text(oversized, ANCHOR_TEXT_MAX) is None
+    assert strip_calls == []
+
+
+@pytest.mark.parametrize(
+    "accepted",
+    [
+        pytest.param("x" * ANCHOR_TEXT_MAX, id="exactly_at_the_limit"),
+        pytest.param(f"  {_MARGIN_QUOTE}  ", id="whitespace_padded"),
+    ],
+)
+def test_bounded_text_returns_usable_text_verbatim(accepted: str) -> None:
+    """Usable text comes back as the very object that went in, untouched.
+
+    The limit is a ceiling rather than a threshold, so a value of exactly
+    ``ANCHOR_TEXT_MAX`` is still usable text. Identity rather than equality is the
+    assertion that matters: adepthood anchors a quote by matching it
+    character-for-character against the entry body, so a helper that trimmed the
+    padding it checked for would break the anchor it exists to protect.
+    """
+    assert _bounded_text(accepted, ANCHOR_TEXT_MAX) is accepted
+
+
+@pytest.mark.parametrize(
+    "refused",
+    [
+        pytest.param("x" * (ANCHOR_TEXT_MAX + 1), id="one_over_the_limit"),
+        pytest.param(" \n\t ", id="whitespace_only"),
+        pytest.param(7, id="not_a_string"),
+    ],
+)
+def test_bounded_text_refuses_what_cannot_anchor(refused: object) -> None:
+    """Each of the three ways a value fails to be usable text drops it on its own.
+
+    A number is not text, a blank quote anchors to nothing, and a value past the
+    ceiling would let a vault answer with an unbounded string -- so all three are
+    refused rather than repaired, and none of them may be salvaged by another.
+    """
+    assert _bounded_text(refused, ANCHOR_TEXT_MAX) is None
 
 
 async def _reflected_notes(


### PR DESCRIPTION
## Summary

`_bounded_text` — the bound every untrusted Creek Vault string passes through — asked `str.strip()` of a value *before* it asked whether the value was even within its limit:

```python
if not isinstance(raw, str) or not raw.strip() or len(raw) > limit:
```

All three operands are side-effect-free predicates behind a short-circuiting `or`, so which one answers first cannot change what the helper returns. But `strip` on an oversized string is not free. Reordering so the cheap check runs first refuses an over-limit value on its length alone:

```python
if not isinstance(raw, str) or len(raw) > limit or not raw.strip():
```

**What the ordering actually costs.** Less than the issue estimated, and worth stating precisely: CPython's `str.strip()` returns *the receiver itself* when it is an exact `str` with nothing to remove, so a long **unpadded** value never allocated a copy. The waste is real only for **whitespace-padded** input — `" " + "x" * N` forces a full N-character transient copy before the length check rejects it. A vault that chooses its own payload chooses the padding too, so the amplification is available to anything hostile; it is just narrower than "any oversized string." The docstring now says this rather than the broader claim.

**Reach.** Three call sites, all read-only projections of untrusted vault JSON: `_reflection_note`'s `quote` and `note` (up to twelve per reflection) and `_wheel_aspect`'s `name` (one per Frequency, ten per wheel read). The vault HTTP transport still has no response-size cap, so the string arriving here really is unbounded in principle — which is why this is worth fixing, and equally why it is defence in depth rather than the primary control. The bound itself remains that.

**Not a correctness change.** Worth being explicit, since "strips before it length-checks" in an input path reads like it might be: the length bound is applied to the *unstripped* value in both orders (`len(raw)`, never `len(raw.strip())`), so nothing oversized was ever admitted. The value is still returned verbatim — adepthood anchors a quote by matching it character-for-character against the entry body, and trimming here would break the anchor the check exists to protect. Behaviour is identical for every production input; only the work done before a refusal differs. No message, log, or counter is added, so the content-safe telemetry vocabulary is untouched.

## Test plan

A pure reorder is invisible to any input/output assertion, so the test that holds it pins the **evaluation order** instead — a `str` subclass whose `strip` override records each consultation and delegates to `super()` (`isinstance(raw, str)` admits a subclass, so the helper walks the identical path). It is fed a whitespace-padded value exactly one character over the limit: the smallest shape in which the copy actually happened.

- `test_bounded_text_rejects_an_over_limit_value_without_consulting_strip` — the RED case. Failed before the fix with `assert [None] == []` (the value was already refused; the logged `strip` call was the wasted work), passes after.
- `test_bounded_text_returns_usable_text_verbatim` — identity (`is`) assertions at **exactly** the limit and on a whitespace-padded value, pinning both the ceiling boundary and the verbatim/anchor promise.
- `test_bounded_text_refuses_what_cannot_anchor` — one over the limit, whitespace-only, and a non-string.

The five characterization cases pass in both orders by design; they exist to hold the helper's contract at unit level, where previously only the end-to-end HTTP path covered it.

- `./scripts/backend/check-all.sh` — **exit 0**, all 7 stages (deps preflight, ruff, ruff-format, mypy, bandit + pip-audit, xenon/radon, tests + coverage). Total coverage 97%; `creek_vault_payload.py` 98%.
- Full backend suite green. The strict-xfail conformance tripwire `test_ratified_capability_documents_are_understood` stayed XFAIL (no XPASS), and the vendored `/v1` contract drift and conformance suites are unchanged and passing — no fixture was touched.

Closes #2079