### PR TITLE
fix(frontend): unblock the audit gate — fix nanoid, time-box the two unfixable advisories

### DIFF
--- a/frontend/.audit-allowlist.json
+++ b/frontend/.audit-allowlist.json
@@ -2,10 +2,25 @@
   "$comment": [
     "Advisories deliberately not failing the high+ audit gate, each scoped to one",
     "GHSA id and each with a hard expiry the gate ENFORCES. An expired entry fails",
-    "the build exactly like an unallowlisted advisory would — the time box is real,",
+    "the build exactly like an unallowlisted advisory would \u2014 the time box is real,",
     "not a comment. Adding an entry here is an owner-level policy decision, not an",
     "engineering convenience: everything else, including anything newly introduced,",
     "still fails the gate. See scripts/frontend/audit-gate.mjs."
   ],
-  "allow": []
+  "allow": [
+    {
+      "id": "GHSA-w3rx-r6r6-pgpr",
+      "package": "image-size",
+      "expires": "2026-11-08",
+      "issue": 2159,
+      "reason": "No patched release exists: first_patched_version is null and the vulnerable range (<= 2.0.2) covers every published version, so there is nothing to override to. Reached only through Metro, the build-time bundler reading local project assets, not a runtime path parsing untrusted images. The SDK ladder does not remove it - metro declares image-size ^1.0.2 in every published version (0.82-0.87), and a resolved SDK 57 tree still yields image-size@1.2.1 in prod via metro@0.84.4 and community-cli-plugin's nested metro@0.83.7. npm audit's only proposed remedy is react-native@0.72.17 (isSemVerMajor), a major downgrade of the whole stack. Removal tracked in #2159."
+    },
+    {
+      "id": "GHSA-5p2g-fcmc-qvqq",
+      "package": "image-size",
+      "expires": "2026-11-08",
+      "issue": 2159,
+      "reason": "Same package, same unfixable posture as GHSA-w3rx-r6r6-pgpr - JXL and HEIF parsers rather than ICNS. See that entry for the full evidence. Removal tracked in #2159."
+    }
+  ]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14171,9 +14171,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,6 +98,7 @@
     "brace-expansion@5": "5.0.9",
     "js-yaml@3": "3.15.1",
     "js-yaml@4": "4.3.1",
-    "postcss": "^8.5.23"
+    "postcss": "^8.5.23",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
## Why this is the keystone

`frontend-quality` has been red on `main`, and therefore on **every** PR that triggers Frontend CI. This one PR unblocks four things at once:

- **#2145** closes.
- **PR #2156** (pre-push hooks) goes green **with no code change** — just a CI re-run. It is stuck today on exactly this.
- **PR #2144** (vault settings surface) becomes mergeable.
- The entire **#2158** SDK subtree becomes buildable — none of #2161–#2166 can go green until this lands.

## Three advisories, two different problems, two different treatments

### `nanoid` — a real fix, not a suppression

#2145 recorded this as already handled in PR #2144. **It was not.** That PR's `package.json` is byte-identical to `main`, and no `nanoid` override existed:

```
$ npm ls nanoid
`-- nanoid@3.3.16          <- vulnerable
```

`3.3.18` is published on the `legacy` dist-tag and is patched, so an `overrides` pin of `^3.3.17` resolves it while staying inside the `3.x` line `@react-navigation/routers` expects:

```
node_modules/nanoid 3.3.18   <- after
```

Allowlisting a *fixable* advisory is precisely the failure mode the gate exists to prevent, so this one gets fixed.

### The two `image-size` advisories — provably unfixable, so time-boxed

`first_patched_version` is `null` on both and the vulnerable range (`<= 2.0.2`) covers **every published version** — there is nothing to override *to*.

The SDK ladder does not rescue it, and that was verified rather than assumed: `metro` declares `image-size@^1.0.2` in every published version (0.82 → 0.87), and a resolved SDK 57 tree still yields `image-size@1.2.1`.

Reach is **Metro — the build-time bundler reading local project assets**, not a runtime path parsing untrusted user images. Both advisories are DoS-by-infinite-loop in the ICNS / JXL / HEIF parsers.

Each entry carries a hard expiry the gate **enforces** (an expired entry fails the build exactly like an unallowlisted one) and an issue that owns its removal (**#2159**). The suppression has a deadline *and* a designated remover, which is what separates a time-box from a permanent exception nobody revisits.

## Verification

```
$ npm ls nanoid                          -> 3.3.18, no 3.3.16 remaining
$ node scripts/frontend/audit-gate.mjs
audit-gate: allowing GHSA-w3rx-r6r6-pgpr until 2026-11-08 (tracked in #2159)
audit-gate: allowing GHSA-5p2g-fcmc-qvqq until 2026-11-08 (tracked in #2159)
audit-gate: clean — no unallowed high/critical advisories (2 allowlisted).
EXIT=0
$ ./scripts/frontend/check-all.sh        -> exit 0
Test Suites: 449 passed, 449 total
Tests:       5229 passed, 5229 total
```

Note the suite count: **449**, not the 442 stated in #2164 or the 451 in #2145. Worth correcting in #2164 before it is dispatched.

## Scope held deliberately

No SDK upgrade, no third allowlist entry, no widened glob, no lowered `--audit-level`, no change to the gate's fail-closed behaviour. This PR is the critical path and stays small enough to merge immediately.

## Follow-up queued

`expo export` and `expo-doctor` have **never run** in this repo's CI or Gate 2 — there is no `frontend/ios` or `android` directory, so `newArchEnabled: true` has never been compiled here. Across a five-major SDK jump, "green" currently certifies only that Jest ran. Hardening CI, `check-all.sh` and the pre-push hook with both commands is queued as its own PR immediately after this one, since it needs this gate green to have any chance of going green itself.

Closes #2160
