### PR TITLE
fix(backend): audit cross-tenant practice-session probes instead of silently rejecting

### DIFF
--- a/backend/src/routers/practice_sessions.py
+++ b/backend/src/routers/practice_sessions.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, func, select
 
 from database import get_session
-from dependencies.ownership import require_owned_user_practice
+from dependencies.ownership import require_owned_user_practice, resolve_owned_user_practice
 from dependencies.timezone import current_user_timezone
 from domain.practice_insights import build_insights
 from domain.practice_resolution import effective_config
@@ -48,32 +48,6 @@ _INSIGHTS_CACHE_CONTROL = "private, max-age=60"
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/practice-sessions", tags=["practice-sessions"])
-
-
-async def _resolve_user_practice_for_session(
-    session: AsyncSession,
-    user_practice_id: int,
-    current_user: int,
-) -> UserPractice:
-    """Fetch the target ``UserPractice`` and enforce the 404→403 split.
-
-    Pulled out of :func:`create_session` because the body-parameter
-    ownership check can't ride :func:`require_owned_user_practice`
-    (FastAPI's DI cannot extract body fields into sub-deps).  Keeping
-    the lookup here keeps the handler's branching shallow enough for
-    xenon rank A while preserving the canonical 404-then-403 order the
-    IDOR matrix test relies on.
-    """
-    user_practice = (
-        (await session.execute(select(UserPractice).where(UserPractice.id == user_practice_id)))
-        .scalars()
-        .first()
-    )
-    if user_practice is None:
-        raise not_found("user_practice")
-    if user_practice.user_id != current_user:
-        raise forbidden("forbidden")
-    return user_practice
 
 
 async def _require_stage_unlocked_for_session(
@@ -270,7 +244,7 @@ async def _perform_create_session(
         if cached_id is not None:
             return await _load_session(session, cached_id)
 
-    user_practice = await _resolve_user_practice_for_session(
+    user_practice = await resolve_owned_user_practice(
         session, payload.user_practice_id, current_user
     )
     await _require_stage_unlocked_for_session(session, current_user, user_practice, user_tz)

--- a/backend/src/schemas/__init__.py
+++ b/backend/src/schemas/__init__.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for API models."""
 
-from schemas.checkin import CheckInRequest, CheckInResult
+from schemas.checkin import CheckInResult
 from schemas.energy import (
     EnergyPlan,
     EnergyPlanItem,
@@ -24,7 +24,6 @@ from schemas.practice import PracticeSessionCreate, PracticeSessionResponse
 __all__ = [
     "DEFAULT_PAGE_SIZE",
     "MAX_PAGE_SIZE",
-    "CheckInRequest",
     "CheckInResult",
     "EnergyHabit",
     "EnergyPlan",

--- a/backend/src/schemas/checkin.py
+++ b/backend/src/schemas/checkin.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Literal
 
 from pydantic import BaseModel
@@ -19,11 +18,6 @@ CheckInReasonCode = Literal[
     "streak_held",
     "already_logged_today",
 ]
-
-
-class CheckInRequest(BaseModel):
-    goal_id: int
-    date: date
 
 
 class CheckInResult(BaseModel):

--- a/backend/tests/test_practice_sessions.py
+++ b/backend/tests/test_practice_sessions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime, time, timedelta
 from http import HTTPStatus
 from typing import cast
@@ -1348,6 +1349,39 @@ async def _insert_stage_two_user_practice(db_session: AsyncSession, user_id: int
     await db_session.commit()
     await db_session.refresh(user_practice)
     return cast("int", user_practice.id)
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_session_probe_emits_audit_log(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cross-tenant probe is denied *and* leaves an audit row.
+
+    The rejection has always worked; the audit row has not. Without it nothing
+    distinguishes someone enumerating other users' ``user_practice`` ids from
+    ordinary 403s, so the one signal that would reveal an active probe never
+    reached the logs. A test that only asserted the 403 passed the whole time
+    this was missing, which is why this one asserts the log.
+    """
+    _alice_headers, alice_id = await _signup(async_client, "alice_probe")
+    bob_headers, _bob_id = await _signup(async_client, "bob_probe")
+    alice_practice_id = await _create_user_practice(async_client, db_session, _alice_headers)
+
+    with caplog.at_level(logging.WARNING, logger="dependencies.ownership"):
+        resp = await async_client.post(
+            "/practice-sessions/",
+            json=_session_payload(alice_practice_id),
+            headers=bob_headers,
+        )
+
+    assert resp.status_code == HTTPStatus.FORBIDDEN
+    deny_logs = [r for r in caplog.records if r.message == "resource_access_denied"]
+    assert deny_logs, "expected a resource_access_denied audit log entry"
+    assert getattr(deny_logs[0], "resource", None) == "user_practice"
+    assert getattr(deny_logs[0], "resource_id", None) == alice_practice_id
+    assert getattr(deny_logs[0], "user_id", None) != alice_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> **Stacked on #2189** so the diff stays clean and the pinned requirements match
> the venv these gates ran against. GitHub retargets this to `main`
> automatically when #2189 merges.

`POST /practice-sessions/` enforced the right ownership rule with a bespoke
resolver (`_resolve_user_practice_for_session`) that omitted
`log_ownership_denied`.

So a cross-tenant probe was correctly **rejected** and left **no trace**.
Nothing distinguished someone enumerating other users' `user_practice` ids from
an ordinary 403, and the one signal that would reveal an active probe never
reached the logs.

This is not an authorization hole — the control worked. It is a missing
detection surface on a control that works, which is harder to notice precisely
because the 403 looks correct from the outside.

## The fix

Replaced with the shared `resolve_owned_user_practice` from
`dependencies/ownership.py`, which carries the audit call. The rule now lives in
one place regardless of whether the id arrived in the path or the body, rather
than as a third divergent copy.

**The status contract is unchanged**, which the issue asked me to confirm rather
than assume. Both resolvers raise `not_found("user_practice")` first and
`forbidden("forbidden")` second — same codes, same order, which is what the IDOR
matrix test relies on. Nothing observable to a client changes.

## The test asserts the log, not the status

```python
assert resp.status_code == HTTPStatus.FORBIDDEN
deny_logs = [r for r in caplog.records if r.message == "resource_access_denied"]
assert deny_logs, "expected a resource_access_denied audit log entry"
assert getattr(deny_logs[0], "resource", None) == "user_practice"
assert getattr(deny_logs[0], "resource_id", None) == alice_practice_id
```

A test that only checked the 403 passed for the entire time this was missing —
which is exactly why the gap survived. Confirmed it fails without the fix:

```
E       AssertionError: expected a resource_access_denied audit log entry
E       assert []
```

## `CheckInRequest` is removed entirely, not just its `goal_id`

The issue flagged `goal_id` as a dead field. It is worse than that: **the whole
DTO is dead**. `grep -rn CheckInRequest backend` returns only its own definition
and its re-export — no route consumes it, no test references it.

A body model that no handler reads is precisely the shape the issue warns about
("becomes an unauthorized write the day someone wires it up"), so removing one
field and leaving the husk would have been the half-measure. `CheckInResult`,
which `routers/goal_completions.py:16,35,41` does use, stays.

Nothing appears in the OpenAPI schema for this — it was never attached to a
route — so there is no client-visible surface change.

## Verification

```
$ ./scripts/backend/check-all.sh
=== Quality Checks Summary ===
Passed: 7
Failed: 0
✓ All quality checks passed!        # exit 0
```

Closes #2133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9