### PR TITLE
fix(frontend): stop dropping reflection fields, and stop one bad sender failing a list

### DIFF
--- a/frontend/src/api/__tests__/journalReflectionFields.test.ts
+++ b/frontend/src/api/__tests__/journalReflectionFields.test.ts
@@ -1,0 +1,84 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+
+/**
+ * Guards two pieces of client/server drift on ``journalMessageSchema``.
+ *
+ * Both are the same class of bug and neither is loud: Zod strips unknown keys,
+ * so a field the backend sends and the schema omits vanishes without an error
+ * anywhere. And a `z.enum` at a list boundary fails the *whole* response when a
+ * single row carries a value the enum has not heard of.
+ */
+import { journalListResponseSchema, journalMessageSchema, narrowSender } from '../schemas';
+
+/** A row shaped the way the backend actually serialises one. */
+const BACKEND_ROW = {
+  id: 1,
+  message: 'A page about rivers.',
+  sender: 'user',
+  timestamp: '2026-06-01T00:00:00Z',
+  tag: 'freeform',
+  practice_session_id: null,
+  user_practice_id: null,
+  reflection_level: 'week',
+  reflection_scope_key: '2026-W23',
+};
+
+describe('journalMessageSchema — reflection fields', () => {
+  it('carries reflection_level and reflection_scope_key through validation', () => {
+    // Before this schema knew the fields, Zod stripped them and the assertion
+    // below read undefined — silently, with the parse still reported as valid.
+    const parsed = journalMessageSchema.parse(BACKEND_ROW);
+    expect(parsed.reflection_level).toBe('week');
+    expect(parsed.reflection_scope_key).toBe('2026-W23');
+  });
+
+  it('still parses a row predating the columns', () => {
+    const older: Record<string, unknown> = { ...BACKEND_ROW };
+    delete older.reflection_level;
+    delete older.reflection_scope_key;
+    const parsed = journalMessageSchema.parse(older);
+    expect(parsed.reflection_level).toBeUndefined();
+    expect(parsed.reflection_scope_key).toBeUndefined();
+  });
+
+  it('accepts an explicit null, which is what the backend sends when unset', () => {
+    const parsed = journalMessageSchema.parse({
+      ...BACKEND_ROW,
+      reflection_level: null,
+      reflection_scope_key: null,
+    });
+    expect(parsed.reflection_level).toBeNull();
+    expect(parsed.reflection_scope_key).toBeNull();
+  });
+});
+
+describe('journalMessageSchema — sender', () => {
+  it('does not fail the whole list when one row has an unrecognised sender', () => {
+    // The backend types sender as a bare `str`, so a third value is a schema
+    // change away. With a z.enum here that would have taken down every other
+    // row in the response with it — the failure mode narrowTier exists to stop.
+    const parsed = journalListResponseSchema.parse({
+      items: [BACKEND_ROW, { ...BACKEND_ROW, id: 2, sender: 'oracle' }],
+      total: 2,
+      has_more: false,
+    });
+    expect(parsed.items).toHaveLength(2);
+    expect(parsed.items[1]?.sender).toBe('oracle');
+  });
+
+  it('narrows a known sender and falls back for anything else', () => {
+    expect(narrowSender('user')).toBe('user');
+    expect(narrowSender('bot')).toBe('bot');
+    // Falls back to 'bot' rather than 'user': an unknown speaker is not the
+    // person writing, and attributing someone else's words to them is the worse
+    // of the two wrong answers.
+    expect(narrowSender('oracle')).toBe('bot');
+    expect(narrowSender('')).toBe('bot');
+  });
+
+  it('still rejects a row whose sender is not a string at all', () => {
+    // Loosened, not abandoned: the field must still be present and a string.
+    expect(() => journalMessageSchema.parse({ ...BACKEND_ROW, sender: 7 })).toThrow();
+  });
+});

--- a/frontend/src/api/__tests__/schemas.test.ts
+++ b/frontend/src/api/__tests__/schemas.test.ts
@@ -284,14 +284,18 @@ describe('journalListResponseSchema validation', () => {
     expect(parsed.items[0]?.tag).toBe('weekly_prompt');
   });
 
-  it('rejects an unknown sender', () => {
-    expect(() =>
-      journalListResponseSchema.parse({
-        items: [{ ...message, sender: 'system' }],
-        total: 1,
-        has_more: false,
-      }),
-    ).toThrow();
+  it('accepts an unknown sender rather than failing the whole list', () => {
+    // This asserted the opposite until 2026-08-09. The backend types `sender`
+    // as a bare `str`, so a third value is one server change away -- and under
+    // the old `z.enum` a single unrecognised row took down every other entry in
+    // the response with it. Narrowing moved to the point of use (`narrowSender`),
+    // which is the same trade `narrowTier` already makes for `tier`.
+    const parsed = journalListResponseSchema.parse({
+      items: [{ ...message, sender: 'system' }],
+      total: 1,
+      has_more: false,
+    });
+    expect(parsed.items[0]?.sender).toBe('system');
   });
 
   it('rejects a non-ISO timestamp (same contract as other timestamp columns)', () => {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1237,7 +1237,12 @@ export type EntryStatus = 'draft' | 'finished';
 export interface JournalMessage {
   id: number;
   message: string;
-  sender: 'user' | 'bot';
+  /**
+   * Widened from ``'user' | 'bot'`` to match the backend, which types this as a
+   * bare ``str``. Narrow with ``narrowSender`` before branching on it, rather
+   * than assuming the union -- see the note on ``SENDER_VALUES`` in schemas.ts.
+   */
+  sender: string;
   timestamp: string;
   tag: JournalTag;
   practice_session_id: number | null;
@@ -1252,6 +1257,12 @@ export interface JournalMessage {
   primary_aspect?: number | null;
   /** Secondary chord Aspect (a stage 1..10); only meaningful with a primary. */
   secondary_aspect?: number | null;
+  /**
+   * Hierarchical-journaling scope (``schemas/journal.py:137-138``). Absent on
+   * responses predating the columns, null when the entry is not a reflection.
+   */
+  reflection_level?: string | null;
+  reflection_scope_key?: string | null;
 }
 
 /**

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -244,11 +244,34 @@ const MIN_ASPECT = 1;
 /** Highest Aspect tag (stage 10); the curriculum has ten stages. */
 const MAX_ASPECT = 10;
 
+/**
+ * The two senders the client renders differently. The backend types ``sender``
+ * as a bare ``str`` (``schemas/journal.py:128``), so a third value is one server
+ * change away -- and a ``z.enum`` at a *list* boundary fails the whole response
+ * over a single unrecognised row. Same reasoning as ``TIER_VALUES`` above:
+ * accept the string at the boundary, narrow at the point of use.
+ */
+export const SENDER_VALUES = ['user', 'bot'] as const;
+export type Sender = (typeof SENDER_VALUES)[number];
+
+/**
+ * Narrow a server-supplied sender, falling back to ``bot`` for anything else.
+ *
+ * ``bot`` rather than ``user`` on purpose: an unrecognised speaker is not the
+ * person who was writing, and rendering someone else's words as theirs is the
+ * worse of the two wrong answers.
+ */
+export function narrowSender(value: unknown): Sender {
+  return typeof value === 'string' && (SENDER_VALUES as readonly string[]).includes(value)
+    ? (value as Sender)
+    : 'bot';
+}
+
 /** One journal message (mirrors the backend ``JournalMessage`` response). */
 export const journalMessageSchema = z.object({
   id: z.number().int(),
   message: z.string(),
-  sender: z.enum(['user', 'bot']),
+  sender: z.string(),
   // Same ISO-8601 contract as every other timestamp column (goal completions
   // etc.) — bare z.string() would silently accept "not-a-date".
   timestamp: isoDateTime,
@@ -267,6 +290,12 @@ export const journalMessageSchema = z.object({
   // untagged / pre-column responses still validate.
   primary_aspect: z.number().int().min(MIN_ASPECT).max(MAX_ASPECT).nullable().optional(),
   secondary_aspect: z.number().int().min(MIN_ASPECT).max(MAX_ASPECT).nullable().optional(),
+  // Hierarchical-journaling fields (``schemas/journal.py:137-138``). Zod strips
+  // what it does not declare, so omitting these did not fail validation -- it
+  // silently deleted them from every validated list response. Optional *and*
+  // nullable to match the backend's ``str | None = None`` exactly.
+  reflection_level: z.string().nullable().optional(),
+  reflection_scope_key: z.string().nullable().optional(),
 });
 
 /** Journal list envelope: ``{ items, total, has_more }`` (bespoke, not ``Page``). */


### PR DESCRIPTION
Two pieces of client/server drift on `journalMessageSchema`, both found by the
adepthood-docs deep-reference audit. Both are quiet — neither produces an error
anywhere.

## 1. Reflection fields were being *deleted*, not rejected

The backend has carried `reflection_level` and `reflection_scope_key` since the
hierarchical-journaling epic (`backend/src/schemas/journal.py:137-138`). Neither
the Zod schema nor the TS interface knew about them.

**Zod strips what it does not declare.** So every validated `journal.list`
response lost both fields — with the parse still reported as valid. Meanwhile
`journal.get` is unvalidated, so it passed them through at runtime while the
type denied they existed; any consumer reading them today is typecast-blind.

Both are now `z.string().nullable().optional()`, matching the backend's
`str | None = None` exactly. Rows predating the columns still parse, and so do
rows where the entry simply is not a reflection.

## 2. `sender` was stricter on the client than on the server

The backend types it as a bare `str` (`journal.py:128`); the schema pinned
`z.enum(['user', 'bot'])`.

A third sender value introduced server-side would not have failed *one row* — it
would have failed **the entire list response**, taking every other entry down
with it. That is precisely the failure mode `narrowTier` was introduced to
design out of `tier` (`schemas.ts:128-141`).

`sender` is now `z.string()` at the validation boundary, with a `narrowSender`
helper to narrow at the point of use.

**The fallback is `bot`, not `user`, and that is deliberate**: an unrecognised
speaker is not the person who was writing, and rendering someone else's words as
theirs is the worse of the two wrong answers.

Loosened, not abandoned — a non-string `sender` is still rejected, and a test
pins that.

## One existing test now asserts the opposite of what it did

`schemas.test.ts` had `rejects an unknown sender`, which pinned exactly the
behaviour this issue asks to remove. It now asserts the new contract, with the
reasoning written inline rather than left as a bare diff for a reviewer to
reverse-engineer.

## Worth flagging: `narrowSender` has no production caller yet

Nothing in the app currently branches on `JournalMessage.sender` — I checked.
So the helper is exported and tested but unused for now, and the practical
effect of this PR is that an unknown sender no longer nukes a list. The helper
exists because widening the boundary without giving consumers a safe way to
narrow would just move the problem; #2051 asked for it explicitly.

`sender` on the TS interface widened from `'user' | 'bot'` to `string` to match.
`tsc` is clean, which confirms nothing was relying on the narrower type.

## Verification

```
$ ./scripts/frontend/check-all.sh
=== Quality Checks Summary ===
Passed: 5
Failed: 0
✓ All quality checks passed!        # exit 0
```

456 api tests pass, including 6 new ones covering both fields present, absent,
explicitly null, an unknown sender surviving list validation, the narrowing
fallback, and a non-string sender still being rejected.

Closes #2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9