### PR TITLE
fix(ralph): check the bridge marker even when a bot body carries a changelog link

### DIFF
--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -41,20 +41,31 @@
 # limit or an expired token silently defeat the one control a human retains over this
 # loop. So is an UNPROVABLE one on a bot PR about to be merged (see below).
 #
-# WHY THE MARKER FALLBACK EXISTS: the body-link route to the hold vanishes on exactly
+# WHY THE MARKER ROUTE EXISTS: the body-link route to the hold vanishes on exactly
 # the PRs the hold exists for. Dependabot regenerates its PR body from its own template
 # on every rebase and group recomputation, taking the bridge's appended `Closes #N` with
 # it — so `linked_issue` comes back empty and "no link" would be read as "no hold", a
 # fail-OPEN on the one PR class this loop merges with no review verdict. The bridge also
 # stamps `<!-- dependabot-pr:<N> -->` into the ISSUE body, which that rewrite cannot
-# reach because it lives on another object; that is the durable route. It is scanned only
-# on a Dependabot-authored PR whose body links nothing (human PRs routinely link nothing
-# and must classify normally, and an empty author reads as human), so in steady state the
-# extra `gh issue list` costs no lane anything. A scan that matches NOTHING is silence,
-# not proof: it is filtered by the `dependencies` label, which this repo has watched fail
-# to stick — hence `ensure-issue-label.sh`. Such a lane therefore classifies normally and
-# is refused only at the point of merge, so `behind` still prints `behind` (a sync is
-# always safe, and re-linking the body is often what makes the hold provable again).
+# reach because it lives on another object; that is the durable route.
+#
+# It is NOT a fallback: it runs on EVERY Dependabot-authored lane, whether or not the
+# body links something. It was a fallback until #2127, and that was the bug — a
+# regenerated body carrying an upstream changelog line (`Fixes #456`) still matches the
+# reference pattern, `linked_issue` takes the LAST match, and the hold lookup then
+# consulted an unrelated issue while the bridge went unread. A parked PR printed `ready`.
+# The two routes are independent answers to "is there a hold?" and either may be the one
+# that has it, so both are asked.
+#
+# The cost is one `gh issue list` per bot lane — paid on every bot lane now, not only
+# unlinked ones. Human lanes still pay nothing (they routinely link nothing and must
+# classify normally, and an empty author reads as human).
+#
+# A scan that matches NOTHING is silence, not proof: it is filtered by the `dependencies`
+# label, which this repo has watched fail to stick — hence `ensure-issue-label.sh`. A
+# lane where NEITHER route resolved anything therefore classifies normally and is refused
+# only at the point of merge, so `behind` still prints `behind` (a sync is always safe,
+# and re-linking the body is often what makes the hold provable again).
 #
 # An unresolvable hold on a bot PR that would otherwise merge is likewise one of those
 # exit-2 tooling errors: no token, and the next wake retries.

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -291,16 +291,30 @@ hold_unproven=""
 issue_n="$(linked_issue "$pr_body")"
 if [[ -n "$issue_n" ]]; then
   exit_if_issue_holds "$issue_n" "linked by"
-elif [[ "$pr_author" == "$DEPENDABOT_AUTHOR" ]]; then
-  # Only Dependabot rewrites its own body, so only Dependabot can have lost the
-  # link. An empty author reads as human here, which is safe: the sole
-  # merge-without-review path re-verifies the author itself and fails closed on
-  # empty. A failed scan dies at once — unlike a matchless one, no later answer
-  # can arrive to settle it.
+fi
+
+# The marker route runs for EVERY bot lane, not only one whose body links
+# nothing. `linked_issue` takes the last reference match, so a regenerated body
+# carrying an upstream changelog line -- `Fixes #456` -- resolves an unrelated
+# issue in this repo. The hold lookup then consulted that issue, the bridge was
+# never reached, and a PR a human had parked printed `ready` and merged. Checking
+# the body link first and the marker as well costs one extra scan on bot lanes
+# and closes that: the two routes are independent answers to "is there a hold?",
+# and either may be the one that has it.
+#
+# Only Dependabot rewrites its own body, so only Dependabot can have lost the
+# link, and the scan stays off human lanes. An empty author reads as human here,
+# which is safe: the sole merge-without-review path re-verifies the author itself
+# and fails closed on empty. A failed scan dies at once -- unlike a matchless
+# one, no later answer can arrive to settle it.
+if [[ "$pr_author" == "$DEPENDABOT_AUTHOR" ]]; then
   bridge_issues="$(bridge_issues_for_pr)" ||
     die "could not scan for the bridge issue of PR #$pr; refusing to guess whether $OPTOUT_LABEL is set"
   if [[ -z "$bridge_issues" ]]; then
-    hold_unproven="yes"
+    # Unchanged from #2027, deliberately: unproven means NEITHER route resolved
+    # anything. A body that did resolve an issue is a resolution, so widening the
+    # scan must not start refusing lanes that classified fine before.
+    [[ -n "$issue_n" ]] || hold_unproven="yes"
   else
     while IFS= read -r bridge_n; do
       [[ -n "$bridge_n" ]] || continue

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -798,7 +798,57 @@ check "a bot PR whose body still links an issue classifies from the link" "ready
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
      PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LABELS="dependencies" \
      ISSUE_LIST_SENTINEL="$S_ISSUE_LINKED" run 100)"
-probed "an intact body link never scans for a marker" "no" "$S_ISSUE_LINKED"
+# Was `"no"` until #2127. That pinned the narrower rule this issue replaces: the
+# marker scan ran ONLY when the body linked nothing, so a rewritten bot body
+# carrying an unrelated changelog `Fixes #456` resolved the wrong issue and the
+# bridge's hold was never consulted. A bot lane now checks both routes, so the
+# scan does run here. Kept rather than deleted -- it is still the pin that says
+# whether the scan happened, only its expected answer moved.
+probed "a bot lane checks the marker route as well as the body link" "yes" "$S_ISSUE_LINKED"
+
+# --- #2127: a changelog link in a rewritten bot body must not hide the bridge
+# `linked_issue` takes the LAST reference match, so an upstream changelog line
+# resolved to an unrelated issue in this repo, the hold lookup consulted *that*,
+# and the bridge marker was never reached. A parked PR would then merge.
+CHANGELOG_BODY="Bumps foo from 1 to 2.
+Release notes: Fixes #456
+<!-- dependabot-pr:100 -->"
+HELD_BRIDGE='[{"number":1982,"body":"<!-- dependabot-pr:100 -->"}]'
+
+# ISSUE_LABELS_FOR pins the hold to the BRIDGE issue only, so #456 -- the
+# changelog link -- reads unlabelled. Without it the fake answers every issue
+# identically and the case would pass even with the bug present.
+check "a bridge hold is honoured despite a changelog link in the body" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="$CHANGELOG_BODY" ISSUE_LIST_JSON="$HELD_BRIDGE" \
+     ISSUE_LABELS="do-not-auto-merge" ISSUE_LABELS_FOR=1982 run 100)"
+
+# The body-link route must keep working on its own -- this is #2027's case and
+# it must not regress while widening to check both.
+check "a hold reachable by the body link alone is still honoured" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LABELS="do-not-auto-merge" \
+     ISSUE_LABELS_FOR=1982 run 100)"
+
+# Both routes present and agreeing: one optout, not a double-exit or a crash.
+check "both routes agreeing still yields exactly optout" "optout" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LIST_JSON="$HELD_BRIDGE" \
+     ISSUE_LABELS="do-not-auto-merge" ISSUE_LABELS_FOR=1982 run 100)"
+
+# Neither route holds: the lane merges as before. Widening must not invent holds.
+check "an unheld bot lane with a changelog link still reaches ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="$DEPENDABOT" PR_BODY="$CHANGELOG_BODY" ISSUE_LIST_JSON="$HELD_BRIDGE" \
+     ISSUE_LABELS="dependencies" run 100)"
+
+# Human lanes keep "last link wins" and pay for no extra scan.
+S_HUMAN_SCAN="$WORK/issue-list-human"
+check "a human PR with a changelog link is unaffected" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
+     PR_AUTHOR="someone" PR_BODY="$CHANGELOG_BODY" ISSUE_LABELS="enhancement" \
+     ISSUE_LIST_SENTINEL="$S_HUMAN_SCAN" run 100)"
+probed "a human lane never pays for the marker scan" "no" "$S_HUMAN_SCAN"
 
 # The knowing cost of checking the hold FIRST, pinned rather than hidden: an
 # unlinked bot lane pays for the scan even while CI is still running. That is the

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -830,8 +830,13 @@ check "a hold reachable by the body link alone is still honoured" "optout" \
      PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LABELS="do-not-auto-merge" \
      ISSUE_LABELS_FOR=1982 run 100)"
 
-# Both routes present and agreeing: one optout, not a double-exit or a crash.
-check "both routes agreeing still yields exactly optout" "optout" \
+# Named for what it actually verifies. `exit_if_issue_holds` exits on the FIRST
+# hold it finds, so with the body link held the marker route is never reached --
+# this pins that the body-link route still short-circuits cleanly when both are
+# present, not that both are consulted. The case where both genuinely run is the
+# changelog one above: the body link resolves an UNHELD issue, so evaluation
+# continues into the marker scan, which is where the hold actually is.
+check "a held body link short-circuits before the marker route" "optout" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 \
      PR_AUTHOR="$DEPENDABOT" PR_BODY="Closes #1982" ISSUE_LIST_JSON="$HELD_BRIDGE" \
      ISSUE_LABELS="do-not-auto-merge" ISSUE_LABELS_FOR=1982 run 100)"


### PR DESCRIPTION
`linked_issue` takes the **last** reference match, and the marker scan only ran
when the body linked *nothing*. So a regenerated Dependabot body containing an
upstream changelog line — `Fixes #456` — resolved an unrelated issue in this
repo, the hold lookup consulted that one, the bridge issue was never reached,
and `hold_unproven` was never set either, so the deferred exit-2 guard could not
fire.

## The severity, stated as the test states it

Before the fix, the new headline case reports:

```
FAIL - a bridge hold is honoured despite a changelog link in the body
       (expected 'optout', got 'ready')
```

`ready` means **merge now**. A PR a human deliberately parked with
`do-not-auto-merge` would have been merged by the loop.

## The fix

Both routes now run on bot lanes. They are independent answers to "is there a
hold?", and either may be the one that has it — so the body link is checked
first and the marker as well, at the cost of one extra scan per bot lane.

`hold_unproven` keeps #2027's exact meaning — *neither* route resolved anything.
A body that did resolve an issue still counts as a resolution, so widening the
scan does not start refusing lanes that classified fine before. That is the AC's
"unprovable-hold semantics preserved" clause, and it is why the condition is
`[[ -n "$issue_n" ]] || hold_unproven="yes"` rather than an unconditional set.

## The fixture change that made the test real

Worth a reviewer's attention, because the first version of this test **passed
with the bug present**.

`ISSUE_LABELS` in the fake answers *every* issue number identically, so
`#456` looked held too and the case went green for entirely the wrong reason. It
only started failing once I added `ISSUE_LABELS_FOR=1982`, which pins the hold to
the bridge issue alone and lets `#456` read unlabelled.

That is the same trap this repo keeps hitting — a fake that agrees with whatever
it is asked — and it is why the "got `ready`" line above is quoted from a run
rather than reasoned about.

## The pin that was updated rather than deleted

Per the issue's explicit instruction:

```
- probed "an intact body link never scans for a marker" "no"  $S_ISSUE_LINKED
+ probed "a bot lane checks the marker route as well as the body link" "yes"  $S_ISSUE_LINKED
```

It encoded the narrower rule this issue replaces. It is still the pin that says
whether the scan happened — only its expected answer moved, and the reasoning is
inline.

## Coverage

Per the AC: hold on the bridge with a changelog link present; hold reachable by
the body link alone (#2027's case, must not regress); both routes present and
agreeing (exactly one `optout`, no double-exit); neither route holding (still
`ready` — widening must not invent holds); and human lanes unaffected, with a
sentinel pinning that they pay for no extra scan.

```
$ bash scripts/ralph/test_pr_ready.sh
pr-ready tests: 127 passed, 0 failed
$ shellcheck scripts/ralph/pr-ready.sh    # clean
```

Closes #2127 · refs #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9