### PR TITLE
fix(tooling): route the pre-push suite through test.sh so it takes the lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -172,11 +172,19 @@ repos:
       - id: backend-tests-coverage
         name: backend tests (coverage required)
         language: system
-        # Bare ``--cov`` (not ``--cov=.``) so the measured set is the single
-        # declaration in [tool.coverage.run] source (= {src, scripts}), the
-        # same set backend-ci.yml's branch-coverage step asserts over.
-        # ``-n auto`` distributes the suite: 15m58s -> 4m07s on 4 cores (#2076).
-        entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; cd backend && pytest -n auto --dist loadfile --cov --cov-report=term-missing --cov-fail-under=90'
+        # Routed through test.sh rather than calling pytest directly, because
+        # that script takes .gate-state/locks/backend-suite.lock first. A push
+        # firing while check-all.sh is mid-run otherwise gives two whole-suite
+        # runs sharing one coverage data file, one set of SQLite fixtures, and
+        # the cores ``-n auto`` sized for a single process -- and the damage is
+        # a wrong number rather than a crash, so nothing announces it.
+        #
+        # ``--all --coverage`` is the same run this line used to spell out:
+        # distributed (``-n "$PYTEST_WORKERS" --dist loadfile``), bare ``--cov``
+        # so the measured set stays the single [tool.coverage.run] declaration
+        # (= {src, scripts}) that backend-ci.yml's branch-coverage step asserts
+        # over, and ``--cov-fail-under=90``.
+        entry: bash -c '[ -f .venv/bin/activate ] && source .venv/bin/activate; ./scripts/backend/test.sh --all --coverage'
         pass_filenames: false
         files: ^backend/
         stages: [pre-push]

--- a/backend/tests/scripts/test_backend_test_runner.py
+++ b/backend/tests/scripts/test_backend_test_runner.py
@@ -865,3 +865,51 @@ def test_a_whole_suite_run_keeps_its_distribution_and_marker_selection(
         _WHOLE_SUITE_TARGET,
     ):
         assert expected in argv, f"the whole-suite invocation lost {expected!r}; got: {argv}"
+
+
+# --- the pre-push hook must not bypass the lock this module exists to prove ---
+
+_HOOK_ID = "backend-tests-coverage"
+_RUNNER_PATH = "scripts/backend/test.sh"
+
+
+def _hook_entry(hook_id: str) -> str:
+    """Return the ``entry:`` line of one pre-commit hook, as raw text.
+
+    Parsed as text rather than with PyYAML on purpose: that package is absent
+    from every requirements file here, and importing it turns this guard into a
+    collection error on the 3.11 compat job instead of a test.
+    """
+    config = (_REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    block = config.split(f"- id: {hook_id}", 1)[1]
+    for line in block.splitlines():
+        if line.strip().startswith("entry:"):
+            return line
+    raise AssertionError(f"hook {hook_id!r} has no entry: line")
+
+
+def test_the_pre_push_suite_hook_routes_through_the_test_script() -> None:
+    """The pre-push whole-suite run takes the lock, like every other whole-suite run.
+
+    The hook used to invoke ``pytest`` directly, which is the one path in the
+    repo that runs the entire suite *without* acquiring
+    ``.gate-state/locks/backend-suite.lock``. That is not a style point: a
+    ``git push`` firing while ``check-all.sh`` is mid-run gives two whole-suite
+    runs sharing one coverage data file, one set of SQLite fixtures, and the
+    cores ``-n auto`` sized for a single process. Neither result describes the
+    machine it claims to -- and the failure is a wrong *number*, not a crash,
+    so nothing announces it.
+
+    ``test.sh --all --coverage`` is the same run: it distributes
+    (``-n "$PYTEST_WORKERS" --dist loadfile``) and applies
+    ``--cov-fail-under=90``, and it takes the lock first.
+    """
+    entry = _hook_entry(_HOOK_ID)
+
+    assert _RUNNER_PATH in entry, (
+        f"the {_HOOK_ID} hook must run the whole suite through {_RUNNER_PATH}, "
+        f"which takes the whole-suite lock; got: {entry.strip()}"
+    )
+    assert "pytest -n auto" not in entry, (
+        f"the hook invokes pytest directly, bypassing the whole-suite lock; got: {entry.strip()}"
+    )

--- a/backend/tests/test_config_consolidation.py
+++ b/backend/tests/test_config_consolidation.py
@@ -60,9 +60,24 @@ class TestConfigConsolidation:
         assert '"test.sh" --unit --coverage-data' in check_all
 
     def test_pre_push_hook_still_enforces_the_threshold(self) -> None:
-        """The pre-push hook is the second place the 90% gate is enforced."""
+        """The pre-push hook is the second place the 90% gate is enforced.
+
+        Asserted through the runner rather than by grepping the hook file. The
+        hook stopped spelling the flag out when it was rerouted through
+        ``test.sh`` to take the whole-suite lock, and a substring search over
+        the YAML then matched the *comment* explaining that -- passing whether
+        or not any threshold was still applied. Following the value to where it
+        actually lives is what keeps this a guard instead of a spell-check.
+        """
         hooks = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
-        assert "--cov-fail-under=90" in hooks
+        entry = next(
+            line
+            for line in hooks.split("- id: backend-tests-coverage", 1)[1].splitlines()
+            if line.strip().startswith("entry:")
+        )
+        assert "--coverage" in entry, entry
+        runner = (REPO_ROOT / "scripts" / "backend" / "test.sh").read_text()
+        assert "--cov-fail-under=90" in runner
 
     def test_suite_runs_distributed(self) -> None:
         """Whole-suite runs must be distributed; serial costs 16 min a round.


### PR DESCRIPTION
The `backend-tests-coverage` hook invoked `pytest` directly — the one path in the
repo that runs the whole suite **without** acquiring
`.gate-state/locks/backend-suite.lock`.

A `git push` firing while `check-all.sh` is mid-run gives two whole-suite runs
sharing one coverage data file, one set of SQLite fixtures, and the cores
`-n auto` sized for a single process. `test.sh`'s own lock docstring says it
plainly: *"a result observed while another is in flight is unproven"*. The damage
is a wrong **number**, not a crash — nothing announces it.

## The swap is behaviour-preserving

`./scripts/backend/test.sh --all --coverage` is the same run the hook spelled
out, plus the lock:

| | old hook entry | `test.sh --all --coverage` |
|---|---|---|
| distribution | `-n auto --dist loadfile` | `-n "$PYTEST_WORKERS" --dist loadfile` (`test.sh:312`) |
| coverage set | bare `--cov` | bare `--cov` (same `[tool.coverage.run]` source) |
| threshold | `--cov-fail-under=90` | `--cov-fail-under=90` (`test.sh:348`) |
| whole-suite lock | ❌ | ✅ |

**No new runner mode was needed.** The issue's "Proposed fix" suspects one is,
on the grounds that `--coverage` applies the unit marker — that is wrong, and
`--all --coverage` already does exactly this. I'll correct the issue body.

The `[ -f .venv/bin/activate ] && source .venv/bin/activate;` prefix is kept
verbatim: it is what makes the hook work outside an activated shell.

## A guard went vacuous as a side effect — this is the interesting part

`test_config_consolidation.py` asserted:

```python
hooks = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
assert "--cov-fail-under=90" in hooks
```

Once the entry stopped spelling the flag out, that substring matched **the
comment explaining why** (`.pre-commit-config.yaml:186`). The test passed while
proving nothing, and would have kept passing if the threshold were never applied
anywhere at all.

It now follows the value to where it lives: the hook entry must request
`--coverage`, and `test.sh` must carry the threshold. **Inverted, not deleted**,
per the issue's instruction.

Worth calling out because it is the fourth instance of this exact shape in this
repo recently — a guard matching prose or a manifest rather than the behaviour it
claims to protect (the `python-multipart` guard reading the manifest instead of
the lock; every chart test mocking the library under test; a test pinning the
sender behaviour #2051 removed).

## Verification

```
$ pytest tests/scripts/test_backend_test_runner.py -k pre_push_suite_hook
AssertionError: the backend-tests-coverage hook must run the whole suite through
scripts/backend/test.sh ... got: entry: bash -c '... pytest -n auto ...'   # before

$ ./scripts/backend/check-all.sh
Passed: 7 / Failed: 0        # exit 0
```

Closes #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzBnyKwpsBWTiu6DD4DcJ9