### PR TITLE
fix(backend): read Creek's own capability document, and stop guessing an upload route

### DIFF
--- a/backend/src/services/creek_vault_client.py
+++ b/backend/src/services/creek_vault_client.py
@@ -93,8 +93,8 @@ import logging
 import os
 from collections.abc import Callable, Mapping
 from http import HTTPStatus
-from types import TracebackType
-from typing import NoReturn, TypeGuard
+from types import MappingProxyType, TracebackType
+from typing import NoReturn
 from urllib.parse import quote
 
 import httpx
@@ -479,8 +479,30 @@ def _require_str(payload: Mapping[str, object], key: str) -> str:
     return value
 
 
+# Creek advertises its capabilities under these published names.
+# :class:`CreekCapability` spells the same ideas as ``creek.*`` values, which are
+# deliberately *adepthood's* vocabulary and telemetry keys rather than a claim
+# about the wire (see that enum's docstring). The translation therefore lives
+# here, at the parse boundary, and nowhere else.
+#
+# Only four of the seven members have a published name. UPLOAD, SAVE and
+# CLASSIFY are adepthood-side concepts Creek does not advertise at contract
+# 0.2.0, so :meth:`supports` is permanently ``False`` for them and every
+# capability-gated path degrades. That is the contract reporting a capability
+# that does not exist yet, not a hole in this table -- do not invent wire names
+# for them.
+_CAPABILITY_BY_WIRE_NAME: Mapping[str, CreekCapability] = MappingProxyType(
+    {
+        "capabilities": CreekCapability.HANDSHAKE,
+        "journal-upsert": CreekCapability.JOURNAL,
+        "reflections": CreekCapability.REFLECT,
+        "wheel": CreekCapability.WHEEL,
+    }
+)
+
+
 def _coerce_capability(item: object) -> CreekCapability | None:
-    """Map one advertised wire string to a capability, or ``None`` if unknown.
+    """Map one advertised wire name to a capability, or ``None`` if unknown.
 
     Unknown/forward-compatible capability strings are dropped rather than
     erroring, so a vault can advertise new capabilities without breaking an
@@ -488,10 +510,7 @@ def _coerce_capability(item: object) -> CreekCapability | None:
     """
     if not isinstance(item, str):
         return None
-    try:
-        return CreekCapability(item)
-    except ValueError:
-        return None
+    return _CAPABILITY_BY_WIRE_NAME.get(item)
 
 
 def _parse_capabilities(raw: object) -> frozenset[CreekCapability]:
@@ -548,16 +567,20 @@ def _parse_handshake(payload: Mapping[str, object]) -> HandshakeResult:
     Reads and version-checks the contract before anything else: an incompatible
     version raises :class:`_IncompatibleContractVersionError` (we will not call a
     surface we do not understand), which every caller degrades to unavailable.
-    Then honors the vault's own ``available`` field, fail-closed: a
-    reachable server is not necessarily an available vault, so anything other
-    than a literal ``True`` (including a missing field) degrades to
+    Then honors the vault's own availability, fail-closed: a reachable server is
+    not necessarily an available vault, so anything other than a literal ``True``
+    -- a missing ``vault`` object, a missing or wrong-typed ``available`` inside
+    it -- degrades to unavailable. Creek publishes that flag *nested* under
+    ``vault``; reading a top-level ``available`` (which its documents do not
+    carry) is what made every handshake against a conformant vault report
     unavailable. Any missing key or wrong-typed field raises out of the helpers
     and is caught by :meth:`HttpCreekVaultClient._probe`.
     """
     contract_version = _require_str(payload, "contract_version")
     if not _contract_version_compatible(contract_version):
         raise _IncompatibleContractVersionError
-    if payload.get("available") is not True:
+    vault = payload.get("vault")
+    if not isinstance(vault, Mapping) or vault.get("available") is not True:
         return HandshakeResult.unavailable()
     return HandshakeResult(
         available=True,
@@ -815,12 +838,6 @@ _CAPABILITIES_PATH = "/v1/capabilities"
 # capability document are the only ``/v1`` shapes Creek has ratified.
 _JOURNAL_ENTRIES_PATH = "/v1/journal-entries/"
 
-# Where one uploaded document is addressed, relative to the configured base URL.
-# A separate collection from journal entries because the two are different kinds
-# of object: an entry is text adepthood authored the shape of, while an upload is
-# a file the vault's own ingestor registry parses. Sharing one collection would
-# make the vault infer which it received from the body's fields.
-_UPLOADS_PATH = "/v1/uploads/"
 
 # The whole-corpus frequency aggregate, relative to the configured base URL. Not
 # a resource but a computation over every admitted fragment, so it is read from
@@ -906,28 +923,11 @@ _CREDENTIAL_REJECTED_MESSAGE = _capability_message(_CREDENTIAL_REJECTED, CreekCa
 _WHEEL_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.WHEEL)
 _WHEEL_UNREADABLE_MESSAGE = _capability_message(_RESPONSE_UNREADABLE, CreekCapability.WHEEL)
 _REFLECT_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.REFLECT)
-# The upload path's own triple. Named apart from the journal one rather than
-# shared, because the whole point of the separate capability is that an operator
-# can tell "the vault will not take our files" from "the vault will not take our
-# entries" -- one message for both would erase exactly that distinction.
-_UPLOAD_FAILED_MESSAGE = _capability_message(_CALL_FAILED, CreekCapability.UPLOAD)
-_UPLOAD_REJECTED_MESSAGE = _capability_message(_REQUEST_REJECTED, CreekCapability.UPLOAD)
-_UPLOAD_CREDENTIAL_MESSAGE = _capability_message(_CREDENTIAL_REJECTED, CreekCapability.UPLOAD)
 
-# How many tags adepthood will read off one upload response, and how long each
-# may be. The vault classifies in its own pipeline and we store what it says, so
-# these bound what a compromised or malfunctioning vault can push into our
-# response on the back of a single upload.
-_MAX_UPLOAD_TAGS = 32
-_MAX_UPLOAD_TAG_LENGTH = 64
 # The one not-stored result every unreadable 2xx collapses to. Interned because
 # it is value-identical on each of those paths, and named so no branch is
 # tempted to invent a ``vault_ref`` the vault never issued.
 _NOT_STORED_RESULT = VaultIngestResult(stored=False, vault_ref=None, action=None)
-
-# The upload path's equivalent: the one not-stored answer every unreadable 2xx
-# on an upload collapses to.
-_NOT_UPLOADED_RESULT = VaultUploadResult(stored=False, vault_ref=None, action=None, tags=())
 
 
 def _build_pooled_vault_client() -> httpx.AsyncClient:
@@ -1028,76 +1028,6 @@ def _inert_path_segment(raw: str) -> str:
     the start, which is exactly the case that rule exists for.
     """
     return quote(raw, safe="").replace(".", _ENCODED_DOT)
-
-
-def _upload_body(request: VaultUploadRequest) -> Mapping[str, object]:
-    """Map an upload request onto the vault's document fields.
-
-    Four fields: the bytes, the filename the vault reads an extension off to
-    choose an ingestor, when the document entered the corpus, and the tier it is
-    stored at. The external id travels in the URL because it is the resource,
-    exactly as an entry id does.
-
-    Notably absent is any source or content type. The vault owns ingestor
-    selection; adepthood declaring one would override a decision made by the
-    side that actually parses the file.
-    """
-    return {
-        "filename": request.filename,
-        "content_base64": request.content_base64,
-        "timestamp": request.created_at.isoformat(),
-        "tier": request.tier.value,
-    }
-
-
-def _is_usable_tag(item: object) -> TypeGuard[str]:
-    """Return whether one element of a vault tag list is safe to carry onward.
-
-    The same three properties :func:`_is_storable_ref` demands of a fragment id,
-    for the same reason: a tag is vault-chosen text that adepthood puts into its
-    own API response, so it must be a real string, printable (no NUL, no CR/LF
-    to inject into a log, no zero-width or bidi-override codepoints), and
-    bounded in length.
-    """
-    if not isinstance(item, str) or not item.isprintable():
-        return False
-    return 0 < len(item) <= _MAX_UPLOAD_TAG_LENGTH
-
-
-def _upload_tags(raw: object) -> tuple[str, ...]:
-    """Read the vault's per-fragment tags, keeping only what is plainly usable.
-
-    Drop-unknown-items, exactly as :func:`_parse_capabilities` treats an
-    advertised capability list: a non-list, or any element failing
-    :func:`_is_usable_tag`, is discarded rather than raising, so a malformed
-    answer costs the caller its tags and never its upload. The count bound keeps
-    a single upload from carrying an unbounded amount of vault-chosen text back
-    into adepthood's own response.
-    """
-    if not isinstance(raw, list):
-        return ()
-    return tuple(item for item in raw[:_MAX_UPLOAD_TAGS] if _is_usable_tag(item))
-
-
-def _parse_http_upload_result(payload: object) -> VaultUploadResult:
-    """Project a 2xx upload body onto a result, as conservatively as ingest does.
-
-    A durable upload needs both halves -- an action we recognize *and* a storable
-    fragment id -- so anything less parses to not-stored and the caller records a
-    degraded upload. Tags are read only once the write itself is established:
-    tags without a stored document would describe something that is not there.
-    """
-    if isinstance(payload, Mapping):
-        action = _coerce_ingest_action(payload.get("action"))
-        fragment_id = _usable_fragment_id(payload)
-        if action is not None and fragment_id is not None:
-            return VaultUploadResult(
-                stored=True,
-                vault_ref=fragment_id,
-                action=action,
-                tags=_upload_tags(payload.get("tags")),
-            )
-    return _NOT_UPLOADED_RESULT
 
 
 def _journal_entry_body(request: VaultIngestRequest) -> Mapping[str, object]:
@@ -1235,16 +1165,6 @@ def _ingest_failure(response: httpx.Response) -> CreekVaultError:
         call_failed=_INGEST_FAILED_MESSAGE,
         request_rejected=_INGEST_REJECTED_MESSAGE,
         credential_rejected=_CREDENTIAL_REJECTED_MESSAGE,
-    )
-
-
-def _upload_failure(response: httpx.Response) -> CreekVaultError:
-    """Classify a failed document upload, naming the UPLOAD capability."""
-    return _write_failure(
-        response,
-        call_failed=_UPLOAD_FAILED_MESSAGE,
-        request_rejected=_UPLOAD_REJECTED_MESSAGE,
-        credential_rejected=_UPLOAD_CREDENTIAL_MESSAGE,
     )
 
 
@@ -1662,67 +1582,31 @@ class HttpCreekVaultClient:
         )
         return result
 
-    async def _put_upload(self, request: VaultUploadRequest) -> httpx.Response:
-        """Upsert one document at its own URL, normalizing any transport failure.
+    async def upload(self, _request: VaultUploadRequest, /) -> VaultUploadResult:
+        """Refuse a document upload: Creek publishes no ``/v1`` surface for one.
 
-        The same discipline :meth:`_put_journal_entry` follows, and for a
-        sharper reason: an upload's external id is a *string* rather than an
-        integer, so :func:`_inert_path_segment` is load-bearing here rather than
-        merely future-proofing. Every transport failure becomes
-        :class:`CreekVaultUnavailableError` with ``from None``, since the
-        original exception's text can carry the URL or the document bytes and
-        neither may ride along in a message or a traceback.
-        """
-        upload_url = f"{self._url}{_UPLOADS_PATH}{_inert_path_segment(request.external_id)}"
-        try:
-            return await self._authorized_request("PUT", upload_url, _upload_body(request))
-        except _HTTP_CALL_TIMED_OUT_ERRORS:
-            raise VaultCallTimedOutError(_UPLOAD_FAILED_MESSAGE) from None
-        except _HTTP_CALL_FAILED_ERRORS:
-            raise CreekVaultUnavailableError(_UPLOAD_FAILED_MESSAGE) from None
+        This looks like ``classify``'s refusal because it is the same situation.
+        The ratified ``/v1`` capability vocabulary is a closed enum of exactly
+        four names -- ``capabilities``, ``journal-upsert``, ``reflections``,
+        ``wheel`` -- under ``additionalProperties: false``, identical across every
+        supported contract minor. There is no upload name, no upload schema, and
+        no upload route, so no conformant vault can ever advertise or serve one.
 
-    async def upload(self, request: VaultUploadRequest, /) -> VaultUploadResult:
-        """Upsert ``request`` into the vault, requiring the UPLOAD capability.
+        ``creek.upload`` is real, but it is an **MCP tool** at contract 0.3.0
+        (Geoffe-Ga/Creek-Vault#1023), and adepthood's MCP client was retired by
+        ADR 0004. Reaching it would be a transport decision, not a parsing one.
 
-        A thin wrapper over :meth:`_upload` so the attempt is counted exactly
-        once, exactly as :meth:`ingest` wraps :meth:`_ingest`.
+        This previously ``PUT`` a body to an invented ``/v1/uploads/{id}`` URL.
+        Creek has never served that route. Guessing a wire shape is exactly what
+        this seam exists to refuse, so the guess is gone and the refusal is
+        counted under its own capability like every other.
         """
         with _CountingOutcome(CreekCapability.UPLOAD):
-            return await self._upload(request)
+            return await self._upload()
 
-    async def _upload(self, request: VaultUploadRequest) -> VaultUploadResult:
-        """Perform the document upsert and report how it ended.
-
-        Gated on the cached handshake first, and this gate matters more than
-        journal ingest's: a vault may well advertise ``creek.journal`` without
-        ``creek.upload``, so refusing *locally* is what keeps a user's document
-        off the wire toward a surface that never claimed it could take one.
-
-        The answer splits the same three ways ingest's does -- a readable 2xx
-        projected by :func:`_parse_http_upload_result`, an undecodable 2xx read
-        as an unavailable vault rather than a successful write, and a non-2xx
-        classified by :func:`_upload_failure`. A 2xx that does not describe a
-        durable write is counted as a schema failure, because reporting it as a
-        success would tell a user their document is in the vault when the vault
-        never said so.
-        """
-        if not self.supports(CreekCapability.UPLOAD):
-            raise CreekCapabilityUnsupportedError(_unsupported_message(CreekCapability.UPLOAD))
-        response = await self._put_upload(request)
-        if not response.is_success:
-            raise _upload_failure(response) from None
-        try:
-            payload = response.json()
-        except ValueError:
-            raise CreekVaultUnavailableError(_UPLOAD_FAILED_MESSAGE) from None
-        result = _parse_http_upload_result(payload)
-        record_vault_outcome(
-            VaultTelemetryOutcome.SUCCESS
-            if result.stored
-            else VaultTelemetryOutcome.SCHEMA_FAILURE,
-            CreekCapability.UPLOAD,
-        )
-        return result
+    async def _upload(self) -> VaultUploadResult:
+        """Refuse the upload, naming the capability and nothing else."""
+        _refuse_unratified(CreekCapability.UPLOAD)
 
     async def classify(self, _body: str, _tier_ceiling: VaultTierCeiling, /) -> VaultClassification:
         """Refuse classification: its ``/v1`` request/response shape is unratified.

--- a/backend/tests/test_creek_contract_conformance.py
+++ b/backend/tests/test_creek_contract_conformance.py
@@ -77,7 +77,11 @@ from domain.creek_vault import (
     VaultTierCeiling,
 )
 from scripts.creek_contract_drift import BUNDLE_ROOT, EXIT_DRIFT, verify_local
-from services.creek_vault_client import HandshakeDegradeReason, HttpCreekVaultClient
+from services.creek_vault_client import (
+    _CAPABILITY_BY_WIRE_NAME,
+    HandshakeDegradeReason,
+    HttpCreekVaultClient,
+)
 
 MANIFEST_NAME = "manifest.json"
 README_NAME = "README.md"
@@ -159,20 +163,13 @@ _ERROR_STATES = frozenset(
     state for state, status in _STATUS_BY_STATE.items() if status != HTTPStatus.OK
 )
 
-# TRANSLATION THAT EXISTS ONLY BECAUSE OF TWO DIVERGENCES. Creek advertises its
-# capabilities by their published names; ``CreekCapability`` spells the same four
-# ideas as ``creek.*`` values, and the two sets share no member. This table, plus
-# the lifting of ``vault.available`` in :func:`_client_readable_capabilities`, is
-# the entire difference between Creek's ratified capability document and a
-# document today's client can complete a handshake against. Both must be deleted
-# the moment the client reads Creek's document natively: they are scaffolding
-# around a bug, not part of the contract.
-_CAPABILITY_BY_CREEK_NAME: Mapping[str, CreekCapability] = {
-    "capabilities": CreekCapability.HANDSHAKE,
-    "journal-upsert": CreekCapability.JOURNAL,
-    "reflections": CreekCapability.REFLECT,
-    "wheel": CreekCapability.WHEEL,
-}
+# The client's own wire-name translation, imported rather than restated. It used
+# to be duplicated here as scaffolding around two divergences -- the client read
+# a top-level ``available`` Creek does not publish, and mapped advertised names
+# through ``CreekCapability``, whose ``creek.*`` values share no member with
+# Creek's published names. Both are fixed, so the fixture is served verbatim and
+# this alias exists only so the guard below asserts against the SHIPPED table.
+_CAPABILITY_BY_CREEK_NAME = _CAPABILITY_BY_WIRE_NAME
 
 Handler = Callable[[httpx.Request], httpx.Response]
 ClientFactory = Callable[[Handler], HttpCreekVaultClient]
@@ -256,31 +253,6 @@ _CAPABILITY_ERROR_CELLS = tuple(
 )
 
 
-def _client_readable_capabilities() -> dict[str, object]:
-    """Derive a handshake document today's client can complete, from Creek's own.
-
-    Exactly two edits to ``examples/capabilities/success.json``, each undoing one
-    known divergence: ``vault.available`` is lifted to the top-level key the
-    client reads, and Creek's published capability names are translated through
-    :data:`_CAPABILITY_BY_CREEK_NAME`. Every other field is Creek's, unmodified.
-
-    This is scaffolding around a bug. When the client reads Creek's document
-    natively it must be deleted rather than generalised -- keeping it would let
-    the journal conformance cells go on passing against a document Creek does not
-    publish.
-    """
-    published = _read_json("examples/capabilities/success.json")
-    vault = published["vault"]
-    assert isinstance(vault, dict)
-    advertised = published["capabilities"]
-    assert isinstance(advertised, list)
-    return {
-        **published,
-        "available": vault["available"],
-        "capabilities": [_CAPABILITY_BY_CREEK_NAME[str(name)].value for name in advertised],
-    }
-
-
 @dataclass
 class _Recorder:
     """A route-aware ``MockTransport`` handler that records every request it sees.
@@ -303,7 +275,9 @@ class _Recorder:
         """Answer one request, recording the method and path it arrived on."""
         self.calls.append(f"{request.method} {request.url.path}")
         if request.url.path == _CAPABILITIES_PATH:
-            return httpx.Response(HTTPStatus.OK, json=_client_readable_capabilities())
+            return httpx.Response(
+                HTTPStatus.OK, json=_read_json("examples/capabilities/success.json")
+            )
         if request.url.path == _WHEEL_PATH:
             return httpx.Response(self.wheel_status, json=self.wheel_payload)
         if request.url.path == _REFLECTIONS_PATH:
@@ -540,7 +514,7 @@ def test_state_status_table_matches_the_manifest() -> None:
 
 
 def test_capability_translation_table_matches_the_manifest() -> None:
-    """The divergence-bridging table must name exactly Creek's four capabilities."""
+    """The client's wire-name table must name exactly Creek's four published capabilities."""
     assert frozenset(_CAPABILITY_BY_CREEK_NAME) == _CAPABILITIES
     assert len(frozenset(_CAPABILITY_BY_CREEK_NAME.values())) == CAPABILITY_COUNT
 
@@ -564,14 +538,6 @@ def test_every_published_error_code_has_a_status_and_a_retry_disposition() -> No
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "the client reads a top-level 'available' where Creek nests 'vault.available', "
-        "and maps advertised names through CreekCapability, whose creek.* values share "
-        "no member with Creek's published capabilities/journal-upsert/reflections/wheel"
-    ),
-)
 async def test_ratified_capability_documents_are_understood(
     vault_clients: ClientFactory,
 ) -> None:
@@ -600,30 +566,6 @@ async def test_ratified_capability_documents_are_understood(
 
     assert empty_result.available is False
     assert empty.last_degrade_reason == HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
-
-
-@pytest.mark.asyncio
-async def test_observed_capability_success_degrades_to_vault_reported_unavailable(
-    vault_clients: ClientFactory,
-) -> None:
-    """The observed outcome is the divergence, not the contract.
-
-    Creek's ratified success document advertises an available vault and four
-    capabilities. Today's client reports the vault unavailable and supports
-    nothing, and the reason it records is the maximally misleading one: it never
-    reaches the capability list, because the top-level ``available`` key it looks
-    for is absent, so it concludes the vault reported itself unavailable.
-    """
-    client = vault_clients(
-        _static_handler(_read_json("examples/capabilities/success.json"), HTTPStatus.OK),
-    )
-
-    result = await client.handshake()
-
-    assert result.available is False
-    assert result.capabilities == frozenset()
-    assert client.last_degrade_reason == HandshakeDegradeReason.VAULT_REPORTED_UNAVAILABLE
-    assert client.supports(CreekCapability.JOURNAL) is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_creek_vault_http_client.py
+++ b/backend/tests/test_creek_vault_http_client.py
@@ -235,10 +235,27 @@ def _handshake_payload(
     *,
     available: bool = True,
 ) -> dict[str, object]:
-    """Build the only capability response shape adepthood already parses."""
+    """Build a handshake document in the shape Creek actually publishes.
+
+    Callers pass adepthood-side capability values (``creek.*``) because that is
+    the vocabulary the assertions are written in; this translates them to Creek's
+    published wire names on the way out, so every test exercises the real
+    document shape rather than one shaped to the client's former bugs.
+    Availability is nested under ``vault``, where Creek puts it.
+
+    A capability with no published name (UPLOAD, SAVE, CLASSIFY) is emitted
+    unchanged so a test can still assert that an unrecognised advertisement is
+    dropped rather than coerced.
+    """
+    wire_name = {
+        CreekCapability.HANDSHAKE.value: "capabilities",
+        CreekCapability.JOURNAL.value: "journal-upsert",
+        CreekCapability.REFLECT.value: "reflections",
+        CreekCapability.WHEEL.value: "wheel",
+    }
     return {
-        "available": available,
-        "capabilities": list(capabilities),
+        "vault": {"available": available},
+        "capabilities": [wire_name.get(c, c) for c in capabilities],
         "contract_version": contract_version,
         "ontology_version": ontology_version,
         "attestation": attestation,
@@ -1394,11 +1411,14 @@ async def test_a_url_with_a_path_prefix_keeps_it_in_the_capability_url(
 async def test_classify_is_still_refused_when_advertised(
     http_clients: ClientFactory,
 ) -> None:
-    """Classify is the one capability left unratified, so it refuses even when advertised.
+    """Classify refuses, and at contract 0.2.0 it cannot even be advertised.
 
-    Its ``/v1`` payload shape has not shipped, so an advertised classify still
-    degrades the caller onto its local pipeline rather than guessing a wire
-    format.
+    Two guarantees, and the second is stronger than it used to be. Creek
+    publishes no wire name for classify, so an advertisement of it is dropped at
+    the parse boundary and :meth:`supports` is ``False`` -- there is no document
+    a conformant vault can send that turns it on. And independently of that, the
+    call refuses rather than guessing a payload shape that has never shipped, so
+    the caller degrades onto its local pipeline either way.
     """
     advertised = [
         CreekCapability.JOURNAL.value,
@@ -1410,7 +1430,8 @@ async def test_classify_is_still_refused_when_advertised(
         _VAULT_URL, _API_KEY, http_client=http_clients(_healthy_handler(advertised))
     )
     await client.handshake()
-    assert client.supports(CreekCapability.CLASSIFY) is True
+    # Unadvertisable by construction: Creek has no published name for it.
+    assert client.supports(CreekCapability.CLASSIFY) is False
     with pytest.raises(CreekCapabilityUnsupportedError) as exc_info:
         await client.classify(_ENTRY_BODY, VaultTierCeiling.OPEN)
     assert CreekCapability.CLASSIFY.value in str(exc_info.value)
@@ -3191,7 +3212,8 @@ async def test_handshake_drops_a_non_string_capability_beside_the_valid_ones(
     """
     payload = {
         **_handshake_payload([]),
-        "capabilities": [CreekCapability.JOURNAL.value, 42, CreekCapability.WHEEL.value],
+        # Creek's published wire names, since this bypasses the helper's translation.
+        "capabilities": ["journal-upsert", 42, "wheel"],
     }
     client = HttpCreekVaultClient(
         _VAULT_URL, _API_KEY, http_client=http_clients(_json_handler(payload))

--- a/backend/tests/test_creek_vault_telemetry.py
+++ b/backend/tests/test_creek_vault_telemetry.py
@@ -96,10 +96,13 @@ _SENTINELS: tuple[str, ...] = (
 
 # The capabilities a healthy scripted vault advertises: every ratified surface,
 # so one handler serves the ingest, reflect, and wheel exchanges alike.
+# Creek's PUBLISHED wire names, not adepthood's ``creek.*`` telemetry keys. The
+# two vocabularies are translated at the client's parse boundary, so a fixture
+# advertising the internal names would be a document no vault can send.
 _RATIFIED_CAPABILITIES: tuple[str, ...] = (
-    CreekCapability.JOURNAL.value,
-    CreekCapability.REFLECT.value,
-    CreekCapability.WHEEL.value,
+    "journal-upsert",
+    "reflections",
+    "wheel",
 )
 
 Handler = Callable[[httpx.Request], httpx.Response]
@@ -193,7 +196,8 @@ class _ScriptedVault:
     def _capability_document(self) -> dict[str, object]:
         """Build the capability document this scripted vault advertises."""
         return {
-            "available": True,
+            # Creek nests availability under ``vault``; the client reads it there.
+            "vault": {"available": True},
             "capabilities": self._capabilities,
             "contract_version": self._contract_version,
             "ontology_version": _ONTOLOGY_VERSION,
@@ -230,7 +234,7 @@ class _ScriptedHandshake:
 # serve. It is the one degrade reason with no error behind it at all.
 _VAULT_REPORTED_UNAVAILABLE_REPLY = _Reply(
     payload={
-        "available": False,
+        "vault": {"available": False},
         "capabilities": list(_RATIFIED_CAPABILITIES),
         "contract_version": CONTRACT_VERSION,
         "ontology_version": _ONTOLOGY_VERSION,

--- a/backend/tests/test_creek_vault_upload.py
+++ b/backend/tests/test_creek_vault_upload.py
@@ -21,7 +21,6 @@ The endpoint sitting on top of all three is covered in
 from __future__ import annotations
 
 import base64
-import json
 import logging
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime
@@ -547,85 +546,28 @@ def _stored_payload(
     return {"action": action, "fragment_id": _FRAGMENT_ID, **extra}
 
 
-class TestHttpClientUpload:
-    """The HTTP adapter gates on the capability and sends the ratified upload shape."""
+class TestHttpClientUploadRefuses:
+    """There is no ``/v1`` upload surface, so the adapter refuses rather than guessing.
+
+    This class used to drive a ``PUT`` against ``/v1/uploads/{external_id}`` — a
+    route Creek has never served. The ratified ``/v1`` capability vocabulary is a
+    closed enum of exactly four names (``capabilities``, ``journal-upsert``,
+    ``reflections``, ``wheel``) under ``additionalProperties: false``, identical
+    across every supported contract minor. No upload name, no upload schema, no
+    upload route.
+
+    ``creek.upload`` does exist, as an **MCP tool** at contract 0.3.0
+    (Geoffe-Ga/Creek-Vault#1023, closed) — on the transport ADR 0004 retired.
+    Reaching it is a transport decision, not a parsing one, so it is not marked
+    xfail here: an xfail would name a *closed* upstream issue and could never
+    flip green.
+    """
 
     @pytest.mark.asyncio
-    async def test_upload_is_refused_locally_when_capability_absent(
+    async def test_upload_refuses_and_names_the_capability(
         self, vault_http_clients: _VaultClientFactory
     ) -> None:
-        """No document bytes reach the wire toward a surface that never claimed them."""
-        seen: list[httpx.Request] = []
-        handler = _routed_handler(_stored_payload(), capabilities=[CreekCapability.JOURNAL.value])
-
-        def _record(request: httpx.Request) -> httpx.Response:
-            """Record the request before answering it."""
-            seen.append(request)
-            return handler(request)
-
-        client = HttpCreekVaultClient(
-            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
-        )
-        await client.handshake()
-        before = len(seen)
-
-        with pytest.raises(CreekCapabilityUnsupportedError):
-            await client.upload(_upload_request())
-
-        assert len(seen) == before
-
-    @pytest.mark.asyncio
-    async def test_upload_sends_filename_bytes_tier_and_timestamp(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """The vault needs all four to select an ingestor and store at the right tier."""
-        seen: list[httpx.Request] = []
-        handler = _routed_handler(_stored_payload())
-
-        def _record(request: httpx.Request) -> httpx.Response:
-            """Record the request before answering it."""
-            seen.append(request)
-            return handler(request)
-
-        client = HttpCreekVaultClient(
-            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
-        )
-        await client.handshake()
-        await client.upload(_upload_request())
-
-        body = json.loads(seen[-1].content)
-        assert body["filename"] == _FILENAME
-        assert body["content_base64"] == _CONTENT_B64
-        assert body["tier"] == VaultTierCeiling.PERSONAL.value
-        assert body["timestamp"] == _CREATED_AT.isoformat()
-
-    @pytest.mark.asyncio
-    async def test_upload_addresses_the_fragment_by_external_id(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """Keying off the stable id is what makes a re-send edit in place."""
-        seen: list[httpx.Request] = []
-        handler = _routed_handler(_stored_payload(VaultIngestAction.UPDATED.value))
-
-        def _record(request: httpx.Request) -> httpx.Response:
-            """Record the request before answering it."""
-            seen.append(request)
-            return handler(request)
-
-        client = HttpCreekVaultClient(
-            _VAULT_URL, _VAULT_API_KEY, http_client=vault_http_clients(_record)
-        )
-        await client.handshake()
-        request = _upload_request()
-        await client.upload(request)
-
-        assert seen[-1].url.path.endswith(request.external_id)
-
-    @pytest.mark.asyncio
-    async def test_durable_upload_reports_stored_with_the_fragment_id(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """A recognized action plus a usable id is the only shape counted as stored."""
+        """Refusing beats inventing a wire shape, which is this seam's whole discipline."""
         client = HttpCreekVaultClient(
             _VAULT_URL,
             _VAULT_API_KEY,
@@ -633,136 +575,24 @@ class TestHttpClientUpload:
         )
         await client.handshake()
 
-        result = await client.upload(_upload_request())
-
-        assert result == VaultUploadResult(
-            stored=True, vault_ref=_FRAGMENT_ID, action=VaultIngestAction.CREATED, tags=()
-        )
-
-    @pytest.mark.asyncio
-    async def test_upload_reads_per_fragment_tags_when_the_vault_sends_them(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """The vault classifies in-pipeline; adepthood reads its answer, never re-derives it."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler(_stored_payload(tags=["courage", "threshold"]))
-            ),
-        )
-        await client.handshake()
-
-        result = await client.upload(_upload_request())
-
-        assert result.tags == ("courage", "threshold")
-
-    @pytest.mark.asyncio
-    async def test_unreadable_tags_drop_to_empty_rather_than_raising(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """A wrong-typed tag list is dropped on the floor, exactly as capabilities are."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler(_stored_payload(tags=[{"not": "a string"}, 7]))
-            ),
-        )
-        await client.handshake()
-
-        result = await client.upload(_upload_request())
-
-        assert result.tags == ()
-
-    @pytest.mark.asyncio
-    async def test_unrecognized_action_reports_not_stored(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """Reporting a write we cannot verify would let a lost document look replicated."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(_routed_handler(_stored_payload("teleported"))),
-        )
-        await client.handshake()
-
-        result = await client.upload(_upload_request())
-
-        assert result.stored is False
-
-    @pytest.mark.asyncio
-    async def test_undecodable_success_body_is_an_unavailable_vault(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """A proxy error page served as 200 is not a successful upload."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler(None, upload_text="<html>not json</html>")
-            ),
-        )
-        await client.handshake()
-
-        with pytest.raises(CreekVaultUnavailableError):
+        with pytest.raises(CreekCapabilityUnsupportedError) as caught:
             await client.upload(_upload_request())
 
+        assert CreekCapability.UPLOAD.value in str(caught.value)
+
     @pytest.mark.asyncio
-    async def test_rejected_request_raises_a_contract_error(
+    async def test_upload_is_never_advertised_by_a_conformant_vault(
         self, vault_http_clients: _VaultClientFactory
     ) -> None:
-        """A 4xx that is not retryable blames the request adepthood sent."""
+        """Even a vault naming it gets it dropped: it is outside the published enum."""
         client = HttpCreekVaultClient(
             _VAULT_URL,
             _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler(
-                    {"error": {"code": "invalid_request"}}, upload_status=HTTPStatus.BAD_REQUEST
-                )
-            ),
+            http_client=vault_http_clients(_routed_handler(_stored_payload())),
         )
         await client.handshake()
 
-        with pytest.raises(CreekVaultContractError):
-            await client.upload(_upload_request())
-
-    @pytest.mark.asyncio
-    async def test_refused_credential_raises_an_auth_error(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """A rejected bearer is a configuration fault with its own remedy."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler({}, upload_status=HTTPStatus.UNAUTHORIZED)
-            ),
-        )
-        await client.handshake()
-
-        with pytest.raises(CreekVaultAuthError):
-            await client.upload(_upload_request())
-
-    @pytest.mark.asyncio
-    async def test_transport_failure_raises_unavailable_without_the_payload(
-        self, vault_http_clients: _VaultClientFactory
-    ) -> None:
-        """The original exception's text may quote the URL or the bytes; neither rides along."""
-        client = HttpCreekVaultClient(
-            _VAULT_URL,
-            _VAULT_API_KEY,
-            http_client=vault_http_clients(
-                _routed_handler(None, upload_error=httpx.ConnectError(_SENTINEL_ERROR_TEXT))
-            ),
-        )
-        await client.handshake()
-
-        with pytest.raises(CreekVaultUnavailableError) as caught:
-            await client.upload(_upload_request())
-
-        assert _SENTINEL_ERROR_TEXT not in str(caught.value)
-        assert caught.value.__cause__ is None
+        assert client.supports(CreekCapability.UPLOAD) is False
 
 
 class TestLocalFallbackUpload:

--- a/backend/tests/test_creek_vault_url_defects.py
+++ b/backend/tests/test_creek_vault_url_defects.py
@@ -47,7 +47,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from domain.creek_vault import CONTRACT_VERSION, CreekCapability
+from domain.creek_vault import CONTRACT_VERSION
 from models.journal_entry import JournalEntry
 from services.creek_vault_client import (
     _RETIRED_PROTOCOL_EVENT,
@@ -154,8 +154,10 @@ _ENTRY_BODY = "The willow bent without breaking, and I noticed that I did too."
 # keeps the test's failure the fact that it happened rather than a transport
 # error somewhere downstream of it.
 _CAPABILITY_PAYLOAD: dict[str, object] = {
-    "available": True,
-    "capabilities": [CreekCapability.JOURNAL.value],
+    # Creek's real document shape: availability nested, capabilities by their
+    # published wire names.
+    "vault": {"available": True},
+    "capabilities": ["journal-upsert"],
     "contract_version": CONTRACT_VERSION,
     "ontology_version": "aptitude-wavelength/2026-05-23",
     "attestation": None,

--- a/backend/tests/test_creek_vault_wheel.py
+++ b/backend/tests/test_creek_vault_wheel.py
@@ -327,8 +327,8 @@ def _published_shares(payload: dict[str, object]) -> list[object]:
 def _capability_document() -> dict[str, object]:
     """Build the handshake document a vault advertising only the wheel would serve."""
     return {
-        "available": True,
-        "capabilities": [CreekCapability.WHEEL.value],
+        "vault": {"available": True},
+        "capabilities": ["wheel"],
         "contract_version": CONTRACT_VERSION,
         "ontology_version": _ONTOLOGY_VERSION,
         "attestation": None,


### PR DESCRIPTION
## The handshake could never succeed

Two divergences, one behaviour. The client read a top-level `available` where Creek nests `vault.available`, and mapped advertised names through `CreekCapability`, whose `creek.*` values share **no member** with Creek's published `capabilities` / `journal-upsert` / `reflections` / `wheel`.

So availability parsed as absent, every capability was dropped, and every gate degraded:

```
available=False, capabilities=frozenset()
```

**Journal ingest, reflect and wheel have all been unreachable in production.** The repo knew — `test_creek_contract_conformance.py` parked the proof under `@pytest.mark.xfail(strict=True)` naming both defects, and ADR 0004 says of this capability *"Not met, and not claimed as met."* It had never been filed as work.

## The fix

Availability is read where Creek publishes it. Wire names are translated at the parse boundary via a new `_CAPABILITY_BY_WIRE_NAME`.

`CreekCapability` keeps its `creek.*` values **deliberately** — its own docstring says they are adepthood's vocabulary and telemetry keys rather than a claim about the wire, and `test_creek_vault_telemetry.py` counts outcomes by them. Renaming the members would have churned telemetry to fix a parsing bug. The translation belongs at the boundary and nowhere else.

The `strict=True` xfail is gone and passing. So is the scaffolding built around it: `_client_readable_capabilities()` is **deleted** and the conformance recorder now serves Creek's fixture **verbatim** — which is exactly what that scaffolding's own comment instructed *"the moment the client reads Creek's document natively."* The test asserting the observed broken outcome is deleted rather than inverted; it existed only to record the bug.

## It also removes an endpoint that never existed

`HttpCreekVaultClient.upload` `PUT` to `/v1/uploads/{external_id}`. **Creek has never served that route and publishes no schema for it.**

The ratified `/v1` capability vocabulary is a closed enum of exactly four names under `additionalProperties: false`, *identical for every minor in `SUPPORTED_CONTRACT_MINORS`*. No conformant vault can advertise or serve an upload.

That route was invented in #2149 while translating #1924's *"forward via the existing MCP client"* onto a transport ADR 0004 had retired. Its tests passed only because they ran against a fake client — and a fake answers any URL it is given.

`upload()` now refuses through `_refuse_unratified`, exactly as `classify` does. **Not** marked xfail: `creek.upload` is real but shipped as an **MCP tool at contract 0.3.0** (`Creek-Vault#1023`, **closed/completed**), so an xfail would name a closed issue and could never flip green. Reaching it is a transport decision — filed as **#2171**, deliberately not answered here.

The domain seam survives untouched and fully covered: `VaultUploadRequest`, `upload_external_id`, the four degrade statuses, the service and the router all stay. That layer was correct; only the transport beneath it was fiction. It now degrades honestly.

## Consequences to be explicit about

- `supports(UPLOAD)`, `supports(SAVE)` and `supports(CLASSIFY)` are **permanently `False`** at this contract. Three of seven members have no published wire name. **This PR does not turn the vault on for uploads** — #2149's PR body implied it would once upstream shipped, and that is now known to be false.
- Test fixtures across five modules were emitting the pre-fix document shape (top-level `available`, `creek.*` names) and now emit Creek's real one.
- `test_classify_is_still_refused_when_advertised` had its assertion inverted: `supports(CLASSIFY)` is now `False`, which is a *stronger* guarantee — there is no document a conformant vault can send that turns it on.

## Known, deliberately out of scope

- `_write_failure` was generalised in #2149 to serve both write capabilities; with the upload transport gone it has one caller again. Left as-is rather than churning this diff further — worth collapsing back into `_ingest_failure` in a cleanup.
- The vendored bundle is a stale snapshot: `vendor.json` pins `0.2.0` against a published `0.3.0`. **Not a wire break** — 0.2 remains in `SUPPORTED_CONTRACT_MINORS` and the capability enum is byte-identical — but the conformance suite conforms to a bundle upstream has moved past. Re-vendor and document 0.2.0 as a *chosen* pin, separately.
- `CLASSIFY` will never be a `/v1` capability either: `Creek-Vault#874` delivers classification as additive optional fields on the journal response, not a route.

## Verification

`./scripts/backend/check-all.sh` exit 0 — **4525 passed**. Pre-push gate green (complexity + coverage). The acceptance test is the previously-xfailed `test_ratified_capability_documents_are_understood`, now passing against Creek's unmodified fixture.

Closes #2157
