### PR TITLE
fix(tests): give the concurrency fixture the writer queue SQLite lacks

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,6 +1,7 @@
+import asyncio
 import os
 import sys
-from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, MutableMapping
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -22,15 +23,21 @@ sys.path.insert(0, str(REPO_ROOT / "backend/src"))
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
 from httpx import ASGITransport, AsyncClient, Response  # noqa: E402
-from sqlalchemy import JSON, text  # noqa: E402
+from sqlalchemy import JSON, event, text  # noqa: E402
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY  # noqa: E402
+from sqlalchemy.engine import Connection  # noqa: E402
+from sqlalchemy.engine.default import DefaultExecutionContext  # noqa: E402
+from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor  # noqa: E402
 from sqlalchemy.exc import SQLAlchemyError  # noqa: E402
 from sqlalchemy.ext.asyncio import (  # noqa: E402
     AsyncConnection,
+    AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import ConnectionPoolEntry  # noqa: E402
+from sqlalchemy.util import await_only  # noqa: E402
 from sqlmodel import SQLModel  # noqa: E402
 
 import models as _models  # noqa: E402, F401
@@ -54,18 +61,24 @@ _STUB_LICENSE_SALE_PREFIX = "stub-sale-"
 # ---------------------------------------------------------------------------
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
-# SQLite serialises writers behind a lock and fails the statement outright once
-# its busy timeout expires, rather than queueing. The concurrency fixtures below
-# deliberately drive several simultaneous writers against one file, so on a
-# loaded machine — every xdist worker running its own share of the suite
-# (#2076) — the default 5 s ceiling is reached and the write raises
-# "database is locked" instead of waiting its turn.
+# A backstop, no longer the mechanism. What actually keeps the concurrency
+# fixtures from failing on "database is locked" is the in-process writer queue
+# below: SQLite has no lock queue of its own, so when several connections open
+# write transactions at once the losers sleep in its busy handler and each retry
+# briefly takes a SHARED read lock, denying the one connection holding RESERVED
+# the EXCLUSIVE promotion it needs in order to COMMIT. Nothing arbitrates that
+# pile-up, so a loaded runner simply runs out the clock. Serialising writers
+# ourselves leaves SQLite only a reader waiting on a single committing writer,
+# which is bounded by one commit rather than by the whole pile-up.
+#
+# The same constant bounds the wait for the in-process queue, so a write
+# transaction that somehow leaks its slot fails loudly instead of parking the
+# suite until the CI job ceiling.
 #
 # Raising the ceiling cannot mask a real defect: these tests assert an *outcome*
 # invariant (exactly one token pack credited, exactly one audit row), never a
 # latency bound. A genuine double-credit still fails the assertions no matter
-# how long a writer waits. All this buys is that the test stops failing for want
-# of CPU.
+# how long a writer waits.
 _CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS = 30
 
 test_engine = create_async_engine(TEST_DATABASE_URL, echo=False)
@@ -290,6 +303,142 @@ def zero_monthly_cap(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOTMASON_MONTHLY_CAP", "0")
 
 
+# ---------------------------------------------------------------------------
+# In-process writer queue for the concurrency fixture's file-backed SQLite
+# ---------------------------------------------------------------------------
+# Key on the connection's own ``info`` dict rather than on the queue, so a
+# transaction that issues two or three write statements claims the slot once.
+_WRITER_SLOT_HELD_KEY = "adepthood_sqlite_writer_slot_held"
+
+# ``isinsert`` / ``isupdate`` / ``isdelete`` are set from the *compiled* DML
+# construct, and a textual statement compiles to none of them -- yet a raw
+# ``UPDATE`` opens a write transaction just the same. The leading keyword is
+# what closes that gap.
+_TEXTUAL_WRITE_VERBS = ("INSERT", "UPDATE", "DELETE", "REPLACE")
+
+_WRITER_QUEUE_STALLED_MESSAGE = (
+    "The concurrency fixture's SQLite writer queue stalled: no connection freed "
+    f"the single write slot within {_CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS}s. A write "
+    "transaction leaked its slot -- it was neither committed, rolled back, nor closed."
+)
+
+
+class _SqliteWriterQueue:
+    """A single write slot for one engine, handed out in fair FIFO order.
+
+    SQLite fails a contended write once its busy timeout expires instead of
+    queueing it, so the fixture engine arbitrates writers itself. A connection
+    claims the slot before the first write statement of a transaction and holds
+    it until that transaction ends. Reads never touch the slot.
+    """
+
+    def __init__(self) -> None:
+        self._slot = asyncio.Lock()
+        self._waiters = 0
+
+    @property
+    def locked(self) -> bool:
+        """Whether some connection currently holds the write slot."""
+        return self._slot.locked()
+
+    @property
+    def waiters(self) -> int:
+        """How many writers are queued behind the current holder."""
+        return self._waiters
+
+    async def acquire(self) -> None:
+        """Wait for the write slot, counted as queued for as long as it waits."""
+        self._waiters += 1
+        try:
+            await self._slot.acquire()
+        finally:
+            self._waiters -= 1
+
+    def release(self) -> None:
+        """Hand the slot on; a no-op when nobody holds it.
+
+        Every connection checks in, including the read-only ones that never
+        claimed the slot, so releasing has to tolerate an idle queue.
+        """
+        if self._slot.locked():
+            self._slot.release()
+
+
+def _opens_a_write_transaction(statement: str, context: DefaultExecutionContext) -> bool:
+    """Whether this statement is the DML that puts SQLite into a write transaction."""
+    if context.isinsert or context.isupdate or context.isdelete:
+        return True
+    return statement.lstrip().upper().startswith(_TEXTUAL_WRITE_VERBS)
+
+
+async def _claim_writer_slot(queue: _SqliteWriterQueue) -> None:
+    """Take the write slot, failing loudly rather than hanging if it is stuck."""
+    try:
+        await asyncio.wait_for(queue.acquire(), _CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        raise RuntimeError(_WRITER_QUEUE_STALLED_MESSAGE) from exc
+
+
+def _free_writer_slot(queue: _SqliteWriterQueue, info: MutableMapping[str, object]) -> None:
+    """Release the write slot if the connection owning ``info`` is holding it."""
+    if info.pop(_WRITER_SLOT_HELD_KEY, False):
+        queue.release()
+
+
+def _install_sqlite_writer_queue(engine: AsyncEngine) -> _SqliteWriterQueue:
+    """Serialise ``engine``'s write transactions through one in-process slot.
+
+    The slot is taken at the first write statement rather than at transaction
+    start, which is what keeps reads running in parallel with an open write --
+    the wide read/write window the concurrency tests need in order to catch a
+    time-of-check/time-of-use regression.
+
+    It is freed on pool checkin, because a session returns its connection to the
+    pool at the end of every transaction and at no other time. Releasing on the
+    ``commit`` / ``rollback`` events instead would be too early: those fire
+    *before* the DBAPI call, so the next writer would start while this one still
+    held SQLite's write lock. Savepoints are correspondingly invisible here -- a
+    savepoint rollback never checks the connection in, and the outer transaction
+    it leaves open still owns the slot.
+    """
+    queue = _SqliteWriterQueue()
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def claim_slot_before_writing(
+        conn: Connection,
+        _cursor: DBAPICursor,
+        statement: str,
+        _parameters: object,
+        context: DefaultExecutionContext,
+        _executemany: object,
+    ) -> None:
+        """Claim the slot for a connection's first write of a transaction."""
+        if not _opens_a_write_transaction(statement, context):
+            return
+        if conn.info.get(_WRITER_SLOT_HELD_KEY, False):
+            return
+        await_only(_claim_writer_slot(queue))
+        conn.info[_WRITER_SLOT_HELD_KEY] = True
+
+    @event.listens_for(engine.sync_engine, "checkin")
+    def free_slot_on_checkin(
+        _dbapi_connection: DBAPIConnection, record: ConnectionPoolEntry
+    ) -> None:
+        """Free the slot when the transaction ends and the connection is pooled."""
+        _free_writer_slot(queue, record.info)
+
+    @event.listens_for(engine.sync_engine, "invalidate")
+    def free_slot_on_invalidate(
+        _dbapi_connection: DBAPIConnection,
+        record: ConnectionPoolEntry,
+        _exception: BaseException | None,
+    ) -> None:
+        """Free the slot when a hard failure retires the connection without a checkin."""
+        _free_writer_slot(queue, record.info)
+
+    return queue
+
+
 @pytest_asyncio.fixture
 async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient, None]:
     """HTTP client with per-request sessions for concurrency testing.
@@ -309,6 +458,7 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
     concurrent_factory = async_sessionmaker(
         concurrent_engine, class_=AsyncSession, expire_on_commit=False
     )
+    writer_queue = _install_sqlite_writer_queue(concurrent_engine)
 
     _replace_array_columns()
     async with concurrent_engine.begin() as conn:
@@ -321,12 +471,14 @@ async def concurrent_async_client(tmp_path: Path) -> AsyncGenerator[AsyncClient,
 
     app.dependency_overrides[get_session] = _per_request_session
     app.state.concurrent_session_factory = concurrent_factory
+    app.state.concurrent_writer_queue = writer_queue
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
 
     app.dependency_overrides.clear()
     app.state.concurrent_session_factory = None
+    app.state.concurrent_writer_queue = None
     await concurrent_engine.dispose()
 
 
@@ -345,6 +497,22 @@ async def concurrent_session_factory(
         msg = "concurrent_async_client must be requested before concurrent_session_factory"
         raise RuntimeError(msg)
     return factory
+
+
+@pytest_asyncio.fixture
+async def concurrent_writer_queue(
+    concurrent_async_client: AsyncClient,  # noqa: ARG001 — side-effect: installs the queue
+) -> _SqliteWriterQueue:
+    """Write-slot queue guarding the :func:`concurrent_async_client` engine.
+
+    Tests that assert *when* the single SQLite write slot is held depend on this
+    fixture; it is the same object the engine's own listeners drive.
+    """
+    queue: _SqliteWriterQueue | None = app.state.concurrent_writer_queue
+    if queue is None:
+        msg = "concurrent_async_client must be requested before concurrent_writer_queue"
+        raise RuntimeError(msg)
+    return queue
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_concurrency_fixture.py
+++ b/backend/tests/test_concurrency_fixture.py
@@ -1,0 +1,239 @@
+"""Guarantees of the concurrency fixture's in-process SQLite writer queue.
+
+SQLite has no writer queue of its own. When several connections open write
+transactions at once, the losers sleep inside SQLite's busy handler and each
+retry briefly takes a SHARED read lock, which denies the one connection holding
+RESERVED the EXCLUSIVE promotion it needs to COMMIT. The pile-up is bounded
+only by the busy timeout, so a loaded runner turns a race into a wall-clock
+stall and then a "database is locked" failure.
+
+The fixture therefore serialises writers itself: at most one connection may
+hold a write transaction, and a waiting writer sleeps on a fair FIFO lock
+instead of gambling in SQLite's retry lottery -- which is what production
+PostgreSQL does natively with row-lock wait queues.
+
+The invariant asserted here is about *when* the single write slot is held. It
+is taken at a connection's first write statement of a transaction and released
+only when that transaction ends -- by commit, by rollback, or by the session
+closing. Reads are never serialised behind it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+import pytest
+from sqlalchemy import func, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from models.user import User
+
+# Distinct emails per writer: ``User.email`` is unique, so reusing one across
+# tests would make an unrelated IntegrityError look like the savepoint case.
+COMMITTING_WRITER_EMAIL = "queue-committing-writer@example.com"
+SAVEPOINT_WRITER_EMAIL = "queue-savepoint-writer@example.com"
+UNCOMMITTED_WRITER_EMAIL = "queue-uncommitted-writer@example.com"
+PLACEHOLDER_PASSWORD_HASH = "x"  # pragma: allowlist secret
+
+# A conditional UPDATE whose predicate matches nothing still opens a write
+# transaction, which is the leak shape the queue has to survive: the handler
+# returns without committing and the transaction ends only at session close.
+UPDATE_MATCHING_NO_ROWS = (
+    'UPDATE "user" SET offering_balance = offering_balance + 1 WHERE id = :user_id'
+)
+MISSING_USER_ID = -1
+NO_ROWS_MATCHED = 0
+
+# The rollback journal, not WAL. See the WAL test below for why.
+EXPECTED_JOURNAL_MODE = "delete"
+
+# Ordering labels for the reader/writer interleaving assertion.
+READ_COMPLETED = "read-completed"
+WRITE_COMMITTED = "write-committed"
+
+# Generous enough that a slow runner never trips it, small enough that a
+# regression which serialises reads behind writers fails the run in seconds
+# instead of parking the suite on the 30 s SQLite busy timeout.
+ORDERING_TIMEOUT_SECONDS = 10.0
+
+# No user rows exist before the concurrent writer's uncommitted INSERT, so a
+# reader that correctly sees the pre-write snapshot counts zero.
+USERS_VISIBLE_BEFORE_COMMIT = 0
+
+
+class WriterQueue(Protocol):
+    """The slice of the fixture's writer-queue API these tests depend on."""
+
+    @property
+    def locked(self) -> bool:
+        """Whether some connection currently holds the single write slot."""
+
+    @property
+    def waiters(self) -> int:
+        """How many writers are queued behind the current holder."""
+
+
+def new_user(email: str) -> User:
+    """Build a minimal user row for a write whose only job is to exist."""
+    return User(email=email, password_hash=PLACEHOLDER_PASSWORD_HASH)
+
+
+async def insert_duplicate_inside_a_savepoint(session: AsyncSession, email: str) -> None:
+    """Re-insert ``email`` inside a SAVEPOINT so the unique index rejects it.
+
+    Raises IntegrityError once the savepoint has been rolled back, leaving the
+    outer transaction open -- the shape the production handlers rely on.
+    """
+    async with session.begin_nested():
+        session.add(new_user(email))
+        await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_writer_queue_is_held_by_an_uncommitted_write_and_freed_by_commit(
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+    concurrent_writer_queue: WriterQueue,
+) -> None:
+    """A flushed-but-uncommitted INSERT holds the write slot until it commits.
+
+    Taking the slot at the first write statement, rather than at transaction
+    start, is what keeps reads parallel; releasing it at commit is what lets
+    the next writer through without touching SQLite's busy handler.
+    """
+    async with concurrent_session_factory() as session:
+        session.add(new_user(COMMITTING_WRITER_EMAIL))
+        await session.flush()
+
+        assert concurrent_writer_queue.locked is True
+        assert concurrent_writer_queue.waiters == 0
+
+        await session.commit()
+
+        assert concurrent_writer_queue.locked is False
+
+
+@pytest.mark.asyncio
+async def test_writer_queue_is_freed_when_a_session_closes_without_committing(
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+    concurrent_writer_queue: WriterQueue,
+) -> None:
+    """A write transaction that is never committed frees the slot at session close.
+
+    This is the real leak shape. A handler whose conditional UPDATE matches
+    zero rows has still opened a write transaction, and it returns without
+    committing, so the only thing that ends that transaction is the session
+    closing. A queue released solely on commit would strand every later writer.
+    """
+    async with concurrent_session_factory() as session:
+        connection = await session.connection()
+        result = await connection.execute(
+            text(UPDATE_MATCHING_NO_ROWS), {"user_id": MISSING_USER_ID}
+        )
+
+        assert result.rowcount == NO_ROWS_MATCHED
+        assert concurrent_writer_queue.locked is True
+
+    assert concurrent_writer_queue.locked is False
+
+
+@pytest.mark.asyncio
+async def test_rolling_back_a_savepoint_does_not_free_the_writer_queue(
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+    concurrent_writer_queue: WriterQueue,
+) -> None:
+    """A rolled-back SAVEPOINT keeps the slot: the outer transaction is still open.
+
+    Several handlers make a SAVEPOINT their first write and roll it back on
+    IntegrityError while the outer transaction carries on. Releasing the slot
+    on that inner rollback would hand the write lock to a second connection
+    while this one still holds SQLite's RESERVED lock -- reintroducing exactly
+    the contention the queue exists to remove.
+    """
+    async with concurrent_session_factory() as session:
+        session.add(new_user(SAVEPOINT_WRITER_EMAIL))
+        await session.flush()
+
+        assert concurrent_writer_queue.locked is True
+
+        with pytest.raises(IntegrityError):
+            await insert_duplicate_inside_a_savepoint(session, SAVEPOINT_WRITER_EMAIL)
+
+        assert concurrent_writer_queue.locked is True
+
+        await session.commit()
+
+        assert concurrent_writer_queue.locked is False
+
+
+@pytest.mark.asyncio
+async def test_reads_are_not_serialized_behind_an_uncommitted_writer(
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A SELECT on a second connection completes while a write is still open.
+
+    This guards the sibling concurrency tests' coverage rather than the queue
+    itself. Those tests only catch a time-of-check/time-of-use regression
+    because the window between one request's read and another's write is wide;
+    serialising reads behind writers would slam that window shut and turn a
+    real double-credit into a green run.
+
+    The ordering is coordinated with events, not sleeps: the writer refuses to
+    commit until the reader reports done, so if reads ever queue behind the
+    uncommitted writer the two deadlock and the timeout fails the test loudly.
+    """
+    write_is_open = asyncio.Event()
+    read_is_done = asyncio.Event()
+    order: list[str] = []
+    users_seen_by_reader = -1
+
+    async def write_and_wait_for_the_reader() -> None:
+        async with concurrent_session_factory() as session:
+            session.add(new_user(UNCOMMITTED_WRITER_EMAIL))
+            await session.flush()
+            write_is_open.set()
+            await read_is_done.wait()
+            await session.commit()
+            order.append(WRITE_COMMITTED)
+
+    async def read_while_the_write_is_open() -> None:
+        nonlocal users_seen_by_reader
+        await write_is_open.wait()
+        async with concurrent_session_factory() as session:
+            users_seen_by_reader = int(
+                (await session.execute(select(func.count()).select_from(User))).scalar_one()
+            )
+        order.append(READ_COMPLETED)
+        read_is_done.set()
+
+    await asyncio.wait_for(
+        asyncio.gather(write_and_wait_for_the_reader(), read_while_the_write_is_open()),
+        timeout=ORDERING_TIMEOUT_SECONDS,
+    )
+
+    assert order == [READ_COMPLETED, WRITE_COMMITTED]
+    assert users_seen_by_reader == USERS_VISIBLE_BEFORE_COMMIT
+
+
+@pytest.mark.asyncio
+async def test_concurrency_fixture_does_not_use_wal(
+    concurrent_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The fixture database stays on the rollback journal, deliberately.
+
+    WAL is the obvious way to stop writers from blocking readers, and it was
+    measured and rejected. It shrinks the write window so far that the sibling
+    concurrency tests stop catching a time-of-check/time-of-use regression:
+    seeded against a known-broken handler they failed 25 of 25 runs on the
+    rollback journal and only 7 of 25 under WAL. The in-process writer queue
+    buys the same freedom from lock contention without narrowing the window.
+
+    This test exists so a future well-meant switch to WAL announces itself here
+    instead of silently blinding the tests that guard the money path.
+    """
+    async with concurrent_session_factory() as session:
+        journal_mode = (await session.execute(text("PRAGMA journal_mode"))).scalar_one()
+
+    assert journal_mode == EXPECTED_JOURNAL_MODE


### PR DESCRIPTION
## Summary

`test_concurrent_token_pack_pings_credit_exactly_one_pack` flaked on CI with `sqlite3.OperationalError: database is locked`. The issue proposed WAL. I measured WAL and it is the wrong fix — it would have made the test green *and blind*. What ships instead is the thing SQLite actually lacks: a writer queue.

### The race, named

SQLite has no lock queue. When several connections open write transactions at once, the losers sleep inside SQLite's busy handler, and **every retry briefly takes a SHARED read lock**. A SHARED holder denies the one connection holding RESERVED the EXCLUSIVE promotion it needs in order to COMMIT — so the committer cannot finish, so the retriers keep retrying, so they keep taking SHARED. Nothing arbitrates that pile-up; it is bounded only by the busy timeout.

The CI log (run 31148836319 attempt 1, `backend-compat (3.11)`, gw3) shows exactly this shape:

- the failing statement is always the claim `UPDATE gumroadsale ... WHERE token_pack_credited_at IS NULL` (`backend/src/services/token_packs.py:55`);
- **3 of the 5** concurrent requests failed, 2 returned 200;
- the `datetime.now(UTC)` values bound into the three failing UPDATEs were built at `04:56:34.42`, and the failures surfaced at `~04:57:07.8` — **~30 s**, precisely `_CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS`.

So the busy handler was engaged and consumed its entire budget. This is not SQLite's immediate-`SQLITE_BUSY`-on-lock-upgrade case: I instrumented the real request path with a `before_cursor_execute` listener reading pysqlite's `in_transaction`, and under legacy pysqlite transaction control no session ever upgrades a read lock — each write transaction begins at its first write.

### Harness-only, not a production race

Production runs PostgreSQL 16. There the same conditional `UPDATE ... WHERE token_pack_credited_at IS NULL` serializes on a **fair row-lock wait queue**, and the loser simply re-evaluates its predicate and gets rowcount 0. There is no "database is locked" analogue and no unfair lottery. `_take_credit_claim` is correct as written; only the SQLite harness was asking SQLite to play a role it does not have. This PR touches no production code.

### The fix

Give the concurrency fixture's engine the writer queue SQLite lacks. One `asyncio.Lock`-backed write slot per fixture engine, with **fair FIFO** wakeup — the same guarantee Postgres row locks give production:

- **claimed** at a connection's *first write statement of a transaction* (`before_cursor_execute`), never at transaction start;
- **released** on pool `checkin` (and `invalidate`), because a session returns its connection to the pool at the end of every transaction and at no other time;
- **bounded** by the existing 30 s constant, so a leaked slot raises a named `RuntimeError` instead of hanging CI to the job ceiling.

Three deliberate choices, each of which I got wrong first and corrected with measurement:

1. **Claimed at first write, not at transaction start.** Claiming at transaction start would serialize the *read* phases too, slamming shut the read/write window that makes these tests able to catch a time-of-check/time-of-use bug at all.
2. **Released on checkin, not on the `commit`/`rollback` events.** Those events fire *before* the DBAPI call, so releasing there hands the slot to the next writer while this connection still holds SQLite's write lock — measurably reintroducing the contention. A savepoint rollback correspondingly never frees the slot, which matters because several production handlers make a SAVEPOINT their first write and roll it back while the outer transaction stays open.
3. **No WAL.** See below.

### Why not WAL

WAL is the obvious remedy and the issue's preferred option. It fails on both counts:

- **It does not cure the contention.** At an amplified busy timeout, WAL alone still failed 42 of 75 requests (status quo: 75/75).
- **It blinds the test.** Seeding a TOCTOU-vulnerable read-then-write claim, the concurrency test caught it in **25/25** runs on the rollback journal and only **7/25** under WAL — WAL makes commits so fast that the concurrent requests stop overlapping. A future double-credit regression would have escaped roughly three runs in four.

`test_concurrency_fixture_does_not_use_wal` pins the rollback journal so a future well-meant switch announces itself instead of silently blinding the money path.

## Evidence

The flake does **not** reproduce on this machine (macOS, 10 cores, APFS): 15 runs of the file under 24 CPU burners, then 48 runs across 8 parallel pytest processes under 32 burners — **0 failures**. It is specific to CI's 2-core, real-fsync, 4-xdist-worker environment. Rather than guess, I built a harness that drives the real app's 5-ping gather against a replica of the fixture and uses the busy timeout as a **load amplifier** — shrinking it reproduces CI-scale contention on an idle laptop, so candidate fixes can be compared under identical pressure.

Contention, under CPU oversubscription (20 burners), 20 ms busy timeout, 30 reps:

| fixture | reps with failures |
| --- | --- |
| status quo (rollback journal) | **12 / 30** |
| writer queue (this PR) | **0 / 30** |

Contention at extreme amplification (0.2 ms busy timeout, 15 reps, 75 requests):

| fixture | failed requests |
| --- | --- |
| status quo | 75 / 75 |
| WAL only | 42 / 75 |
| writer queue only | 75 / 75 |
| writer queue + WAL | 0 / 75 |

(That last row is why the first draft of this change carried WAL. The mutation numbers below are why it does not.)

Mutation detection — a naive read-then-write claim seeded in place of the atomic conditional UPDATE, 25 reps:

| fixture | mutant caught |
| --- | --- |
| status quo | 25 / 25 |
| WAL only | 7 / 25 |
| writer queue + WAL | 15 / 25 |
| **writer queue (this PR)** | **25 / 25** |

And in situ, against the real fixture rather than the replica, running the actual concurrency test 15 times with the mutation applied through a throwaway pytest plugin:

- **pre-fix: caught 15/15** — **post-fix: caught 15/15**

The test is exactly as sensitive as it was; it just no longer loses a coin flip against the busy timeout.

## Test plan

- `backend/tests/test_concurrency_fixture.py` (new) specifies the fixture's guarantees. Three were RED before the change: the slot is held by an uncommitted write and freed by commit; it is freed when a session closes *without* committing (the real leak shape — a conditional UPDATE matching zero rows still opens a write transaction and the handler returns without committing); and a rolled-back SAVEPOINT does *not* free it. Two are pinning guards that passed before and must keep passing: reads are not serialized behind an uncommitted writer, and the journal mode is not WAL.
- All 11 test files that consume the `concurrent_*` fixtures pass: **466 tests, no hang**. A hang would be the signature of a leaked slot, so it was watched for explicitly.
- `./scripts/backend/check-all.sh` → **exit 0, 7/7 checks, 97% coverage**.
- Reviewed at Gate 2.5 by the code-review orchestrator.

One acknowledged gap: nothing exercises the stalled-queue `RuntimeError` path itself, since provoking it means waiting out the 30 s bound. It is a backstop for a leak that the release tests are designed to prevent, so the cost of testing it directly outweighed the coverage.

No production code is touched, no assertion is relaxed, and no skip/xfail/flaky/retry marker is introduced. `_CONCURRENT_SQLITE_BUSY_TIMEOUT_SECONDS` keeps its value of 30 and is re-documented as what it now is: a backstop, not the mechanism.

Closes #2108
