### PR TITLE
chore(deps): upgrade react-native-chart-kit to 7, and render it in a test

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -55,6 +55,10 @@ module.exports = {
       'sentry-expo|' +
       'native-base|' +
       'react-native-markdown-display|' +
+      // chart-kit 7 ships ESM where 6 shipped CJS, so the real module now needs
+      // transforming. Nothing caught this for a while because every StatsModal
+      // test mocked the library away; StatsModal.realCharts.test.tsx renders it.
+      'react-native-chart-kit|' +
       'uuid' +
       ')/)',
   ],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,7 @@
         "react-dom": "19.2.3",
         "react-native": "0.86.2",
         "react-native-calendars": "^1.1314.0",
-        "react-native-chart-kit": "^6.12.0",
+        "react-native-chart-kit": "7.0.2",
         "react-native-draggable-flatlist": "^4.0.2",
         "react-native-gesture-handler": "~2.32.0",
         "react-native-markdown-display": "7.0.2",
@@ -12516,12 +12516,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/point-in-polygon": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
-      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "license": "MIT"
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -12978,18 +12972,24 @@
       }
     },
     "node_modules/react-native-chart-kit": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.3.tgz",
-      "integrity": "sha512-Wc7akObFaa7wAF42JGSvmd25OUpngLy412aIgJIjkmOMy3jBoPEX/yu8OPiSV3F2bSliWqlAcaqOrxuKIJy5Iw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-7.0.2.tgz",
+      "integrity": "sha512-rN2Q7Dak8FFC1clbkkTu7eF9gWBovYD45Fnb64hFmlxn0bYmWFv9MwG+KlNGXsmfrxZ3oU4EUbf5gOTjHtcpoQ==",
       "license": "MIT",
+      "workspaces": [
+        "packages/*",
+        "apps/site"
+      ],
       "dependencies": {
-        "paths-js": "^0.4.10",
-        "point-in-polygon": "^1.0.1"
+        "paths-js": "^0.4.11"
+      },
+      "engines": {
+        "node": ">=20.19.4"
       },
       "peerDependencies": {
-        "react": "> 16.7.0",
-        "react-native": ">= 0.50.0",
-        "react-native-svg": "> 6.4.1"
+        "react": ">=19.1.0 <20",
+        "react-native": ">=0.81 <1",
+        "react-native-svg": ">=15.12.1 <16"
       }
     },
     "node_modules/react-native-draggable-flatlist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.86.2",
     "react-native-calendars": "^1.1314.0",
-    "react-native-chart-kit": "^6.12.0",
+    "react-native-chart-kit": "7.0.2",
     "react-native-draggable-flatlist": "^4.0.2",
     "react-native-gesture-handler": "~2.32.0",
     "react-native-markdown-display": "7.0.2",

--- a/frontend/src/features/Habits/components/__tests__/StatsModal.realCharts.test.tsx
+++ b/frontend/src/features/Habits/components/__tests__/StatsModal.realCharts.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Renders StatsModal against the *real* react-native-chart-kit.
+ *
+ * The two existing StatsModal suites both `jest.mock('react-native-chart-kit')`,
+ * which is right for them -- they assert the props StatsModal computes, and a
+ * stub is the cleanest way to capture those. But it means no test in the tree
+ * has ever executed the charting library itself, so a major upgrade of it could
+ * land fully green while rendering nothing. That is the gap this file closes:
+ * the charting library is real here, and so is `react-native-svg`, since that is
+ * what the charts actually draw with. Only the calendar is stubbed, because it
+ * belongs to the one tab these two assertions do not look at.
+ *
+ * It earned itself immediately: chart-kit 7 ships ESM where 6 shipped CJS, and
+ * the real module would not even parse until it was added to
+ * `transformIgnorePatterns`.
+ */
+import { jest, describe, it, expect } from '@jest/globals';
+import { render, fireEvent } from '@testing-library/react-native';
+import React from 'react';
+
+jest.mock('react-native-calendars', () => ({
+  Calendar: () => null,
+}));
+
+import type { Habit, HabitStatsData } from '../../Habits.types';
+import { StatsModal } from '../StatsModal';
+
+const habit: Habit = {
+  id: 42,
+  stage: 'Beige',
+  name: 'Meditation',
+  icon: '\u{1F9D8}',
+  streak: 5,
+  energy_cost: 2,
+  energy_return: 3,
+  start_date: new Date('2024-01-01'),
+  goals: [],
+  completions: [],
+};
+
+// Non-zero and uneven on purpose: a flat all-zero series can be drawn by a
+// degenerate implementation that never computes a scale.
+const stats: HabitStatsData = {
+  values: [1, 4, 2, 7, 3, 6, 5],
+  completionsByDay: [1, 2, 0, 4, 3, 2, 1],
+  dayLabels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  longestStreak: 4,
+  currentStreak: 2,
+  totalCompletions: 13,
+  completionRate: 0.6,
+  completionDates: ['2024-01-01'],
+};
+
+describe('StatsModal against the real charting library', () => {
+  it('draws the progress line chart without throwing', () => {
+    const { getByText, UNSAFE_root } = render(
+      <StatsModal habit={habit} stats={stats} visible onClose={() => undefined} />,
+    );
+
+    fireEvent.press(getByText('Progress'));
+
+    // Charts draw in SVG, so a rendered chart means Svg host views exist in the
+    // tree. Asserting on the host element name rather than a testID because the
+    // library owns this subtree and publishes no testIDs of its own.
+    expect(UNSAFE_root.findAllByType('RNSVGSvgView' as never).length).toBeGreaterThan(0);
+  });
+
+  it('draws the by-day bar chart without throwing', () => {
+    const { getByText, UNSAFE_root } = render(
+      <StatsModal habit={habit} stats={stats} visible onClose={() => undefined} />,
+    );
+
+    fireEvent.press(getByText('By Day'));
+
+    expect(UNSAFE_root.findAllByType('RNSVGSvgView' as never).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The last open item of #2168's third-party sweep. Every other package in that
table is settled — see [the status comment](https://github.com/Geoffe-Ga/adepthood/issues/2168#issuecomment-5229902663).

## Why it is safe now, and why it was held back

All three peers are satisfied since the SDK 57 bump:

| Peer required by chart-kit 7 | Installed |
|---|---|
| `react >=19.1.0 <20` | 19.2.3 |
| `react-native >=0.81 <1` | 0.86.2 |
| `react-native-svg >=15.12.1 <16` | 15.15.4 |

It was deliberately kept out of #2175 rather than forgotten: it is the only
change in that chain that can alter *rendered chart output*, and an SDK major is
exactly the thing you want to `git bisect` away from.

## The part worth reviewing

**No existing test could have caught a regression here.** Both StatsModal suites
`jest.mock('react-native-chart-kit')` — correctly, since they assert the props
StatsModal computes, and a stub is the cleanest way to capture those. But the
consequence is that nothing in the tree had ever *executed* the charting
library. A major that rendered nothing at all would have gone fully green.

`StatsModal.realCharts.test.tsx` renders the real library — with
`react-native-svg` left real too, since that is what the charts actually draw
with — and asserts SVG host views reach the tree.

**It earned itself immediately.** chart-kit 7 ships ESM where 6 shipped CJS, so
the real module would not even parse under Jest:

```
SyntaxError: Cannot use import statement outside a module
  node_modules/react-native-chart-kit/dist/index.js:1
  import BarChart from "./charts/bar";
```

That needed `react-native-chart-kit` added to `transformIgnorePatterns`. It is a
Jest-only problem — Metro handles ESM — but it is a real packaging change in the
major, and the mocks would have hidden it indefinitely.

## Verification

```
$ ./scripts/frontend/check-all.sh
Test Suites: 450 passed, 450 total
Tests:       5233 passed, 5233 total
Passed: 5 / Failed: 0        # exit 0

$ npm run web:build          # exit 0, exports dist
$ node scripts/frontend/audit-gate.mjs
audit-gate: clean — no unallowed high/critical advisories (2 allowlisted).   # exit 0
```

`tsc --noEmit` is clean, so StatsModal's `LineChart`/`BarChart` props still
type-check against the new major unchanged.

Closes #2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9