### PR TITLE
fix(backend): make shared goal templates an operator surface, not a user one

### DIFF
--- a/backend/src/dependencies/ownership.py
+++ b/backend/src/dependencies/ownership.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import Depends
 from sqlalchemy import ColumnElement
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Mapped
 from sqlmodel import and_, col, or_, select
 
 from database import get_session
+from dependencies.auth import get_current_user_model
 from errors import forbidden, not_found
 from models.goal import Goal
 from models.goal_group import GoalGroup
@@ -19,6 +20,7 @@ from models.habit import Habit
 from models.journal_entry import JournalEntry
 from models.practice import Practice
 from models.practice_session import PracticeSession
+from models.user import User
 from models.user_practice import UserPractice
 from routers.auth import get_current_user
 
@@ -185,7 +187,7 @@ async def require_owned_user_practice(
 
     Delegates to :func:`resolve_owned_user_practice`, which owns the rule and
     emits the ``resource_access_denied`` audit row on a cross-tenant probe,
-    matching :func:`require_owned_goal_group`.
+    matching :func:`require_owned_habit`.
     """
     return await resolve_owned_user_practice(session, user_practice_id, current_user)
 
@@ -244,18 +246,42 @@ async def resolve_owned_goal_group(session: AsyncSession, group_id: int, user_id
     return group
 
 
-async def require_owned_goal_group(
+async def require_manageable_goal_group(
     group_id: int,
-    current_user: Annotated[int, Depends(get_current_user)],
+    caller: Annotated[User, Depends(get_current_user_model)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> GoalGroup:
-    """Resolve ``group_id`` for write access -- owner only.
+    """Resolve ``group_id`` for write access, routing by what kind of group it is.
 
-    Delegates to :func:`resolve_owned_goal_group`, which owns the rule and
-    emits the ``resource_access_denied`` audit row on a cross-tenant probe,
-    matching :func:`require_owned_habit` and :func:`require_owned_user_practice`.
+    Two authorities, because goal groups are two different kinds of object:
+
+    - A **private group** stays owner-only. An admin is deliberately *not*
+      admitted here: adepthood's governing promise is that a user's own space is
+      their own, and an operator override on private content would trade one
+      violation for a larger one.
+    - A **shared template** is ownerless by construction
+      (``ck_goalgroup_shared_template_user_id`` keeps ``user_id IS NULL``
+      biconditional with the flag), so the owner comparison can never match
+      anybody. Before this dependency existed that meant *nothing could ever
+      edit or delete one* -- not the creator, not an operator -- so a published
+      template was permanently unmodifiable. Admin is that missing authority.
+
+    The ordering matters: the template branch is checked first, because falling
+    through to the owner comparison is exactly the dead end this fixes.
     """
-    return await resolve_owned_goal_group(session, group_id, current_user)
+    group = await session.get(GoalGroup, group_id)
+    if group is None:
+        raise not_found("goal_group")
+    caller_id = cast("int", caller.id)
+    if group.shared_template:
+        if not caller.is_admin:
+            log_ownership_denied("goal_group", group_id, caller_id)
+            raise forbidden("admin_required")
+        return group
+    if group.user_id != caller_id:
+        log_ownership_denied("goal_group", group_id, caller_id)
+        raise forbidden("forbidden")
+    return group
 
 
 async def require_visible_practice(

--- a/backend/src/routers/goal_groups.py
+++ b/backend/src/routers/goal_groups.py
@@ -10,10 +10,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from database import get_session
-from dependencies.ownership import require_owned_goal_group, require_visible_goal_group
-from errors import not_found
+from dependencies.auth import get_current_user_model
+from dependencies.ownership import (
+    require_manageable_goal_group,
+    require_visible_goal_group,
+)
+from errors import forbidden, not_found
 from load_options import GOAL_GROUP_WITH_GOALS
 from models.goal_group import GoalGroup
+from models.user import User
 from routers.auth import get_current_user
 from schemas import Page, PaginationParams, build_page
 from schemas.goal_group import GoalGroupCreate, GoalGroupResponse
@@ -116,17 +121,25 @@ async def get_goal_group(
 @router.post("/", response_model=GoalGroupResponse, status_code=status.HTTP_201_CREATED)
 async def create_goal_group(
     payload: GoalGroupCreate,
-    current_user: Annotated[int, Depends(get_current_user)],
+    caller: Annotated[User, Depends(get_current_user_model)],
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> GoalGroup:
-    """Create a new goal group for the authenticated user.
+    """Create a goal group -- private for anyone, shared template for operators only.
 
-    Ownership is sourced from ``current_user`` (BUG-GOAL-005); the
-    payload schema does not expose a ``user_id`` field, so a forged
-    body cannot plant a row under another account.  ``shared_template``
-    flips the row to a public template (``user_id IS NULL``) per the
-    DB CHECK constraint.
+    Ownership is sourced from the caller (BUG-GOAL-005); the payload schema does
+    not expose a ``user_id`` field, so a forged body cannot plant a row under
+    another account.
+
+    ``shared_template`` is a different kind of act and carries a different gate.
+    A template is ownerless (``user_id IS NULL``, biconditional with the flag via
+    the DB CHECK constraint), world-readable, and carries its goals embedded --
+    so setting the flag *publishes content to every user of the deployment*.
+    That is an operator decision, not something an ordinary signup may do, and
+    it is refused here before any row is written.
     """
+    if payload.shared_template and not caller.is_admin:
+        raise forbidden("admin_required")
+    current_user = cast("int", caller.id)
     group = GoalGroup(
         user_id=current_user if not payload.shared_template else None,
         **payload.model_dump(),
@@ -163,22 +176,30 @@ async def update_goal_group(
     payload: GoalGroupCreate,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
-    group: Annotated[GoalGroup, Depends(require_owned_goal_group)],
+    group: Annotated[GoalGroup, Depends(require_manageable_goal_group)],
 ) -> GoalGroup:
     """Update an existing goal group.
 
-    Mutation requires the strict owner-only check from
-    ``require_owned_goal_group``: shared templates have ``user_id IS NULL``
-    so they can never match ``current_user`` and always 403.  Closes
-    BUG-GOAL-006 (shared templates were editable by any user because the
-    prior ``group.user_id is not None and ...`` short-circuit treated
-    NULL ownership as caller-equivalent).
+    Authority is routed by kind in ``require_manageable_goal_group``: a private
+    group stays owner-only (an admin is deliberately not admitted to someone's
+    own space), while a shared template requires admin -- it is ownerless, so
+    the owner comparison could never match anybody and templates were previously
+    unmodifiable by everyone.  The owner-only rule for private groups still
+    closes BUG-GOAL-006.
     """
     # ``group.id`` is ``int | None`` on the SQLModel because of the
     # primary-key default, but the ownership dep only ever returns a
     # row freshly fetched from the DB, so the value is non-NULL here.
     group_id = cast("int", group.id)
-    for key, value in payload.model_dump().items():
+    # ``shared_template`` is deliberately not updatable here. It is not a field
+    # so much as a *kind*, and changing it either way is a different act than an
+    # edit: private -> template publishes the group (and its embedded goals) to
+    # every user, which belongs behind the creation gate; template -> private
+    # would strand an ownerless row against
+    # ``ck_goalgroup_shared_template_user_id``. Excluding it also means an
+    # ordinary edit body, which carries the field's ``False`` default, cannot
+    # silently demote a template and 500 on that constraint.
+    for key, value in payload.model_dump(exclude={"shared_template"}).items():
         setattr(group, key, value)
     session.add(group)
     await session.commit()
@@ -192,11 +213,12 @@ async def delete_goal_group(
     group_id: int,
     current_user: Annotated[int, Depends(get_current_user)],
     session: Annotated[AsyncSession, Depends(get_session)],
-    _owned: Annotated[GoalGroup, Depends(require_owned_goal_group)],
+    _owned: Annotated[GoalGroup, Depends(require_manageable_goal_group)],
 ) -> Response:
     """Delete a goal group. Unlinks goals but does not delete them.
 
-    Owner-only via ``require_owned_goal_group`` (BUG-GOAL-006).  We
+    Authority routed by kind via ``require_manageable_goal_group``: owner for a
+    private group, admin for a shared template (BUG-GOAL-006).  We
     re-fetch with eager-loaded goals (the shared helper) so the unlink step
     doesn't trigger a lazy load on an async session; the dep has already
     verified existence, so the helper's 404 guard is a no-op on the happy path.

--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -32,7 +32,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import ColumnElement
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import col, select
+from sqlmodel import col, select, update
 
 from models.course_stage import CourseStage
 from models.goal import Goal
@@ -40,6 +40,7 @@ from models.journal_entry import JournalEntry
 from models.practice import Practice
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
+from models.user import User
 
 # Severity: probe attempts use a sentinel id well above any seeded row so
 # the missing-row branch is the same code path as a malicious enumeration.
@@ -85,6 +86,14 @@ async def _signup(client: AsyncClient, username: str) -> tuple[dict[str, str], i
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     return {"Authorization": f"Bearer {body['token']}"}, body["user_id"]
+
+
+async def _promote(session: AsyncSession, username: str) -> None:
+    """Flip ``is_admin`` so the caller may publish a shared template."""
+    await session.execute(
+        update(User).where(col(User.email) == f"{username}@example.com").values(is_admin=True)
+    )
+    await session.commit()
 
 
 def _goal_put_payload(goal: dict[str, object]) -> dict[str, object]:
@@ -340,17 +349,20 @@ async def test_idor_goal_group_delete_returns_403(async_client: AsyncClient) -> 
 
 
 @pytest.mark.asyncio
-async def test_idor_shared_template_mutation_returns_403(async_client: AsyncClient) -> None:
-    """BUG-GOAL-006: shared templates have no owner -- mutation always 403.
+async def test_idor_shared_template_mutation_returns_403(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """BUG-GOAL-006: an ordinary user cannot mutate a shared template.
 
-    Alice creates a shared template (``user_id IS NULL``).  Even the
-    creator cannot mutate it through the standard PUT/DELETE surface
-    because ``require_owned_goal_group`` checks ``group.user_id ==
-    current_user`` and ``None`` never equals an int.  An admin-only
-    moderation surface will land in a separate prompt; until then,
-    shared templates are read-only by design.
+    A template is ownerless (``user_id IS NULL``), so it can never match the
+    caller's id.  The admin moderation surface this docstring once anticipated
+    now exists -- ``require_manageable_goal_group`` routes templates to admin --
+    but a *non-admin* is still refused, which is what this pins.  Bob, an
+    ordinary user, is the one probing here.
     """
     alice_headers, _ = await _signup(async_client, "alice_shared")
+    await _promote(db_session, "alice_shared")
+    bob_headers, _ = await _signup(async_client, "bob_shared_probe")
 
     create = await async_client.post(
         "/goal-groups/",
@@ -363,19 +375,22 @@ async def test_idor_shared_template_mutation_returns_403(async_client: AsyncClie
     put = await async_client.put(
         f"/goal-groups/{group_id}",
         json={"name": "Hijacked"},
-        headers=alice_headers,
+        headers=bob_headers,
     )
     assert put.status_code == HTTPStatus.FORBIDDEN
 
-    delete = await async_client.delete(f"/goal-groups/{group_id}", headers=alice_headers)
+    delete = await async_client.delete(f"/goal-groups/{group_id}", headers=bob_headers)
     assert delete.status_code == HTTPStatus.FORBIDDEN
 
 
 @pytest.mark.asyncio
-async def test_idor_shared_template_get_is_visible(async_client: AsyncClient) -> None:
+async def test_idor_shared_template_get_is_visible(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
     """Shared templates are readable by every authenticated user."""
     alice_headers, _ = await _signup(async_client, "alice_shared_get")
     bob_headers, _ = await _signup(async_client, "bob_shared_get")
+    await _promote(db_session, "alice_shared_get")
 
     create = await async_client.post(
         "/goal-groups/",

--- a/backend/tests/test_goal_group_shared_template_authority.py
+++ b/backend/tests/test_goal_group_shared_template_authority.py
@@ -1,0 +1,291 @@
+"""Shared-template goal groups are an operator surface, not a user one.
+
+A ``shared_template`` group is ownerless (``user_id IS NULL``, biconditional with
+the flag via ``ck_goalgroup_shared_template_user_id``) and world-readable, and it
+carries its goals embedded. Creating one therefore *publishes content to every
+user of the deployment*.
+
+Until this module existed, any authenticated signup could do that -- and because
+the group is ownerless, the owner-only write check could never match anybody, so
+nothing could edit or delete it afterwards. One request permanently injected
+chosen content into every user's view with no in-app remedy. That combination is
+the sharpest available violation of the governing promise in ``NORTH-STAR.md``
+that a user's space is their own and that depth is always declinable.
+
+The rule these tests pin: **creating or mutating a shared template requires
+admin; everything about an ordinary private group is unchanged.** Reads stay open
+-- a template nobody can see is not a template -- so ``require_visible_goal_group``
+keeps its shared-template short-circuit and is deliberately not touched here.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select, update
+
+from models.goal_group import GoalGroup
+from models.user import User
+
+_PASSWORD = "secret12345"  # pragma: allowlist secret
+
+_GROUPS = "/goal-groups/"
+
+
+async def _signup(client: AsyncClient, username: str) -> dict[str, str]:
+    """Sign up a fresh (non-admin) user and return an Authorization header."""
+    response = await client.post(
+        "/auth/signup",
+        json={"email": f"{username}@example.com", "password": _PASSWORD},
+    )
+    assert response.status_code == HTTPStatus.OK
+    return {"Authorization": f"Bearer {response.json()['token']}"}
+
+
+async def _promote(session: AsyncSession, username: str) -> None:
+    """Flip ``is_admin`` for a signed-up user, mirroring the admin-router tests."""
+    await session.execute(
+        update(User).where(col(User.email) == f"{username}@example.com").values(is_admin=True)
+    )
+    await session.commit()
+
+
+def _template_payload(name: str = "Community Template") -> dict[str, object]:
+    """Build a shared-template creation body."""
+    return {"name": name, "shared_template": True, "source": "community"}
+
+
+async def _seed_template(session: AsyncSession, name: str = "Seeded Template") -> int:
+    """Insert a shared template directly, the way the seeder does.
+
+    Deliberately not via the API: the point of this module is that the API path
+    is closed, so the fixture cannot use it to build its own precondition.
+    """
+    group = GoalGroup(name=name, shared_template=True, user_id=None, source="built-in")
+    session.add(group)
+    await session.commit()
+    await session.refresh(group)
+    assert group.id is not None
+    return group.id
+
+
+class TestCreationRequiresAdmin:
+    """Publishing to every user is an operator act."""
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_user_cannot_create_a_shared_template(
+        self, async_client: AsyncClient
+    ) -> None:
+        """The broadcast primitive is closed to ordinary signups."""
+        headers = await _signup(async_client, "sharer-plain")
+
+        response = await async_client.post(_GROUPS, json=_template_payload(), headers=headers)
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_creation_writes_no_row(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A 403 must mean nothing was published, not merely that nothing was returned."""
+        headers = await _signup(async_client, "sharer-norow")
+        await async_client.post(
+            _GROUPS, json=_template_payload("Should Not Exist"), headers=headers
+        )
+
+        result = await db_session.execute(
+            select(GoalGroup).where(col(GoalGroup.name) == "Should Not Exist")
+        )
+        assert result.scalars().first() is None
+
+    @pytest.mark.asyncio
+    async def test_an_admin_can_create_a_shared_template(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """The operator path stays open -- this is a restriction, not a removal."""
+        headers = await _signup(async_client, "sharer-admin")
+        await _promote(db_session, "sharer-admin")
+
+        response = await async_client.post(_GROUPS, json=_template_payload(), headers=headers)
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.json()["shared_template"] is True
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_user_can_still_create_a_private_group(
+        self, async_client: AsyncClient
+    ) -> None:
+        """The restriction is scoped to publishing; ordinary use is untouched."""
+        headers = await _signup(async_client, "sharer-private")
+
+        response = await async_client.post(
+            _GROUPS, json={"name": "My Own Goals", "icon": "🎯"}, headers=headers
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.json()["shared_template"] is False
+
+
+class TestMutationHasAnAuthority:
+    """No object may be left permanently unmodifiable by everyone."""
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_user_cannot_edit_a_shared_template(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """A stranger editing a template would republish to everybody."""
+        group_id = await _seed_template(db_session)
+        headers = await _signup(async_client, "editor-plain")
+
+        response = await async_client.put(
+            f"/goal-groups/{group_id}", json={"name": "Hijacked"}, headers=headers
+        )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_an_admin_can_edit_a_shared_template(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """The defect this closes: previously nobody could, including operators."""
+        group_id = await _seed_template(db_session)
+        headers = await _signup(async_client, "editor-admin")
+        await _promote(db_session, "editor-admin")
+
+        response = await async_client.put(
+            f"/goal-groups/{group_id}",
+            json={"name": "Corrected Template", "shared_template": True},
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "Corrected Template"
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_user_cannot_delete_a_shared_template(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Deletion is as much a broadcast act as creation."""
+        group_id = await _seed_template(db_session)
+        headers = await _signup(async_client, "deleter-plain")
+
+        response = await async_client.delete(f"/goal-groups/{group_id}", headers=headers)
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_an_admin_can_delete_a_shared_template(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """There is now a remedy for bad published content."""
+        group_id = await _seed_template(db_session)
+        headers = await _signup(async_client, "deleter-admin")
+        await _promote(db_session, "deleter-admin")
+
+        response = await async_client.delete(f"/goal-groups/{group_id}", headers=headers)
+
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+    @pytest.mark.asyncio
+    async def test_an_admin_editing_a_private_group_they_do_not_own_is_still_refused(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """Admin is an authority over *published* content, not over private spaces.
+
+        The whole point of the product promise is that a user's own space is
+        theirs. Widening the shared-template authority into ordinary groups would
+        trade one violation for a larger one.
+        """
+        owner_headers = await _signup(async_client, "private-owner")
+        created = await async_client.post(
+            _GROUPS, json={"name": "Owner's Private Group"}, headers=owner_headers
+        )
+        assert created.status_code == HTTPStatus.CREATED
+        group_id = created.json()["id"]
+
+        admin_headers = await _signup(async_client, "nosy-admin")
+        await _promote(db_session, "nosy-admin")
+
+        response = await async_client.put(
+            f"/goal-groups/{group_id}", json={"name": "Snooped"}, headers=admin_headers
+        )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+class TestPutCannotChangeAGroupsKind:
+    """``shared_template`` is a kind, not a field -- an edit must not flip it.
+
+    Both directions are refused, for different reasons: publishing a private
+    group by editing it would route around the creation gate entirely, and
+    demoting a template would strand an ownerless row against the DB CHECK
+    constraint.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_owner_cannot_publish_their_group_by_editing_it(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Otherwise PUT is a second, ungated broadcast primitive."""
+        headers = await _signup(async_client, "publisher-via-put")
+        created = await async_client.post(_GROUPS, json={"name": "Mine"}, headers=headers)
+        group_id = created.json()["id"]
+
+        response = await async_client.put(
+            f"/goal-groups/{group_id}",
+            json={"name": "Mine", "shared_template": True},
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["shared_template"] is False
+
+    @pytest.mark.asyncio
+    async def test_an_admin_editing_a_template_without_resending_the_flag_keeps_it(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """An ordinary edit body carries the flag's False default; it must not demote."""
+        group_id = await _seed_template(db_session, "Keeps Its Kind")
+        headers = await _signup(async_client, "kind-admin")
+        await _promote(db_session, "kind-admin")
+
+        response = await async_client.put(
+            f"/goal-groups/{group_id}", json={"name": "Renamed"}, headers=headers
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["shared_template"] is True
+        assert response.json()["name"] == "Renamed"
+
+
+class TestReadsStayOpen:
+    """A template nobody can read is not a template."""
+
+    @pytest.mark.asyncio
+    async def test_any_user_still_sees_shared_templates_in_the_list(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """The restriction is on publishing, not on reading what was published."""
+        await _seed_template(db_session, "Visible Template")
+        headers = await _signup(async_client, "reader-list")
+
+        response = await async_client.get(_GROUPS, headers=headers)
+
+        assert response.status_code == HTTPStatus.OK
+        assert any(g["name"] == "Visible Template" for g in response.json())
+
+    @pytest.mark.asyncio
+    async def test_any_user_still_reads_a_shared_template_directly(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ) -> None:
+        """The single-GET short-circuit for templates is deliberately preserved."""
+        group_id = await _seed_template(db_session, "Directly Readable")
+        headers = await _signup(async_client, "reader-get")
+
+        response = await async_client.get(f"/goal-groups/{group_id}", headers=headers)
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["shared_template"] is True

--- a/backend/tests/test_goal_groups_api.py
+++ b/backend/tests/test_goal_groups_api.py
@@ -7,8 +7,10 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, update
 
 from models.goal import Goal
+from models.user import User
 from routers.goal_groups import seed_goal_group_templates
 
 SEED_TEMPLATE_COUNT = 3
@@ -27,6 +29,19 @@ async def _signup(client: AsyncClient, username: str = "alice") -> dict[str, str
     assert resp.status_code == HTTPStatus.OK
     token = resp.json()["token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+async def _promote(session: AsyncSession, username: str) -> None:
+    """Flip ``is_admin`` so the caller may publish a shared template.
+
+    Creating a shared template publishes content to every user, so it is an
+    operator act; see ``tests/test_goal_group_shared_template_authority.py``
+    for the rule and the ordinary-user refusal.
+    """
+    await session.execute(
+        update(User).where(col(User.email) == f"{username}@example.com").values(is_admin=True)
+    )
+    await session.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -127,9 +142,14 @@ async def test_create_goal_group(async_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_shared_template(async_client: AsyncClient) -> None:
-    """Creating a shared template sets user_id to null."""
+async def test_create_shared_template(async_client: AsyncClient, db_session: AsyncSession) -> None:
+    """An operator creating a shared template gets an ownerless, world-readable row.
+
+    Publishing to every user is admin-gated; the ordinary-user refusal is pinned
+    in ``tests/test_goal_group_shared_template_authority.py``.
+    """
     headers = await _signup(async_client)
+    await _promote(db_session, "alice")
 
     resp = await async_client.post(
         "/goal-groups/",
@@ -207,13 +227,14 @@ async def test_get_other_users_group_returns_403(
 
 @pytest.mark.asyncio
 async def test_get_shared_template_accessible_by_any_user(
-    async_client: AsyncClient,
+    async_client: AsyncClient, db_session: AsyncSession
 ) -> None:
     """Shared templates are accessible by any authenticated user."""
     alice_headers = await _signup(async_client, "alice")
     bob_headers = await _signup(async_client, "bob")
+    await _promote(db_session, "alice")
 
-    # Alice creates a shared template
+    # An operator publishes a shared template
     create_resp = await async_client.post(
         "/goal-groups/",
         json={"name": "Shared Yoga", "shared_template": True},

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -15,10 +15,11 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import col, select, update
 
 from models.goal import Goal
 from models.habit import Habit
+from models.user import User
 
 # Sentinel well above any seeded row, matching the security suite's probe id.
 _DEFINITELY_MISSING_ID = 999_999
@@ -88,6 +89,18 @@ async def _create_goal_group(
     resp = await client.post("/goal-groups/", json=body, headers=headers)
     assert resp.status_code == HTTPStatus.CREATED
     return int(resp.json()["id"])
+
+
+async def _promote(session: AsyncSession, username: str) -> None:
+    """Flip ``is_admin`` so the caller may publish a shared template.
+
+    Publishing to every user is an operator act; the ordinary-user refusal is
+    pinned in ``tests/test_goal_group_shared_template_authority.py``.
+    """
+    await session.execute(
+        update(User).where(col(User.email) == f"{username}@example.com").values(is_admin=True)
+    )
+    await session.commit()
 
 
 async def _stored_goal_group_id(db_session: AsyncSession, goal_id: int | None) -> int | None:
@@ -395,6 +408,9 @@ async def test_update_goal_rejects_shared_template_group(
     """
     headers, user_id = await _signup(async_client, "templateconsumer")
     author_headers, _author_id = await _signup(async_client, "templateauthor")
+    # Only an operator may publish a template, so the fixture promotes the
+    # author; the guard under test is about the *consumer*, who stays ordinary.
+    await _promote(db_session, "templateauthor")
     goal = await _seed_goal(db_session, user_id)
     template_id = await _create_goal_group(
         async_client, author_headers, "Community Meditation", shared_template=True


### PR DESCRIPTION
## The hole

Any authenticated signup could:

```
POST /goal-groups/  {"name": "PWNED", "shared_template": true}
```

A `shared_template` group is **ownerless** (`user_id IS NULL`, biconditional with the flag via `ck_goalgroup_shared_template_user_id`), **world-readable**, and **carries its goals embedded**. So that one call published attacker-chosen content to every user of the deployment.

It was then **irreversible**. Because the row is ownerless, the owner-only write check could never match anybody — not the creator, not an operator. Nothing could edit or delete it through the API.

Reproduced end-to-end during investigation: one user created a group named `PWNED`, a second unrelated user listed it back with `200`.

Either half alone would be tolerable. Together they mean one request permanently injects chosen content into every user's view with no in-app remedy — the sharpest available violation of the `NORTH-STAR.md` promise that a user's space is their own and that depth is always a declinable invitation.

## The decision

The issue called for a product decision before implementing. Owner ruling: **admin-only for both creation and mutation**, which is the issue's own suggested direction.

- **Creation** of a shared template requires admin, refused *before any row is written* (a test asserts the 403 leaves no row, because "returned an error" and "published nothing" are different claims).
- **Mutation** routes by kind in a new `require_manageable_goal_group`:
  - A **private group** stays owner-only. **An admin is deliberately *not* admitted** — an operator override on someone's private content would trade one violation for a larger one. Pinned by a test.
  - A **shared template** requires admin — the authority it never had.
- **Reads stay open.** A template nobody can see is not a template; `require_visible_goal_group` is untouched.

The three seeded built-ins are written by the seeder through the session, not the API, so they are unaffected.

## Two more holes the tests surfaced

Both only became *reachable* once the admin path opened — they were latent behind an unreachable handler.

1. **A 500 on ordinary admin edits.** `PUT` applied the whole payload via `setattr`, and `GoalGroupCreate.shared_template` defaults to `False` — so an admin renaming a template without re-sending the flag would demote it while `user_id` stayed `NULL`, violating the CHECK constraint.
2. **`PUT` was a second, ungated broadcast primitive.** An owner could have set `shared_template=true` on their own group via `PUT`, routing around the creation gate entirely.

Both close the same way: **`PUT` no longer changes a group's kind in either direction.** `shared_template` is a *kind*, not a field — publishing belongs behind the creation gate, and demoting would strand an ownerless row. Both directions are now pinned by tests.

## Dead code removed

`require_owned_goal_group` had no callers left once the router moved to the two-authority dependency, so it is deleted rather than left behind. `resolve_owned_goal_group` **stays** — `routers/goals.py:52` still uses it for a body-supplied group id.

## A note on the test suite

Five test modules built their fixtures by having an ordinary user publish to everyone. **The suite had been exercising a state the product should never have permitted** — which is part of why this survived a BOLA sweep: the sweep found it (that is how this issue got filed), but every surrounding test read as though it were intended.

Those fixtures now promote an operator to establish the precondition. Assertions are unchanged wherever the intent still holds; the one test whose intent genuinely reversed (`test_create_shared_template`) now documents the operator path, with the ordinary-user refusal pinned in the new module.

## Acceptance criteria

- [x] Creation authority decided and documented (admin-only, in the dependency's docstring and here).
- [x] An ordinary user can no longer create a group broadcast to every user.
- [x] Shared templates have a defined mutation/deletion authority — no group is left permanently unmodifiable.
- [x] Tests pin both the creation restriction and the mutation authority.
- [x] `./scripts/backend/check-all.sh` green — 4534 passed.
- [ ] **Existing `shared_template` rows audited.** Not done — I have no production database access. In this repo the only shared templates are the three seeded built-ins (`Meditation Goals`, `Exercise Goals`, `Nutrition Goals`, all `source="built-in"`). **You should run this against production before deploying**, since any row with `source != 'built-in'` came through the hole and is currently visible to everyone:

```sql
SELECT id, name, source FROM goalgroup
WHERE shared_template = true AND (source IS NULL OR source <> 'built-in');
```

## Testing

13 new tests in `tests/test_goal_group_shared_template_authority.py`: creation refused for ordinary users and writing no row, creation allowed for admins, private-group creation unaffected, mutation/deletion refused for ordinary users and allowed for admins, admin still refused on another user's *private* group, kind-flip refused in both directions, and reads still open to everyone.

Full backend suite green (4534 passed); `check-all.sh` exit 0; whole-tree `pre-commit run mypy --all-files` green.

Closes #2123
