### PR TITLE
perf(tooling): stop re-verifying what is already green, and make contention refuse instead of mislead

### DIFF
--- a/.claude/agents/shared/adepthood-constraints.md
+++ b/.claude/agents/shared/adepthood-constraints.md
@@ -56,6 +56,14 @@ Q&A only — never user data or secrets.
 "Drop to Gate 1" means: fix the **root cause** with a failing-test-first cycle,
 re-clear Gate 2 locally, push, climb again. **Never weaken a gate to pass it.**
 
+Gates 1-2 are a ladder, cheapest first, each rung run once: targeted tests
+(`./scripts/backend/test.sh <paths>`) every Red→Green cycle, then
+`check-all.sh` once when Gate 1 is green — detail and costs in
+`scripts/ralph/PROMPT.md` step 7 and the `stay-green` skill. A whole-suite
+test run takes an exclusive per-worktree lock and refuses a concurrent second
+run in the same worktree with exit 3, naming the holder at
+`.gate-state/locks/backend-suite.lock`; wait for it, do not route around it.
+
 ## Quality thresholds (non-negotiable — from `CLAUDE.md`)
 
 - **Backend:** ≥90% line / ≥80% branch coverage (pytest-cov), ≥85% docstring

--- a/.claude/skills/stay-green/SKILL.md
+++ b/.claude/skills/stay-green/SKILL.md
@@ -52,7 +52,13 @@ nothing and doubles the wait:
 | `./scripts/backend/test.sh <paths>` (targeted) | every Red-Green cycle | seconds |
 | `./scripts/<side>/check-all.sh` | once, when Gate 1 is green | ~4m23s cold backend; ~8s on a receipt hit |
 | `git commit` hooks (staged files only) | automatic | seconds to ~1 min |
-| `git push` hooks (full suite + coverage) | automatic | ~5 min |
+| `git push` hooks (full suite + coverage) | automatic *if installed* | ~5 min |
+
+The push rung fires only where the `pre-push` hook type is installed
+(`pre-commit install --hook-type pre-push`); `scripts/dev-setup.sh` does not
+install it today, so on most dev boxes `git push` runs nothing. Backend CI runs
+that stage regardless, so nothing is skipped outright -- it just surfaces ~18
+minutes later instead of ~5. A silent push is not a pass.
 
 ```bash
 ./scripts/backend/check-all.sh    # drift preflight, lint, format, mypy,

--- a/.claude/skills/stay-green/SKILL.md
+++ b/.claude/skills/stay-green/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: stay-green
 description: >-
-  2-gate TDD development workflow: Gate 1 is Red-Green-Refactor testing,
-  Gate 2 is pre-commit quality checks. Use when implementing features,
-  fixing bugs, or doing any development work. Ensures code is never
-  committed without passing tests and quality checks.
+  Local TDD + quality-gate workflow: Gate 1 is Red-Green-Refactor testing,
+  Gate 2 is `./scripts/<side>/check-all.sh` exiting 0. Use when implementing
+  features, fixing bugs, or doing any development work. Ensures code is never
+  pushed without passing tests and quality checks. Gates 3 (CI) and 4 (Claude
+  review) are covered by `ci-debugging` and `address-feedback`.
   Do NOT use for bug-specific debugging (use bug-squashing-methodology).
 metadata:
   author: Geoff
-  version: 1.0.0
+  version: 2.0.0
 ---
 
 # Stay Green
 
 Write tests first, then code. Never declare work finished until all checks pass.
+This skill covers Gates 1-2 of the four-gate model in
+`.claude/agents/shared/adepthood-constraints.md`; Gates 3 (CI) and 4 (Claude
+review) live in `ci-debugging` and `address-feedback`.
 
 ## Instructions
 
@@ -21,34 +25,67 @@ Write tests first, then code. Never declare work finished until all checks pass.
 
 1. **Red** - Write a failing test describing the behavior you want
    ```bash
-   ./scripts/test.sh --all  # Should fail
+   ./scripts/backend/test.sh <path/to/test_file.py>  # Should fail
    ```
 
 2. **Green** - Write just enough code to make the test pass
    ```bash
-   ./scripts/test.sh --all  # Should pass
+   ./scripts/backend/test.sh <path/to/test_file.py>  # Should pass
    ```
 
 3. **Refactor** - Clean up while keeping tests green
    ```bash
-   ./scripts/test.sh --all  # Should still pass
+   ./scripts/backend/test.sh <path/to/test_file.py>  # Should still pass
    ```
 
-Repeat for each small piece of functionality. Write tests incrementally, not all at once.
+Repeat for each small piece of functionality. Write tests incrementally, not
+all at once. A positional path runs unsharded, without coverage, and never
+touches the whole-suite lock, so it is cheap enough to run every cycle.
 
-### Gate 2: Pre-Commit Quality Checks
+### Gate 2: `check-all.sh`, once, when Gate 1 is green
+
+The gate ladder runs each rung once — running one on top of another buys
+nothing and doubles the wait:
+
+| Rung | Runs | Cost |
+| --- | --- | --- |
+| `./scripts/backend/test.sh <paths>` (targeted) | every Red-Green cycle | seconds |
+| `./scripts/<side>/check-all.sh` | once, when Gate 1 is green | ~4m23s cold backend; ~8s on a receipt hit |
+| `git commit` hooks (staged files only) | automatic | seconds to ~1 min |
+| `git push` hooks (full suite + coverage) | automatic | ~5 min |
 
 ```bash
-pre-commit run --all-files
+./scripts/backend/check-all.sh    # drift preflight, lint, format, mypy,
+                                  # security, complexity, tests, coverage
 ```
 
 When checks fail: read errors, fix issues, run again. Repeat until all green.
+`./scripts/<side>/fix-all.sh` auto-fixes lint/format; never hand-patch what
+the formatter owns.
 
-Quality checks include: formatting (Black + isort), linting (Ruff), type checking (MyPy), complexity (xenon A grade, <=5 per block), security (Bandit), tests with coverage (>=90%), file hygiene.
+Quality checks include: formatting (ruff-format), linting (ruff), type
+checking (mypy), complexity (xenon A grade, radon MI >= B), security
+(bandit + pip-audit), tests with coverage (>=90%), file hygiene.
+
+Do not also hand-run `pre-commit run --all-files` before every commit --
+`git commit` already re-runs lint/format/type checks on your staged diff
+seconds later, and `check-all.sh` already swept the whole tree, so the ritual
+whole-tree pass earns nothing those two didn't already cover. Reserve it for
+what staged-file hooks cannot see: a wide rename, a suspected cross-file type
+error, or a change to the hook configuration itself.
+
+A whole-suite `test.sh` run (no positional path) takes an exclusive
+per-worktree lock at `.gate-state/locks/backend-suite.lock`. A second
+whole-suite run racing against itself in the same worktree exits 3, naming the
+holding PID, rather than corrupting the shared coverage file and fixture
+databases both runs would otherwise write. On exit 3: wait for the in-flight
+run, do not route around the lock. A failure observed while another
+whole-suite run was concurrently in flight is unproven until it is re-run
+alone.
 
 ### Work is DONE when:
 1. All tests pass (Gate 1 complete)
-2. All pre-commit checks pass (Gate 2 complete)
+2. `check-all.sh` exits 0 (Gate 2 complete)
 
 No exceptions.
 
@@ -71,19 +108,20 @@ def calculate_cost(impressions: int, cpm: float) -> float:
     return impressions * (cpm / 1000)
 
 # Gate 1 - Refactor: (already clean, move on)
-# Gate 2: pre-commit run --all-files -> All passed!
+# Gate 2: ./scripts/backend/check-all.sh -> All passed!
 ```
 
 ### Example 2: Fixing a Formatting Failure
 
 ```bash
 # Gate 2 fails on formatting
-$ pre-commit run --all-files
-black....Failed
+$ ./scripts/backend/check-all.sh
+Running: Formatting
+...failed
 
 # Auto-fix and re-run
-$ ./scripts/format.sh --fix
-$ pre-commit run --all-files
+$ ./scripts/backend/fix-all.sh
+$ ./scripts/backend/check-all.sh
 # All passed!
 ```
 
@@ -91,20 +129,20 @@ $ pre-commit run --all-files
 
 ### Error: Coverage below 90%
 ```bash
-./scripts/test.sh --all --coverage  # See what's not covered
-# Add tests for uncovered lines, then re-run pre-commit
+./scripts/backend/coverage.sh  # See what's not covered
+# Add tests for uncovered lines, then re-run ./scripts/backend/check-all.sh
 ```
 
 ### Error: Complexity worse than A grade (cyclomatic 5, maintainability rank B)
 ```bash
 ./scripts/backend/complexity.sh  # Find complex functions
 # Extract helper functions, simplify branching
-# Then verify: ./scripts/backend/complexity.sh && pre-commit run --all-files
+# Then verify: ./scripts/backend/complexity.sh && ./scripts/backend/check-all.sh
 ```
 
 ### Error: Type errors from MyPy
 ```bash
-./scripts/typecheck.sh  # See specific errors
+./scripts/backend/typecheck.sh  # See specific errors
 # Add/fix type annotations
-# Then verify: ./scripts/typecheck.sh && pre-commit run --all-files
+# Then verify: ./scripts/backend/typecheck.sh && ./scripts/backend/check-all.sh
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,12 @@ scripts/ralph/state.json
 # Knowledge-graph build artifacts (rebuilt locally / via release; see scripts/graph/)
 graphify-out/
 
+# Gate receipts and suite locks (scripts/quality/verified.sh) — machine-local
+# verification state, keyed on this checkout's contents, interpreter, packages
+# and host. A committed receipt would hand every other machine a green nobody
+# earned there.
+.gate-state/
+
 # Coordinates of the server one e2e run booted — a dead port from a previous run
 # would be worse than no file at all, so it is never shared and never committed.
 frontend/e2e/.e2e-state.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ Agents working on this project must abide by the following operating principles:
   - Every bug fix must include a failing test that reproduces the bug before it is resolved.
 
 2. **CI is Your Feedback Loop**
-  - Always run `pre-commit run --all-files` before attempting a commit
+  - Run the relevant `./scripts/<side>/check-all.sh` before opening a PR; reserve
+    a full `pre-commit run --all-files` sweep for a wide rename, a suspected
+    cross-file type error, or a hook-config change — `git commit` already
+    re-runs the hooks on your staged diff
 
   - GitHub Actions is the source of truth for project health.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,9 @@ once:
    backend; ~8s when it reuses a receipt for an unchanged tree).
 3. **Git hooks** (automatic): `git commit` runs the pre-commit-stage hooks on
    your staged files; `git push` runs the pre-push-stage hooks (full suite +
-   coverage + complexity).
+   coverage + complexity) — but only where the `pre-push` hook type is
+   installed, which `scripts/dev-setup.sh` does not do today. CI runs that
+   stage regardless; a silent push is not a pass.
 4. **CI**: all of the above plus cross-version compat (3.11/3.12/3.13),
    docstring coverage, branch coverage, security audit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,11 @@ pip install -r backend/requirements.txt -r backend/requirements-dev.txt
 # Installs what is missing but never what is stale; scripts/backend/deps.sh fails the gate on drift
 
 # Quality checks
-pre-commit run --all-files          # Run ALL hooks — do this before every commit
+pre-commit run --all-files          # Whole-tree sweep — reserve for a wide
+                                    # rename, a suspected cross-file type
+                                    # error, or a hook-config change; git
+                                    # commit already re-runs the hooks on
+                                    # your staged diff seconds later
 pre-commit run <hook-id> --all-files  # Run a specific hook
 
 # Backend
@@ -89,7 +93,10 @@ cd frontend && npx tsc --noEmit     # Type check
 - Read issue files and acceptance criteria before starting work
 - Follow the dependency graph in `prompts/github-issues/README.md`
 - Use TDD: write the test first, watch it fail, then implement
-- Run `pre-commit run --all-files` before every commit attempt
+- Run `./scripts/<side>/check-all.sh` once Gate 1 is green; reserve a full
+  `pre-commit run --all-files` sweep for a wide rename, a suspected
+  cross-file type error, or a hook-config change — `git commit` already
+  re-runs the hooks on your staged diff
 - Use conventional commit messages (enforced by commitlint)
 - Keep commits small and atomic — one logical change each
 - Respect existing patterns and conventions in the codebase
@@ -116,11 +123,18 @@ cd frontend && npx tsc --noEmit     # Type check
 - **Complexity:** xenon A-grade absolute/modules/average, radon MI ≥ B
 
 ### Stay Green Workflow
-Quality is enforced through a 3-gate process:
-1. **Gate 1 — Pre-commit** (~10s): format + lint + hygiene (28 hooks)
-2. **Gate 2 — Pre-push**: full test suite + coverage + complexity
-3. **Gate 3 — CI**: all of the above + cross-version compat (3.11/3.12/3.13)
-   + docstring coverage + branch coverage + security audit
+Quality is enforced through a graduated ladder, cheapest first, each rung run
+once:
+1. **Targeted tests** (`./scripts/backend/test.sh <paths>`) on every TDD
+   red → green cycle: seconds.
+2. **`./scripts/<side>/check-all.sh`**, once targeted tests are green: lint,
+   format, mypy, security, complexity, full suite, coverage (~4m23s cold
+   backend; ~8s when it reuses a receipt for an unchanged tree).
+3. **Git hooks** (automatic): `git commit` runs the pre-commit-stage hooks on
+   your staged files; `git push` runs the pre-push-stage hooks (full suite +
+   coverage + complexity).
+4. **CI**: all of the above plus cross-version compat (3.11/3.12/3.13),
+   docstring coverage, branch coverage, security audit.
 
 Never commit with `--no-verify`. Never push with failing gates. If a gate
 fails, fix the root cause — don't suppress the check.

--- a/backend/tests/scripts/test_backend_test_runner.py
+++ b/backend/tests/scripts/test_backend_test_runner.py
@@ -1,0 +1,609 @@
+"""Tests for the suite lock and targeted runs in ``scripts/backend/test.sh``.
+
+Two whole-suite runs in one tree fight over the same coverage data file, the
+same SQLite fixtures, and the same CPU allotment that ``-n auto`` sized for one
+process. The results they print are not wrong so much as unproven: neither run
+observed the machine it claims to describe. The lock below refuses the second
+run outright rather than letting it produce a number nobody can act on, and it
+does so by PID so a crashed run cannot wedge the tree forever.
+
+The second half of the contract is the targeted run. Driving a single test file
+through this script currently means either editing it or bypassing it, because
+the whole-suite argv -- xdist distribution and marker selection -- is applied
+unconditionally. That is what pushes people to call ``pytest`` directly during
+the red-to-green loop, which is also how they discover the hard way that a
+partial run cannot satisfy a whole-repo coverage threshold. So a positional path
+runs exactly that path, unsharded and unfiltered, and asking for coverage
+alongside it is a usage error rather than a confusing failure at the end.
+
+Every test copies the real script into a miniature checkout under ``tmp_path``
+and drives it through a fake ``pytest`` on ``PATH`` that records its argv, can
+be told to fail, can report what the lock file held while it ran, and can
+overwrite the lock to impersonate another owner. Invoking the real runner here
+is not merely slow: this file executes inside the very suite the lock guards, so
+a real whole-suite run would take the lock against itself and hang.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TEST_SCRIPT = _REPO_ROOT / "scripts" / "backend" / "test.sh"
+
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+# Documented exit codes. 3 is new and deliberately distinct from 1: "your tests
+# failed" and "this result would not have been trustworthy" call for opposite
+# responses from the operator.
+_PASSED_EXIT_CODE = 0
+_TESTS_FAILED_EXIT_CODE = 1
+_USAGE_ERROR_EXIT_CODE = 2
+_REFUSED_EXIT_CODE = 3
+
+_LOCK_RELATIVE_PATH = Path(".gate-state") / "locks" / "backend-suite.lock"
+
+# The whole-suite argv, which a targeted run must not inherit: xdist would shard
+# a single file across workers whose module-scoped database fixtures assume one
+# worker per file, and the marker expression would silently drop a test the
+# caller named explicitly.
+_WORKER_FLAG = "-n"
+_DIST_FLAG = "--dist"
+_DIST_STRATEGY = "loadfile"
+_MARKER_FLAG = "-m"
+_UNIT_MARKER_EXPRESSION = "not integration and not e2e"
+_WHOLE_SUITE_TARGET = "tests/"
+
+_TARGETED_PATH = "tests/test_fixture_module.py"
+_TARGETED_NODE_ID = "tests/test_fixture_module.py::test_one_behaviour"
+
+_COVERAGE_FLAG = "--coverage"
+_COVERAGE_DATA_FLAG = "--coverage-data"
+_UNKNOWN_FLAG = "--not-a-real-option"
+
+# The words the refusal has to carry: the rule, so the operator understands the
+# refusal is about trust rather than about tidiness, and the threshold, so the
+# coverage rejection points at the reason instead of just saying no.
+_UNPROVEN_MARKER = "unproven"
+_THRESHOLD_MARKER = "threshold"
+
+_PYTEST_LOG_ENV = "ADEPTHOOD_FAKE_PYTEST_LOG"
+_PYTEST_EXIT_ENV = "ADEPTHOOD_FAKE_PYTEST_EXIT"
+_LOCK_FILE_ENV = "ADEPTHOOD_LOCK_FILE"
+_LOCK_PROBE_ENV = "ADEPTHOOD_LOCK_PROBE"
+_HIJACK_PID_ENV = "ADEPTHOOD_HIJACK_PID"
+_PATH_ENV = "PATH"
+
+_ARGV_MARKER = "--ARGV--"
+_SHIM_MODE = 0o755
+_SHIM_DIR_NAME = "bin"
+_CHECKOUT_DIR_NAME = "repo"
+_OTHER_CHECKOUT_DIR_NAME = "other-repo"
+
+_SCRIPT_RELATIVE_PATH = Path("scripts") / "backend" / "test.sh"
+_BACKEND_TESTS_DIR = Path("backend") / "tests"
+
+# A PID that no longer exists, standing in for a run killed mid-suite.
+_DEAD_PID_SEARCH_START = 40000
+_DEAD_PID_SEARCH_STOP = 49999
+
+# The signals the release has to survive. A lock left behind by a run cancelled
+# with a keystroke wedges the tree until somebody deletes a file they have never
+# heard of, and the second-best outcome of that is a bypass flag.
+_TRAP_SIGNALS = ("EXIT", "INT", "TERM")
+_TRAP_KEYWORD = "trap"
+
+_HIJACKING_PID = "999999"
+
+# Placeholders are substituted by replacement rather than by ``str.format`` so
+# the shell's own ``${...}`` expansions do not have to be brace-escaped, which
+# is how a shim ends up writing to a path named after a literal dollar sign.
+_PYTEST_SHIM = """#!/usr/bin/env bash
+{ printf '%s\\n' "@MARKER@"; printf '%s\\n' "$@"; } >> "@LOG@"
+if [ -n "${@PROBE@:-}" ] && [ -f "@LOCK@" ]; then
+    cp "@LOCK@" "${@PROBE@}"
+fi
+if [ -n "${@HIJACK@:-}" ]; then
+    printf '%s\\n' "${@HIJACK@}" > "@LOCK@"
+fi
+exit "${@EXIT@:-0}"
+"""
+
+
+def _bash_executable() -> str:
+    """Return an absolute path to bash, failing the test if there is none.
+
+    Returns:
+        The resolved interpreter path.
+    """
+    found = shutil.which("bash")
+    if found is None:
+        pytest.fail("bash is required to exercise the shell scripts under test")
+    return found
+
+
+def _dead_pid() -> int:
+    """Return a PID that is not running, for the stale-lock cases.
+
+    Returns:
+        A process id no live process holds.
+    """
+    for candidate in range(_DEAD_PID_SEARCH_START, _DEAD_PID_SEARCH_STOP):
+        try:
+            os.kill(candidate, 0)
+        except ProcessLookupError:
+            return candidate
+        except PermissionError:
+            continue
+    pytest.fail("no unused process id could be found for the stale-lock fixture")
+
+
+def _invocations(log: Path) -> list[list[str]]:
+    """Return the argv of every fake ``pytest`` call, one list per call.
+
+    Args:
+        log: File the shim appends to; absent until pytest is invoked once.
+
+    Returns:
+        The recorded argument lists, in invocation order.
+    """
+    if not log.exists():
+        return []
+    chunks = log.read_text().split(f"{_ARGV_MARKER}\n")
+    return [[line for line in chunk.splitlines() if line] for chunk in chunks if chunk.strip()]
+
+
+@dataclass(frozen=True)
+class _Runner:
+    """A miniature checkout the real test runner can be relocated into."""
+
+    root: Path
+    script: Path
+    log: Path
+    env: dict[str, str]
+
+    def run(
+        self,
+        *args: str,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Invoke the runner and capture its outcome.
+
+        Args:
+            *args: Flags and positional paths passed to the script.
+            extra_env: Additional environment entries, such as a forced exit.
+
+        Returns:
+            The completed process, never raising on a non-zero exit code.
+        """
+        return subprocess.run(
+            [_bash_executable(), str(self.script), *args],
+            cwd=self.root,
+            env={**self.env, **(extra_env or {})},
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+
+    def lock_path(self) -> Path:
+        """Return this tree's whole-suite lock location.
+
+        Returns:
+            The lock path, whether or not it exists yet.
+        """
+        return self.root / _LOCK_RELATIVE_PATH
+
+    def hold_lock(self, pid: int) -> Path:
+        """Plant a lock file naming the given process.
+
+        Args:
+            pid: Process id recorded as the holder.
+
+        Returns:
+            The lock path that was written.
+        """
+        lock = self.lock_path()
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text(f"{pid}\n")
+        return lock
+
+    def invocations(self) -> list[list[str]]:
+        """Return the argv of every fake ``pytest`` call.
+
+        Returns:
+            The recorded argument lists, in invocation order.
+        """
+        return _invocations(self.log)
+
+    def only_invocation(self) -> list[str]:
+        """Return the argv of the single expected ``pytest`` call.
+
+        Returns:
+            The recorded argument list.
+        """
+        calls = self.invocations()
+        if len(calls) != 1:
+            pytest.fail(f"expected exactly one pytest invocation; got: {calls}")
+        return calls[0]
+
+    def output(self, result: subprocess.CompletedProcess[str]) -> str:
+        """Return both captured streams lowercased, for substring assertions.
+
+        Args:
+            result: A completed process whose streams were captured.
+
+        Returns:
+            stdout and stderr concatenated and lowercased.
+        """
+        return f"{result.stdout}{result.stderr}".lower()
+
+
+def _stage_runner(parent: Path, *, directory_name: str = _CHECKOUT_DIR_NAME) -> _Runner:
+    """Build a checkout holding the real runner and a fake ``pytest``.
+
+    Args:
+        parent: Directory the checkout and its shim are created under.
+        directory_name: Name of the tree root, so two independent trees can
+            coexist for the cross-tree isolation case.
+
+    Returns:
+        The staged runner, ready to invoke.
+    """
+    root = parent / directory_name
+    (root / _SCRIPT_RELATIVE_PATH.parent).mkdir(parents=True)
+    (root / _BACKEND_TESTS_DIR).mkdir(parents=True)
+    shutil.copy(_TEST_SCRIPT, root / _SCRIPT_RELATIVE_PATH)
+
+    shim_dir = parent / f"{_SHIM_DIR_NAME}-{directory_name}"
+    shim_dir.mkdir(parents=True)
+    log = parent / f"pytest-calls-{directory_name}.log"
+    lock = root / _LOCK_RELATIVE_PATH
+    shim = shim_dir / "pytest"
+    substitutions = {
+        "@MARKER@": _ARGV_MARKER,
+        "@LOG@": str(log),
+        "@LOCK@": str(lock),
+        "@PROBE@": _LOCK_PROBE_ENV,
+        "@HIJACK@": _HIJACK_PID_ENV,
+        "@EXIT@": _PYTEST_EXIT_ENV,
+    }
+    body = _PYTEST_SHIM
+    for placeholder, value in substitutions.items():
+        body = body.replace(placeholder, value)
+    shim.write_text(body)
+    shim.chmod(_SHIM_MODE)
+
+    env = dict(os.environ)
+    env[_PATH_ENV] = f"{shim_dir}{os.pathsep}{env[_PATH_ENV]}"
+    env[_PYTEST_LOG_ENV] = str(log)
+    env[_LOCK_FILE_ENV] = str(lock)
+    for knob in (_PYTEST_EXIT_ENV, _LOCK_PROBE_ENV, _HIJACK_PID_ENV):
+        env.pop(knob, None)
+
+    return _Runner(root=root, script=root / _SCRIPT_RELATIVE_PATH, log=log, env=env)
+
+
+@pytest.fixture
+def runner(tmp_path: Path) -> _Runner:
+    """Return a staged runner with the fake ``pytest`` in place.
+
+    Args:
+        tmp_path: Per-test directory holding the checkout, shim and log.
+
+    Returns:
+        The staged runner under test.
+    """
+    return _stage_runner(tmp_path)
+
+
+def test_a_second_whole_suite_run_is_refused_while_one_is_in_flight(
+    runner: _Runner,
+) -> None:
+    """Two suites in one tree produce two results and prove neither.
+
+    They share the coverage data file, the fixture database, and the cores that
+    ``-n auto`` allocated to a single process. The honest response is to refuse
+    the second run and say why, because a red that came from contention teaches
+    the operator to rerun until green, which is how a real failure gets rerun
+    away.
+    """
+    holder = os.getpid()
+    runner.hold_lock(holder)
+
+    result = runner.run()
+
+    assert result.returncode == _REFUSED_EXIT_CODE, (
+        f"a contended whole-suite run must exit {_REFUSED_EXIT_CODE}, distinctly "
+        f"from a test failure; got exit {result.returncode} with "
+        f"stderr: {result.stderr!r}"
+    )
+    assert str(holder) in f"{result.stdout}{result.stderr}", (
+        f"the refusal must name the holding PID so it can be inspected or "
+        f"killed; got: {result.stderr!r}"
+    )
+    assert _UNPROVEN_MARKER in runner.output(result), (
+        f"the refusal must state that a contended result is unproven until "
+        f"re-run alone; got: {result.stderr!r}"
+    )
+    assert runner.invocations() == [], "a refused run must not start pytest at all"
+
+
+def test_a_lock_held_by_a_dead_process_is_stolen(runner: _Runner) -> None:
+    """A crashed run must not wedge the tree until somebody deletes a file.
+
+    A lock nobody can clear is worse than no lock: the documented workaround
+    becomes deleting state by hand, and the next step from there is bypassing
+    the gate entirely.
+    """
+    runner.hold_lock(_dead_pid())
+
+    result = runner.run()
+
+    assert result.returncode == _PASSED_EXIT_CODE, (
+        f"a stale lock must be stolen, not obeyed; got exit {result.returncode} "
+        f"with stderr: {result.stderr!r}"
+    )
+    assert len(runner.invocations()) == 1, runner.invocations()
+    assert not runner.lock_path().exists(), "the stolen lock must be released at the end"
+
+
+def test_the_lock_is_held_for_the_duration_and_released_afterwards(
+    runner: _Runner,
+    tmp_path: Path,
+) -> None:
+    """The lock exists while the suite runs and is gone once it stops.
+
+    Taking it after the suite, or never writing the PID into it, would leave the
+    refusal above with nothing to detect and nothing to name.
+    """
+    probe = tmp_path / "lock-during-run.txt"
+
+    result = runner.run(extra_env={_LOCK_PROBE_ENV: str(probe)})
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    assert probe.exists(), "no lock file existed while the suite was running"
+    recorded = probe.read_text().strip()
+    assert recorded.isdigit(), (
+        f"the lock must contain the holding PID so a stale one can be detected; got: {recorded!r}"
+    )
+    assert recorded != str(os.getpid()), (
+        "the lock recorded this test process rather than the running script"
+    )
+    assert not runner.lock_path().exists(), "the lock must be released when the run ends"
+
+
+def test_the_lock_is_released_after_a_failing_run(
+    runner: _Runner,
+    tmp_path: Path,
+) -> None:
+    """Failing tests are the normal case, so they must not leave a lock behind.
+
+    Releasing only on success would mean the first red run blocks every
+    subsequent run in that tree, which converts an ordinary failure into an
+    unexplained refusal. The probe is what makes this test mean something: a
+    run that never took the lock at all would also end with no lock file.
+    """
+    probe = tmp_path / "lock-during-failing-run.txt"
+
+    result = runner.run(
+        extra_env={
+            _PYTEST_EXIT_ENV: str(_TESTS_FAILED_EXIT_CODE),
+            _LOCK_PROBE_ENV: str(probe),
+        },
+    )
+
+    assert result.returncode == _TESTS_FAILED_EXIT_CODE, (
+        f"test failures must still exit {_TESTS_FAILED_EXIT_CODE}; got exit "
+        f"{result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert probe.exists(), "the failing run never held the lock, so releasing it proves nothing"
+    assert not runner.lock_path().exists(), (
+        "a failing run left its lock behind, so the next run in this tree is refused"
+    )
+
+
+def test_a_run_does_not_release_a_lock_it_no_longer_owns(runner: _Runner) -> None:
+    """Release is by ownership, not by path.
+
+    If the holder was stolen from -- because this run overran and another took
+    over -- deleting the file on the way out would strip the new owner's
+    protection and let a third run start against a suite already in flight.
+    """
+    result = runner.run(extra_env={_HIJACK_PID_ENV: _HIJACKING_PID})
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    lock = runner.lock_path()
+    assert lock.exists(), (
+        "the lock was removed by a process that no longer owned it, unprotecting "
+        "whichever run took it over"
+    )
+    assert lock.read_text().strip() == _HIJACKING_PID, lock.read_text()
+
+
+def test_the_release_trap_covers_interruption_and_termination() -> None:
+    """A cancelled run releases its lock, or the tree is wedged by a keystroke.
+
+    Read statically because the interesting states are a signal delivered
+    mid-suite, which cannot be staged without running a suite.
+    """
+    trap_lines = [
+        line.strip()
+        for line in _TEST_SCRIPT.read_text().splitlines()
+        if line.strip().startswith(_TRAP_KEYWORD)
+    ]
+
+    assert trap_lines, f"{_TEST_SCRIPT.name} installs no trap, so a cancelled run keeps the lock"
+    assert any(all(signal in line.split() for signal in _TRAP_SIGNALS) for line in trap_lines), (
+        f"one trap must cover {list(_TRAP_SIGNALS)}; got: {trap_lines}"
+    )
+
+
+def test_a_lock_in_another_tree_does_not_block_this_one(
+    runner: _Runner,
+    tmp_path: Path,
+) -> None:
+    """Worktree lanes run in parallel and must not serialise against each other.
+
+    The contention being prevented is over one tree's shared files. A lock keyed
+    anywhere but the tree root would collapse four independent lanes into a
+    queue and cost more time than the whole change saves.
+    """
+    other = _stage_runner(tmp_path, directory_name=_OTHER_CHECKOUT_DIR_NAME)
+    other.hold_lock(os.getpid())
+
+    result = runner.run()
+
+    assert result.returncode == _PASSED_EXIT_CODE, (
+        f"a lock held in an unrelated tree blocked this one; got exit "
+        f"{result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert len(runner.invocations()) == 1, runner.invocations()
+
+
+def test_a_targeted_run_neither_takes_nor_blocks_on_the_lock(runner: _Runner) -> None:
+    """One file is cheap and shares almost nothing, so it is allowed to proceed.
+
+    Blocking it would make the red-to-green loop wait on a suite the developer
+    is not interested in, and taking the lock would let a trivial run refuse the
+    whole-suite run behind it. The warning is what stops a surprising result
+    from being read as a real one, since the machine really is busy.
+    """
+    holder = os.getpid()
+    lock = runner.hold_lock(holder)
+
+    result = runner.run(_TARGETED_PATH)
+
+    assert result.returncode == _PASSED_EXIT_CODE, (
+        f"a targeted run must not be blocked by the suite lock; got exit "
+        f"{result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert str(holder) in f"{result.stdout}{result.stderr}", (
+        f"a targeted run under contention must warn and name the holder; got: "
+        f"{result.stdout!r} {result.stderr!r}"
+    )
+    assert lock.read_text().strip() == str(holder), (
+        "a targeted run must leave the whole-suite lock exactly as it found it"
+    )
+
+
+def test_a_targeted_run_creates_no_lock(runner: _Runner) -> None:
+    """Nothing is written for a run that does not need protecting.
+
+    A lock taken and released by every single-file run is a window in which the
+    whole-suite run is refused for no reason at all.
+    """
+    result = runner.run(_TARGETED_PATH)
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    assert not runner.lock_path().exists(), (
+        "a targeted run created the whole-suite lock, which can refuse an unrelated full run"
+    )
+
+
+def test_a_positional_path_runs_pytest_on_exactly_that_path(runner: _Runner) -> None:
+    """The named path is run, alone, unsharded and unfiltered.
+
+    Sharding one file across xdist workers breaks the module-scoped database
+    fixtures the suite relies on, and applying the unit marker expression would
+    silently drop a test the caller asked for by name. Appending the whole
+    ``tests/`` tree would quietly restore the full run the caller was avoiding.
+    """
+    result = runner.run(_TARGETED_PATH)
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    argv = runner.only_invocation()
+    assert _TARGETED_PATH in argv, f"the requested path must be run; got: {argv}"
+    for unwanted in (_WORKER_FLAG, _DIST_FLAG, _MARKER_FLAG, _WHOLE_SUITE_TARGET):
+        assert unwanted not in argv, (
+            f"a targeted run must not carry the whole-suite argument {unwanted!r}; got: {argv}"
+        )
+
+
+def test_a_node_id_is_passed_through_unchanged(runner: _Runner) -> None:
+    """A single test can be named, which is the whole point during a fix.
+
+    Rewriting or splitting the ``::`` syntax would turn a request for one test
+    into a request for its file, and the developer would never notice.
+    """
+    result = runner.run(_TARGETED_NODE_ID)
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    argv = runner.only_invocation()
+    assert _TARGETED_NODE_ID in argv, f"the node id must reach pytest intact; got: {argv}"
+
+
+@pytest.mark.parametrize("flag", [_COVERAGE_FLAG, _COVERAGE_DATA_FLAG])
+def test_coverage_with_a_positional_path_is_a_usage_error(
+    runner: _Runner,
+    flag: str,
+) -> None:
+    """A partial run cannot satisfy a whole-repo threshold, so it is refused up front.
+
+    Allowing the combination produces a run that measures one file against a
+    ninety-percent gate over the whole codebase and fails for a reason that has
+    nothing to do with the test being written. Failing at parse time, with the
+    reason stated, is the difference between a lesson and an hour lost.
+
+    Args:
+        runner: The staged runner.
+        flag: The coverage option combined with a positional path.
+    """
+    result = runner.run(flag, _TARGETED_PATH)
+
+    assert result.returncode == _USAGE_ERROR_EXIT_CODE, (
+        f"{flag} with a positional path must exit {_USAGE_ERROR_EXIT_CODE}; got "
+        f"exit {result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert _THRESHOLD_MARKER in runner.output(result), (
+        f"the refusal must explain that a partial run cannot meet a whole-repo "
+        f"coverage threshold; got: {result.stderr!r}"
+    )
+    assert runner.invocations() == [], "a usage error must not start pytest"
+
+
+def test_an_unknown_flag_is_still_a_usage_error(runner: _Runner) -> None:
+    """Accepting positional paths must not turn a typo into a silent path.
+
+    Existing contract, pinned so the new parsing keeps it: a mistyped option
+    that fell through to the positional list would be handed to pytest as a
+    file name and reported as a collection error nobody can read.
+    """
+    result = runner.run(_UNKNOWN_FLAG)
+
+    assert result.returncode == _USAGE_ERROR_EXIT_CODE, (
+        f"got exit {result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert _UNKNOWN_FLAG in result.stderr, (
+        f"stderr must name the rejected flag; got: {result.stderr!r}"
+    )
+
+
+def test_a_whole_suite_run_keeps_its_distribution_and_marker_selection(
+    runner: _Runner,
+) -> None:
+    """The default invocation is unchanged by the addition of targeted runs.
+
+    The distribution strategy and the marker expression are what make the full
+    run correct and fast; a refactor that reached them while adding positional
+    handling would quietly change what the gate measures.
+    """
+    result = runner.run()
+
+    assert result.returncode == _PASSED_EXIT_CODE, result.stderr
+    argv = runner.only_invocation()
+    for expected in (
+        _WORKER_FLAG,
+        _DIST_FLAG,
+        _DIST_STRATEGY,
+        _MARKER_FLAG,
+        _UNIT_MARKER_EXPRESSION,
+        _WHOLE_SUITE_TARGET,
+    ):
+        assert expected in argv, f"the whole-suite invocation lost {expected!r}; got: {argv}"

--- a/backend/tests/scripts/test_backend_test_runner.py
+++ b/backend/tests/scripts/test_backend_test_runner.py
@@ -16,19 +16,33 @@ partial run cannot satisfy a whole-repo coverage threshold. So a positional path
 runs exactly that path, unsharded and unfiltered, and asking for coverage
 alongside it is a usage error rather than a confusing failure at the end.
 
+Taking the lock is atomic; recovering from a stale one is the part that is not.
+The recovery reads the holder, decides it is dead, removes the file, and creates
+its own -- four steps, with a whole scheduling quantum available between any two
+of them. Two runs that both looked at the same dead PID can therefore both come
+away owning the suite, the second having deleted the first's brand-new lock on
+the strength of a decision about a file that no longer existed. That is the one
+outcome the lock exists to prevent, so it is tested by holding the window open
+on purpose rather than by racing for it.
+
 Every test copies the real script into a miniature checkout under ``tmp_path``
 and drives it through a fake ``pytest`` on ``PATH`` that records its argv, can
-be told to fail, can report what the lock file held while it ran, and can
-overwrite the lock to impersonate another owner. Invoking the real runner here
-is not merely slow: this file executes inside the very suite the lock guards, so
-a real whole-suite run would take the lock against itself and hang.
+be told to fail, can report what the lock file held while it ran, can overwrite
+the lock to impersonate another owner, and can block until the test releases it.
+A ``head`` shim beside it can freeze a run just after it has read the lock file,
+which is the read half of the read-decide-remove-create sequence. Invoking the
+real runner here is not merely slow: this file executes inside the very suite the
+lock guards, so a real whole-suite run would take the lock against itself and
+hang.
 """
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -80,6 +94,23 @@ _LOCK_PROBE_ENV = "ADEPTHOOD_LOCK_PROBE"
 _HIJACK_PID_ENV = "ADEPTHOOD_HIJACK_PID"
 _PATH_ENV = "PATH"
 
+# Each names a file the corresponding shim waits for before returning, so a run
+# can be frozen at a chosen point. ``pytest`` freezes a run that already holds
+# the lock; ``head`` freezes one immediately after it has read the lock file,
+# which is where the stale-lock recovery makes its decision.
+_PYTEST_GATE_ENV = "ADEPTHOOD_PYTEST_GATE"
+_HEAD_GATE_ENV = "ADEPTHOOD_HEAD_GATE"
+
+# Written by a shim once it is actually blocked, so the test waits on an
+# observed state rather than on a duration.
+_BLOCKED_MARKER_SUFFIX = ".blocked"
+_GATE_RELEASE_TEXT = "go\n"
+_GATE_POLL_SECONDS = 0.02
+_GATE_WAIT_TIMEOUT_SECONDS = 30.0
+
+_WINNER_GATE_NAME = "winner-pytest-gate"
+_LOSER_GATE_NAME = "loser-head-gate"
+
 _ARGV_MARKER = "--ARGV--"
 _SHIM_MODE = 0o755
 _SHIM_DIR_NAME = "bin"
@@ -112,7 +143,27 @@ fi
 if [ -n "${@HIJACK@:-}" ]; then
     printf '%s\\n' "${@HIJACK@}" > "@LOCK@"
 fi
+gate="${@PYTEST_GATE@:-}"
+if [ -n "$gate" ] && [ ! -f "$gate" ]; then
+    : > "$gate@BLOCKED@"
+    while [ ! -f "$gate" ]; do sleep @POLL@; done
+fi
 exit "${@EXIT@:-0}"
+"""
+
+# Reads the lock file for real, then -- and only when the gate variable names a
+# file that does not exist yet -- stalls before handing the answer back. That
+# reproduces a run descheduled after the read in the read-decide-remove-create
+# recovery, with the decision already made against the state it saw. Untouched
+# in every other test: with the variable unset it is a plain delegation.
+_HEAD_SHIM = """#!/usr/bin/env bash
+answer="$("@REAL@" "$@")"
+gate="${@HEAD_GATE@:-}"
+if [ -n "$gate" ] && [ ! -f "$gate" ]; then
+    : > "$gate@BLOCKED@"
+    while [ ! -f "$gate" ]; do sleep @POLL@; done
+fi
+printf '%s\\n' "$answer"
 """
 
 
@@ -126,6 +177,66 @@ def _bash_executable() -> str:
     if found is None:
         pytest.fail("bash is required to exercise the shell scripts under test")
     return found
+
+
+def _real_executable(name: str) -> str:
+    """Return the absolute path of a command before a shim shadows it.
+
+    Args:
+        name: Command whose real implementation a shim delegates to.
+
+    Returns:
+        The resolved path to the real command.
+    """
+    found = shutil.which(name)
+    if found is None:
+        pytest.fail(f"{name} is required to build the shim for {name}")
+    return found
+
+
+def _blocked_marker(gate: Path) -> Path:
+    """Return the file a shim creates once it is blocked on this gate.
+
+    Args:
+        gate: Path the shim waits for.
+
+    Returns:
+        The announcement file's path.
+    """
+    return Path(f"{gate}{_BLOCKED_MARKER_SUFFIX}")
+
+
+def _release(gate: Path) -> None:
+    """Let whatever is blocked on this gate proceed; safe to call twice.
+
+    Args:
+        gate: Path the shim waits for.
+    """
+    gate.write_text(_GATE_RELEASE_TEXT)
+
+
+def _wait_until_blocked(
+    gate: Path,
+    process: subprocess.Popen[str],
+    reason: str,
+) -> None:
+    """Block until a run announces it is frozen, failing rather than hanging.
+
+    Args:
+        gate: Path the shim waits for; its marker is what this waits on.
+        process: The run expected to reach the shim, so an early exit is
+            reported as itself instead of as a timeout.
+        reason: What the absent marker would mean, for the failure message.
+    """
+    marker = _blocked_marker(gate)
+    deadline = time.monotonic() + _GATE_WAIT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if marker.exists():
+            return
+        if process.poll() is not None:
+            pytest.fail(f"{reason}: the run exited {process.returncode} instead")
+        time.sleep(_GATE_POLL_SECONDS)
+    pytest.fail(f"{reason}: {marker} never appeared within {_GATE_WAIT_TIMEOUT_SECONDS}s")
 
 
 def _dead_pid() -> int:
@@ -190,6 +301,29 @@ class _Runner:
             text=True,
             check=False,
             timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+
+    def spawn(
+        self,
+        *args: str,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.Popen[str]:
+        """Start the runner without waiting for it, for the concurrency cases.
+
+        Args:
+            *args: Flags and positional paths passed to the script.
+            extra_env: Additional environment entries, such as a shim gate.
+
+        Returns:
+            The running process, to be waited on once the test releases it.
+        """
+        return subprocess.Popen(
+            [_bash_executable(), str(self.script), *args],
+            cwd=self.root,
+            env={**self.env, **(extra_env or {})},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
 
     def lock_path(self) -> Path:
@@ -265,7 +399,6 @@ def _stage_runner(parent: Path, *, directory_name: str = _CHECKOUT_DIR_NAME) -> 
     shim_dir.mkdir(parents=True)
     log = parent / f"pytest-calls-{directory_name}.log"
     lock = root / _LOCK_RELATIVE_PATH
-    shim = shim_dir / "pytest"
     substitutions = {
         "@MARKER@": _ARGV_MARKER,
         "@LOG@": str(log),
@@ -273,18 +406,31 @@ def _stage_runner(parent: Path, *, directory_name: str = _CHECKOUT_DIR_NAME) -> 
         "@PROBE@": _LOCK_PROBE_ENV,
         "@HIJACK@": _HIJACK_PID_ENV,
         "@EXIT@": _PYTEST_EXIT_ENV,
+        "@PYTEST_GATE@": _PYTEST_GATE_ENV,
+        "@HEAD_GATE@": _HEAD_GATE_ENV,
+        "@BLOCKED@": _BLOCKED_MARKER_SUFFIX,
+        "@POLL@": str(_GATE_POLL_SECONDS),
+        "@REAL@": _real_executable("head"),
     }
-    body = _PYTEST_SHIM
-    for placeholder, value in substitutions.items():
-        body = body.replace(placeholder, value)
-    shim.write_text(body)
-    shim.chmod(_SHIM_MODE)
+    for name, template in (("pytest", _PYTEST_SHIM), ("head", _HEAD_SHIM)):
+        body = template
+        for placeholder, value in substitutions.items():
+            body = body.replace(placeholder, value)
+        shim = shim_dir / name
+        shim.write_text(body)
+        shim.chmod(_SHIM_MODE)
 
     env = dict(os.environ)
     env[_PATH_ENV] = f"{shim_dir}{os.pathsep}{env[_PATH_ENV]}"
     env[_PYTEST_LOG_ENV] = str(log)
     env[_LOCK_FILE_ENV] = str(lock)
-    for knob in (_PYTEST_EXIT_ENV, _LOCK_PROBE_ENV, _HIJACK_PID_ENV):
+    for knob in (
+        _PYTEST_EXIT_ENV,
+        _LOCK_PROBE_ENV,
+        _HIJACK_PID_ENV,
+        _PYTEST_GATE_ENV,
+        _HEAD_GATE_ENV,
+    ):
         env.pop(knob, None)
 
     return _Runner(root=root, script=root / _SCRIPT_RELATIVE_PATH, log=log, env=env)
@@ -352,6 +498,118 @@ def test_a_lock_held_by_a_dead_process_is_stolen(runner: _Runner) -> None:
     )
     assert len(runner.invocations()) == 1, runner.invocations()
     assert not runner.lock_path().exists(), "the stolen lock must be released at the end"
+
+
+@dataclass(frozen=True)
+class _Outcome:
+    """What one of two concurrently started runs came away with."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+    def output(self) -> str:
+        """Return both captured streams, for substring assertions.
+
+        Returns:
+            stdout and stderr concatenated.
+        """
+        return f"{self.stdout}{self.stderr}"
+
+
+def _await(process: subprocess.Popen[str]) -> _Outcome:
+    """Wait for a spawned run and capture what it said.
+
+    Args:
+        process: A run started with :meth:`_Runner.spawn`.
+
+    Returns:
+        Its exit code and both streams.
+    """
+    stdout, stderr = process.communicate(timeout=_SUBPROCESS_TIMEOUT_SECONDS)
+    return _Outcome(returncode=process.returncode, stdout=stdout, stderr=stderr)
+
+
+def _race_two_stealers(runner: _Runner, tmp_path: Path) -> tuple[_Outcome, _Outcome]:
+    """Point two whole-suite runs at one stale lock with the window held open.
+
+    The loser is frozen by its ``head`` shim the instant it has read the stale
+    PID -- decision made, file not yet removed. Only then is the winner started,
+    and it is allowed to complete the whole steal and reach pytest, where its own
+    shim holds it so the lock stays taken. Releasing the loser at that point
+    replays exactly the interleaving a scheduler would produce by chance.
+
+    Args:
+        runner: The staged runner; both runs share its tree and its pytest log.
+        tmp_path: Per-test directory holding the two gate files.
+
+    Returns:
+        The outcome of the run that acquired first, then of the run that was
+        descheduled mid-recovery.
+    """
+    winner_gate = tmp_path / _WINNER_GATE_NAME
+    loser_gate = tmp_path / _LOSER_GATE_NAME
+    runner.hold_lock(_dead_pid())
+
+    with contextlib.ExitStack() as stack:
+        loser = stack.enter_context(runner.spawn(extra_env={_HEAD_GATE_ENV: str(loser_gate)}))
+        stack.callback(_release, loser_gate)
+        _wait_until_blocked(loser_gate, loser, "the second run never read the stale lock")
+
+        winner = stack.enter_context(runner.spawn(extra_env={_PYTEST_GATE_ENV: str(winner_gate)}))
+        stack.callback(_release, winner_gate)
+        _wait_until_blocked(winner_gate, winner, "the first run never reached pytest")
+
+        _release(loser_gate)
+        loser_outcome = _await(loser)
+        _release(winner_gate)
+        winner_outcome = _await(winner)
+
+    return winner_outcome, loser_outcome
+
+
+def test_two_runs_stealing_one_stale_lock_do_not_both_proceed(
+    runner: _Runner,
+    tmp_path: Path,
+) -> None:
+    """Only the fast path is atomic; the stale-lock recovery has to be too.
+
+    Recovering from a dead holder is four steps -- read the PID, judge it dead,
+    remove the file, create a new one -- and nothing binds them together. Two
+    runs that both read the same dead PID can both conclude they may steal; the
+    second then removes the first's brand-new lock on the strength of a decision
+    about a file that no longer exists, and creates its own. Both proceed, which
+    is precisely the concurrent whole-suite run the lock exists to refuse:
+    one coverage data file, one set of fixture databases, and cores that
+    ``-n auto`` handed out twice.
+
+    The assertion is on how many times pytest was started, not on the lock
+    file's contents, because starting the suite twice is the harm. A version of
+    this test that started both runs and hoped they collided would pass on a
+    loaded machine, pass on a fast one, and never once prove the window was
+    closed -- a green that means nothing is worse than no test, because it
+    licenses the next change to the recovery path.
+
+    Args:
+        runner: The staged runner.
+        tmp_path: Per-test directory holding the two shim gates.
+    """
+    winner, loser = _race_two_stealers(runner, tmp_path)
+
+    assert len(runner.invocations()) == 1, (
+        "two whole-suite runs started pytest against the same tree; the second "
+        "stole a lock it had already decided was stale. Invocations: "
+        f"{runner.invocations()}"
+    )
+    assert winner.returncode == _PASSED_EXIT_CODE, (
+        f"the run that acquired the lock must finish normally; got exit "
+        f"{winner.returncode} with stderr: {winner.stderr!r}"
+    )
+    assert loser.returncode == _REFUSED_EXIT_CODE, (
+        f"the run descheduled mid-recovery must be refused with exit "
+        f"{_REFUSED_EXIT_CODE} once it finds the lock taken; got exit "
+        f"{loser.returncode} with output: {loser.output()!r}"
+    )
 
 
 def test_the_lock_is_held_for_the_duration_and_released_afterwards(

--- a/backend/tests/scripts/test_check_all_receipt_wiring.py
+++ b/backend/tests/scripts/test_check_all_receipt_wiring.py
@@ -1,0 +1,768 @@
+"""Tests for the receipt wiring in ``scripts/backend/check-all.sh``.
+
+The gate runs every stage from scratch every time, including the runs where
+nothing it measures has moved. Absorbing main into a worktree lane routinely
+changes only planning notes, and paying a full backend suite to discover that
+is the cost this wiring removes: the gate asks the receipt primitive whether the
+verdict it already earned still describes this tree, and reuses it when it does.
+
+The danger in that trade is obvious and the tests are weighted accordingly. Most
+of them assert the gate ran anyway. The single most important one asserts that
+the security stage runs even on a short-circuit: lint, format, mypy, complexity
+and the tests are a pure function of the fingerprinted inputs, but ``pip-audit``
+consults an advisory database over the network, so an advisory published after
+the receipt was written would make an unchanged tree print green about a
+vulnerability that now exists. A cached security check is a cached lie with a
+publication date on it. The dependency-drift preflight runs for the same reason:
+it compares the installed environment against the pinned requirements, which can
+change without any file in the tree changing.
+
+Recording is fenced just as tightly. A receipt is written only when a full run
+passed every stage AND the tree was byte-identical at the start and the end of
+the run. Without that second condition, editing a file while a seven-minute
+suite is in flight records a verdict for a tree that was never tested as a
+whole -- half the run measured the old bytes and half the new.
+
+The skip is asserted to live inside the ``run_check`` helper rather than at its
+call sites, because two existing suites parse the seven ``run_check "`` lines of
+this script as text. A rewrite that renamed or restructured those calls would
+turn this change into a silent failure of unrelated tests, so the coupling is
+pinned here where it is visible.
+
+Nothing here runs a real stage. The sibling stage scripts are replaced with
+shims in a miniature checkout under ``tmp_path``: each records that it ran, can
+be told to fail, and can be told to edit the tree mid-run. Running the real
+``check-all.sh`` in place would run the very suite this change exists to stop
+re-running -- and would deadlock against the whole-suite lock while this file is
+itself executing under that suite.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts" / "backend"
+_CHECK_ALL_SCRIPT = _SCRIPTS_DIR / "check-all.sh"
+_VERIFIED_SCRIPT = _REPO_ROOT / "scripts" / "quality" / "verified.sh"
+
+_CLAUDE_DOC = _REPO_ROOT / "CLAUDE.md"
+_AGENTS_DOC = _REPO_ROOT / "AGENTS.md"
+_RALPH_PROMPT = _REPO_ROOT / "scripts" / "ralph" / "PROMPT.md"
+_STAY_GREEN_SKILL = _REPO_ROOT / ".claude" / "skills" / "stay-green" / "SKILL.md"
+
+_SUBPROCESS_TIMEOUT_SECONDS = 120
+
+_GATE = "backend"
+_FORCE_FLAG = "--force"
+
+_ALL_PASSED_EXIT_CODE = 0
+_CHECK_FAILED_EXIT_CODE = 1
+
+# Stage scripts, split by whether a receipt may excuse them. The two always-run
+# stages measure things no content hash can see: the installed environment, and
+# an advisory database that changes without the tree changing.
+_DEPS_STAGE = "deps.sh"
+_SECURITY_STAGE = "security.sh"
+_ALWAYS_RUN_STAGES = (_DEPS_STAGE, _SECURITY_STAGE)
+_SKIPPABLE_STAGES = (
+    "lint.sh",
+    "format.sh",
+    "typecheck.sh",
+    "complexity.sh",
+    "test.sh",
+    "coverage.sh",
+)
+_ALL_STAGES = (*_ALWAYS_RUN_STAGES, *_SKIPPABLE_STAGES)
+
+# The operator-visible check names, in the order the script runs them. Two other
+# suites match these as text, so the skip must not touch the call sites.
+_EXPECTED_CHECK_NAMES = (
+    "Linting",
+    "Formatting",
+    "Type checking",
+    "Security checks",
+    "Complexity analysis",
+    "Unit tests",
+    "Coverage report",
+)
+_RUN_CHECK_CALL_PREFIX = 'run_check "'
+
+_RECEIPTS_DIR = Path(".gate-state") / "receipts"
+_RECEIPT_SUFFIX = ".receipt"
+_RECORDED_AT_FIELD = "recorded_at"
+
+_TREE_CHANGED_MESSAGE = "tree changed during the run"
+_SECURITY_MENTION = "security"
+
+_MARKER_DIR_ENV = "ADEPTHOOD_MARKER_DIR"
+_FAILING_STAGE_ENV = "ADEPTHOOD_FAILING_STAGE"
+_MUTATE_ON_STAGE_ENV = "ADEPTHOOD_MUTATE_ON_STAGE"
+_MUTATE_FILE_ENV = "ADEPTHOOD_MUTATE_FILE"
+
+_PATH_ENV = "PATH"
+_VIRTUALENV_ENV = "VIRTUAL_ENV"
+_POSTGRES_URL_ENV = "TEST_POSTGRES_URL"
+_REQUIRE_POSTGRES_ENV = "INTEGRATION_LANE_REQUIRE_POSTGRES"
+_FAKE_PIP_FREEZE_ENV = "ADEPTHOOD_FAKE_PIP_FREEZE"
+_FAKE_PYTHON_VERSION_ENV = "ADEPTHOOD_FAKE_PYTHON_VERSION"
+_FAKE_HOSTNAME_ENV = "ADEPTHOOD_FAKE_HOSTNAME"
+
+_BASELINE_PIP_FREEZE = "example-package==1.0.0"
+_BASELINE_PYTHON_VERSION = "Python 3.12.0 (stub build)"
+_BASELINE_HOSTNAME = "gate-host-one"
+_BASELINE_VIRTUALENV = "/opt/gate/venv-one"
+
+_SHIM_MODE = 0o755
+_SHIM_DIR_NAME = "bin"
+_CHECKOUT_DIR_NAME = "repo"
+_MARKERS_DIR_NAME = "markers"
+_RUN_DIR_PREFIX = "run-"
+
+_CHECK_ALL_RELATIVE_PATH = Path("scripts") / "backend" / "check-all.sh"
+_VERIFIED_RELATIVE_PATH = Path("scripts") / "quality" / "verified.sh"
+_BACKEND_DIR = Path("backend")
+_MUTABLE_FILE = _BACKEND_DIR / "src" / "service.py"
+_PRE_COMMIT_CONFIG = Path(".pre-commit-config.yaml")
+
+# Comfortably above any degenerate-input floor, so the ample checkout is never
+# mistaken for a misconfigured gate.
+_TRACKED_FILE_COUNT = 80
+_SPARSE_FILE_COUNT = 0
+
+_MODULE_TEXT = '"""Fixture module measured by the backend gate."""\n\nVALUE = 1\n'
+_PYPROJECT_TEXT = "[tool.example]\nvalue = 1\n"
+_PRE_COMMIT_TEXT = "repos: []\n"
+_MID_RUN_EDIT_TEXT = "EDITED_WHILE_THE_GATE_RAN = True"
+
+_DEFAULT_BRANCH = "main"
+_INITIAL_COMMIT_MESSAGE = "stage the fixture checkout"
+_GIT_IDENTITY_ARGS = (
+    "-c",
+    "user.email=gate@example.invalid",
+    "-c",
+    "user.name=Gate Fixture",
+    "-c",
+    "commit.gpgsign=false",
+)
+
+# The documentation this change has to correct. The unconditional instruction to
+# run every hook over every file before every commit is what trains an operator
+# to treat the gate as a ritual rather than a signal; the replacement is nuanced
+# rather than absent, so only the unconditional phrasing is asserted against.
+_UNCONDITIONAL_MANDATE_CASES = (
+    pytest.param(_CLAUDE_DOC, "before every commit attempt", id="claude-guardrail"),
+    pytest.param(_CLAUDE_DOC, "do this before every commit", id="claude-command-comment"),
+    pytest.param(_AGENTS_DOC, "before attempting a commit", id="agents-feedback-loop"),
+)
+
+# The rule an operator needs when a run is refused, and the file name that lets
+# them find the lock that refused it.
+_CONCURRENCY_RULE_MARKERS = ("concurrent", "backend-suite.lock")
+_CONCURRENCY_DOC_CASES = (
+    pytest.param(_RALPH_PROMPT, id="ralph-prompt"),
+    pytest.param(_STAY_GREEN_SKILL, id="stay-green-skill"),
+)
+
+_STAGE_SHIM = """#!/usr/bin/env bash
+STAGE="@STAGE@"
+printf '%s\\n' "$*" >> "$ADEPTHOOD_MARKER_DIR/$STAGE"
+if [ "${ADEPTHOOD_MUTATE_ON_STAGE:-}" = "$STAGE" ]; then
+    printf '%s\\n' "@MID_RUN_EDIT@" >> "$ADEPTHOOD_MUTATE_FILE"
+fi
+if [ "${ADEPTHOOD_FAILING_STAGE:-}" = "$STAGE" ]; then
+    exit 1
+fi
+exit 0
+"""
+
+_PIP_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "freeze" ]; then
+    printf '%s\\n' "${{{freeze_env}:-{default}}}"
+    exit 0
+fi
+exit 0
+"""
+
+_PYTHON_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "-VV" ]; then
+    printf '%s\\n' "${{{version_env}:-{default}}}"
+    exit 0
+fi
+exec "{real}" "$@"
+"""
+
+_UNAME_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "-n" ]; then
+    printf '%s\\n' "${{{hostname_env}:-{default}}}"
+    exit 0
+fi
+exec "{real}" "$@"
+"""
+
+
+def _bash_executable() -> str:
+    """Return an absolute path to bash, failing the test if there is none.
+
+    Returns:
+        The resolved interpreter path.
+    """
+    found = shutil.which("bash")
+    if found is None:
+        pytest.fail("bash is required to exercise the shell scripts under test")
+    return found
+
+
+def _git_executable() -> str:
+    """Return an absolute path to git, failing the test if there is none.
+
+    Returns:
+        The resolved git path used to build the miniature checkout.
+    """
+    found = shutil.which("git")
+    if found is None:
+        pytest.fail("git is required to build the fixture checkout")
+    return found
+
+
+def _real_executable(name: str) -> str:
+    """Return the absolute path of a command before the shims shadow it.
+
+    Args:
+        name: Command whose real implementation a shim delegates to.
+
+    Returns:
+        The resolved path to the real command.
+    """
+    found = shutil.which(name)
+    if found is None:
+        pytest.fail(f"{name} is required to build the shim for {name}")
+    return found
+
+
+def _require_script(path: Path) -> Path:
+    """Return the script path, failing with a clear reason when it is absent.
+
+    Args:
+        path: Location the production script is expected to occupy.
+
+    Returns:
+        The same path, once its existence is established.
+    """
+    if not path.exists():
+        pytest.fail(f"{path} does not exist; the gate-receipt wiring is unimplemented")
+    return path
+
+
+def _write(root: Path, relative: Path, text: str) -> None:
+    """Write a fixture file into the staged checkout, creating parents.
+
+    Args:
+        root: Tree root of the staged checkout.
+        relative: Path of the file relative to that root.
+        text: Contents to write.
+    """
+    destination = root / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(text)
+
+
+def _git(root: Path, *args: str) -> None:
+    """Run a git command inside the staged checkout, failing the test on error.
+
+    Args:
+        root: Working directory for the command.
+        *args: Arguments following ``git``.
+    """
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull}
+    result = subprocess.run(
+        [_git_executable(), *_GIT_IDENTITY_ARGS, *args],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"git {args} failed in {root}: {result.stdout!r} {result.stderr!r}")
+
+
+def _install_stage_shims(scripts_dir: Path) -> None:
+    """Replace every sibling stage script with a recorder.
+
+    Args:
+        scripts_dir: The staged ``scripts/backend`` directory.
+    """
+    for stage in _ALL_STAGES:
+        shim = scripts_dir / stage
+        shim.write_text(
+            _STAGE_SHIM.replace("@STAGE@", stage).replace("@MID_RUN_EDIT@", _MID_RUN_EDIT_TEXT),
+        )
+        shim.chmod(_SHIM_MODE)
+
+
+def _install_tool_shims(shim_dir: Path) -> None:
+    """Write the ``pip``, ``python3`` and ``uname`` stand-ins onto disk.
+
+    The fingerprint reads all three, so they are pinned to fixed values; a
+    machine-dependent component would make the receipt tests flaky rather than
+    wrong, which is worse.
+
+    Args:
+        shim_dir: Directory that will be prepended to ``PATH``.
+    """
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    pip = shim_dir / "pip"
+    pip.write_text(
+        _PIP_SHIM.format(freeze_env=_FAKE_PIP_FREEZE_ENV, default=_BASELINE_PIP_FREEZE),
+    )
+    python = shim_dir / "python3"
+    python.write_text(
+        _PYTHON_SHIM.format(
+            version_env=_FAKE_PYTHON_VERSION_ENV,
+            default=_BASELINE_PYTHON_VERSION,
+            real=_real_executable("python3"),
+        ),
+    )
+    uname = shim_dir / "uname"
+    uname.write_text(
+        _UNAME_SHIM.format(
+            hostname_env=_FAKE_HOSTNAME_ENV,
+            default=_BASELINE_HOSTNAME,
+            real=_real_executable("uname"),
+        ),
+    )
+    for shim in (pip, python, uname):
+        shim.chmod(_SHIM_MODE)
+
+
+@dataclass(frozen=True)
+class _Run:
+    """One invocation of the staged gate, plus the markers it left behind."""
+
+    result: subprocess.CompletedProcess[str]
+    marker_dir: Path
+
+    def stages_that_ran(self) -> set[str]:
+        """Return the names of the stage scripts that were invoked.
+
+        Returns:
+            One entry per stage that recorded a marker.
+        """
+        return {marker.name for marker in self.marker_dir.iterdir()}
+
+    def output(self) -> str:
+        """Return both captured streams lowercased, for substring assertions.
+
+        Returns:
+            stdout and stderr concatenated and lowercased.
+        """
+        return f"{self.result.stdout}{self.result.stderr}".lower()
+
+
+@dataclass
+class _Gate:
+    """A miniature checkout whose stages are recorders rather than real checks."""
+
+    root: Path
+    script: Path
+    markers_root: Path
+    env: dict[str, str]
+    runs: itertools.count[int] = field(default_factory=itertools.count)
+
+    def run(self, *args: str, extra_env: dict[str, str] | None = None) -> _Run:
+        """Invoke the staged gate with a fresh marker directory.
+
+        Args:
+            *args: Flags passed to ``check-all.sh``.
+            extra_env: Additional environment entries, such as a stage to fail.
+
+        Returns:
+            The completed process together with the markers it produced.
+        """
+        marker_dir = self.markers_root / f"{_RUN_DIR_PREFIX}{next(self.runs)}"
+        marker_dir.mkdir(parents=True)
+        env = {**self.env, _MARKER_DIR_ENV: str(marker_dir), **(extra_env or {})}
+        result = subprocess.run(
+            [_bash_executable(), str(self.script), *args],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        return _Run(result=result, marker_dir=marker_dir)
+
+    def receipt_path(self) -> Path:
+        """Return the location of the backend gate's receipt.
+
+        Returns:
+            The single per-gate receipt path, whether or not it exists yet.
+        """
+        return self.root / _RECEIPTS_DIR / f"{_GATE}{_RECEIPT_SUFFIX}"
+
+
+def _stage_gate(
+    parent: Path,
+    *,
+    tracked_file_count: int = _TRACKED_FILE_COUNT,
+) -> _Gate:
+    """Build a checkout holding the real gate, the real primitive, and shims.
+
+    Markers are written outside the tree root on purpose: a stage that recorded
+    itself inside a fingerprinted path would make every run look like a tree
+    edited mid-flight.
+
+    Args:
+        parent: Directory the checkout, shims and markers are created under.
+        tracked_file_count: Number of filler modules inside the declared paths.
+
+    Returns:
+        The staged gate, ready to run.
+    """
+    root = parent / _CHECKOUT_DIR_NAME
+    scripts_dir = root / _CHECK_ALL_RELATIVE_PATH.parent
+    scripts_dir.mkdir(parents=True)
+    (root / _VERIFIED_RELATIVE_PATH.parent).mkdir(parents=True)
+
+    shutil.copy(_require_script(_CHECK_ALL_SCRIPT), root / _CHECK_ALL_RELATIVE_PATH)
+    shutil.copy(_require_script(_VERIFIED_SCRIPT), root / _VERIFIED_RELATIVE_PATH)
+    _install_stage_shims(scripts_dir)
+
+    _write(root, _PRE_COMMIT_CONFIG, _PRE_COMMIT_TEXT)
+    _write(root, _BACKEND_DIR / "pyproject.toml", _PYPROJECT_TEXT)
+    _write(root, _MUTABLE_FILE, _MODULE_TEXT)
+    for index in range(tracked_file_count):
+        _write(root, _BACKEND_DIR / "src" / f"filler_{index:03d}.py", _MODULE_TEXT)
+
+    _git(root, "init", "-q", "-b", _DEFAULT_BRANCH)
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "--no-verify", "-m", _INITIAL_COMMIT_MESSAGE)
+
+    _install_tool_shims(parent / _SHIM_DIR_NAME)
+    env = dict(os.environ)
+    env[_PATH_ENV] = f"{parent / _SHIM_DIR_NAME}{os.pathsep}{env[_PATH_ENV]}"
+    env[_VIRTUALENV_ENV] = _BASELINE_VIRTUALENV
+    env[_FAKE_PIP_FREEZE_ENV] = _BASELINE_PIP_FREEZE
+    env[_FAKE_PYTHON_VERSION_ENV] = _BASELINE_PYTHON_VERSION
+    env[_FAKE_HOSTNAME_ENV] = _BASELINE_HOSTNAME
+    env.pop(_POSTGRES_URL_ENV, None)
+    env.pop(_REQUIRE_POSTGRES_ENV, None)
+    env.pop(_FAILING_STAGE_ENV, None)
+    env.pop(_MUTATE_ON_STAGE_ENV, None)
+
+    return _Gate(
+        root=root,
+        script=root / _CHECK_ALL_RELATIVE_PATH,
+        markers_root=parent / _MARKERS_DIR_NAME,
+        env=env,
+    )
+
+
+@pytest.fixture
+def gate(tmp_path: Path) -> _Gate:
+    """Return an ample staged gate with recorder stages in place.
+
+    Args:
+        tmp_path: Per-test directory holding the checkout, shims and markers.
+
+    Returns:
+        The staged gate under test.
+    """
+    return _stage_gate(tmp_path)
+
+
+def _run_check_invocations() -> list[str]:
+    """Return the ``run_check`` call lines of the real check-all.sh.
+
+    Returns:
+        The stripped call lines, in the order the script runs them.
+    """
+    return [
+        line.strip()
+        for line in _CHECK_ALL_SCRIPT.read_text().splitlines()
+        if line.strip().startswith(_RUN_CHECK_CALL_PREFIX)
+    ]
+
+
+def _receipt_field(text: str, key: str) -> str:
+    """Return one ``key=value`` field of a receipt.
+
+    Args:
+        text: Full receipt contents.
+        key: Field name to extract.
+
+    Returns:
+        The field's value with surrounding whitespace removed.
+    """
+    match = re.search(rf"^\s*{key}\s*=\s*(?P<value>\S.*?)\s*$", text, re.MULTILINE)
+    if match is None:
+        pytest.fail(f"the receipt does not record {key!r}; got: {text!r}")
+    return match.group("value")
+
+
+def _record_a_receipt(subject: _Gate) -> _Run:
+    """Run the gate once so a receipt exists to be reused.
+
+    Args:
+        subject: The staged gate.
+
+    Returns:
+        The completed first run, asserted green and asserted to have recorded.
+    """
+    first = subject.run()
+    assert first.result.returncode == _ALL_PASSED_EXIT_CODE, first.result.stderr
+    assert subject.receipt_path().exists(), (
+        "a full run with every stage passing must record a receipt, or nothing "
+        f"downstream can ever be reused; output: {first.output()!r}"
+    )
+    return first
+
+
+def test_a_matching_receipt_skips_the_deterministic_stages(gate: _Gate) -> None:
+    """Lint, format, mypy, complexity and the suite are reused, not re-run.
+
+    These five are a pure function of the fingerprinted inputs, so re-deriving
+    them from an identical tree buys nothing and costs the whole reason the gate
+    gets skipped by hand instead of run.
+    """
+    _record_a_receipt(gate)
+
+    second = gate.run()
+
+    assert second.result.returncode == _ALL_PASSED_EXIT_CODE, second.result.stderr
+    ran = second.stages_that_ran()
+    for stage in _SKIPPABLE_STAGES:
+        assert stage not in ran, (
+            f"{stage} ran again against an unchanged tree; the receipt bought "
+            f"nothing. Stages that ran: {sorted(ran)}"
+        )
+
+
+def test_a_matching_receipt_still_runs_security_and_the_drift_preflight(
+    gate: _Gate,
+) -> None:
+    """The two network- and environment-dated stages are never cached.
+
+    ``pip-audit`` asks an advisory database that changes without any file in
+    the tree changing, so a fingerprint match says nothing about whether the
+    dependencies are still safe today. The drift preflight is exempt for the
+    mirror-image reason: it compares the installed packages against the pinned
+    requirements, and the installed packages are not part of the tree at all.
+    A short-circuit that skipped either would turn the receipt into a way of
+    outrunning a vulnerability disclosure.
+    """
+    _record_a_receipt(gate)
+
+    second = gate.run()
+
+    ran = second.stages_that_ran()
+    for stage in _ALWAYS_RUN_STAGES:
+        assert stage in ran, (
+            f"{stage} was skipped on a receipt hit, so a change it alone can "
+            f"detect would go unreported. Stages that ran: {sorted(ran)}"
+        )
+
+
+def test_force_runs_every_stage_despite_a_matching_receipt(gate: _Gate) -> None:
+    """The escape hatch re-derives everything from scratch.
+
+    An operator who suspects the cache needs a way to prove the tree from
+    nothing, and it has to be a flag on this run rather than a way to delete
+    or forge receipts.
+    """
+    _record_a_receipt(gate)
+
+    forced = gate.run(_FORCE_FLAG)
+
+    assert forced.result.returncode == _ALL_PASSED_EXIT_CODE, forced.result.stderr
+    assert forced.stages_that_ran() == set(_ALL_STAGES), (
+        f"{_FORCE_FLAG} must run every stage; ran: {sorted(forced.stages_that_ran())}"
+    )
+
+
+def test_a_first_run_executes_every_stage_and_records_a_receipt(gate: _Gate) -> None:
+    """With nothing recorded, the gate does all the work and banks the result.
+
+    Recording is the whole point of the full run; a gate that never writes a
+    receipt is simply the old gate with extra code paths.
+    """
+    first = gate.run()
+
+    assert first.result.returncode == _ALL_PASSED_EXIT_CODE, first.result.stderr
+    assert first.stages_that_ran() == set(_ALL_STAGES), (
+        f"a run with no receipt must run everything; ran: {sorted(first.stages_that_ran())}"
+    )
+    assert gate.receipt_path().exists(), "a clean full run must record a receipt"
+
+
+def test_a_failing_stage_records_no_receipt(gate: _Gate) -> None:
+    """A red run banks nothing, so the next run cannot inherit its green.
+
+    Recording unconditionally at the end would make the very first failure
+    permanent: the next invocation would short-circuit past the stage that
+    failed and report success.
+    """
+    failed = gate.run(extra_env={_FAILING_STAGE_ENV: "lint.sh"})
+
+    assert failed.result.returncode == _CHECK_FAILED_EXIT_CODE, (
+        f"a failing stage must fail the gate; got exit {failed.result.returncode}"
+    )
+    assert not gate.receipt_path().exists(), (
+        "a run with a failing check recorded a receipt, so the failure can be "
+        "skipped past on the next invocation"
+    )
+
+
+def test_a_tree_edited_during_the_run_records_no_receipt(gate: _Gate) -> None:
+    """A run that measured two different trees proves nothing about either.
+
+    Editing a file while a long suite is in flight is ordinary developer
+    behaviour, and the resulting run tested the old bytes in some stages and
+    the new bytes in others. Recording the end-state fingerprint would attach
+    that mixture's green to a tree that was never checked as a whole, and the
+    operator would never know, so the run stays green while the receipt is
+    withheld and the reason is said out loud.
+    """
+    edited = gate.run(
+        extra_env={
+            _MUTATE_ON_STAGE_ENV: "test.sh",
+            _MUTATE_FILE_ENV: str(gate.root / _MUTABLE_FILE),
+        },
+    )
+
+    assert edited.result.returncode == _ALL_PASSED_EXIT_CODE, (
+        f"every stage passed, so the run itself is green; got exit "
+        f"{edited.result.returncode} with output: {edited.output()!r}"
+    )
+    assert not gate.receipt_path().exists(), (
+        "the tree changed mid-run, so the verdict describes a mixture of two "
+        "trees and must not be banked"
+    )
+    assert _TREE_CHANGED_MESSAGE in edited.output(), (
+        f"the withheld receipt must be explained; got: {edited.output()!r}"
+    )
+
+
+def test_the_short_circuit_names_the_gate_the_time_and_the_security_stage(
+    gate: _Gate,
+) -> None:
+    """A reused verdict has to say what it is reusing and what it still ran.
+
+    An operator looking at a gate that finished in seconds needs three facts to
+    trust it: which gate was reused, when that verdict was earned, and that the
+    security stage was not part of the bargain.
+    """
+    _record_a_receipt(gate)
+    recorded_at = _receipt_field(gate.receipt_path().read_text(), _RECORDED_AT_FIELD)
+
+    second = gate.run()
+
+    output = second.output()
+    assert _GATE in output, f"the short-circuit must name the gate; got: {output!r}"
+    assert recorded_at.lower() in output, (
+        f"the short-circuit must name when the verdict was earned "
+        f"({recorded_at!r}); got: {output!r}"
+    )
+    assert _SECURITY_MENTION in output, (
+        f"the short-circuit must state that the security stage still ran; got: {output!r}"
+    )
+
+
+def test_a_gate_that_cannot_be_evaluated_runs_everything(tmp_path: Path) -> None:
+    """An unevaluable receipt is not permission to skip, nor a reason to fail.
+
+    The primitive refuses degenerate input rather than hashing the empty string
+    into a fingerprint that matches everywhere. The caller's only safe response
+    is to do all the work, and it must not turn an otherwise-green run red just
+    because the cache was unusable.
+    """
+    sparse = _stage_gate(tmp_path, tracked_file_count=_SPARSE_FILE_COUNT)
+
+    run = sparse.run()
+
+    assert run.stages_that_ran() == set(_ALL_STAGES), (
+        "an unevaluable receipt check must fall back to the full gate; ran: "
+        f"{sorted(run.stages_that_ran())}"
+    )
+    assert run.result.returncode == _ALL_PASSED_EXIT_CODE, (
+        "every stage passed, so an unusable cache must not fail the run; got "
+        f"exit {run.result.returncode} with output: {run.output()!r}"
+    )
+
+
+def test_the_seven_run_check_call_lines_are_unchanged() -> None:
+    """The skip lives inside ``run_check``, not at its call sites.
+
+    Two other suites in this directory read these lines as text to discover the
+    stage names and the flags they carry. Implementing the short-circuit by
+    renaming, conditioning, or reordering the calls would break those suites
+    from a distance, which is the kind of coupling that gets diagnosed as a
+    flaky test rather than as a design decision.
+    """
+    calls = _run_check_invocations()
+
+    assert len(calls) == len(_EXPECTED_CHECK_NAMES), (
+        f"expected exactly {len(_EXPECTED_CHECK_NAMES)} run_check calls; got: {calls}"
+    )
+    for call, name in zip(calls, _EXPECTED_CHECK_NAMES, strict=True):
+        assert call.startswith(f'{_RUN_CHECK_CALL_PREFIX}{name}"'), (
+            f"the call line for {name!r} changed shape, which breaks the suites "
+            f"that parse it as text; got: {call!r}"
+        )
+
+
+@pytest.mark.parametrize(("document", "mandate"), _UNCONDITIONAL_MANDATE_CASES)
+def test_the_docs_drop_the_unconditional_whole_tree_precommit_mandate(
+    document: Path,
+    mandate: str,
+) -> None:
+    """Running every hook over every file before every commit is no longer the rule.
+
+    The instruction is what teaches an operator that the gate is a ritual with a
+    fixed price rather than a signal proportional to the change, and a fixed
+    price that high is what makes bypassing it attractive. The replacement keeps
+    the whole-tree run available for the cases that need it -- wide renames,
+    suspected cross-file type errors -- so this asserts only that the
+    unconditional phrasing is gone, not that the command is never mentioned.
+
+    Args:
+        document: The documentation file under test.
+        mandate: The unconditional phrasing that must no longer appear.
+    """
+    text = document.read_text()
+
+    assert mandate not in text, (
+        f"{document.name} still issues the unconditional mandate {mandate!r}; "
+        "the rule must become proportional to the change being made"
+    )
+
+
+@pytest.mark.parametrize("document", _CONCURRENCY_DOC_CASES)
+def test_the_agent_docs_state_the_no_concurrent_suite_rule(document: Path) -> None:
+    """Agents driving lanes must know why a suite run can be refused outright.
+
+    A worker that meets the refusal without having read the rule will read it as
+    a broken script and route around it, which is precisely the behaviour the
+    lock exists to prevent. Naming the lock file gives them somewhere to look.
+
+    Args:
+        document: The agent-facing document under test.
+    """
+    text = document.read_text().lower()
+
+    for marker in _CONCURRENCY_RULE_MARKERS:
+        assert marker in text, (
+            f"{document.name} does not state the no-concurrent-suite rule "
+            f"(missing {marker!r}), so an agent meeting the refusal has nothing to read"
+        )

--- a/backend/tests/scripts/test_gate_receipts.py
+++ b/backend/tests/scripts/test_gate_receipts.py
@@ -29,14 +29,28 @@ run the gate" and exit 2 means "cannot evaluate"; neither one may ever be read
 as permission to skip, which is why the caller tests assert the full run happens
 in both cases.
 
+Three later refusals are quieter still, because in each of them git answers
+without complaining. ``git hash-object`` stops at the first path it cannot open,
+so one broken symlink or one unreadable file truncates the hash stream and every
+path after it contributes nothing -- and because the failure is reproducible,
+the receipt and the check agree on the same degraded value and the gate is
+skipped over files that were free to change. ``git hash-object`` also hashes
+blob content only, so ``chmod +x`` on a stage script is invisible even though
+the caller execs that script by path. And it honours ``.gitattributes``, so a
+file rewritten from LF to CRLF hashes identically while the formatting stage
+that would have rejected it gets skipped. The fixture therefore carries the
+repository's own attributes file, verbatim, or the last of those would pass
+against a tree that never normalised anything.
+
 Every test copies the real script into a miniature checkout under ``tmp_path``,
 initialises it as a git repository, and runs it there. The script derives its
 tree root from ``SCRIPT_DIR/../..`` precisely so it cannot be aimed at the live
 checkout by an unlucky working directory, and one test pins that by running it
-from an unrelated repository. ``pip``, ``python3`` and ``uname`` are shadowed on
-``PATH`` by shims reporting values a test controls, so the environment
-components can be mutated one at a time without touching the machine or the
-shared virtualenv.
+from an unrelated repository. ``pip``, ``python3``, ``uname`` and ``date`` are
+shadowed on ``PATH`` by shims reporting values a test controls, so the
+environment components can be mutated one at a time without touching the machine
+or the shared virtualenv, and so a single ``record`` can be frozen mid-write to
+hold a concurrency window open on purpose rather than by hoping for one.
 """
 
 from __future__ import annotations
@@ -45,6 +59,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -76,6 +91,10 @@ _CANNOT_EVALUATE_EXIT_CODE = 2
 _GATE_STATE_DIR = Path(".gate-state")
 _RECEIPTS_DIR = _GATE_STATE_DIR / "receipts"
 _RECEIPT_SUFFIX = ".receipt"
+# A receipt is published by renaming a scratch file over it, so the scratch file
+# has to live in the receipts directory: a rename is only atomic within one
+# filesystem. One left behind is the visible symptom of a torn write.
+_TEMP_RECEIPT_GLOB = ".tmp-*"
 
 _SHA256_PATTERN = re.compile(r"\A[0-9a-f]{64}\Z")
 
@@ -120,6 +139,23 @@ _REQUIRE_POSTGRES_ENV = "INTEGRATION_LANE_REQUIRE_POSTGRES"
 _FAKE_PIP_FREEZE_ENV = "ADEPTHOOD_FAKE_PIP_FREEZE"
 _FAKE_PYTHON_VERSION_ENV = "ADEPTHOOD_FAKE_PYTHON_VERSION"
 _FAKE_HOSTNAME_ENV = "ADEPTHOOD_FAKE_HOSTNAME"
+# Names a file the ``date`` shim waits for before answering. ``record`` stamps
+# the receipt with the time after it has opened its scratch file and written the
+# first fields, so freezing ``date`` freezes one run exactly halfway through the
+# write -- which is the interleaving a second run has to survive.
+_DATE_GATE_ENV = "ADEPTHOOD_DATE_GATE"
+
+# Written by the shim once it is actually blocked, so the test waits on an
+# observed state instead of on a duration.
+_BLOCKED_MARKER_SUFFIX = ".blocked"
+_GATE_RELEASE_TEXT = "go\n"
+_GATE_POLL_SECONDS = 0.02
+_GATE_WAIT_TIMEOUT_SECONDS = 30.0
+
+# Deliberately a different length from a real ``%Y-%m-%dT%H:%M:%SZ`` stamp: two
+# runs interleaving on one scratch file would otherwise write byte-identical
+# receipts, and the corruption would be undetectable rather than absent.
+_STUB_TIMESTAMP = "STUB"
 
 _BASELINE_PIP_FREEZE = "example-package==1.0.0"
 _OTHER_PIP_FREEZE = "example-package==2.0.0"
@@ -134,6 +170,8 @@ _OTHER_POSTGRES_URL = "postgresql://gate/two"
 _TRUTHY = "1"
 
 _SHIM_MODE = 0o755
+_EXECUTABLE_FILE_MODE = 0o755
+_EXECUTE_BITS = 0o111
 _SHIM_DIR_NAME = "bin"
 _CHECKOUT_DIR_NAME = "repo"
 _DECOY_DIR_NAME = "decoy"
@@ -149,6 +187,44 @@ _RENAMED_FILE = Path("backend") / "src" / "renamed.py"
 _DELETABLE_FILE = Path("backend") / "src" / "deletable.py"
 _UNTRACKED_FILE = Path("backend") / "src" / "appeared.py"
 _PRE_COMMIT_CONFIG = Path(".pre-commit-config.yaml")
+
+# A stage script of the shape check-all.sh execs by path. Its executable bit is
+# part of whether the gate can run at all, and none of its bytes change when
+# that bit does.
+_STAGE_SCRIPT = Path("scripts") / "backend" / "stage.sh"
+_STAGE_SCRIPT_TEXT = "#!/usr/bin/env bash\necho 'a stage the gate would exec'\n"
+
+# The unhashable-path pair. ``git hash-object`` stops at the first path it
+# cannot open, so the names are chosen -- and the ordering asserted -- to put a
+# real, editable file AFTER the failure under LC_ALL=C ordering, which is the
+# order the paths are fed in.
+_UNHASHABLE_FILE = Path("backend") / "src" / "a_broken_symlink.py"
+_UNHASHABLE_SYMLINK_TARGET = "definitely-not-a-real-target"
+_ORDERED_LAST_FILE = Path("backend") / "src" / "z_real.py"
+# git names the path it could not open; a refusal that says nothing at all
+# leaves an operator with a bare exit code.
+_UNHASHABLE_MESSAGE_MARKERS = (str(_UNHASHABLE_FILE), "hash")
+
+# The repository's own attributes file, copied verbatim into every fixture. The
+# CRLF case is vacuous without it: `* text=auto eol=lf` is precisely what makes
+# `git hash-object` normalise line endings away before hashing.
+_GITATTRIBUTES_FILE = Path(".gitattributes")
+_NORMALISING_ATTRIBUTE = "* text=auto eol=lf"
+_CARRIAGE_RETURN_NEWLINE = "\r\n"
+_NEWLINE = "\n"
+
+# The gate registry lives in the script; mirrored here only to count what the
+# backend gate would list, so the unhashable fixture can be shown to clear the
+# degenerate-input floor rather than trip it.
+_DECLARED_PATHSPECS = ("backend", "scripts", ".pre-commit-config.yaml")
+_MINIMUM_FILES_PATTERN = re.compile(r"MINIMUM_DECLARED_FILES=(?P<floor>[0-9]+)")
+
+# A receipt is a flat key=value file over a closed vocabulary. A line that is
+# neither -- a bare fragment, or a key that is the tail of a real one -- is the
+# residue of two runs writing over each other, and both shapes occur depending
+# on where the second write landed.
+_RECEIPT_LINE_PATTERN = re.compile(r"\A[a-z_]+=\S*\Z")
+_COMPONENT_FIELD_PREFIX = "component_"
 
 # Files outside every declared path. A merge that touches only these is the
 # case the whole receipt mechanism exists to make cheap.
@@ -211,6 +287,21 @@ fi
 exec "{real}" "$@"
 """
 
+# Blocks until the file named by the gate variable appears, announcing that it
+# is blocked first so the test can wait on the state rather than on a duration.
+# Untouched -- a plain delegation to the real command -- whenever the gate
+# variable is unset, which is every test but the concurrency one.
+_DATE_SHIM = """#!/usr/bin/env bash
+gate="${{{gate_env}:-}}"
+if [ -n "$gate" ] && [ ! -f "$gate" ]; then
+    : > "$gate{blocked}"
+    while [ ! -f "$gate" ]; do sleep {poll}; done
+    printf '%s\\n' "{stub}"
+    exit 0
+fi
+exec "{real}" "$@"
+"""
+
 
 def _bash_executable() -> str:
     """Return an absolute path to bash, failing the test if there is none.
@@ -267,6 +358,80 @@ def _require_script(path: Path) -> Path:
     return path
 
 
+def _gitattributes_text() -> str:
+    """Return the repository's attributes file, refusing a fixture without it.
+
+    Read verbatim rather than restated, so the fixture cannot drift into a tree
+    that never normalises line endings -- against which the CRLF refusal would
+    pass while proving nothing.
+
+    Returns:
+        The contents of the repository's own ``.gitattributes``.
+    """
+    source = _REPO_ROOT / _GITATTRIBUTES_FILE
+    if not source.exists():
+        pytest.fail(f"{source} is missing; the line-ending fixture would be vacuous")
+    text = source.read_text()
+    if _NORMALISING_ATTRIBUTE not in text:
+        pytest.fail(
+            f"{source} no longer declares {_NORMALISING_ATTRIBUTE!r}, so a CRLF "
+            "rewrite would not be normalised away and the fixture proves nothing",
+        )
+    return text
+
+
+def _minimum_declared_files() -> int:
+    """Return the degenerate-input floor the script itself enforces.
+
+    Parsed from the script rather than restated, so a change to the floor cannot
+    silently turn the ampleness guard below into a tautology.
+
+    Returns:
+        The minimum number of declared files the gate accepts.
+    """
+    match = _MINIMUM_FILES_PATTERN.search(_require_script(_VERIFIED_SCRIPT).read_text())
+    if match is None:
+        pytest.fail(f"{_VERIFIED_SCRIPT} no longer declares a degenerate-input floor")
+    return int(match.group("floor"))
+
+
+def _declared_listing(root: Path) -> list[str]:
+    """Return the gate's declared files in the order the fingerprint hashes them.
+
+    Args:
+        root: Tree root of the staged checkout.
+
+    Returns:
+        Every tracked-or-untracked-and-unignored path under the declared paths,
+        sorted the way ``LC_ALL=C sort`` sorts them.
+    """
+    listing = _git(
+        root,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        *_DECLARED_PATHSPECS,
+    )
+    return sorted(line for line in listing.splitlines() if line)
+
+
+def _wait_for(marker: Path, reason: str) -> None:
+    """Block until a shim announces it is blocked, failing rather than hanging.
+
+    Args:
+        marker: File the shim creates once it has reached its blocking point.
+        reason: What the absent marker would mean, for the failure message.
+    """
+    deadline = time.monotonic() + _GATE_WAIT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if marker.exists():
+            return
+        time.sleep(_GATE_POLL_SECONDS)
+    pytest.fail(f"{reason}: {marker} never appeared within {_GATE_WAIT_TIMEOUT_SECONDS}s")
+
+
 def _write(root: Path, relative: Path, text: str) -> None:
     """Write a fixture file into the staged checkout, creating parents.
 
@@ -280,7 +445,7 @@ def _write(root: Path, relative: Path, text: str) -> None:
     destination.write_text(text)
 
 
-def _git(root: Path, *args: str) -> None:
+def _git(root: Path, *args: str) -> str:
     """Run a git command inside the staged checkout, failing the test on error.
 
     The global configuration is detached so an operator's hooks path, commit
@@ -289,6 +454,9 @@ def _git(root: Path, *args: str) -> None:
     Args:
         root: Working directory for the command.
         *args: Arguments following ``git``.
+
+    Returns:
+        Whatever the command printed on stdout, so a listing can be inspected.
     """
     env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull}
     result = subprocess.run(
@@ -302,10 +470,11 @@ def _git(root: Path, *args: str) -> None:
     )
     if result.returncode != 0:
         pytest.fail(f"git {args} failed in {root}: {result.stdout!r} {result.stderr!r}")
+    return result.stdout
 
 
 def _install_shims(shim_dir: Path) -> None:
-    """Write the ``pip``, ``python3`` and ``uname`` stand-ins onto disk.
+    """Write the ``pip``, ``python3``, ``uname`` and ``date`` stand-ins onto disk.
 
     Each shim answers only the one query the fingerprint asks it and delegates
     everything else to the real command, so shadowing them cannot disturb
@@ -315,6 +484,17 @@ def _install_shims(shim_dir: Path) -> None:
         shim_dir: Directory that will be prepended to ``PATH``.
     """
     shim_dir.mkdir(parents=True, exist_ok=True)
+    date = shim_dir / "date"
+    date.write_text(
+        _DATE_SHIM.format(
+            gate_env=_DATE_GATE_ENV,
+            blocked=_BLOCKED_MARKER_SUFFIX,
+            poll=_GATE_POLL_SECONDS,
+            stub=_STUB_TIMESTAMP,
+            real=_real_executable("date"),
+        ),
+    )
+    date.chmod(_SHIM_MODE)
     pip = shim_dir / "pip"
     pip.write_text(
         _PIP_SHIM.format(freeze_env=_FAKE_PIP_FREEZE_ENV, default=_BASELINE_PIP_FREEZE),
@@ -358,6 +538,7 @@ def _shim_env(shim_dir: Path) -> dict[str, str]:
     env[_FAKE_HOSTNAME_ENV] = _BASELINE_HOSTNAME
     env.pop(_POSTGRES_URL_ENV, None)
     env.pop(_REQUIRE_POSTGRES_ENV, None)
+    env.pop(_DATE_GATE_ENV, None)
     return env
 
 
@@ -486,9 +667,21 @@ def _stage_checkout(
     (root / _SCRIPT_RELATIVE_PATH.parent).mkdir(parents=True)
     shutil.copy(_require_script(_VERIFIED_SCRIPT), root / _SCRIPT_RELATIVE_PATH)
 
+    # Verbatim, so the fixture normalises line endings exactly as the real tree
+    # does and the CRLF refusal cannot pass against a repository that never
+    # normalised in the first place.
+    _write(root, _GITATTRIBUTES_FILE, _gitattributes_text())
     _write(root, _PRE_COMMIT_CONFIG, _PRE_COMMIT_TEXT)
     _write(root, _PYPROJECT_FILE, _PYPROJECT_TEXT)
-    for fixture in (_SOURCE_FILE, _TEST_FILE, _RENAMABLE_FILE, _DELETABLE_FILE):
+    _write(root, _STAGE_SCRIPT, _STAGE_SCRIPT_TEXT)
+    (root / _STAGE_SCRIPT).chmod(_EXECUTABLE_FILE_MODE)
+    for fixture in (
+        _SOURCE_FILE,
+        _TEST_FILE,
+        _RENAMABLE_FILE,
+        _DELETABLE_FILE,
+        _ORDERED_LAST_FILE,
+    ):
         _write(root, fixture, _MODULE_TEXT)
     for index in range(tracked_file_count):
         _write(root, Path("backend") / "src" / f"filler_{index:03d}.py", _MODULE_TEXT)
@@ -705,6 +898,147 @@ def _rename_with_identical_content(root: Path) -> None:
     shutil.move(str(root / _RENAMABLE_FILE), str(root / _RENAMED_FILE))
 
 
+def _grant_execute(path: Path) -> None:
+    """Make a file executable, failing if the filesystem cannot express it.
+
+    Args:
+        path: File to mark executable.
+    """
+    path.chmod(path.stat().st_mode | _EXECUTE_BITS)
+    assert os.access(path, os.X_OK), (
+        f"{path} did not become executable, so this filesystem cannot stage the "
+        "change under test and a refusal here would prove nothing"
+    )
+
+
+def _revoke_execute(path: Path) -> None:
+    """Strip a file's executable bits, failing if the filesystem ignores it.
+
+    Args:
+        path: File to mark non-executable.
+    """
+    path.chmod(path.stat().st_mode & ~_EXECUTE_BITS)
+    assert not os.access(path, os.X_OK), (
+        f"{path} is still executable, so this filesystem cannot stage the change "
+        "under test and a refusal here would prove nothing"
+    )
+
+
+def _make_source_executable(root: Path) -> None:
+    """Add the executable bit to a tracked, non-executable source file.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    _grant_execute(root / _SOURCE_FILE)
+
+
+def _make_stage_script_unexecutable(root: Path) -> None:
+    """Strip the executable bit from a tracked stage script.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    _revoke_execute(root / _STAGE_SCRIPT)
+
+
+def _make_untracked_file_executable(root: Path) -> None:
+    """Add the executable bit to an untracked-but-unignored file.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    _grant_execute(root / _UNTRACKED_FILE)
+
+
+def _make_source_executable_and_edited(root: Path) -> None:
+    """Flip a source file's mode and its content in one move.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    _edit_source(root)
+    _grant_execute(root / _SOURCE_FILE)
+
+
+def _rewrite_source_with_crlf(root: Path) -> None:
+    """Rewrite a source file with CRLF endings and no other change.
+
+    Written as bytes so the line endings are exactly what is intended rather
+    than whatever the platform's text mode would translate them into.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    path = root / _SOURCE_FILE
+    original = path.read_bytes()
+    path.write_bytes(_MODULE_TEXT.replace(_NEWLINE, _CARRIAGE_RETURN_NEWLINE).encode())
+    assert path.read_bytes() != original, (
+        "the CRLF rewrite changed nothing on disk, so the refusal would be vacuous"
+    )
+
+
+def _break_hashing(root: Path) -> None:
+    """Plant a declared path that ``git hash-object`` cannot open.
+
+    A broken symlink is the reproducible form of the failure -- an unreadable
+    file or a stale index lock behave the same way -- and reproducibility is
+    what makes it dangerous: the record and the check both degrade identically,
+    so they agree.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    link = root / _UNHASHABLE_FILE
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(_UNHASHABLE_SYMLINK_TARGET)
+    assert not link.exists(), f"{link} resolves to something, so git can hash it after all"
+
+
+def _assert_fixture_is_ample(root: Path) -> None:
+    """Assert the checkout clears the degenerate-input floor.
+
+    Without this, a refusal in one of the unhashable-path tests could be the
+    already-tested "your gate matches almost nothing" guard firing instead of
+    the failure under test.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    listing = _declared_listing(root)
+    floor = _minimum_declared_files()
+    assert len(listing) >= floor, (
+        f"the fixture lists only {len(listing)} declared files, under the "
+        f"degenerate-input floor of {floor}; the refusal under test would be "
+        "indistinguishable from the degenerate-gate refusal"
+    )
+
+
+def _assert_receipt_is_well_formed(text: str) -> None:
+    """Assert a receipt is one run's output rather than two runs interleaved.
+
+    Args:
+        text: Full receipt contents.
+    """
+    lines = [line for line in text.splitlines() if line]
+    for line in lines:
+        assert _RECEIPT_LINE_PATTERN.match(line), (
+            f"the receipt carries {line!r}, which is not a key=value field; a "
+            f"fragment like this is the residue of two runs writing over one "
+            f"another. Full receipt: {text!r}"
+        )
+    keys = [line.split("=", 1)[0] for line in lines]
+    for key in keys:
+        assert key in _RECEIPT_FIELDS or key.startswith(_COMPONENT_FIELD_PREFIX), (
+            f"the receipt carries an unknown field {key!r}; the tail of a real "
+            f"key left behind by a longer write looks exactly like this. Full "
+            f"receipt: {text!r}"
+        )
+    assert len(keys) == len(set(keys)), f"the receipt repeats a field: {keys}"
+    for field in _RECEIPT_FIELDS:
+        assert field in keys, f"the receipt lost {field!r}; got: {text!r}"
+
+
 def test_fingerprint_is_a_stable_sha256_over_repeated_calls(checkout: _Checkout) -> None:
     """Two reads of an untouched tree must agree, byte for byte.
 
@@ -909,6 +1243,96 @@ def test_renaming_a_file_without_changing_it_refuses_the_verdict(
         checkout,
         _rename_with_identical_content,
         "a file renamed with identical content",
+    )
+
+
+def test_gaining_an_executable_bit_refuses_the_verdict(checkout: _Checkout) -> None:
+    """A mode-only change is invisible to a content hash, and it matters.
+
+    ``git hash-object`` hashes bytes, and ``chmod +x`` moves none of them, so a
+    fingerprint built from blob hashes alone cannot see this at all. The gate
+    runner execs ``scripts/backend/*.sh`` by path, which makes the mode part of
+    whether the stage can run rather than a cosmetic detail, and ``--explain``
+    has to call it what it is -- a change under the declared paths -- or the
+    operator goes looking for an edit that does not exist.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    _assert_hit(checkout.check(), "an untouched tree must reuse its verdict")
+
+    _make_source_executable(checkout.root)
+
+    _assert_explains(checkout.check(_EXPLAIN_FLAG), _PATHS_COMPONENT)
+
+
+def test_losing_an_executable_bit_refuses_the_verdict(checkout: _Checkout) -> None:
+    """The direction that actually breaks the gate: a stage script it cannot exec.
+
+    A receipt recorded while ``scripts/backend/stage.sh`` was executable, and
+    honoured after it stopped being executable, skips a stage whose runner can
+    no longer be invoked -- and reports green for it.
+    """
+    _assert_tree_mutation_misses(
+        checkout,
+        _make_stage_script_unexecutable,
+        "a stage script that lost its executable bit",
+    )
+
+
+def test_an_untracked_file_gaining_an_executable_bit_refuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """Mode has to be read from the working tree, not from the index.
+
+    The index records a mode only for tracked paths, and even for those it
+    keeps the mode from the last ``git add`` rather than the one on disk. A
+    fingerprint that consulted index modes would therefore miss this case
+    entirely, while still passing the tracked-file cases above.
+    """
+    _add_untracked_file(checkout.root)
+
+    _assert_tree_mutation_misses(
+        checkout,
+        _make_untracked_file_executable,
+        "an untracked file that became executable",
+    )
+
+
+def test_a_mode_flip_alongside_a_content_edit_refuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """Adding mode to the fingerprint must not displace content from it.
+
+    The obvious wrong fix is to hash the mode listing instead of the content
+    stream. This is the case that catches it: both inputs moved, so a
+    fingerprint that measures either one must refuse.
+    """
+    _assert_tree_mutation_misses(
+        checkout,
+        _make_source_executable_and_edited,
+        "a file that changed in both mode and content",
+    )
+
+
+def test_rewriting_a_file_with_crlf_endings_refuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """Line endings survive the hash only because git is asked to erase them.
+
+    ``.gitattributes`` sets ``* text=auto eol=lf`` and ``git hash-object``
+    honours it, so a file rewritten CRLF hashes to the same blob as its LF
+    spelling. That is the one difference ruff-format would reject and the
+    fingerprint would certify: the receipt skips the formatting stage over a
+    tree that stage was about to fail.
+    """
+    assert _NORMALISING_ATTRIBUTE in (checkout.root / _GITATTRIBUTES_FILE).read_text(), (
+        "the fixture does not normalise line endings, so this test would pass "
+        "against a tree where CRLF was never hidden in the first place"
+    )
+
+    _assert_tree_mutation_misses(
+        checkout,
+        _rewrite_source_with_crlf,
+        "a file rewritten with CRLF line endings",
     )
 
 
@@ -1238,6 +1662,182 @@ def test_explain_names_the_env_component(checkout: _Checkout) -> None:
         ),
         _ENV_COMPONENT,
     )
+
+
+def test_recording_over_a_path_git_cannot_hash_is_refused(checkout: _Checkout) -> None:
+    """A listing git could not finish reading is not evidence about anything.
+
+    ``git hash-object --stdin-paths`` aborts at the first path it cannot open,
+    emitting fewer hashes than it was given paths, and every command in the
+    fingerprint runs inside a command substitution where bash does not apply
+    errexit. So the failure is swallowed, the missing hashes are padded with
+    empty fields, and a receipt gets written about a tree that was never fully
+    read. The only honest answer is to refuse to record at all.
+    """
+    _break_hashing(checkout.root)
+    _assert_fixture_is_ample(checkout.root)
+
+    result = checkout.record()
+
+    assert result.returncode == _CANNOT_EVALUATE_EXIT_CODE, (
+        f"a tree git cannot finish hashing must exit {_CANNOT_EVALUATE_EXIT_CODE}; "
+        f"got exit {result.returncode} with stdout: {result.stdout!r} "
+        f"stderr: {result.stderr!r}"
+    )
+    assert not checkout.receipt_path().exists(), "a refused record must write no receipt"
+    message = f"{result.stdout}{result.stderr}"
+    assert _TRACEBACK_MARKER not in message, (
+        f"the refusal must be reported, not crashed on; got: {message!r}"
+    )
+    assert any(marker in message for marker in _UNHASHABLE_MESSAGE_MARKERS), (
+        f"the refusal must say what could not be hashed (one of "
+        f"{list(_UNHASHABLE_MESSAGE_MARKERS)}); got: {message!r}"
+    )
+
+
+def test_checking_a_tree_git_cannot_hash_never_hits(checkout: _Checkout) -> None:
+    """The read side has to refuse for the same reason the write side does.
+
+    A degraded fingerprint is stable, so a check computed under the same broken
+    condition matches the receipt recorded under it and reports a hit. Refusing
+    to record but still honouring a check would leave the exploit intact
+    wherever a receipt already exists.
+    """
+    _break_hashing(checkout.root)
+    checkout.record()
+
+    result = checkout.check()
+
+    assert result.returncode != _HIT_EXIT_CODE, (
+        "a tree git cannot finish hashing was reported as verified; the "
+        f"fingerprint is degraded identically on both sides. Got stdout: "
+        f"{result.stdout!r} stderr: {result.stderr!r}"
+    )
+
+
+def test_a_swallowed_hash_failure_cannot_certify_a_later_edit(checkout: _Checkout) -> None:
+    """The exploit itself: an edit past the failure point inherits a green run.
+
+    ``git hash-object`` is fed the declared paths in ``LC_ALL=C`` order and
+    stops at the first one it cannot open, so every path after that one is
+    paired with an empty hash. Record while the failure is present, edit a file
+    that sorts after it, and both fingerprints are the same degraded value --
+    the gate skips ruff, mypy, pytest and the coverage threshold over a file it
+    never hashed. The ordering is asserted from git's own listing so a rename of
+    either fixture file cannot quietly make this test vacuous.
+    """
+    _break_hashing(checkout.root)
+    listing = _declared_listing(checkout.root)
+    for member in (str(_UNHASHABLE_FILE), str(_ORDERED_LAST_FILE)):
+        assert member in listing, f"{member} is not a declared file; got: {listing}"
+    assert listing.index(str(_UNHASHABLE_FILE)) < listing.index(str(_ORDERED_LAST_FILE)), (
+        f"{_ORDERED_LAST_FILE} must be hashed after {_UNHASHABLE_FILE} for the "
+        f"truncated hash stream to reach it; got: {listing}"
+    )
+    _assert_fixture_is_ample(checkout.root)
+
+    checkout.record()
+    (checkout.root / _ORDERED_LAST_FILE).write_text(_MODULE_TEXT + _MUTATION_TEXT)
+    result = checkout.check()
+
+    assert result.returncode != _HIT_EXIT_CODE, (
+        f"{_ORDERED_LAST_FILE} was edited after the receipt was recorded and the "
+        "gate still reported verified: the unreadable path truncated the hash "
+        "stream, so neither fingerprint ever contained this file's content. Got "
+        f"stdout: {result.stdout!r} stderr: {result.stderr!r}"
+    )
+
+
+def _assert_a_scratch_file_is_open(subject: _Checkout) -> None:
+    """Assert a record in flight really is writing through a scratch file.
+
+    Without this the concurrency test could pass by accident against an
+    implementation that never had a window to lose.
+
+    Args:
+        subject: The staged checkout, with one ``record`` frozen mid-write.
+    """
+    entries = sorted((subject.root / _RECEIPTS_DIR).iterdir())
+    assert [entry for entry in entries if entry != subject.receipt_path()], (
+        "the frozen record has no scratch file in the receipts directory, so "
+        f"there is no interleaving to test; found: {entries}"
+    )
+
+
+def test_two_concurrent_records_do_not_tear_the_receipt(
+    checkout: _Checkout,
+    tmp_path: Path,
+) -> None:
+    """Two runs recording at once must not write through one another's scratch file.
+
+    Nothing serialises two ``check-all.sh`` runs in one tree -- the suite lock
+    only guards the pytest step -- so both can reach ``record`` together. A
+    scratch file named after the gate alone is the same path for both: the
+    second truncates and publishes the file the first still holds open, and the
+    first then writes its tail into whatever now sits at that inode.
+
+    The window is held open deliberately rather than raced for: the ``date``
+    shim freezes the first run after it has opened its scratch file and written
+    the leading fields, which is exactly the interleaving point, and the second
+    run is released only once the first has announced that it is blocked. A
+    version that started both and hoped would pass on a fast machine and prove
+    nothing on any machine.
+
+    Args:
+        checkout: The staged checkout.
+        tmp_path: Per-test directory holding the shim's gate files.
+    """
+    gate = tmp_path / "date-gate"
+    blocked = Path(f"{gate}{_BLOCKED_MARKER_SUFFIX}")
+    frozen_env = checkout.env_with({_DATE_GATE_ENV: str(gate)})
+
+    with subprocess.Popen(
+        [_bash_executable(), str(checkout.script), _RECORD_COMMAND, _GATE],
+        cwd=checkout.root,
+        env=frozen_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ) as frozen:
+        try:
+            _wait_for(blocked, "the first record never reached its timestamp field")
+            _assert_a_scratch_file_is_open(checkout)
+            second = checkout.record()
+        finally:
+            gate.write_text(_GATE_RELEASE_TEXT)
+        first_stdout, first_stderr = frozen.communicate(timeout=_SUBPROCESS_TIMEOUT_SECONDS)
+
+    assert frozen.returncode == _HIT_EXIT_CODE, (
+        f"the interleaved record failed; got exit {frozen.returncode} with "
+        f"stdout: {first_stdout!r} stderr: {first_stderr!r}"
+    )
+    assert not first_stderr, (
+        f"the interleaved record reported an error while claiming success, which "
+        f"is what writing through another run's scratch file looks like: "
+        f"{first_stderr!r}"
+    )
+    assert second.returncode == _HIT_EXIT_CODE, second.stderr
+    assert not second.stderr, second.stderr
+
+    _assert_receipt_is_well_formed(checkout.receipt_path().read_text())
+    assert sorted((checkout.root / _RECEIPTS_DIR).iterdir()) == [checkout.receipt_path()], (
+        "a scratch file outlived the run that made it"
+    )
+    _assert_hit(checkout.check(), "a receipt published by two concurrent records")
+
+
+def test_no_scratch_file_survives_a_record(checkout: _Checkout) -> None:
+    """The receipts directory holds receipts, and nothing else, once a run ends.
+
+    A surviving ``.tmp-`` file is the visible symptom of a write that was torn
+    or abandoned rather than published by rename, and a reader that ever picked
+    one up would be reading a half-formed claim.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    leftovers = sorted((checkout.root / _RECEIPTS_DIR).glob(_TEMP_RECEIPT_GLOB))
+
+    assert leftovers == [], f"a scratch file outlived the record that made it: {leftovers}"
 
 
 def test_help_documents_the_three_subcommands(checkout: _Checkout) -> None:

--- a/backend/tests/scripts/test_gate_receipts.py
+++ b/backend/tests/scripts/test_gate_receipts.py
@@ -1,0 +1,1256 @@
+"""Tests for the gate-receipt primitive in ``scripts/quality/verified.sh``.
+
+A quality gate that takes seven minutes gets skipped, and a gate that is skipped
+protects nothing. The primitive under test lets a gate prove that a previous
+green run is *still true*, so an unchanged tree can reuse the verdict it already
+earned instead of re-running the whole backend suite to absorb a merge that
+touched only a planning note.
+
+The entire value of that claim rests on the fingerprint being impossible to
+satisfy dishonestly. A timestamp, a commit SHA, or a flag an agent sets about
+itself would all produce a receipt that says "verified" about a tree nobody
+verified. So the fingerprint is a content hash of the declared inputs plus the
+environment those inputs were measured in, and the majority of the tests below
+exist to prove a receipt is REFUSED: one for each way the tree, the interpreter,
+the installed packages, the virtualenv, the host, or the outcome-affecting
+environment can differ from the state that earned the verdict. A cache test that
+only proves the cache hits is worthless.
+
+Two of the refusals are worth more than the rest because they are silent rather
+than loud. Hashing the stream of content hashes alone would let a file renamed
+with identical content collide with the tree it came from, so each path is
+hashed alongside its content. And a gate whose declared paths match nothing
+hashes the empty string into a *stable* fingerprint that matches in every tree
+on earth -- which is exactly what a wrong working directory or a typo'd path
+looks like -- so degenerate input is an error, never a hit.
+
+The two failure exits are kept distinct on purpose. Exit 1 means "not verified,
+run the gate" and exit 2 means "cannot evaluate"; neither one may ever be read
+as permission to skip, which is why the caller tests assert the full run happens
+in both cases.
+
+Every test copies the real script into a miniature checkout under ``tmp_path``,
+initialises it as a git repository, and runs it there. The script derives its
+tree root from ``SCRIPT_DIR/../..`` precisely so it cannot be aimed at the live
+checkout by an unlucky working directory, and one test pins that by running it
+from an unrelated repository. ``pip``, ``python3`` and ``uname`` are shadowed on
+``PATH`` by shims reporting values a test controls, so the environment
+components can be mutated one at a time without touching the machine or the
+shared virtualenv.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VERIFIED_SCRIPT = _REPO_ROOT / "scripts" / "quality" / "verified.sh"
+
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+# The only gate in the registry today, plus a name that is well formed but
+# unregistered: the two must not be confused, since one is a refusal and the
+# other is an operator typo.
+_GATE = "backend"
+_UNREGISTERED_GATE = "frontend"
+
+_FINGERPRINT_COMMAND = "fingerprint"
+_RECORD_COMMAND = "record"
+_CHECK_COMMAND = "check"
+_EXPLAIN_FLAG = "--explain"
+_HELP_FLAG = "--help"
+
+# Documented exit codes. 0 is the only one that may license reuse of a verdict.
+_HIT_EXIT_CODE = 0
+_MISS_EXIT_CODE = 1
+_CANNOT_EVALUATE_EXIT_CODE = 2
+
+_GATE_STATE_DIR = Path(".gate-state")
+_RECEIPTS_DIR = _GATE_STATE_DIR / "receipts"
+_RECEIPT_SUFFIX = ".receipt"
+
+_SHA256_PATTERN = re.compile(r"\A[0-9a-f]{64}\Z")
+
+# The named components of the fingerprint, in the vocabulary ``--explain`` uses.
+_PATHS_COMPONENT = "paths"
+_INTERPRETER_COMPONENT = "interpreter"
+_PACKAGES_COMPONENT = "packages"
+_VENV_COMPONENT = "venv"
+_HOST_COMPONENT = "host"
+_ENV_COMPONENT = "env"
+_COMPONENTS = (
+    _PATHS_COMPONENT,
+    _INTERPRETER_COMPONENT,
+    _PACKAGES_COMPONENT,
+    _VENV_COMPONENT,
+    _HOST_COMPONENT,
+    _ENV_COMPONENT,
+)
+
+# A receipt has to say which gate it was written for, under which schema, and
+# when. Without the gate name a receipt copied between gates is undetectable;
+# without the schema version a change to the hashing scheme silently keeps
+# honouring receipts computed the old way; without the timestamp the caller
+# cannot tell an operator when the verdict it is reusing was earned.
+_GATE_FIELD = "gate"
+_SCHEMA_VERSION_FIELD = "schema_version"
+_FINGERPRINT_FIELD = "fingerprint"
+_RECORDED_AT_FIELD = "recorded_at"
+_RECEIPT_FIELDS = (
+    _SCHEMA_VERSION_FIELD,
+    _GATE_FIELD,
+    _FINGERPRINT_FIELD,
+    _RECORDED_AT_FIELD,
+)
+
+_PATH_ENV = "PATH"
+_VIRTUALENV_ENV = "VIRTUAL_ENV"
+_POSTGRES_URL_ENV = "TEST_POSTGRES_URL"
+_REQUIRE_POSTGRES_ENV = "INTEGRATION_LANE_REQUIRE_POSTGRES"
+
+# Knobs the shims read, so a test can move exactly one environment component.
+_FAKE_PIP_FREEZE_ENV = "ADEPTHOOD_FAKE_PIP_FREEZE"
+_FAKE_PYTHON_VERSION_ENV = "ADEPTHOOD_FAKE_PYTHON_VERSION"
+_FAKE_HOSTNAME_ENV = "ADEPTHOOD_FAKE_HOSTNAME"
+
+_BASELINE_PIP_FREEZE = "example-package==1.0.0"
+_OTHER_PIP_FREEZE = "example-package==2.0.0"
+_BASELINE_PYTHON_VERSION = "Python 3.12.0 (stub build)"
+_OTHER_PYTHON_VERSION = "Python 3.13.0 (stub build)"
+_BASELINE_HOSTNAME = "gate-host-one"
+_OTHER_HOSTNAME = "gate-host-two"
+_BASELINE_VIRTUALENV = "/opt/gate/venv-one"
+_OTHER_VIRTUALENV = "/opt/gate/venv-two"
+_POSTGRES_URL = "postgresql://gate/one"
+_OTHER_POSTGRES_URL = "postgresql://gate/two"
+_TRUTHY = "1"
+
+_SHIM_MODE = 0o755
+_SHIM_DIR_NAME = "bin"
+_CHECKOUT_DIR_NAME = "repo"
+_DECOY_DIR_NAME = "decoy"
+
+_SCRIPT_RELATIVE_PATH = Path("scripts") / "quality" / "verified.sh"
+
+# Fixture files inside the gate's declared paths, each staged for one refusal.
+_SOURCE_FILE = Path("backend") / "src" / "service.py"
+_TEST_FILE = Path("backend") / "tests" / "test_service.py"
+_PYPROJECT_FILE = Path("backend") / "pyproject.toml"
+_RENAMABLE_FILE = Path("backend") / "src" / "renamable.py"
+_RENAMED_FILE = Path("backend") / "src" / "renamed.py"
+_DELETABLE_FILE = Path("backend") / "src" / "deletable.py"
+_UNTRACKED_FILE = Path("backend") / "src" / "appeared.py"
+_PRE_COMMIT_CONFIG = Path(".pre-commit-config.yaml")
+
+# Files outside every declared path. A merge that touches only these is the
+# case the whole receipt mechanism exists to make cheap.
+_OUTSIDE_FILES = (Path("README.md"), Path("plan") / "notes.md")
+
+# Comfortably above any sane degenerate-input floor, so the ample checkout is
+# never mistaken for a misconfigured one.
+_TRACKED_FILE_COUNT = 80
+# A checkout with essentially nothing in the declared paths: what a typo'd path
+# or a wrong tree root produces.
+_SPARSE_FILE_COUNT = 0
+_DECOY_FILE_COUNT = 12
+
+_MODULE_TEXT = '"""Fixture module measured by the backend gate."""\n\nVALUE = 1\n'
+_OUTSIDE_TEXT = "A note the backend gate does not measure.\n"
+_PYPROJECT_TEXT = "[tool.example]\nvalue = 1\n"
+_PRE_COMMIT_TEXT = "repos: []\n"
+_MUTATION_TEXT = "\nEXTRA = 2\n"
+
+_DEFAULT_BRANCH = "main"
+_INITIAL_COMMIT_MESSAGE = "stage the fixture checkout"
+_EMPTY_COMMIT_MESSAGE = "a commit that changes no file content"
+_GIT_IDENTITY_ARGS = (
+    "-c",
+    "user.email=gate@example.invalid",
+    "-c",
+    "user.name=Gate Fixture",
+    "-c",
+    "commit.gpgsign=false",
+)
+
+_USAGE_MARKER = "Usage:"
+_TRACEBACK_MARKER = "Traceback"
+_DEGENERATE_MESSAGE_MARKERS = ("path", "match")
+
+# Well-formed-looking names that must be rejected before any interpolation.
+_INVALID_GATE_NAMES = ("../escape", "back end", "Backend", "back/end", "")
+
+_PIP_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "freeze" ]; then
+    printf '%s\\n' "${{{freeze_env}:-{default}}}"
+    exit 0
+fi
+exit 0
+"""
+
+_PYTHON_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "-VV" ]; then
+    printf '%s\\n' "${{{version_env}:-{default}}}"
+    exit 0
+fi
+exec "{real}" "$@"
+"""
+
+_UNAME_SHIM = """#!/usr/bin/env bash
+if [ "${{1:-}}" = "-n" ]; then
+    printf '%s\\n' "${{{hostname_env}:-{default}}}"
+    exit 0
+fi
+exec "{real}" "$@"
+"""
+
+
+def _bash_executable() -> str:
+    """Return an absolute path to bash, failing the test if there is none.
+
+    Returns:
+        The resolved interpreter path, so no subprocess call relies on a
+        partial executable name.
+    """
+    found = shutil.which("bash")
+    if found is None:
+        pytest.fail("bash is required to exercise the shell scripts under test")
+    return found
+
+
+def _git_executable() -> str:
+    """Return an absolute path to git, failing the test if there is none.
+
+    Returns:
+        The resolved git path used to build the miniature checkouts.
+    """
+    found = shutil.which("git")
+    if found is None:
+        pytest.fail("git is required to build the fixture checkouts")
+    return found
+
+
+def _real_executable(name: str) -> str:
+    """Return the absolute path of a command before the shims shadow it.
+
+    Args:
+        name: Command whose real implementation a shim delegates to for the
+            arguments it does not stub.
+
+    Returns:
+        The resolved path to the real command.
+    """
+    found = shutil.which(name)
+    if found is None:
+        pytest.fail(f"{name} is required to build the shim for {name}")
+    return found
+
+
+def _require_script(path: Path) -> Path:
+    """Return the script path, failing with a clear reason when it is absent.
+
+    Args:
+        path: Location the production script is expected to occupy.
+
+    Returns:
+        The same path, once its existence is established.
+    """
+    if not path.exists():
+        pytest.fail(f"{path} does not exist; the gate-receipt primitive is unimplemented")
+    return path
+
+
+def _write(root: Path, relative: Path, text: str) -> None:
+    """Write a fixture file into the staged checkout, creating parents.
+
+    Args:
+        root: Tree root of the staged checkout.
+        relative: Path of the file relative to that root.
+        text: Contents to write.
+    """
+    destination = root / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(text)
+
+
+def _git(root: Path, *args: str) -> None:
+    """Run a git command inside the staged checkout, failing the test on error.
+
+    The global configuration is detached so an operator's hooks path, commit
+    template, or signing settings cannot reach into the fixture.
+
+    Args:
+        root: Working directory for the command.
+        *args: Arguments following ``git``.
+    """
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": os.devnull}
+    result = subprocess.run(
+        [_git_executable(), *_GIT_IDENTITY_ARGS, *args],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"git {args} failed in {root}: {result.stdout!r} {result.stderr!r}")
+
+
+def _install_shims(shim_dir: Path) -> None:
+    """Write the ``pip``, ``python3`` and ``uname`` stand-ins onto disk.
+
+    Each shim answers only the one query the fingerprint asks it and delegates
+    everything else to the real command, so shadowing them cannot disturb
+    unrelated tooling.
+
+    Args:
+        shim_dir: Directory that will be prepended to ``PATH``.
+    """
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    pip = shim_dir / "pip"
+    pip.write_text(
+        _PIP_SHIM.format(freeze_env=_FAKE_PIP_FREEZE_ENV, default=_BASELINE_PIP_FREEZE),
+    )
+    python = shim_dir / "python3"
+    python.write_text(
+        _PYTHON_SHIM.format(
+            version_env=_FAKE_PYTHON_VERSION_ENV,
+            default=_BASELINE_PYTHON_VERSION,
+            real=_real_executable("python3"),
+        ),
+    )
+    uname = shim_dir / "uname"
+    uname.write_text(
+        _UNAME_SHIM.format(
+            hostname_env=_FAKE_HOSTNAME_ENV,
+            default=_BASELINE_HOSTNAME,
+            real=_real_executable("uname"),
+        ),
+    )
+    for shim in (pip, python, uname):
+        shim.chmod(_SHIM_MODE)
+
+
+def _shim_env(shim_dir: Path) -> dict[str, str]:
+    """Return an environment where every fingerprint input is under test control.
+
+    Args:
+        shim_dir: Directory holding the stand-in executables.
+
+    Returns:
+        A copy of the ambient environment with the shims in front on ``PATH``
+        and the outcome-affecting variables pinned to known values.
+    """
+    _install_shims(shim_dir)
+    env = dict(os.environ)
+    env[_PATH_ENV] = f"{shim_dir}{os.pathsep}{env[_PATH_ENV]}"
+    env[_VIRTUALENV_ENV] = _BASELINE_VIRTUALENV
+    env[_FAKE_PIP_FREEZE_ENV] = _BASELINE_PIP_FREEZE
+    env[_FAKE_PYTHON_VERSION_ENV] = _BASELINE_PYTHON_VERSION
+    env[_FAKE_HOSTNAME_ENV] = _BASELINE_HOSTNAME
+    env.pop(_POSTGRES_URL_ENV, None)
+    env.pop(_REQUIRE_POSTGRES_ENV, None)
+    return env
+
+
+@dataclass(frozen=True)
+class _Checkout:
+    """A miniature repository the real script can be relocated into and run."""
+
+    root: Path
+    script: Path
+    env: dict[str, str]
+
+    def run(
+        self,
+        *args: str,
+        env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Invoke the script under test and capture its outcome.
+
+        Args:
+            *args: Subcommand and flags.
+            env: Environment override; ``None`` uses the checkout's own.
+            cwd: Working directory override; ``None`` uses the tree root.
+
+        Returns:
+            The completed process, never raising on a non-zero exit code.
+        """
+        return subprocess.run(
+            [_bash_executable(), str(self.script), *args],
+            cwd=cwd if cwd is not None else self.root,
+            env=env if env is not None else self.env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+
+    def fingerprint(self, env: dict[str, str] | None = None) -> str:
+        """Return the current fingerprint, failing the test if it cannot be taken.
+
+        Args:
+            env: Environment override; ``None`` uses the checkout's own.
+
+        Returns:
+            The fingerprint printed on stdout, stripped of trailing newline.
+        """
+        result = self.run(_FINGERPRINT_COMMAND, _GATE, env=env)
+        if result.returncode != _HIT_EXIT_CODE:
+            pytest.fail(
+                f"fingerprint exited {result.returncode}: {result.stdout!r} {result.stderr!r}",
+            )
+        return result.stdout.strip()
+
+    def record(self, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        """Write a receipt for the backend gate.
+
+        Args:
+            env: Environment override; ``None`` uses the checkout's own.
+
+        Returns:
+            The completed process, so callers can assert on refusals too.
+        """
+        return self.run(_RECORD_COMMAND, _GATE, env=env)
+
+    def check(
+        self,
+        *flags: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Ask whether the recorded verdict still describes this tree.
+
+        Args:
+            *flags: Extra flags, such as ``--explain``.
+            env: Environment override; ``None`` uses the checkout's own.
+
+        Returns:
+            The completed process, never raising on a non-zero exit code.
+        """
+        return self.run(_CHECK_COMMAND, _GATE, *flags, env=env)
+
+    def receipt_path(self) -> Path:
+        """Return the location of the backend gate's receipt.
+
+        Returns:
+            The single per-gate receipt path, whether or not it exists yet.
+        """
+        return self.root / _RECEIPTS_DIR / f"{_GATE}{_RECEIPT_SUFFIX}"
+
+    def env_with(self, changes: dict[str, str | None]) -> dict[str, str]:
+        """Return the checkout environment with variables set or removed.
+
+        Args:
+            changes: Variables to apply; a ``None`` value removes the variable,
+                which is how the unset cases are expressed.
+
+        Returns:
+            A new environment mapping; the checkout's own stays untouched.
+        """
+        env = dict(self.env)
+        for key, value in changes.items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value
+        return env
+
+
+def _stage_checkout(
+    parent: Path,
+    *,
+    tracked_file_count: int = _TRACKED_FILE_COUNT,
+    initialise_git: bool = True,
+) -> _Checkout:
+    """Build a miniature checkout holding the real script and fixture inputs.
+
+    Args:
+        parent: Directory the checkout and its shim directory are created under.
+        tracked_file_count: Number of filler modules inside the declared paths;
+            a small count stands in for a misconfigured gate.
+        initialise_git: Whether to make the tree a git repository at all.
+
+    Returns:
+        The staged checkout, ready to run.
+    """
+    root = parent / _CHECKOUT_DIR_NAME
+    (root / _SCRIPT_RELATIVE_PATH.parent).mkdir(parents=True)
+    shutil.copy(_require_script(_VERIFIED_SCRIPT), root / _SCRIPT_RELATIVE_PATH)
+
+    _write(root, _PRE_COMMIT_CONFIG, _PRE_COMMIT_TEXT)
+    _write(root, _PYPROJECT_FILE, _PYPROJECT_TEXT)
+    for fixture in (_SOURCE_FILE, _TEST_FILE, _RENAMABLE_FILE, _DELETABLE_FILE):
+        _write(root, fixture, _MODULE_TEXT)
+    for index in range(tracked_file_count):
+        _write(root, Path("backend") / "src" / f"filler_{index:03d}.py", _MODULE_TEXT)
+    for outside in _OUTSIDE_FILES:
+        _write(root, outside, _OUTSIDE_TEXT)
+
+    if initialise_git:
+        _git(root, "init", "-q", "-b", _DEFAULT_BRANCH)
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "--no-verify", "-m", _INITIAL_COMMIT_MESSAGE)
+
+    return _Checkout(
+        root=root,
+        script=root / _SCRIPT_RELATIVE_PATH,
+        env=_shim_env(parent / _SHIM_DIR_NAME),
+    )
+
+
+@pytest.fixture
+def checkout(tmp_path: Path) -> _Checkout:
+    """Return an ample, committed checkout with the shims already in place.
+
+    Args:
+        tmp_path: Per-test directory holding the checkout and its shims.
+
+    Returns:
+        The staged checkout under test.
+    """
+    return _stage_checkout(tmp_path)
+
+
+def _receipt_field(text: str, key: str) -> str:
+    """Return one ``key=value`` field of a receipt.
+
+    Args:
+        text: Full receipt contents.
+        key: Field name to extract.
+
+    Returns:
+        The field's value with surrounding whitespace removed.
+    """
+    match = re.search(rf"^\s*{key}\s*=\s*(?P<value>\S.*?)\s*$", text, re.MULTILINE)
+    if match is None:
+        pytest.fail(f"the receipt does not record {key!r}; got: {text!r}")
+    return match.group("value")
+
+
+def _rewritten_field(text: str, key: str, value: str) -> str:
+    """Return the receipt with one field replaced.
+
+    Args:
+        text: Full receipt contents.
+        key: Field name to overwrite.
+        value: Replacement value.
+
+    Returns:
+        The rewritten receipt text.
+    """
+    return re.sub(
+        rf"^(\s*{key}\s*=\s*).*$",
+        rf"\g<1>{value}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+
+def _assert_hit(result: subprocess.CompletedProcess[str], reason: str) -> None:
+    """Assert the receipt was honoured.
+
+    Args:
+        result: Completed ``check`` invocation.
+        reason: Why this state deserves to reuse the earlier verdict.
+    """
+    assert result.returncode == _HIT_EXIT_CODE, (
+        f"{reason}; got exit {result.returncode} with "
+        f"stdout: {result.stdout!r} stderr: {result.stderr!r}"
+    )
+
+
+def _assert_miss(result: subprocess.CompletedProcess[str], reason: str) -> None:
+    """Assert the receipt was refused as stale rather than as unevaluable.
+
+    Args:
+        result: Completed ``check`` invocation.
+        reason: The difference that must invalidate the earlier verdict.
+    """
+    assert result.returncode == _MISS_EXIT_CODE, (
+        f"{reason} must force the gate to run again (exit {_MISS_EXIT_CODE}); "
+        f"got exit {result.returncode} with stdout: {result.stdout!r} "
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def _assert_tree_mutation_misses(
+    subject: _Checkout,
+    mutate: Callable[[Path], None],
+    reason: str,
+) -> None:
+    """Record a verdict, change the tree, and assert the verdict is refused.
+
+    The hit is asserted before the mutation so a refusal afterwards is
+    attributable to the mutation rather than to a fingerprint that never
+    matched anything.
+
+    Args:
+        subject: The staged checkout.
+        mutate: Callable applying the change, given the tree root.
+        reason: Description of the change, used in assertion messages.
+    """
+    assert subject.record().returncode == _HIT_EXIT_CODE
+    _assert_hit(subject.check(), "an untouched tree must reuse its verdict")
+
+    mutate(subject.root)
+
+    _assert_miss(subject.check(), reason)
+
+
+def _assert_env_mutation_misses(
+    subject: _Checkout,
+    baseline: dict[str, str | None],
+    mutation: dict[str, str | None],
+    reason: str,
+) -> None:
+    """Record under one environment and assert a changed one is refused.
+
+    Args:
+        subject: The staged checkout.
+        baseline: Environment changes in force when the receipt is written.
+        mutation: Further changes applied before the check.
+        reason: Description of the change, used in assertion messages.
+    """
+    recording_env = subject.env_with(baseline)
+    assert subject.record(env=recording_env).returncode == _HIT_EXIT_CODE
+    _assert_hit(
+        subject.check(env=recording_env),
+        "the recording environment must reuse its own verdict",
+    )
+
+    _assert_miss(subject.check(env=subject.env_with({**baseline, **mutation})), reason)
+
+
+def _assert_explains(result: subprocess.CompletedProcess[str], expected: str) -> None:
+    """Assert ``--explain`` named exactly the component that moved.
+
+    Args:
+        result: Completed ``check --explain`` invocation.
+        expected: The component name that must be reported.
+    """
+    _assert_miss(result, f"a changed {expected} component")
+    named = result.stdout.split()
+    assert expected in named, (
+        f"--explain must name the {expected!r} component; got stdout: {result.stdout!r}"
+    )
+    for other in _COMPONENTS:
+        if other != expected:
+            assert other not in named, (
+                f"only {expected!r} changed, but --explain also named {other!r}; "
+                f"got stdout: {result.stdout!r}"
+            )
+
+
+def _edit_source(root: Path) -> None:
+    """Append a line to a source file inside the declared paths.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    (root / _SOURCE_FILE).write_text(_MODULE_TEXT + _MUTATION_TEXT)
+
+
+def _edit_test(root: Path) -> None:
+    """Append a line to a test file inside the declared paths.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    (root / _TEST_FILE).write_text(_MODULE_TEXT + _MUTATION_TEXT)
+
+
+def _edit_pyproject(root: Path) -> None:
+    """Change the backend tool configuration.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    (root / _PYPROJECT_FILE).write_text(_PYPROJECT_TEXT + "other = 2\n")
+
+
+def _add_untracked_file(root: Path) -> None:
+    """Create a new, uncommitted, unignored file inside a declared path.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    _write(root, _UNTRACKED_FILE, _MODULE_TEXT)
+
+
+def _delete_declared_file(root: Path) -> None:
+    """Remove a tracked file from the working tree.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    (root / _DELETABLE_FILE).unlink()
+
+
+def _rename_with_identical_content(root: Path) -> None:
+    """Move a file without altering a single byte of its content.
+
+    Args:
+        root: Tree root of the staged checkout.
+    """
+    shutil.move(str(root / _RENAMABLE_FILE), str(root / _RENAMED_FILE))
+
+
+def test_fingerprint_is_a_stable_sha256_over_repeated_calls(checkout: _Checkout) -> None:
+    """Two reads of an untouched tree must agree, byte for byte.
+
+    Everything downstream is an equality comparison against this string, so any
+    instability -- a timestamp, an unsorted listing, a hash of a directory
+    iteration order -- turns every receipt into a coin flip and the gate learns
+    to distrust its own cache.
+    """
+    first = checkout.fingerprint()
+    second = checkout.fingerprint()
+
+    assert _SHA256_PATTERN.match(first), (
+        f"the fingerprint must be a lowercase sha256 hex digest; got: {first!r}"
+    )
+    assert first == second, (
+        "repeated fingerprints of an untouched tree diverged, so no receipt "
+        f"could ever match: {first!r} then {second!r}"
+    )
+
+
+def test_fingerprint_ignores_the_current_working_directory(
+    checkout: _Checkout,
+    tmp_path: Path,
+) -> None:
+    """The tree measured is the script's own, never the one the caller stands in.
+
+    Deriving the root from ``git rev-parse --show-toplevel`` would make the
+    fingerprint depend on where the caller happened to be, so a worktree lane
+    invoked from inside another checkout would record a receipt about somebody
+    else's files.
+    """
+    decoy = _stage_checkout(tmp_path / _DECOY_DIR_NAME, tracked_file_count=_DECOY_FILE_COUNT)
+
+    from_root = checkout.fingerprint()
+    from_decoy = checkout.run(_FINGERPRINT_COMMAND, _GATE, cwd=decoy.root)
+
+    assert from_decoy.returncode == _HIT_EXIT_CODE, from_decoy.stderr
+    assert from_decoy.stdout.strip() == from_root, (
+        "the fingerprint changed with the working directory, so the tree root "
+        "is being resolved from the caller's cwd instead of from the script"
+    )
+
+
+def test_unchanged_tree_reuses_its_recorded_verdict(checkout: _Checkout) -> None:
+    """The one case that may skip work: nothing at all has moved.
+
+    Every other test in this module exists to fence this one in.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    assert checkout.receipt_path().exists(), "record must write the gate's receipt"
+
+    _assert_hit(checkout.check(), "an untouched tree must reuse its verdict")
+
+
+def test_receipt_records_the_gate_schema_fingerprint_and_time(checkout: _Checkout) -> None:
+    """A receipt has to carry enough to be audited and to be invalidated.
+
+    The fingerprint is what the check compares; the gate name is what makes a
+    misfiled receipt detectable; the schema version is what lets a change to
+    the hashing scheme retire every receipt at once; the timestamp is what the
+    caller shows an operator when it reuses a verdict.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    text = checkout.receipt_path().read_text()
+
+    for field in _RECEIPT_FIELDS:
+        assert _receipt_field(text, field), f"the receipt must record {field}"
+    assert _receipt_field(text, _GATE_FIELD) == _GATE
+    assert _receipt_field(text, _FINGERPRINT_FIELD) == checkout.fingerprint(), (
+        "the recorded fingerprint must be the one the tree currently produces"
+    )
+
+
+def test_recording_a_receipt_does_not_invalidate_it(checkout: _Checkout) -> None:
+    """Writing the receipt must not change what the receipt describes.
+
+    A receipt stored inside a fingerprinted path would invalidate itself the
+    instant it was written, and the resulting permanent miss would look exactly
+    like a working cache that simply never hits.
+    """
+    before = checkout.fingerprint()
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    assert checkout.fingerprint() == before, (
+        "the receipt is stored somewhere the fingerprint measures, so the act "
+        "of recording a verdict destroys it"
+    )
+    _assert_hit(checkout.check(), "a freshly recorded receipt")
+
+
+def test_receipts_do_not_accumulate(checkout: _Checkout) -> None:
+    """One file per gate, overwritten, with no partial writes left behind.
+
+    A directory that grows a file per run is a disk leak on a machine running
+    four worktree lanes, and a stray temp file is the visible symptom of a
+    non-atomic write that a concurrent reader could observe half-finished.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    receipts = sorted((checkout.root / _RECEIPTS_DIR).iterdir())
+    assert receipts == [checkout.receipt_path()], (
+        f"exactly one receipt file must exist per gate; found: {receipts}"
+    )
+
+
+def test_a_change_outside_the_declared_paths_still_reuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """A merge that touches only planning notes must not re-run the suite.
+
+    This is the case the whole mechanism is built for: absorbing main into a
+    lane routinely changes nothing the backend gate measures, and paying the
+    full suite to observe that is the cost being removed.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    for outside in _OUTSIDE_FILES:
+        (checkout.root / outside).write_text(_OUTSIDE_TEXT + _MUTATION_TEXT)
+
+    _assert_hit(
+        checkout.check(),
+        "files outside every declared path cannot change what the gate measures",
+    )
+
+
+def test_a_new_commit_with_identical_content_still_reuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """History is not an input; only the bytes on disk are.
+
+    Folding a commit SHA or a branch position into the fingerprint would make
+    every merge commit a miss, which reintroduces the exact cost the receipt
+    removes while looking like a correctness measure.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _git(checkout.root, "commit", "-q", "--no-verify", "--allow-empty", "-m", _EMPTY_COMMIT_MESSAGE)
+
+    _assert_hit(checkout.check(), "a commit that changed no file content")
+
+
+def test_editing_a_source_file_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Changed production code invalidates every verdict about it.
+
+    The most basic honesty requirement: a receipt that survives an edit to the
+    code under test is a lie printed in green.
+    """
+    _assert_tree_mutation_misses(checkout, _edit_source, "an edited source file")
+
+
+def test_editing_a_test_file_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Changed tests invalidate the verdict as surely as changed code.
+
+    The gate's output is a function of both sides. Fingerprinting only ``src``
+    would let a rewritten assertion inherit the previous run's green.
+    """
+    _assert_tree_mutation_misses(checkout, _edit_test, "an edited test file")
+
+
+def test_editing_the_backend_configuration_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Tool configuration decides what the gate even checks.
+
+    Lint rules, coverage thresholds and marker definitions all live in
+    ``pyproject.toml``, so a receipt that survives an edit to it can carry a
+    verdict earned under different rules entirely.
+    """
+    _assert_tree_mutation_misses(checkout, _edit_pyproject, "an edited pyproject.toml")
+
+
+def test_a_new_untracked_file_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Work in progress counts, because the gate would have run against it.
+
+    Listing only ``--cached`` paths would make a brand-new, uncommitted module
+    invisible to the fingerprint while being perfectly visible to pytest, which
+    is the most common shape of a mid-development tree.
+    """
+    _assert_tree_mutation_misses(checkout, _add_untracked_file, "a new untracked file")
+
+
+def test_deleting_a_declared_file_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Removing an input changes the input set, hence the fingerprint.
+
+    A deleted-but-still-cached path that keeps contributing its old hash would
+    let a tree that no longer contains a module claim a verdict earned while it
+    did.
+    """
+    _assert_tree_mutation_misses(checkout, _delete_declared_file, "a deleted file")
+
+
+def test_renaming_a_file_without_changing_it_refuses_the_verdict(
+    checkout: _Checkout,
+) -> None:
+    """Paths are hashed alongside content, not merely the content stream.
+
+    A rename moves code between packages, changes what imports resolve, and can
+    break collection outright, yet the multiset of blob hashes is untouched. If
+    only the hashes were combined, this move would be invisible -- the quietest
+    possible way for the cache to be wrong.
+    """
+    _assert_tree_mutation_misses(
+        checkout,
+        _rename_with_identical_content,
+        "a file renamed with identical content",
+    )
+
+
+def test_changed_installed_packages_refuse_the_verdict(checkout: _Checkout) -> None:
+    """A different dependency set is a different program.
+
+    The suite's outcome depends on what is installed, which is why the gate
+    already runs a drift preflight; a receipt that outlives an upgrade would
+    hand back a verdict earned against packages that are no longer present.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    _assert_hit(checkout.check(), "an unchanged package set")
+
+    _assert_miss(
+        checkout.check(env=checkout.env_with({_FAKE_PIP_FREEZE_ENV: _OTHER_PIP_FREEZE})),
+        "a changed pip freeze",
+    )
+
+
+def test_a_changed_interpreter_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Cross-version behaviour is precisely what the compat matrix exists for.
+
+    Syntax accepted by one interpreter and rejected by another is a recurring
+    source of CI-only failures here, so a verdict earned on one interpreter
+    must never be reused on a different one.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_miss(
+        checkout.check(env=checkout.env_with({_FAKE_PYTHON_VERSION_ENV: _OTHER_PYTHON_VERSION})),
+        "a changed python3 -VV",
+    )
+
+
+def test_a_changed_virtualenv_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Two virtualenvs on one machine are two different package sets.
+
+    The lanes each have their own environment, and reusing a verdict across
+    them measures whichever one happened to be active last.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_miss(
+        checkout.check(env=checkout.env_with({_VIRTUALENV_ENV: _OTHER_VIRTUALENV})),
+        "a different active virtualenv",
+    )
+
+
+def test_an_unset_virtualenv_refuses_the_verdict(checkout: _Checkout) -> None:
+    """No virtualenv at all is the shape of the most common operator mistake.
+
+    Invoking the gate without activating the environment in the same shell call
+    runs everything against the system interpreter. That state must never
+    inherit a verdict earned inside the virtualenv, or the cache silently
+    converts a misconfigured run into a green one.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_miss(
+        checkout.check(env=checkout.env_with({_VIRTUALENV_ENV: None})),
+        "an unset VIRTUAL_ENV",
+    )
+
+
+def test_a_changed_hostname_refuses_the_verdict(checkout: _Checkout) -> None:
+    """Receipts are local claims and must not survive a move between machines.
+
+    A receipts directory that ever reaches CI or another developer would
+    otherwise assert that a suite passed on hardware it never ran on.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_miss(
+        checkout.check(env=checkout.env_with({_FAKE_HOSTNAME_ENV: _OTHER_HOSTNAME})),
+        "a different host",
+    )
+
+
+@pytest.mark.parametrize(
+    ("baseline", "mutation"),
+    [
+        pytest.param({}, {_POSTGRES_URL_ENV: _POSTGRES_URL}, id="postgres-url-appears"),
+        pytest.param(
+            {_POSTGRES_URL_ENV: _POSTGRES_URL},
+            {_POSTGRES_URL_ENV: None},
+            id="postgres-url-disappears",
+        ),
+        pytest.param(
+            {_POSTGRES_URL_ENV: _POSTGRES_URL},
+            {_POSTGRES_URL_ENV: _OTHER_POSTGRES_URL},
+            id="postgres-url-changes",
+        ),
+        pytest.param({}, {_REQUIRE_POSTGRES_ENV: _TRUTHY}, id="require-postgres-appears"),
+    ],
+)
+def test_outcome_affecting_environment_variables_refuse_the_verdict(
+    checkout: _Checkout,
+    baseline: dict[str, str | None],
+    mutation: dict[str, str | None],
+) -> None:
+    """The integration lane's switches decide which tests run at all.
+
+    These two variables select between a skipped integration lane, a live
+    Postgres lane, and a hard failure when Postgres is demanded but missing.
+    A receipt that survives them would let a run with the lane switched off
+    hand its green to a run that was supposed to exercise the real database.
+
+    Args:
+        checkout: The staged checkout.
+        baseline: Environment in force when the receipt is written.
+        mutation: The single change applied before the check.
+    """
+    _assert_env_mutation_misses(checkout, baseline, mutation, "a changed lane switch")
+
+
+def test_a_missing_receipt_is_a_miss_not_a_hit(checkout: _Checkout) -> None:
+    """With nothing recorded there is nothing to reuse.
+
+    The default has to be "run the gate": an absent receipt is the state of
+    every fresh clone and every worktree the fleet creates.
+    """
+    assert not checkout.receipt_path().exists()
+
+    _assert_miss(checkout.check(), "no receipt at all")
+
+
+def test_a_receipt_naming_another_gate_is_refused(checkout: _Checkout) -> None:
+    """A receipt is only evidence about the gate it names.
+
+    Receipts are per-gate files, so a copied or misfiled one is otherwise
+    indistinguishable from a legitimate verdict; recording the gate inside the
+    receipt is what makes that detectable at all.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    receipt = checkout.receipt_path()
+    receipt.write_text(_rewritten_field(receipt.read_text(), _GATE_FIELD, _UNREGISTERED_GATE))
+
+    _assert_miss(checkout.check(), "a receipt written for a different gate")
+
+
+def test_a_receipt_from_an_older_schema_is_refused(checkout: _Checkout) -> None:
+    """Bumping the schema retires every receipt in existence.
+
+    When the set of hashed components changes, old fingerprints answer a
+    different question. Without the version, the first receipt written under
+    the old scheme keeps being honoured under the new one.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    receipt = checkout.receipt_path()
+    current = _receipt_field(receipt.read_text(), _SCHEMA_VERSION_FIELD)
+    stale = f"{current}-superseded"
+    receipt.write_text(_rewritten_field(receipt.read_text(), _SCHEMA_VERSION_FIELD, stale))
+
+    _assert_miss(checkout.check(), f"a receipt recorded under schema {stale}")
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("schema", id="truncated"),
+        pytest.param("\x00\x01 not a receipt\n", id="binary-junk"),
+    ],
+)
+def test_a_corrupt_receipt_is_refused_without_crashing(
+    checkout: _Checkout,
+    contents: str,
+) -> None:
+    """A half-written receipt sends the gate back to work, quietly and safely.
+
+    An interrupted run, a full disk, or a killed process can all leave a stub
+    behind. Refusing it is the only safe reading, and doing so without a shell
+    traceback is what keeps operators from assuming the tool itself is broken
+    and reaching for a bypass flag.
+
+    Args:
+        checkout: The staged checkout.
+        contents: Damaged receipt contents to plant.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    checkout.receipt_path().write_text(contents)
+
+    result = checkout.check()
+
+    _assert_miss(result, "a corrupt receipt")
+    assert _TRACEBACK_MARKER not in f"{result.stdout}{result.stderr}", (
+        f"a corrupt receipt must be handled, not crashed on; got: {result.stderr!r}"
+    )
+
+
+def test_a_degenerate_gate_cannot_be_recorded_or_checked(tmp_path: Path) -> None:
+    """Declared paths that match almost nothing are an error, never a hit.
+
+    This is the failure that would defeat every other test in this file. A
+    typo'd path or a wrong tree root hashes the empty input into a perfectly
+    stable fingerprint, so the receipt matches in any tree at all and the gate
+    reports green about a codebase it never looked at. Both writing and reading
+    such a receipt must refuse, and the message must point at the paths so the
+    operator fixes the configuration instead of the code.
+    """
+    sparse = _stage_checkout(tmp_path, tracked_file_count=_SPARSE_FILE_COUNT)
+
+    recorded = sparse.record()
+    checked = sparse.check()
+
+    for label, result in (("record", recorded), ("check", checked)):
+        assert result.returncode == _CANNOT_EVALUATE_EXIT_CODE, (
+            f"{label} on a gate matching almost no files must exit "
+            f"{_CANNOT_EVALUATE_EXIT_CODE}; got exit {result.returncode} with "
+            f"stdout: {result.stdout!r} stderr: {result.stderr!r}"
+        )
+    message = f"{recorded.stdout}{recorded.stderr}".lower()
+    for marker in _DEGENERATE_MESSAGE_MARKERS:
+        assert marker in message, (
+            f"the refusal must explain that the declared paths matched too few "
+            f"files (missing {marker!r}); got: {message!r}"
+        )
+    assert not sparse.receipt_path().exists(), "a refused record must write no receipt"
+
+
+@pytest.mark.parametrize("name", _INVALID_GATE_NAMES)
+def test_an_invalid_gate_name_is_rejected_before_any_path_is_touched(
+    checkout: _Checkout,
+    name: str,
+) -> None:
+    """The gate name is the only value that reaches a path, so it is validated.
+
+    A name carrying a separator or a traversal segment would let a caller aim
+    the receipt read or write anywhere on disk. Rejecting the name up front,
+    without creating or reading a single file, is what keeps the receipt
+    directory the only thing this script can touch.
+
+    Args:
+        checkout: The staged checkout.
+        name: A malformed gate name.
+    """
+    before = sorted(path.relative_to(checkout.root) for path in checkout.root.rglob("*"))
+
+    result = checkout.run(_CHECK_COMMAND, name)
+
+    assert result.returncode == _CANNOT_EVALUATE_EXIT_CODE, (
+        f"the malformed gate name {name!r} must exit {_CANNOT_EVALUATE_EXIT_CODE}; "
+        f"got exit {result.returncode} with stderr: {result.stderr!r}"
+    )
+    after = sorted(path.relative_to(checkout.root) for path in checkout.root.rglob("*"))
+    assert after == before, (
+        f"the malformed gate name {name!r} changed the tree; a rejected name "
+        "must not create, read, or remove anything"
+    )
+
+
+def test_an_unregistered_gate_name_cannot_be_evaluated(checkout: _Checkout) -> None:
+    """A well-formed name with no declared paths is a caller error, not a miss.
+
+    Returning "not verified" for a gate that does not exist would send the
+    caller off to run a gate nobody defined; exit 2 names the real problem.
+    """
+    result = checkout.run(_CHECK_COMMAND, _UNREGISTERED_GATE)
+
+    assert result.returncode == _CANNOT_EVALUATE_EXIT_CODE, (
+        f"an unregistered gate must exit {_CANNOT_EVALUATE_EXIT_CODE}; got exit "
+        f"{result.returncode} with stderr: {result.stderr!r}"
+    )
+    assert _UNREGISTERED_GATE in f"{result.stdout}{result.stderr}", (
+        f"the message must name the unknown gate; got: {result.stderr!r}"
+    )
+
+
+def test_a_tree_that_is_not_a_repository_cannot_be_evaluated(tmp_path: Path) -> None:
+    """Without git there is no file listing, so there is no honest answer.
+
+    Falling back to an empty listing here would produce the same stable
+    fingerprint the degenerate-input guard exists to reject.
+    """
+    unversioned = _stage_checkout(tmp_path, initialise_git=False)
+
+    result = unversioned.run(_FINGERPRINT_COMMAND, _GATE)
+
+    assert result.returncode == _CANNOT_EVALUATE_EXIT_CODE, (
+        f"a non-repository must exit {_CANNOT_EVALUATE_EXIT_CODE}; got exit "
+        f"{result.returncode} with stdout: {result.stdout!r} stderr: {result.stderr!r}"
+    )
+
+
+def test_explain_names_the_paths_component(checkout: _Checkout) -> None:
+    """An operator who is refused deserves to know which input moved.
+
+    Without this, a refusal is indistinguishable from a broken cache, and the
+    documented response to a cache nobody understands is to disable it.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+    _edit_source(checkout.root)
+
+    _assert_explains(checkout.check(_EXPLAIN_FLAG), _PATHS_COMPONENT)
+
+
+def test_explain_names_the_packages_component(checkout: _Checkout) -> None:
+    """An environment refusal must not be reported as a code change.
+
+    Naming ``paths`` when the real difference was an upgraded dependency sends
+    the operator to diff a tree that did not move.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_explains(
+        checkout.check(
+            _EXPLAIN_FLAG,
+            env=checkout.env_with({_FAKE_PIP_FREEZE_ENV: _OTHER_PIP_FREEZE}),
+        ),
+        _PACKAGES_COMPONENT,
+    )
+
+
+def test_explain_names_the_env_component(checkout: _Checkout) -> None:
+    """A lane switch is the least visible difference, so it must be named.
+
+    Nothing about the tree or the environment looks different to the eye when
+    a single exported variable changes, which makes this the refusal most
+    likely to be mistaken for a bug in the receipt mechanism.
+    """
+    assert checkout.record().returncode == _HIT_EXIT_CODE
+
+    _assert_explains(
+        checkout.check(
+            _EXPLAIN_FLAG,
+            env=checkout.env_with({_POSTGRES_URL_ENV: _POSTGRES_URL}),
+        ),
+        _ENV_COMPONENT,
+    )
+
+
+def test_help_documents_the_three_subcommands(checkout: _Checkout) -> None:
+    """The primitive is meant to be called by other gates, so it documents itself.
+
+    A gate author who cannot discover ``record`` and ``check`` will hand-roll a
+    timestamp file instead, which is the design this replaces.
+    """
+    result = checkout.run(_HELP_FLAG)
+
+    assert result.returncode == _HIT_EXIT_CODE, result.stderr
+    assert _USAGE_MARKER in result.stdout, f"--help must print usage; got: {result.stdout!r}"
+    for command in (_FINGERPRINT_COMMAND, _RECORD_COMMAND, _CHECK_COMMAND):
+        assert command in result.stdout, (
+            f"--help must document the {command!r} subcommand; got: {result.stdout!r}"
+        )

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,8 @@ scripts/
 │   ├── typecheck.sh   # mypy
 │   ├── test.sh        # pytest, xdist-distributed (--unit / --integration / --e2e / --all;
 │   │                  #   --coverage to report+gate, --coverage-data to collect only)
+│   │                  #   Positional paths run just those, unsharded; one whole-suite
+│   │                  #   run at a time per tree (exit 3 if another is in flight)
 │   ├── coverage.sh    # pytest with coverage (≥90%); --report-only reports on existing data
 │   ├── security.sh    # bandit + pip-audit
 │   ├── complexity.sh  # radon + xenon; gates at xenon A grade and MI rank ≥ B
@@ -30,6 +32,9 @@ scripts/
 │   ├── typecheck.sh   # tsc --noEmit
 │   ├── test.sh        # jest
 │   └── pr-status.sh
+├── quality/           # Cross-cutting gate primitives
+│   └── verified.sh    # Gate receipts: fingerprint / record / check that a green
+│                      #   run still describes this tree (only exit 0 licenses reuse)
 ├── dev-setup.sh       # Pre-existing: idempotent dev env bootstrap
 └── pre-deploy-check.sh # Pre-existing: deployment readiness check
 ```

--- a/scripts/backend/check-all.sh
+++ b/scripts/backend/check-all.sh
@@ -1,19 +1,44 @@
 #!/usr/bin/env bash
 # scripts/check-all.sh - Run all quality checks
-# Usage: ./scripts/check-all.sh [--verbose] [--help]
+# Usage: ./scripts/check-all.sh [--verbose] [--force] [--help]
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
 
+readonly GATE_NAME="backend"
+readonly VERIFIED_SCRIPT="$SCRIPT_DIR/../quality/verified.sh"
+# The one exit code from the receipt primitive that licenses reusing a verdict.
+# "Not verified" and "cannot evaluate" both mean: do the work.
+readonly RECEIPT_HIT_EXIT_CODE=0
+
+# Checks a receipt may never excuse, named rather than positional so the
+# asymmetry survives a reordering of the stages.
+#
+# Lint, format, mypy, complexity, the suite and the coverage report are a pure
+# function of the fingerprinted inputs, so re-deriving them from a byte-identical
+# tree buys nothing. The security stage is not: security.sh runs pip-audit
+# against the PyPI advisory database over the network, so an advisory published
+# after the receipt was written makes yesterday's green false today, and no
+# content hash of this tree can see that. A network-dated check is never
+# cacheable. The dependency-drift preflight below is exempt for the mirror-image
+# reason - it measures the installed packages, which are not part of the tree
+# at all.
+ALWAYS_RUN_CHECKS=("Security checks")
+
 VERBOSE=false
+FORCE=false
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --verbose)
             VERBOSE=true
+            shift
+            ;;
+        --force)
+            FORCE=true
             shift
             ;;
         --help)
@@ -35,8 +60,14 @@ Runs:
   6. Unit tests (measured under coverage)
   7. Coverage report (reports on the data step 6 wrote; no second test run)
 
+When a gate receipt proves the previous green run still describes this tree,
+steps 1-3 and 5-7 are reused instead of re-run. Step 0 and step 4 always run:
+they measure the installed packages and a network advisory database, neither
+of which is part of the tree being fingerprinted.
+
 OPTIONS:
     --verbose   Show detailed output
+    --force     Re-derive every check from scratch, ignoring any receipt
     --help      Display this help message
 
 EXIT CODES:
@@ -47,6 +78,7 @@ EXIT CODES:
 EXAMPLES:
     $(basename "$0")          # Run all checks
     $(basename "$0") --verbose # Show detailed output
+    $(basename "$0") --force   # Ignore the receipt and prove the tree again
 EOF
             exit 0
             ;;
@@ -68,6 +100,27 @@ fi
 echo "=== Running All Quality Checks ==="
 echo ""
 
+# Consult the gate receipt. Only a hit may license reuse: a miss and an
+# unevaluable gate both fall through to the full run, and neither turns an
+# otherwise-green run red, because an unusable cache is not a quality finding.
+SHORT_CIRCUIT=false
+RECEIPT_DETAIL=""
+if ! $FORCE; then
+    RECEIPT_STATUS=0
+    RECEIPT_DETAIL="$("$VERIFIED_SCRIPT" check "$GATE_NAME" 2> /dev/null)" || RECEIPT_STATUS=$?
+    if [ "$RECEIPT_STATUS" -eq "$RECEIPT_HIT_EXIT_CODE" ]; then
+        SHORT_CIRCUIT=true
+    fi
+fi
+
+if $SHORT_CIRCUIT; then
+    echo "Reusing the verified verdict for the $GATE_NAME gate ($RECEIPT_DETAIL)."
+    echo "Nothing this gate measures has changed since that run."
+    echo "The security checks still run: pip-audit consults an advisory database"
+    echo "that changes without this tree changing, so it is never reused."
+    echo ""
+fi
+
 # Fail-fast preflight, not a collected run_check: every check below measures
 # the *installed* packages, so a verdict produced from a drifted virtualenv
 # does not predict CI. Carrying on would hand back seven meaningless results
@@ -87,15 +140,49 @@ if [ "$DRIFT_EXIT" -ne 0 ]; then
 fi
 echo ""
 
+# The fingerprint the checks below are about to be run against. Captured before
+# the first check and compared against the tree's fingerprint at the end, so a
+# file edited while the gate was in flight cannot bank a verdict for a tree that
+# was never checked as a whole. Empty means the gate could not be fingerprinted
+# at all, which withholds the receipt rather than failing the run.
+START_FINGERPRINT=""
+if ! $SHORT_CIRCUIT; then
+    START_FINGERPRINT="$("$VERIFIED_SCRIPT" fingerprint "$GATE_NAME" 2> /dev/null)" || true
+fi
+
 FAILED_CHECKS=()
 PASSED_CHECKS=()
+SKIPPED_CHECKS=()
+
+# Whether a receipt may excuse this check. See ALWAYS_RUN_CHECKS above for why
+# the answer is no for anything measuring the network or the environment.
+is_always_run() {
+    local candidate=$1
+    local always_run
+    for always_run in "${ALWAYS_RUN_CHECKS[@]}"; do
+        if [ "$candidate" = "$always_run" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
 
 # Helper function to run a check
+#
+# The receipt short-circuit lives here rather than at the call sites: the seven
+# `run_check "<Name>" ...` lines are parsed as text by other suites to discover
+# the stage names and flags, so conditioning or reordering them would break
+# those suites from a distance.
 run_check() {
     local check_name=$1
     local script=$2
     shift 2
     local args=("$@")
+
+    if $SHORT_CIRCUIT && ! is_always_run "$check_name"; then
+        SKIPPED_CHECKS+=("$check_name")
+        return 0
+    fi
 
     echo "Running: $check_name"
     if "$SCRIPT_DIR/$script" "${args[@]+"${args[@]}"}" $VERBOSE_FLAG; then
@@ -117,15 +204,45 @@ run_check "Complexity analysis" "complexity.sh"
 # The coverage stage reports on whatever data is on disk, so the disk has to
 # be cleared first: coverage.py appends parallel data files, and a leftover
 # .coverage or coverage.xml would be reported - and handed to CI - as if it
-# described this run.
-rm -f .coverage .coverage.* coverage.xml
+# described this run. A short-circuited run writes no new data, so it must not
+# delete the artifacts produced by the verified run it is standing on.
+if ! $SHORT_CIRCUIT; then
+    rm -f .coverage .coverage.* coverage.xml
+fi
 
 run_check "Unit tests" "test.sh" --unit --coverage-data
 run_check "Coverage report" "coverage.sh" --report-only --xml
 
+# Bank the verdict only when this run actually earned it: a full run, every
+# check green, and a tree that did not move underneath it. A run that measured
+# the old bytes in some stages and the new bytes in others proved nothing about
+# either tree, so it stays green and says why it recorded nothing.
+record_receipt_if_earned() {
+    if $SHORT_CIRCUIT || [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
+        return 0
+    fi
+    if [ -z "$START_FINGERPRINT" ]; then
+        return 0
+    fi
+    local end_fingerprint=""
+    end_fingerprint="$("$VERIFIED_SCRIPT" fingerprint "$GATE_NAME" 2> /dev/null)" || true
+    if [ "$end_fingerprint" != "$START_FINGERPRINT" ]; then
+        echo ""
+        echo "No receipt recorded: the tree changed during the run, so these results"
+        echo "describe a mixture of two trees rather than the one on disk now."
+        return 0
+    fi
+    "$VERIFIED_SCRIPT" record "$GATE_NAME" > /dev/null 2>&1 || true
+}
+
+record_receipt_if_earned
+
 echo "=== Quality Checks Summary ==="
 echo "Passed: ${#PASSED_CHECKS[@]}"
 echo "Failed: ${#FAILED_CHECKS[@]}"
+if [ ${#SKIPPED_CHECKS[@]} -gt 0 ]; then
+    echo "Reused from the receipt (not re-run): ${SKIPPED_CHECKS[*]}"
+fi
 
 if [ ${#FAILED_CHECKS[@]} -gt 0 ]; then
     echo ""

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -15,6 +15,18 @@ TREE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 readonly LOCK_DIR="$TREE_ROOT/.gate-state/locks"
 readonly LOCK_FILE="$LOCK_DIR/backend-suite.lock"
+# Stealing a lock from a dead holder is a read-decide-replace sequence, and
+# nothing about a plain file makes those three steps one. `mkdir` is the
+# portable atomic primitive: exactly one of two racing runs creates the
+# directory, so the steal can be re-verified under it and the loser sees the
+# winner's brand-new lock instead of deleting it.
+readonly STEAL_MUTEX_DIR="$LOCK_DIR/backend-suite.steal"
+readonly STEAL_MUTEX_HOLDER="$STEAL_MUTEX_DIR/holder"
+# The mutex is held only long enough to re-read one small file, so a handful of
+# short attempts is generous. A run that still cannot take it is contending
+# with something that is not going to finish.
+readonly STEAL_MUTEX_ATTEMPTS=5
+readonly STEAL_MUTEX_RETRY_SECONDS=0.05
 
 readonly TEST_FAILURE_EXIT_CODE=1
 readonly USAGE_EXIT_CODE=2
@@ -28,6 +40,7 @@ COVERAGE_DATA=false
 VERBOSE=false
 TARGETS=()
 LOCK_HELD=false
+STEAL_MUTEX_HELD=false
 
 # Whole-suite runs are distributed across cores with pytest-xdist. Measured on
 # a 4-core box: 15m58s serial -> 4m07s at -n auto, identical coverage (#2076).
@@ -165,6 +178,69 @@ take_lock_file() {
     return 1
 }
 
+steal_mutex_holder() {
+    [ -f "$STEAL_MUTEX_HOLDER" ] || return 0
+    head -n 1 "$STEAL_MUTEX_HOLDER" 2> /dev/null | tr -d '[:space:]'
+}
+
+take_steal_mutex() {
+    local attempt=0
+    while [ "$attempt" -lt "$STEAL_MUTEX_ATTEMPTS" ]; do
+        if mkdir "$STEAL_MUTEX_DIR" 2> /dev/null; then
+            STEAL_MUTEX_HELD=true
+            printf '%s\n' "$$" > "$STEAL_MUTEX_HOLDER"
+            return 0
+        fi
+        # The pause comes first so a holder that has only just created the
+        # directory has had its moment to name itself. What is still unnamed,
+        # or named after a process that no longer exists, is residue from a run
+        # that was killed - and leaving it in place would wedge every future
+        # steal exactly as the stale lock it guards would.
+        sleep "$STEAL_MUTEX_RETRY_SECONDS"
+        if ! holder_is_live "$(steal_mutex_holder)"; then
+            rm -rf "$STEAL_MUTEX_DIR"
+        fi
+        attempt=$((attempt + 1))
+    done
+    return 1
+}
+
+release_steal_mutex() {
+    # Released on every path out, and by ownership rather than by path, for the
+    # same reason the suite lock is.
+    [ "$STEAL_MUTEX_HELD" = true ] || return 0
+    STEAL_MUTEX_HELD=false
+    if [ "$(steal_mutex_holder)" = "$$" ]; then
+        rm -rf "$STEAL_MUTEX_DIR"
+    fi
+}
+
+steal_stale_lock() {
+    # A lock naming a process that no longer exists is the residue of a run
+    # killed mid-suite. Obeying it would wedge the tree until somebody deleted
+    # a file they have never heard of, and the step after that is a bypass.
+    #
+    # The steal is a compare-and-swap, not a removal: two runs that read the
+    # same dead PID both conclude they may steal, and without the mutex the
+    # second deletes the first's brand-new lock on the strength of a decision
+    # about a file that no longer exists. Both then run pytest against one
+    # coverage data file, one set of fixture databases, and cores that
+    # `-n auto` handed out twice.
+    local observed=$1
+    take_steal_mutex || return 1
+    # The lock is removed only while it still names the dead holder this run
+    # judged. If it names anyone else the world moved under that decision, and
+    # take_lock_file is the honest way to ask again: it succeeds when the lock
+    # was simply released in the meantime, and fails - leaving the new owner's
+    # file untouched - when somebody else got there first.
+    if [ "$(lock_holder)" = "$observed" ]; then
+        rm -f "$LOCK_FILE"
+    fi
+    take_lock_file || true
+    release_steal_mutex
+    [ "$LOCK_HELD" = true ]
+}
+
 acquire_suite_lock() {
     mkdir -p "$LOCK_DIR"
     take_lock_file && return 0
@@ -173,11 +249,7 @@ acquire_suite_lock() {
     if holder_is_live "$holder"; then
         refuse_contended_run "$holder"
     fi
-    # A lock naming a process that no longer exists is the residue of a run
-    # killed mid-suite. Obeying it would wedge the tree until somebody deleted
-    # a file they have never heard of, and the step after that is a bypass.
-    rm -f "$LOCK_FILE"
-    take_lock_file && return 0
+    steal_stale_lock "$holder" && return 0
     refuse_contended_run "$(lock_holder)"
 }
 
@@ -191,6 +263,11 @@ release_suite_lock() {
     fi
 }
 
+release_held_locks() {
+    release_steal_mutex
+    release_suite_lock
+}
+
 warn_if_suite_lock_is_held() {
     # A targeted run neither takes nor waits for the lock, but the machine
     # really is busy, so a surprising result deserves a reason.
@@ -201,7 +278,7 @@ warn_if_suite_lock_is_held() {
     fi
 }
 
-trap release_suite_lock EXIT INT TERM
+trap release_held_locks EXIT INT TERM
 
 if [ ${#TARGETS[@]} -gt 0 ] && { $COVERAGE || $COVERAGE_DATA; }; then
     echo "Error: coverage cannot be combined with a positional path." >&2

--- a/scripts/backend/test.sh
+++ b/scripts/backend/test.sh
@@ -1,17 +1,33 @@
 #!/usr/bin/env bash
 # scripts/test.sh - Run tests with Pytest
 # Usage: ./scripts/test.sh [--unit|--integration|--e2e|--all] [--coverage]
-#                          [--verbose] [--help]
+#                          [--verbose] [--help] [PATH...]
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../backend" && pwd)"
+# The lock is keyed per tree root, derived from this script's own location and
+# never from `git rev-parse`, which inside a linked worktree names a different
+# tree. Per tree is the point: the parallel worktree lanes contend over nothing,
+# so only an agent racing itself inside one lane is refused.
+TREE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+readonly LOCK_DIR="$TREE_ROOT/.gate-state/locks"
+readonly LOCK_FILE="$LOCK_DIR/backend-suite.lock"
+
+readonly TEST_FAILURE_EXIT_CODE=1
+readonly USAGE_EXIT_CODE=2
+# Distinct from a test failure on purpose: "your tests failed" and "this result
+# would not have been trustworthy" call for opposite responses.
+readonly REFUSED_EXIT_CODE=3
 
 TEST_TYPE="unit"
 COVERAGE=false
 COVERAGE_DATA=false
 VERBOSE=false
+TARGETS=()
+LOCK_HELD=false
 
 # Whole-suite runs are distributed across cores with pytest-xdist. Measured on
 # a 4-core box: 15m58s serial -> 4m07s at -n auto, identical coverage (#2076).
@@ -57,6 +73,16 @@ Usage: $(basename "$0") [OPTIONS]
 
 Run tests using Pytest.
 
+With no positional argument the whole suite runs, distributed across cores and
+filtered by marker. Positional paths (relative to backend/, node ids included)
+run exactly those paths instead: unsharded, unfiltered, and without taking the
+whole-suite lock.
+
+Only one whole-suite run at a time is allowed per tree. Two of them share the
+coverage data file, the fixture databases and the cores that -n auto sized for
+one process, so a result observed while another is in flight is unproven until
+it is re-run alone.
+
 OPTIONS:
     --unit          Run unit tests only (default)
     --integration   Run integration tests only
@@ -77,21 +103,113 @@ ENVIRONMENT:
 EXIT CODES:
     0               All tests passed
     1               Test failures
-    2               Error running tests
+    2               Usage error
+    3               Refused: another whole-suite run is in flight in this tree
 
 EXAMPLES:
     $(basename "$0")                     # Run unit tests
     $(basename "$0") --all               # Run all tests
     $(basename "$0") --unit --coverage   # Unit tests with coverage
+    $(basename "$0") tests/test_x.py     # Run one file, unsharded
+    $(basename "$0") tests/test_x.py::test_y  # Run one test
 EOF
             exit 0
             ;;
-        *)
+        -*)
+            # A mistyped option must not fall through to the positional list,
+            # where pytest would take it for a file name and report a
+            # collection error nobody can read.
             echo "Error: Unknown option: $1" >&2
-            exit 2
+            exit "$USAGE_EXIT_CODE"
+            ;;
+        *)
+            TARGETS+=("$1")
+            shift
             ;;
     esac
 done
+
+lock_holder() {
+    [ -f "$LOCK_FILE" ] || return 0
+    head -n 1 "$LOCK_FILE" 2> /dev/null | tr -d '[:space:]'
+}
+
+holder_is_live() {
+    local holder=$1
+    case "$holder" in
+        "" | *[!0-9]*) return 1 ;;
+        *) kill -0 "$holder" 2> /dev/null ;;
+    esac
+}
+
+refuse_contended_run() {
+    local holder=$1
+    echo "Refusing to run: whole-suite run PID $holder is already in flight in this tree." >&2
+    echo "Two of them share the coverage data file, the fixture databases and the cores" >&2
+    echo "that -n auto sized for one process, so whatever either prints is unproven until" >&2
+    echo "it is re-run alone. Wait for PID $holder, or kill it." >&2
+    echo "Lock: $LOCK_FILE" >&2
+    exit "$REFUSED_EXIT_CODE"
+}
+
+take_lock_file() {
+    # `set -o noclobber` makes create-and-write a single atomic step, so two
+    # runs racing here cannot both come away believing they own the suite.
+    if (
+        set -o noclobber
+        printf '%s\n' "$$" > "$LOCK_FILE"
+    ) 2> /dev/null; then
+        LOCK_HELD=true
+        return 0
+    fi
+    return 1
+}
+
+acquire_suite_lock() {
+    mkdir -p "$LOCK_DIR"
+    take_lock_file && return 0
+    local holder
+    holder="$(lock_holder)"
+    if holder_is_live "$holder"; then
+        refuse_contended_run "$holder"
+    fi
+    # A lock naming a process that no longer exists is the residue of a run
+    # killed mid-suite. Obeying it would wedge the tree until somebody deleted
+    # a file they have never heard of, and the step after that is a bypass.
+    rm -f "$LOCK_FILE"
+    take_lock_file && return 0
+    refuse_contended_run "$(lock_holder)"
+}
+
+release_suite_lock() {
+    # Release by ownership, never by path: if this run overran and another
+    # stole the lock, deleting the file would strip the new owner's protection
+    # and let a third run start against a suite already in flight.
+    [ "$LOCK_HELD" = true ] || return 0
+    if [ "$(lock_holder)" = "$$" ]; then
+        rm -f "$LOCK_FILE"
+    fi
+}
+
+warn_if_suite_lock_is_held() {
+    # A targeted run neither takes nor waits for the lock, but the machine
+    # really is busy, so a surprising result deserves a reason.
+    local holder
+    holder="$(lock_holder)"
+    if holder_is_live "$holder"; then
+        echo "Note: whole-suite run PID $holder is in flight here; a contended result may mislead." >&2
+    fi
+}
+
+trap release_suite_lock EXIT INT TERM
+
+if [ ${#TARGETS[@]} -gt 0 ] && { $COVERAGE || $COVERAGE_DATA; }; then
+    echo "Error: coverage cannot be combined with a positional path." >&2
+    echo "A partial run measures a fraction of the codebase against a whole-repo" >&2
+    echo "threshold, so it fails for a reason that has nothing to do with the test being" >&2
+    echo "written. Run the named path without coverage, or the whole suite with it." >&2
+    exit "$USAGE_EXIT_CODE"
+fi
 
 cd "$PROJECT_ROOT"
 
@@ -100,26 +218,39 @@ if $VERBOSE; then
     set -x
 fi
 
-# Build pytest arguments
-PYTEST_ARGS=(-v -n "$PYTEST_WORKERS" --dist loadfile)
+# Build pytest arguments. A targeted run inherits none of the whole-suite argv:
+# xdist would shard one file across workers whose module-scoped database
+# fixtures assume a single worker per file, the marker expression would silently
+# drop a test named explicitly, and appending tests/ would quietly restore the
+# full run the caller was avoiding.
+PYTEST_ARGS=(-v)
 
-case "$TEST_TYPE" in
-    unit)
-        echo "=== Running Unit Tests ==="
-        PYTEST_ARGS+=(-m "not integration and not e2e")
-        ;;
-    integration)
-        echo "=== Running Integration Tests ==="
-        PYTEST_ARGS+=(-m "integration")
-        ;;
-    e2e)
-        echo "=== Running End-to-End Tests ==="
-        PYTEST_ARGS+=(-m "e2e")
-        ;;
-    all)
-        echo "=== Running All Tests ==="
-        ;;
-esac
+if [ ${#TARGETS[@]} -gt 0 ]; then
+    echo "=== Running Targeted Tests ==="
+    warn_if_suite_lock_is_held
+    PYTEST_TARGETS=("${TARGETS[@]}")
+else
+    acquire_suite_lock
+    PYTEST_TARGETS=("tests/")
+    PYTEST_ARGS+=(-n "$PYTEST_WORKERS" --dist loadfile)
+    case "$TEST_TYPE" in
+        unit)
+            echo "=== Running Unit Tests ==="
+            PYTEST_ARGS+=(-m "not integration and not e2e")
+            ;;
+        integration)
+            echo "=== Running Integration Tests ==="
+            PYTEST_ARGS+=(-m "integration")
+            ;;
+        e2e)
+            echo "=== Running End-to-End Tests ==="
+            PYTEST_ARGS+=(-m "e2e")
+            ;;
+        all)
+            echo "=== Running All Tests ==="
+            ;;
+    esac
+fi
 
 # Add coverage if requested.
 #
@@ -155,7 +286,10 @@ if $VERBOSE; then
     echo "Running pytest with args: ${PYTEST_ARGS[*]}"
 fi
 
-pytest "${PYTEST_ARGS[@]}" tests/ || { echo "✗ Tests failed" >&2; exit 1; }
+pytest "${PYTEST_ARGS[@]}" "${PYTEST_TARGETS[@]}" || {
+    echo "✗ Tests failed" >&2
+    exit "$TEST_FAILURE_EXIT_CODE"
+}
 
 echo "✓ Tests passed"
 

--- a/scripts/quality/verified.sh
+++ b/scripts/quality/verified.sh
@@ -22,7 +22,9 @@ TREE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Bumping this retires every receipt in existence. It is the only safe response
 # to a change in what the fingerprint measures, or in how it combines it.
-readonly SCHEMA_VERSION="1"
+# Bumped to 2 when the paths component gained each file's executable bit and
+# stopped letting .gitattributes normalise line endings out of the content.
+readonly SCHEMA_VERSION="2"
 
 readonly RECEIPTS_DIR="$TREE_ROOT/.gate-state/receipts"
 readonly RECEIPT_SUFFIX=".receipt"
@@ -37,6 +39,11 @@ readonly GATE_NAME_PATTERN='^[a-z0-9-]+$'
 # That is exactly what a typo'd path or a misplaced script looks like, so too
 # few files is an error rather than a hit.
 readonly MINIMUM_DECLARED_FILES=50
+
+# How a file's executable bit is spelled in the hashed listing. One character,
+# so folding the mode in costs the digest a byte per file rather than a process.
+readonly EXECUTABLE_MODE_FLAG="x"
+readonly REGULAR_MODE_FLAG="-"
 
 # Only EXIT_HIT may ever license reuse of a verdict. EXIT_MISS means "not
 # verified, run the gate"; EXIT_CANNOT_EVALUATE means "no honest answer is
@@ -140,30 +147,111 @@ require_git_repository() {
     return "$EXIT_CANNOT_EVALUATE"
 }
 
+count_lines() {
+    # Counts a captured multi-line string, reading the empty string as zero
+    # rather than as the one phantom line a bare `printf '%s\n' ""` produces.
+    print_lines "$1" | wc -l | tr -d '[:space:]'
+}
+
+refuse_unlistable_paths() {
+    printf 'Error: git could not list the declared paths (%s) under %s.\n' \
+        "$*" "$TREE_ROOT" >&2
+    printf 'A listing that failed partway through is not evidence about this tree, and\n' >&2
+    printf 'an empty one fingerprints identically in every tree on earth.\n' >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
+refuse_unhashable_paths() {
+    printf 'Error: git could not hash every declared path under %s.\n' "$TREE_ROOT" >&2
+    printf 'hash-object stops at the first path it cannot open - a broken symlink, an\n' >&2
+    printf 'unreadable file, a stale index lock - so every path after it would\n' >&2
+    printf 'contribute nothing, and would do so again on the next run: a degraded\n' >&2
+    printf 'fingerprint that matches itself and certifies whatever changed behind it.\n' >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
 declared_files() {
     # Every file the gate measures: tracked plus untracked-and-unignored, minus
     # the ones deleted from the working tree. Work in progress counts, because
     # the gate would have collected it; a still-cached deletion does not,
     # because the tree no longer contains it.
+    #
+    # Every step's status is checked by hand. This function is reached only
+    # through command substitutions, inside which bash does not apply errexit,
+    # and the caller's `|| exit $?` suppresses it for the whole call tree
+    # besides - so a failure that went unchecked here would quietly contribute
+    # a short listing to a fingerprint that then matches itself.
     local listed deleted
-    listed="$(git -C "$TREE_ROOT" ls-files --cached --others --exclude-standard -- "$@")"
-    deleted="$(git -C "$TREE_ROOT" ls-files --deleted -- "$@")"
-    LC_ALL=C comm -23 \
-        <(print_lines "$listed" | LC_ALL=C sort -u) \
-        <(print_lines "$deleted" | LC_ALL=C sort -u)
+    if ! listed="$(git -C "$TREE_ROOT" ls-files --cached --others --exclude-standard \
+        -- "$@" | LC_ALL=C sort -u)"; then
+        refuse_unlistable_paths "$@"
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    if ! deleted="$(git -C "$TREE_ROOT" ls-files --deleted -- "$@" | LC_ALL=C sort -u)"; then
+        refuse_unlistable_paths "$@"
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    if ! LC_ALL=C comm -23 <(print_lines "$listed") <(print_lines "$deleted"); then
+        refuse_unlistable_paths "$@"
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+}
+
+path_mode_lines() {
+    # Reads the file listing on stdin and emits "<path> <mode flag>".
+    #
+    # `git hash-object` hashes blob content only, so `chmod +x` moves none of
+    # the bytes it reads. That is not cosmetic here: check-all.sh execs
+    # scripts/backend/*.sh by path, so the mode decides whether a stage can run
+    # at all. The bit is read from the WORKING TREE rather than from the index,
+    # because an untracked file has no index entry and a tracked one carries
+    # the mode of its last `git add` instead of the one on disk.
+    #
+    # One builtin test per file, in a single shell: the whole fingerprint is
+    # taken up to three times per check-all run over roughly nine hundred
+    # files, which is no place to spawn a process each.
+    local file
+    while IFS= read -r file; do
+        if [ -x "$TREE_ROOT/$file" ]; then
+            printf '%s %s\n' "$file" "$EXECUTABLE_MODE_FLAG"
+        else
+            printf '%s %s\n' "$file" "$REGULAR_MODE_FLAG"
+        fi
+    done
 }
 
 paths_digest() {
-    # Each path is hashed ALONGSIDE its content. Combining the content hashes
-    # alone would leave a file renamed without an edit indistinguishable from
-    # an untouched tree - a move that changes what imports resolve, and the
-    # quietest possible way for a receipt to be wrong. One `git hash-object`
-    # process reads every path and answers in the order it was asked, so its
-    # output pairs back against the path list line for line.
+    # Each path is hashed ALONGSIDE its content and its executable bit.
+    # Combining the content hashes alone would leave a file renamed without an
+    # edit indistinguishable from an untouched tree - a move that changes what
+    # imports resolve, and the quietest possible way for a receipt to be wrong.
+    # One `git hash-object` process reads every path and answers in the order it
+    # was asked, so its output pairs back against the path list line for line.
+    #
+    # `--no-filters` hashes the literal bytes on disk. Without it git applies
+    # .gitattributes, where `* text=auto eol=lf` makes the CRLF and LF spellings
+    # of one file hash identically - the single difference ruff-format would
+    # reject, certified by a fingerprint that could not see it.
     local files="$1"
-    local hashes
-    hashes="$(print_lines "$files" | git -C "$TREE_ROOT" hash-object --stdin-paths)"
-    paste -d ' ' <(print_lines "$files") <(print_lines "$hashes") | LC_ALL=C sort | sha256_hex
+    local hashes paired
+    if ! hashes="$(print_lines "$files" \
+        | git -C "$TREE_ROOT" hash-object --no-filters --stdin-paths)"; then
+        refuse_unhashable_paths
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    # Fewer hashes than paths is the signature of the truncation above: git
+    # aborts wholesale, and `paste` would pad the missing pairs with empty
+    # fields rather than complain.
+    if [ "$(count_lines "$hashes")" -ne "$(count_lines "$files")" ]; then
+        refuse_unhashable_paths
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    if ! paired="$(paste -d ' ' \
+        <(print_lines "$files" | path_mode_lines) <(print_lines "$hashes"))"; then
+        refuse_unhashable_paths
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    print_lines "$paired" | LC_ALL=C sort | sha256_hex
 }
 
 refuse_degenerate_input() {
@@ -180,20 +268,25 @@ refuse_degenerate_input() {
 compute_components() {
     # Fills COMPONENT_DIGESTS in COMPONENT_NAMES order. Called directly and
     # never through a command substitution: a non-zero status raised inside
-    # `$(...)` is discarded by the caller, and the fail-closed guard below is
-    # the one refusal that has to reach the exit code.
-    local files file_count
-    files="$(declared_files "$@")"
-    file_count=0
-    if [ -n "$files" ]; then
-        file_count="$(print_lines "$files" | wc -l | tr -d '[:space:]')"
+    # `$(...)` is discarded by the caller, so every refusal that has to reach
+    # the exit code is captured and returned by hand on the way up.
+    local files file_count paths
+    if ! files="$(declared_files "$@")"; then
+        return "$EXIT_CANNOT_EVALUATE"
     fi
+    file_count="$(count_lines "$files")"
     if [ "$file_count" -lt "$MINIMUM_DECLARED_FILES" ]; then
         refuse_degenerate_input "$file_count" "$@"
         return "$EXIT_CANNOT_EVALUATE"
     fi
+    # Taken outside the array literal below: a non-zero status raised inside an
+    # element's `$(...)` would be discarded, which is the whole shape of bug the
+    # explicit checks in paths_digest exist to close.
+    if ! paths="$(paths_digest "$files")"; then
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
     COMPONENT_DIGESTS=(
-        "$(paths_digest "$files")"
+        "$paths"
         "$(python3 -VV 2>&1 | sha256_hex)"
         "$(pip freeze 2> /dev/null | sha256_hex)"
         "$(sha256_of "${VIRTUAL_ENV-}")"
@@ -235,23 +328,37 @@ receipt_field() {
             'found != 1 && $1 == key { sub(/^[^=]*=/, ""); print; found = 1 }'
 }
 
+receipt_fields() {
+    local gate="$1"
+    printf '%s=%s\n' "$FIELD_SCHEMA_VERSION" "$SCHEMA_VERSION"
+    printf '%s=%s\n' "$FIELD_GATE" "$gate"
+    printf '%s=%s\n' "$FIELD_FINGERPRINT" "$(combined_fingerprint)"
+    printf '%s=%s\n' "$FIELD_RECORDED_AT" "$(date -u "$TIMESTAMP_FORMAT")"
+    component_lines | sed "s/^/$FIELD_COMPONENT_PREFIX/"
+}
+
 record_receipt() {
     local gate="$1"
-    local receipt temp
+    local receipt scratch scratch_name
     receipt="$(receipt_path_for "$gate")"
-    temp="$RECEIPTS_DIR/$TEMP_RECEIPT_PREFIX$gate$RECEIPT_SUFFIX"
+    # The scratch name carries this process id because nothing serialises two
+    # check-all runs in one tree - the suite lock guards only the pytest step.
+    # On a name shared by gate alone, the second run truncates and publishes the
+    # file the first still holds open, and the first then writes its tail into
+    # whatever now sits at that path: a published receipt made of one run's head
+    # and another's remainder.
+    scratch_name="$TEMP_RECEIPT_PREFIX$gate-$$"
+    scratch="$RECEIPTS_DIR/$scratch_name$RECEIPT_SUFFIX"
     mkdir -p "$RECEIPTS_DIR"
-    {
-        printf '%s=%s\n' "$FIELD_SCHEMA_VERSION" "$SCHEMA_VERSION"
-        printf '%s=%s\n' "$FIELD_GATE" "$gate"
-        printf '%s=%s\n' "$FIELD_FINGERPRINT" "$(combined_fingerprint)"
-        printf '%s=%s\n' "$FIELD_RECORDED_AT" "$(date -u "$TIMESTAMP_FORMAT")"
-        component_lines | sed "s/^/$FIELD_COMPONENT_PREFIX/"
-    } > "$temp"
+    if ! receipt_fields "$gate" > "$scratch"; then
+        rm -f "$scratch"
+        printf 'Error: the receipt for gate %s could not be written.\n' "$gate" >&2
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
     # Publish atomically. A reader must never observe a half-written receipt,
-    # and a temp file left in the receipts directory is the visible symptom of
-    # a torn write.
-    mv -f "$temp" "$receipt"
+    # and a scratch file left in the receipts directory is the visible symptom
+    # of a torn write.
+    mv -f "$scratch" "$receipt"
 }
 
 explain_mismatch() {

--- a/scripts/quality/verified.sh
+++ b/scripts/quality/verified.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# scripts/quality/verified.sh - gate receipts: proof that a green run is still true
+# Usage: ./scripts/quality/verified.sh {fingerprint|record|check} <gate> [--explain]
+#
+# A gate that takes seven minutes gets skipped by hand, and a gate that is
+# skipped protects nothing. This primitive lets a gate reuse the verdict it
+# already earned when - and only when - nothing that verdict depended on has
+# moved. The claim is keyed on a content hash of the declared inputs plus the
+# environment they were measured in: never a timestamp, never a commit SHA,
+# never a flag a caller sets about itself, because each of those would produce
+# a receipt that says "verified" about a tree nobody verified.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The tree root is derived from this script's own location, never from
+# `git rev-parse --show-toplevel`: inside a linked worktree, or when the caller
+# stands in a directory nested under an unrelated checkout, rev-parse names a
+# tree this script was not copied into and the receipt would describe somebody
+# else's files.
+TREE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Bumping this retires every receipt in existence. It is the only safe response
+# to a change in what the fingerprint measures, or in how it combines it.
+readonly SCHEMA_VERSION="1"
+
+readonly RECEIPTS_DIR="$TREE_ROOT/.gate-state/receipts"
+readonly RECEIPT_SUFFIX=".receipt"
+readonly TEMP_RECEIPT_PREFIX=".tmp-"
+
+# The gate name is the only caller-supplied value that reaches a path, so the
+# set of legal names excludes separators and traversal segments entirely.
+readonly GATE_NAME_PATTERN='^[a-z0-9-]+$'
+
+# A gate whose declared paths match almost nothing hashes the empty input into
+# a perfectly stable fingerprint - one that matches in every tree on earth.
+# That is exactly what a typo'd path or a misplaced script looks like, so too
+# few files is an error rather than a hit.
+readonly MINIMUM_DECLARED_FILES=50
+
+# Only EXIT_HIT may ever license reuse of a verdict. EXIT_MISS means "not
+# verified, run the gate"; EXIT_CANNOT_EVALUATE means "no honest answer is
+# available". Neither failure is permission to skip.
+readonly EXIT_HIT=0
+readonly EXIT_MISS=1
+readonly EXIT_CANNOT_EVALUATE=2
+
+readonly FIELD_SCHEMA_VERSION="schema_version"
+readonly FIELD_GATE="gate"
+readonly FIELD_FINGERPRINT="fingerprint"
+readonly FIELD_RECORDED_AT="recorded_at"
+readonly FIELD_COMPONENT_PREFIX="component_"
+
+readonly TIMESTAMP_FORMAT="+%Y-%m-%dT%H:%M:%SZ"
+
+readonly COMMAND_FINGERPRINT="fingerprint"
+readonly COMMAND_RECORD="record"
+readonly COMMAND_CHECK="check"
+readonly FLAG_EXPLAIN="--explain"
+readonly FLAG_HELP="--help"
+
+# The fingerprint components, in the vocabulary --explain reports. Each is
+# digested separately so a refusal can name the single input that moved; an
+# operator who cannot tell a dependency upgrade from a code edit learns to
+# distrust the cache, and the documented response to a cache nobody
+# understands is to disable it.
+COMPONENT_NAMES=(paths interpreter packages venv host env)
+COMPONENT_DIGESTS=()
+
+EXPLAIN=false
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") {$COMMAND_FINGERPRINT|$COMMAND_RECORD|$COMMAND_CHECK} <gate> [$FLAG_EXPLAIN]
+
+Prove that a previously green gate run still describes this tree.
+
+COMMANDS:
+    $COMMAND_FINGERPRINT <gate>   Print the gate's current fingerprint (sha256 hex)
+    $COMMAND_RECORD <gate>        Write the gate's receipt for the current fingerprint
+    $COMMAND_CHECK <gate>         Ask whether the recorded verdict still holds
+
+OPTIONS:
+    $FLAG_EXPLAIN       On a refusal, name the first component that differs:
+                    ${COMPONENT_NAMES[*]}
+    $FLAG_HELP          Display this help message
+
+GATES:
+    backend       backend/ + scripts/ + .pre-commit-config.yaml
+
+EXIT CODES:
+    $EXIT_HIT             The recorded verdict still describes this tree
+    $EXIT_MISS             Not verified - run the gate
+    $EXIT_CANNOT_EVALUATE             Cannot evaluate - unknown gate, degenerate input, or no repository
+
+Only exit $EXIT_HIT may be read as permission to reuse a verdict.
+EOF
+}
+
+# Gate registry. One line per gate: the paths whose working-tree content the
+# gate's verdict is a function of. Registering a second gate is one more line.
+declared_paths_for_gate() {
+    case "$1" in
+        backend) printf '%s' "backend scripts .pre-commit-config.yaml" ;;
+        *) return 1 ;;
+    esac
+}
+
+sha256_hex() {
+    # Reads stdin, prints the bare digest. The two platforms this repo runs on
+    # spell the tool differently.
+    if command -v sha256sum > /dev/null 2>&1; then
+        sha256sum | cut -d ' ' -f 1
+    else
+        shasum -a 256 | cut -d ' ' -f 1
+    fi
+}
+
+sha256_of() {
+    printf '%s' "$1" | sha256_hex
+}
+
+print_lines() {
+    # Prints a captured multi-line string as lines, and prints nothing at all
+    # when it is empty: `printf '%s\n' ""` would emit a phantom blank line and
+    # make an empty listing look like one file.
+    [ -n "$1" ] || return 0
+    printf '%s\n' "$1"
+}
+
+require_git_repository() {
+    # Without git there is no file listing, and falling back to an empty one
+    # would produce the same everywhere-matching fingerprint the degenerate
+    # guard exists to reject.
+    if git -C "$TREE_ROOT" rev-parse --git-dir > /dev/null 2>&1; then
+        return 0
+    fi
+    printf 'Error: %s is not a git repository, so the declared paths cannot be listed.\n' \
+        "$TREE_ROOT" >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
+declared_files() {
+    # Every file the gate measures: tracked plus untracked-and-unignored, minus
+    # the ones deleted from the working tree. Work in progress counts, because
+    # the gate would have collected it; a still-cached deletion does not,
+    # because the tree no longer contains it.
+    local listed deleted
+    listed="$(git -C "$TREE_ROOT" ls-files --cached --others --exclude-standard -- "$@")"
+    deleted="$(git -C "$TREE_ROOT" ls-files --deleted -- "$@")"
+    LC_ALL=C comm -23 \
+        <(print_lines "$listed" | LC_ALL=C sort -u) \
+        <(print_lines "$deleted" | LC_ALL=C sort -u)
+}
+
+paths_digest() {
+    # Each path is hashed ALONGSIDE its content. Combining the content hashes
+    # alone would leave a file renamed without an edit indistinguishable from
+    # an untouched tree - a move that changes what imports resolve, and the
+    # quietest possible way for a receipt to be wrong. One `git hash-object`
+    # process reads every path and answers in the order it was asked, so its
+    # output pairs back against the path list line for line.
+    local files="$1"
+    local hashes
+    hashes="$(print_lines "$files" | git -C "$TREE_ROOT" hash-object --stdin-paths)"
+    paste -d ' ' <(print_lines "$files") <(print_lines "$hashes") | LC_ALL=C sort | sha256_hex
+}
+
+refuse_degenerate_input() {
+    local file_count="$1"
+    shift
+    printf 'Error: the declared paths (%s) match only %s files under %s.\n' \
+        "$*" "$file_count" "$TREE_ROOT" >&2
+    printf 'At least %s are expected; a gate that measures almost nothing produces a\n' \
+        "$MINIMUM_DECLARED_FILES" >&2
+    printf 'stable fingerprint that would match in any tree at all.\n' >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
+compute_components() {
+    # Fills COMPONENT_DIGESTS in COMPONENT_NAMES order. Called directly and
+    # never through a command substitution: a non-zero status raised inside
+    # `$(...)` is discarded by the caller, and the fail-closed guard below is
+    # the one refusal that has to reach the exit code.
+    local files file_count
+    files="$(declared_files "$@")"
+    file_count=0
+    if [ -n "$files" ]; then
+        file_count="$(print_lines "$files" | wc -l | tr -d '[:space:]')"
+    fi
+    if [ "$file_count" -lt "$MINIMUM_DECLARED_FILES" ]; then
+        refuse_degenerate_input "$file_count" "$@"
+        return "$EXIT_CANNOT_EVALUATE"
+    fi
+    COMPONENT_DIGESTS=(
+        "$(paths_digest "$files")"
+        "$(python3 -VV 2>&1 | sha256_hex)"
+        "$(pip freeze 2> /dev/null | sha256_hex)"
+        "$(sha256_of "${VIRTUAL_ENV-}")"
+        "$(uname -n | sha256_hex)"
+        "$(sha256_of "${TEST_POSTGRES_URL-}|${INTEGRATION_LANE_REQUIRE_POSTGRES-}")"
+    )
+}
+
+component_lines() {
+    local index=0
+    while [ "$index" -lt "${#COMPONENT_NAMES[@]}" ]; do
+        printf '%s=%s\n' "${COMPONENT_NAMES[$index]}" "${COMPONENT_DIGESTS[$index]}"
+        index=$((index + 1))
+    done
+}
+
+combined_fingerprint() {
+    # Combined WITH the schema version, so a change to the algorithm retires
+    # every old receipt instead of silently reinterpreting it.
+    {
+        printf '%s=%s\n' "$FIELD_SCHEMA_VERSION" "$SCHEMA_VERSION"
+        component_lines
+    } | sha256_hex
+}
+
+receipt_path_for() {
+    printf '%s/%s%s' "$RECEIPTS_DIR" "$1" "$RECEIPT_SUFFIX"
+}
+
+receipt_field() {
+    # Reads one key=value field, tolerating a truncated or binary-damaged
+    # receipt: an interrupted run, a full disk or a killed process can each
+    # leave a stub behind, and the only safe reading of one is a refusal said
+    # without a shell traceback that would look like a broken tool.
+    local file="$1"
+    local key="$2"
+    LC_ALL=C tr -d '\000' < "$file" 2> /dev/null \
+        | LC_ALL=C awk -F '=' -v key="$key" \
+            'found != 1 && $1 == key { sub(/^[^=]*=/, ""); print; found = 1 }'
+}
+
+record_receipt() {
+    local gate="$1"
+    local receipt temp
+    receipt="$(receipt_path_for "$gate")"
+    temp="$RECEIPTS_DIR/$TEMP_RECEIPT_PREFIX$gate$RECEIPT_SUFFIX"
+    mkdir -p "$RECEIPTS_DIR"
+    {
+        printf '%s=%s\n' "$FIELD_SCHEMA_VERSION" "$SCHEMA_VERSION"
+        printf '%s=%s\n' "$FIELD_GATE" "$gate"
+        printf '%s=%s\n' "$FIELD_FINGERPRINT" "$(combined_fingerprint)"
+        printf '%s=%s\n' "$FIELD_RECORDED_AT" "$(date -u "$TIMESTAMP_FORMAT")"
+        component_lines | sed "s/^/$FIELD_COMPONENT_PREFIX/"
+    } > "$temp"
+    # Publish atomically. A reader must never observe a half-written receipt,
+    # and a temp file left in the receipts directory is the visible symptom of
+    # a torn write.
+    mv -f "$temp" "$receipt"
+}
+
+explain_mismatch() {
+    # Names the first component that differs, and only the first: a refusal
+    # that listed every downstream difference would bury the one input the
+    # operator actually changed.
+    local receipt="$1"
+    local index=0
+    local name
+    while [ "$index" -lt "${#COMPONENT_NAMES[@]}" ]; do
+        name="${COMPONENT_NAMES[$index]}"
+        if [ "$(receipt_field "$receipt" "$FIELD_COMPONENT_PREFIX$name")" \
+            != "${COMPONENT_DIGESTS[$index]}" ]; then
+            printf '%s\n' "$name"
+            return 0
+        fi
+        index=$((index + 1))
+    done
+}
+
+receipt_is_addressed_to() {
+    # A receipt is evidence only about the gate it names, under the schema it
+    # was computed with. Without both, a misfiled or superseded receipt is
+    # indistinguishable from a legitimate verdict.
+    local receipt="$1"
+    local gate="$2"
+    [ "$(receipt_field "$receipt" "$FIELD_SCHEMA_VERSION")" = "$SCHEMA_VERSION" ] \
+        && [ "$(receipt_field "$receipt" "$FIELD_GATE")" = "$gate" ]
+}
+
+check_receipt() {
+    local gate="$1"
+    local receipt current recorded
+    receipt="$(receipt_path_for "$gate")"
+    if [ ! -f "$receipt" ]; then
+        printf 'No receipt for gate %s; the gate has to run.\n' "$gate" >&2
+        return "$EXIT_MISS"
+    fi
+    if ! receipt_is_addressed_to "$receipt" "$gate"; then
+        printf 'The receipt for gate %s is damaged or was written under other terms.\n' \
+            "$gate" >&2
+        return "$EXIT_MISS"
+    fi
+    current="$(combined_fingerprint)"
+    recorded="$(receipt_field "$receipt" "$FIELD_FINGERPRINT")"
+    if [ -n "$recorded" ] && [ "$recorded" = "$current" ]; then
+        printf '%s=%s\n' "$FIELD_RECORDED_AT" "$(receipt_field "$receipt" "$FIELD_RECORDED_AT")"
+        return "$EXIT_HIT"
+    fi
+    if [ "$EXPLAIN" = true ]; then
+        explain_mismatch "$receipt"
+    fi
+    printf 'The recorded verdict for gate %s no longer describes this tree.\n' "$gate" >&2
+    return "$EXIT_MISS"
+}
+
+require_known_command() {
+    case "$1" in
+        "$COMMAND_FINGERPRINT" | "$COMMAND_RECORD" | "$COMMAND_CHECK") return 0 ;;
+        *) ;;
+    esac
+    printf 'Error: unknown command: %s\n' "$1" >&2
+    usage >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
+require_valid_gate_name() {
+    # Validated before a single file is created or read, so a name carrying a
+    # separator or a traversal segment can never aim a receipt write elsewhere
+    # on disk.
+    if [[ "$1" =~ $GATE_NAME_PATTERN ]]; then
+        return 0
+    fi
+    printf 'Error: %s is not a valid gate name; expected %s.\n' "$1" "$GATE_NAME_PATTERN" >&2
+    return "$EXIT_CANNOT_EVALUATE"
+}
+
+parse_trailing_flags() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            "$FLAG_EXPLAIN")
+                EXPLAIN=true
+                shift
+                ;;
+            *)
+                printf 'Error: unknown option: %s\n' "$1" >&2
+                return "$EXIT_CANNOT_EVALUATE"
+                ;;
+        esac
+    done
+}
+
+run_command() {
+    local command="$1"
+    local gate="$2"
+    local status=0
+    case "$command" in
+        "$COMMAND_FINGERPRINT") combined_fingerprint ;;
+        "$COMMAND_RECORD") record_receipt "$gate" ;;
+        "$COMMAND_CHECK") check_receipt "$gate" || status=$? ;;
+        *) status="$EXIT_CANNOT_EVALUATE" ;;
+    esac
+    return "$status"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        usage >&2
+        exit "$EXIT_CANNOT_EVALUATE"
+    fi
+    local command="$1"
+    shift
+    if [ "$command" = "$FLAG_HELP" ]; then
+        usage
+        exit "$EXIT_HIT"
+    fi
+    local gate=""
+    if [ $# -gt 0 ]; then
+        gate="$1"
+        shift
+    fi
+
+    require_known_command "$command" || exit $?
+    require_valid_gate_name "$gate" || exit $?
+    parse_trailing_flags "$@" || exit $?
+
+    local paths_spec
+    if ! paths_spec="$(declared_paths_for_gate "$gate")"; then
+        printf 'Error: no gate named %s is registered.\n' "$gate" >&2
+        exit "$EXIT_CANNOT_EVALUATE"
+    fi
+    require_git_repository || exit $?
+
+    local declared=()
+    read -r -a declared <<< "$paths_spec"
+    compute_components "${declared[@]}" || exit $?
+
+    local status=0
+    run_command "$command" "$gate" || status=$?
+    exit "$status"
+}
+
+main "$@"

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -106,9 +106,34 @@ behind-main rebases across parallel lanes.
    `shared/adepthood-constraints.md`): backend ≥90% line / ≥80% branch (pytest-cov),
    ≥85% docstring (interrogate), xenon A, radon MI ≥ B, mypy strict, ruff
    `select = ["ALL"]`; frontend ≥90% jest, ESLint zero-warning, `tsc --noEmit`.
-7. **Gate 2 → Gate 2.5.** Run the relevant `./scripts/<side>/check-all.sh` until
-   exit 0 (`scripts/backend/check-all.sh` and/or `scripts/frontend/check-all.sh`;
-   `./scripts/<side>/fix-all.sh` for autofixable lint/format — never bypass).
+7. **Gate 2 → Gate 2.5.** The gate ladder runs each rung once — stacking one on
+   top of another buys nothing and doubles the wait:
+
+   | Rung | Runs | Cost |
+   | --- | --- | --- |
+   | `./scripts/backend/test.sh <paths>` (targeted) | every Red→Green cycle | seconds |
+   | `./scripts/<side>/check-all.sh` | once, when Gate 1 is green | ~4m23s cold backend; ~8s on a receipt hit |
+   | `git commit` hooks (staged files only) | automatic | seconds to ~1 min |
+   | `git push` hooks (full suite + coverage) | automatic | ~5 min |
+
+   Run `check-all.sh` until exit 0 (`scripts/backend/check-all.sh` and/or
+   `scripts/frontend/check-all.sh`; `./scripts/<side>/fix-all.sh` for
+   autofixable lint/format — never bypass). Do not also hand-run `pre-commit
+   run --all-files` before committing: the commit hooks already re-run
+   lint/format/type checks on your staged diff seconds later, and
+   `check-all.sh` already swept the whole tree, so the ritual whole-tree pass
+   earns nothing those two didn't already cover. Reserve it for what
+   staged-file hooks cannot see — a wide rename, a suspected cross-file type
+   error, or a change to the hook configuration itself.
+
+   A whole-suite `test.sh` run (no positional path) takes an exclusive
+   per-worktree lock at `.gate-state/locks/backend-suite.lock`; a second one
+   racing against itself in the same worktree exits 3, naming the holding PID,
+   rather than corrupting a shared coverage file and fixture databases. On
+   exit 3: wait for the in-flight run, do not route around the lock. A failure
+   observed while another whole-suite run was concurrently in flight is
+   unproven until it is re-run alone.
+
    Then dispatch **`Agent(code-review-orchestrator)`** over the diff and fix every
    blocking finding (drop to Gate 1 via the owning specialist) until `CLEAN`.
 8. **Stay scoped.** Implement exactly the issue. Found an unrelated bug?

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -114,7 +114,14 @@ behind-main rebases across parallel lanes.
    | `./scripts/backend/test.sh <paths>` (targeted) | every Red→Green cycle | seconds |
    | `./scripts/<side>/check-all.sh` | once, when Gate 1 is green | ~4m23s cold backend; ~8s on a receipt hit |
    | `git commit` hooks (staged files only) | automatic | seconds to ~1 min |
-   | `git push` hooks (full suite + coverage) | automatic | ~5 min |
+   | `git push` hooks (full suite + coverage) | automatic *if installed* | ~5 min |
+
+   The push rung fires only where the `pre-push` hook type is installed
+   (`pre-commit install --hook-type pre-push`); `scripts/dev-setup.sh` does not
+   install it today, so on most dev boxes `git push` runs nothing. Backend CI
+   runs that stage regardless, so the checks are never skipped outright — they
+   just land ~18 minutes later instead of ~5. Do not treat a silent push as a
+   pass.
 
    Run `check-all.sh` until exit 0 (`scripts/backend/check-all.sh` and/or
    `scripts/frontend/check-all.sh`; `./scripts/<side>/fix-all.sh` for


### PR DESCRIPTION
## Summary

- **`check-all.sh` stops re-deriving a verdict it already earned.** A new gate-receipt primitive (`scripts/quality/verified.sh`) keys a green run to a content hash of the gate's declared inputs plus the environment they were measured in. A re-run over a byte-identical tree goes from **2m03s to 5.17s**.
- **Contention now refuses instead of misleading.** A whole-suite `scripts/backend/test.sh` takes an exclusive per-worktree lock; a second whole-suite run racing itself exits 3 naming the holder, rather than producing a core-contended result neither run can trust.
- **The cheapest rung of the ladder is finally reachable through the sanctioned script.** `test.sh` learns positional paths: targeted, unsharded, no marker filter, and it refuses coverage flags because a partial run cannot meet a whole-repo threshold.
- The docs state the ladder and the run-once rule, and no longer mandate a whole-tree `pre-commit run --all-files` before every commit.

## What I measured

The gate ladder as it actually exists in this repo, timed on this box:

| Rung | Trigger | Cost |
| --- | --- | --- |
| targeted `pytest <path>` | every Red→Green cycle | seconds |
| `scripts/backend/check-all.sh` | Gate 2 | **2m03s** cold |
| `pre-commit run --all-files` | hand-run only | **71s**, and every hook re-runs at `git commit` seconds later |
| `git commit` | automatic | seconds |
| `git push` | automatic | see "the rung that wasn't there" below |

Stage-level breakdown of `check-all.sh`: deps preflight **0.22s**, security (bandit + pip-audit) **7.5s**, complexity **1.5s**, typecheck **11.4s**, and the suite **~2m** — so the suite is ~95% of the cost and everything else is noise.

The redundancy is structural, not occasional: per tick the backend suite runs at least twice (check-all + pre-push), the lint/type/security set three times (check-all, commit, and a hand-run sweep), and the complexity gate twice.

**The instruction was the root cause, not agent whim.** `CLAUDE.md` ("Run `pre-commit run --all-files` before every commit attempt", under *Things I Must Always Do*) and `AGENTS.md` both mandated the redundant run, and `.claude/skills/stay-green/SKILL.md` made it Gate 2 outright.

## What I eliminated, and the evidence licensing each skip

**1. The redundant `check-all.sh` re-run — 2m03s → 5.17s.** Licensed by a fingerprint over: working-tree content of `backend` + `scripts` + `.pre-commit-config.yaml` (as `path SP mode SP hash`, `LC_ALL=C` sorted, hashed with `git hash-object --no-filters`), `python3 -VV`, `pip freeze`, `$VIRTUAL_ENV`, `uname -n`, and `TEST_POSTGRES_URL` / `INTEGRATION_LANE_REQUIRE_POSTGRES`, combined with a `SCHEMA_VERSION`. Only exit 0 licenses reuse; exit 1 ("run the gate") and exit 2 ("cannot evaluate") never do. Cost of computing it: **0.32s** over ~900 files.

This is also what makes a **fleet sync re-green** cheap. After the orchestrator merges `main` into a lane, a merge that touched only `plan/*.md` leaves the backend gate's inputs byte-identical — today that re-runs 4306 tests to absorb one appended line.

**2. The ritual `pre-commit run --all-files` — 71s per tick.** Licensed by the fact that `git commit` re-runs the identical hook set seconds later, on a superset of the same rules.

**3. The false-red diagnostic run.** Not made cheaper — made impossible. The lock refuses the second concurrent whole-suite run instead of letting it corrupt both.

**The security stage and the drift preflight always run, even on a hit.** This asymmetry is the honesty of the change: lint, format, mypy, complexity, the suite and the coverage gate are a pure function of the fingerprinted inputs, but `security.sh` runs `pip-audit` against the PyPI advisory database over the network. A vulnerability published *after* the receipt was written would let an unchanged fingerprint still print green, and no content hash of this tree can see that. A network-dated check is never cacheable. (This is not hypothetical — #2103 records `cryptography` 49→50 landing mid-branch for PYSEC-2026-3552.) A warm run is 5.17s rather than ~1s precisely because bandit and pip-audit still execute; their output is in the log.

## What must invalidate a green, and the tests that drive it RED

The design question was not "how do we skip re-runs" but "what evidence makes a prior green still true". Every case below is a separate test, and each was observed failing before the fix:

| Invalidation | Result | Pinned by |
| --- | --- | --- |
| Source / test / `pyproject.toml` edited | MISS(`paths`) | `test_gate_receipts.py` |
| New untracked-not-ignored file under a declared path | MISS(`paths`) | proves `--others` is in the listing |
| Declared file deleted | MISS(`paths`) | proves path-set membership is hashed |
| File **renamed with identical content** | MISS(`paths`) | proves paths are hashed, not just the content stream |
| **Executable bit flipped** (tracked *and* untracked) | MISS(`paths`) | a stage script losing `+x` was previously invisible |
| **LF → CRLF, text identical** | MISS(`paths`) | `.gitattributes` normalization used to hide it |
| `pip freeze` differs (venv drifted from pins) | MISS(`packages`) | |
| `python3 -VV` differs | MISS(`interpreter`) | |
| **`VIRTUAL_ENV` unset** | MISS(`venv`) | this is what a `check-all.sh` whose shell never activated the venv looks like |
| `TEST_POSTGRES_URL` / `INTEGRATION_LANE_REQUIRE_POSTGRES` changed | MISS(`env`) | |
| No receipt / a receipt for a different gate / wrong `SCHEMA_VERSION` / corrupt or truncated receipt | MISS | fail closed, no traceback |
| Declared paths match almost no files | exit 2 on both `record` and `check` | an empty listing hashes to a *stable* fingerprint that would match in any tree |
| A path `git` cannot hash (broken symlink, unreadable file) | exit 2 | see below |
| Invalid gate name (`../`, space, uppercase) | exit 2, before any path interpolation | |

**`main` moving is deliberately NOT an invalidator.** Gate 2 attests *your working tree*; freshness against `main` is the orchestrator's `behind_by` check (`pr-ready.sh`), and today's `check-all.sh` does not know `main` moved either. Putting a SHA in the fingerprint would also invalidate every receipt whenever any sibling lane merged anything, destroying the sync-re-green case. This is verified rather than asserted: the first receipt on this branch was recorded while all 13 files were **uncommitted** (HEAD `95dce3f1`); after committing them, HEAD moved and the content did not, and `check` still HIT.

### Self-review found five ways the receipt could still have lied

All fixed test-first in `71cccd66`, each pinned by a test that was RED first:

1. **BLOCKER — a swallowed `git` failure produced a stable-but-wrong fingerprint that matched itself.** `git hash-object --stdin-paths` aborts wholesale at the first path it cannot open, emitting fewer hashes than paths, and `paste` padded the missing pairs with empty fields. A reproducible failure (broken symlink, unreadable file, stale `index.lock`) made `record` and a later `check` agree on the same degraded value while every file past the failure point went unmeasured. Bash applies no errexit inside `$(...)`, and the caller's `|| exit $?` suppresses it for the whole call tree — so every fallible command now has its status captured explicitly, and the hash count is cross-checked against the path count. The sharpest test records while broken, edits a file that sorts *after* the failing path, and asserts a MISS.
2. **MAJOR — the executable bit was not hashed.** Read from the working tree, not the index, so untracked files and unstaged chmods are both seen.
3. **MAJOR — TOCTOU in the stale-lock steal.** Two runs racing one dead-PID lock could both win. Now a compare-and-swap under a `mkdir` mutex.
4. **MINOR — the receipt scratch file was not unique**, so two concurrent records could tear each other's write.
5. **MINOR — `.gitattributes` normalization** (`* text=auto eol=lf`) made CRLF and LF spellings hash identically, which would have skipped the formatting stage that rejects one of them.

`SCHEMA_VERSION` moves 1 → 2, because 2 and 5 change what the digest is taken over; every existing receipt is retired rather than reinterpreted.

## The house-rules change, on its own terms

Moving `pre-commit run --all-files` from *always* to *when staged-file hooks cannot see it* is a real change to the documented workflow, not a perf tweak, so it is worth stating what a developer loses.

**It is deliberately not a prohibition.** Commit-stage hooks run on **staged files only**, and mypy over a subset genuinely misses cross-file type errors — the hazard is real and this repo has hit it. So the rule is proportionality, not abstinence: `check-all.sh` already sweeps the whole backend for lint, type and security, and `git commit` re-runs them on your staged diff seconds later, so the *ritual* whole-tree pass before every commit buys nothing those two did not already cover. What you lose by skipping it is whole-tree coverage of changes your staged diff does not name — so the docs explicitly reserve it for a wide rename, a suspected cross-file type error, or a change to the hook configuration itself.

**No gate is weakened.** Nothing changes *what* any check verifies; only whether a provably redundant re-run repeats. No threshold moved, no test was deleted or skipped, no `# noqa` / `# type: ignore` was added.

## The rung that wasn't there

While verifying the ladder I documented, I found that **the pre-push hook stage has never fired locally.** `.pre-commit-config.yaml` defines three `stages: [pre-push]` hooks (`backend-complexity`, `backend-tests-coverage`, `frontend-tests-coverage`), but nothing installs the hook type: `scripts/dev-setup.sh` installs only `pre-commit` and `commit-msg`, and no `default_install_hook_types` is set. `.git/hooks/` contains no `pre-push`, and pushing this 13-file backend change produced zero hook output.

Nothing ships unverified — `backend-ci.yml` runs `pre-commit run --hook-stage pre-push` explicitly — but the local rung is fiction, so the docs in this PR say so rather than claiming a gate that does not run. Installing it is one line, but it would add a full suite to every push in every lane, which is a throughput trade that deserves an explicit decision: **#2139**.

## Test plan

- `scripts/backend/check-all.sh` (Gate 2): **7/7 passed, 4306 tests passed, 2 skipped, 1 xfailed, coverage 97%, exit 0, 2m19s.** Run three times across the branch; green each time.
- Warm re-run on a byte-identical tree: **exit 0 in 5.17s**, six stages reused, security stage observably executed (bandit + pip-audit output present in the log).
- `pytest backend/tests/scripts/ -q`: **399 passed.** The two concurrency tests were re-run 5x and the lock suite 6x with no flakes; both hold their window open with a shim and a marker file, and fail (not skip) on a 30s deadline rather than racing a sleep.
- `shellcheck --severity=warning` clean on `verified.sh`, `check-all.sh`, `test.sh`.
- Live probes on the real tree for every row of the invalidation table above, each followed by a restore that returns to HIT; worktree left clean.
- Observed the lock working under a real Gate 2: a second `test.sh` exited 3 naming the holder PID and started no pytest.
- Gate 2.5 `code-review-orchestrator`: first pass FIX_REQUIRED (1 blocker, 2 major), re-review after the fixes **CLEAN**.

## Graph

`skipped: graphify is not on PATH and this worktree has no graphify-out/graph.json`. The change is confined to shell tooling under `scripts/` plus agent-facing Markdown, none of which the code graph indexes; orientation came from reading `.pre-commit-config.yaml`, the `scripts/backend/*.sh` chain, and the existing `backend/tests/scripts/` harness.

## Follow-ups filed (not fixed here, to stay scoped)

- **#2139** — the `pre-push` hook type is never installed, so the pre-push gate never fires locally.
- **#2138** — the pre-push `backend-tests-coverage` hook calls `pytest` inline rather than through `test.sh`, so a `git push` racing a `check-all.sh` still bypasses the suite lock.
- **#2137** — six of eight `scripts/graph/test_*.sh` suites are invoked by no gate.

Deliberately left uncut: making the pre-push suite hook consume the receipt. The acceptance criteria bless "at most twice (check-all + pre-push)", and a check-all pass is **not** a superset of a pre-push pass — `check-all.sh` deselects the `integration`-marked tests the pre-push hook runs. Just as importantly, an unreceipted pre-push run gives a flaky test one independent second look before it reaches CI, and consuming the receipt there would remove that.

Closes #2102
Refs #2073
