### PR TITLE
fix(frontend): make the rate-limit message true on every surface that emits it

### DIFF
--- a/frontend/src/api/__tests__/errorMessages.test.ts
+++ b/frontend/src/api/__tests__/errorMessages.test.ts
@@ -305,3 +305,35 @@ describe('formatApiError', () => {
     expect(result).toMatch(/offline/i);
   });
 });
+
+describe('rate_limit_exceeded copy is surface-neutral', () => {
+  // The backend emits one shared `rate_limit_exceeded` for every limiter
+  // (`main.py:424`, registered app-wide at `:599`), and those limiters span
+  // BotMason chat at 5/minute through auth routes at 1/minute and 10/hour. Copy
+  // that names any one surface is wrong on all the others -- a user tripping the
+  // signup limiter was told about sending chat messages to BotMason.
+  const copy = USER_FACING_ERROR_MESSAGES.rate_limit_exceeded ?? '';
+
+  it('names no product surface, since every limiter shares this code', () => {
+    expect(copy).not.toMatch(/botmason/i);
+    expect(copy).not.toMatch(/message/i);
+    expect(copy).not.toMatch(/chat/i);
+  });
+
+  it('quotes no specific limit, since the limiters disagree', () => {
+    // The old copy said "10 messages per minute" -- wrong even for BotMason,
+    // whose own decorator is 5/minute.
+    expect(copy).not.toMatch(/\d+\s*(per|\/)\s*(minute|hour)/i);
+    expect(copy).not.toMatch(/\d+\s+messages/i);
+  });
+
+  it('stays non-coercive, per "you choose your depth"', () => {
+    // No scolding and no urgency: hitting a limiter is not a transgression.
+    expect(copy).not.toMatch(/too many|slow down|stop|must|immediately|warning/i);
+  });
+
+  it('still tells the user what happened and that waiting resolves it', () => {
+    expect(copy).toBeTruthy();
+    expect(copy).toMatch(/again|moment|minute|shortly/i);
+  });
+});

--- a/frontend/src/api/errorMessages.ts
+++ b/frontend/src/api/errorMessages.ts
@@ -136,8 +136,14 @@ export const USER_FACING_ERROR_MESSAGES: Readonly<Record<string, string>> = Obje
     "That API key doesn't look right. Copy the full key from your OpenAI or Anthropic dashboard and paste it into Settings.",
 
   // --- Streaming / rate limits / network -------------------------------
-  rate_limit_exceeded:
-    "You're sending messages faster than BotMason can keep up. Slow down to 10 messages per minute.",
+  // Deliberately surface-neutral and number-free. The backend emits this one
+  // code from a single app-wide handler (``main.py:424``), and the limiters
+  // behind it range from BotMason chat at 5/minute to auth routes at 1/minute
+  // and 10/hour -- so any wording that names a surface, or quotes a rate, is
+  // wrong everywhere else. The previous copy named BotMason *and* said
+  // "10 messages per minute", which was wrong even for BotMason. A surface that
+  // wants its own real limit can override this locally.
+  rate_limit_exceeded: "That's a lot of requests in a short time. Give it a moment and try again.",
   llm_provider_error: PROVIDER_TROUBLE,
   malformed_stream_frame: PROVIDER_TROUBLE,
   incomplete_stream:


### PR DESCRIPTION
The backend emits one shared `rate_limit_exceeded` from a single app-wide
handler (`backend/src/main.py:424`, registered at `:599`). The frontend mapped
that one code to BotMason-chat copy:

> You're sending messages faster than BotMason can keep up. Slow down to 10
> messages per minute.

So a user tripping the **signup** limiter (`POST /auth/signup`, `3/minute`) was
told they were sending chat messages too fast.

**The number was wrong too — including for the surface it named.** BotMason's
own decorator is `5/minute` (`routers/botmason.py:78`), not 10. And the limiters
sharing this code span `1/minute` to `10/hour` across eight auth routes plus
chat, so any wording that names a surface, or quotes a rate, is wrong on all the
others.

## The fix

> That's a lot of requests in a short time. Give it a moment and try again.

Names no surface, quotes no rate. This is **option 1** from the issue, which the
2026-08-08 audit confirmed as the right first move; a surface that later wants
its own real limit can override locally, and option 2 (per-surface codes from
the handler) stays available if one does.

## The tests pin properties, not the string

So the copy can be reworded later without them quietly going vacuous:

- names no product surface (`botmason` / `message` / `chat`)
- quotes no specific limit (`\d+ per minute`, `\d+ messages`) — this is the one
  that would have caught the wrong `10` even before the surface mismatch
- stays non-coercive: no *too many*, *slow down*, *must*, *immediately*. Per
  "you choose your depth" — hitting a limiter is not a transgression and the
  copy should not scold
- still says what happened and that waiting resolves it

Confirmed all three new assertions fail against the old copy before the change:

```
✕ names no product surface, since every limiter shares this code
✕ quotes no specific limit, since the limiters disagree
✕ stays non-coercive, per "you choose your depth"
```

The pre-existing assertion that the code is present and non-empty
(`errorMessages.test.ts:62`) keeps passing untouched.

## Verification

```
$ ./scripts/frontend/check-all.sh
=== Quality Checks Summary ===
Passed: 5
Failed: 0
✓ All quality checks passed!        # exit 0
```

Closes #1973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9