### PR TITLE
fix(backend): audit the cross-tenant probes POST /practice-sessions/ was already rejecting

### DIFF
--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, func, select
 
 from database import get_session
-from dependencies.ownership import require_owned_user_practice
+from dependencies.ownership import require_owned_user_practice, resolve_owned_user_practice
 from dependencies.timezone import current_user_timezone
 from domain.practice_insights import build_insights
 from domain.practice_resolution import effective_config
@@ -48,32 +48,6 @@ _INSIGHTS_CACHE_CONTROL = "private, max-age=60"
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/practice-sessions", tags=["practice-sessions"])
-
-
-async def _resolve_user_practice_for_session(
-    session: AsyncSession,
-    user_practice_id: int,
-    current_user: int,
-) -> UserPractice:
-    """Fetch the target ``UserPractice`` and enforce the 404→403 split.
-
-    Pulled out of :func:`create_session` because the body-parameter
-    ownership check can't ride :func:`require_owned_user_practice`
-    (FastAPI's DI cannot extract body fields into sub-deps).  Keeping
-    the lookup here keeps the handler's branching shallow enough for
-    xenon rank A while preserving the canonical 404-then-403 order the
-    IDOR matrix test relies on.
-    """
-    user_practice = (
-        (await session.execute(select(UserPractice).where(UserPractice.id == user_practice_id)))
-        .scalars()
-        .first()
-    )
-    if user_practice is None:
-        raise not_found("user_practice")
-    if user_practice.user_id != current_user:
-        raise forbidden("forbidden")
-    return user_practice
 
 
 async def _require_stage_unlocked_for_session(
@@ -270,7 +244,7 @@ async def _perform_create_session(
         if cached_id is not None:
             return await _load_session(session, cached_id)
 
-    user_practice = await _resolve_user_practice_for_session(
+    user_practice = await resolve_owned_user_practice(
         session, payload.user_practice_id, current_user
     )
     await _require_stage_unlocked_for_session(session, current_user, user_practice, user_tz)
@@ -318,11 +292,13 @@ async def create_session(
 ) -> PracticeSession:
     """Log a practice session against a user-practice selection.
 
-    Inline 404→403 split (rather than ``require_owned_user_practice``)
-    because the ``user_practice_id`` arrives in the body, not as a path
-    or query parameter — FastAPI's DI cannot extract body fields into
-    sub-dependencies.  The ordering and exception types match the shared
-    dep so the IDOR matrix test sees the same 403 for cross-user calls.
+    Ownership of the body-carried ``user_practice_id`` is delegated to
+    :func:`resolve_owned_user_practice`, which owns the 404-then-403 rule and
+    emits the ``resource_access_denied`` audit row on a cross-tenant probe.
+    Only the ``require_``-prefixed *dependency* is unusable here: FastAPI's DI
+    cannot extract a body field into a sub-dependency.  The plain callable
+    underneath it is exactly what body-carried ids are meant to call, as
+    ``POST /journal/`` does.
 
     A user may assign a practice to a future stage for forward planning, but
     logging a real session there is gated: a not-yet-unlocked stage yields 403

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for API models."""
 
-from schemas.checkin import CheckInRequest, CheckInResult
+from schemas.checkin import CheckInResult
 from schemas.energy import (
     EnergyPlan,
     EnergyPlanItem,
@@ -24,7 +24,6 @@ from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
 __all__ = [
     "DEFAULT_PAGE_SIZE",
     "MAX_PAGE_SIZE",
-    "CheckInRequest",
     "CheckInResult",
     "EnergyHabit",
     "EnergyPlan",

--- a/backend/src/schemas/checkin.py
+++ b/backend/src/schemas/checkin.py
@@ -1,8 +1,7 @@
-"""Check-in request/response schemas."""
+"""Check-in response schemas."""
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Literal
 
 from pydantic import BaseModel
@@ -19,11 +18,6 @@ CheckInReasonCode = Literal[
     "streak_held",
     "already_logged_today",
 ]
-
-
-class CheckInRequest(BaseModel):
-    goal_id: int
-    date: date
 
 
 class CheckInResult(BaseModel):

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -38,6 +38,7 @@ from models.course_stage import CourseStage
 from models.goal import Goal
 from models.journal_entry import JournalEntry
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
 
@@ -478,22 +479,94 @@ async def test_idor_user_practice_get_returns_403(
 
 @pytest.mark.asyncio
 async def test_idor_practice_session_create_returns_403(
-    async_client: AsyncClient, db_session: AsyncSession
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cross-user POST /practice-sessions/ — body's user_practice_id is Alice's."""
-    alice_headers, alice_id = await _signup(async_client, "alice_ps_post")
-    bob_headers, _ = await _signup(async_client, "bob_ps_post")
+    """Bob cannot log a practice session against Alice's user-practice.
 
-    user_practice_id = await _create_user_practice(
-        async_client, db_session, alice_headers, alice_id
+    ``POST /practice-sessions/`` takes ``user_practice_id`` from the request
+    body, so the path-parameter ownership dependencies never see it.  An
+    unguarded write would graft sessions onto a victim's practice history --
+    rows that then surface in her session list and analytics rollups -- and a
+    denial that is not audited is a cross-tenant probe nobody can see.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_ps_post")
+    bob_headers, bob_id = await _signup(async_client, "bob_ps_post")
+
+    alice_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id, practice_name="Alice PS Post"
+    )
+    bob_practice_id = await _create_user_practice(
+        async_client, db_session, bob_headers, bob_id, practice_name="Bob PS Post"
     )
 
-    resp = await async_client.post(
+    with caplog.at_level(logging.WARNING):
+        attack = await async_client.post(
+            "/practice-sessions/",
+            json=_session_window_payload(alice_practice_id),
+            headers=bob_headers,
+        )
+
+    assert attack.status_code == HTTPStatus.FORBIDDEN
+    assert attack.json()["detail"] == "forbidden"
+
+    # The identical payload against Bob's own practice is accepted, so the 403
+    # above can only be about ownership -- not a bad body or a locked stage.
+    baseline = await async_client.post(
         "/practice-sessions/",
-        json=_session_window_payload(user_practice_id),
+        json=_session_window_payload(bob_practice_id),
         headers=bob_headers,
     )
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert baseline.status_code == HTTPStatus.CREATED
+    assert baseline.json()["user_practice_id"] == bob_practice_id
+
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(PracticeSession).where(col(PracticeSession.user_practice_id) == alice_practice_id)
+    )
+    smuggled = list(result.scalars().all())
+    assert smuggled == [], "cross-user session persisted against the victim's user-practice"
+
+    victim_view = await async_client.get(
+        "/practice-sessions/",
+        params={"user_practice_id": alice_practice_id},
+        headers=alice_headers,
+    )
+    assert victim_view.status_code == HTTPStatus.OK
+    assert victim_view.json() == []
+
+    denials = _denial_records(caplog)
+    assert len(denials) == 1, "expected exactly one resource_access_denied audit log entry"
+    assert getattr(denials[0], "resource", None) == "user_practice"
+    assert getattr(denials[0], "resource_id", None) == alice_practice_id
+    assert getattr(denials[0], "user_id", None) == bob_id
+
+
+@pytest.mark.asyncio
+async def test_practice_session_create_missing_user_practice_is_404_and_unaudited(
+    async_client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``user_practice_id`` that exists for nobody 404s, and audits nothing.
+
+    A missing row must never reach the ownership comparison -- inverting that
+    order makes the endpoint an existence oracle.  A denial record for a row
+    that never existed would likewise poison the audit signal that genuine
+    cross-tenant probes are meant to raise.
+    """
+    headers, _ = await _signup(async_client, "ps_post_missing_up")
+
+    with caplog.at_level(logging.WARNING):
+        resp = await async_client.post(
+            "/practice-sessions/",
+            json=_session_window_payload(_DEFINITELY_MISSING_ID),
+            headers=headers,
+        )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "user_practice_not_found"
+    assert _denial_records(caplog) == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -170,6 +170,7 @@ async def test_create_session_invalid_user_practice(
         headers=headers,
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.json()["detail"] == "user_practice_not_found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`POST /practice-sessions/` enforced ownership of its body-carried `user_practice_id` through a bespoke local resolver, `_resolve_user_practice_for_session`. That resolver returned the correct status codes but never called `log_ownership_denied` — so a cross-tenant probe was rejected **correctly and invisibly**. Nothing distinguished an attacker enumerating another user's `user_practice` ids from an ordinary 403, and the one signal that would reveal an active probe never reached the logs. This was never a live authorization hole; it was a missing detection surface on a control that already worked.

The fix is the consolidation, not a bolted-on log call: the bespoke resolver is deleted and the check routes through the shared `resolve_owned_user_practice` (`backend/src/dependencies/ownership.py`), which owns the same 404-then-403 rule and emits the audit row. `POST /journal/` already calls that same plain callable for its own body-carried FK, so this makes the third copy of the rule the same copy rather than a third divergent one.

**Status codes are unchanged**, verified at the `errors.py` helper level rather than by inspection: both the deleted helper and the shared resolver raise `not_found("user_practice")` → 404 `user_practice_not_found` and `forbidden("forbidden")` → 403 `forbidden`, in that order. The missing-row branch raises unconditionally, so a nonexistent id can never reach the ownership comparison — the endpoint does not become an existence oracle. The only observable delta is additive: the 403 path now emits a WARNING.

**What gets logged, and why it is safe.** `log_ownership_denied` emits `resource_access_denied` with `extra={"resource": "user_practice", "resource_id": <int>, "user_id": <int>}` — a hard-coded literal and two integers. The id is coerced by Pydantic under `extra="forbid"`, the `user_id` is JWT-derived, and `UserPractice` declares no relationships, so the user-authored `custom_name` is never traversed. No user content, no credentials, no log-injection surface.

**Also in scope (from the issue).** `CheckInRequest` is removed. A repo-wide grep found it referenced only by its own definition and its re-export — no route, no test, no frontend type, and it never reached OpenAPI. This is a deliberate widening of the issue's literal wording, which asked about the `goal_id` field: removing only the field would leave a one-field DTO that still nothing reads. The live check-in body schema is `GoalCompletionRequest` (`backend/src/routers/goal_completions.py`, `extra="forbid"`). `CheckInResult` and `CheckInReasonCode` are live and untouched.

## Test plan

The acceptance criterion asks for a test that fails if the logging call is removed. A log-only test would also pass if the rejection itself regressed to a 201 — re-routing an authz check through a different code path is exactly where a working control gets quietly broken — so the tests assert the rejection first and the audit row last.

`backend/tests/security/test_idor.py::test_idor_practice_session_create_returns_403`, upgraded in place from a status-only check:

- 403 with `detail == "forbidden"`
- a **baseline 201** for the identical payload against the attacker's *own* user-practice, proving the 403 is about ownership and not a malformed body or a locked stage
- **zero persisted `PracticeSession` rows** for the victim's user-practice, read after `expire_all()` so it sees committed state
- the victim's own session list still empty
- exactly one `resource_access_denied` record, with `resource` / `resource_id` / `user_id`

A regression to 201 fails four of those independently; the audit-drop defect this issue is about fails only the last one.

New sibling `test_practice_session_create_missing_user_practice_is_404_and_unaudited` pins 404 + `user_practice_not_found` + **no** denial record, so a 404/403 inversion cannot land silently and a nonexistent id cannot pollute the audit signal. `backend/tests/test_practice_sessions.py` gained a `detail` assertion on its missing-row case so the `select` → `session.get` swap is pinned on the body, not just the status.

RED was observed before the fix: only the audit assertion failed (`1 failed, 82 passed`); every rejection assertion already passed, which is exactly the issue's framing.

`./scripts/backend/check-all.sh` → exit 0, 7/7 stages. Full suite `4420 passed, 2 skipped, 1 xfailed`; coverage 97% (floor 90%); xenon A across the board with `_perform_create_session` unchanged at A(5).

## Graph

skipped: `graphify-out/graph.json` is absent in this worktree and no `graphify` binary is on PATH, so no query was run. The change is a two-call-site consolidation onto an existing shared helper with no new edges.

## Follow-ups found while reviewing (not fixed here)

- `_resolve_suggestion_practice` (`backend/src/routers/journal.py`) has the identical gap: a hand-rolled `session.get` + ownership compare with no `log_ownership_denied`. It cannot simply call the shared callable — it deliberately returns the suggestion-family 404 — so it needs the `resolve_owned_goal_and_habit` precedent of auditing while still returning 404.
- `_APP_LOG_FORMAT` (`backend/src/observability.py`) renders `%(message)s` only, so `extra` fields never reach the log stream. Pre-existing across the whole `log_ownership_denied` family, but it caps the operational value of the row this PR adds.

Closes #2133
