### PR TITLE
fix(backend): degrade an unusable CREEK_VAULT_URL instead of 500ing every journal write

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -147,9 +147,15 @@ APPLE_OAUTH_CLIENT_IDS=  # e.g. com.adepthood.app,com.adepthood.web
 # Wholly optional. Leaving CREEK_VAULT_URL unset selects the local fallback
 # client: the app is fully functional without a vault, with Postgres as the sole
 # system of record and every vault-backed feature degrading to its local path.
-# A plaintext http:// URL is refused at construction for any non-loopback host,
-# because the request carries the bearer key below (http://localhost stays
-# allowed so a vault can be run locally).
+# A configured URL this seam cannot use -- plaintext http:// to a non-loopback
+# host (the request carries the bearer key below; http://localhost stays
+# allowed so a vault can be run locally), userinfo/a query/a fragment, no host
+# at all, or a value that will not parse -- does not fail the deploy and does
+# not fail your writes: the app boots, every entry keeps saving to Postgres,
+# and the vault is silently unused. One WARNING says so at boot, and one more
+# per request while it stays misconfigured -- fix the value or unset it to run
+# with no vault. Left unset or blank (whitespace included) there is nothing to
+# report, so both stay quiet: no vault is a supported way to run this.
 CREEK_VAULT_URL=  # e.g. https://vault.example.com
 CREEK_VAULT_API_KEY=  # bearer credential; used only to build the Authorization header
 # Which transport a configured vault is reached over. http is the default and

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -74,7 +74,11 @@ from services.content_repository import (
     content_version_info,
     get_content_repository,
 )
-from services.creek_vault_client import close_creek_vault_http_pool
+from services.creek_vault_client import (
+    CREEK_VAULT_URL_ENV_VAR,
+    close_creek_vault_http_pool,
+    unusable_creek_vault_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -360,6 +364,48 @@ def validate_ipv6_throttle_prefix_config() -> None:
     )
 
 
+def validate_creek_vault_url_config() -> None:
+    """Announce a configured vault URL no transport can be built for.
+
+    ``CREEK_VAULT_URL`` is read by a *per-request* dependency, and a value the
+    transport cannot use degrades that request onto the local fallback.  That
+    path says so, but it says so at request rate and to whoever happens to be
+    reading logs under load.  Boot is the one place the finding can be stated
+    once, before any traffic, which makes this the operator's first and best
+    chance to notice that their vault is configured and inert -- a deployment
+    with a typo here looks perfectly healthy to everything except this record,
+    because the entries keep saving and nothing ever reaches the vault.
+
+    Never raises, on any defect, and not gated on ``ENV`` -- the same two
+    choices ``validate_ipv6_throttle_prefix_config`` makes, for the same kind of
+    setting.  A vault is an optional capability layered over a deployment that
+    works without it, so refusing to boot over a typo in it would be a worse
+    outage than the typo; and a value typed wrong in staging is wrong there too,
+    staging being exactly where it gets typed.  Unset and blank stay silent,
+    since running without a vault is this product's supported floor.
+
+    The record names the variable and the defect, and renders neither the
+    configured value nor any credential: a vault URL sits next to
+    ``CREEK_VAULT_API_KEY`` in every deployment's configuration and can carry
+    userinfo that is a credential in its own right.
+    """
+    finding = unusable_creek_vault_url()
+    if finding is None:
+        return
+    logger.warning(
+        "creek_vault_url_unusable: %s is set to a value the vault transport "
+        "cannot use (%s: %s), so this deployment replicates no journal entry to "
+        "the vault, consults no vault reflection, and reads no vault wheel; "
+        "entries still save to Postgres, which is the system of record. Correct "
+        "the value or unset %s to run without a vault -- backend/.env.example "
+        "documents the format",
+        CREEK_VAULT_URL_ENV_VAR,
+        finding.defect.value,
+        finding.detail,
+        CREEK_VAULT_URL_ENV_VAR,
+    )
+
+
 def _rate_limit_exceeded_handler(_request: Request, exc: Exception) -> JSONResponse:
     """Return a JSON 429 response with Retry-After header when rate limit is exceeded.
 
@@ -510,6 +556,11 @@ async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
     # A prefix length that is not a prefix length is discarded silently on every
     # request, so boot is the only place a typo in it can be said out loud.
     validate_ipv6_throttle_prefix_config()
+
+    # A vault URL nothing can be built for degrades every write onto the local
+    # fallback in a per-request warning; said once here, it reaches the operator
+    # before the first entry rather than at request rate.
+    validate_creek_vault_url_config()
 
     # ritual-practice ops: on every boot, seed the catalog (stages, presets,
     # course content) so a fresh database is immediately usable.

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -38,24 +38,36 @@ by Creek and called by nothing in this repository.
 :func:`build_creek_vault_client` chooses between the two from
 ``CREEK_VAULT_URL`` (unset means the local fallback, so an unconfigured
 deployment transparently degrades) and ``CREEK_VAULT_PROTOCOL``, which now
-admits exactly one value. Neither stale selector is ever guessed at, since
-guessing a transport would send vault traffic somewhere the operator did not
-choose -- but the retired ``mcp`` selector degrades to the local fallback with a
-warning rather than raising, because this factory runs per request and a raise
-there would cost the writer their entry, while an unrecognized selector still
-raises, having no knowable intent to honour. It answers that question and no
-other: *who* may hold a configured client is settled one layer up, in
-:mod:`dependencies.creek_vault`, because a vault reached under a single
+admits exactly one value. Nothing here is ever guessed at, since guessing a
+transport would send vault traffic somewhere the operator did not choose --
+but every way the configuration can be unusable degrades to the local fallback
+with one WARNING rather than raising: a stale ``mcp`` selector, a selector
+nobody ever supported, and a ``CREEK_VAULT_URL`` no transport can be built for
+alike. This factory runs inside a per-request dependency, so a raise there would
+cost the writer their entry over an optional capability. It answers that
+question and no other: *who* may hold a configured client is settled one layer
+up, in :mod:`dependencies.creek_vault`, because a vault reached under a single
 deployment-wide identity is one shared corpus rather than any user's.
 
-Transport security: the configured transport refuses a plaintext ``http://`` URL
-to any non-loopback host, because every request carries the
-``CREEK_VAULT_API_KEY`` bearer credential that must never cross a network in
-cleartext -- TLS misconfiguration fails closed at construction, before the key is
-bound to anything. It also refuses a URL carrying userinfo, a query, or a
-fragment: userinfo is itself a credential that httpx would log unmasked and turn
-into a Basic-auth downgrade of our bearer, and a query or fragment would
-silently redirect the credential away from the endpoint the operator configured.
+Transport security: a URL is refused outright if it is one this seam cannot
+safely bind the ``CREEK_VAULT_API_KEY`` bearer credential to -- plaintext
+``http://`` to any non-loopback host, because the credential must never cross a
+network in cleartext; userinfo, which is itself a credential that httpx would
+log unmasked and turn into a Basic-auth downgrade of our bearer; a query or
+fragment, either of which would silently redirect the credential away from the
+endpoint the operator configured; and a value that parses to no host, or does
+not parse at all, which no request could ever be built from. Deciding which of
+those a given string is belongs to :mod:`services.creek_vault_url`, a
+stdlib-only leaf that reads no environment and holds no credential; what to *do*
+about the answer is decided here.
+:func:`unusable_creek_vault_url` names which of those a configured value is,
+and the two callers answer it differently *on purpose*.
+:class:`HttpCreekVaultClient` fails closed at construction, before the key is
+bound to anything: reaching its constructor with a URL nobody classified is a
+programming error, and it does not run on a request path, so it stays loud.
+:func:`build_creek_vault_client` does run on one, per request, so it warns and
+returns the local fallback -- the credential still never reaches the suspect
+URL, because no HTTP adapter is built at all.
 :class:`HttpCreekVaultClient` speaks request/response JSON over a shared,
 credential-free pooled connection (:class:`_VaultHttpPool`), building its
 authorization header per call so the pooled connection never holds the key. This
@@ -83,7 +95,7 @@ from collections.abc import Callable, Mapping
 from http import HTTPStatus
 from types import TracebackType
 from typing import NoReturn
-from urllib.parse import SplitResult, quote, urlsplit
+from urllib.parse import quote
 
 import httpx
 
@@ -129,6 +141,7 @@ from services.creek_vault_telemetry import (
     outcome_for_error,
     record_vault_outcome,
 )
+from services.creek_vault_url import VaultUrlDefect, VaultUrlFinding, classify_vault_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -283,10 +296,12 @@ class _IncompatibleContractVersionError(Exception):
     """
 
 
-# Hosts for which a plaintext ``http://`` vault URL is tolerated: a developer
-# running the vault on the same machine. Every other host must use TLS so the
-# bearer credential never crosses a network in cleartext.
-_LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+# Where the vault lives. Public, and the only one of this seam's variable names
+# that is, because :mod:`main` names it in the boot record it emits about it --
+# exactly as ``client_ip`` publishes the throttle-prefix variable name, and for
+# the same reason: one spelling, so a check and the record announcing it can
+# never name different variables.
+CREEK_VAULT_URL_ENV_VAR = "CREEK_VAULT_URL"
 
 # Which transport a *configured* vault is reached over, and the one value that
 # selector still admits. It survives as a selector at all so a stale setting left
@@ -326,6 +341,24 @@ _UNKNOWN_PROTOCOL_EVENT = (
     "creek vault protocol selector is not recognized; using the local fallback -- "
     "unset CREEK_VAULT_PROTOCOL or set it to http"
 )
+# The third way a deployment lands on the local fallback with something wrong in
+# its environment: the selector is honoured, but the URL it points at is one no
+# transport can be built for. A third message rather than a share of either
+# protocol one, because an operator reading a degrade needs to know *which
+# variable* to go and look at, and a record that named the selector for a typo in
+# the URL would send them to the wrong file. Static and value-free like its
+# siblings: what was configured travels as structured fields, and the one field
+# that could carry a value carries a component name instead -- see
+# :func:`~services.creek_vault_url.classify_vault_url`. One message for all four
+# defects, with the defect itself as a field, on the same reasoning
+# :mod:`dependencies.creek_vault`'s
+# ``binding`` field follows: a dashboard should be able to count "the vault URL
+# is unusable" without unioning four filters, and still break it down when it
+# wants to.
+_UNUSABLE_URL_EVENT = (
+    "creek vault URL is unusable; using the local fallback -- "
+    "fix CREEK_VAULT_URL or unset it to run without a vault"
+)
 
 
 def _protocol_fields(protocol: str) -> Mapping[str, str]:
@@ -340,66 +373,43 @@ def _protocol_fields(protocol: str) -> Mapping[str, str]:
     return {"protocol": protocol, "supported_protocol": _PROTOCOL_HTTP}
 
 
-# URL components a configured vault URL must not carry, in the order their
-# names are reported. ``userinfo`` (the ``user:pass@`` prefix) is itself a
-# credential: httpx renders it *unmasked* in ``str(url)`` -- which is what its
-# own INFO request log formats -- and, absent an explicit ``auth=``, derives
-# ``BasicAuth`` from it whose auth flow *assigns* ``Authorization``, silently
-# replacing our bearer with a weaker scheme. ``query`` and ``fragment`` break
-# the capability URL instead: it is built by appending a path to the configured
-# string, so either one swallows that path and aims the credential at an
-# endpoint the operator never configured.
-_FORBIDDEN_URL_PARTS = ("userinfo", "query", "fragment")
-
-# The delimiters that *introduce* a query and a fragment. Presence is tested on
-# the raw configured string rather than on the parsed component, and that is the
-# whole point: ``urlsplit`` reports both as ``""`` when they are absent *and*
-# when they are present but empty, so ``https://vault.example/`` and
-# ``https://vault.example/?`` are indistinguishable once parsed. The second is
-# the dangerous one -- the capability path is appended to the configured string,
-# so a trailing ``?`` would build ``https://vault.example/?/v1/journal-entries/5``
-# and send every path as a query string against ``/``, aiming the bearer
-# credential at an endpoint nobody configured. Per RFC 3986 these two characters
-# can only ever be those delimiters in a URL (a literal one inside a path or a
-# credential must be percent-encoded), so their presence *is* the component's
-# presence. Reconstructing a normalized URL from the parsed parts would also
-# close the hole, but by editing an operator's configuration into something they
-# did not write; refusing it and saying so is the honest half of that trade.
-_QUERY_DELIMITER = "?"
-_FRAGMENT_DELIMITER = "#"
+# What the constructor says about each defect, keyed rather than branched so the
+# refusal is a lookup and the four wordings sit where they can be read together.
+# The environment variable's name is prefixed at the raise site rather than
+# written into each clause, so no future member can be added that forgets to name
+# the variable an operator has to go and fix. The forbidden-components and
+# insecure-transport wordings are the ones this seam has always used and are
+# preserved verbatim: they are in runbooks.
+_REFUSAL_CLAUSES: Mapping[VaultUrlDefect, str] = {
+    VaultUrlDefect.UNPARSEABLE: "is unusable: {detail}",
+    VaultUrlDefect.FORBIDDEN_COMPONENTS: "must not carry these URL components: {detail}",
+    VaultUrlDefect.MALFORMED: "is missing required URL components: {detail}",
+    VaultUrlDefect.INSECURE_TRANSPORT: "must use https for a non-loopback host ({detail})",
+}
 
 
-def _forbidden_url_parts(url: str, parsed: SplitResult) -> tuple[str, ...]:
-    """Return the names of the disallowed components ``url`` carries.
+def unusable_creek_vault_url() -> VaultUrlFinding | None:
+    """Return what the runtime cannot use about the configured vault URL, else ``None``.
 
-    Userinfo counts as present whenever either half is set, so a degenerate
-    ``https://user@host`` (empty password) is caught alongside the full form.
-    Query and fragment count as present whenever their delimiter appears at all,
-    empty component included -- see :data:`_QUERY_DELIMITER`. The query
-    delimiter is looked for only *before* any fragment delimiter, since a ``?``
-    after a ``#`` is part of the fragment rather than a query of its own, and
-    naming both components for one mistake would send an operator hunting a
-    second problem they do not have.
+    Exists so a caller that *can* log once -- boot -- can say what the
+    per-request path would otherwise only ever say at request rate, mirroring
+    :func:`client_ip.unusable_throttle_prefix_config` for the same kind of
+    setting.
+
+    Unset and blank both answer ``None``. ``backend/.env.example`` ships
+    ``CREEK_VAULT_URL`` present and empty, so treating blank as a fault would
+    fire on every stock boot and teach operators to scroll past the finding that
+    matters -- and running with no vault is this product's supported floor, not a
+    misconfiguration. :func:`build_creek_vault_client` asks the same question the
+    same way, deliberately: a variable holding nothing but a stray space would
+    otherwise be unset to this check and configured-but-broken to the factory,
+    which is the worst pairing available -- silence at boot, where an operator is
+    actually looking, and a WARNING on every request, where it costs the most.
     """
-    before_fragment, _, _ = url.partition(_FRAGMENT_DELIMITER)
-    carried = (
-        parsed.username is not None or parsed.password is not None,
-        _QUERY_DELIMITER in before_fragment,
-        _FRAGMENT_DELIMITER in url,
-    )
-    return tuple(name for name, found in zip(_FORBIDDEN_URL_PARTS, carried, strict=True) if found)
-
-
-def _require_bare_vault_url(url: str, parsed: SplitResult) -> None:
-    """Reject a vault URL carrying userinfo, a query, or a fragment.
-
-    The message names only the offending *component names*: it reaches logs,
-    and one of the components it can name -- userinfo -- is a credential, so
-    echoing any value here would be the very leak this check exists to prevent.
-    """
-    parts = _forbidden_url_parts(url, parsed)
-    if parts:
-        raise ValueError(f"CREEK_VAULT_URL must not carry these URL components: {', '.join(parts)}")
+    raw = os.getenv(CREEK_VAULT_URL_ENV_VAR)
+    if raw is None or not raw.strip():
+        return None
+    return classify_vault_url(raw)
 
 
 def _require_secure_vault_url(url: str) -> None:
@@ -410,29 +420,49 @@ def _require_secure_vault_url(url: str) -> None:
     -- so any future transport must keep calling it too. It is a free function
     rather than a method for exactly that reason: the rule belongs to the
     credential, not to whichever adapter happens to be carrying it today.
-    Two rules: the URL must carry no userinfo, query, or fragment
-    (:func:`_require_bare_vault_url`, applied to every scheme), and a plaintext
-    ``http://`` URL is allowed only to a loopback host, since cleartext to a
-    remote host would expose the credential on the network. A misconfiguration
-    raises here rather than silently leaking, before the key is bound to
-    anything. The message names only component names, the scheme, and the host
-    -- never the API key.
 
-    Both the raw string and its parsed form are needed: the string is what a
-    capability URL is built from and the only place an empty-but-present query
-    or fragment survives, while the parse is what answers for the scheme, the
-    host, and the userinfo halves.
+    It raises where :func:`build_creek_vault_client` degrades, and the asymmetry
+    is the design rather than an oversight. The factory sits behind a per-request
+    dependency, so a raise there costs the writer their entry over an optional
+    capability. This constructor does not: a caller reaching it with a URL nobody
+    classified is a programming error, and letting that through would bind the
+    bearer credential to an endpoint no check approved. So it stays loud.
+
+    The message names the variable an operator has to go and fix, repeats the
+    finding's detail, and carries nothing else -- never the API key, never
+    userinfo, never the configured value.
+
+    ``from None`` is not decoration. The classifier
+    (:func:`~services.creek_vault_url.classify_vault_url`) has already
+    discarded the parser's exception, so nothing is being suppressed here today;
+    the clause states the invariant at the boundary that must never regress,
+    because the object it keeps out is the one guaranteed to quote a netloc --
+    userinfo included -- into whatever traceback a 500 handler renders.
+    :func:`_refuse_unratified` cuts its chain for the same reason.
     """
-    parsed = urlsplit(url)
-    _require_bare_vault_url(url, parsed)
-    if parsed.scheme == "https":
+    finding = classify_vault_url(url)
+    if finding is None:
         return
-    if parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS:
-        return
-    raise ValueError(
-        f"CREEK_VAULT_URL must use https for a non-loopback host "
-        f"(scheme {parsed.scheme!r}, host {parsed.hostname!r})"
-    )
+    clause = _REFUSAL_CLAUSES[finding.defect].format(detail=finding.detail)
+    raise ValueError(f"{CREEK_VAULT_URL_ENV_VAR} {clause}") from None
+
+
+def _url_defect_fields(finding: VaultUrlFinding) -> Mapping[str, str]:
+    """Build the structured fields the unusable-URL degrade record carries.
+
+    A builder rather than a literal at the call site, for the reason
+    :func:`_protocol_fields` is one: the key names are what a dashboard groups
+    on, so they belong in one place. Three fields and no fourth -- the variable,
+    the defect, and the defect's value-free detail. What is deliberately absent
+    is the configured URL itself: it is the one setting most likely to have a
+    credential pasted into it, and this record is emitted on the writer's request
+    path, at request rate, into whatever aggregator the deployment ships to.
+    """
+    return {
+        "env_var": CREEK_VAULT_URL_ENV_VAR,
+        "url_defect": finding.defect.value,
+        "url_detail": finding.detail,
+    }
 
 
 def _require_str(payload: Mapping[str, object], key: str) -> str:
@@ -1775,12 +1805,38 @@ def build_creek_vault_client() -> CreekVaultClient:
     guess this seam exists to refuse. Both records name the offending value and
     the supported one and nothing else -- they reach logs, so neither the URL nor
     the bearer credential may travel with them.
+
+    Only with a selector this deployment will actually honour is the URL itself
+    judged, by :func:`~services.creek_vault_url.classify_vault_url`, and a
+    defective one degrades the same way for the same reason. The ordering
+    carries two decisions. A deployment
+    that will not use the URL at all has no business complaining about it, so a
+    selector that already refused the transport short-circuits first and one
+    misconfiguration stays one record. And the URL is judged *before*
+    ``CREEK_VAULT_API_KEY`` is so much as read, because there is no reason to
+    fetch a credential for an endpoint that is about to be refused.
+
+    The refusal itself lives in :func:`_require_secure_vault_url`, which
+    :class:`HttpCreekVaultClient` still calls, and the constructor below is
+    therefore unreachable with a URL that would trip it. That is deliberately an
+    *ordering* guarantee rather than a ``try``: catching the constructor's
+    ``ValueError`` here would turn a genuine bug in it into a silent degrade, and
+    a vault that quietly stopped replicating is the failure this seam is least
+    able to notice.
     """
-    # ``CREEK_VAULT_URL`` being unset or empty is the signal that no vault is
+    # ``CREEK_VAULT_URL`` being unset or blank is the signal that no vault is
     # configured; the bearer credential is read only to build the adapter's
     # auth header and is never logged or placed in any exception message.
-    url = os.getenv("CREEK_VAULT_URL", "")
-    if not url:
+    # ``strip`` is asked only whether anything was configured at all, and the
+    # answer is thrown away -- ``url`` travels on exactly as the operator wrote
+    # it, since normalizing it here is the one thing this seam refuses to do.
+    # Blank has to mean the same thing here as it does to
+    # :func:`unusable_creek_vault_url`, or a stray space in an otherwise empty
+    # variable would go unmentioned at boot and then warn on every request --
+    # silence in the one place an operator is looking, noise in the one place
+    # it costs.
+    url = os.getenv(CREEK_VAULT_URL_ENV_VAR, "")
+    if not url.strip():
         return LocalFallbackCreekVaultClient()
     protocol = os.getenv(_PROTOCOL_ENV_VAR, _PROTOCOL_HTTP).strip().lower()
     if protocol == _PROTOCOL_RETIRED_MCP:
@@ -1789,4 +1845,12 @@ def build_creek_vault_client() -> CreekVaultClient:
     if protocol != _PROTOCOL_HTTP:
         _LOGGER.warning(_UNKNOWN_PROTOCOL_EVENT, extra=_protocol_fields(protocol))
         return LocalFallbackCreekVaultClient()
+    finding = classify_vault_url(url)
+    if finding is not None:
+        _LOGGER.warning(_UNUSABLE_URL_EVENT, extra=_url_defect_fields(finding))
+        return LocalFallbackCreekVaultClient()
+    # Reached only for a URL every check above approved, which is why the
+    # constructor's own refusal is unreachable from here rather than caught: a
+    # ``try`` around it would swallow a genuine bug in it as if it were a
+    # misconfiguration.
     return HttpCreekVaultClient(url, os.getenv("CREEK_VAULT_API_KEY", ""))

--- a/backend/src/services/creek_vault_url.py
+++ b/backend/src/services/creek_vault_url.py
@@ -1,0 +1,231 @@
+"""What shape a Creek Vault base URL must have, and the order those rules run in.
+
+The pure half of the vault seam's configuration checks, split out of
+:mod:`services.creek_vault_client` along the same seam
+:mod:`services.creek_vault_payload` was split along: the adapters there are left
+holding transports, sessions, and a connection pool, while the *rules* for
+judging an untrusted configured string live in one place with no I/O in sight.
+:func:`classify_vault_url` is the single judgement behind all three callers --
+the constructor's raise, the factory's degrade, and the boot check -- so no two
+layers can disagree about what a given string is.
+
+A URL is refused for four reasons, and the *order* they are decided in is a
+safety property rather than a taste. ``urlsplit`` puts a username in the
+**scheme** slot for ``user:pass@host`` (no ``//``, so no netloc, so both userinfo
+halves come back empty and the credential sits where a scheme belongs), and
+reports no host at all for ``https://``. So a value that will not parse is named
+before anything is read out of a parse, forbidden components before any parsed
+component is quoted, and a missing host before a scheme is -- which is what makes
+the one finding that repeats any part of the configured value safe to build.
+
+This module is a leaf on purpose: :mod:`enum`, :mod:`dataclasses`, and
+:mod:`urllib.parse`, and nothing else. No ``httpx``, so the rules that decide
+where a credential may be sent can be read and exercised without a transport in
+the way. No ``os``, because *which* string is configured is the caller's
+question, and reading the environment here would fold two decisions into one
+function. And no logging and no credential, because judging a value and
+reporting on it are deliberately different jobs: what to *do* about a defect --
+raise, warn once at boot, or degrade this one request -- is decided in
+:mod:`services.creek_vault_client`, which is also the only place the
+``CREEK_VAULT_API_KEY`` bearer these rules exist to protect is ever handled.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from urllib.parse import SplitResult, urlsplit
+
+# Hosts for which a plaintext ``http://`` vault URL is tolerated: a developer
+# running the vault on the same machine. Every other host must use TLS so the
+# bearer credential never crosses a network in cleartext.
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# URL components a configured vault URL must not carry, in the order their
+# names are reported. ``userinfo`` (the ``user:pass@`` prefix) is itself a
+# credential: httpx renders it *unmasked* in ``str(url)`` -- which is what its
+# own INFO request log formats -- and, absent an explicit ``auth=``, derives
+# ``BasicAuth`` from it whose auth flow *assigns* ``Authorization``, silently
+# replacing our bearer with a weaker scheme. ``query`` and ``fragment`` break
+# the capability URL instead: it is built by appending a path to the configured
+# string, so either one swallows that path and aims the credential at an
+# endpoint the operator never configured.
+_FORBIDDEN_URL_PARTS = ("userinfo", "query", "fragment")
+
+# The delimiters that *introduce* a query and a fragment. Presence is tested on
+# the raw configured string rather than on the parsed component, and that is the
+# whole point: ``urlsplit`` reports both as ``""`` when they are absent *and*
+# when they are present but empty, so ``https://vault.example/`` and
+# ``https://vault.example/?`` are indistinguishable once parsed. The second is
+# the dangerous one -- the capability path is appended to the configured string,
+# so a trailing ``?`` would build ``https://vault.example/?/v1/journal-entries/5``
+# and send every path as a query string against ``/``, aiming the bearer
+# credential at an endpoint nobody configured. Per RFC 3986 these two characters
+# can only ever be those delimiters in a URL (a literal one inside a path or a
+# credential must be percent-encoded), so their presence *is* the component's
+# presence. Reconstructing a normalized URL from the parsed parts would also
+# close the hole, but by editing an operator's configuration into something they
+# did not write; refusing it and saying so is the honest half of that trade.
+_QUERY_DELIMITER = "?"
+_FRAGMENT_DELIMITER = "#"
+
+
+def _forbidden_url_parts(url: str, parsed: SplitResult) -> tuple[str, ...]:
+    """Return the names of the disallowed components ``url`` carries.
+
+    Userinfo counts as present whenever either half is set, so a degenerate
+    ``https://user@host`` (empty password) is caught alongside the full form.
+    Query and fragment count as present whenever their delimiter appears at all,
+    empty component included -- see :data:`_QUERY_DELIMITER`. The query
+    delimiter is looked for only *before* any fragment delimiter, since a ``?``
+    after a ``#`` is part of the fragment rather than a query of its own, and
+    naming both components for one mistake would send an operator hunting a
+    second problem they do not have.
+    """
+    before_fragment, _, _ = url.partition(_FRAGMENT_DELIMITER)
+    carried = (
+        parsed.username is not None or parsed.password is not None,
+        _QUERY_DELIMITER in before_fragment,
+        _FRAGMENT_DELIMITER in url,
+    )
+    return tuple(name for name, found in zip(_FORBIDDEN_URL_PARTS, carried, strict=True) if found)
+
+
+class VaultUrlDefect(enum.StrEnum):
+    """Why a configured ``CREEK_VAULT_URL`` cannot be used, in four kinds.
+
+    A closed vocabulary, because the classifier's whole job is to answer "which
+    of these": a member with no classification rule behind it would be a defect
+    nothing can ever report, and a defect with no member would be one nothing can
+    ever describe. The values travel in a structured log field, so they are this
+    seam's contract with whoever wrote the alert -- renaming one silently retires
+    somebody's filter.
+
+    Declared in the order the classifier decides in, and that order is a safety
+    property rather than a taste (see :func:`classify_vault_url`).
+    """
+
+    UNPARSEABLE = "unparseable"
+    FORBIDDEN_COMPONENTS = "forbidden_components"
+    MALFORMED = "malformed"
+    INSECURE_TRANSPORT = "insecure_transport"
+
+
+@dataclass(frozen=True)
+class VaultUrlFinding:
+    """One defect and the short, value-free phrase describing it.
+
+    Frozen because this is a value, not a record of one: it is classified in one
+    place and rendered in another -- a raise, a per-request WARNING, a boot
+    WARNING -- and nothing between those points has any business editing it.
+    Frozen also buys hashability, so two reads of one misconfiguration compare
+    and deduplicate as the same finding.
+
+    ``detail`` is always either a constant of this module or one of its own
+    component names, with the single exception of the insecure-transport wording,
+    which quotes a scheme and a host that three earlier classifications have
+    already made safe to quote. It is never anything else drawn from the
+    configured value, because this string is destined for a log line and the
+    configured value is a URL that can contain a credential.
+    """
+
+    defect: VaultUrlDefect
+    detail: str
+
+
+# The whole detail an unparseable value gets. Static because there is no parse to
+# draw a component name from, and *safe* for the same reason: anything derived
+# from a string nobody could parse could be any part of it, credential included.
+# Two different unparseable URLs therefore produce the identical finding.
+_UNPARSEABLE_DETAIL = "the configured value could not be parsed as a URL"
+
+# The components a URL must actually have before a request can be built for it,
+# in the order a finding names them. Two names and no more, which is what keeps a
+# MALFORMED detail a closed vocabulary -- "scheme", "host", or "scheme, host" --
+# rather than a rendering of whatever the operator typed.
+_REQUIRED_URL_PARTS = ("scheme", "host")
+
+
+def _transport_is_secure(parsed: SplitResult) -> bool:
+    """Report whether this scheme and host may carry the bearer credential.
+
+    TLS, or plaintext to a host that never leaves the machine. The loopback
+    exemption is the long-standing one that lets a developer run a vault locally;
+    every other host must use ``https``, because cleartext to a remote host would
+    put the credential on a network.
+    """
+    return parsed.scheme == "https" or (
+        parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS
+    )
+
+
+def _transport_finding(parsed: SplitResult) -> VaultUrlFinding | None:
+    """Classify what a parsed, component-clean URL still gets wrong, or ``None``.
+
+    Split out from :func:`classify_vault_url` because these are the two rules
+    that may speak about a parse at all, and they must run in this order.
+    Missing components come first: ``https://`` carries a perfectly good scheme
+    and names no host, so a check that stopped at the scheme would accept a URL
+    no request can be built for -- and ``ftp://`` is answerable both ways, where
+    "there is no host" is the true and value-free answer.
+
+    Only once a host is known to exist may a finding quote a scheme, which is why
+    the insecure-transport detail is the one place in this seam that repeats any
+    part of the configured value. That wording is the one the refusal has always
+    carried, and it is what an operator actually needs to see.
+    """
+    missing = tuple(
+        name
+        for name, present in zip(
+            _REQUIRED_URL_PARTS, (bool(parsed.scheme), bool(parsed.hostname)), strict=True
+        )
+        if not present
+    )
+    if missing:
+        return VaultUrlFinding(VaultUrlDefect.MALFORMED, ", ".join(missing))
+    if _transport_is_secure(parsed):
+        return None
+    return VaultUrlFinding(
+        VaultUrlDefect.INSECURE_TRANSPORT,
+        f"scheme {parsed.scheme!r}, host {parsed.hostname!r}",
+    )
+
+
+def classify_vault_url(url: str) -> VaultUrlFinding | None:
+    """Name the one defect that makes ``url`` unusable, or ``None`` if it is fine.
+
+    The single judgement behind all three callers -- the constructor's raise, the
+    factory's degrade, and the boot check -- so no two layers can disagree about
+    what a given string is. A disagreement is how a URL ends up refused in one
+    place and accepted in another.
+
+    The order is the safety property. ``urlsplit`` puts a username in the
+    *scheme* slot for ``user:pass@host`` (no ``//``, so no netloc, so both
+    userinfo halves come back empty and the credential sits where a scheme
+    belongs), and reports no host at all for ``https://``. So a finding may quote
+    a scheme only after userinfo has been excluded *and* a host is known to
+    exist, which is exactly what running forbidden-components before
+    :func:`_transport_finding`, and missing-components before the transport rule,
+    guarantees.
+
+    The parser's own ``ValueError`` is discarded rather than inspected, and that
+    is deliberate: ``urlsplit`` quotes the whole offending netloc back in its
+    message when it refuses one under NFKC normalization, and a netloc includes
+    userinfo. That exception object is the one thing in this seam guaranteed to
+    hold a credential when the configured URL has one, so it is never bound,
+    rendered, or chained to.
+
+    Nothing is ever normalized. A value is judged as configured and refused as
+    configured -- reconstructing a URL from its parsed parts would close the same
+    holes by editing something nobody wrote, and a deployment replicating to an
+    endpoint subtly different from the configured one is worse than one
+    replicating nowhere and saying so.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return VaultUrlFinding(VaultUrlDefect.UNPARSEABLE, _UNPARSEABLE_DETAIL)
+    parts = _forbidden_url_parts(url, parsed)
+    if parts:
+        return VaultUrlFinding(VaultUrlDefect.FORBIDDEN_COMPONENTS, ", ".join(parts))
+    return _transport_finding(parsed)

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -1281,17 +1281,50 @@ def test_factory_degrades_an_unrecognized_protocol_to_the_local_fallback(
         assert _SENTINEL_KEY not in rendered
 
 
-def test_http_factory_rejects_a_plaintext_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Plaintext to a remote host fails closed at construction, before the key is bound."""
-    monkeypatch.setenv("CREEK_VAULT_URL", "http://vault.example.test")
-    monkeypatch.setenv("CREEK_VAULT_API_KEY", _SENTINEL_KEY)
-    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+def test_http_client_rejects_a_plaintext_remote_url() -> None:
+    """Plaintext to a remote host fails closed at construction, before the key is bound.
+
+    The refusal belongs to the constructor, which is where the credential would
+    otherwise be bound to a URL nothing approved. Its *caller* is a different
+    question: :func:`build_creek_vault_client` runs per request and degrades
+    instead, since a raise there would cost the writer their entry -- the whole
+    taxonomy of unusable URLs, and what each of them does to a journal save,
+    lives in ``test_creek_vault_url_defects.py``.
+    """
     with pytest.raises(ValueError, match="https") as exc_info:
-        build_creek_vault_client()
+        HttpCreekVaultClient("http://vault.example.test", _SENTINEL_KEY)
     message = str(exc_info.value)
     assert "http" in message
     assert "vault.example.test" in message
     assert _SENTINEL_KEY not in message
+
+
+def test_http_factory_degrades_a_plaintext_remote_url_to_the_local_fallback(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The per-request factory skips the optional replication rather than losing the entry.
+
+    Same reasoning as the retired and unrecognized protocol selectors above: this
+    factory is reached from a dependency, so raising means the journal handler's
+    body never runs. The credential still never reaches the suspect URL -- no
+    HTTP adapter is built at all -- and the WARNING is how the operator finds
+    out.
+    """
+    monkeypatch.setenv("CREEK_VAULT_URL", "http://vault.example.test")
+    monkeypatch.setenv("CREEK_VAULT_API_KEY", _SENTINEL_KEY)
+    monkeypatch.setenv("CREEK_VAULT_PROTOCOL", "http")
+    caplog.set_level(logging.WARNING)
+
+    client = build_creek_vault_client()
+
+    assert isinstance(client, LocalFallbackCreekVaultClient)
+    assert len(caplog.records) == 1
+    assert "CREEK_VAULT_URL" in caplog.records[0].getMessage()
+    for rendered in [
+        caplog.records[0].getMessage(),
+        *[str(value) for value in caplog.records[0].__dict__.values()],
+    ]:
+        assert _SENTINEL_KEY not in rendered
 
 
 def test_http_factory_accepts_a_plaintext_loopback_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_creek_vault_url_defects.py
+++ b/backend/tests/test_creek_vault_url_defects.py
@@ -1,0 +1,798 @@
+"""What a configured Creek Vault URL that cannot be used does to a journal save.
+
+``CREEK_VAULT_URL`` is read by a *per-request* dependency, so whatever the vault
+seam decides about it, it decides on the writer's request path. That is the whole
+weight behind these tests: a URL the transport refuses to bind a credential to
+must not become a 500 on ``POST /journal/``, because the entry the writer just
+typed exists nowhere else yet. Replication into a vault is documented
+best-effort -- a failed one is dropped, not queued, and the local Postgres row is
+the system of record -- so skipping the optional half is the honest answer to a
+URL nobody can use. Skipping it *quietly* is not, which is why every degrade here
+is paired with exactly one WARNING.
+
+Three layers, pinned in that order.
+
+The classifier :func:`unusable_creek_vault_url` names the defect in a closed
+four-member vocabulary, and the *order* it decides in is load-bearing rather than
+incidental: ``urlsplit`` puts a username in the scheme slot for
+``user:pass@host``, and reports no host at all for ``https://``, so a finding may
+only name a scheme once userinfo has been ruled out and a host is known to exist.
+Every detail string a finding carries is either static, one of this module's own
+component names, or the scheme-and-host wording the transport check already used
+-- never anything else drawn from the configured value, because this finding
+reaches a log and one of the components it can name is a credential.
+
+The adapter :class:`HttpCreekVaultClient` still fails closed on every one of
+those defects. Constructing it with a URL nobody validated is a programming
+error, and the credential must never reach a suspect endpoint, so the refusal
+stays a raise.
+
+The factory :func:`build_creek_vault_client` -- the one reached per request --
+degrades instead, and the end-to-end cases at the bottom are the point of the
+whole file: the entry is saved, the response is not a 500, no request leaves the
+process, and the API key appears in no record.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import traceback
+from collections.abc import AsyncGenerator
+from http import HTTPStatus
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain.creek_vault import CONTRACT_VERSION, CreekCapability
+from models.journal_entry import JournalEntry
+from services.creek_vault_client import (
+    _RETIRED_PROTOCOL_EVENT,
+    _UNKNOWN_PROTOCOL_EVENT,
+    HttpCreekVaultClient,
+    LocalFallbackCreekVaultClient,
+    VaultUrlDefect,
+    VaultUrlFinding,
+    _VaultHttpPool,
+    build_creek_vault_client,
+    unusable_creek_vault_url,
+)
+
+_URL_ENV_VAR = "CREEK_VAULT_URL"
+_KEY_ENV_VAR = "CREEK_VAULT_API_KEY"
+_PROTOCOL_ENV_VAR = "CREEK_VAULT_PROTOCOL"
+_OWNER_ENV_VAR = "CREEK_VAULT_OWNER_USER_ID"
+
+_POOL_ATTR = "services.creek_vault_client._VAULT_HTTP_POOL"
+
+_VAULT_URL = "https://vault.example.test"
+
+# The bearer credential, spelled so that finding it anywhere is unambiguous. It
+# is the reason the transport refuses an unusable URL at all, so no refusal, log
+# record, or degrade may ever repeat it.
+_SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"  # pragma: allowlist secret
+
+# Userinfo smuggled into the configured URL. It is itself a credential -- httpx
+# renders it unmasked in ``str(url)`` and would derive Basic auth from it -- so
+# neither half may reach a message, a structured field, or a finding's detail.
+_SENTINEL_USER = "SENTINELUSER"
+_SENTINEL_PASSWORD = "SENTINELPASSWORD"  # pragma: allowlist secret
+
+_USERINFO_URL = f"https://{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@vault.example.test"
+
+# The same userinfo with no host behind it, and with a plaintext scheme in front
+# of it: the two URLs that decide whether userinfo is ruled out before anything
+# else is reported.
+_USERINFO_NO_HOST_URL = f"https://{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@"
+_USERINFO_PLAINTEXT_URL = f"http://{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@vault.example.test"
+
+# Userinfo written without the ``//`` that would make it userinfo at all.
+# ``urlsplit`` reads the username as the *scheme* here and finds no host, which
+# is exactly why a finding may not name a scheme until a host is known.
+_SCHEME_SLOT_USERINFO_URL = f"{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@vault.example.test"
+
+# An unterminated IPv6 literal: ``urlsplit`` raises ``ValueError`` on it, so it
+# escapes ahead of any validator that assumes a parse succeeded.
+_UNPARSEABLE_URL = "https://[::1"
+_UNPARSEABLE_WITH_USERINFO_URL = f"https://{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@[::1"
+
+# The unparseable URL whose refusal ``urlsplit`` describes by quoting the entire
+# netloc back at the caller -- userinfo included, which is to say the vault
+# password. U+2100 is one of the codepoints NFKC normalization rewrites, and
+# rewriting a netloc is exactly what that check refuses to let a URL do; it is
+# written as an escape so this file stays ASCII. This is the reason the parser's
+# own exception may never be re-raised from, chained to, or rendered.
+_NETLOC_ECHOING_URL = f"https://{_SENTINEL_USER}:{_SENTINEL_PASSWORD}@\u2100vault.example.test"
+
+# The whole taxonomy, one case per way a configured URL can be unusable. Shared
+# by the classifier, the adapter, and the factory so all three are asserted to
+# agree about what a given string is -- a disagreement between them is how a URL
+# ends up refused in one layer and accepted in another.
+_DEFECTIVE_URLS = [
+    pytest.param(_UNPARSEABLE_URL, VaultUrlDefect.UNPARSEABLE, id="unparseable_ipv6_literal"),
+    pytest.param(_NETLOC_ECHOING_URL, VaultUrlDefect.UNPARSEABLE, id="unparseable_netloc"),
+    pytest.param("https://", VaultUrlDefect.MALFORMED, id="scheme_but_no_host"),
+    pytest.param("vault.example.test", VaultUrlDefect.MALFORMED, id="bare_hostname"),
+    pytest.param(_USERINFO_URL, VaultUrlDefect.FORBIDDEN_COMPONENTS, id="userinfo"),
+    pytest.param(f"{_VAULT_URL}?", VaultUrlDefect.FORBIDDEN_COMPONENTS, id="empty_query"),
+    pytest.param(f"{_VAULT_URL}#", VaultUrlDefect.FORBIDDEN_COMPONENTS, id="empty_fragment"),
+    pytest.param(f"{_VAULT_URL}/api?tenant=1", VaultUrlDefect.FORBIDDEN_COMPONENTS, id="query"),
+    pytest.param("http://vault.example.test", VaultUrlDefect.INSECURE_TRANSPORT, id="plaintext"),
+    pytest.param("ftp://vault.example.test", VaultUrlDefect.INSECURE_TRANSPORT, id="wrong_scheme"),
+]
+
+# Every detail a MALFORMED finding may carry: which components are missing, and
+# nothing else. A closed vocabulary rather than a formatted value, because the
+# string an operator mistyped is the one thing this finding must not repeat.
+_MALFORMED_DETAILS = frozenset({"scheme", "host", "scheme, host"})
+
+# Values the runtime honours, so the classifier has nothing to report about them.
+# The loopback plaintext cases are the developer exemption the transport check
+# has always made; the path-prefix and trailing-slash cases are legal shapes a
+# careless "tidy the URL" refactor would start rejecting.
+_USABLE_URLS = [
+    _VAULT_URL,
+    f"{_VAULT_URL}/",
+    f"{_VAULT_URL}/vault/",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "http://[::1]:8000",
+]
+
+# Unset, empty, and whitespace-only: three spellings of "I configured no vault".
+_ABSENT_URLS = [None, "", "   "]
+
+_SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
+
+_ENTRY_BODY = "The willow bent without breaking, and I noticed that I did too."
+
+# One capability document, healthy: any request reaching the recording transport
+# below is a request that should never have been sent, and answering it happily
+# keeps the test's failure the fact that it happened rather than a transport
+# error somewhere downstream of it.
+_CAPABILITY_PAYLOAD: dict[str, object] = {
+    "available": True,
+    "capabilities": [CreekCapability.JOURNAL.value],
+    "contract_version": CONTRACT_VERSION,
+    "ontology_version": "aptitude-wavelength/2026-05-23",
+    "attestation": None,
+}
+
+
+class _OfflineVault:
+    """The vault's whole outside world: what was configured, and what ever left the process.
+
+    One object because the two are one question. "Was a request made?" is only
+    meaningful against a particular configuration, and a test that had to reach
+    for the environment and the transport separately would be free to assert the
+    second while forgetting the first.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Start with nothing built, nothing served, and nothing configured."""
+        self._monkeypatch = monkeypatch
+        self.builds = 0
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self) -> httpx.AsyncClient:
+        """Build one in-memory client and count the build."""
+        self.builds += 1
+        return httpx.AsyncClient(transport=httpx.MockTransport(self._serve))
+
+    def _serve(self, request: httpx.Request) -> httpx.Response:
+        """Record the request and answer with a healthy capability document."""
+        self.requests.append(request)
+        return httpx.Response(HTTPStatus.OK, json=_CAPABILITY_PAYLOAD)
+
+    def configure(self, url: str, owner_id: int | None = None) -> None:
+        """Point the deployment at ``url``, optionally binding it to one user."""
+        self._monkeypatch.setenv(_URL_ENV_VAR, url)
+        if owner_id is not None:
+            self._monkeypatch.setenv(_OWNER_ENV_VAR, str(owner_id))
+
+
+@pytest_asyncio.fixture
+async def offline_vault(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[_OfflineVault, None]:
+    """Replace the shared vault HTTP pool with one that records instead of connecting."""
+    vault = _OfflineVault(monkeypatch)
+    pool = _VaultHttpPool(build=vault)
+    monkeypatch.setattr(_POOL_ATTR, pool)
+    yield vault
+    await pool.aclose()
+
+
+@pytest.fixture
+def configured_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bind the sentinel credential and clear the protocol selector.
+
+    The selector is cleared rather than set so a stale value in a developer's own
+    environment cannot degrade the client out from under a test that is asserting
+    what the *URL* check does.
+    """
+    monkeypatch.setenv(_KEY_ENV_VAR, _SENTINEL_KEY)
+    monkeypatch.delenv(_PROTOCOL_ENV_VAR, raising=False)
+
+
+def _rendered_values(record: logging.LogRecord) -> list[str]:
+    """Render every string one record could carry: its message plus each of its fields."""
+    return [record.getMessage(), *[str(value) for value in record.__dict__.values()]]
+
+
+def _finding_for(url: str, monkeypatch: pytest.MonkeyPatch) -> VaultUrlFinding:
+    """Configure ``url`` and return the finding the classifier reports for it."""
+    monkeypatch.setenv(_URL_ENV_VAR, url)
+    finding = unusable_creek_vault_url()
+    assert finding is not None, f"{url!r} must be reported as unusable"
+    return finding
+
+
+def _degrade_record(
+    url: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> logging.LogRecord:
+    """Build a client from ``url`` and return the single WARNING the factory emitted."""
+    monkeypatch.setenv(_URL_ENV_VAR, url)
+    caplog.set_level(logging.WARNING)
+
+    client = build_creek_vault_client()
+
+    assert isinstance(client, LocalFallbackCreekVaultClient)
+    assert len(caplog.records) == 1
+    return caplog.records[0]
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Sign up a fresh user and return its auth header and DB-assigned id."""
+    response = await client.post(
+        "/auth/signup",
+        json={"email": f"{username}@example.com", "password": _SIGNUP_PASSWORD},
+    )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    return {"Authorization": f"Bearer {data['token']}"}, int(data["user_id"])
+
+
+def test_the_defect_vocabulary_is_closed_and_its_wire_values_are_stable() -> None:
+    """Four defects, spelled the way a dashboard and an operator will read them back.
+
+    The values travel in a structured log field, so they are part of the seam's
+    contract with whoever is grepping: renaming one silently retires somebody's
+    filter. Four and only four, because the classifier's whole job is to answer
+    "which of these" -- a fifth member added without a classification rule would
+    be a defect nothing can ever report.
+
+    The second assertion is about the *rendering*, not the member: a structured
+    log field is written out through ``str``, and only a string enum renders as
+    its own wire value there. A plain :class:`enum.Enum` would put
+    ``VaultUrlDefect.MALFORMED`` in the log line instead, which is a different
+    contract with a different grep.
+    """
+    assert [defect.value for defect in VaultUrlDefect] == [
+        "unparseable",
+        "forbidden_components",
+        "malformed",
+        "insecure_transport",
+    ]
+    assert str(VaultUrlDefect.MALFORMED) == "malformed"
+
+
+def test_a_finding_is_an_immutable_pair_of_defect_and_detail() -> None:
+    """The finding is a value, so two reads of one misconfiguration compare equal.
+
+    Hashability is the observable half of frozen: a mutable dataclass with
+    equality is unhashable, so a finding that can be put in a set is one nothing
+    downstream can edit between the classifier and the log record it becomes.
+    """
+    assert tuple(field.name for field in dataclasses.fields(VaultUrlFinding)) == (
+        "defect",
+        "detail",
+    )
+    finding = VaultUrlFinding(defect=VaultUrlDefect.MALFORMED, detail="host")
+    twin = VaultUrlFinding(defect=VaultUrlDefect.MALFORMED, detail="host")
+    assert finding == twin
+    assert len({finding, twin}) == 1
+
+
+@pytest.mark.parametrize("url", _ABSENT_URLS)
+def test_no_configured_url_is_nothing_to_report(
+    url: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployment that configured no vault is the supported normal case, not a fault.
+
+    Blank counts as unset for the same reason the throttle-prefix check treats it
+    that way: ``backend/.env.example`` ships vault variables present and empty, so
+    reporting blank would fire on every stock boot and teach operators to ignore
+    the finding that matters.
+    """
+    if url is None:
+        monkeypatch.delenv(_URL_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(_URL_ENV_VAR, url)
+
+    assert unusable_creek_vault_url() is None
+
+
+@pytest.mark.parametrize("url", _USABLE_URLS)
+def test_a_usable_url_is_nothing_to_report(url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every shape the transport accepts stays silent, loopback plaintext included."""
+    monkeypatch.setenv(_URL_ENV_VAR, url)
+
+    assert unusable_creek_vault_url() is None
+
+
+@pytest.mark.parametrize(("url", "defect"), _DEFECTIVE_URLS)
+def test_every_unusable_url_is_classified_into_the_taxonomy(
+    url: str, defect: VaultUrlDefect, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One defect per URL, and the same answer whichever layer asks the question."""
+    assert _finding_for(url, monkeypatch).defect is defect
+
+
+def test_an_unparseable_url_says_only_that_it_is_unparseable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A URL ``urlsplit`` refuses is described by a static string and nothing else.
+
+    There is no parse to draw a component name from, so the only honest detail is
+    a constant -- and a constant is also the only *safe* detail, since anything
+    derived from a string nobody could parse could be any part of it, credential
+    included. Two different unparseable URLs therefore produce the identical
+    finding, which is the assertion a "helpful" detail would break.
+    """
+    finding = _finding_for(_UNPARSEABLE_URL, monkeypatch)
+    with_userinfo = _finding_for(_UNPARSEABLE_WITH_USERINFO_URL, monkeypatch)
+
+    assert finding == with_userinfo
+    for leaked in (_SENTINEL_USER, _SENTINEL_PASSWORD, "::1"):
+        assert leaked not in finding.detail
+        assert leaked not in with_userinfo.detail
+
+
+@pytest.mark.parametrize(
+    ("url", "detail"),
+    [
+        pytest.param(_USERINFO_URL, "userinfo", id="userinfo"),
+        pytest.param(f"https://{_SENTINEL_USER}@vault.example.test", "userinfo", id="no_password"),
+        pytest.param(f"{_VAULT_URL}?", "query", id="empty_query"),
+        pytest.param(f"{_VAULT_URL}/api?tenant=1", "query", id="query"),
+        pytest.param(f"{_VAULT_URL}#", "fragment", id="empty_fragment"),
+        pytest.param(f"{_VAULT_URL}#anchor?tenant=1", "fragment", id="question_mark_in_fragment"),
+    ],
+)
+def test_forbidden_components_are_named_and_never_quoted(
+    url: str, detail: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The finding names which components are present, exactly as the transport already did.
+
+    Component *names* and no values, because one of the names it can report --
+    userinfo -- is a credential, and this detail is destined for a log line. The
+    question-mark-inside-a-fragment case is the one where naming both components
+    would send an operator hunting a second problem they do not have.
+    """
+    finding = _finding_for(url, monkeypatch)
+
+    assert finding.defect is VaultUrlDefect.FORBIDDEN_COMPONENTS
+    assert finding.detail == detail
+
+
+@pytest.mark.parametrize(
+    ("url", "detail"),
+    [
+        pytest.param("https://", "host", id="scheme_only"),
+        pytest.param("https:///path", "host", id="scheme_and_path_no_host"),
+        pytest.param("//vault.example.test", "scheme", id="host_only"),
+        pytest.param("vault.example.test", "scheme, host", id="bare_hostname"),
+    ],
+)
+def test_a_malformed_url_names_only_the_missing_components(
+    url: str, detail: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Which components are missing, drawn from a closed vocabulary, and no part of the value.
+
+    ``https://`` is the case that matters most: it parses, it carries the right
+    scheme, and it names no host at all -- so a check that stopped at the scheme
+    would accept a URL no request can ever be built for. The detail is a
+    component name rather than a formatted value because a URL missing its scheme
+    is precisely the one whose first token may be anything, credential included.
+    """
+    finding = _finding_for(url, monkeypatch)
+
+    assert finding.defect is VaultUrlDefect.MALFORMED
+    assert finding.detail == detail
+    assert finding.detail in _MALFORMED_DETAILS
+
+
+@pytest.mark.parametrize(
+    ("url", "detail"),
+    [
+        pytest.param(
+            "http://vault.example.test",
+            "scheme 'http', host 'vault.example.test'",
+            id="plaintext_remote",
+        ),
+        pytest.param(
+            "ftp://vault.example.test",
+            "scheme 'ftp', host 'vault.example.test'",
+            id="scheme_nobody_speaks",
+        ),
+    ],
+)
+def test_insecure_transport_keeps_the_wording_the_transport_check_already_used(
+    url: str, detail: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A parsed scheme and host are safe to quote, and are what an operator needs to see.
+
+    Safe only because the three earlier classifications have run: userinfo is
+    ruled out, so the scheme is a scheme rather than somebody's username, and a
+    host is known to exist. This is the one detail that quotes the configured
+    value at all, and it is the wording the raise has always carried.
+    """
+    finding = _finding_for(url, monkeypatch)
+
+    assert finding.defect is VaultUrlDefect.INSECURE_TRANSPORT
+    assert finding.detail == detail
+
+
+def test_userinfo_is_ruled_out_before_anything_derived_from_a_parse_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Userinfo outranks both malformation and transport, and never appears in the finding.
+
+    The ordering is the safety property, not a preference. ``urlsplit`` puts a
+    username in the scheme slot when the ``//`` is missing, so any finding that
+    quotes a scheme before userinfo has been excluded can quote a credential
+    instead. A userinfo URL with no host and a userinfo URL over plaintext are
+    both answerable in two ways; the answer that mentions no value is the one
+    that must win.
+    """
+    no_host = _finding_for(_USERINFO_NO_HOST_URL, monkeypatch)
+    plaintext = _finding_for(_USERINFO_PLAINTEXT_URL, monkeypatch)
+
+    assert no_host.defect is VaultUrlDefect.FORBIDDEN_COMPONENTS
+    assert plaintext.defect is VaultUrlDefect.FORBIDDEN_COMPONENTS
+    for finding in (no_host, plaintext):
+        assert finding.detail == "userinfo"
+        assert _SENTINEL_USER not in finding.detail
+        assert _SENTINEL_PASSWORD not in finding.detail
+
+
+def test_a_username_in_the_scheme_slot_is_never_reported_as_a_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``user:pass@host`` parses as a scheme named after the user, and must not be quoted.
+
+    Nothing marks this string as userinfo once ``urlsplit`` is done with it: with
+    no ``//`` there is no netloc, so the username and password halves come back
+    empty and the credential sits in the scheme. Reporting it as a missing host
+    is both true and silent about the value, which is the only combination that
+    is safe here.
+    """
+    finding = _finding_for(_SCHEME_SLOT_USERINFO_URL, monkeypatch)
+
+    assert finding.defect is VaultUrlDefect.MALFORMED
+    assert finding.detail == "host"
+    assert _SENTINEL_USER not in finding.detail
+    assert _SENTINEL_PASSWORD not in finding.detail
+
+
+def test_a_missing_host_outranks_an_unusable_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No host means no request, whatever the scheme says, so malformation is reported first."""
+    finding = _finding_for("ftp://", monkeypatch)
+
+    assert finding.defect is VaultUrlDefect.MALFORMED
+    assert finding.detail == "host"
+
+
+@pytest.mark.parametrize(("url", "defect"), _DEFECTIVE_URLS)
+def test_constructing_the_adapter_directly_still_fails_closed(
+    url: str, defect: VaultUrlDefect, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Handing the transport an unusable URL is a programming error and stays loud.
+
+    The factory degrades because it runs on the writer's request path; this
+    constructor does not, and a caller reaching it with a URL nobody classified
+    would be binding the bearer credential to an endpoint no check approved. So
+    the refusal stays a raise, it names the variable an operator has to go and
+    fix, it repeats the finding's detail and nothing more, and the credential it
+    was called with never reaches the message.
+    """
+    finding = _finding_for(url, monkeypatch)
+
+    with pytest.raises(ValueError, match=_URL_ENV_VAR) as exc_info:
+        HttpCreekVaultClient(url, _SENTINEL_KEY)
+
+    message = str(exc_info.value)
+    assert finding.defect is defect
+    assert finding.detail in message
+    assert _SENTINEL_KEY not in message
+    assert _SENTINEL_USER not in message
+    assert _SENTINEL_PASSWORD not in message
+
+
+def test_the_forbidden_component_refusal_keeps_its_exact_message() -> None:
+    """The message operators and runbooks already know is preserved verbatim."""
+    with pytest.raises(ValueError, match=_URL_ENV_VAR) as exc_info:
+        HttpCreekVaultClient(_USERINFO_URL, _SENTINEL_KEY)
+
+    assert str(exc_info.value) == "CREEK_VAULT_URL must not carry these URL components: userinfo"
+
+
+def test_the_insecure_transport_refusal_keeps_its_exact_message() -> None:
+    """The plaintext-remote refusal is unchanged, wording and all."""
+    with pytest.raises(ValueError, match=_URL_ENV_VAR) as exc_info:
+        HttpCreekVaultClient("http://vault.example.test", _SENTINEL_KEY)
+
+    assert str(exc_info.value) == (
+        "CREEK_VAULT_URL must use https for a non-loopback host "
+        "(scheme 'http', host 'vault.example.test')"
+    )
+
+
+def test_the_parsers_own_complaint_never_rides_along_with_the_refusal() -> None:
+    """A rejected URL is described in our words, and the parser's are dropped, chain included.
+
+    ``urlsplit`` does not merely fail on a netloc it cannot normalize -- it quotes
+    the whole netloc back in the message, and a netloc includes userinfo. So the
+    parser's own exception is the one object in this seam that is *guaranteed* to
+    hold a credential when it exists, and a plain ``raise`` inside its ``except``
+    would hand it to Python as ``__context__``, where the traceback renders it
+    into whatever log caught the request. Clearing the message is not enough;
+    the chain has to be cut, which is what makes this an assertion about
+    ``__cause__`` and ``__context__`` rather than about wording.
+
+    The whole formatted traceback is searched rather than just the message,
+    because that rendering is what a 500 handler and an ``exception()`` call both
+    actually write down.
+    """
+    with pytest.raises(ValueError, match=_URL_ENV_VAR) as exc_info:
+        HttpCreekVaultClient(_NETLOC_ECHOING_URL, _SENTINEL_KEY)
+
+    error = exc_info.value
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    rendered = "".join(traceback.format_exception(error))
+    for leaked in (_SENTINEL_USER, _SENTINEL_PASSWORD, _SENTINEL_KEY):
+        assert leaked not in rendered
+
+
+@pytest.mark.usefixtures("configured_key")
+@pytest.mark.parametrize(("url", "defect"), _DEFECTIVE_URLS)
+def test_the_factory_degrades_an_unusable_url_instead_of_raising(
+    url: str,
+    defect: VaultUrlDefect,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A URL nobody can use costs the deployment its vault, never the writer their entry.
+
+    This factory is reached from a per-request dependency, so a raise here means
+    the journal handler's body never runs and the entry exists nowhere. The vault
+    is best-effort by construction -- a dropped replication is dropped, and
+    Postgres is the system of record -- so skipping the optional half is the
+    honest answer. What makes it honest rather than negligent is the record: one
+    WARNING, naming the variable, carrying the defect and the detail as
+    structured fields a dashboard can group on, and repeating neither the
+    configured value nor the credential.
+    """
+    record = _degrade_record(url, monkeypatch, caplog)
+
+    assert record.levelno == logging.WARNING
+    message = record.getMessage()
+    assert _URL_ENV_VAR in message
+    assert "unset" in message
+    assert record.__dict__["env_var"] == _URL_ENV_VAR
+    assert record.__dict__["url_defect"] == defect.value
+    assert record.__dict__["url_detail"] == _finding_for(url, monkeypatch).detail
+    for rendered in _rendered_values(record):
+        assert _SENTINEL_KEY not in rendered
+
+
+@pytest.mark.usefixtures("configured_key")
+def test_the_degrade_record_repeats_neither_the_credential_nor_the_userinfo(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Two credentials are in play at once here, and neither may reach a log.
+
+    The bearer key is what the URL check exists to protect; the userinfo is a
+    second credential the operator put in the URL itself, which httpx would
+    render unmasked given the chance. The configured string is swept as a whole
+    as well, because a record that echoed the URL verbatim would carry the
+    userinfo inside it. Every value is checked, not just the message: a
+    structured field is logged exactly as faithfully as a formatted one.
+    """
+    record = _degrade_record(_USERINFO_URL, monkeypatch, caplog)
+
+    for rendered in _rendered_values(record):
+        assert _SENTINEL_KEY not in rendered
+        assert _SENTINEL_USER not in rendered
+        assert _SENTINEL_PASSWORD not in rendered
+        assert _USERINFO_URL not in rendered
+
+
+@pytest.mark.usefixtures("configured_key")
+def test_the_url_degrade_is_its_own_news(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A broken URL is a different fault from a protocol selector nobody honours.
+
+    Three degrades now land a deployment on the local fallback, and an operator
+    reading one of them has to be able to tell which variable to go and look at.
+    A message shared with either protocol record would send them to
+    ``CREEK_VAULT_PROTOCOL`` for a typo that is in ``CREEK_VAULT_URL``.
+    """
+    message = _degrade_record("http://vault.example.test", monkeypatch, caplog).getMessage()
+
+    assert message != _RETIRED_PROTOCOL_EVENT
+    assert message != _UNKNOWN_PROTOCOL_EVENT
+
+
+@pytest.mark.usefixtures("configured_key")
+@pytest.mark.parametrize(
+    ("protocol", "event"),
+    [
+        pytest.param("mcp", _RETIRED_PROTOCOL_EVENT, id="retired_protocol"),
+        pytest.param("grpc", _UNKNOWN_PROTOCOL_EVENT, id="unrecognized_protocol"),
+    ],
+)
+def test_an_unhonoured_protocol_is_reported_before_the_url_is_judged(
+    protocol: str,
+    event: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deployment that will not use the URL at all has no business complaining about it.
+
+    With the selector already refusing the transport, the URL is never read, so
+    reporting a defect in it would be reporting a fault that has no consequence
+    -- and would double the record count for one misconfiguration. The order of
+    the checks is what keeps the loudest thing said the true one.
+    """
+    monkeypatch.setenv(_PROTOCOL_ENV_VAR, protocol)
+    monkeypatch.setenv(_URL_ENV_VAR, "http://vault.example.test")
+    caplog.set_level(logging.WARNING)
+
+    client = build_creek_vault_client()
+
+    assert isinstance(client, LocalFallbackCreekVaultClient)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].getMessage() == event
+
+
+@pytest.mark.usefixtures("configured_key")
+@pytest.mark.parametrize("url", _ABSENT_URLS)
+def test_an_unconfigured_deployment_still_gets_the_local_fallback(
+    url: str | None, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No vault configured is not a defect, and the new check must not make it one.
+
+    Silently, too: running with no vault is this product's supported floor, so a
+    deployment that chose it must not be told off once per request for the
+    choice.
+
+    The whitespace-only case is the one worth spelling out, because it is the one
+    place the two layers could have disagreed. Both read blank the same way --
+    unset -- so an operator who left a stray space in an otherwise empty variable
+    gets the same silence everywhere rather than nothing at boot, where they are
+    looking, and a WARNING on every request, where it costs the most. What blank
+    must never become is a raise: that would cost that operator every entry the
+    deployment takes.
+    """
+    if url is None:
+        monkeypatch.delenv(_URL_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(_URL_ENV_VAR, url)
+    caplog.set_level(logging.WARNING)
+
+    assert isinstance(build_creek_vault_client(), LocalFallbackCreekVaultClient)
+    assert caplog.records == []
+
+
+@pytest.mark.usefixtures("configured_key")
+def test_a_defective_url_is_never_quietly_repaired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trailing ``?`` is refused, not trimmed: the operator's configuration is theirs.
+
+    Reconstructing a URL from its parsed parts would close the hole by editing
+    something nobody wrote, and the edit would be invisible -- a deployment
+    replicating to an endpoint subtly different from the configured one is worse
+    than a deployment replicating nowhere and saying so.
+    """
+    monkeypatch.setenv(_URL_ENV_VAR, f"{_VAULT_URL}?")
+
+    assert isinstance(build_creek_vault_client(), LocalFallbackCreekVaultClient)
+
+
+@pytest.mark.usefixtures("configured_key")
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(f"{_VAULT_URL}/Vault/Prefix", id="no_trailing_slash"),
+        pytest.param(f"{_VAULT_URL}/Vault/Prefix/", id="trailing_slash"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_usable_url_reaches_the_transport_byte_for_byte(
+    url: str,
+    offline_vault: _OfflineVault,
+) -> None:
+    """The only edit a usable URL receives is the documented trailing-slash strip.
+
+    Case, path prefix, and everything else survive intact. Classifying a URL
+    means reading it, and a reader is one refactor away from becoming a rewriter
+    -- so the request that actually leaves is asserted against the configured
+    string rather than against a re-derived one.
+    """
+    offline_vault.configure(url)
+
+    client = build_creek_vault_client()
+    assert isinstance(client, HttpCreekVaultClient)
+    assert (await client.handshake()).available is True
+
+    assert len(offline_vault.requests) == 1
+    assert str(offline_vault.requests[0].url) == f"{_VAULT_URL}/Vault/Prefix/v1/capabilities"
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(("https://", VaultUrlDefect.MALFORMED), id="malformed"),
+        pytest.param(
+            ("http://vault.example.test", VaultUrlDefect.INSECURE_TRANSPORT), id="insecure"
+        ),
+    ],
+)
+@pytest.mark.usefixtures("configured_key")
+@pytest.mark.asyncio
+async def test_the_writer_keeps_their_entry_when_the_vault_url_is_unusable(
+    case: tuple[str, VaultUrlDefect],
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+    offline_vault: _OfflineVault,
+) -> None:
+    """The whole point, end to end: a typo in one variable costs the vault, not the entry.
+
+    Driven through the real app, with the vault bound to the user doing the
+    writing, because that is the only configuration in which the factory is
+    reached at all -- and the configuration in which a raise used to turn every
+    save into a 500 with the writer's words nowhere on disk.
+
+    Four things have to hold at once. The save succeeds and the entry reads back,
+    since Postgres is the system of record and always was. Its ``vault_ref`` is
+    empty rather than optimistic, because nothing was replicated and a ref for a
+    fragment no vault holds would be a lie the read path later trips over. Not
+    one request leaves the process, since the credential must never be bound to
+    a URL that failed its check -- that is what the refusal was always for. And
+    the credential appears in no record emitted along the way, message or field.
+    """
+    url, defect = case
+    caplog.set_level(logging.DEBUG)
+    headers, user_id = await _signup(async_client, "vault_url_defect")
+    offline_vault.configure(url, owner_id=user_id)
+
+    created = await async_client.post(
+        "/journal/",
+        json={"message": _ENTRY_BODY, "classification": "personal"},
+        headers=headers,
+    )
+
+    assert created.status_code == HTTPStatus.CREATED
+    entry_id = int(created.json()["id"])
+
+    fetched = await async_client.get(f"/journal/{entry_id}", headers=headers)
+    assert fetched.status_code == HTTPStatus.OK
+    assert fetched.json()["message"] == _ENTRY_BODY
+
+    stored = await db_session.get(JournalEntry, entry_id)
+    assert stored is not None
+    assert stored.vault_ref is None
+
+    assert offline_vault.builds == 0, "an unusable URL must not open a connection to anything"
+    assert offline_vault.requests == []
+
+    defects = [record.__dict__.get("url_defect") for record in caplog.records]
+    assert defect.value in defects, "the degrade must still be announced on the request path"
+    for record in caplog.records:
+        for rendered in _rendered_values(record):
+            assert _SENTINEL_KEY not in rendered

--- a/backend/tests/test_creek_vault_url_startup_config.py
+++ b/backend/tests/test_creek_vault_url_startup_config.py
@@ -1,0 +1,312 @@
+"""Tests for the startup Creek Vault URL configuration check.
+
+Contract: ``CREEK_VAULT_URL`` is read per request, and a value the transport
+cannot use degrades that request onto the local fallback. The request path says
+so, but it says so at request rate and to whoever happens to be reading logs
+under load. Boot is the one place the finding can be stated once, before any
+traffic, which makes this the operator's first and best chance to notice that
+their vault is configured and inert.
+
+It never raises, on any defect. The vault is an optional capability layered over
+a deployment that works without it, so refusing to boot over a typo in it would
+be a worse outage than the typo -- the same reasoning
+``validate_ipv6_throttle_prefix_config`` follows, and for the same kind of
+setting. Unset and blank stay silent, because a deployment with no vault is the
+normal, fully supported case and ``backend/.env.example`` ships the variable
+present and empty.
+
+Every call below that reaches its assertions is the proof that nothing raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from conftest import test_engine
+from main import app, lifespan, validate_creek_vault_url_config
+from services.creek_vault_client import VaultUrlDefect, build_creek_vault_client
+
+URL_ENV_VAR = "CREEK_VAULT_URL"
+KEY_ENV_VAR = "CREEK_VAULT_API_KEY"
+PROTOCOL_ENV_VAR = "CREEK_VAULT_PROTOCOL"
+ENV_VAR = "ENV"
+
+# The greppable event name this record is filtered and alerted on, in the shape
+# its siblings in ``main`` already use (``ipv6_throttle_prefix_unusable``,
+# ``trusted_proxies_unconfigured``). Part of the contract with whoever wrote the
+# alert, so renaming it is a breaking change rather than an edit.
+UNUSABLE_MARKER = "creek_vault_url_unusable"
+
+MAIN_LOGGER = "main"
+EXPECTED_WARNING_COUNT = 1
+
+# The credential the vault seam exists to protect, and a userinfo pair the
+# operator put in the URL itself. A boot record is the least supervised log line
+# a deployment emits, so neither may appear in it.
+SENTINEL_KEY = "SENTINEL_VAULT_KEY_DO_NOT_LEAK"  # pragma: allowlist secret
+SENTINEL_USER = "SENTINELUSER"
+SENTINEL_PASSWORD = "SENTINELPASSWORD"  # pragma: allowlist secret
+
+USERINFO_URL = f"https://{SENTINEL_USER}:{SENTINEL_PASSWORD}@vault.example.test"
+
+# What the record has to tell an operator who has never read this seam's code:
+# what stops happening, what keeps happening, and what to do about it. Matched
+# case-insensitively as substrings so the sentence can be rewritten without the
+# test dictating its prose -- what is pinned is that each fact is present.
+CONSEQUENCE_MARKERS = ("replicat", "reflect", "wheel", "postgres")
+REMEDY_MARKER = "unset"
+
+# One URL per defect class, so "never raises" is asserted against every branch
+# the classifier can take rather than against whichever one is cheapest to type.
+DEFECTIVE_URLS = [
+    pytest.param("https://[::1", VaultUrlDefect.UNPARSEABLE, id="unparseable"),
+    pytest.param(USERINFO_URL, VaultUrlDefect.FORBIDDEN_COMPONENTS, id="forbidden_components"),
+    pytest.param("https://", VaultUrlDefect.MALFORMED, id="malformed"),
+    pytest.param("http://vault.example.test", VaultUrlDefect.INSECURE_TRANSPORT, id="insecure"),
+]
+
+USABLE_URLS = [
+    "https://vault.example.test",
+    "https://vault.example.test/vault/",
+    "http://localhost:8000",
+]
+
+ABSENT_URLS = [None, "", "   "]
+
+ENV_VALUES = [None, "development", "staging", "production"]
+
+
+def _unusable_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the captured records carrying the unusable-config marker."""
+    return [record for record in caplog.records if UNUSABLE_MARKER in record.getMessage()]
+
+
+def _rendered_values(record: logging.LogRecord) -> list[str]:
+    """Render every string one record could carry: its message plus each of its fields."""
+    return [record.getMessage(), *[str(value) for value in record.__dict__.values()]]
+
+
+def _set_url(monkeypatch: pytest.MonkeyPatch, url: str | None) -> None:
+    """Set the vault URL variable, treating None as unset."""
+    if url is None:
+        monkeypatch.delenv(URL_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(URL_ENV_VAR, url)
+
+
+@asynccontextmanager
+async def _isolated_factory_patch() -> AsyncGenerator[None, None]:
+    """Point main's session factory at the conftest SQLite engine for lifespan runs."""
+    factory = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    with patch("main.async_session_factory", new=factory):
+        yield
+
+
+@pytest.mark.parametrize(("url", "defect"), DEFECTIVE_URLS)
+def test_an_unusable_url_warns_once_carrying_the_defect_and_the_detail(
+    url: str,
+    defect: VaultUrlDefect,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every defect class is announced, once, in terms an operator can act on.
+
+    Which variable is wrong and what is wrong with it, because "the vault is not
+    working" is the one thing the deployment's behaviour already shows: the
+    entries keep saving and nothing ever reaches the vault, which looks exactly
+    like a healthy app to everything except this record.
+    """
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setenv(URL_ENV_VAR, url)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    warnings = _unusable_warnings(caplog)
+    assert len(warnings) == EXPECTED_WARNING_COUNT
+    assert warnings[0].levelno == logging.WARNING
+    rendered = " ".join(_rendered_values(warnings[0]))
+    assert URL_ENV_VAR in rendered
+    assert defect.value in rendered
+
+
+def test_the_warning_says_what_stops_what_continues_and_what_to_do(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An operator reading this once, at boot, must not have to read the code next.
+
+    The three facts are inseparable: replication, reflection, and the wheel all
+    stop; the entries themselves keep saving to Postgres, which is the
+    reassurance that decides whether this is a page or a ticket; and the remedy
+    includes unsetting the variable, because running without a vault is a
+    supported configuration rather than a failure to be tolerated.
+    """
+    monkeypatch.setenv(URL_ENV_VAR, "http://vault.example.test")
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    message = _unusable_warnings(caplog)[0].getMessage().lower()
+    for marker in CONSEQUENCE_MARKERS:
+        assert marker in message
+    assert REMEDY_MARKER in message
+
+
+def test_the_boot_warning_is_not_the_per_request_one(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Boot and request rate are different news, and must read differently.
+
+    The boot record is addressed to whoever deployed this, minutes before any
+    traffic; the per-request one is addressed to whoever is reading logs while a
+    user saves an entry. One message doing both jobs would either bury the boot
+    finding in repetition or leave the request degrade unexplained.
+    """
+    monkeypatch.setenv(URL_ENV_VAR, "http://vault.example.test")
+    monkeypatch.setenv(KEY_ENV_VAR, SENTINEL_KEY)
+    monkeypatch.delenv(PROTOCOL_ENV_VAR, raising=False)
+    caplog.set_level(logging.WARNING)
+
+    validate_creek_vault_url_config()
+    boot_messages = [record.getMessage() for record in _unusable_warnings(caplog)]
+    caplog.clear()
+    build_creek_vault_client()
+    request_messages = [record.getMessage() for record in caplog.records]
+
+    assert len(boot_messages) == EXPECTED_WARNING_COUNT
+    assert len(request_messages) == EXPECTED_WARNING_COUNT
+    assert boot_messages[0] != request_messages[0]
+
+
+def test_the_boot_record_carries_neither_the_url_nor_any_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The one variable most likely to hold a pasted secret is the one never echoed.
+
+    A vault URL sits next to ``CREEK_VAULT_API_KEY`` in every deployment's
+    configuration, and can carry userinfo that is a credential in its own right.
+    The record names the variable and the defect; the value stays where the
+    operator put it.
+    """
+    monkeypatch.setenv(URL_ENV_VAR, USERINFO_URL)
+    monkeypatch.setenv(KEY_ENV_VAR, SENTINEL_KEY)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    for record in _unusable_warnings(caplog):
+        for rendered in _rendered_values(record):
+            assert USERINFO_URL not in rendered
+            assert SENTINEL_USER not in rendered
+            assert SENTINEL_PASSWORD not in rendered
+            assert SENTINEL_KEY not in rendered
+
+
+@pytest.mark.parametrize("url", USABLE_URLS)
+def test_a_usable_url_stays_silent(
+    url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A vault the deployment can actually reach has nothing to announce."""
+    monkeypatch.setenv(URL_ENV_VAR, url)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    assert _unusable_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("url", ABSENT_URLS)
+def test_unset_and_blank_stay_silent(
+    url: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Choosing no vault is the floor this whole product runs on, not a misconfiguration.
+
+    Blank counts as unset because the shipped ``.env.example`` leaves the
+    variable present and empty; warning there would fire on every stock boot and
+    train operators to scroll past the one record that means something.
+    """
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    _set_url(monkeypatch, url)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    assert _unusable_warnings(caplog) == []
+
+
+@pytest.mark.parametrize("env_value", ENV_VALUES)
+def test_the_warning_is_not_gated_on_env(
+    env_value: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A URL nobody can use is wrong in staging too -- staging is where it gets typed."""
+    if env_value is None:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(ENV_VAR, env_value)
+    monkeypatch.setenv(URL_ENV_VAR, "http://vault.example.test")
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    validate_creek_vault_url_config()
+
+    assert len(_unusable_warnings(caplog)) == EXPECTED_WARNING_COUNT
+
+
+def test_the_check_reads_the_environment_afresh_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The check keeps no state: it announces, returns, and judges the next read anew."""
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+    monkeypatch.setenv(URL_ENV_VAR, "https://")
+
+    validate_creek_vault_url_config()
+
+    monkeypatch.setenv(URL_ENV_VAR, "https://vault.example.test")
+
+    validate_creek_vault_url_config()
+
+    assert len(_unusable_warnings(caplog)) == EXPECTED_WARNING_COUNT
+
+
+@pytest.mark.parametrize(("url", "defect"), DEFECTIVE_URLS)
+@pytest.mark.asyncio
+async def test_boot_completes_with_the_warning_for_every_defect(
+    url: str,
+    defect: VaultUrlDefect,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup runs the check and finishes anyway, which is the whole design.
+
+    Driven through the real ``lifespan`` rather than by calling the function,
+    because a validator nobody wired in is a validator that warns in a test suite
+    and nowhere else. Reaching the assertions at all is the proof that no defect
+    class takes a deployment down: an optional capability is not worth an outage,
+    and the entries keep saving without it.
+    """
+    monkeypatch.setenv("SKIP_STARTUP_SEED", "1")
+    monkeypatch.setenv(URL_ENV_VAR, url)
+    monkeypatch.setenv(KEY_ENV_VAR, SENTINEL_KEY)
+    caplog.set_level(logging.WARNING, logger=MAIN_LOGGER)
+
+    async with _isolated_factory_patch(), lifespan(app):
+        pass
+
+    warnings = _unusable_warnings(caplog)
+    assert len(warnings) == EXPECTED_WARNING_COUNT
+    assert defect.value in " ".join(_rendered_values(warnings[0]))

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -9,10 +9,13 @@ tests assume.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
 from datetime import UTC, datetime
+from http import HTTPStatus
 
+import httpx
 import pytest
+import pytest_asyncio
 
 from dependencies.creek_vault import get_creek_vault_client
 from domain.creek_vault import (
@@ -33,7 +36,7 @@ from domain.creek_vault import (
     VaultTierCeiling,
     VaultWheelBalance,
 )
-from services.creek_vault_client import LocalFallbackCreekVaultClient
+from services.creek_vault_client import HttpCreekVaultClient, LocalFallbackCreekVaultClient
 from services.creek_vault_telemetry import (
     reset_vault_telemetry_for_tests,
     vault_outcome_counts,
@@ -44,6 +47,11 @@ from services.creek_vault_write import (
     VaultWriteStatus,
     store_and_classify,
 )
+from tests.test_creek_vault_http_client import Handler as _VaultHandler
+from tests.test_creek_vault_http_client import _handshake_payload as _vault_capability_payload
+from tests.test_creek_vault_http_client import _json_handler as _vault_json_handler
+from tests.test_creek_vault_http_client import _raising_handler as _vault_raising_handler
+from tests.test_creek_vault_http_client import _text_handler as _vault_text_handler
 
 _CREATED_AT = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
 _BODY = "A quiet entry about the week's practice."
@@ -524,3 +532,82 @@ async def test_intimate_entry_records_no_telemetry_outcome() -> None:
 
     assert outcome.status is VaultWriteStatus.SKIPPED_INTIMATE
     assert vault_outcome_counts() == {}
+
+
+# A real vault URL and credential for the handshake pin below: the point of that
+# test is that a *real* adapter, not a fake, is what the write path awaits.
+_VAULT_URL = "https://vault.example.test"
+_VAULT_API_KEY = "creek-vault-write-path-key"  # pragma: allowlist secret
+
+_VaultClientFactory = Callable[[_VaultHandler], httpx.AsyncClient]
+
+# Every way the capability probe can end badly, from a socket that never opened
+# to a vault that answered fluently in a contract version we cannot read.
+_UNUSABLE_VAULT_HANDLERS = [
+    pytest.param(_vault_raising_handler(httpx.ConnectError("refused")), id="connection_refused"),
+    pytest.param(_vault_raising_handler(httpx.InvalidURL("unbuildable")), id="unbuildable_request"),
+    pytest.param(_vault_raising_handler(httpx.ReadTimeout("no answer")), id="timed_out"),
+    pytest.param(
+        _vault_json_handler({"detail": "boom"}, HTTPStatus.INTERNAL_SERVER_ERROR),
+        id="server_error",
+    ),
+    pytest.param(
+        _vault_json_handler({"detail": "unauthorized"}, HTTPStatus.UNAUTHORIZED),
+        id="unauthorized",
+    ),
+    pytest.param(_vault_text_handler("<html><body>Bad Gateway</body></html>"), id="non_json_body"),
+    pytest.param(
+        _vault_json_handler(_vault_capability_payload([CreekCapability.JOURNAL.value], "0.3.0")),
+        id="incompatible_contract_version",
+    ),
+]
+
+
+@pytest_asyncio.fixture
+async def vault_http_clients() -> AsyncGenerator[_VaultClientFactory, None]:
+    """Yield a factory for MockTransport-backed clients, closing each afterwards."""
+    created: list[httpx.AsyncClient] = []
+
+    def _build(handler: _VaultHandler) -> httpx.AsyncClient:
+        """Build one in-memory client and register it for teardown."""
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        created.append(client)
+        return client
+
+    yield _build
+    for client in created:
+        await client.aclose()
+
+
+@pytest.mark.parametrize("handler", _UNUSABLE_VAULT_HANDLERS)
+@pytest.mark.asyncio
+async def test_a_failed_handshake_degrades_the_write_and_never_propagates(
+    handler: _VaultHandler,
+    vault_http_clients: _VaultClientFactory,
+) -> None:
+    """``store_and_classify`` awaits ``handshake()`` unguarded, which only holds if it cannot raise.
+
+    That bare ``await`` is deliberate and stays that way: guarding it would mean
+    catching ``Exception``, which this repository refuses and which the adapter's
+    own counting wrapper argues against -- an unrelated internal bug must stay
+    the loud defect it is. So the invariant it rests on is pinned here instead,
+    at the call site, against a real :class:`HttpCreekVaultClient` rather than a
+    fake that has been told not to raise. Every failure a probe can meet ends the
+    same way: the write reports UNAVAILABLE, the caller persists the entry, and
+    nothing reaches the router.
+    """
+    client = HttpCreekVaultClient(
+        _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(handler)
+    )
+
+    outcome = await store_and_classify(
+        client,
+        body=_BODY,
+        classification="personal",
+        created_at=_CREATED_AT,
+        entry_id=_ENTRY_ID,
+    )
+
+    assert outcome == VaultWriteOutcome(
+        status=VaultWriteStatus.UNAVAILABLE, vault_ref=None, tags=()
+    )

--- a/docs/adr/0004-creek-vault-http-application-boundary.md
+++ b/docs/adr/0004-creek-vault-http-application-boundary.md
@@ -703,3 +703,105 @@ it — Decision 7(a)'s citation of the schemas that carry no tenant
 field, and (d)'s naming of the specific creek-side change (a tenant
 field, or an advertised partitioning guarantee) that would be needed
 before adepthood could ever claim otherwise.
+
+## Note, 2026-08-08 — a malformed or insecure CREEK_VAULT_URL degrades
+
+Issue #2119, filed while reviewing #2117's protocol-selector fix,
+named the asymmetry that fix left standing: `_require_secure_vault_url`
+still raised straight out of `build_creek_vault_client`, which runs
+inside the per-request FastAPI dependency every router resolves its
+vault client through, whenever a configured `CREEK_VAULT_URL` was
+insecure or malformed. Every journal write on such a deployment 500'd,
+and the entry the writer had just typed existed nowhere — the same
+loss #2117 had just finished closing for a stale protocol selector,
+left standing one variable over.
+
+**Insecure and malformed now degrade the same way at the factory, and
+that was a decision, not a convenience.** The two had different
+histories: forbidden components (userinfo, a query, a fragment) and
+insecure transport were already refused inline, while a URL with no
+host at all — `https://` — parsed cleanly under the old scheme-only
+check and was silently accepted, and an unparseable URL escaped every
+check by raising straight out of `urlsplit`. All four now route
+through one classifier, `classify_vault_url`, into a closed
+four-member taxonomy, `VaultUrlDefect`, carried on the WARNING as a
+structured `url_defect` field rather than as four differently-shaped
+outcomes. The argument for failing closed on the insecure case does
+not survive contact with what failing closed actually buys here: in
+both designs — raise, or degrade — no request reaches the suspect URL
+and the bearer credential never leaves the process. Nothing about that
+guarantee changed; `HttpCreekVaultClient.__init__` still fails closed
+on every one of these defects, via the same classifier, because
+reaching its constructor with an unclassified URL is a programming
+error and it does not sit on a request path. What failing closed at
+the *factory* actually cost was never the credential's exposure — it
+was whether the writer's entry survived someone else's typo. Labelling
+the four defects apart, rather than collapsing them into one generic
+"unusable," is what keeps a plaintext URL countable apart from a
+missing host even though both now answer the same way.
+
+**Startup validation and the per-request degrade both shipped — this
+was not a choice between them.** `main.validate_creek_vault_url_config`,
+called from `lifespan` immediately after
+`validate_ipv6_throttle_prefix_config`, states the same finding once,
+before any traffic — an operator's first and best chance to notice a
+vault that is configured and inert, since the request path only ever
+says so at request rate, to whoever happens to be reading logs under
+load at the time. It follows `validate_ipv6_throttle_prefix_config`'s
+own two choices for the same kind of setting: it never raises, on any
+defect, and it is not gated on `ENV`, because refusing to boot over an
+optional capability would be a worse outage than the typo, and a value
+typed wrong in staging is wrong there too — staging is exactly where
+it gets typed. Neither check makes the other redundant. Boot is what
+an operator reads once, at deploy time; the per-request degrade is
+what actually keeps every subsequent entry landing in Postgres.
+
+**The URL is still never normalized.** No trailing `?` is stripped, no
+URL is rebuilt from its parsed components — `classify_vault_url`
+judges the string exactly as configured and refuses it exactly as
+configured, the same discipline #2117 already established for the
+protocol selector. Reconstructing a URL from its parts would close the
+same holes, but by editing configuration nobody wrote; refusing it and
+saying so remains the honest half of that trade.
+
+**A credential leak closed on the way, worth stating plainly rather
+than folding into the rest.** `urlsplit` does not merely fail on a
+netloc it cannot NFKC-normalize — it quotes the whole offending
+netloc, userinfo included, back into its own message. Checked directly
+against this repository's interpreter, a URL whose netloc is
+`user:PASSWORD@` followed by a host carrying a codepoint NFKC
+normalization rewrites raises `ValueError("netloc
+'user:PASSWORD@<host>' contains invalid characters under NFKC
+normalization")` — the password, quoted back verbatim by the standard
+library. Before this issue, `_require_secure_vault_url`
+called `urlsplit` unguarded, so that `ValueError` — the vault password
+included — propagated straight out of the per-request dependency and
+into whatever traceback the unhandled 500 wrote to the logs.
+`classify_vault_url` now catches `ValueError` and discards it,
+reporting only the static, value-free `VaultUrlDefect.UNPARSEABLE`
+finding, and `_require_secure_vault_url` re-raises with `from None` so
+neither `__cause__` nor `__context__` can carry the parser's own
+exception forward. Two live acceptance holes closed alongside it,
+neither previously covered by any check: `https://[::1`, unparseable,
+which used to escape every validator that assumed `urlsplit` had
+already succeeded; and `https://`, which parses cleanly with the right
+scheme and no host at all, and which the old scheme-only check — `if
+parsed.scheme == "https": return` — accepted outright.
+
+**What is not claimed: the degrade is still counted as
+`vault_fallback_unconfigured`.** `LocalFallbackCreekVaultClient`'s
+default outcome is unchanged by this issue, so a deployment whose
+`CREEK_VAULT_URL` is a typo records identically, in
+`VaultTelemetryOutcome`, to one that configured no vault at all — the
+same conflation Decision 7(c) already accepts for an unreadable owner
+binding, and the one #2117 already accepts for a stale or unrecognized
+protocol selector. The two WARNINGs (one at boot, one per request) are
+the only signal that distinguishes "chose no vault" from "meant to
+have one and mistyped it." No new `VaultTelemetryOutcome` member was
+added here: that enum's membership and order are pinned by test as
+contract, and adding one is a separate, independently-reviewable
+change from this issue's scope. This is recorded as a known
+limitation, not a virtue — an operator watching only the fallback-rate
+counter cannot tell a misconfigured vault from an intentionally absent
+one today; the WARNING is what carries that distinction until a future
+issue gives the URL defect its own telemetry.


### PR DESCRIPTION
## Summary

`_require_secure_vault_url` raised out of `build_creek_vault_client`, which is reached from `dependencies.creek_vault.get_creek_vault_client` -- a **per-request FastAPI dependency** behind five endpoints (`routers/journal.py` x3, `routers/stages.py`, `routers/invitations.py`). A malformed or insecure `CREEK_VAULT_URL` therefore turned every journal save into a 500, and the entry the writer had just typed existed nowhere. It now degrades to `LocalFallbackCreekVaultClient` with one WARNING.

**The vault write on the journal path is best-effort replication, not a durability step**, so degrading is not hiding a failed write. Evidence: `services/creek_vault_write.py`'s module docstring ("one best-effort call that *never raises a vault error* -- so the user's entry is saved regardless"; "**A failed replication is dropped, not queued**"; Postgres is the system of record), ADR 0004 Decision 6(d), and Decision 7(c), which already made this exact call for the owner binding. `store_and_classify` returns a `VaultWriteOutcome` and never raises.

**Failing closed protected nothing extra, and that is the whole argument.** In both designs no request is made to the suspect URL and the bearer credential never leaves the process. The only thing that changed is whether the user's entry survives someone else's typo.

### Three failure modes kept apart, not collapsed

PR #2067 separated contract failure from unavailability on the replication path; this adds a third thing that is neither -- a configuration that will never work, where nothing was ever sent -- without disturbing that split. `CreekVaultContractError` / `CreekVaultUnavailableError` / `HandshakeDegradeReason` are untouched. The new axis is a closed four-member taxonomy carried as a structured `url_defect` field:

| defect | meaning | detail carried |
| --- | --- | --- |
| `unparseable` | `urlsplit` itself refuses it | a static constant -- nothing value-derived |
| `forbidden_components` | userinfo / query / fragment | component *names* only |
| `malformed` | parses, but no scheme or no host | which components are missing, from a closed vocabulary |
| `insecure_transport` | not https, not loopback http | `scheme '...', host '...'` -- today's wording, unchanged |

**The classification order is a safety property, not a taste, and is pinned as one.** `urlsplit("user:pass@host")` yields `scheme='user'` -- a username in the scheme slot. So a finding may quote a scheme only once userinfo has been excluded *and* a host is known to exist, which is exactly what running forbidden-components before the transport rule, and missing-components before the https rule, guarantees.

### Startup **and** per-request, not either/or

`main.validate_creek_vault_url_config()` states the finding once at boot, before any traffic -- the operator's first and best chance to see it. The per-request degrade is what actually preserves the entry. Boot **warns and never raises** and is not gated on `ENV`, matching `validate_ipv6_throttle_prefix_config`: refusing to boot over an *optional* capability would be a worse outage than the typo, and contradicts the seam's floor that a vault-less deployment is fully supported. Validating only at startup was considered and rejected -- config is read per request, so a mid-life change would still reach the request path unvalidated.

### What an operator sees

At boot, once:

```
WARNING creek_vault_url_unusable: CREEK_VAULT_URL is set to a value the vault
transport cannot use (insecure_transport: scheme 'http', host 'vault.example.test'),
so this deployment replicates no journal entry to the vault, consults no vault
reflection, and reads no vault wheel; entries still save to Postgres, which is the
system of record. Correct the value or unset CREEK_VAULT_URL to run without a vault
-- backend/.env.example documents the format
```

Then per request, while it stays broken -- a static, greppable message distinct from both protocol-selector records, with `env_var`, `url_defect`, and `url_detail` as structured fields:

```
WARNING creek vault URL is unusable; using the local fallback -- fix CREEK_VAULT_URL
or unset it to run without a vault
```

**The raw URL is never rendered**, in either record or in any exception. That is deliberate and not an oversight of "name the offending value": a vault URL can carry userinfo, which *is* a credential, and it sits next to `CREEK_VAULT_API_KEY` in every deployment's config. The records name the variable, the defect, and a detail that is either a constant, one of our own component names, or a scheme/host the ordering above has already made safe to quote.

### A credential leak closed on the way

`urlsplit` does not merely fail on a netloc it cannot NFKC-normalize -- **it quotes the whole netloc back in its own message, and a netloc includes userinfo**:

```python
urlsplit("https://user:PASSWORD@℀host")
# ValueError("netloc 'user:PASSWORD@...' contains invalid characters under NFKC normalization")
```

That `ValueError` previously escaped the dependency uncaught, so the resulting 500's traceback wrote the **vault password into the server log**. The classifier now catches it without binding it and the refusal re-raises `from None`, so neither `__cause__` nor `__context__` carries it forward. A test formats the entire traceback and asserts neither the userinfo nor the API key appears in it.

Two live acceptance holes closed alongside it: `https://` parsed with the right scheme and **no host at all** and was *accepted*; `https://[::1` raised out of `urlsplit` ahead of every validator that assumed a parse had succeeded.

### Recorded honestly

- **The degrade is still counted as `vault_fallback_unconfigured`**, exactly as the protocol-selector degrade already is, so a misconfigured vault is not countable apart from a deliberately absent one. The two WARNINGs are what distinguish them. No telemetry member was added: `VaultTelemetryOutcome`'s membership and order are test-pinned contract and expanding it is a separate change.
- **Blank and whitespace-only are silent in both layers.** An earlier revision had boot silent and the request path warning for a whitespace-only value -- the worst pairing available (silence where the operator is looking, noise where it costs most). Both now read blank the same way.
- `HttpCreekVaultClient.__init__` still **raises** for every defect. Only the per-request factory degrades. `test_http_factory_rejects_a_plaintext_remote_url` was re-pointed at direct construction rather than deleted, keeping its assertions.
- The `handshake()` invariant `store_and_classify` rests on is **pinned by test, not guarded** -- a guard would have to catch bare `Exception`, which this repo forbids and which `_CountingOutcome`'s own docstring argues against.
- `services/creek_vault_url.py` is a stdlib-only leaf mirroring `services/creek_vault_payload.py`'s existing split. It is not tidying: the classifier had pushed the client module's radon MI to **9.65** against a rank-C gate floor of **9.0**, where twenty added comment lines flipped it to C. It is back to **12.87**.

## Test plan

- `./scripts/backend/check-all.sh` -- **green**, 7 passed / 0 failed. Full suite 4413 passed, coverage 97% (`creek_vault_url.py` 100%, `creek_vault_client.py` 99%); xenon A/A/A; `radon mi -n C` reports nothing.
- New `backend/tests/test_creek_vault_url_defects.py` (24 tests / 60+ cases) and `backend/tests/test_creek_vault_url_startup_config.py` (9 tests / 22 cases).
- **The money test** -- `POST /journal/` with a malformed and with an insecure `CREEK_VAULT_URL`, owner bound: returns 201 not 500, the entry reads back from the database, `vault_ref is None`, **zero HTTP clients built and zero requests served** (the pooled-client factory is replaced with a recorder), and the sentinel API key appears in no log record.
- Every defect class is exercised on **both** sides -- the constructor's raise and the factory's degrade -- so the branch-coverage gate has no gap.
- No-normalization pinned: `https://vault.example.test?` degrades rather than being trimmed to a working URL.
- Handshake invariant pinned by driving `store_and_classify` with a real `HttpCreekVaultClient` over seven failure modes (connect error, `httpx.InvalidURL`, timeout, 500, 401, non-JSON body, version skew).
- I additionally probed the loopback exemption by hand: `127.0.0.001`, `127.1`, `2130706433`, `::ffff:127.0.0.1`, and `localhost.evil.test` are all **rejected** rather than treated as loopback, and `https://vault.example.test\@evil.test` is caught as userinfo.
- Gate 2.5 self-review over the full diff returned **CLEAN** with no blockers; its two non-blocking nits (the whitespace divergence, and confirming the `test_creek_vault_write.py` change was the invariant pin rather than drift) are both resolved above.

Closes #2119
Refs #2043
