### PR TITLE
chore(deps): drop the retired MCP pins, and fix the two things that were hiding behind them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic", "uvicorn==0.52.1"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
         files: ^backend/
         exclude: ^backend/migrations/
         args: ["--config-file=backend/pyproject.toml"]
-        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic", "mcp==2.0.0", "httpx2==2.9.1"]
+        additional_dependencies: ["types-jsonschema", "types-cachetools", "types-requests", "openai", "anthropic", "pydantic", "sqlmodel", "fastapi", "starlette", "pytest", "pytest-asyncio", "httpx", "aiosqlite", "PyJWT", "bcrypt", "cryptography", "slowapi", "limits", "alembic"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/backend/requirements-lock.txt
+++ b/backend/requirements-lock.txt
@@ -14,10 +14,7 @@ anyio==4.14.2
     # via
     #   anthropic
     #   httpx
-    #   httpx2
-    #   mcp
     #   openai
-    #   sse-starlette
     #   starlette
 asyncpg==0.31.0
     # via -r backend/requirements.txt
@@ -38,9 +35,7 @@ cffi==2.1.1
 click==8.4.2
     # via uvicorn
 cryptography==50.0.0
-    # via
-    #   -r backend/requirements.txt
-    #   pyjwt
+    # via -r backend/requirements.txt
 deprecated==1.3.1
     # via limits
 distro==1.9.0
@@ -55,30 +50,24 @@ email-validator==2.3.0
     # via -r backend/requirements.txt
 fastapi==0.141.1
     # via -r backend/requirements.txt
+greenlet==3.5.4
+    # via sqlalchemy
 h11==0.16.0
     # via
     #   httpcore
-    #   httpcore2
     #   uvicorn
 httpcore==1.0.9
     # via httpx
-httpcore2==2.9.1
-    # via httpx2
 httpx==0.28.1
     # via
     #   -r backend/requirements.txt
     #   anthropic
     #   openai
-httpx2==2.9.1
-    # via
-    #   -r backend/requirements.txt
-    #   mcp
 idna==3.18
     # via
     #   anyio
     #   email-validator
     #   httpx
-    #   httpx2
 iniconfig==2.3.0
     # via pytest
 jiter==0.16.0
@@ -86,9 +75,7 @@ jiter==0.16.0
     #   anthropic
     #   openai
 jsonschema==4.26.0
-    # via
-    #   -r backend/requirements.txt
-    #   mcp
+    # via -r backend/requirements.txt
 jsonschema-specifications==2025.9.1
     # via jsonschema
 limits==5.8.0
@@ -99,14 +86,8 @@ mako==1.4.1
     # via alembic
 markupsafe==3.0.3
     # via mako
-mcp==2.0.0
-    # via -r backend/requirements.txt
-mcp-types==2.0.0
-    # via mcp
 openai==2.53.0
     # via -r backend/requirements.txt
-opentelemetry-api==1.44.0
-    # via mcp
 packaging==26.3
     # via
     #   limits
@@ -120,8 +101,6 @@ pydantic==2.13.4
     #   -r backend/requirements.txt
     #   anthropic
     #   fastapi
-    #   mcp
-    #   mcp-types
     #   openai
     #   sqlmodel
 pydantic-core==2.46.4
@@ -129,17 +108,13 @@ pydantic-core==2.46.4
 pygments==2.20.0
     # via pytest
 pyjwt==2.13.0
-    # via
-    #   -r backend/requirements.txt
-    #   mcp
+    # via -r backend/requirements.txt
 pytest==9.1.1
     # via
     #   -r backend/requirements.txt
     #   pytest-asyncio
 pytest-asyncio==1.4.0
     # via -r backend/requirements.txt
-python-multipart==0.0.32
-    # via mcp
 referencing==0.37.0
     # via
     #   jsonschema
@@ -161,29 +136,17 @@ sqlalchemy==2.0.51
     #   sqlmodel
 sqlmodel==0.0.39
     # via -r backend/requirements.txt
-sse-starlette==3.4.8
-    # via mcp
 starlette==1.4.0
-    # via
-    #   fastapi
-    #   mcp
-    #   sse-starlette
+    # via fastapi
 tqdm==4.70.0
     # via openai
-truststore==0.10.4
-    # via
-    #   httpcore2
-    #   httpx2
 typing-extensions==4.16.0
     # via
     #   alembic
     #   anthropic
     #   fastapi
     #   limits
-    #   mcp
-    #   mcp-types
     #   openai
-    #   opentelemetry-api
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
@@ -192,13 +155,10 @@ typing-extensions==4.16.0
 typing-inspection==0.4.2
     # via
     #   fastapi
-    #   mcp
     #   pydantic
 tzdata==2026.3
     # via -r backend/requirements.txt
 uvicorn==0.52.1
-    # via
-    #   -r backend/requirements.txt
-    #   mcp
+    # via -r backend/requirements.txt
 wrapt==2.3.0
     # via deprecated

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,17 @@ fastapi==0.141.1
 uvicorn==0.52.1
 pydantic==2.13.4
 email-validator==2.3.0
-sqlalchemy==2.0.51
+# The ``asyncio`` extra, not bare sqlalchemy, because that is what this app
+# actually uses -- and it is the only way greenlet gets declared honestly.
+# SQLAlchemy's bare dependency on greenlet carries a platform marker listing
+# aarch64/ppc64le/x86_64/amd64/win32; macOS on Apple silicon reports ``arm64``,
+# which is in none of them, so a from-scratch install on the primary dev
+# platform silently omitted it and every async DB test died with "the greenlet
+# library is required". CI never saw it -- ubuntu-latest is x86_64. The extra
+# requires greenlet unconditionally, so the single source of truth stays
+# SQLAlchemy's own metadata rather than a version we would have to keep in step
+# by hand.
+sqlalchemy[asyncio]==2.0.51
 sqlmodel==0.0.39
 alembic==1.19.0
 asyncpg==0.31.0
@@ -28,14 +38,6 @@ tzdata==2026.3
 pytest==9.1.1
 pytest-asyncio==1.4.0
 httpx==0.28.1
-# MCP SDK powering the Creek Vault streamable-HTTP transport
-# (services/creek_vault_client.py); unconfigured deployments never open it.
-mcp==2.0.0
-# The HTTP library the MCP SDK speaks, distinct from the ``httpx`` the plain
-# HTTP vault client uses. Already a transitive mcp dependency; pinned here
-# because the vault client imports it directly to build the MCP transport's
-# timeout budget and to name its errors in the degrade set.
-httpx2==2.9.1
 # LLM provider SDKs for BotMason (issue #402) — the stub provider stays the
 # default; these activate via BOTMASON_PROVIDER + LLM_API_KEY or a BYOK key.
 openai==2.53.0

--- a/backend/src/routers/gumroad.py
+++ b/backend/src/routers/gumroad.py
@@ -33,6 +33,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 from typing import Annotated
+from urllib.parse import parse_qsl
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import func
@@ -97,10 +98,21 @@ async def _read_ping_payload(request: Request) -> dict[str, str]:
     ``sale_id`` is the idempotency key — without it a ping cannot be stored
     or deduplicated, so the payload is rejected as malformed.
     """
-    form = await request.form()
+    # Parsed with the stdlib rather than Starlette's form reader on purpose.
+    # Gumroad pings are ``application/x-www-form-urlencoded``, which
+    # ``parse_qsl`` handles natively -- while Starlette's reader requires a
+    # third-party parser this app deliberately does not depend on, because that
+    # parser spools request bodies to disk and ``test_transcription_privacy``
+    # forbids the whole surface. Reaching for it here would have pulled a
+    # disk-spooling body parser back in to serve a payload that never needed one.
+    try:
+        raw = (await request.body()).decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("gumroad_webhook_rejected reason_code=malformed_payload")
+        raise bad_request("malformed_payload") from None
     # Last-value-wins for duplicated keys: Gumroad pings send each field once,
     # so collapsing to a plain str -> str dict is intentional, not lossy.
-    payload = {key: value for key, value in form.multi_items() if isinstance(value, str)}
+    payload = dict(parse_qsl(raw, keep_blank_values=True))
     if not payload.get("sale_id"):
         logger.warning("gumroad_webhook_rejected reason_code=malformed_payload")
         raise bad_request("malformed_payload")

--- a/backend/tests/routers/test_gumroad_webhook.py
+++ b/backend/tests/routers/test_gumroad_webhook.py
@@ -254,6 +254,37 @@ async def test_payload_missing_sale_id_returns_400_and_writes_nothing(
 
 
 @pytest.mark.asyncio
+async def test_non_utf8_body_returns_400_and_writes_nothing(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    webhook_secret: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A body that is not UTF-8 is rejected with 400 and persists zero rows.
+
+    Reads the ping body directly rather than through Starlette's form reader
+    (which needs a parser this app deliberately does not depend on -- see
+    ``test_transcription_privacy``), so decoding is this router's own step and
+    its failure is this router's own to answer for. Undecodable bytes are the
+    same class of fault as a missing ``sale_id``: nothing usable arrived, so it
+    gets the same 400 and the same reason code rather than a 500 traceback on a
+    payment surface.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    response = await async_client.post(
+        WEBHOOK_PATH,
+        params={"secret": webhook_secret},
+        content=b"sale_id=\xff\xfe_not_utf8",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "reason_code=malformed_payload" in caplog.text
+    assert await _count_sales(db_session) == 0
+
+
+@pytest.mark.asyncio
 async def test_concurrent_replay_collapses_via_unique_constraint(
     async_client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_transcription_privacy.py
+++ b/backend/tests/test_transcription_privacy.py
@@ -222,11 +222,22 @@ def test_no_multipart_upload_surface_in_source_tree() -> None:
 
 
 def test_no_python_multipart_dependency() -> None:
-    """``python-multipart`` is absent from both requirement files."""
+    """``python-multipart`` is absent from every requirement file, lock included.
+
+    The lock is the load-bearing one, and it is why this test now reads three
+    files instead of two. Until 2026-08-09 it checked only the two hand-written
+    manifests, and the package was installed the entire time anyway -- pulled in
+    transitively by ``mcp``, which the old lock recorded in as many words:
+    ``python-multipart==0.0.32  # via mcp``. So this guard reported "absent"
+    about a library that was present in every environment it was meant to keep
+    it out of, and ``routers/gumroad.py`` was quietly relying on it to read a
+    webhook body. Checking the manifests alone can only ever prove nobody asked
+    for it *directly*; the lock is what actually gets installed.
+    """
     backend_dir = _SRC_DIR.parent
-    for filename in ("requirements.txt", "requirements-dev.txt"):
+    for filename in ("requirements.txt", "requirements-dev.txt", "requirements-lock.txt"):
         text = (backend_dir / filename).read_text()
-        assert "python-multipart" not in text
+        assert "python-multipart" not in text, filename
 
 
 # ── D: request-log safety ──────────────────────────────────────────────────


### PR DESCRIPTION
Removes `mcp==2.0.0` and `httpx2==2.9.1` from `backend/requirements.txt`, the
mypy hook's `additional_dependencies`, and the regenerated lock. Nothing has
imported either since the MCP application client was retired — a repo-wide
search finds zero references outside historical docs and ADRs — and their
comments described a transport that no longer exists.

That part is #2118 as written. **Regenerating the lock is what made the next two
visible**, and they are why this is not a one-line change.

---

## `python-multipart` was a live production dependency, supplied only by accident

`routers/gumroad.py:100` read its webhook body with Starlette's
`request.form()`, which requires that parser. Nothing declared it. The old lock
recorded exactly where it came from:

```
python-multipart==0.0.32
    # via mcp
```

So dropping `mcp` removed it and **65 Gumroad tests failed** — a payment surface
was depending on a transitive of a transport we retired.

**Pinning it would have been the wrong fix.** `test_transcription_privacy`
forbids that library deliberately: Starlette spools those bodies to disk, and
the transcribe endpoint takes base64 in JSON precisely so image bytes stay in
request-scoped memory and never touch disk.

**And that guard had been vacuous the entire time.** It read only the two
hand-written manifests, while the library sat installed in every environment via
MCP's dependency tree — and `gumroad.py` quietly relied on it being there. The
guard reported "absent" about something present everywhere it was meant to be
kept out of.

Two changes follow from that:

- **Gumroad parses its own body.** The pings are
  `application/x-www-form-urlencoded`, which `urllib.parse.parse_qsl` handles
  natively — no third-party parser, no disk, no behaviour change. A
  non-UTF-8 body now returns the same `malformed_payload` 400 the missing-`sale_id`
  path already returned, rather than raising.
- **The guard now reads the lock too.** Checking the manifests alone can only
  prove nobody asked for it *directly*; the lock is what actually gets installed.

## `greenlet` was never in the lock at all — this is #2070

SQLAlchemy's bare dependency on it carries a platform marker:

```
greenlet>=1; platform_machine == "aarch64" or ppc64le or x86_64 or amd64 or AMD64 or win32 or WIN32
```

macOS on Apple silicon reports `arm64`, which is in none of them — Linux ARM is
`aarch64`, macOS ARM is `arm64`, and only the former is listed. CI never saw it
(`ubuntu-latest` is x86_64) and the shared local venv had it from some earlier
install, so it only bites a **from-scratch** install on the primary dev
platform, where no async DB test can run at all.

I hit it directly: `uv pip sync` to the regenerated lock produced
`ConfigError: Couldn't trace with concurrency=greenlet, the module isn't installed.`

Fixed by declaring **`sqlalchemy[asyncio]==2.0.51`** rather than pinning a
greenlet version by hand — #2070 offered both and called the extra "arguably the
most honest statement of intent". It keeps SQLAlchemy's own metadata as the
single source of truth; the extra requires `greenlet>=1` unconditionally, with no
marker. The lock now carries `greenlet==3.5.4 # via sqlalchemy`.

## What the lock dropped, and why each is safe

`mcp`, `mcp-types`, `httpx2`, `httpcore2` (the MCP tree), plus `opentelemetry-api`,
`sse-starlette` and `truststore` — all transitives of `mcp` with zero references
in `backend/src`. `python-multipart` is the one that was *not* safe, handled
above. The full suite is the real check on this, and it is green.

## The mypy hook needed `uvicorn` declared, for the same reason

Third instance of the same root cause, and the only one CI could see. The mypy
hook installs its own isolated environment from `additional_dependencies`, and
`mcp==2.0.0` was pulling `uvicorn` into it transitively. Dropping the MCP pins
took uvicorn with it, so the hook could no longer resolve the direct imports in
`tests/e2e/server.py` and `tests/security/test_client_ip.py`:

```
Cannot find implementation or library stub for module named "uvicorn"
Found 4 errors in 2 files (checked 453 source files)
```

Invisible to `check-all.sh`, which type-checks against the project venv where
uvicorn is a first-class pin. Pinned to `0.52.1` to match `requirements.txt:11`
so the two cannot drift.

## Scope held

Creek's MCP **server** and its agent tools are untouched, per ADR 0004: MCP is
retired for the application path only and deliberately retained for agents.

## Verification

```
$ ./scripts/backend/check-all.sh
=== Quality Checks Summary ===
Passed: 7
Failed: 0
✓ All quality checks passed!        # exit 0
```

4541 tests, 97% line coverage, with the venv resynced to the new lock (so the
run genuinely exercised the new pins rather than leftovers).

Closes #2118
Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9
