### PR TITLE
fix(backend): declare the goal tier CHECK constraint the migration created

### DIFF
--- a/backend/src/models/goal.py
+++ b/backend/src/models/goal.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy import CheckConstraint, Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -19,6 +19,18 @@ class GoalTier(StrEnum):
     STRETCH = "stretch"
 
 
+# The name migration ``c3d4e5f6a7b8`` creates the tier CHECK constraint under.
+# The model must declare it under the same name: a differently-named constraint
+# with identical semantics still reads to Alembic's autogenerate as one dropped
+# and one added.
+TIER_CONSTRAINT_NAME = "ck_goal_tier_valid"
+
+# Rendered from :class:`GoalTier` rather than restated, so adding a tier to the
+# enum cannot leave the constraint silently bounding the old set. The rendered
+# text matches the migration's literal ``tier IN ('low', 'clear', 'stretch')``.
+_TIER_CONSTRAINT_SQL = "tier IN ({})".format(", ".join(f"'{tier.value}'" for tier in GoalTier))
+
+
 class Goal(SQLModel, table=True):
     """Represents a single measurable target for a habit.
 
@@ -34,7 +46,17 @@ class Goal(SQLModel, table=True):
     system (e.g. low, clear, stretch), they should be grouped using
     goal_group_id. This allows the system to evaluate all tiers together based on
     the same logged completions.
+
+    ``tier`` is bounded to the :class:`GoalTier` members by a CHECK constraint
+    declared in ``__table_args__``. The constraint has existed in Postgres since
+    migration ``c3d4e5f6a7b8`` (BUG-GOAL-006); declaring it here is what makes
+    the model an accurate account of the table, which is the thing Alembic's
+    autogenerate compares against. It also means the SQLite test fixture builds
+    the constraint too, so a bad tier fails in tests rather than only in
+    production.
     """
+
+    __table_args__ = (CheckConstraint(_TIER_CONSTRAINT_SQL, name=TIER_CONSTRAINT_NAME),)
 
     id: int | None = Field(default=None, primary_key=True)
     habit_id: int = Field(

--- a/backend/tests/domain/test_stage_progress_queries.py
+++ b/backend/tests/domain/test_stage_progress_queries.py
@@ -28,7 +28,7 @@ from sqlmodel import SQLModel
 from domain.stage_progress import compute_stage_progress, get_stage_habit_history
 from models.content_completion import ContentCompletion
 from models.course_stage import CourseStage
-from models.goal import Goal
+from models.goal import Goal, GoalTier
 from models.goal_completion import GoalCompletion
 from models.habit import Habit
 from models.practice import Practice
@@ -41,6 +41,10 @@ _MAX_QUERIES_FOR_HABIT_HISTORY = 2
 
 # Constants used by the seeded-history assertions, named so the assertions are
 # self-documenting and ruff's PLR2004 stays satisfied.
+# The real tiers the seed cycles through; goal.tier is CHECK-constrained
+# to exactly these, so a placeholder label would be an unstorable row.
+_SEED_TIERS = tuple(t.value for t in GoalTier)
+
 _HABITS_SEEDED = 5
 _GOALS_PER_HABIT = 3
 _COMPLETIONS_PER_GOAL = 4
@@ -130,15 +134,19 @@ async def _seed_habits_with_goals(
     goals = [
         Goal(
             habit_id=h.id,
-            title=f"Goal {tier}",
-            tier=tier,
+            title=f"Goal {n}",
+            # The seed needs `goals_per_habit` *distinct goals*, not distinct
+            # tiers, so it cycles the real ones rather than inventing labels.
+            # `goal.tier` is CHECK-constrained to the GoalTier members, so an
+            # invented value is a row the database would never hold.
+            tier=_SEED_TIERS[n % len(_SEED_TIERS)],
             target=10,
             target_unit="reps",
             frequency=1,
             frequency_unit="per_day",
         )
         for h in habits
-        for tier in [f"tier-{n}" for n in range(goals_per_habit)]
+        for n in range(goals_per_habit)
     ]
     session.add_all(goals)
     await session.commit()
@@ -227,7 +235,9 @@ async def test_habit_history_marks_unachieved_goals_false(
 
     assert len(result) == 1
     assert result[0].total_completions == 0
-    assert result[0].goals_achieved == {"tier-0": False, "tier-1": False}
+    # Keyed by tier, and the seed cycles the real GoalTier members -- so two
+    # goals per habit are the first two of those, not invented labels.
+    assert result[0].goals_achieved == dict.fromkeys(_SEED_TIERS[:2], False)
 
 
 @pytest.mark.asyncio
@@ -328,7 +338,7 @@ async def _seed_habits(
         goal = Goal(
             habit_id=h.id,
             title="g",
-            tier="t",
+            tier="clear",
             target=10,
             target_unit="reps",
             frequency=1,

--- a/backend/tests/domain/test_wheel.py
+++ b/backend/tests/domain/test_wheel.py
@@ -109,7 +109,7 @@ async def _seed_habit_with_completion(s: AsyncSession, user_id: int, stage_numbe
     goal = Goal(
         habit_id=habit.id,
         title="g",
-        tier="t",
+        tier="clear",
         target=1,
         target_unit="rep",
         frequency=1,
@@ -316,7 +316,7 @@ async def test_wheel_fullness_sourced_from_batch_overall_progress(
         goal = Goal(
             habit_id=habit.id,
             title="g",
-            tier="t",
+            tier="clear",
             target=1,
             target_unit="rep",
             frequency=1,

--- a/backend/tests/domain/test_wheel_chord.py
+++ b/backend/tests/domain/test_wheel_chord.py
@@ -123,7 +123,7 @@ async def _seed_habit_with_completion(s: AsyncSession, user_id: int, stage_numbe
     goal = Goal(
         habit_id=habit.id,
         title="g",
-        tier="t",
+        tier="clear",
         target=1,
         target_unit="rep",
         frequency=1,

--- a/backend/tests/test_creek_vault_wheel.py
+++ b/backend/tests/test_creek_vault_wheel.py
@@ -285,7 +285,7 @@ async def _seed_habit_with_completion(
     goal = Goal(
         habit_id=habit.id,
         title="g",
-        tier="t",
+        tier="clear",
         target=1,
         target_unit="rep",
         frequency=1,

--- a/backend/tests/test_goal_tier_constraint.py
+++ b/backend/tests/test_goal_tier_constraint.py
@@ -1,0 +1,136 @@
+"""The Goal model declares the tier CHECK constraint its migration creates.
+
+Migration ``c3d4e5f6a7b8`` added ``ck_goal_tier_valid`` to bound ``goal.tier`` to
+the :class:`GoalTier` members, but the model never declared it. That divergence
+was invisible for as long as it existed: Alembic 1.18.x did not compare CHECK
+constraints during autogenerate, so ``alembic check`` saw a clean tree. Alembic
+1.19 does compare them, and immediately reported the constraint as *removed* --
+the model, being metadata's only account of the table, appeared to have dropped
+something the database has.
+
+These tests pin the model side of that agreement so the drift cannot come back,
+and pin the constraint's *effect* so it is more than a shape that satisfies a
+gate: the ORM must actually refuse a tier outside the enum.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from sqlalchemy import CheckConstraint
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import SQLModel
+
+from models.goal import Goal, GoalTier
+from models.habit import Habit
+
+# The name migration c3d4e5f6a7b8 creates the constraint under. The model must
+# use the same one -- a differently-named constraint with identical semantics
+# still reads to Alembic as one dropped and one added.
+_CONSTRAINT_NAME = "ck_goal_tier_valid"
+
+
+# Reached through the shared metadata rather than ``Goal.__table__``: SQLModel
+# does not type the latter, so mypy rejects it, and the registry is the same
+# Table object Alembic's autogenerate compares against anyway.
+_GOAL_TABLE_NAME = "goal"
+
+
+def _tier_check_constraints() -> list[CheckConstraint]:
+    """Return every CHECK constraint the Goal table declares under the pinned name."""
+    table = SQLModel.metadata.tables[_GOAL_TABLE_NAME]
+    return [
+        constraint
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint) and constraint.name == _CONSTRAINT_NAME
+    ]
+
+
+def _habit(name: str) -> Habit:
+    """Build a minimally valid Habit to hang a Goal off.
+
+    Every NOT NULL column is supplied: this fixture exists only to satisfy the
+    goal's foreign key, so nothing here is under test and the values are the
+    least interesting ones that are legal.
+    """
+    return Habit(
+        user_id=1,
+        name=name,
+        icon="circle",
+        start_date=date(2026, 1, 1),
+        energy_cost=1,
+        energy_return=1,
+    )
+
+
+class TestGoalTierConstraintIsDeclared:
+    """The model's metadata carries the constraint the migration created."""
+
+    def test_the_constraint_is_declared_exactly_once(self) -> None:
+        """Present, and not duplicated by a second declaration under the same name."""
+        assert len(_tier_check_constraints()) == 1
+
+    @pytest.mark.parametrize("tier", list(GoalTier))
+    def test_every_enum_member_appears_in_the_predicate(self, tier: GoalTier) -> None:
+        """A member missing from the predicate would be rejected despite being valid."""
+        sqltext = str(_tier_check_constraints()[0].sqltext)
+        assert f"'{tier.value}'" in sqltext
+
+    def test_the_predicate_constrains_the_tier_column(self) -> None:
+        """A predicate over some other column would bound the wrong thing entirely."""
+        assert "tier" in str(_tier_check_constraints()[0].sqltext)
+
+
+class TestGoalTierConstraintIsEnforced:
+    """The constraint does its job, rather than merely existing to satisfy a gate."""
+
+    @pytest.mark.asyncio
+    async def test_a_tier_outside_the_enum_is_rejected(self, db_session: AsyncSession) -> None:
+        """The whole point of the constraint: an unlisted tier cannot be stored."""
+        habit = _habit("Morning sit")
+        db_session.add(habit)
+        await db_session.commit()
+        await db_session.refresh(habit)
+
+        db_session.add(
+            Goal(
+                habit_id=habit.id,
+                title="A goal with an invented tier",
+                tier="platinum",
+                target=1.0,
+                target_unit="minutes",
+                frequency=1.0,
+                frequency_unit="per_day",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+        await db_session.rollback()
+
+    @pytest.mark.parametrize("tier", list(GoalTier))
+    @pytest.mark.asyncio
+    async def test_every_enum_member_is_accepted(
+        self, db_session: AsyncSession, tier: GoalTier
+    ) -> None:
+        """A constraint that rejected a legitimate tier would be worse than none."""
+        habit = _habit(f"Habit for {tier.value}")
+        db_session.add(habit)
+        await db_session.commit()
+        await db_session.refresh(habit)
+
+        goal = Goal(
+            habit_id=habit.id,
+            title=f"A {tier.value} goal",
+            tier=tier.value,
+            target=1.0,
+            target_unit="minutes",
+            frequency=1.0,
+            frequency_unit="per_day",
+        )
+        db_session.add(goal)
+        await db_session.commit()
+        await db_session.refresh(goal)
+
+        assert goal.tier == tier.value

--- a/backend/tests/test_wheel_api.py
+++ b/backend/tests/test_wheel_api.py
@@ -107,7 +107,7 @@ async def _seed_habit_with_completion(
     goal = Goal(
         habit_id=habit.id,
         title="g",
-        tier="t",
+        tier="clear",
         target=1,
         target_unit="rep",
         frequency=1,


### PR DESCRIPTION
## What

Declares `ck_goal_tier_valid` on the `Goal` model. Migration `c3d4e5f6a7b8` has
created that CHECK constraint in Postgres since April (BUG-GOAL-006), but
`models/goal.py` never declared it — and metadata is Alembic's only account of
the table, so the model looked like it had dropped a constraint the database has.

## Why now

`migration-drift` went red on Dependabot PR #2150 (bridge #2151) with:

```
FAILED: New upgrade operations detected:
  [('remove_constraint', CheckConstraint(..., name='ck_goal_tier_valid', ...))]
```

The bump did not cause that. **Alembic 1.18.x does not compare CHECK constraints
during autogenerate; 1.19 does.** The upgrade revealed a divergence that had been
invisible for months. Reverting the pin would have re-hidden it.

## Why declare it rather than exclude it

`migrations/env.py` has an `_include_object` hook that tells autogenerate to
ignore migration-owned artifacts, and adding one line there would also turn the
gate green. That hook is for objects that genuinely **cannot** be modelled —
functional and partial indexes whose Postgres-specific SQL breaks the SQLite test
fixture. A CHECK constraint has no such problem.

Declaring it is strictly better: models match migrations, and the SQLite test
fixture now builds the constraint too, so a bad tier fails in tests rather than
only in production. The predicate renders from `GoalTier` rather than restating
it, so adding a member cannot leave the constraint silently bounding the old set.

## What enforcing it immediately caught

Five test modules were seeding goals with `tier="t"` or `tier=f"tier-{n}"` —
values Postgres has **rejected since April**. Those fixtures were exercising
states the real database cannot hold:

- `tests/domain/test_wheel.py` (×2), `tests/domain/test_wheel_chord.py`,
  `tests/test_wheel_api.py`, `tests/test_creek_vault_wheel.py` — single-goal
  fixtures where the tier is incidental; now `"clear"`.
- `tests/domain/test_stage_progress_queries.py` — its seeding helper needed
  `goals_per_habit` **distinct goals**, not distinct tiers, so it now cycles the
  real members. One assertion keyed off the old labels and now derives from the
  same constant.

## Verification, and its limit

`./scripts/backend/check-all.sh` exit 0 — 4428 passed, lint/format/mypy/security/
complexity/coverage all green.

**This PR's own CI cannot prove the fix works.** It runs alembic 1.18.5, which
does not compare CHECK constraints, so `migration-drift` passes here trivially.
The real verification is rebasing #2150 onto main after this merges and watching
its 1.19 run. If Alembic's text normalization still reports a diff between the
model's rendered predicate and Postgres's stored form, the fallback is the
`_include_object` exclusion — I'd rather try the correct fix first and find out.

Unblocks #2151.
