### PR TITLE
fix(ci): trigger frontend CI on the audit gate script, which nothing guarded

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,10 +7,30 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
+      # Narrow on purpose, not an oversight. This workflow already documents a
+      # decision to shed trigger paths that pull the whole pipeline (audit gate
+      # and ~450 Jest suites) into PRs with no frontend change -- see the
+      # .pre-commit-config.yaml note below. So only the security-relevant script
+      # is listed, not all of scripts/frontend/: audit-gate.mjs is what reads
+      # .audit-allowlist.json and enforces the 2026-11-08 expiry on the two
+      # image-size advisories, and it was previously unguarded by any CI at all.
+      # A tweak to lint.sh or format.sh still triggers nothing, which is the
+      # existing tradeoff kept intact.
+      - "scripts/frontend/audit-gate.mjs"
       - ".github/workflows/frontend-ci.yml"
   pull_request:
     paths:
       - "frontend/**"
+      # Narrow on purpose, not an oversight. This workflow already documents a
+      # decision to shed trigger paths that pull the whole pipeline (audit gate
+      # and ~450 Jest suites) into PRs with no frontend change -- see the
+      # .pre-commit-config.yaml note below. So only the security-relevant script
+      # is listed, not all of scripts/frontend/: audit-gate.mjs is what reads
+      # .audit-allowlist.json and enforces the 2026-11-08 expiry on the two
+      # image-size advisories, and it was previously unguarded by any CI at all.
+      # A tweak to lint.sh or format.sh still triggers nothing, which is the
+      # existing tradeoff kept intact.
+      - "scripts/frontend/audit-gate.mjs"
       - ".github/workflows/frontend-ci.yml"
 
 # ``.pre-commit-config.yaml`` is deliberately NOT a trigger path. It used to be,


### PR DESCRIPTION
`frontend-ci.yml` filtered on `frontend/**`, and `scripts/frontend/` is not
under it. So **a PR editing only `audit-gate.mjs` ran no frontend CI at all** —
including the audit gate that script *is*.

That file reads `frontend/.audit-allowlist.json` and enforces the **2026-11-08**
expiry on the two `image-size` advisories. A change to its allowlist parsing,
its expiry logic, or its exit codes could have landed completely unexercised.

Found while fixing the same defect on the backend side, in review of #2038 /
PR #2196.

## Why this is narrower than the backend fix

`backend-ci.yml` took all of `scripts/backend/**`. This takes **one file**, and
the asymmetry is deliberate.

This workflow already documents a decision to *shed* trigger paths:

> ``.pre-commit-config.yaml`` is deliberately NOT a trigger path. It used to be
> … but the cost outweighed it: a change to that one file pulled the entire
> frontend pipeline, audit gate included, into PRs containing no frontend
> change.

Widening to `scripts/frontend/**` would undo exactly that for every `lint.sh` or
`format.sh` tweak — pulling the audit gate and ~450 Jest suites into changes that
touch no frontend code. Guarding the one security-relevant file honours both
concerns.

The existing tradeoff is left intact for the rest of the directory, and that is
now written down next to the filter rather than silently reversed. `backend-ci.yml`
carries no equivalent note, which is why the broad fix was safe there.

## Verification

Both trigger blocks carry it — they must agree, and a `push`/`pull_request`
divergence is its own bug:

```
$ grep -c '^      - "scripts/frontend/audit-gate.mjs"$' .github/workflows/frontend-ci.yml
2
$ pre-commit run check-yaml --files .github/workflows/frontend-ci.yml
check yaml...............................................................Passed
```

Closes #2199 · refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9