### PR TITLE
fix(backend): remediate cross-tenant references forged before the goal-group and journal BOLAs closed

### DIFF
--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -67,14 +67,16 @@ _RAW_SQL_MANAGED_INDEXES: frozenset[str] = frozenset(
     }
 )
 
-# Migration-internal archive tables created by dedup steps (see e.g.
-# ``e1f2a3b4c5d6_contentcompletion_unique_user_content``).  These hold
-# rows that were dropped to satisfy a freshly-added unique constraint
-# and are intentionally not modeled in SQLModel — there is no router or
-# RLS policy that exposes them.  We tell autogenerate / ``alembic check``
-# to leave them alone so a successful ``upgrade head`` does not register
-# as drift the next time the gate runs.
-_MIGRATION_ARCHIVE_TABLE_PREFIX = "_duplicates_"
+# Migration-internal side tables.  ``_duplicates_*`` archives are created by
+# dedup steps (see e.g. ``e1f2a3b4c5d6_contentcompletion_unique_user_content``)
+# and hold rows that were dropped to satisfy a freshly-added unique
+# constraint; ``_quarantine_*`` tables are created by remediation steps (see
+# ``c1d2e3f4a5b7_quarantine_cross_tenant_references``) and hold the forensic
+# record of references that were detached.  Both are intentionally not modeled
+# in SQLModel — there is no router or RLS policy that exposes them.  We tell
+# autogenerate / ``alembic check`` to leave them alone so a successful
+# ``upgrade head`` does not register as drift the next time the gate runs.
+_MIGRATION_ARCHIVE_TABLE_PREFIXES: tuple[str, ...] = ("_duplicates_", "_quarantine_")
 
 
 def _include_object(
@@ -84,17 +86,22 @@ def _include_object(
     reflected: bool,  # noqa: ARG001
     compare_to: Any,  # noqa: ARG001
 ) -> bool:
-    """Skip raw-SQL-managed indexes and dedup archive tables.
+    """Skip raw-SQL-managed indexes and dedup / quarantine side tables.
 
     Without this, ``alembic check`` reports drift for every functional /
     partial index (see :data:`_RAW_SQL_MANAGED_INDEXES`) and for every
-    ``_duplicates_*`` archive table left behind by a dedup migration.
-    Both are migration-owned artifacts that the model layer
-    intentionally does not declare.
+    ``_duplicates_*`` archive table left behind by a dedup migration or
+    ``_quarantine_*`` table left behind by a remediation migration.  All
+    are migration-owned artifacts that the model layer intentionally does
+    not declare.
     """
     if type_ == "index" and name in _RAW_SQL_MANAGED_INDEXES:
         return False
-    if type_ == "table" and name is not None and name.startswith(_MIGRATION_ARCHIVE_TABLE_PREFIX):
+    if (
+        type_ == "table"
+        and name is not None
+        and name.startswith(_MIGRATION_ARCHIVE_TABLE_PREFIXES)
+    ):
         return False
     return True
 

--- a/backend/migrations/versions/c1d2e3f4a5b7_quarantine_cross_tenant_references.py
+++ b/backend/migrations/versions/c1d2e3f4a5b7_quarantine_cross_tenant_references.py
@@ -1,0 +1,285 @@
+"""quarantine and detach forged cross-tenant references
+
+Revision ID: c1d2e3f4a5b7
+Revises: b0c1d2e3f4a5
+Create Date: 2026-08-08 00:00:00.000000
+
+Issue #2121: remediate the data that issues #2064 and #2065 made possible.
+
+**What a planted row is.** Two body-parameter authorization holes let a caller
+name another tenant's object in a field the server never authorized:
+``PUT /goals/{id}`` accepted any ``goal_group_id`` (#2064), and
+``POST /journal/`` accepted any ``user_practice_id`` /
+``practice_session_id`` (#2065). Both write paths are guarded now --
+``src/routers/goals.py`` resolves the target group through
+``resolve_owned_goal_group`` before assigning it -- but every reference forged
+before those guards landed is still sitting in the database, silently exposing
+one user's object to another user's screen.
+
+**Why the invariant holds.** A non-NULL ``goal.goal_group_id`` may only ever
+name a group owned by the same user who owns the goal's habit. The only writer
+that *sets* a non-NULL value is ``PUT /goals/{id}``, which now authorizes the
+target; ``_build_default_goals`` in ``src/routers/habits.py`` creates every
+default goal ungrouped, group deletion only ever writes ``NULL``, and no
+seeder touches the column at all. There is therefore no legitimate producer of
+a cross-owner value, and the same reasoning applies to the two journal columns,
+whose only writer is the (now-guarded) journal create path.
+
+**Why remediation is DETACH and never DELETE.** A goal and a journal entry are
+things a person sat down and wrote. The forgery is in the *link*, not in the
+content, so the fix is to null the link and leave the row exactly where its
+author put it. Nothing in this migration deletes a user row.
+
+**Why the quarantine table stores ids and reasons only.** It records what was
+detached (table, row id, column, the value that was planted, both owner ids,
+and the classification) and never any row content. Journal bodies are
+encrypted at rest; copying ciphertext into an unmodeled side table would
+create a second, less-guarded copy of exactly the data the encryption exists
+to protect.
+
+**The ``shared_template`` false positive.** Before the fix a user could
+innocently park their OWN goal in an ownerless community template -- that is
+not an attack, just a state the UI once allowed. It is unreachable through the
+API today. Detaching costs that user a grouping they can recreate in one tap;
+leaving it keeps their private goal title visible to every user in the app.
+Detach is the privacy-safe default, and the quarantine row is the receipt an
+operator uses to put such a goal back by hand.
+
+**Why an ownerless group is always a template.** ``goalgroup.user_id`` is
+``ON DELETE SET NULL``, so the obvious worry is that deleting a user turns
+their group ownerless and frames an innocent bystander's still-valid goal as
+``shared_template``. It cannot happen: nulling ``user_id`` while
+``shared_template`` stays false violates
+``ck_goalgroup_shared_template_user_id``, so such a delete aborts atomically
+rather than committing an ownerless private group. (There is no hard-delete
+path for a user today in any case.) ``user_id IS NULL`` therefore means
+"shared template" and nothing else.
+"""
+
+import logging
+from collections.abc import Sequence
+from typing import NamedTuple
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b7"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "b0c1d2e3f4a5"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Opt-out marker for the migration round-trip-pattern test: the downgrade is
+# deliberately empty, for the reasons spelled out in its docstring.
+ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE = True
+
+
+_logger = logging.getLogger("alembic.runtime.migration")
+
+_QUARANTINE_TABLE = "_quarantine_cross_tenant_reference"
+
+# Classification of why a reference failed the same-owner invariant.
+_REASON_DANGLING = "dangling"  # the referenced row does not exist
+_REASON_SHARED_TEMPLATE = "shared_template"  # it exists but is ownerless
+_REASON_FOREIGN_OWNER = "foreign_owner"  # it exists and belongs to someone else
+
+
+class _ReferenceShape(NamedTuple):
+    """One (source table, source column) reference that must stay same-owner.
+
+    ``owner_expr`` is the SQL expression that yields the *referencing* row's
+    owner, and ``owner_join`` is whatever join that expression needs. A goal
+    has no ``user_id`` of its own, so its owner comes from its habit; a
+    journal entry carries its owner directly and needs no join.
+    """
+
+    source_table: str
+    source_column: str
+    referenced_table: str
+    owner_expr: str
+    owner_join: str
+
+
+_SHAPES: tuple[_ReferenceShape, ...] = (
+    _ReferenceShape(
+        source_table="goal",
+        source_column="goal_group_id",
+        referenced_table="goalgroup",
+        owner_expr="h.user_id",
+        owner_join="JOIN habit h ON h.id = s.habit_id",
+    ),
+    _ReferenceShape(
+        source_table="journalentry",
+        source_column="user_practice_id",
+        referenced_table="userpractice",
+        owner_expr="s.user_id",
+        owner_join="",
+    ),
+    _ReferenceShape(
+        source_table="journalentry",
+        source_column="practice_session_id",
+        referenced_table="practicesession",
+        owner_expr="s.user_id",
+        owner_join="",
+    ),
+)
+
+# Column order here is the table's declaration order; ``detected_at`` is
+# defaulted rather than inserted.
+_QUARANTINE_INSERT_COLUMNS = (
+    "source_table",
+    "source_row_id",
+    "source_column",
+    "planted_value",
+    "owner_user_id",
+    "referenced_owner_user_id",
+    "reason",
+)
+
+
+def _create_quarantine_table() -> None:
+    """Create the forensic side table if this database does not have it yet.
+
+    Only portable types are used, and the table deliberately has NO surrogate
+    primary key: without one, ``INSERT ... SELECT`` needs no dialect-specific
+    sequence handling and renders identically on SQLite and Postgres. The
+    table is unmodeled on purpose -- ``migrations/env.py`` excludes the
+    ``_quarantine_`` prefix from autogenerate so it never registers as drift.
+
+    ``detected_at`` is ``TIMESTAMP WITH TIME ZONE`` to match the conversion
+    revision ``78b1620cafde`` applied to every other datetime column in this
+    schema: a forensic stamp that cannot say which zone it was taken in is
+    worth much less to the operator reading it. SQLite accepts the multi-word
+    type name and applies its usual affinity rules.
+    """
+    op.execute(
+        f"CREATE TABLE IF NOT EXISTS {_QUARANTINE_TABLE} ("
+        " source_table VARCHAR(64) NOT NULL,"
+        " source_row_id INTEGER NOT NULL,"
+        " source_column VARCHAR(64) NOT NULL,"
+        " planted_value INTEGER NOT NULL,"
+        " owner_user_id INTEGER,"
+        " referenced_owner_user_id INTEGER,"
+        " reason VARCHAR(32) NOT NULL,"
+        " detected_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+    )
+
+
+def _detection_tail(shape: _ReferenceShape) -> str:
+    """Build the FROM/JOIN/WHERE clause that selects every violating row.
+
+    A reference violates the invariant when its target is missing, ownerless,
+    or owned by anyone other than the referencing row's owner. Ownerlessness
+    is detected as ``user_id IS NULL`` rather than via a ``shared_template``
+    boolean, because boolean literals do not render the same way on SQLite and
+    Postgres and the ``goalgroup`` CHECK constraint makes the two conditions
+    exactly equivalent anyway.
+    """
+    clauses = (
+        f"FROM {shape.source_table} s",
+        shape.owner_join,
+        f"LEFT JOIN {shape.referenced_table} r ON r.id = s.{shape.source_column}",
+        f"WHERE s.{shape.source_column} IS NOT NULL",
+        f"AND (r.id IS NULL OR r.user_id IS NULL OR r.user_id <> {shape.owner_expr})",
+    )
+    return " ".join(clause for clause in clauses if clause)
+
+
+def _violation_count(shape: _ReferenceShape) -> int:
+    """Count the rows this shape is about to quarantine."""
+    count = op.get_bind().scalar(sa.text(f"SELECT count(*) {_detection_tail(shape)}"))
+    return int(count or 0)
+
+
+def _record_violations(shape: _ReferenceShape) -> None:
+    """Copy every violating reference into the quarantine table."""
+    columns = ", ".join(_QUARANTINE_INSERT_COLUMNS)
+    op.execute(
+        f"INSERT INTO {_QUARANTINE_TABLE} ({columns})"
+        f" SELECT '{shape.source_table}', s.id, '{shape.source_column}',"
+        f" s.{shape.source_column}, {shape.owner_expr}, r.user_id,"
+        f" CASE WHEN r.id IS NULL THEN '{_REASON_DANGLING}'"
+        f" WHEN r.user_id IS NULL THEN '{_REASON_SHARED_TEMPLATE}'"
+        f" ELSE '{_REASON_FOREIGN_OWNER}' END"
+        f" {_detection_tail(shape)}"
+    )
+
+
+def _detach_violations(shape: _ReferenceShape) -> None:
+    """Null every violating reference, leaving the row itself untouched.
+
+    The ``WHERE id IN (...)`` re-runs the DETECTION predicate rather than
+    selecting from the quarantine table. Selecting from the quarantine would
+    re-null a row that an operator had deliberately restored to a legitimate
+    group after reviewing a false positive; re-running the predicate only ever
+    touches references that violate the invariant *right now*.
+
+    ``UPDATE ... FROM`` is avoided for the same reason the whole file sticks to
+    plain SQL: it is Postgres-only, and this migration also runs on SQLite.
+    """
+    op.execute(
+        f"UPDATE {shape.source_table} SET {shape.source_column} = NULL"
+        f" WHERE id IN (SELECT s.id {_detection_tail(shape)})"
+    )
+
+
+def _quarantine_shape(shape: _ReferenceShape) -> int:
+    """Record, then detach, every violating reference for one shape.
+
+    Returns the number of references detached so the caller can log a total.
+    """
+    count = _violation_count(shape)
+    if count:
+        _record_violations(shape)
+        _detach_violations(shape)
+        # A non-zero count means the authorization hole was actually
+        # exploited on this database -- that operational finding is the whole
+        # reason this migration logs rather than working silently.
+        _logger.warning(
+            "cross_tenant_reference_quarantined: %s.%s -> %d reference(s) detached",
+            shape.source_table,
+            shape.source_column,
+            count,
+        )
+    else:
+        _logger.info(
+            "cross_tenant_reference_quarantined: %s.%s -> none found",
+            shape.source_table,
+            shape.source_column,
+        )
+    return count
+
+
+def upgrade() -> None:
+    """Record and detach every cross-tenant reference, deleting nothing."""
+    _create_quarantine_table()
+    total = sum(_quarantine_shape(shape) for shape in _SHAPES)
+    if total:
+        _logger.warning(
+            "cross_tenant_reference_audit: %d forged reference(s) detached; "
+            "review %s before restoring any of them.",
+            total,
+            _QUARANTINE_TABLE,
+        )
+    else:
+        _logger.info("cross_tenant_reference_audit: no forged references found")
+
+
+def downgrade() -> None:
+    """Deliberately a no-op: neither the evidence nor the exposure comes back.
+
+    The quarantine table is kept, not dropped. It is the forensic record of
+    what was detached and the only path back for a reference an operator
+    later judges legitimate.
+
+    The detached references are deliberately NOT re-planted. Re-planting them
+    would recreate a live cross-tenant disclosure -- one user's private goal
+    or practice showing up under another user's object -- which is precisely
+    the state the upgrade existed to end.
+
+    An operator who has confirmed a specific quarantine row was a false
+    positive restores that one reference by hand, sourcing both values from
+    ``_quarantine_cross_tenant_reference``::
+
+        UPDATE goal SET goal_group_id = <planted_value> WHERE id = <source_row_id>
+    """

--- a/backend/tests/security/test_cross_tenant_invariants.py
+++ b/backend/tests/security/test_cross_tenant_invariants.py
@@ -1,0 +1,395 @@
+"""Cross-tenant reference invariant — asserted against persisted state, not status codes.
+
+Two body-parameter authorisation holes once let a caller file their own row
+against another tenant's object: ``PUT /goals/{id}`` accepted a
+``goal_group_id`` no dependency had authorised, and ``POST /journal/``
+accepted an unauthorised ``user_practice_id`` / ``practice_session_id``.
+Both write paths are guarded now, and ``test_idor.py`` pins the guards by
+response code.
+
+This module pins the *other half* of the contract, which a status-code test
+cannot reach: after real write traffic, no row in the database references an
+object owned by a different user.  It therefore fails if an endpoint returns
+403/404 and writes anyway, and it fails if some future endpoint learns to
+plant a cross-tenant reference through a path nobody thought to probe.
+
+The invariant covers three (table, column) pairs:
+
+- ``goal.goal_group_id`` -> ``goalgroup`` (the goal's owner is
+  ``habit.user_id``, reached through ``goal.habit_id``);
+- ``journalentry.user_practice_id`` -> ``userpractice``;
+- ``journalentry.practice_session_id`` -> ``practicesession``.
+
+A non-NULL value must reference a row owned by the same user who owns the
+referencing row.  A violation is classified as ``dangling`` (the target does
+not exist), ``shared_template`` (the target exists but is ownerless --
+reachable only for ``goalgroup``), or ``foreign_owner``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+from typing import NamedTuple
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import TextClause
+
+from models.goal import Goal
+from models.journal_entry import JournalEntry
+from models.practice import Practice
+from models.stage_progress import StageProgress
+
+_JOURNAL_PROBE_MESSAGE = "A perfectly ordinary entry."
+
+_HABIT_PAYLOAD: dict[str, object] = {
+    "name": "Drink Water",
+    "icon": "💧",
+    "start_date": "2024-01-01",
+    "energy_cost": 1,
+    "energy_return": 2,
+}
+
+_PRACTICE_DEFAULTS: dict[str, object] = {
+    "stage_number": 1,
+    "name": "Meditation",
+    "description": "Sit quietly",
+    "instructions": "Close your eyes and breathe",
+    "default_duration_minutes": 10,
+    "approved": True,
+    "mode": "meditation_timer",
+    "mode_config": {
+        "mode": "meditation_timer",
+        "duration_minutes": 10,
+        "start_bell": True,
+        "halfway_bell": False,
+        "end_bell": True,
+    },
+}
+
+# Two tenants, each carrying one grouped goal plus one journal entry that
+# links both a user-practice and a practice session: six live references for
+# the detector to inspect, so an empty violation list cannot be an artefact
+# of an empty database.
+_EXPECTED_LIVE_REFERENCE_COUNT = 6
+
+# Ownership for a goal rides ``goal.habit_id -> habit.user_id`` because
+# ``goal`` carries no ``user_id`` of its own.  The LEFT JOIN plus CASE keeps
+# the predicate portable across SQLite and Postgres, and ownerlessness is
+# read as ``user_id IS NULL`` rather than as a boolean literal.
+_GOAL_GROUP_VIOLATIONS = text(
+    "SELECT g.id,"
+    " CASE WHEN gg.id IS NULL THEN 'dangling'"
+    " WHEN gg.user_id IS NULL THEN 'shared_template'"
+    " ELSE 'foreign_owner' END"
+    " FROM goal g"
+    " JOIN habit h ON h.id = g.habit_id"
+    " LEFT JOIN goalgroup gg ON gg.id = g.goal_group_id"
+    " WHERE g.goal_group_id IS NOT NULL"
+    " AND (gg.id IS NULL OR gg.user_id IS NULL OR gg.user_id <> h.user_id)"
+)
+
+_JOURNAL_USER_PRACTICE_VIOLATIONS = text(
+    "SELECT j.id,"
+    " CASE WHEN r.id IS NULL THEN 'dangling' ELSE 'foreign_owner' END"
+    " FROM journalentry j"
+    " LEFT JOIN userpractice r ON r.id = j.user_practice_id"
+    " WHERE j.user_practice_id IS NOT NULL"
+    " AND (r.id IS NULL OR r.user_id <> j.user_id)"
+)
+
+# ``practicesession`` holds its owner directly, so the check reads
+# ``practicesession.user_id`` rather than routing back through userpractice.
+_JOURNAL_PRACTICE_SESSION_VIOLATIONS = text(
+    "SELECT j.id,"
+    " CASE WHEN r.id IS NULL THEN 'dangling' ELSE 'foreign_owner' END"
+    " FROM journalentry j"
+    " LEFT JOIN practicesession r ON r.id = j.practice_session_id"
+    " WHERE j.practice_session_id IS NOT NULL"
+    " AND (r.id IS NULL OR r.user_id <> j.user_id)"
+)
+
+_DETECTION_QUERIES: tuple[tuple[str, TextClause], ...] = (
+    ("goal", _GOAL_GROUP_VIOLATIONS),
+    ("journalentry", _JOURNAL_USER_PRACTICE_VIOLATIONS),
+    ("journalentry", _JOURNAL_PRACTICE_SESSION_VIOLATIONS),
+)
+
+_LIVE_REFERENCE_COUNT = text(
+    "SELECT (SELECT COUNT(*) FROM goal WHERE goal_group_id IS NOT NULL)"
+    " + (SELECT COUNT(*) FROM journalentry WHERE user_practice_id IS NOT NULL)"
+    " + (SELECT COUNT(*) FROM journalentry WHERE practice_session_id IS NOT NULL)"
+)
+
+
+async def _cross_tenant_violations(session: AsyncSession) -> list[tuple[str, int, str]]:
+    """Return every cross-tenant reference in the database, as (table, row id, reason).
+
+    Runs the same family of predicate the remediation migration uses, so a
+    regression here and a row the migration would have quarantined are the
+    same finding.
+    """
+    session.expire_all()
+    violations: list[tuple[str, int, str]] = []
+    for source_table, statement in _DETECTION_QUERIES:
+        result = await session.execute(statement)
+        violations.extend((source_table, int(row[0]), str(row[1])) for row in result.all())
+    return sorted(violations)
+
+
+async def _live_reference_count(session: AsyncSession) -> int:
+    """Return how many non-NULL references across the three guarded columns exist."""
+    session.expire_all()
+    result = await session.execute(_LIVE_REFERENCE_COUNT)
+    return int(result.scalar_one())
+
+
+async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], int]:
+    """Create a user and return (auth headers, user_id)."""
+    resp = await client.post(
+        "/auth/signup",
+        json={
+            "email": f"{username}@example.com",
+            "password": "securepassword123",  # pragma: allowlist secret
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+def _goal_put_payload(goal: dict[str, object]) -> dict[str, object]:
+    """Rebuild the full-replace ``PUT /goals/{id}`` body from an API-returned goal."""
+    return {
+        field: goal[field]
+        for field in (
+            "title",
+            "tier",
+            "target",
+            "target_unit",
+            "frequency",
+            "frequency_unit",
+            "is_additive",
+        )
+    }
+
+
+def _journal_payload(**foreign_keys: int) -> dict[str, object]:
+    """Build an otherwise-valid ``POST /journal/`` body carrying the given body FKs."""
+    return {"message": _JOURNAL_PROBE_MESSAGE, **foreign_keys}
+
+
+def _session_window_payload(user_practice_id: int) -> dict[str, object]:
+    """Build a 5-minute ``started_at``/``ended_at`` window for a session log."""
+    ended = datetime.now(UTC)
+    started = ended - timedelta(minutes=5)
+    return {
+        "user_practice_id": user_practice_id,
+        "started_at": started.isoformat(),
+        "ended_at": ended.isoformat(),
+    }
+
+
+async def _create_user_practice(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    headers: dict[str, str],
+    user_id: int,
+    practice_name: str,
+) -> int:
+    """Seed a catalog practice, unlock stage 1, and select it for the user.
+
+    ``practice_name`` is always explicit: the preset catalog is uniquely
+    indexed on (stage_number, normalized name) and every test here seeds two.
+    """
+    practice = Practice(**{**_PRACTICE_DEFAULTS, "name": practice_name})
+    db_session.add(practice)
+    db_session.add(
+        StageProgress(
+            user_id=user_id,
+            current_stage=1,
+            completed_stages=[],
+            stage_started_at=datetime.now(UTC),
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(practice)
+
+    resp = await client.post(
+        "/user-practices/",
+        json={"practice_id": practice.id, "stage_number": 1},
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+async def _create_practice_session(
+    client: AsyncClient, headers: dict[str, str], user_practice_id: int
+) -> int:
+    """Log a practice session against the given user-practice."""
+    resp = await client.post(
+        "/practice-sessions/",
+        json=_session_window_payload(user_practice_id),
+        headers=headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+    return int(resp.json()["id"])
+
+
+class _Tenant(NamedTuple):
+    """One provisioned user plus the ids of the objects that user owns."""
+
+    headers: dict[str, str]
+    user_id: int
+    goal_id: int
+    goal_payload: dict[str, object]
+    goal_group_id: int
+    user_practice_id: int
+    practice_session_id: int
+
+
+async def _provision_tenant(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    username: str,
+    practice_name: str,
+) -> _Tenant:
+    """Drive the real write paths that produce every reference the invariant covers."""
+    headers, user_id = await _signup(client, username)
+
+    habit = await client.post("/habits/", json=_HABIT_PAYLOAD, headers=headers)
+    assert habit.status_code == HTTPStatus.OK
+    goal = habit.json()["goals"][0]
+    goal_id = int(goal["id"])
+    goal_payload = _goal_put_payload(goal)
+
+    group = await client.post("/goal-groups/", json={"name": f"{username} group"}, headers=headers)
+    assert group.status_code == HTTPStatus.CREATED
+    goal_group_id = int(group.json()["id"])
+
+    assigned = await client.put(
+        f"/goals/{goal_id}",
+        json={**goal_payload, "goal_group_id": goal_group_id},
+        headers=headers,
+    )
+    assert assigned.status_code == HTTPStatus.OK
+    assert assigned.json()["goal_group_id"] == goal_group_id
+
+    user_practice_id = await _create_user_practice(
+        client, db_session, headers, user_id, practice_name
+    )
+    practice_session_id = await _create_practice_session(client, headers, user_practice_id)
+
+    entry = await client.post(
+        "/journal/",
+        json=_journal_payload(
+            user_practice_id=user_practice_id, practice_session_id=practice_session_id
+        ),
+        headers=headers,
+    )
+    assert entry.status_code == HTTPStatus.CREATED
+    assert entry.json()["user_practice_id"] == user_practice_id
+    assert entry.json()["practice_session_id"] == practice_session_id
+
+    return _Tenant(
+        headers=headers,
+        user_id=user_id,
+        goal_id=goal_id,
+        goal_payload=goal_payload,
+        goal_group_id=goal_group_id,
+        user_practice_id=user_practice_id,
+        practice_session_id=practice_session_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_detector_finds_a_planted_cross_tenant_reference(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Self-test: the detector reports a violation planted beneath the API.
+
+    Without this, an empty violation list proves nothing -- a detector whose
+    predicate never matches would look identical to a clean database.  The
+    API can no longer forge a cross-tenant reference, so both shapes are
+    planted through the ORM instead.
+    """
+    alice_headers, _alice_id = await _signup(async_client, "alice_detector")
+    bob_headers, bob_id = await _signup(async_client, "bob_detector")
+
+    habit = await async_client.post("/habits/", json=_HABIT_PAYLOAD, headers=alice_headers)
+    assert habit.status_code == HTTPStatus.OK
+    goal_id = int(habit.json()["goals"][0]["id"])
+
+    group = await async_client.post(
+        "/goal-groups/", json={"name": "Bob Private"}, headers=bob_headers
+    )
+    assert group.status_code == HTTPStatus.CREATED
+    bob_group_id = int(group.json()["id"])
+
+    entry = await async_client.post("/journal/", json=_journal_payload(), headers=alice_headers)
+    assert entry.status_code == HTTPStatus.CREATED
+    entry_id = int(entry.json()["id"])
+
+    bob_practice_id = await _create_user_practice(
+        async_client, db_session, bob_headers, bob_id, "Bob Sit"
+    )
+
+    assert await _cross_tenant_violations(db_session) == [], "fixture setup already violates"
+
+    planted_goal = await db_session.get(Goal, goal_id)
+    assert planted_goal is not None
+    planted_goal.goal_group_id = bob_group_id
+    planted_entry = await db_session.get(JournalEntry, entry_id)
+    assert planted_entry is not None
+    planted_entry.user_practice_id = bob_practice_id
+    await db_session.flush()
+
+    assert await _cross_tenant_violations(db_session) == [
+        ("goal", goal_id, "foreign_owner"),
+        ("journalentry", entry_id, "foreign_owner"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_invariant_holds_after_live_write_traffic(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Real write traffic from two tenants leaves zero cross-tenant references persisted.
+
+    Both users exercise every write path that can set one of the guarded
+    columns, then each attempts the two writes that are now refused.  The
+    detector must come back empty -- a 403 that still persisted its row would
+    surface here even though the status-code assertions above passed.
+    """
+    alice = await _provision_tenant(async_client, db_session, "alice_invariant", "Alice Sit")
+    bob = await _provision_tenant(async_client, db_session, "bob_invariant", "Bob Sit")
+
+    attack_goal = await async_client.put(
+        f"/goals/{alice.goal_id}",
+        json={**alice.goal_payload, "goal_group_id": bob.goal_group_id},
+        headers=alice.headers,
+    )
+    assert attack_goal.status_code == HTTPStatus.FORBIDDEN
+
+    attack_journal = await async_client.post(
+        "/journal/",
+        json=_journal_payload(user_practice_id=bob.user_practice_id),
+        headers=alice.headers,
+    )
+    assert attack_journal.status_code == HTTPStatus.FORBIDDEN
+
+    attack_session_link = await async_client.post(
+        "/journal/",
+        json=_journal_payload(practice_session_id=alice.practice_session_id),
+        headers=bob.headers,
+    )
+    assert attack_session_link.status_code == HTTPStatus.FORBIDDEN
+
+    assert await _live_reference_count(db_session) == _EXPECTED_LIVE_REFERENCE_COUNT, (
+        "the invariant must be checked against real references, not an empty database"
+    )
+    assert await _cross_tenant_violations(db_session) == []

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -2969,3 +2969,359 @@ def test_habit_carryover_migration_round_trip_on_sqlite(
     command.upgrade(cfg, _HABIT_CARRYOVER_REVISION)
     assert "is_carryover" in _columns_of(db_url, "habit")
     assert bool(_habit_row(db_url, habit_id=1)["is_carryover"]) is False
+
+
+# -- cross-tenant reference quarantine + detach -----------------------------
+#
+# Two body-parameter authorisation holes (``PUT /goals/{id}`` accepting a
+# ``goal_group_id`` it never authorised, and ``POST /journal/`` accepting an
+# unauthorised ``user_practice_id`` / ``practice_session_id``) let a caller
+# file their own row against another tenant's object.  Both write paths are
+# now guarded, but rows forged before the guards landed are still in the
+# database.  This migration finds them, records them, and detaches them --
+# it never deletes a user's row.
+
+# The base is the current single head; the second anchor is the revision ID
+# of the remediation migration the implementer authors.
+_CROSS_TENANT_BASE_REVISION = "b0c1d2e3f4a5"  # pragma: allowlist secret
+_CROSS_TENANT_REVISION = "c1d2e3f4a5b7"  # pragma: allowlist secret
+
+# Forensic side-table: one row per reference the migration detaches, so every
+# nulled link stays reconstructible by hand afterwards.
+_QUARANTINE_TABLE = "_quarantine_cross_tenant_reference"
+
+# ``detected_at`` is deliberately absent from the projection -- it is a
+# wall-clock stamp no assertion can pin -- but naming the other seven columns
+# in declaration order pins both their names and their order.
+_QUARANTINE_PROJECTION = (
+    "SELECT source_table, source_row_id, source_column, planted_value,"
+    " owner_user_id, referenced_owner_user_id, reason"
+    " FROM _quarantine_cross_tenant_reference"
+)
+
+_QUARANTINE_COLUMNS = {
+    "source_table",
+    "source_row_id",
+    "source_column",
+    "planted_value",
+    "owner_user_id",
+    "referenced_owner_user_id",
+    "reason",
+    "detected_at",
+}
+
+# An id no seeded row uses, so the reference genuinely resolves to nothing.
+# The seed statements below spell it literally rather than interpolating it,
+# because building SQL by string formatting is exactly the pattern the lint
+# rules (rightly) refuse; keep the two in step by hand.
+_MISSING_REFERENCE_ID = 999_999
+
+# Every planted reference, as ``(source_table, source_row_id, source_column,
+# planted_value, owner_user_id, referenced_owner_user_id, reason)``.  Owner
+# ids come from the *referencing* row's owner (habit.user_id for a goal,
+# journalentry.user_id for an entry); ``referenced_owner_user_id`` is NULL
+# when the target is ownerless or absent.
+_EXPECTED_QUARANTINE_ROWS: list[tuple[Any, ...]] = [
+    ("goal", 3, "goal_group_id", 2, 1, 2, "foreign_owner"),
+    ("goal", 4, "goal_group_id", 3, 2, None, "shared_template"),
+    ("goal", 5, "goal_group_id", _MISSING_REFERENCE_ID, 1, None, "dangling"),
+    ("journalentry", 2, "user_practice_id", 2, 1, 2, "foreign_owner"),
+    ("journalentry", 3, "practice_session_id", 2, 1, 2, "foreign_owner"),
+    ("journalentry", 4, "user_practice_id", _MISSING_REFERENCE_ID, 1, None, "dangling"),
+]
+
+# Post-remediation link state.  Goal 1 and journal entry 1 are the legitimate
+# controls: their references point at objects their own owner owns, so they
+# must survive untouched while every neighbouring forged link goes NULL.
+_EXPECTED_GOAL_LINKS: list[tuple[Any, ...]] = [
+    (1, 1),
+    (2, None),
+    (3, None),
+    (4, None),
+    (5, None),
+]
+_EXPECTED_JOURNAL_LINKS: list[tuple[Any, ...]] = [
+    (1, 1, 1),
+    (2, None, None),
+    (3, None, None),
+    (4, None, None),
+    (5, None, None),
+]
+
+
+def _bootstrap_cross_tenant_tables(sync_url: str) -> None:
+    """Pre-create the minimal tables the cross-tenant remediation touches.
+
+    Only the columns the migration reads or writes are declared.  The
+    foreign keys are omitted on purpose: SQLite would not enforce them here
+    anyway, and their absence is what lets the fixture seed a genuinely
+    dangling reference for the ``dangling`` classification branch.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text('CREATE TABLE "user" ( id INTEGER PRIMARY KEY, email VARCHAR(255) NOT NULL)')
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE habit ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " name VARCHAR(255) NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE goalgroup ("
+                " id INTEGER PRIMARY KEY,"
+                " name VARCHAR(255) NOT NULL,"
+                " user_id INTEGER,"
+                " shared_template BOOLEAN NOT NULL DEFAULT 0)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE goal ("
+                " id INTEGER PRIMARY KEY,"
+                " habit_id INTEGER NOT NULL,"
+                " title VARCHAR(255) NOT NULL,"
+                " goal_group_id INTEGER)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE userpractice ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " practice_id INTEGER NOT NULL,"
+                " stage_number INTEGER NOT NULL,"
+                " start_date DATE NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE practicesession ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " user_practice_id INTEGER NOT NULL,"
+                " duration_minutes FLOAT NOT NULL)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE journalentry ("
+                " id INTEGER PRIMARY KEY,"
+                " user_id INTEGER NOT NULL,"
+                " sender VARCHAR(10) NOT NULL,"
+                " message TEXT NOT NULL,"
+                " user_practice_id INTEGER,"
+                " practice_session_id INTEGER)"
+            )
+        )
+    engine.dispose()
+
+
+def _seed_cross_tenant_fixtures(sync_url: str) -> None:
+    """Seed every violation shape alongside a legitimate control for each.
+
+    User 1 is the attacker in the goal/journal cases and the victim in the
+    goal-group case; user 2 owns the objects that were written into.  Goals 1
+    and 2 and journal entries 1 and 5 are the controls -- same-owner or NULL
+    references that must come through the migration unchanged.
+    """
+    engine = create_engine(sync_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                'INSERT INTO "user" (id, email) VALUES'
+                " (1, 'owner@example.com'), (2, 'other@example.com')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO habit (id, user_id, name) VALUES"
+                " (1, 1, 'Owner Habit'), (2, 2, 'Other Habit')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goalgroup (id, name, user_id, shared_template) VALUES"
+                " (1, 'Owner Group', 1, 0),"
+                " (2, 'Other Private Group', 2, 0),"
+                " (3, 'Community Template', NULL, 1)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO goal (id, habit_id, title, goal_group_id) VALUES"
+                " (1, 1, 'Filed under its own owner group', 1),"
+                " (2, 1, 'Filed under no group at all', NULL),"
+                " (3, 1, 'Planted into the other tenant private group', 2),"
+                " (4, 2, 'Parked in an ownerless shared template', 3),"
+                " (5, 1, 'Points at a group that does not exist', 999999)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO userpractice"
+                " (id, user_id, practice_id, stage_number, start_date) VALUES"
+                " (1, 1, 1, 1, '2024-01-01'), (2, 2, 1, 1, '2024-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO practicesession"
+                " (id, user_id, user_practice_id, duration_minutes) VALUES"
+                " (1, 1, 1, 10.0), (2, 2, 2, 10.0)"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO journalentry"
+                " (id, user_id, sender, message, user_practice_id, practice_session_id) VALUES"
+                " (1, 1, 'user', 'Own practice and own session.', 1, 1),"
+                " (2, 1, 'user', 'Planted onto the other tenant practice.', 2, NULL),"
+                " (3, 1, 'user', 'Planted onto the other tenant session.', NULL, 2),"
+                " (4, 1, 'user', 'Points at a practice that does not exist.', 999999, NULL),"
+                " (5, 1, 'user', 'Carries no practice link at all.', NULL, NULL)"
+            )
+        )
+    engine.dispose()
+
+
+@pytest.fixture
+def alembic_sqlite_config_cross_tenant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Config:
+    """Stamped SQLite config seeded with forged cross-tenant references."""
+    db_path = tmp_path / "cross_tenant_round_trip.sqlite"
+    sync_url = f"sqlite:///{db_path}"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+
+    _bootstrap_cross_tenant_tables(sync_url)
+    _seed_cross_tenant_fixtures(sync_url)
+
+    cfg = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    cfg.config_file_name = None
+    cfg.set_main_option("script_location", str(Path(__file__).parent.parent / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.stamp(cfg, _CROSS_TENANT_BASE_REVISION)
+    return cfg
+
+
+def _quarantine_rows(db_url: str) -> list[tuple[Any, ...]]:
+    """Return every quarantine row in declaration order, sorted deterministically.
+
+    ``(source_table, source_row_id, source_column)`` identifies a quarantined
+    reference uniquely, so sorting on it never has to compare the nullable
+    owner columns.
+    """
+    return sorted(
+        _rows(db_url, _QUARANTINE_PROJECTION),
+        key=lambda row: (str(row[0]), int(row[1]), str(row[2])),
+    )
+
+
+def _goal_group_links(db_url: str) -> list[tuple[Any, ...]]:
+    """Return ``(id, goal_group_id)`` for every goal, ordered by id."""
+    return _rows(db_url, "SELECT id, goal_group_id FROM goal ORDER BY id")
+
+
+def _journal_practice_links(db_url: str) -> list[tuple[Any, ...]]:
+    """Return ``(id, user_practice_id, practice_session_id)`` per entry, ordered by id."""
+    return _rows(
+        db_url,
+        "SELECT id, user_practice_id, practice_session_id FROM journalentry ORDER BY id",
+    )
+
+
+def test_cross_tenant_quarantine_migration_detaches_and_records_on_sqlite(
+    alembic_sqlite_config_cross_tenant: Config,
+) -> None:
+    """Upgrade detaches every forged reference and records it, deleting nothing.
+
+    Each planted reference is nulled in place, each legitimate reference is
+    left alone, no ``goal`` or ``journalentry`` row disappears, and the
+    quarantine table holds exactly one correctly-classified row per detached
+    reference -- ``dangling`` when the target is absent, ``shared_template``
+    when it is ownerless, ``foreign_owner`` when it belongs to someone else.
+    """
+    cfg = alembic_sqlite_config_cross_tenant
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _CROSS_TENANT_REVISION)
+
+    assert _goal_group_links(db_url) == _EXPECTED_GOAL_LINKS
+    assert _journal_practice_links(db_url) == _EXPECTED_JOURNAL_LINKS
+
+    # Remediation is detach-only: not one row is deleted.
+    assert _ids_from_query(db_url, "SELECT id FROM goal ORDER BY id") == [1, 2, 3, 4, 5]
+    assert _ids_from_query(db_url, "SELECT id FROM journalentry ORDER BY id") == [1, 2, 3, 4, 5]
+
+    assert _table_exists(db_url, _QUARANTINE_TABLE)
+    assert _columns_of(db_url, _QUARANTINE_TABLE) == _QUARANTINE_COLUMNS
+    assert _quarantine_rows(db_url) == _EXPECTED_QUARANTINE_ROWS
+
+
+def test_cross_tenant_quarantine_migration_leaves_same_owner_references_intact_on_sqlite(
+    alembic_sqlite_config_cross_tenant: Config,
+) -> None:
+    """A reference to an object its own owner owns is never quarantined.
+
+    The migration runs over a table that also holds forged references, so
+    this pins that the predicate discriminates by owner rather than sweeping
+    every non-null reference in the table.
+    """
+    cfg = alembic_sqlite_config_cross_tenant
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _CROSS_TENANT_REVISION)
+
+    assert _rows(db_url, "SELECT goal_group_id FROM goal WHERE id = 1") == [(1,)]
+    assert _rows(
+        db_url,
+        "SELECT user_practice_id, practice_session_id FROM journalentry WHERE id = 1",
+    ) == [(1, 1)]
+
+    quarantined = {(row[0], row[1]) for row in _quarantine_rows(db_url)}
+    assert ("goal", 1) not in quarantined
+    assert ("journalentry", 1) not in quarantined
+    assert ("goal", 2) not in quarantined, "a NULL reference is not a cross-tenant reference"
+    assert ("journalentry", 5) not in quarantined
+
+
+def test_cross_tenant_quarantine_migration_is_idempotent_on_sqlite(
+    alembic_sqlite_config_cross_tenant: Config,
+) -> None:
+    """Downgrade is deliberately one-way and re-upgrade adds no duplicate rows.
+
+    Phase 1 upgrades and snapshots the quarantine.  Phase 2 downgrades to the
+    base revision: the forensic record and the detached NULLs both survive,
+    because re-planting a reference into another tenant's object would
+    re-open the very hole the migration closed.  Phase 3 re-upgrades onto the
+    already-clean database and finds nothing new to quarantine.
+    """
+    cfg = alembic_sqlite_config_cross_tenant
+    db_url = cfg.get_main_option("sqlalchemy.url")
+    assert db_url is not None
+
+    command.upgrade(cfg, _CROSS_TENANT_REVISION)
+    snapshot = _quarantine_rows(db_url)
+    assert snapshot == _EXPECTED_QUARANTINE_ROWS
+
+    # Phase 2: the downgrade neither drops the evidence nor re-plants a link.
+    command.downgrade(cfg, _CROSS_TENANT_BASE_REVISION)
+    assert _table_exists(db_url, _QUARANTINE_TABLE)
+    assert _quarantine_rows(db_url) == snapshot
+    assert _goal_group_links(db_url) == _EXPECTED_GOAL_LINKS
+    assert _journal_practice_links(db_url) == _EXPECTED_JOURNAL_LINKS
+
+    # Phase 3: re-upgrade is a no-op -- nothing violates the invariant now.
+    command.upgrade(cfg, _CROSS_TENANT_REVISION)
+    assert _quarantine_rows(db_url) == snapshot
+    assert _goal_group_links(db_url) == _EXPECTED_GOAL_LINKS
+    assert _journal_practice_links(db_url) == _EXPECTED_JOURNAL_LINKS


### PR DESCRIPTION
## Summary

#2120 and #2132 closed two body-parameter BOLAs, but **both fixes are prospective only**. Every reference forged while the holes were open is still in the database: a victim still sees a stranger's goal sitting inside their own goal group, and a forged journal link still pins another user's practice row against deletion. This is the cleanup.

One migration (`c1d2e3f4a5b7`) records each violating reference in a forensic side table and then **detaches** it (`SET NULL`). **Nothing is deleted** — the forgery is in the link, not in the content a person wrote.

### The invariant that identifies a planted row

A non-NULL reference must point at a row owned by the same user who owns the referencing row:

| source | column | referenced owner | referencing owner |
|---|---|---|---|
| `goal` | `goal_group_id` | `goalgroup.user_id` | `habit.user_id` via `goal.habit_id` |
| `journalentry` | `user_practice_id` | `userpractice.user_id` | `journalentry.user_id` |
| `journalentry` | `practice_session_id` | `practicesession.user_id` | `journalentry.user_id` |

Classified as `foreign_owner`, `shared_template` (ownerless target), or `dangling` (missing target).

### How false positives were ruled out

- **No legitimate producer exists.** The only writer that sets a non-NULL `goal.goal_group_id` is `PUT /goals/{id}`, which now authorizes the target group; `_build_default_goals` creates every default goal ungrouped; group deletion only ever writes `NULL`; no seeder touches the column. Same for the two journal columns, whose only writer is the now-guarded journal create path.
- **An ownerless group is always a shared template.** `goalgroup.user_id` is `ON DELETE SET NULL`, so the obvious worry is that deleting a user turns their group ownerless and frames a bystander's still-valid goal. Verified empirically against Postgres 16 that this cannot happen: nulling `user_id` while `shared_template` stays false violates `ck_goalgroup_shared_template_user_id`, so such a delete aborts atomically. (No hard-delete path for a user exists today in any case.)
- **`dangling` cannot occur in production.** Verified on Postgres that both FKs reject a non-existent id. #2065 observed a `user_practice_id` of `999999` being accepted, but that was the FK-less SQLite test engine, not Postgres. The branch is kept as defense-in-depth and is exercised on SQLite.

### Why detach rather than delete

A goal and a journal entry are things a person sat down and wrote. Detaching removes the disclosure while leaving the row exactly where its author put it. The quarantine table stores **ids and reasons only, never row content** — journal bodies are encrypted at rest, and copying ciphertext into an unmodeled side table would create a second, less-guarded copy of exactly what the encryption protects.

**If the detection is wrong about a row**, its owner loses one grouping — the goal or entry itself is untouched — and the quarantine row is the receipt an operator uses to restore it by hand. The one shape where an innocent row can be flagged is `shared_template`: before the fix a user could park their *own* goal in a community template, which is not an attack. Detaching costs them a grouping they can recreate in one tap; leaving it keeps their private goal title visible to every user in the app. Detach is the privacy-safe default.

### Downgrade

`downgrade()` is an intentional no-op (marked `ALEMBIC_INTENTIONAL_EMPTY_DOWNGRADE`), and says so plainly rather than pretending to reverse:

- The quarantine table is **kept**, not dropped — it is the forensic record and the only path back.
- The detached references are **not re-planted**, because re-planting would recreate a live cross-tenant disclosure. The migration docstring gives the operator the exact per-row restore statement.

The detach re-runs the detection predicate rather than reading the quarantine table, so an operator's deliberate restore is never re-nulled on a later run.

## Test plan

- `./scripts/backend/check-all.sh` — **7/7 passed**, 97% coverage.
- `pytest tests/test_migrations.py` — 104 passed, including three new round-trip tests (detach + record, legitimate rows untouched, idempotency/one-way downgrade).
- New `tests/security/test_cross_tenant_invariants.py` — asserts **persisted state** rather than status codes, so it fails if a route returns 403 but writes anyway, and it fails if any *future* endpoint plants a cross-tenant reference. Includes a detector self-test that plants a violation through the ORM, so the empty-violations assertion is not vacuous.
- **Validated against real Postgres 16** (mirroring CI's `migration-drift` job), not just SQLite: full `alembic upgrade head` clean, `alembic check` reports no drift with the quarantine table present, `upgrade → downgrade → upgrade` round trip clean, exactly one head.
- **Realistic-dataset rehearsal** (no production access): seeded 20 users, 60 habits, 180 legitimately-grouped goals, 41 goal groups, 80 journal entries with 40 practice links, then planted 6 references the way the two exploits would. The migration detached exactly those 6, classified them correctly, left all 216 legitimate references intact, and deleted zero rows. A re-run produced no duplicate quarantine rows, and a deliberate operator restore survived it.

## Note for follow-up

`goalgroup.user_id ON DELETE SET NULL` and `ck_goalgroup_shared_template_user_id` contradict each other: deleting a user who owns any goal group is refused by the CHECK. Harmless today (no hard-delete path exists) but it will block the account-purge / GDPR-erasure path the issue discussion anticipates. Out of scope here; worth its own issue.

Closes #2121
Refs #2064, #2065
