### PR TITLE
test(backend): assert the practice-session IDOR denial is audited and writes nothing

### DIFF
--- a/backend/tests/security/test_idor.py
+++ b/backend/tests/security/test_idor.py
@@ -38,6 +38,7 @@ from models.course_stage import CourseStage
 from models.goal import Goal
 from models.journal_entry import JournalEntry
 from models.practice import Practice
+from models.practice_session import PracticeSession
 from models.stage_content import StageContent
 from models.stage_progress import StageProgress
 from models.user import User
@@ -184,6 +185,20 @@ def _journal_payload(**foreign_keys: int) -> dict[str, object]:
 def _denial_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
     """Return the ``resource_access_denied`` audit records captured so far."""
     return [record for record in caplog.records if record.message == "resource_access_denied"]
+
+
+async def _sessions_where(
+    db_session: AsyncSession, condition: ColumnElement[bool]
+) -> list[PracticeSession]:
+    """Return every persisted practice session matching ``condition``.
+
+    Sibling of :func:`_entries_where`, and expires the shared session for the
+    same reason: the assertion has to read committed state, not the identity
+    map the request left behind.
+    """
+    db_session.expire_all()
+    result = await db_session.execute(select(PracticeSession).where(condition))
+    return list(result.scalars().all())
 
 
 async def _entries_where(
@@ -493,22 +508,61 @@ async def test_idor_user_practice_get_returns_403(
 
 @pytest.mark.asyncio
 async def test_idor_practice_session_create_returns_403(
-    async_client: AsyncClient, db_session: AsyncSession
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cross-user POST /practice-sessions/ — body's user_practice_id is Alice's."""
-    alice_headers, alice_id = await _signup(async_client, "alice_ps_post")
-    bob_headers, _ = await _signup(async_client, "bob_ps_post")
+    """Bob cannot log a practice session against Alice's user-practice.
 
-    user_practice_id = await _create_user_practice(
-        async_client, db_session, alice_headers, alice_id
+    ``POST /practice-sessions/`` takes ``user_practice_id`` from the request
+    body, so the path-parameter ownership dependencies never see it.  An
+    unguarded write would graft sessions onto a victim's practice history --
+    rows that then surface in her session list and her analytics rollups.
+
+    Asserted three ways rather than on the status alone.  The 403 was already
+    correct before this test grew; what was missing is that a *denial nobody
+    records* is a cross-tenant probe nobody can see, and that a status code
+    says nothing about whether a row was written anyway.
+    """
+    alice_headers, alice_id = await _signup(async_client, "alice_ps_post")
+    bob_headers, bob_id = await _signup(async_client, "bob_ps_post")
+
+    alice_practice_id = await _create_user_practice(
+        async_client, db_session, alice_headers, alice_id, practice_name="Alice PS Post"
+    )
+    bob_practice_id = await _create_user_practice(
+        async_client, db_session, bob_headers, bob_id, practice_name="Bob PS Post"
     )
 
-    resp = await async_client.post(
+    with caplog.at_level(logging.WARNING):
+        attack = await async_client.post(
+            "/practice-sessions/",
+            json=_session_window_payload(alice_practice_id),
+            headers=bob_headers,
+        )
+
+    assert attack.status_code == HTTPStatus.FORBIDDEN
+    assert attack.json()["detail"] == "forbidden"
+
+    # The identical payload against Bob's own practice is accepted, so the 403
+    # above can only be about ownership -- not a malformed body or a stage gate.
+    baseline = await async_client.post(
         "/practice-sessions/",
-        json=_session_window_payload(user_practice_id),
+        json=_session_window_payload(bob_practice_id),
         headers=bob_headers,
     )
-    assert resp.status_code == HTTPStatus.FORBIDDEN
+    assert baseline.status_code == HTTPStatus.CREATED
+
+    smuggled = await _sessions_where(
+        db_session, col(PracticeSession.user_practice_id) == alice_practice_id
+    )
+    assert smuggled == [], "cross-user practice session persisted against the victim's practice"
+
+    denials = _denial_records(caplog)
+    assert denials, "expected a resource_access_denied audit log entry"
+    assert getattr(denials[0], "resource", None) == "user_practice"
+    assert getattr(denials[0], "resource_id", None) == alice_practice_id
+    assert getattr(denials[0], "user_id", None) == bob_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Salvaged from **#2146**, which overlapped #2192 (already merged) on four files
but carried one improvement the merged version did not.

## What was worth rescuing

`test_idor_practice_session_create_returns_403` asserted only the status code.
That is the weakest of the three things worth knowing here, and the other two are
where the real failures hide:

- **A denial nobody records is a probe nobody can see.** The 403 was always
  correct — the missing `log_ownership_denied` was invisible *precisely because*
  the status looked right from outside. That was #2133, fixed in #2192, and this
  pins it in the security suite, which is where a reviewer looks for it.
- **A status code says nothing about whether a row was written anyway.** The test
  now queries for sessions grafted onto the victim's practice and asserts none
  exist. That is the consequence the control exists to prevent.

## The `baseline` leg, and why it matters

Copied from the sibling journal test directly below: the identical payload
against Bob's **own** practice must return 201.

Without it, a cross-tenant test can pass because the request was invalid for some
entirely unrelated reason — a malformed body, a stage gate, a schema change — and
you would never know the ownership check had stopped running. That is the quiet
way this class of test goes vacuous, and this repo has hit the shape repeatedly
today (a guard reading the manifest instead of the lock; every chart test mocking
the library under test).

## Not a cherry-pick

#2146's patch no longer applied — `main` moved. This is written against the
file's current shape and follows its own idiom (`_denial_records`,
`_entries_where`) rather than importing a foreign style. `_sessions_where`
mirrors `_entries_where` exactly, `expire_all()` included, since the assertion
must read committed state rather than the identity map the request left behind.

## On #2146 itself

Left open with a comment explaining the overlap. Its remaining four files are
redundant with #2192 and will conflict; this PR takes the part that was better
than what I merged. I did not want to close someone's stronger test by fiat.

```
$ ./scripts/backend/check-all.sh
Passed: 7 / Failed: 0        # exit 0
$ pytest tests/security/test_idor.py
34 passed
```

Refs #2146, #2133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9