### PR TITLE
feat(backend): forward a user document to the vault's creek.upload seam

### DIFF
--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import enum
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Protocol
 
@@ -56,6 +56,7 @@ class CreekCapability(enum.StrEnum):
 
     HANDSHAKE = "creek.handshake"
     JOURNAL = "creek.journal"
+    UPLOAD = "creek.upload"
     SAVE = "creek.save"
     CLASSIFY = "creek.classify"
     REFLECT = "creek.reflect"
@@ -419,6 +420,59 @@ class VaultIngestResult:
 
 
 @dataclass(frozen=True)
+class VaultUploadRequest:
+    """One user-supplied document handed to the vault for its own ingestors to parse.
+
+    The sibling of :class:`VaultIngestRequest` rather than a widening of it: a
+    journal entry is text adepthood already holds, while an upload is a *file*
+    -- bytes plus the filename the vault reads an extension off to choose an
+    ingestor. Adepthood never parses the document itself and never names a
+    source type; guessing one here would override a decision the vault is
+    better placed to make.
+
+    ``external_id`` is the stable identity the vault keys the stored fragment
+    off, so re-sending the same document edits that fragment in place instead of
+    accumulating duplicates -- the same idempotence a journal entry gets from its
+    entry id. ``tier`` and ``tier_ceiling`` are both the uploader's own tier, so
+    the vault stores at exactly the depth the user chose and refuses any
+    widening.
+
+    ``content_base64`` is excluded from ``repr()``: this dataclass is the one
+    object carrying a user's document through the seam, and a frozen dataclass's
+    generated ``repr`` is exactly what a logging call or a traceback would
+    otherwise render in full.
+    """
+
+    external_id: str
+    filename: str
+    content_base64: str = field(repr=False)
+    tier: VaultTierCeiling
+    tier_ceiling: VaultTierCeiling
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class VaultUploadResult:
+    """Outcome of an upload attempt, mirroring :class:`VaultIngestResult`.
+
+    ``stored`` is ``False`` (with ``vault_ref`` ``None``) whenever the document
+    was not durably written -- notably on the local-fallback path, where there
+    is no vault to hold it and Postgres remains the sole system of record.
+
+    ``tags`` are the per-fragment classification tags the vault assigns *in its
+    own ingest pipeline*. Adepthood reads them and never re-derives them: a
+    second local classifier would be a second opinion nobody asked for. A vault
+    that does not return them yields an empty tuple, which is the expected
+    answer today rather than a failure.
+    """
+
+    stored: bool
+    vault_ref: str | None
+    action: VaultIngestAction | None = None
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class VaultClassification:
     """Frequency/Wavelength-phase tags Creek assigns to a piece of content."""
 
@@ -543,6 +597,23 @@ class CreekVaultClient(Protocol):
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Hand a piece of writing to the vault for durable storage."""
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Hand one user-supplied document to the vault for its ingestors to parse.
+
+        Separate from :meth:`ingest` because the two carry different things and
+        are advertised separately: a vault may accept journal text without
+        accepting files, so a caller must gate on
+        :attr:`CreekCapability.UPLOAD` rather than assuming journal ingest
+        implies it.
+
+        Fails exactly as ingest does -- a refused request as
+        :class:`CreekVaultContractError`, a rejected credential as
+        :class:`CreekVaultAuthError`, an absent or unreadable vault as
+        :class:`CreekVaultUnavailableError`, and a capability the vault never
+        advertised as :class:`CreekCapabilityUnsupportedError` raised *before*
+        any document bytes reach the wire.
+        """
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Request Frequency/Wavelength-phase tags for ``body``."""

--- a/backend/src/domain/creek_vault.py
+++ b/backend/src/domain/creek_vault.py
@@ -419,6 +419,23 @@ class VaultIngestResult:
     action: VaultIngestAction | None = None
 
 
+class VaultUploadStatus(enum.StrEnum):
+    """The terminal outcome of a :func:`store_upload` attempt.
+
+    Exactly one is always returned, and the three non-accepted values stay apart
+    because each sends the user somewhere different: ``VAULT_UNAVAILABLE`` is
+    "connect or fix your vault", ``CAPABILITY_UNSUPPORTED`` is "your vault cannot
+    take files yet", and ``DEGRADED`` is "it broke, try again". Values are the
+    wire strings the API answers with, so they are contract and must not be
+    reworded casually.
+    """
+
+    ACCEPTED = "accepted"
+    VAULT_UNAVAILABLE = "vault_unavailable"
+    CAPABILITY_UNSUPPORTED = "capability_unsupported"
+    DEGRADED = "degraded"
+
+
 @dataclass(frozen=True)
 class VaultUploadRequest:
     """One user-supplied document handed to the vault for its own ingestors to parse.

--- a/backend/src/errors.py
+++ b/backend/src/errors.py
@@ -68,6 +68,17 @@ def unprocessable(reason: str) -> HTTPException:
     return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=reason)
 
 
+def payload_too_large(reason: str) -> HTTPException:
+    """Return a 413 HTTPException for a request body past a declared ceiling.
+
+    Distinct from :func:`unprocessable` because size is the one rejection the
+    client can act on without changing anything else about the request: the
+    status alone tells them to send something smaller, and a proxy in front of
+    the app answers an oversized body with this same code.
+    """
+    return HTTPException(status_code=status.HTTP_413_CONTENT_TOO_LARGE, detail=reason)
+
+
 def bad_gateway(reason: str) -> HTTPException:
     """Return a 502 HTTPException for an upstream-dependency failure.
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -425,6 +425,20 @@ _UPLOAD_MESSAGES: Mapping[VaultUploadStatus, str] = MappingProxyType(
 )
 
 
+# Matched to ``transcription.TRANSCRIBE_RATE_LIMIT`` rather than to the stricter
+# resonance limit, because this endpoint is the same *class* of thing: a base64
+# payload a person submits deliberately, in bursts, with no LLM spend attached.
+# Someone adding a folder of documents legitimately makes a dozen calls in a row,
+# and one document per request is the shipped contract (batching is a follow-up),
+# so a tighter cap would throttle ordinary use rather than abuse.
+#
+# It is bounded at all because an upload is heavier than an ordinary write: 10 MB
+# per call, twice what transcription accepts, and every accepted call is forwarded
+# to an external network dependency. A plain ``POST /journal/`` carries neither
+# cost, which is why it is unrated and this is not.
+UPLOAD_RATE_LIMIT = "20/minute"
+
+
 def _guard_upload_size(content_base64: str) -> None:
     """Refuse an oversized document before any of it is decoded.
 
@@ -453,7 +467,9 @@ def _guard_upload_size(content_base64: str) -> None:
     response_model=UploadDocumentResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
+@limiter.limit(UPLOAD_RATE_LIMIT)
 async def upload_document(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
     payload: UploadDocumentRequest,
     current_user: Annotated[int, Depends(get_current_user)],
     vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -405,11 +405,6 @@ _UPLOAD_MESSAGES: Mapping[VaultUploadStatus, str] = MappingProxyType(
         VaultUploadStatus.ACCEPTED: (
             "Your document is in your vault. It will show up in reflections from here on."
         ),
-        VaultUploadStatus.SKIPPED_INTIMATE: (
-            "Intimate documents stay on this device for now — the private channel that "
-            "would carry them to your vault isn't built yet, so this one wasn't sent "
-            "anywhere. Re-classify it as personal to upload it."
-        ),
         VaultUploadStatus.VAULT_UNAVAILABLE: (
             "Your vault didn't answer, so the document wasn't sent. Check that your vault "
             "is running and reachable, then upload it again."

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
+from types import MappingProxyType
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
@@ -35,7 +39,14 @@ from domain.resonance import (
 )
 from domain.safety import assess_distress
 from domain.stage_progress import get_user_progress, is_stage_unlocked
-from errors import bad_gateway, conflict, forbidden, not_found, unprocessable
+from errors import (
+    bad_gateway,
+    conflict,
+    forbidden,
+    not_found,
+    payload_too_large,
+    unprocessable,
+)
 from models.completion_suggestion import (
     CompletionSuggestion,
     CompletionTargetType,
@@ -63,6 +74,12 @@ from schemas.journal import (
     JournalMessageCreate,
     JournalMessageResponse,
 )
+from schemas.journal_upload import (
+    MAX_UPLOAD_BASE64_CHARS,
+    MAX_UPLOAD_BYTES,
+    UploadDocumentRequest,
+    UploadDocumentResponse,
+)
 from schemas.marginalia import (
     CareResourceResponse,
     CareResponse,
@@ -79,6 +96,7 @@ from services.checkin import CheckInContext, current_check_in, record_goal_compl
 from services.completion_candidates import gather_candidates
 from services.contraction import gather_contraction_aggregates
 from services.creek_vault_reflect import select_reflection_llm
+from services.creek_vault_upload import UploadedDocument, VaultUploadStatus, store_upload
 from services.creek_vault_write import (
     VaultWriteOutcome,
     VaultWriteStatus,
@@ -376,6 +394,109 @@ async def _encrypted_search_page(
         items=[JournalMessageResponse.model_validate(e, from_attributes=True) for e in page],
         total=len(matched),
         has_more=page_has_more(filters.offset, filters.limit, len(matched)),
+    )
+
+
+# What each upload outcome tells the person who sent the document. Every line
+# names what happened, why, and the one thing they can do next -- none of them
+# ends at "contact support", because every one of these has a self-serve remedy.
+_UPLOAD_MESSAGES: Mapping[VaultUploadStatus, str] = MappingProxyType(
+    {
+        VaultUploadStatus.ACCEPTED: (
+            "Your document is in your vault. It will show up in reflections from here on."
+        ),
+        VaultUploadStatus.SKIPPED_INTIMATE: (
+            "Intimate documents stay on this device for now — the private channel that "
+            "would carry them to your vault isn't built yet, so this one wasn't sent "
+            "anywhere. Re-classify it as personal to upload it."
+        ),
+        VaultUploadStatus.VAULT_UNAVAILABLE: (
+            "Your vault didn't answer, so the document wasn't sent. Check that your vault "
+            "is running and reachable, then upload it again."
+        ),
+        VaultUploadStatus.CAPABILITY_UNSUPPORTED: (
+            "Your vault accepts journal entries but not file uploads yet. Update your "
+            "vault to a version that supports uploads, then try again."
+        ),
+        VaultUploadStatus.DEGRADED: (
+            "The upload didn't complete and the document wasn't stored. Nothing was "
+            "changed in your vault — please try again."
+        ),
+    }
+)
+
+
+def _guard_upload_size(content_base64: str) -> None:
+    """Refuse an oversized document before any of it is decoded.
+
+    Two gates, cheapest first, mirroring ``routers/transcription.py``: the
+    encoded length is checked against :data:`MAX_UPLOAD_BASE64_CHARS` so a huge
+    payload is rejected without allocating the decoded bytes at all, and the
+    decoded length is then checked against the real ceiling so a payload that
+    slipped past the first by rounding still cannot exceed it.
+
+    A malformed encoding is a 422 rather than a 413: it is a different defect
+    with a different fix, and forwarding bytes we could not decode would hand
+    the vault a file its ingestor cannot open.
+    """
+    if len(content_base64) > MAX_UPLOAD_BASE64_CHARS:
+        raise payload_too_large("document_too_large")
+    try:
+        raw = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise unprocessable("invalid_document_encoding") from exc
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise payload_too_large("document_too_large")
+
+
+@router.post(
+    "/upload",
+    response_model=UploadDocumentResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def upload_document(
+    payload: UploadDocumentRequest,
+    current_user: Annotated[int, Depends(get_current_user)],
+    vault_client: Annotated[CreekVaultClient, Depends(get_creek_vault_client)],
+) -> UploadDocumentResponse:
+    """Forward one user document to the Creek Vault for its own ingestors to parse.
+
+    202 rather than 201, and 202 for *every* vault outcome including the
+    degraded ones. The status code says adepthood accepted the request and acted
+    on it; what became of the document is in the body, where a client can render
+    a specific, actionable sentence instead of inferring one from an error code.
+    A vault that is missing, unreachable, or unable to take files is a normal
+    condition of an optional integration, not a server fault, so none of them is
+    a 5xx.
+
+    Deliberately stateless: no row is written, no upload table exists, and
+    adepthood keeps no copy of the document. The vault's stored fragment is the
+    only record, addressed by an id derived from the upload's identity so a
+    re-send edits it in place. That also means an upload has no local fallback --
+    if the vault will not take it, it went nowhere, and the response says so
+    plainly rather than implying a success.
+
+    The size guard runs before anything else touches the payload, and an
+    ``intimate`` classification is withheld inside
+    :func:`~services.creek_vault_upload.store_upload` before any vault call at
+    all.
+    """
+    _guard_upload_size(payload.content_base64)
+    outcome = await store_upload(
+        vault_client,
+        UploadedDocument(
+            owner_user_id=current_user,
+            filename=payload.filename,
+            content_base64=payload.content_base64,
+            classification=payload.classification,
+            created_at=datetime.now(UTC),
+        ),
+    )
+    return UploadDocumentResponse(
+        status=outcome.status,
+        vault_ref=outcome.vault_ref,
+        tags=list(outcome.tags),
+        message=_UPLOAD_MESSAGES[outcome.status],
     )
 
 

--- a/backend/src/routers/journal.py
+++ b/backend/src/routers/journal.py
@@ -27,7 +27,11 @@ from dependencies.ownership import (
 from dependencies.timezone import current_user_timezone
 from domain.care import CarePayload, build_care_payload
 from domain.contraction import build_contraction_invitation, detect_contraction
-from domain.creek_vault import CreekVaultCareEscalationError, CreekVaultClient
+from domain.creek_vault import (
+    CreekVaultCareEscalationError,
+    CreekVaultClient,
+    VaultUploadStatus,
+)
 from domain.detection import CompletionDetected, detect_completions
 from domain.practice_resolution import effective_config
 from domain.reflection_hierarchy import ReflectionLevel
@@ -96,7 +100,7 @@ from services.checkin import CheckInContext, current_check_in, record_goal_compl
 from services.completion_candidates import gather_candidates
 from services.contraction import gather_contraction_aggregates
 from services.creek_vault_reflect import select_reflection_llm
-from services.creek_vault_upload import UploadedDocument, VaultUploadStatus, store_upload
+from services.creek_vault_upload import UploadedDocument, store_upload
 from services.creek_vault_write import (
     VaultWriteOutcome,
     VaultWriteStatus,
@@ -471,10 +475,11 @@ async def upload_document(
     if the vault will not take it, it went nowhere, and the response says so
     plainly rather than implying a success.
 
-    The size guard runs before anything else touches the payload, and an
-    ``intimate`` classification is withheld inside
-    :func:`~services.creek_vault_upload.store_upload` before any vault call at
-    all.
+    The size guard runs before anything else touches the payload. Every
+    classification is forwarded, ``intimate`` included, at the tier the uploader
+    chose -- see :mod:`services.creek_vault_upload` for why the vault is not the
+    disclosure the privacy floor guards against, and note that this path calls no
+    cloud LLM at any tier.
     """
     _guard_upload_size(payload.content_base64)
     outcome = await store_upload(

--- a/backend/src/schemas/journal_upload.py
+++ b/backend/src/schemas/journal_upload.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, field_validator
 
+from domain.creek_vault import VaultUploadStatus
 from models.journal_entry import JournalClassification
-from services.creek_vault_upload import VaultUploadStatus
 
 # The decoded-bytes ceiling for one document. Ten megabytes comfortably admits a
 # scanned PDF or a long export while bounding what a single request can make the
@@ -86,9 +86,10 @@ class UploadDocumentRequest(BaseModel):
     to it on the far side.
 
     ``classification`` is the privacy tier the uploader chose, and it is honored
-    end to end -- an ``intimate`` document is withheld from the vault entirely
-    (see :mod:`services.creek_vault_upload`), never quietly downgraded so it can
-    be sent.
+    end to end: the document is stored at exactly that tier, never quietly
+    downgraded so a call can succeed. An ``intimate`` document *is* forwarded to
+    the vault -- see :mod:`services.creek_vault_upload` for the ratified reasoning
+    -- and to nothing else; no tier on this path reaches a cloud LLM.
     """
 
     filename: str = Field(

--- a/backend/src/schemas/journal_upload.py
+++ b/backend/src/schemas/journal_upload.py
@@ -1,0 +1,145 @@
+"""Request/response DTOs for handing one user document to the Creek Vault.
+
+The transport is deliberately **base64-in-JSON**, exactly as the page-capture
+flow moves image bytes, and deliberately *not* the form-encoded file transport
+Starlette spools to disk. That is a standing constraint rather than a
+preference: ``tests/test_transcription_privacy.py`` asserts the source tree
+carries no such surface anywhere, so an endpoint that reached for one would
+break a privacy guarantee the repository enforces by grep. Document bytes stay
+in request-scoped memory and never touch disk.
+
+Nothing on either DTO is persisted locally. The document travels through
+adepthood to the vault and adepthood keeps no copy: there is no upload table, no
+spool, and no row that outlives the request. What comes back is the vault's own
+outcome, which is the only record either side keeps.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+from models.journal_entry import JournalClassification
+from services.creek_vault_upload import VaultUploadStatus
+
+# The decoded-bytes ceiling for one document. Ten megabytes comfortably admits a
+# scanned PDF or a long export while bounding what a single request can make the
+# process allocate. Exported (not underscore-private) because the frontend picker
+# and the user-facing copy both need to name the same number.
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+# Cheap oversize pre-guard on the *encoded* string, so a huge payload is rejected
+# without ever allocating the decoded bytes. Base64 expands raw bytes by 4/3; the
+# ``+ 4`` absorbs the padding block so a legitimately max-sized document is not
+# rejected by rounding. The same shape ``routers/transcription.py`` uses.
+MAX_UPLOAD_BASE64_CHARS = (MAX_UPLOAD_BYTES * 4) // 3 + 4
+
+# Longest filename accepted. Generous for real documents, and short enough that a
+# name cannot itself become a payload.
+MAX_FILENAME_LENGTH = 255
+
+# The two characters that turn a name into a path. Rejected rather than escaped,
+# because the name is what the vault reads an ingestor choice off -- a name whose
+# meaning we cannot state is one we should not forward.
+_PATH_SEPARATORS = frozenset({"/", "\\"})
+
+# A run of dots is how a name climbs out of the collection it was meant to sit in.
+_CONSECUTIVE_DOTS = ".."
+
+
+def _is_safe_filename(value: str) -> bool:
+    """Return whether ``value`` is one plain, inert filename.
+
+    Deliberately a *denylist of dangerous shapes* rather than an
+    allowlist of permitted characters. An ASCII allowlist is the obvious
+    implementation and the wrong one: it would refuse ``résumé.pdf``, every CJK
+    filename, and most of the world's documents, which is a far larger harm than
+    the one it prevents. What actually has to be excluded is small and nameable.
+
+    ``str.isprintable`` carries most of the weight, and carries it for the same
+    reasons :func:`security.sanitize_user_text` scrubs journal text: it rejects
+    NUL (which a path cannot carry anyway), CR/LF (log injection, should the name
+    ever be rendered), every other control character, and the zero-width and
+    bidi-override codepoints that make a name display as something other than
+    what it is -- a ``.txt`` that reads as a ``.exe``. It also rejects the
+    non-ASCII separators, since Unicode ``Zs`` is non-printable by this test while
+    the plain ASCII space, which real filenames use constantly, is allowed.
+
+    The rest is explicit: no path separator, no dot run, and no leading dot or
+    surrounding whitespace -- a leading dot both hides the file and, for a name
+    that is only dots, is the traversal shape itself.
+    """
+    if not value.isprintable():
+        return False
+    if _CONSECUTIVE_DOTS in value or value.startswith("."):
+        return False
+    if _PATH_SEPARATORS.intersection(value):
+        return False
+    return value == value.strip()
+
+
+class UploadDocumentRequest(BaseModel):
+    """One user-supplied document submitted for the vault to ingest.
+
+    ``filename`` is what the vault reads an extension off to pick its ingestor,
+    so it is validated here rather than passed through: adepthood does not parse
+    the document, which makes the name the single field that steers what happens
+    to it on the far side.
+
+    ``classification`` is the privacy tier the uploader chose, and it is honored
+    end to end -- an ``intimate`` document is withheld from the vault entirely
+    (see :mod:`services.creek_vault_upload`), never quietly downgraded so it can
+    be sent.
+    """
+
+    filename: str = Field(
+        min_length=1,
+        max_length=MAX_FILENAME_LENGTH,
+        description="The document's own name; its extension selects the vault's ingestor.",
+    )
+    content_base64: str = Field(
+        min_length=1,
+        description="Base64-encoded document bytes.",
+        # Kept out of ``repr()``/``str()`` so the document can never leak into a
+        # log line or a traceback that stringifies the model.
+        repr=False,
+    )
+    classification: JournalClassification = Field(
+        description="The privacy tier the uploader chose for this document."
+    )
+
+    @field_validator("filename")
+    @classmethod
+    def _reject_unsafe_filename(cls, value: str) -> str:
+        """Reject any name that is not one plain, inert filename.
+
+        Fails closed on anything ambiguous. The name ends up in a request the
+        vault routes on and, before that, in adepthood's own identity digest, so
+        "reject what we cannot state the meaning of" is cheaper than reasoning
+        about what a path separator or a control character would do to either.
+        """
+        if not _is_safe_filename(value):
+            message = "filename must be a single plain name without path separators"
+            raise ValueError(message)
+        return value
+
+
+class UploadDocumentResponse(BaseModel):
+    """What became of one uploaded document, in the vault's own terms.
+
+    ``status`` is the whole answer: a client renders from it and never has to
+    infer an outcome from the presence or absence of another field.
+    ``vault_ref`` is the vault's handle on the stored fragment, present only when
+    the document was actually accepted. ``tags`` are the classification the
+    vault's ingest pipeline assigned -- empty until the vault returns them, which
+    is the expected answer today rather than a failure. ``message`` is the
+    self-serve sentence shown to the person who uploaded it.
+    """
+
+    status: VaultUploadStatus = Field(description="What the vault did with the document.")
+    vault_ref: str | None = Field(
+        default=None, description="The vault's fragment handle, present only when accepted."
+    )
+    tags: list[str] = Field(
+        default_factory=list, description="Tags the vault's ingest pipeline assigned."
+    )
+    message: str = Field(description="Self-serve explanation for the person who uploaded it.")

--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -94,7 +94,7 @@ import os
 from collections.abc import Callable, Mapping
 from http import HTTPStatus
 from types import TracebackType
-from typing import NoReturn
+from typing import NoReturn, TypeGuard
 from urllib.parse import quote
 
 import httpx
@@ -119,6 +119,8 @@ from domain.creek_vault import (
     VaultIngestResult,
     VaultReflection,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
 )
@@ -813,6 +815,13 @@ _CAPABILITIES_PATH = "/v1/capabilities"
 # capability document are the only ``/v1`` shapes Creek has ratified.
 _JOURNAL_ENTRIES_PATH = "/v1/journal-entries/"
 
+# Where one uploaded document is addressed, relative to the configured base URL.
+# A separate collection from journal entries because the two are different kinds
+# of object: an entry is text adepthood authored the shape of, while an upload is
+# a file the vault's own ingestor registry parses. Sharing one collection would
+# make the vault infer which it received from the body's fields.
+_UPLOADS_PATH = "/v1/uploads/"
+
 # The whole-corpus frequency aggregate, relative to the configured base URL. Not
 # a resource but a computation over every admitted fragment, so it is read from
 # one collection-level URL that takes no identifier -- and, on the ratified
@@ -897,10 +906,28 @@ _CREDENTIAL_REJECTED_MESSAGE = _capability_message(_CREDENTIAL_REJECTED, CreekCa
 _WHEEL_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.WHEEL)
 _WHEEL_UNREADABLE_MESSAGE = _capability_message(_RESPONSE_UNREADABLE, CreekCapability.WHEEL)
 _REFLECT_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.REFLECT)
+# The upload path's own triple. Named apart from the journal one rather than
+# shared, because the whole point of the separate capability is that an operator
+# can tell "the vault will not take our files" from "the vault will not take our
+# entries" -- one message for both would erase exactly that distinction.
+_UPLOAD_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.UPLOAD)
+_UPLOAD_REJECTED_MESSAGE = _capability_message(_REQUEST_REJECTED, CreekCapability.UPLOAD)
+_UPLOAD_CREDENTIAL_MESSAGE = _capability_message(_CREDENTIAL_REJECTED, CreekCapability.UPLOAD)
+
+# How many tags adepthood will read off one upload response, and how long each
+# may be. The vault classifies in its own pipeline and we store what it says, so
+# these bound what a compromised or malfunctioning vault can push into our
+# response on the back of a single upload.
+_MAX_UPLOAD_TAGS = 32
+_MAX_UPLOAD_TAG_LENGTH = 64
 # The one not-stored result every unreadable 2xx collapses to. Interned because
 # it is value-identical on each of those paths, and named so no branch is
 # tempted to invent a ``vault_ref`` the vault never issued.
 _NOT_STORED_RESULT = VaultIngestResult(stored=False, vault_ref=None, action=None)
+
+# The upload path's equivalent: the one not-stored answer every unreadable 2xx
+# on an upload collapses to.
+_NOT_UPLOADED_RESULT = VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
 
 
 def _build_pooled_vault_client() -> httpx.AsyncClient:
@@ -989,7 +1016,88 @@ def _entry_path_segment(entry_id: int) -> str:
     request, and a future identifier type must not be able to redirect it by its
     shape alone.
     """
-    return quote(str(entry_id), safe="").replace(".", _ENCODED_DOT)
+    return _inert_path_segment(str(entry_id))
+
+
+def _inert_path_segment(raw: str) -> str:
+    """Encode ``raw`` into exactly one path segment that cannot climb out of it.
+
+    Factored out of :func:`_entry_path_segment` so the upload path gets the same
+    guarantee from the same code rather than a second implementation that has to
+    remember the dot rule independently -- and an upload's id is a string from
+    the start, which is exactly the case that rule exists for.
+    """
+    return quote(raw, safe="").replace(".", _ENCODED_DOT)
+
+
+def _upload_body(request: VaultUploadRequest) -> Mapping[str, object]:
+    """Map an upload request onto the vault's document fields.
+
+    Four fields: the bytes, the filename the vault reads an extension off to
+    choose an ingestor, when the document entered the corpus, and the tier it is
+    stored at. The external id travels in the URL because it is the resource,
+    exactly as an entry id does.
+
+    Notably absent is any source or content type. The vault owns ingestor
+    selection; adepthood declaring one would override a decision made by the
+    side that actually parses the file.
+    """
+    return {
+        "filename": request.filename,
+        "content_base64": request.content_base64,
+        "timestamp": request.created_at.isoformat(),
+        "tier": request.tier.value,
+    }
+
+
+def _is_usable_tag(item: object) -> TypeGuard[str]:
+    """Return whether one element of a vault tag list is safe to carry onward.
+
+    The same three properties :func:`_is_storable_ref` demands of a fragment id,
+    for the same reason: a tag is vault-chosen text that adepthood puts into its
+    own API response, so it must be a real string, printable (no NUL, no CR/LF
+    to inject into a log, no zero-width or bidi-override codepoints), and
+    bounded in length.
+    """
+    if not isinstance(item, str) or not item.isprintable():
+        return False
+    return 0 < len(item) <= _MAX_UPLOAD_TAG_LENGTH
+
+
+def _upload_tags(raw: object) -> tuple[str, ...]:
+    """Read the vault's per-fragment tags, keeping only what is plainly usable.
+
+    Drop-unknown-items, exactly as :func:`_parse_capabilities` treats an
+    advertised capability list: a non-list, or any element failing
+    :func:`_is_usable_tag`, is discarded rather than raising, so a malformed
+    answer costs the caller its tags and never its upload. The count bound keeps
+    a single upload from carrying an unbounded amount of vault-chosen text back
+    into adepthood's own response.
+    """
+    if not isinstance(raw, list):
+        return ()
+    return tuple(item for item in raw[:_MAX_UPLOAD_TAGS] if _is_usable_tag(item))
+
+
+def _parse_http_upload_result(payload: object) -> VaultUploadResult:
+    """Project a 2xx upload body onto a result, as conservatively as ingest does.
+
+    A durable upload needs both halves -- an action we recognize *and* a storable
+    fragment id -- so anything less parses to not-stored and the caller records a
+    degraded upload. Tags are read only once the write itself is established:
+    tags without a stored document would describe something that is not there.
+    """
+    if isinstance(payload, Mapping):
+        action = _coerce_ingest_action(payload.get("action"))
+        fragment_id = _usable_fragment_id(payload)
+        if action is not None and fragment_id is not None:
+            return VaultUploadResult(
+                stored=True,
+                vault_ref=fragment_id,
+                action=action,
+                tags=_upload_tags(payload.get("tags")),
+            )
+    return _NOT_UPLOADED_RESULT
 
 
 def _journal_entry_body(request: VaultIngestRequest) -> Mapping[str, object]:
@@ -1081,8 +1189,19 @@ def _faults_our_request(response: httpx.Response) -> bool:
     return response.is_client_error and response.status_code not in _RETRYABLE_CLIENT_STATUSES
 
 
-def _ingest_failure(response: httpx.Response) -> CreekVaultError:
-    """Classify a non-2xx ingest response into the failure it actually is.
+def _write_failure(
+    response: httpx.Response,
+    *,
+    call_failed: str,
+    request_rejected: str,
+    credential_rejected: str,
+) -> CreekVaultError:
+    """Classify a non-2xx write response into the failure it actually is.
+
+    Shared by both write capabilities -- journal ingest and document upload --
+    because the *classification* is a property of the answer rather than of what
+    was being written. Only the three static messages differ, and they are
+    parameters precisely so each capability names itself in what it raises.
 
     The order encodes what each answer tells an operator to do:
 
@@ -1100,13 +1219,33 @@ def _ingest_failure(response: httpx.Response) -> CreekVaultError:
        request, so they answer to the availability story instead.
     """
     if response.status_code in _CREDENTIAL_REJECTED_STATUSES:
-        return CreekVaultAuthError(_CREDENTIAL_REJECTED_MESSAGE)
+        return CreekVaultAuthError(credential_rejected)
     code = _vault_error_code(response)
     if code in _CONTRACT_ERROR_CODES:
-        return CreekVaultContractError(_INGEST_REJECTED_MESSAGE, code=code)
+        return CreekVaultContractError(request_rejected, code=code)
     if code is None and _faults_our_request(response):
-        return CreekVaultContractError(_INGEST_REJECTED_MESSAGE)
-    return CreekVaultUnavailableError(_INGEST_FAILED_MESSAGE)
+        return CreekVaultContractError(request_rejected)
+    return CreekVaultUnavailableError(call_failed)
+
+
+def _ingest_failure(response: httpx.Response) -> CreekVaultError:
+    """Classify a failed journal ingest, naming the JOURNAL capability."""
+    return _write_failure(
+        response,
+        call_failed=_INGEST_FAILED_MESSAGE,
+        request_rejected=_INGEST_REJECTED_MESSAGE,
+        credential_rejected=_CREDENTIAL_REJECTED_MESSAGE,
+    )
+
+
+def _upload_failure(response: httpx.Response) -> CreekVaultError:
+    """Classify a failed document upload, naming the UPLOAD capability."""
+    return _write_failure(
+        response,
+        call_failed=_UPLOAD_FAILED_MESSAGE,
+        request_rejected=_UPLOAD_REJECTED_MESSAGE,
+        credential_rejected=_UPLOAD_CREDENTIAL_MESSAGE,
+    )
 
 
 def _coded_read_failure(capability: CreekCapability, code: VaultErrorCode) -> CreekVaultError:
@@ -1523,6 +1662,68 @@ class HttpCreekVaultClient:
         )
         return result
 
+    async def _put_upload(self, request: VaultUploadRequest) -> httpx.Response:
+        """Upsert one document at its own URL, normalizing any transport failure.
+
+        The same discipline :meth:`_put_journal_entry` follows, and for a
+        sharper reason: an upload's external id is a *string* rather than an
+        integer, so :func:`_inert_path_segment` is load-bearing here rather than
+        merely future-proofing. Every transport failure becomes
+        :class:`CreekVaultUnavailableError` with ``from None``, since the
+        original exception's text can carry the URL or the document bytes and
+        neither may ride along in a message or a traceback.
+        """
+        upload_url = f"{self._url}{_UPLOADS_PATH}{_inert_path_segment(request.external_id)}"
+        try:
+            return await self._authorized_request("PUT", upload_url, _upload_body(request))
+        except _HTTP_CALL_TIMED_OUT_ERRORS:
+            raise VaultCallTimedOutError(_UPLOAD_FAILED_MESSAGE) from None
+        except _HTTP_CALL_FAILED_ERRORS:
+            raise CreekVaultUnavailableError(_UPLOAD_FAILED_MESSAGE) from None
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Upsert ``request`` into the vault, requiring the UPLOAD capability.
+
+        A thin wrapper over :meth:`_upload` so the attempt is counted exactly
+        once, exactly as :meth:`ingest` wraps :meth:`_ingest`.
+        """
+        with _CountingOutcome(CreekCapability.UPLOAD):
+            return await self._upload(request)
+
+    async def _upload(self, request: VaultUploadRequest) -> VaultUploadResult:
+        """Perform the document upsert and report how it ended.
+
+        Gated on the cached handshake first, and this gate matters more than
+        journal ingest's: a vault may well advertise ``creek.journal`` without
+        ``creek.upload``, so refusing *locally* is what keeps a user's document
+        off the wire toward a surface that never claimed it could take one.
+
+        The answer splits the same three ways ingest's does -- a readable 2xx
+        projected by :func:`_parse_http_upload_result`, an undecodable 2xx read
+        as an unavailable vault rather than a successful write, and a non-2xx
+        classified by :func:`_upload_failure`. A 2xx that does not describe a
+        durable write is counted as a schema failure, because reporting it as a
+        success would tell a user their document is in the vault when the vault
+        never said so.
+        """
+        if not self.supports(CreekCapability.UPLOAD):
+            raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.UPLOAD))
+        response = await self._put_upload(request)
+        if not response.is_success:
+            raise _upload_failure(response) from None
+        try:
+            payload = response.json()
+        except ValueError:
+            raise CreekVaultUnavailableError(_UPLOAD_FAILED_MESSAGE) from None
+        result = _parse_http_upload_result(payload)
+        record_vault_outcome(
+            VaultTelemetryOutcome.SUCCESS
+            if result.stored
+            else VaultTelemetryOutcome.SCHEMA_FAILURE,
+            CreekCapability.UPLOAD,
+        )
+        return result
+
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Refuse classification: its ``/v1`` request/response shape is unratified.
 
@@ -1736,6 +1937,17 @@ class LocalFallbackCreekVaultClient:
         """No-op ingest: report not stored without raising (Postgres is authoritative)."""
         record_vault_outcome(self._outcome, CreekCapability.JOURNAL)
         return VaultIngestResult(stored=False, vault_ref=None)
+
+    async def upload(self, _request: VaultUploadRequest, /) -> VaultUploadResult:
+        """No-op upload: report not stored without raising, exactly as ingest does.
+
+        Not a raise, because an absent vault is not an error the uploader caused
+        -- the write service turns this into an honest "no vault to keep it in"
+        outcome, and a document nobody could store is the same non-event a
+        journal entry's unreplicated copy is.
+        """
+        record_vault_outcome(self._outcome, CreekCapability.UPLOAD)
+        return VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Raise: classification has no local vault to serve it."""

--- a/backend/src/services/creek_vault_upload.py
+++ b/backend/src/services/creek_vault_upload.py
@@ -1,0 +1,355 @@
+"""Creek Vault upload path: hand one user document to the vault, degrading safely.
+
+The document sibling of :mod:`services.creek_vault_write`. Where that module
+replicates writing adepthood already holds in Postgres, this one forwards a file
+the user chose -- a PDF, a spreadsheet, an export, a photographed page -- so the
+Higher Self corpus can be grounded in more of their life than the in-app journal
+alone. Adepthood carries the bytes and the filename and nothing else: the vault's
+own ingestor registry reads the extension and decides how to parse it, so no
+document parsing, format sniffing, or source-type guessing happens here.
+
+Like the write path, every function takes the client as a parameter and
+constructs none, which keeps this module out of the tenancy decision entirely --
+that belongs to :func:`dependencies.creek_vault.get_creek_vault_client`.
+
+The governing rule is again **graceful degradation**, with one difference that
+matters to the caller. A journal entry is already saved in Postgres before
+replication is attempted, so its degrade is invisible. An upload has no local
+system of record: if the vault will not take the document, there is nowhere else
+it goes. So the outcomes here are deliberately finer-grained than
+:class:`~services.creek_vault_write.VaultWriteStatus` -- an unreachable vault, a
+vault that cannot accept files, and a call that failed mid-flight are three
+different things to tell a user, and flattening them would leave them with
+"something went wrong" and no next step.
+
+**An upload is never queued or retried.** There is no spool of pending
+documents, for the same reason the write path keeps no backlog: durably storing
+user document bytes outside the vault is a privacy decision nobody has made. A
+failed upload is reported honestly to the person who made it, and they can try
+again.
+
+**Intimate documents are deliberately not sent.** A document classified
+``intimate`` short-circuits to :attr:`VaultUploadStatus.SKIPPED_INTIMATE` before
+any vault call -- not even a handshake -- exactly as an intimate journal entry
+does. Decision 6 of ``docs/adr/0004-creek-vault-http-application-boundary.md``
+records that every intimate-transit sub-decision (ciphertext under a user-held
+key, writes only against an attested enclave) is *entirely unshipped*, so
+today's ratified behavior is skip-only. Forwarding an
+intimate document over this plaintext surface because it happens to be a vault
+rather than a cloud LLM would be exactly the widening that decision refuses, so
+the honest answer is to withhold it and say so.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from domain.creek_vault import (
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
+    CreekVaultClient,
+    CreekVaultContractError,
+    CreekVaultError,
+    VaultUploadRequest,
+    VaultUploadResult,
+    tier_ceiling_for,
+)
+from models.journal_entry import JournalClassification
+
+_LOGGER = logging.getLogger(__name__)
+
+# Prefix on every generated external id, so a fragment adepthood uploaded is
+# recognizable as one in a vault that also holds journal entries.
+_EXTERNAL_ID_PREFIX = "adepthood-upload-"
+
+# How much of the identity digest the external id carries. 32 hex characters is
+# 128 bits: far beyond any collision an installation's document count could
+# reach, while keeping the id short enough to read in a log or a URL.
+_EXTERNAL_ID_DIGEST_CHARS = 32
+
+# Separator between the two identity components inside the pre-image. A NUL can
+# appear in neither an integer nor a filename, so no pair of distinct
+# (owner, filename) inputs can collide by rearrangement across the boundary.
+_IDENTITY_SEPARATOR = "\x00"
+
+
+class VaultUploadStatus(enum.StrEnum):
+    """The terminal outcome of a :func:`store_upload` attempt.
+
+    Exactly one is always returned, and the four non-accepted values stay apart
+    because each sends the user somewhere different: ``SKIPPED_INTIMATE`` is a
+    promise adepthood is keeping, ``VAULT_UNAVAILABLE`` is "connect or fix your
+    vault", ``CAPABILITY_UNSUPPORTED`` is "your vault cannot take files yet",
+    and ``DEGRADED`` is "it broke, try again". Values are the wire strings the
+    API answers with, so they are contract and must not be reworded casually.
+    """
+
+    ACCEPTED = "accepted"
+    SKIPPED_INTIMATE = "skipped_intimate"
+    VAULT_UNAVAILABLE = "vault_unavailable"
+    CAPABILITY_UNSUPPORTED = "capability_unsupported"
+    DEGRADED = "degraded"
+
+
+class UploadDegradeReason(enum.StrEnum):
+    """Why one upload failed mid-flight, in terms an operator can act on.
+
+    The user sees a single :attr:`VaultUploadStatus.DEGRADED` -- that is the
+    point of degrading -- so these exist purely so the failures stay countable
+    apart, each with its own remedy: ``CONTRACT`` is a defect in adepthood's own
+    request, ``AUTH`` is a credential to rotate, ``UNAVAILABLE`` is
+    infrastructure, ``UNSUPPORTED_CAPABILITY`` is a vault that withdrew the
+    capability between the handshake and the call, and ``NOT_STORED`` is a vault
+    that answered successfully yet did not durably keep the document.
+    """
+
+    CONTRACT = "contract"
+    AUTH = "auth"
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED_CAPABILITY = "unsupported_capability"
+    NOT_STORED = "not_stored"
+
+
+# The two static log events this module emits. Static because a vault error's
+# own message can quote the document or a string the vault chose: everything
+# variable travels in the structured ``extra`` fields, each of which is either
+# a generated id or one of our own enum values. The filename is absent from both
+# -- a user names their files after their life, and "divorce-settlement.pdf" is
+# content, not metadata.
+_DEGRADED_EVENT = "creek vault upload degraded"
+_UPLOADED_EVENT = "creek vault upload stored"
+
+
+@dataclass(frozen=True)
+class UploadedDocument:
+    """One document as the caller received it, before any vault vocabulary applies.
+
+    The router's own DTO stops at the router: this is the same document expressed
+    in terms this layer owns, so :func:`store_upload` depends on the schema
+    package no more than the write path does. Bundling the five facts also keeps
+    the call site readable -- five loose keyword arguments in a row is where a
+    filename and a classification get transposed silently.
+
+    ``content_base64`` is excluded from ``repr()`` for the same reason it is on
+    :class:`~domain.creek_vault.VaultUploadRequest`: this object is the document,
+    and a generated ``repr`` is what a traceback would otherwise render in full.
+    """
+
+    owner_user_id: int
+    filename: str
+    content_base64: str = field(repr=False)
+    classification: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class VaultUploadOutcome:
+    """Immutable result of an upload attempt: a status plus any earned metadata.
+
+    ``vault_ref`` is populated only on :attr:`VaultUploadStatus.ACCEPTED`.
+    ``tags`` are whatever the vault's own ingest pipeline classified the
+    document as, which is an empty tuple until the vault returns them -- and
+    empty is the correct, expected answer rather than a failure. Frozen so a
+    recorded outcome cannot mutate between the service and the router.
+    """
+
+    status: VaultUploadStatus
+    vault_ref: str | None
+    tags: tuple[str, ...]
+
+
+# The four non-accepted outcomes are value-identical every time, so they are
+# interned as module constants rather than rebuilt on each path.
+_SKIPPED_INTIMATE_OUTCOME = VaultUploadOutcome(
+    status=VaultUploadStatus.SKIPPED_INTIMATE, vault_ref=None, tags=()
+)
+_UNAVAILABLE_OUTCOME = VaultUploadOutcome(
+    status=VaultUploadStatus.VAULT_UNAVAILABLE, vault_ref=None, tags=()
+)
+_UNSUPPORTED_OUTCOME = VaultUploadOutcome(
+    status=VaultUploadStatus.CAPABILITY_UNSUPPORTED, vault_ref=None, tags=()
+)
+_DEGRADED_OUTCOME = VaultUploadOutcome(status=VaultUploadStatus.DEGRADED, vault_ref=None, tags=())
+
+
+def upload_external_id(owner_user_id: int, filename: str) -> str:
+    """Derive the stable fragment id one user's document is always addressed by.
+
+    A pure function of the upload's identity -- who uploaded it and what they
+    called it -- which is what makes a re-send idempotent: the same document
+    sent twice addresses one fragment, so the vault edits it in place instead of
+    accumulating a copy per attempt. That is the same guarantee a journal entry
+    gets from its entry id, obtained without a local row to hold one, so no
+    table and no migration stand between a user and their first upload.
+
+    The filename is *hashed rather than carried*, for two reasons that point the
+    same way. It travels in a URL, and a filename is the user's own words about
+    their life -- "my-divorce-settlement.pdf" is content, and content does not
+    belong in a request line, an access log, or a proxy's history. Hashing also
+    makes the id inert by construction: a digest has no separators, no dots, and
+    nothing to escape, so it cannot redirect the request that carries a
+    document.
+
+    Including the owner is what keeps two users' identically-named files apart;
+    without it, everyone's ``notes.pdf`` would be one shared fragment that each
+    upload overwrote.
+    """
+    identity = f"{owner_user_id}{_IDENTITY_SEPARATOR}{filename}".encode()
+    digest = hashlib.sha256(identity).hexdigest()[:_EXTERNAL_ID_DIGEST_CHARS]
+    return f"{_EXTERNAL_ID_PREFIX}{digest}"
+
+
+def _degrade_reason_for(error: CreekVaultError) -> UploadDegradeReason:
+    """Attribute one vault error to the reason an operator would act on.
+
+    Ordered most-specific first, with ``UNAVAILABLE`` as the catch-all rather
+    than a match: an error type this module has not heard of is far more likely
+    to be an availability fault than a contract one, and guessing "contract"
+    would send someone hunting a bug in adepthood that is not there.
+    """
+    if isinstance(error, CreekVaultContractError):
+        return UploadDegradeReason.CONTRACT
+    if isinstance(error, CreekVaultAuthError):
+        return UploadDegradeReason.AUTH
+    if isinstance(error, CreekCapabilityUnsupportedError):
+        return UploadDegradeReason.UNSUPPORTED_CAPABILITY
+    return UploadDegradeReason.UNAVAILABLE
+
+
+def _degrade_fields(error: CreekVaultError) -> dict[str, object]:
+    """Build the content-free fields describing why an upload degraded.
+
+    ``code`` appears only when the error carries one of *our own*
+    :class:`~domain.creek_vault.VaultErrorCode` members: the adapter has already
+    dropped anything a vault sent that we do not recognize, so this can never put
+    a vault-chosen string into a log line.
+    """
+    fields: dict[str, object] = {"reason": _degrade_reason_for(error).value}
+    if isinstance(error, CreekVaultContractError) and error.code is not None:
+        fields["code"] = error.code.value
+    return fields
+
+
+def _log_extra(request: VaultUploadRequest, fields: Mapping[str, object]) -> dict[str, object]:
+    """Compose the structured payload every upload log record carries.
+
+    Deliberately only the generated external id and closed vocabularies. The
+    document bytes and the filename are absent by construction rather than by
+    redaction, so there is nothing here to forget to scrub -- and the external
+    id is still enough to find the fragment the failure was about.
+    """
+    return {
+        "capability": CreekCapability.UPLOAD.value,
+        "external_id": request.external_id,
+        **fields,
+    }
+
+
+def _log_degraded(request: VaultUploadRequest, fields: Mapping[str, object]) -> None:
+    """Record a failed upload at WARNING with a static message.
+
+    The exception is deliberately neither formatted into the message nor passed
+    as ``exc_info``: its text may quote the document or the vault's own prose,
+    and this record is the one place either would otherwise escape.
+    """
+    _LOGGER.warning(_DEGRADED_EVENT, extra=_log_extra(request, fields))
+
+
+def _log_stored(request: VaultUploadRequest, result: VaultUploadResult) -> None:
+    """Record a durable upload at INFO, carrying which action the vault took.
+
+    INFO rather than WARNING because nothing is wrong. The action is worth
+    keeping because it is how an operator sees that a re-uploaded document
+    edited its existing fragment instead of creating a second one. A transport
+    that does not report an action logs ``None``, which honestly says "the vault
+    did not say".
+    """
+    action = result.action.value if result.action is not None else None
+    _LOGGER.info(_UPLOADED_EVENT, extra=_log_extra(request, {"action": action}))
+
+
+async def _try_upload(
+    client: CreekVaultClient, request: VaultUploadRequest
+) -> VaultUploadResult | None:
+    """Attempt an upload, returning the result on durable storage or ``None``.
+
+    A :class:`CreekVaultError` (the seam's normalized transport failure) and a
+    ``stored=False`` result both collapse to ``None`` -- the caller treats either
+    as a degraded upload rather than propagating the error or fabricating a ref.
+    Each path logs its own reason on the way out, because this is where the
+    document is dropped and nothing downstream will hear of it again.
+    """
+    try:
+        result = await client.upload(request)
+    except CreekVaultError as error:
+        _log_degraded(request, _degrade_fields(error))
+        return None
+    if not result.stored:
+        _log_degraded(request, {"reason": UploadDegradeReason.NOT_STORED.value})
+        return None
+    _log_stored(request, result)
+    return result
+
+
+async def store_upload(
+    client: CreekVaultClient, document: UploadedDocument, /
+) -> VaultUploadOutcome:
+    """Forward one document to the vault, degrading rather than raising.
+
+    The order of checks is load-bearing:
+
+    1. An ``intimate`` classification short-circuits to
+       :attr:`VaultUploadStatus.SKIPPED_INTIMATE` *before touching the client* --
+       see the module docstring for why intimate documents are withheld rather
+       than forwarded.
+    2. :func:`~domain.creek_vault.tier_ceiling_for` resolves the tier, raising
+       ``ValueError`` (fail closed) for an unknown classification -- this
+       propagates, since an unrecognized tier must never widen to OPEN.
+    3. A handshake probes the vault. An unreachable one degrades to
+       :attr:`VaultUploadStatus.VAULT_UNAVAILABLE`; a reachable one that never
+       advertised ``creek.upload`` degrades to
+       :attr:`VaultUploadStatus.CAPABILITY_UNSUPPORTED`. The two are separated
+       because they are separate problems with separate fixes.
+    4. The upload runs; a transport failure or a ``stored=False`` result degrades
+       to :attr:`VaultUploadStatus.DEGRADED`.
+    5. On a durable upload the call returns :attr:`VaultUploadStatus.ACCEPTED`
+       with the fragment ref and whatever tags the vault's own pipeline assigned.
+
+    Both the document's tier and the write ceiling are set to the resolved tier,
+    so the vault stores at exactly the depth the uploader chose. Never raises
+    :class:`~domain.creek_vault.CreekVaultError`: the router answers the user
+    from the status alone.
+    """
+    if document.classification == JournalClassification.INTIMATE:
+        return _SKIPPED_INTIMATE_OUTCOME
+    tier_ceiling = tier_ceiling_for(document.classification)
+    await client.handshake()
+    if not client.is_available():
+        return _UNAVAILABLE_OUTCOME
+    # Gated on UPLOAD specifically, never on JOURNAL: a vault that takes journal
+    # text has said nothing about whether it takes files, and treating one as the
+    # other would put a user's document on the wire toward a surface that never
+    # claimed it. Kept a separate branch from the availability check above because
+    # the two are separate problems the user has to be told apart.
+    if not client.supports(CreekCapability.UPLOAD):
+        return _UNSUPPORTED_OUTCOME
+    request = VaultUploadRequest(
+        external_id=upload_external_id(document.owner_user_id, document.filename),
+        filename=document.filename,
+        content_base64=document.content_base64,
+        tier=tier_ceiling,
+        tier_ceiling=tier_ceiling,
+        created_at=document.created_at,
+    )
+    result = await _try_upload(client, request)
+    if result is None:
+        return _DEGRADED_OUTCOME
+    return VaultUploadOutcome(
+        status=VaultUploadStatus.ACCEPTED, vault_ref=result.vault_ref, tags=result.tags
+    )

--- a/backend/src/services/creek_vault_upload.py
+++ b/backend/src/services/creek_vault_upload.py
@@ -28,16 +28,26 @@ user document bytes outside the vault is a privacy decision nobody has made. A
 failed upload is reported honestly to the person who made it, and they can try
 again.
 
-**Intimate documents are deliberately not sent.** A document classified
-``intimate`` short-circuits to :attr:`VaultUploadStatus.SKIPPED_INTIMATE` before
-any vault call -- not even a handshake -- exactly as an intimate journal entry
-does. Decision 6 of ``docs/adr/0004-creek-vault-http-application-boundary.md``
-records that every intimate-transit sub-decision (ciphertext under a user-held
-key, writes only against an attested enclave) is *entirely unshipped*, so
-today's ratified behavior is skip-only. Forwarding an
-intimate document over this plaintext surface because it happens to be a vault
-rather than a cloud LLM would be exactly the widening that decision refuses, so
-the honest answer is to withhold it and say so.
+**Intimate documents are forwarded to the vault, and to nothing else.** A
+document classified ``intimate`` is uploaded at the ``INTIMATE`` tier ceiling
+like any other, because the vault is the user's *own* private corpus rather than
+a third-party service: the deployment points at one operator-held
+``CREEK_VAULT_URL``, and reaching it is not the cloud disclosure the privacy
+floor exists to prevent. What the floor still forbids -- an intimate document
+reaching a cloud LLM -- this path never does, since it calls no LLM at all.
+
+This was ratified as an amendment to Decision 6 of
+``docs/adr/0004-creek-vault-http-application-boundary.md``; read that decision
+for the transit topology, and the amendment for why the upload surface is
+treated as vault-only rather than skip-only. Note the asymmetry it leaves
+behind: :mod:`services.creek_vault_write` still withholds intimate *journal
+entries*, which is deliberately untouched here and tracked for reconciliation
+in issue #2152 -- widening a shipped write path is not something to do as a side
+effect of adding a new one.
+
+The vault's own router still enforces the ceiling it is handed, so a vault that
+declines to store at ``INTIMATE`` refuses the write and this path degrades
+honestly rather than silently downgrading the tier to make the call succeed.
 """
 
 from __future__ import annotations
@@ -60,7 +70,6 @@ from domain.creek_vault import (
     VaultUploadResult,
     tier_ceiling_for,
 )
-from models.journal_entry import JournalClassification
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,16 +91,15 @@ _IDENTITY_SEPARATOR = "\x00"
 class VaultUploadStatus(enum.StrEnum):
     """The terminal outcome of a :func:`store_upload` attempt.
 
-    Exactly one is always returned, and the four non-accepted values stay apart
-    because each sends the user somewhere different: ``SKIPPED_INTIMATE`` is a
-    promise adepthood is keeping, ``VAULT_UNAVAILABLE`` is "connect or fix your
-    vault", ``CAPABILITY_UNSUPPORTED`` is "your vault cannot take files yet",
-    and ``DEGRADED`` is "it broke, try again". Values are the wire strings the
-    API answers with, so they are contract and must not be reworded casually.
+    Exactly one is always returned, and the three non-accepted values stay apart
+    because each sends the user somewhere different: ``VAULT_UNAVAILABLE`` is
+    "connect or fix your vault", ``CAPABILITY_UNSUPPORTED`` is "your vault cannot
+    take files yet", and ``DEGRADED`` is "it broke, try again". Values are the
+    wire strings the API answers with, so they are contract and must not be
+    reworded casually.
     """
 
     ACCEPTED = "accepted"
-    SKIPPED_INTIMATE = "skipped_intimate"
     VAULT_UNAVAILABLE = "vault_unavailable"
     CAPABILITY_UNSUPPORTED = "capability_unsupported"
     DEGRADED = "degraded"
@@ -164,11 +172,8 @@ class VaultUploadOutcome:
     tags: tuple[str, ...]
 
 
-# The four non-accepted outcomes are value-identical every time, so they are
+# The three non-accepted outcomes are value-identical every time, so they are
 # interned as module constants rather than rebuilt on each path.
-_SKIPPED_INTIMATE_OUTCOME = VaultUploadOutcome(
-    status=VaultUploadStatus.SKIPPED_INTIMATE, vault_ref=None, tags=()
-)
 _UNAVAILABLE_OUTCOME = VaultUploadOutcome(
     status=VaultUploadStatus.VAULT_UNAVAILABLE, vault_ref=None, tags=()
 )
@@ -304,30 +309,27 @@ async def store_upload(
 
     The order of checks is load-bearing:
 
-    1. An ``intimate`` classification short-circuits to
-       :attr:`VaultUploadStatus.SKIPPED_INTIMATE` *before touching the client* --
-       see the module docstring for why intimate documents are withheld rather
-       than forwarded.
-    2. :func:`~domain.creek_vault.tier_ceiling_for` resolves the tier, raising
+    1. :func:`~domain.creek_vault.tier_ceiling_for` resolves the tier, raising
        ``ValueError`` (fail closed) for an unknown classification -- this
-       propagates, since an unrecognized tier must never widen to OPEN.
-    3. A handshake probes the vault. An unreachable one degrades to
+       propagates, since an unrecognized tier must never widen to OPEN. Every
+       tier is forwarded, ``intimate`` included; see the module docstring for
+       why the vault is not the disclosure the privacy floor guards against.
+    2. A handshake probes the vault. An unreachable one degrades to
        :attr:`VaultUploadStatus.VAULT_UNAVAILABLE`; a reachable one that never
        advertised ``creek.upload`` degrades to
        :attr:`VaultUploadStatus.CAPABILITY_UNSUPPORTED`. The two are separated
        because they are separate problems with separate fixes.
-    4. The upload runs; a transport failure or a ``stored=False`` result degrades
+    3. The upload runs; a transport failure or a ``stored=False`` result degrades
        to :attr:`VaultUploadStatus.DEGRADED`.
-    5. On a durable upload the call returns :attr:`VaultUploadStatus.ACCEPTED`
+    4. On a durable upload the call returns :attr:`VaultUploadStatus.ACCEPTED`
        with the fragment ref and whatever tags the vault's own pipeline assigned.
 
     Both the document's tier and the write ceiling are set to the resolved tier,
-    so the vault stores at exactly the depth the uploader chose. Never raises
+    so the vault stores at exactly the depth the uploader chose -- never widened
+    so a call can succeed, and never narrowed. Never raises
     :class:`~domain.creek_vault.CreekVaultError`: the router answers the user
     from the status alone.
     """
-    if document.classification == JournalClassification.INTIMATE:
-        return _SKIPPED_INTIMATE_OUTCOME
     tier_ceiling = tier_ceiling_for(document.classification)
     await client.handshake()
     if not client.is_available():

--- a/backend/src/services/creek_vault_upload.py
+++ b/backend/src/services/creek_vault_upload.py
@@ -68,6 +68,7 @@ from domain.creek_vault import (
     CreekVaultError,
     VaultUploadRequest,
     VaultUploadResult,
+    VaultUploadStatus,
     tier_ceiling_for,
 )
 
@@ -86,23 +87,6 @@ _EXTERNAL_ID_DIGEST_CHARS = 32
 # appear in neither an integer nor a filename, so no pair of distinct
 # (owner, filename) inputs can collide by rearrangement across the boundary.
 _IDENTITY_SEPARATOR = "\x00"
-
-
-class VaultUploadStatus(enum.StrEnum):
-    """The terminal outcome of a :func:`store_upload` attempt.
-
-    Exactly one is always returned, and the three non-accepted values stay apart
-    because each sends the user somewhere different: ``VAULT_UNAVAILABLE`` is
-    "connect or fix your vault", ``CAPABILITY_UNSUPPORTED`` is "your vault cannot
-    take files yet", and ``DEGRADED`` is "it broke, try again". Values are the
-    wire strings the API answers with, so they are contract and must not be
-    reworded casually.
-    """
-
-    ACCEPTED = "accepted"
-    VAULT_UNAVAILABLE = "vault_unavailable"
-    CAPABILITY_UNSUPPORTED = "capability_unsupported"
-    DEGRADED = "degraded"
 
 
 class UploadDegradeReason(enum.StrEnum):

--- a/backend/tests/routers/test_invitations.py
+++ b/backend/tests/routers/test_invitations.py
@@ -21,6 +21,8 @@ from domain.creek_vault import (
     VaultIngestResult,
     VaultReflection,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
 )
@@ -584,6 +586,10 @@ class _ThemeVaultClient:
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
         raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/backend/tests/services/test_invitations_service.py
+++ b/backend/tests/services/test_invitations_service.py
@@ -34,6 +34,8 @@ from domain.creek_vault import (
     VaultIngestResult,
     VaultReflection,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
 )
@@ -759,6 +761,10 @@ class _ThemeVaultClient:
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
         raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/backend/tests/test_creek_vault_domain.py
+++ b/backend/tests/test_creek_vault_domain.py
@@ -116,15 +116,19 @@ def test_tier_ceiling_keys_match_journal_classification_enum() -> None:
 
 
 class TestCreekCapability:
-    """Six wire-name capability members."""
+    """Seven wire-name capability members."""
 
-    def test_has_six_members(self) -> None:
-        """Exactly six capabilities are defined."""
-        assert len(CreekCapability) == 6
+    def test_has_seven_members(self) -> None:
+        """Exactly seven capabilities are defined."""
+        assert len(CreekCapability) == 7
 
     def test_handshake_value_is_wire_name(self) -> None:
         """HANDSHAKE's value is the creek.handshake wire name."""
         assert CreekCapability.HANDSHAKE.value == "creek.handshake"
+
+    def test_upload_value_is_wire_name(self) -> None:
+        """UPLOAD's value is the creek.upload wire name."""
+        assert CreekCapability.UPLOAD.value == "creek.upload"
 
     def test_journal_value_is_wire_name(self) -> None:
         """JOURNAL's value is the creek.journal wire name."""

--- a/backend/tests/test_creek_vault_reflect.py
+++ b/backend/tests/test_creek_vault_reflect.py
@@ -36,6 +36,8 @@ from domain.creek_vault import (
     VaultReflectionNote,
     VaultReflectionStatus,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelBalance,
 )
 from domain.resonance import ResonanceLLM, generate_marginalia
@@ -125,6 +127,10 @@ class RecordingVaultClient:
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Unused on the reflect path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
         raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/backend/tests/test_creek_vault_tenancy.py
+++ b/backend/tests/test_creek_vault_tenancy.py
@@ -45,6 +45,8 @@ from domain.creek_vault import (
     VaultReflectionNote,
     VaultReflectionStatus,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
     resolve_vault_owner,
@@ -376,6 +378,10 @@ class _SharedCorpusVaultClient:
         """Add the body to the one shared corpus and answer with a stored ref."""
         self.ingested_bodies.append(request.body)
         return VaultIngestResult(stored=True, vault_ref=f"vault-ref-{len(self.ingested_bodies)}")
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Raise: adepthood never calls classify, and a fake that answered would hide that."""

--- a/backend/tests/test_creek_vault_upload.py
+++ b/backend/tests/test_creek_vault_upload.py
@@ -1,0 +1,767 @@
+"""Tests for the Creek Vault upload seam (domain, HTTP adapter, and write service).
+
+This is the TDD RED suite for the document-upload path: a user hands adepthood
+one file, adepthood forwards the bytes to the vault's ``creek.upload``
+capability, and the vault -- not adepthood -- decides which ingestor parses it.
+
+Three layers are pinned here, in the order a request crosses them:
+
+1. :mod:`domain.creek_vault` -- the ``UPLOAD`` capability member, the frozen
+   request/result pair, and the promise that document bytes stay out of every
+   ``repr()``.
+2. :mod:`services.creek_vault_client` -- the HTTP adapter's capability gate,
+   its request shape, and the local-fallback no-op.
+3. :mod:`services.creek_vault_upload` -- the graceful-degradation orchestration
+   the router calls, which never raises a vault error.
+
+The endpoint sitting on top of all three is covered in
+``tests/test_journal_upload.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from collections.abc import AsyncGenerator, Callable
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekCapabilityUnsupportedError,
+    CreekVaultAuthError,
+    CreekVaultClient,
+    CreekVaultContractError,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultErrorCode,
+    VaultIngestAction,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultReflection,
+    VaultReflectionStatus,
+    VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
+    VaultWheelBalance,
+)
+from services.creek_vault_client import HttpCreekVaultClient, LocalFallbackCreekVaultClient
+from services.creek_vault_upload import (
+    UploadedDocument,
+    VaultUploadOutcome,
+    VaultUploadStatus,
+    store_upload,
+    upload_external_id,
+)
+from tests.test_creek_vault_http_client import Handler as _VaultHandler
+from tests.test_creek_vault_http_client import _handshake_payload as _vault_capability_payload
+
+_CREATED_AT = datetime(2026, 8, 8, 9, 30, tzinfo=UTC)
+
+_OWNER_ID = 7
+
+_FILENAME = "field-notes.pdf"
+
+_VAULT_URL = "https://vault.example.test"
+_VAULT_API_KEY = "creek-vault-upload-path-key"  # pragma: allowlist secret
+
+# The path prefix the adapter probes for capabilities, mirrored here so the
+# routed handler below can tell a handshake apart from the upload under test.
+_CAPABILITIES_SEGMENT = "/v1/capabilities"
+
+# Distinctive enough to spot anywhere it must not appear: a repr, a log record,
+# or an exception message. The bytes a user uploads are the most private thing
+# this seam touches, so "absent by construction" is asserted, not assumed.
+_SENTINEL_BYTES = b"SENTINEL_DOCUMENT_BYTES_DO_NOT_LOG"
+_CONTENT_B64 = base64.b64encode(_SENTINEL_BYTES).decode("ascii")
+_SENTINEL_B64_FRAGMENT = _CONTENT_B64[:16]
+
+_SENTINEL_ERROR_TEXT = "SENTINEL_VAULT_ERROR_TEXT_DO_NOT_LOG"
+
+_FRAGMENT_ID = "vault-fragment-upload-1"
+
+_VaultClientFactory = Callable[[_VaultHandler], httpx.AsyncClient]
+
+
+def _empty_reflection() -> VaultReflection:
+    """Return the reflection an unexercised reflect path answers with."""
+    return VaultReflection(
+        status=VaultReflectionStatus.EMPTY,
+        notes=(),
+        essay=None,
+        essay_grounded=False,
+        routed_tier=VaultTierCeiling.OPEN,
+    )
+
+
+class RecordingUploadClient:
+    """Fake :class:`CreekVaultClient` recording upload calls and returning scripted results.
+
+    Only the upload surface is scripted; every other capability answers the
+    inert value the upload path never consults, so a test that accidentally
+    reached one would fail on its assertion rather than on an attribute error.
+    """
+
+    def __init__(
+        self,
+        *,
+        capabilities: frozenset[CreekCapability] = frozenset(
+            {CreekCapability.JOURNAL, CreekCapability.UPLOAD}
+        ),
+        available: bool = True,
+        stored: bool = True,
+        tags: tuple[str, ...] = (),
+        upload_error: Exception | None = None,
+    ) -> None:
+        """Bind the advertised capabilities and the scripted upload answer."""
+        self.upload_calls: list[VaultUploadRequest] = []
+        self.handshake_calls = 0
+        self._capabilities = capabilities
+        self._available = available
+        self._stored = stored
+        self._tags = tags
+        self._upload_error = upload_error
+
+    async def handshake(self) -> HandshakeResult:
+        """Count the probe and report the configured availability."""
+        self.handshake_calls += 1
+        if not self._available:
+            return HandshakeResult.unavailable()
+        return HandshakeResult(
+            available=True,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Report the configured availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Report whether ``capability`` is in the configured advertised set."""
+        return capability in self._capabilities
+
+    async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Report not-stored -- the upload path never calls journal ingest."""
+        return VaultIngestResult(stored=False, vault_ref=None)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Record the request, then raise the scripted error or answer with the result."""
+        self.upload_calls.append(request)
+        if self._upload_error is not None:
+            raise self._upload_error
+        if not self._stored:
+            return VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
+        return VaultUploadResult(
+            stored=True,
+            vault_ref=_FRAGMENT_ID,
+            action=VaultIngestAction.CREATED,
+            tags=self._tags,
+        )
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Return no tags -- the upload path never calls classify."""
+        return VaultClassification(tags=())
+
+    async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultReflection:
+        """Return an empty reflection -- the upload path never calls reflect."""
+        return _empty_reflection()
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Return an empty balance -- the upload path never calls wheel."""
+        return VaultWheelBalance(aspects=())
+
+
+def _upload_request(*, filename: str = _FILENAME) -> VaultUploadRequest:
+    """Build a well-formed upload request for the adapter-level tests."""
+    return VaultUploadRequest(
+        external_id=upload_external_id(_OWNER_ID, filename),
+        filename=filename,
+        content_base64=_CONTENT_B64,
+        tier=VaultTierCeiling.PERSONAL,
+        tier_ceiling=VaultTierCeiling.PERSONAL,
+        created_at=_CREATED_AT,
+    )
+
+
+async def _store(
+    client: CreekVaultClient,
+    *,
+    classification: str = "personal",
+    filename: str = _FILENAME,
+) -> VaultUploadOutcome:
+    """Run the write service against a scripted client with the common arguments."""
+    return await store_upload(
+        client,
+        UploadedDocument(
+            owner_user_id=_OWNER_ID,
+            filename=filename,
+            content_base64=_CONTENT_B64,
+            classification=classification,
+            created_at=_CREATED_AT,
+        ),
+    )
+
+
+class TestUploadCapability:
+    """The vault capability vocabulary gains exactly one new, correctly-spelled member."""
+
+    def test_upload_capability_has_the_wire_name_creek_upload(self) -> None:
+        """The member's value is contract: it is what a vault advertises."""
+        assert CreekCapability.UPLOAD.value == "creek.upload"
+
+    def test_advertising_journal_does_not_advertise_upload(self) -> None:
+        """The two are separately advertised: taking entries implies nothing about files."""
+        journal_only = frozenset({CreekCapability.JOURNAL})
+        assert CreekCapability.UPLOAD not in journal_only
+
+
+class TestUploadRequestPrivacy:
+    """Document bytes never reach a repr, a str, or anything built from one."""
+
+    def test_repr_omits_the_document_bytes(self) -> None:
+        """``repr()`` of a request must not carry the base64 payload."""
+        assert _SENTINEL_B64_FRAGMENT not in repr(_upload_request())
+
+    def test_repr_still_identifies_the_upload(self) -> None:
+        """Suppressing the payload must not blind an operator to which upload it was."""
+        assert _FILENAME in repr(_upload_request())
+
+    def test_request_is_frozen(self) -> None:
+        """A built request cannot mutate between construction and the wire."""
+        request = _upload_request()
+        with pytest.raises(AttributeError):
+            request.filename = "other.pdf"  # type: ignore[misc]
+
+
+class TestExternalId:
+    """The external id is a stable, idempotent function of the upload's identity."""
+
+    def test_same_owner_and_filename_yield_the_same_id(self) -> None:
+        """A re-send must address the same fragment so the vault edits in place."""
+        assert upload_external_id(_OWNER_ID, _FILENAME) == upload_external_id(_OWNER_ID, _FILENAME)
+
+    def test_different_filenames_yield_different_ids(self) -> None:
+        """Two documents from one user are two fragments, not one overwritten twice."""
+        assert upload_external_id(_OWNER_ID, _FILENAME) != upload_external_id(
+            _OWNER_ID, "other.pdf"
+        )
+
+    def test_different_owners_yield_different_ids(self) -> None:
+        """One user's upload must never address another user's fragment."""
+        assert upload_external_id(_OWNER_ID, _FILENAME) != upload_external_id(
+            _OWNER_ID + 1, _FILENAME
+        )
+
+    def test_id_does_not_embed_the_filename(self) -> None:
+        """The id travels in a URL; a filename is the user's words and stays out of it."""
+        assert _FILENAME not in upload_external_id(_OWNER_ID, _FILENAME)
+
+    def test_id_is_a_single_inert_url_segment(self) -> None:
+        """Nothing in the id can climb out of its path segment or need escaping."""
+        generated = upload_external_id(_OWNER_ID, _FILENAME)
+        assert generated
+        assert all(character.isalnum() or character == "-" for character in generated)
+
+
+class TestStoreUploadDegradation:
+    """The write service answers with a status for every vault condition, never a raise."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_reports_accepted_with_the_vault_ref(self) -> None:
+        """A durable upload carries the fragment id back for the response."""
+        outcome = await _store(RecordingUploadClient())
+        assert outcome.status is VaultUploadStatus.ACCEPTED
+        assert outcome.vault_ref == _FRAGMENT_ID
+
+    @pytest.mark.asyncio
+    async def test_happy_path_forwards_filename_and_bytes_unparsed(self) -> None:
+        """Adepthood hands over the file; the vault picks the ingestor from the name."""
+        client = RecordingUploadClient()
+        await _store(client)
+        assert client.upload_calls[0].filename == _FILENAME
+        assert client.upload_calls[0].content_base64 == _CONTENT_B64
+
+    @pytest.mark.asyncio
+    async def test_happy_path_labels_the_request_at_the_writers_tier(self) -> None:
+        """Both tier and ceiling are the writer's own tier, as journal ingest does."""
+        client = RecordingUploadClient()
+        await _store(client)
+        assert client.upload_calls[0].tier is VaultTierCeiling.PERSONAL
+        assert client.upload_calls[0].tier_ceiling is VaultTierCeiling.PERSONAL
+
+    @pytest.mark.asyncio
+    async def test_tags_are_empty_until_the_vault_returns_them(self) -> None:
+        """Per-fragment tags depend on unshipped upstream work; empty is the truth today."""
+        outcome = await _store(RecordingUploadClient())
+        assert outcome.tags == ()
+
+    @pytest.mark.asyncio
+    async def test_tags_are_carried_through_when_the_vault_supplies_them(self) -> None:
+        """When the vault does classify in-pipeline, adepthood keeps what it said."""
+        outcome = await _store(RecordingUploadClient(tags=("courage", "threshold")))
+        assert outcome.tags == ("courage", "threshold")
+
+    @pytest.mark.asyncio
+    async def test_capability_absent_degrades_without_calling_upload(self) -> None:
+        """A journal-only vault must degrade, not attempt a call it never advertised."""
+        client = RecordingUploadClient(capabilities=frozenset({CreekCapability.JOURNAL}))
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.CAPABILITY_UNSUPPORTED
+        assert client.upload_calls == []
+
+    @pytest.mark.asyncio
+    async def test_unavailable_vault_degrades_to_vault_unavailable(self) -> None:
+        """An unreachable vault is a distinct outcome from one that cannot upload."""
+        client = RecordingUploadClient(available=False)
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.VAULT_UNAVAILABLE
+        assert client.upload_calls == []
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_degrades_rather_than_raising(self) -> None:
+        """A vault error is absorbed: the caller gets a status, never an exception."""
+        client = RecordingUploadClient(
+            upload_error=CreekVaultUnavailableError(_SENTINEL_ERROR_TEXT)
+        )
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.DEGRADED
+        assert outcome.vault_ref is None
+
+    @pytest.mark.asyncio
+    async def test_contract_failure_degrades_rather_than_raising(self) -> None:
+        """A refused request is our defect to fix, and still must not reach the user as a 500."""
+        client = RecordingUploadClient(upload_error=CreekVaultContractError(_SENTINEL_ERROR_TEXT))
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_degrades_rather_than_raising(self) -> None:
+        """A rejected credential is an operator's problem, not the uploader's crash."""
+        client = RecordingUploadClient(upload_error=CreekVaultAuthError(_SENTINEL_ERROR_TEXT))
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_capability_error_raised_mid_call_degrades(self) -> None:
+        """A vault withdrawing the capability between handshake and call still degrades."""
+        client = RecordingUploadClient(
+            upload_error=CreekCapabilityUnsupportedError(_SENTINEL_ERROR_TEXT)
+        )
+        outcome = await _store(client)
+        assert outcome.status is VaultUploadStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_not_stored_result_degrades_rather_than_inventing_a_ref(self) -> None:
+        """A vault that answered without storing must not look like a success."""
+        outcome = await _store(RecordingUploadClient(stored=False))
+        assert outcome.status is VaultUploadStatus.DEGRADED
+        assert outcome.vault_ref is None
+
+
+class TestStoreUploadIntimateFloor:
+    """An intimate document never crosses the seam, and is never rerouted anywhere.
+
+    ADR 0004 Decision 6 records that every intimate-transit sub-decision is
+    entirely unshipped, so today's rule is skip-only: an intimate
+    classification short-circuits before any vault call at all, exactly as the
+    journal write path does.
+    """
+
+    @pytest.mark.asyncio
+    async def test_intimate_short_circuits_before_any_vault_call(self) -> None:
+        """Not even a handshake: the intimate-transit channel does not exist yet."""
+        client = RecordingUploadClient()
+        outcome = await _store(client, classification="intimate")
+        assert outcome.status is VaultUploadStatus.SKIPPED_INTIMATE
+        assert client.upload_calls == []
+        assert client.handshake_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_intimate_carries_no_vault_ref_or_tags(self) -> None:
+        """Nothing was stored, so there is no handle and no classification to hand back."""
+        outcome = await _store(RecordingUploadClient(), classification="intimate")
+        assert outcome.vault_ref is None
+        assert outcome.tags == ()
+
+    @pytest.mark.asyncio
+    async def test_unknown_classification_fails_closed(self) -> None:
+        """An unrecognized tier must never widen to OPEN; it raises instead."""
+        with pytest.raises(ValueError, match="classification"):
+            await _store(RecordingUploadClient(), classification="not-a-tier")
+
+
+class TestStoreUploadLogging:
+    """A degraded upload is countable without any of it being readable."""
+
+    async def _degraded_records(
+        self, caplog: pytest.LogCaptureFixture, *, filename: str = _FILENAME
+    ) -> None:
+        """Run one degrading upload with WARNING capture enabled."""
+        client = RecordingUploadClient(
+            upload_error=CreekVaultUnavailableError(_SENTINEL_ERROR_TEXT)
+        )
+        with caplog.at_level(logging.WARNING):
+            await _store(client, filename=filename)
+
+    @pytest.mark.asyncio
+    async def test_degrade_log_omits_the_document_bytes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The payload is the one thing a failure log must never quote."""
+        await self._degraded_records(caplog)
+        assert _SENTINEL_B64_FRAGMENT not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_degrade_log_omits_the_vaults_own_error_text(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A vault must not be able to choose what text lands in an operator's log."""
+        await self._degraded_records(caplog)
+        assert _SENTINEL_ERROR_TEXT not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_degrade_log_omits_the_filename(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A filename is the user's own words about their life; it stays out of logs."""
+        await self._degraded_records(caplog, filename="my-divorce-settlement.pdf")
+        assert "divorce" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_degrade_log_names_the_capability_and_a_reason(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """What an operator needs -- which capability, which reason -- is still recorded."""
+        await self._degraded_records(caplog)
+        record = next(r for r in caplog.records if r.levelno == logging.WARNING)
+        assert getattr(record, "capability", None) == CreekCapability.UPLOAD.value
+        assert getattr(record, "reason", None)
+
+    @pytest.mark.asyncio
+    async def test_a_coded_contract_error_logs_its_code(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A code adepthood recognizes is the one vault-derived value worth recording.
+
+        Safe precisely because it is not vault-chosen *text*: the adapter drops any
+        code outside :class:`~domain.creek_vault.VaultErrorCode` before it gets
+        here, so what reaches the log is always one of our own enum values.
+        """
+        client = RecordingUploadClient(
+            upload_error=CreekVaultContractError(
+                _SENTINEL_ERROR_TEXT, code=VaultErrorCode.INVALID_REQUEST
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            await _store(client)
+
+        record = next(r for r in caplog.records if r.levelno == logging.WARNING)
+        assert getattr(record, "code", None) == VaultErrorCode.INVALID_REQUEST.value
+        assert _SENTINEL_ERROR_TEXT not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_an_uncoded_contract_error_logs_no_code_field(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No code means the vault named none -- inventing one would fabricate a fact."""
+        client = RecordingUploadClient(upload_error=CreekVaultContractError(_SENTINEL_ERROR_TEXT))
+        with caplog.at_level(logging.WARNING):
+            await _store(client)
+
+        record = next(r for r in caplog.records if r.levelno == logging.WARNING)
+        assert not hasattr(record, "code")
+
+
+def _routed_handler(
+    upload_payload: object,
+    *,
+    capabilities: list[str] | None = None,
+    upload_status: int = HTTPStatus.OK,
+    upload_error: Exception | None = None,
+    upload_text: str | None = None,
+) -> _VaultHandler:
+    """Answer the capability probe with a handshake and everything else as the upload.
+
+    The shared helpers in ``test_creek_vault_http_client`` answer *every*
+    request identically, which cannot express "handshake succeeded, then the
+    upload did X" -- the two-step shape every adapter test here needs.
+    """
+    advertised = capabilities or [CreekCapability.JOURNAL.value, CreekCapability.UPLOAD.value]
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        """Route the capability probe to the handshake payload, all else to the upload."""
+        if request.url.path.endswith(_CAPABILITIES_SEGMENT):
+            return httpx.Response(
+                HTTPStatus.OK, json=_vault_capability_payload(capabilities=advertised)
+            )
+        if upload_error is not None:
+            raise upload_error
+        if upload_text is not None:
+            return httpx.Response(upload_status, text=upload_text)
+        return httpx.Response(upload_status, json=upload_payload)
+
+    return _handle
+
+
+@pytest_asyncio.fixture
+async def vault_http_clients() -> AsyncGenerator[_VaultClientFactory, None]:
+    """Yield a factory for MockTransport-backed clients, closing each afterwards."""
+    created: list[httpx.AsyncClient] = []
+
+    def _build(handler: _VaultHandler) -> httpx.AsyncClient:
+        """Build one in-memory client and register it for teardown."""
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        created.append(client)
+        return client
+
+    yield _build
+    for client in created:
+        await client.aclose()
+
+
+def _stored_payload(
+    action: str = VaultIngestAction.CREATED.value, **extra: object
+) -> dict[str, object]:
+    """Build the 2xx body a vault answers a durable upload with."""
+    return {"action": action, "fragment_id": _FRAGMENT_ID, **extra}
+
+
+class TestHttpClientUpload:
+    """The HTTP adapter gates on the capability and sends the ratified upload shape."""
+
+    @pytest.mark.asyncio
+    async def test_upload_is_refused_locally_when_capability_absent(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """No document bytes reach the wire toward a surface that never claimed them."""
+        seen: list[httpx.Request] = []
+        handler = _routed_handler(_stored_payload(), capabilities=[CreekCapability.JOURNAL.value])
+
+        def _record(request: httpx.Request) -> httpx.Response:
+            """Record the request before answering it."""
+            seen.append(request)
+            return handler(request)
+
+        client = HttpCreekVaultClient(
+            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
+        )
+        await client.handshake()
+        before = len(seen)
+
+        with pytest.raises(CreekCapabilityUnsupportedError):
+            await client.upload(_upload_request())
+
+        assert len(seen) == before
+
+    @pytest.mark.asyncio
+    async def test_upload_sends_filename_bytes_tier_and_timestamp(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """The vault needs all four to select an ingestor and store at the right tier."""
+        seen: list[httpx.Request] = []
+        handler = _routed_handler(_stored_payload())
+
+        def _record(request: httpx.Request) -> httpx.Response:
+            """Record the request before answering it."""
+            seen.append(request)
+            return handler(request)
+
+        client = HttpCreekVaultClient(
+            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
+        )
+        await client.handshake()
+        await client.upload(_upload_request())
+
+        body = json.loads(seen[-1].content)
+        assert body["filename"] == _FILENAME
+        assert body["content_base64"] == _CONTENT_B64
+        assert body["tier"] == VaultTierCeiling.PERSONAL.value
+        assert body["timestamp"] == _CREATED_AT.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_upload_addresses_the_fragment_by_external_id(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """Keying off the stable id is what makes a re-send edit in place."""
+        seen: list[httpx.Request] = []
+        handler = _routed_handler(_stored_payload(VaultIngestAction.UPDATED.value))
+
+        def _record(request: httpx.Request) -> httpx.Response:
+            """Record the request before answering it."""
+            seen.append(request)
+            return handler(request)
+
+        client = HttpCreekVaultClient(
+            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
+        )
+        await client.handshake()
+        request = _upload_request()
+        await client.upload(request)
+
+        assert seen[-1].url.path.endswith(request.external_id)
+
+    @pytest.mark.asyncio
+    async def test_durable_upload_reports_stored_with_the_fragment_id(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """A recognized action plus a usable id is the only shape counted as stored."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(_routed_handler(_stored_payload())),
+        )
+        await client.handshake()
+
+        result = await client.upload(_upload_request())
+
+        assert result == VaultUploadResult(
+            stored=True, vault_ref=_FRAGMENT_ID, action=VaultIngestAction.CREATED, tags=()
+        )
+
+    @pytest.mark.asyncio
+    async def test_upload_reads_per_fragment_tags_when_the_vault_sends_them(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """The vault classifies in-pipeline; adepthood reads its answer, never re-derives it."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler(_stored_payload(tags=["courage", "threshold"]))
+            ),
+        )
+        await client.handshake()
+
+        result = await client.upload(_upload_request())
+
+        assert result.tags == ("courage", "threshold")
+
+    @pytest.mark.asyncio
+    async def test_unreadable_tags_drop_to_empty_rather_than_raising(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """A wrong-typed tag list is dropped on the floor, exactly as capabilities are."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler(_stored_payload(tags=[{"not": "a string"}, 7]))
+            ),
+        )
+        await client.handshake()
+
+        result = await client.upload(_upload_request())
+
+        assert result.tags == ()
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_action_reports_not_stored(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """Reporting a write we cannot verify would let a lost document look replicated."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(_routed_handler(_stored_payload("teleported"))),
+        )
+        await client.handshake()
+
+        result = await client.upload(_upload_request())
+
+        assert result.stored is False
+
+    @pytest.mark.asyncio
+    async def test_undecodable_success_body_is_an_unavailable_vault(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """A proxy error page served as 200 is not a successful upload."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler(None, upload_text="<html>not json</html>")
+            ),
+        )
+        await client.handshake()
+
+        with pytest.raises(CreekVaultUnavailableError):
+            await client.upload(_upload_request())
+
+    @pytest.mark.asyncio
+    async def test_rejected_request_raises_a_contract_error(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """A 4xx that is not retryable blames the request adepthood sent."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler(
+                    {"error": {"code": "invalid_request"}}, upload_status=HTTPStatus.BAD_REQUEST
+                )
+            ),
+        )
+        await client.handshake()
+
+        with pytest.raises(CreekVaultContractError):
+            await client.upload(_upload_request())
+
+    @pytest.mark.asyncio
+    async def test_refused_credential_raises_an_auth_error(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """A rejected bearer is a configuration fault with its own remedy."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler({}, upload_status=HTTPStatus.UNAUTHORIZED)
+            ),
+        )
+        await client.handshake()
+
+        with pytest.raises(CreekVaultAuthError):
+            await client.upload(_upload_request())
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_raises_unavailable_without_the_payload(
+        self, vault_http_clients: _VaultClientFactory
+    ) -> None:
+        """The original exception's text may quote the URL or the bytes; neither rides along."""
+        client = HttpCreekVaultClient(
+            _VAULT_URL,
+            _VAULT_API_KEY,
+            http_client=vault_http_clients(
+                _routed_handler(None, upload_error=httpx.ConnectError(_SENTINEL_ERROR_TEXT))
+            ),
+        )
+        await client.handshake()
+
+        with pytest.raises(CreekVaultUnavailableError) as caught:
+            await client.upload(_upload_request())
+
+        assert _SENTINEL_ERROR_TEXT not in str(caught.value)
+        assert caught.value.__cause__ is None
+
+
+class TestLocalFallbackUpload:
+    """With no vault configured, an upload is a silent no-op rather than an error."""
+
+    @pytest.mark.asyncio
+    async def test_upload_reports_not_stored_without_raising(self) -> None:
+        """Postgres stays the system of record; there is simply nowhere to put the file."""
+        result = await LocalFallbackCreekVaultClient().upload(_upload_request())
+        assert result == VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
+
+    @pytest.mark.asyncio
+    async def test_fallback_never_advertises_the_upload_capability(self) -> None:
+        """The write service's gate must see "unsupported" and degrade before calling."""
+        assert LocalFallbackCreekVaultClient().supports(CreekCapability.UPLOAD) is False

--- a/backend/tests/test_creek_vault_upload.py
+++ b/backend/tests/test_creek_vault_upload.py
@@ -50,13 +50,13 @@ from domain.creek_vault import (
     VaultTierCeiling,
     VaultUploadRequest,
     VaultUploadResult,
+    VaultUploadStatus,
     VaultWheelBalance,
 )
 from services.creek_vault_client import HttpCreekVaultClient, LocalFallbackCreekVaultClient
 from services.creek_vault_upload import (
     UploadedDocument,
     VaultUploadOutcome,
-    VaultUploadStatus,
     store_upload,
     upload_external_id,
 )

--- a/backend/tests/test_creek_vault_upload.py
+++ b/backend/tests/test_creek_vault_upload.py
@@ -368,30 +368,43 @@ class TestStoreUploadDegradation:
         assert outcome.vault_ref is None
 
 
-class TestStoreUploadIntimateFloor:
-    """An intimate document never crosses the seam, and is never rerouted anywhere.
+class TestStoreUploadIntimateTier:
+    """An intimate document goes to the vault, at the intimate tier, and nowhere else.
 
-    ADR 0004 Decision 6 records that every intimate-transit sub-decision is
-    entirely unshipped, so today's rule is skip-only: an intimate
-    classification short-circuits before any vault call at all, exactly as the
-    journal write path does.
+    The vault is the user's own corpus behind one operator-held
+    ``CREEK_VAULT_URL``, not a third-party service, so reaching it is not the
+    cloud disclosure the privacy floor guards against -- and this path calls no
+    LLM at all. Ratified as an amendment to Decision 6 of
+    ``docs/adr/0004-creek-vault-http-application-boundary.md``.
     """
 
     @pytest.mark.asyncio
-    async def test_intimate_short_circuits_before_any_vault_call(self) -> None:
-        """Not even a handshake: the intimate-transit channel does not exist yet."""
+    async def test_intimate_is_forwarded_to_the_vault(self) -> None:
+        """The document reaches the vault like any other classification."""
         client = RecordingUploadClient()
         outcome = await _store(client, classification="intimate")
-        assert outcome.status is VaultUploadStatus.SKIPPED_INTIMATE
-        assert client.upload_calls == []
-        assert client.handshake_calls == 0
+        assert outcome.status is VaultUploadStatus.ACCEPTED
+        assert len(client.upload_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_intimate_carries_no_vault_ref_or_tags(self) -> None:
-        """Nothing was stored, so there is no handle and no classification to hand back."""
-        outcome = await _store(RecordingUploadClient(), classification="intimate")
-        assert outcome.vault_ref is None
-        assert outcome.tags == ()
+    async def test_intimate_is_labelled_at_the_intimate_tier(self) -> None:
+        """Never widened so a call can succeed: the vault stores at the chosen depth."""
+        client = RecordingUploadClient()
+        await _store(client, classification="intimate")
+        assert client.upload_calls[0].tier is VaultTierCeiling.INTIMATE
+        assert client.upload_calls[0].tier_ceiling is VaultTierCeiling.INTIMATE
+
+    @pytest.mark.asyncio
+    async def test_a_vault_refusing_the_intimate_tier_degrades_honestly(self) -> None:
+        """A refused ceiling must not be retried at a lower one to force a success."""
+        client = RecordingUploadClient(
+            upload_error=CreekVaultContractError(
+                _SENTINEL_ERROR_TEXT, code=VaultErrorCode.PRIVACY_REFUSED
+            )
+        )
+        outcome = await _store(client, classification="intimate")
+        assert outcome.status is VaultUploadStatus.DEGRADED
+        assert len(client.upload_calls) == 1
 
     @pytest.mark.asyncio
     async def test_unknown_classification_fails_closed(self) -> None:

--- a/backend/tests/test_creek_vault_wheel.py
+++ b/backend/tests/test_creek_vault_wheel.py
@@ -34,6 +34,8 @@ from domain.creek_vault import (
     VaultIngestResult,
     VaultReflection,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
 )
@@ -132,6 +134,10 @@ class RecordingWheelVaultClient:
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
         raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/backend/tests/test_creek_vault_write.py
+++ b/backend/tests/test_creek_vault_write.py
@@ -34,6 +34,8 @@ from domain.creek_vault import (
     VaultReflection,
     VaultReflectionStatus,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelBalance,
 )
 from services.creek_vault_client import HttpCreekVaultClient, LocalFallbackCreekVaultClient
@@ -133,6 +135,10 @@ class RecordingVaultClient:
         if isinstance(self._ingest, Exception):
             raise self._ingest
         return self._ingest
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Record the classify call, then raise or return the scripted result."""

--- a/backend/tests/test_journal_upload.py
+++ b/backend/tests/test_journal_upload.py
@@ -46,7 +46,8 @@ from domain.creek_vault import (
     VaultWheelBalance,
 )
 from main import app
-from routers.journal import _UPLOAD_MESSAGES
+from routers.journal import _UPLOAD_MESSAGES, UPLOAD_RATE_LIMIT
+from routers.transcription import TRANSCRIBE_RATE_LIMIT
 from schemas.journal_upload import MAX_UPLOAD_BASE64_CHARS
 
 _SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
@@ -500,6 +501,18 @@ class TestUploadTiering:
         stamped = vault.upload_calls[0].created_at
         assert stamped.tzinfo is not None
         assert stamped >= before
+
+
+class TestUploadIsRateLimited:
+    """The endpoint is bounded, and bounded deliberately rather than by omission."""
+
+    def test_the_endpoint_declares_a_rate_limit(self) -> None:
+        """An unbounded 10 MB endpoint that calls an external dependency is an abuse lever."""
+        assert UPLOAD_RATE_LIMIT
+
+    def test_the_limit_matches_the_other_base64_payload_endpoint(self) -> None:
+        """Same class of endpoint, same bound -- so the two cannot drift apart silently."""
+        assert UPLOAD_RATE_LIMIT == TRANSCRIBE_RATE_LIMIT
 
 
 class TestUploadMessagesAreExhaustive:

--- a/backend/tests/test_journal_upload.py
+++ b/backend/tests/test_journal_upload.py
@@ -10,7 +10,8 @@ Four properties are pinned here that no lower layer can guarantee alone:
 
 - Every vault condition answers 202 with a distinguishable status, never a 500.
 - An oversized document is refused by size *before* its bytes are decoded.
-- An intimate document is withheld, and told so, rather than rerouted.
+- An intimate document is forwarded at its own tier, and is not rerouted
+  anywhere when the vault is unreachable.
 - A rejection never echoes the document back through the error envelope.
 """
 
@@ -41,11 +42,12 @@ from domain.creek_vault import (
     VaultTierCeiling,
     VaultUploadRequest,
     VaultUploadResult,
+    VaultUploadStatus,
     VaultWheelBalance,
 )
 from main import app
+from routers.journal import _UPLOAD_MESSAGES
 from schemas.journal_upload import MAX_UPLOAD_BASE64_CHARS
-from services.creek_vault_upload import VaultUploadStatus
 
 _SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
 
@@ -498,6 +500,28 @@ class TestUploadTiering:
         stamped = vault.upload_calls[0].created_at
         assert stamped.tzinfo is not None
         assert stamped >= before
+
+
+class TestUploadMessagesAreExhaustive:
+    """Every status the service can return has a sentence to show the user.
+
+    The router looks the message up unconditionally, so a status added to
+    :class:`VaultUploadStatus` without a matching entry would raise ``KeyError``
+    inside the handler and answer a 500 -- on the one path whose whole design is
+    that it never 500s. Today the mapping is complete; this makes that a
+    guarantee rather than a coincidence.
+    """
+
+    def test_every_status_has_a_message(self) -> None:
+        """A missing entry is a 500 on a path that must never 500."""
+        assert set(_UPLOAD_MESSAGES) == set(VaultUploadStatus)
+
+    @pytest.mark.parametrize("status", list(VaultUploadStatus))
+    def test_no_message_sends_the_user_to_support(self, status: VaultUploadStatus) -> None:
+        """Each outcome names a next step the user can take themselves."""
+        message = _UPLOAD_MESSAGES[status]
+        assert message.strip()
+        assert "contact support" not in message.lower()
 
 
 def _as_vault_client(client: CreekVaultClient) -> CreekVaultClient:

--- a/backend/tests/test_journal_upload.py
+++ b/backend/tests/test_journal_upload.py
@@ -334,32 +334,32 @@ class TestUploadDegradation:
         assert len(vault.upload_calls) <= 1
 
 
-class TestUploadIntimateFloor:
-    """An intimate document is withheld and said so, never quietly rerouted."""
+class TestUploadIntimateTier:
+    """An intimate document reaches the vault, at its own tier, and nothing else."""
 
     @pytest.mark.asyncio
-    async def test_intimate_is_withheld_from_the_vault(
+    async def test_intimate_is_forwarded_to_the_vault(
         self, async_client: AsyncClient, vault: ScriptedUploadClient
     ) -> None:
-        """ADR 0004 Decision 6: the intimate-transit channel is entirely unshipped."""
+        """The vault is the user's own corpus, not the cloud the privacy floor guards."""
         headers = await _signup(async_client, "uploader-intimate")
         response = await async_client.post(
             _UPLOAD_PATH, json=_payload(classification="intimate"), headers=headers
         )
-        assert response.json()["status"] == VaultUploadStatus.SKIPPED_INTIMATE.value
-        assert vault.upload_calls == []
+        assert response.json()["status"] == VaultUploadStatus.ACCEPTED.value
+        assert vault.upload_calls[0].tier is VaultTierCeiling.INTIMATE
 
     @pytest.mark.parametrize("vault", [{"available": False}], indirect=True)
     @pytest.mark.asyncio
-    async def test_intimate_is_withheld_even_when_the_vault_is_unreachable(
+    async def test_intimate_is_not_rerouted_when_the_vault_is_unreachable(
         self, async_client: AsyncClient, vault: ScriptedUploadClient
     ) -> None:
-        """An unreachable vault must not become an excuse to route the document elsewhere."""
+        """An unreachable vault is an honest failure, never a reason to send it elsewhere."""
         headers = await _signup(async_client, "uploader-intimate-down")
         response = await async_client.post(
             _UPLOAD_PATH, json=_payload(classification="intimate"), headers=headers
         )
-        assert response.json()["status"] == VaultUploadStatus.SKIPPED_INTIMATE.value
+        assert response.json()["status"] == VaultUploadStatus.VAULT_UNAVAILABLE.value
         assert vault.upload_calls == []
 
 

--- a/backend/tests/test_journal_upload.py
+++ b/backend/tests/test_journal_upload.py
@@ -1,0 +1,515 @@
+"""Integration tests for ``POST /journal/upload``, the document upload endpoint.
+
+These drive the real endpoint against a scripted vault client to pin what the
+router owes the person uploading a file. An upload has no local system of
+record -- unlike a journal entry, which is already in Postgres before the vault
+is ever asked -- so every one of these outcomes is the *whole* answer the user
+gets, and each has to be honest and actionable on its own.
+
+Four properties are pinned here that no lower layer can guarantee alone:
+
+- Every vault condition answers 202 with a distinguishable status, never a 500.
+- An oversized document is refused by size *before* its bytes are decoded.
+- An intimate document is withheld, and told so, rather than rerouted.
+- A rejection never echoes the document back through the error envelope.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from http import HTTPStatus
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from dependencies.creek_vault import get_creek_vault_client
+from domain.creek_vault import (
+    CONTRACT_VERSION,
+    CreekCapability,
+    CreekVaultClient,
+    CreekVaultUnavailableError,
+    HandshakeResult,
+    VaultClassification,
+    VaultIngestAction,
+    VaultIngestRequest,
+    VaultIngestResult,
+    VaultReflection,
+    VaultReflectionStatus,
+    VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
+    VaultWheelBalance,
+)
+from main import app
+from schemas.journal_upload import MAX_UPLOAD_BASE64_CHARS
+from services.creek_vault_upload import VaultUploadStatus
+
+_SIGNUP_PASSWORD = "secret12345"  # pragma: allowlist secret
+
+_UPLOAD_PATH = "/journal/upload"
+
+_FILENAME = "field-notes.pdf"
+
+_DOCUMENT_BYTES = b"%PDF-1.7 a page of field notes"
+_CONTENT_B64 = base64.b64encode(_DOCUMENT_BYTES).decode("ascii")
+
+_FRAGMENT_ID = "vault-fragment-upload-1"
+
+
+def _empty_reflection() -> VaultReflection:
+    """Return the reflection an unexercised reflect path answers with."""
+    return VaultReflection(
+        status=VaultReflectionStatus.EMPTY,
+        notes=(),
+        essay=None,
+        essay_grounded=False,
+        routed_tier=VaultTierCeiling.OPEN,
+    )
+
+
+class ScriptedUploadClient:
+    """Fake :class:`CreekVaultClient` whose upload surface is scripted per test."""
+
+    def __init__(
+        self,
+        *,
+        capabilities: frozenset[CreekCapability] = frozenset(
+            {CreekCapability.JOURNAL, CreekCapability.UPLOAD}
+        ),
+        available: bool = True,
+        stored: bool = True,
+        tags: tuple[str, ...] = (),
+        upload_error: Exception | None = None,
+    ) -> None:
+        """Bind the advertised capabilities and the scripted upload answer."""
+        self.upload_calls: list[VaultUploadRequest] = []
+        self._capabilities = capabilities
+        self._available = available
+        self._stored = stored
+        self._tags = tags
+        self._upload_error = upload_error
+
+    async def handshake(self) -> HandshakeResult:
+        """Report the configured availability and capability set."""
+        if not self._available:
+            return HandshakeResult.unavailable()
+        return HandshakeResult(
+            available=True,
+            contract_version=CONTRACT_VERSION,
+            ontology_version="1.0.0",
+            capabilities=self._capabilities,
+            attestation=None,
+        )
+
+    def is_available(self) -> bool:
+        """Report the configured availability."""
+        return self._available
+
+    def supports(self, capability: CreekCapability, /) -> bool:
+        """Report whether ``capability`` is in the configured advertised set."""
+        return capability in self._capabilities
+
+    async def ingest(self, _request: VaultIngestRequest, /) -> VaultIngestResult:
+        """Report not-stored -- the upload endpoint never calls journal ingest."""
+        return VaultIngestResult(stored=False, vault_ref=None)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Record the request, then raise the scripted error or answer with the result."""
+        self.upload_calls.append(request)
+        if self._upload_error is not None:
+            raise self._upload_error
+        if not self._stored:
+            return VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
+        return VaultUploadResult(
+            stored=True,
+            vault_ref=_FRAGMENT_ID,
+            action=VaultIngestAction.CREATED,
+            tags=self._tags,
+        )
+
+    async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
+        """Return no tags -- the upload endpoint never calls classify."""
+        return VaultClassification(tags=())
+
+    async def reflect(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultReflection:
+        """Return an empty reflection -- the upload endpoint never calls reflect."""
+        return _empty_reflection()
+
+    async def wheel(self) -> VaultWheelBalance:
+        """Return an empty balance -- the upload endpoint never calls wheel."""
+        return VaultWheelBalance(aspects=())
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Sign up a fresh user and return an Authorization header for it."""
+    response = await client.post(
+        "/auth/signup",
+        json={"email": f"{username}@example.com", "password": _SIGNUP_PASSWORD},
+    )
+    assert response.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+@pytest_asyncio.fixture
+async def vault(request: pytest.FixtureRequest) -> AsyncGenerator[ScriptedUploadClient, None]:
+    """Install a scripted vault client as the endpoint's dependency for one test.
+
+    Parameterized through ``indirect``: a test that needs a degrading vault names
+    the keyword arguments the client should be built from.
+    """
+    kwargs = getattr(request, "param", {})
+    client = ScriptedUploadClient(**kwargs)
+    app.dependency_overrides[get_creek_vault_client] = lambda: client
+    yield client
+    app.dependency_overrides.pop(get_creek_vault_client, None)
+
+
+def _payload(
+    *,
+    filename: str = _FILENAME,
+    content_base64: str = _CONTENT_B64,
+    classification: str = "personal",
+) -> dict[str, str]:
+    """Build a request body with per-test overrides."""
+    return {
+        "filename": filename,
+        "content_base64": content_base64,
+        "classification": classification,
+    }
+
+
+class TestUploadAcceptance:
+    """A reachable, upload-capable vault takes the document and says so."""
+
+    @pytest.mark.asyncio
+    async def test_accepted_upload_answers_202(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """202: the vault has it, and nothing further is pending on this request."""
+        headers = await _signup(async_client, "uploader-accept")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.status_code == HTTPStatus.ACCEPTED
+        assert response.json()["status"] == VaultUploadStatus.ACCEPTED.value
+        assert len(vault.upload_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_accepted_upload_returns_the_vault_ref(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """The fragment handle is how a client can later refer to what it sent."""
+        headers = await _signup(async_client, "uploader-ref")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["vault_ref"] == _FRAGMENT_ID
+        assert vault.upload_calls[0].external_id
+
+    @pytest.mark.asyncio
+    async def test_tags_are_empty_until_the_vault_returns_them(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Empty is the correct answer today, not a failure -- pinned so it stays honest."""
+        headers = await _signup(async_client, "uploader-tags-empty")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["tags"] == []
+        assert len(vault.upload_calls) == 1
+
+    @pytest.mark.parametrize("vault", [{"tags": ("courage", "threshold")}], indirect=True)
+    @pytest.mark.asyncio
+    async def test_vault_supplied_tags_are_returned_verbatim(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """The vault classifies in-pipeline; adepthood never builds a second classifier."""
+        headers = await _signup(async_client, "uploader-tags")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["tags"] == ["courage", "threshold"]
+        assert len(vault.upload_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_document_is_forwarded_unparsed(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Adepthood hands over bytes and a name; it never parses the file itself."""
+        headers = await _signup(async_client, "uploader-forward")
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert vault.upload_calls[0].filename == _FILENAME
+        assert vault.upload_calls[0].content_base64 == _CONTENT_B64
+
+    @pytest.mark.asyncio
+    async def test_resending_the_same_document_addresses_one_fragment(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Idempotence: a re-send edits the fragment in place instead of duplicating it."""
+        headers = await _signup(async_client, "uploader-idempotent")
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert vault.upload_calls[0].external_id == vault.upload_calls[1].external_id
+
+    @pytest.mark.asyncio
+    async def test_two_users_uploading_the_same_name_get_separate_fragments(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """One user's ``notes.pdf`` must never overwrite another's."""
+        first = await _signup(async_client, "uploader-tenant-a")
+        second = await _signup(async_client, "uploader-tenant-b")
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=first)
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=second)
+        assert vault.upload_calls[0].external_id != vault.upload_calls[1].external_id
+
+
+class TestUploadDegradation:
+    """Every vault condition is a 202 carrying a distinguishable, actionable status."""
+
+    @pytest.mark.parametrize(
+        "vault", [{"capabilities": frozenset({CreekCapability.JOURNAL})}], indirect=True
+    )
+    @pytest.mark.asyncio
+    async def test_capability_absent_reports_capability_unsupported(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A journal-only vault must degrade without the document reaching the wire."""
+        headers = await _signup(async_client, "uploader-nocap")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.status_code == HTTPStatus.ACCEPTED
+        assert response.json()["status"] == VaultUploadStatus.CAPABILITY_UNSUPPORTED.value
+        assert vault.upload_calls == []
+
+    @pytest.mark.parametrize("vault", [{"available": False}], indirect=True)
+    @pytest.mark.asyncio
+    async def test_unreachable_vault_reports_vault_unavailable(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Unreachable and cannot-take-files are different problems with different fixes."""
+        headers = await _signup(async_client, "uploader-down")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["status"] == VaultUploadStatus.VAULT_UNAVAILABLE.value
+        assert vault.upload_calls == []
+
+    @pytest.mark.parametrize(
+        "vault", [{"upload_error": CreekVaultUnavailableError("boom")}], indirect=True
+    )
+    @pytest.mark.asyncio
+    async def test_transport_failure_reports_degraded_not_500(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A vault error must never surface as an unhandled server fault."""
+        headers = await _signup(async_client, "uploader-degrade")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.status_code == HTTPStatus.ACCEPTED
+        assert response.json()["status"] == VaultUploadStatus.DEGRADED.value
+        # A failed upload is dropped, not queued: one attempt, never a retry.
+        assert len(vault.upload_calls) == 1
+
+    @pytest.mark.parametrize("vault", [{"stored": False}], indirect=True)
+    @pytest.mark.asyncio
+    async def test_not_stored_reports_degraded_with_no_ref(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A vault that answered without storing must not look like a success."""
+        headers = await _signup(async_client, "uploader-notstored")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["status"] == VaultUploadStatus.DEGRADED.value
+        assert response.json()["vault_ref"] is None
+        assert len(vault.upload_calls) == 1
+
+    @pytest.mark.parametrize(
+        "vault",
+        [
+            {"available": False},
+            {"capabilities": frozenset({CreekCapability.JOURNAL})},
+            {"stored": False},
+        ],
+        indirect=True,
+    )
+    @pytest.mark.asyncio
+    async def test_every_degraded_outcome_carries_a_self_serve_message(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A status the user cannot act on is a status that sends them to support."""
+        headers = await _signup(async_client, "uploader-message")
+        response = await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        assert response.json()["message"].strip()
+        # However it degraded, it was attempted at most once -- never retried.
+        assert len(vault.upload_calls) <= 1
+
+
+class TestUploadIntimateFloor:
+    """An intimate document is withheld and said so, never quietly rerouted."""
+
+    @pytest.mark.asyncio
+    async def test_intimate_is_withheld_from_the_vault(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """ADR 0004 Decision 6: the intimate-transit channel is entirely unshipped."""
+        headers = await _signup(async_client, "uploader-intimate")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(classification="intimate"), headers=headers
+        )
+        assert response.json()["status"] == VaultUploadStatus.SKIPPED_INTIMATE.value
+        assert vault.upload_calls == []
+
+    @pytest.mark.parametrize("vault", [{"available": False}], indirect=True)
+    @pytest.mark.asyncio
+    async def test_intimate_is_withheld_even_when_the_vault_is_unreachable(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """An unreachable vault must not become an excuse to route the document elsewhere."""
+        headers = await _signup(async_client, "uploader-intimate-down")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(classification="intimate"), headers=headers
+        )
+        assert response.json()["status"] == VaultUploadStatus.SKIPPED_INTIMATE.value
+        assert vault.upload_calls == []
+
+
+class TestUploadGuards:
+    """The endpoint refuses what it cannot safely forward, before doing any work."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_document_is_refused_with_413(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Guarded on the encoded length, so the decoded bytes are never allocated."""
+        headers = await _signup(async_client, "uploader-huge")
+        oversized = "A" * (MAX_UPLOAD_BASE64_CHARS + 1)
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(content_base64=oversized), headers=headers
+        )
+        assert response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+        assert vault.upload_calls == []
+
+    @pytest.mark.asyncio
+    async def test_undecodable_base64_is_refused_with_422(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """Forwarding bytes we could not decode would hand the vault a broken file."""
+        headers = await _signup(async_client, "uploader-badb64")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(content_base64="not!valid!base64!"), headers=headers
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert vault.upload_calls == []
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../escape.pdf",
+            "nested/path.pdf",
+            "back\\slash.pdf",
+            "..",
+            "control\x00.pdf",
+            "line\nbreak.pdf",
+            ".hidden.pdf",
+            " leading-space.pdf",
+            "trailing-space.pdf ",
+            "zero\u200bwidth.pdf",
+            "bidi\u202eexe.pdf",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_unsafe_filenames_are_rejected(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient, filename: str
+    ) -> None:
+        """The name steers the vault's ingestor choice, so an ambiguous one is refused."""
+        headers = await _signup(async_client, "uploader-badname")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(filename=filename), headers=headers
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert vault.upload_calls == []
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "résumé.pdf",
+            "日本語のノート.docx",
+            "Заметки.txt",
+            "quarterly report (final).xlsx",
+            "notes_2026-08-08.md",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_international_and_ordinary_filenames_are_accepted(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient, filename: str
+    ) -> None:
+        """Safety must not mean ASCII-only: most of the world's documents are not.
+
+        The guard exists to exclude path separators and non-printing codepoints,
+        not to exclude the languages people actually name their files in.
+        """
+        headers = await _signup(async_client, "uploader-intl")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(filename=filename), headers=headers
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED
+        assert vault.upload_calls[0].filename == filename
+
+    @pytest.mark.asyncio
+    async def test_upload_requires_authentication(self, async_client: AsyncClient) -> None:
+        """A document belongs to whoever uploaded it, so there is no anonymous path."""
+        response = await async_client.post(_UPLOAD_PATH, json=_payload())
+        assert response.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+
+    @pytest.mark.asyncio
+    async def test_document_bytes_never_appear_in_an_error_body(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A rejection must not echo the document back through the error envelope."""
+        headers = await _signup(async_client, "uploader-echo")
+        response = await async_client.post(
+            _UPLOAD_PATH, json=_payload(filename="../escape.pdf"), headers=headers
+        )
+        assert _CONTENT_B64 not in response.text
+        assert vault.upload_calls == []
+
+
+class TestUploadTiering:
+    """The uploader's chosen depth is what the vault is told to store at."""
+
+    @pytest.mark.parametrize(
+        ("classification", "expected"),
+        [("public", VaultTierCeiling.OPEN), ("personal", VaultTierCeiling.PERSONAL)],
+    )
+    @pytest.mark.asyncio
+    async def test_classification_maps_onto_the_vault_tier(
+        self,
+        async_client: AsyncClient,
+        vault: ScriptedUploadClient,
+        classification: str,
+        expected: VaultTierCeiling,
+    ) -> None:
+        """Stored at exactly the tier chosen -- never widened so a call can succeed."""
+        headers = await _signup(async_client, f"uploader-tier-{classification}")
+        await async_client.post(
+            _UPLOAD_PATH, json=_payload(classification=classification), headers=headers
+        )
+        assert vault.upload_calls[0].tier is expected
+        assert vault.upload_calls[0].tier_ceiling is expected
+
+    @pytest.mark.asyncio
+    async def test_upload_timestamp_is_timezone_aware_utc(
+        self, async_client: AsyncClient, vault: ScriptedUploadClient
+    ) -> None:
+        """A naive timestamp would be read in the vault's local time, not the user's."""
+        headers = await _signup(async_client, "uploader-tz")
+        before = datetime.now(UTC)
+        await async_client.post(_UPLOAD_PATH, json=_payload(), headers=headers)
+        stamped = vault.upload_calls[0].created_at
+        assert stamped.tzinfo is not None
+        assert stamped >= before
+
+
+def _as_vault_client(client: CreekVaultClient) -> CreekVaultClient:
+    """Return ``client`` unchanged; the annotation is the assertion.
+
+    A structural check rather than a runtime one: if ``ScriptedUploadClient``
+    ever drifts from :class:`CreekVaultClient`, mypy fails here rather than the
+    endpoint failing at run time on a method the protocol promised.
+    """
+    return client
+
+
+def test_scripted_client_satisfies_the_vault_protocol() -> None:
+    """The fake must implement the whole seam, upload included."""
+    assert _as_vault_client(ScriptedUploadClient()) is not None

--- a/backend/tests/test_journal_vault_read.py
+++ b/backend/tests/test_journal_vault_read.py
@@ -37,6 +37,8 @@ from domain.creek_vault import (
     VaultReflectionNote,
     VaultReflectionStatus,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelBalance,
 )
 from main import app
@@ -186,6 +188,10 @@ class ReflectingVaultClient:
         """Record the request and return an incrementing vault ref (write path)."""
         self.ingest_calls.append(request)
         return VaultIngestResult(stored=True, vault_ref=f"vault-ref-{len(self.ingest_calls)}")
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Return a fixed classification tag set (write path)."""

--- a/backend/tests/test_journal_vault_write.py
+++ b/backend/tests/test_journal_vault_write.py
@@ -33,6 +33,8 @@ from domain.creek_vault import (
     VaultReflection,
     VaultReflectionStatus,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelBalance,
 )
 from main import app
@@ -113,6 +115,10 @@ class SequencedVaultClient:
         if self._ingest_error is not None:
             raise self._ingest_error
         return VaultIngestResult(stored=True, vault_ref=f"vault-ref-{len(self.ingest_calls)}")
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Return a fixed classification tag set."""

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -19,6 +19,8 @@ from domain.creek_vault import (
     VaultIngestResult,
     VaultReflection,
     VaultTierCeiling,
+    VaultUploadRequest,
+    VaultUploadResult,
     VaultWheelAspect,
     VaultWheelBalance,
 )
@@ -322,6 +324,10 @@ class _WheelVaultClient:
 
     async def ingest(self, request: VaultIngestRequest, /) -> VaultIngestResult:
         """Unused on the wheel path; raises if a test calls it by mistake."""
+        raise NotImplementedError(request)
+
+    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Unused on this path; raises if a test calls it by mistake."""
         raise NotImplementedError(request)
 
     async def classify(self, body: str, tier_ceiling: VaultTierCeiling, /) -> VaultClassification:

--- a/docs/adr/0004-creek-vault-http-application-boundary.md
+++ b/docs/adr/0004-creek-vault-http-application-boundary.md
@@ -234,13 +234,38 @@ authoritative source, one pointer, is the fix.
 
 ## Decision 6 — The intimate-transit rule is carried forward, and is entirely unshipped
 
+> **Amended 2026-08-08 (owner ruling, issue #1924 / PR #2149) — the
+> document-upload surface is vault-only, not skip-only.** Sub-decisions
+> (a)–(d) below are unchanged and still describe the *journal-entry*
+> write path. They do **not** govern `POST /journal/upload`, which
+> forwards an `intimate` document to the vault at the `INTIMATE` tier
+> ceiling, in plaintext, over the configured `CREEK_VAULT_URL`.
+>
+> The ruling rests on who the far end is. A Creek Vault is the user's
+> **own** corpus on operator-held infrastructure, not a third-party
+> service, so reaching it is not the cloud disclosure the privacy floor
+> was built to prevent. What that floor forbids — intimate content
+> reaching a cloud LLM — the upload path never does, because it calls no
+> LLM at all. This is a narrower claim than (a)'s ciphertext topology,
+> and it does not weaken (a): a deployment whose vault is *not*
+> operator-held is outside the assumption this amendment rests on, and
+> nothing here confers a confidential-compute guarantee.
+>
+> **Known asymmetry, deliberately left standing.** The journal-entry
+> write path still withholds intimate entries (skip-only, as below)
+> while the upload path forwards them. That is not an oversight and not
+> a contradiction to resolve silently: widening a shipped write path is
+> its own change, with its own tests and its own review, and it is
+> tracked in issue #2152. Until that lands, read (a)–(d) as governing
+> journal entries only.
+
 The four intimate-transit sub-decisions ratified via #927/#950 move
 into this ADR in condensed form. **Every one of them is entirely
 unshipped**; the owning issues are #958 (frontend vault key setup) and
 creek-vault#757 (Creek's confidential-compute epic). Today's shipped
-behavior remains ADR 0002 / #895's skip-only mode: an `intimate`
-classification short-circuits before any vault call at all, not even a
-handshake (`services/creek_vault_write.py:17-24`).
+behavior for journal entries remains ADR 0002 / #895's skip-only mode:
+an `intimate` classification short-circuits before any vault call at
+all, not even a handshake (`services/creek_vault_write.py:17-24`).
 
 - **(a) Transit topology — ciphertext only.** Intimate content may
   cross the seam through the operator's backend, but only as

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -119,10 +119,11 @@ adepthood is willing to *accept* on the way back, and `_admissible_wheel`
 refuses a response that echoes anything wider
 (`creek_vault_client.py:1109-1122`). `personal` is the honest maximum
 here, on either reading: only aggregate per-Frequency counts and
-shares cross this seam — never fragment content — intimate content
-never reaches the vault from adepthood at all (see "Intimate-tier
-content: pointer only" below), and creek independently caps a network
-consumer below intimate regardless of what adepthood would ask for. The
+shares cross this seam — never fragment content — no intimate *journal
+entry* reaches the vault from adepthood at all (see "Intimate-tier
+content: pointer only" below for the per-surface rule), and creek
+independently caps a network consumer below intimate regardless of what
+adepthood would ask for. The
 server instead applies its own published `open` default to what it
 *counts*, and `open` ranks unclassified content below `personal`: a
 not-yet-classified fragment is silently excluded from the count, so a
@@ -311,8 +312,18 @@ capability is still used for the others it supports:
   Per-fragment classification tags are read from the response when the
   vault supplies them and are otherwise empty, which is the expected
   answer today rather than a failure — adepthood deliberately builds no
-  second, local classifier. Intimate-tier documents are never sent at
-  all; see "Intimate-tier content: pointer only" below.
+  second, local classifier.
+
+  **Intimate documents are forwarded, unlike intimate journal entries.**
+  An `intimate` upload is sent at the `INTIMATE` tier ceiling rather than
+  withheld, per the 2026-08-08 amendment to ADR 0004's Decision 6: the
+  vault is the user's own corpus on operator-held infrastructure, and
+  this path calls no cloud LLM. The vault's router still enforces the
+  ceiling it is handed, so a vault declining to store at `INTIMATE`
+  refuses the write and adepthood degrades honestly rather than
+  downgrading the tier to force a success. Note the asymmetry with
+  JOURNAL, which remains skip-only — see the amendment for why that is
+  deliberate and tracked in issue #2152.
 - **REFLECT** — if absent, adepthood falls back to its existing cloud
   LLM reflection path
   (`select_reflection_llm`, `backend/src/services/creek_vault_reflect.py:158-190`).
@@ -381,12 +392,26 @@ capability is still used for the others it supports:
 The rule governing whether, and how, intimate content may ever cross
 the adepthood-to-vault seam is recorded in
 [ADR 0004](adr/0004-creek-vault-http-application-boundary.md),
-Decision 6, not in this document. That rule is **entirely unshipped**.
-Today's actual behavior is the skip-only mode from
-[ADR 0002](adr/0002-intimate-content-local-routing.md): an `intimate`
-classification short-circuits before any vault call at all, not even a
-handshake. No intimate journal content is transmitted to any vault
-today, in any form.
+Decision 6, not in this document. **It differs by surface**, and the
+split is deliberate:
+
+- **Journal entries — skip-only, unchanged.** The ciphertext/attested
+  transit topology in Decision 6 (a)–(d) is **entirely unshipped**, so
+  today's behavior remains the skip-only mode from
+  [ADR 0002](adr/0002-intimate-content-local-routing.md): an `intimate`
+  classification short-circuits before any vault call at all, not even
+  a handshake. No intimate journal *entry* is transmitted to any vault
+  today, in any form.
+- **Document uploads — vault-only.** Per the 2026-08-08 amendment to
+  Decision 6, an `intimate` document sent to `POST /journal/upload`
+  **is** forwarded to the vault, at the `INTIMATE` tier ceiling. The
+  amendment's reasoning is that the vault is the user's own corpus on
+  operator-held infrastructure rather than a third-party service, and
+  that this path calls no cloud LLM.
+
+The asymmetry between the two is known and tracked in issue #2152;
+read Decision 6's amendment before treating either half as the general
+rule.
 
 ## Vault tenancy: pointer only
 

--- a/docs/creek-vault-mcp-contract.md
+++ b/docs/creek-vault-mcp-contract.md
@@ -273,6 +273,46 @@ capability is still used for the others it supports:
   (ADR 0004's 2026-08-07 note) — Creek's own MCP server is untouched
   and remains what agents like CrawDad, Claude Code, and Hermes talk
   to, but nothing in this repository calls it any more.
+- **UPLOAD** — a *required* capability for the document-upload surface,
+  and gated entirely separately from JOURNAL: a vault that advertises
+  `creek.journal` has said nothing about whether it accepts files, so
+  the upload path checks `creek.upload` on its own
+  (`store_upload`, `backend/src/services/creek_vault_upload.py`) and an
+  unadvertised capability is refused locally with no request sent
+  (`_upload`, `backend/src/services/creek_vault_client.py`). Adepthood
+  `PUT`s the document to its own `/v1/uploads/{external_id}` URL,
+  carrying `filename`, `content_base64`, `timestamp`, and `tier`, and
+  **names no source or content type**: the vault reads the extension
+  off the filename and selects its own ingestor, so adepthood never
+  parses, sniffs, or classifies the document. `external_id` is a
+  deterministic digest of (owner user id, filename), which is what makes
+  a re-send idempotent — the vault edits the same fragment in place
+  rather than accumulating one per attempt — and it is a *digest*
+  specifically so a filename, which is the user's own words about their
+  life, never travels in a request line or an access log.
+
+  Tier semantics match JOURNAL: the document's tier and the declared
+  write ceiling are both the uploader's chosen tier, so the vault stores
+  at exactly that depth and refuses any widening.
+
+  Graceful degradation is finer-grained here than for JOURNAL, because
+  an upload has **no local system of record** — if the vault will not
+  take the document, it went nowhere, and the user has to be told which
+  problem they have. An unreachable vault reports `VAULT_UNAVAILABLE`,
+  a reachable vault that never advertised the capability reports
+  `CAPABILITY_UNSUPPORTED`, and a call that failed mid-flight (or
+  answered without durably storing) reports `DEGRADED`. All three are
+  answered as a `202` carrying the status and a self-serve message —
+  never a 5xx, since an optional integration being absent is not a
+  server fault. As with JOURNAL, **a failed upload is dropped, not
+  queued**: there is no spool, because durably holding user document
+  bytes outside the vault is a privacy decision nobody has made.
+
+  Per-fragment classification tags are read from the response when the
+  vault supplies them and are otherwise empty, which is the expected
+  answer today rather than a failure — adepthood deliberately builds no
+  second, local classifier. Intimate-tier documents are never sent at
+  all; see "Intimate-tier content: pointer only" below.
 - **REFLECT** — if absent, adepthood falls back to its existing cloud
   LLM reflection path
   (`select_reflection_llm`, `backend/src/services/creek_vault_reflect.py:158-190`).


### PR DESCRIPTION
## What

Adds the backend upload seam: `POST /journal/upload` accepts one user document
as `{filename, content_base64, classification}` and forwards it to the Creek
Vault's `creek.upload` capability, so material beyond in-app journal entries can
join the Higher-Self corpus.

Adepthood carries the bytes and the filename and **nothing else** — the vault
reads the extension and selects its own ingestor, so no document parsing, format
sniffing, or `source_type` guessing happens here.

### The seam, layer by layer

- **`domain/creek_vault.py`** — `CreekCapability.UPLOAD = "creek.upload"`, plus
  `VaultUploadRequest` / `VaultUploadResult` as *siblings* of the ingest pair
  (an entry is text we already hold; an upload is a file), and an `upload()`
  method on the `CreekVaultClient` protocol. `content_base64` is `repr=False`,
  so a traceback can never render a user's document.
- **`services/creek_vault_client.py`** — `HttpCreekVaultClient.upload()` `PUT`s
  to `/v1/uploads/{external_id}`, gated on the cached handshake having
  advertised `creek.upload`; `LocalFallbackCreekVaultClient.upload()` is a
  no-op `stored=False`. `_ingest_failure` was generalized into a shared
  `_write_failure` so both write capabilities classify a non-2xx identically
  while each still names *itself* in what it raises.
- **`services/creek_vault_upload.py`** (new) — the graceful-degradation
  orchestration, mirroring `creek_vault_write.py` but with **finer-grained
  outcomes**, because an upload has no local system of record: `VAULT_UNAVAILABLE`
  ("connect your vault"), `CAPABILITY_UNSUPPORTED` ("your vault can't take files
  yet"), and `DEGRADED` ("it broke, try again") are three different things to
  tell a user, and flattening them leaves someone with no next step.
- **`routers/journal.py`** — the endpoint. **202 for every vault outcome**,
  including degraded ones: an optional integration being absent is a normal
  condition, not a server fault, so none of them is a 5xx. The body carries the
  status and a self-serve message.

### Idempotence without a migration

`external_id` is a SHA-256 digest of `(owner_user_id, filename)`. That makes a
re-send address the same fragment — so the vault edits in place rather than
accumulating a copy per attempt — with **no upload table and no Alembic
migration** standing between a user and their first upload. Hashing (rather than
carrying) the filename is also deliberate: a filename is the user's own words
about their life, and `my-divorce-settlement.pdf` does not belong in a request
line, an access log, or a proxy's history. Including the owner is what keeps two
users' identically-named files apart.

## Intimate documents: resolved by owner ruling

This PR originally withheld `intimate` documents from the vault entirely, on the
grounds that ADR 0004 Decision 6 records intimate transit as *entirely unshipped*
and skip-only. I flagged it for a maintainer call, and the reviewer agreed the
call should be made before merge.

**The owner ruled: forward intimate documents to the vault**, which is the issue's
original AC. The reasoning is that a Creek Vault is the user's *own* corpus on
operator-held infrastructure rather than a third-party service, so reaching it is
not the cloud disclosure the privacy floor exists to prevent — and this path calls
no LLM at all. That is now what the code does: an `intimate` upload is forwarded
at the `INTIMATE` tier ceiling, never widened or narrowed to make a call succeed,
and a vault that declines that ceiling degrades honestly rather than being
retried lower.

Because that contradicted a ratified decision, the ruling is **recorded rather
than merely implemented**:

- `docs/adr/0004-...md` Decision 6 carries a dated amendment stating the ruling,
  its reasoning, and its limits (it does not weaken sub-decision (a), and confers
  no confidential-compute guarantee; a deployment whose vault is *not*
  operator-held is outside the assumption it rests on).
- `docs/creek-vault-mcp-contract.md` now states the rule **per surface** instead of
  globally, and two stale claims that "intimate content never reaches the vault"
  were corrected.
- `VaultUploadStatus.SKIPPED_INTIMATE` is gone rather than left dead.

**Known asymmetry, deliberately left standing:** `creek_vault_write.py` still
withholds intimate *journal entries*. Widening a shipped write path changes
behavior for existing users' existing entries and deserves its own tests and
review, so it is filed as **#2152** and cross-referenced from the ADR, the
contract doc, and the module docstring — so the split reads as tracked rather
than as an oversight.

### Filename validation is a denylist, on purpose

The filename is the one field that steers what happens to the document on the far
side, so it is validated rather than passed through. The obvious implementation —
an ASCII allowlist — is the wrong one: it would refuse `résumé.pdf`, every CJK
filename, and most of the world's documents. What actually has to be excluded is
small and nameable, and `str.isprintable()` carries most of it (NUL, CR/LF,
control characters, zero-width and bidi-override codepoints that make a `.txt`
display as a `.exe`), with path separators, dot runs, leading dots, and
surrounding whitespace excluded explicitly. Both directions are tested.

## Notes for the reviewer

- **Tags are empty today, and that is correct.** Per-fragment tags depend on
  upstream `creek-vault#874`; a test asserts exactly that, and a second asserts
  they are carried through verbatim once the vault does send them. Adepthood
  deliberately builds no second, local classifier.
- **No local persistence.** The AC mentioned persisting tags to `vault_tags`
  "or the upload's equivalent record". No such record exists and none is added —
  a new table plus migration to store an always-empty tuple would be speculative,
  so tags are returned in the response instead. Happy to add the table if the
  audit trail is wanted.
- **Upstream dependency.** `creek.upload` itself is `Geoffe-Ga/creek-vault#1023`
  and has not shipped. Built and tested against a faked client, exactly as the
  issue directed; until it lands, the capability gate means every real vault
  degrades to `CAPABILITY_UNSUPPORTED` — which is the honest answer, and is
  pinned by a test.
- **No multipart.** Base64-in-JSON throughout;
  `tests/test_transcription_privacy.py` passes unmodified. (It caught a literal
  `UploadFile` token in one of my *docstrings* — the guard works.)
- `errors.py` gains `payload_too_large()` (413), using the non-deprecated
  `HTTP_413_CONTENT_TOO_LARGE` constant.

## Testing

85 new tests across two suites — `tests/test_creek_vault_upload.py` (domain,
HTTP adapter, write service) and `tests/test_journal_upload.py` (endpoint).
Covers the happy path, capability-absent degrade, vault-unreachable degrade,
intimate forwarding at the INTIMATE tier (and an unreachable vault being an
honest failure rather than a reroute), a refused ceiling degrading instead of
being retried lower, oversize 413,
undecodable-base64 422, unsafe filenames (traversal, separators, control
characters, zero-width, bidi override), international filenames that must be
*accepted*, cross-tenant fragment separation, idempotent re-send, and the
empty-tags-until-#874 assertion.

Privacy is asserted rather than assumed: sentinel document bytes, the vault's own
error prose, and the filename are each checked absent from `repr()`, log records,
exception messages, and error response bodies.

Full backend suite green; `./scripts/backend/check-all.sh` green; `pre-commit run --all-files` green.

Closes #1924
