### PR TITLE
test(tooling): gate every scripts/graph suite, not two of eight

### DIFF
--- a/.github/workflows/graph-tests.yml
+++ b/.github/workflows/graph-tests.yml
@@ -1,14 +1,13 @@
 name: Graph Tests
 
 # Offline tests for the graph tooling under scripts/graph/. These scripts live
-# outside backend/, so the backend-scoped lint/coverage gates don't cover them —
-# this workflow keeps the benchmark-trend ledger, the semantic staleness probe,
-# the scan-prompt preamble guards, the hook guards, the memory loop, the
-# session-start restore and the wiki export honest.
+# outside backend/, so the backend-scoped lint/coverage gates don't cover them.
 #
 # The run step globs the directory rather than naming suites, because naming
 # them drifted: this workflow once listed two of eight, so six suites were
-# gated by nothing at all. See scripts/graph/run_tests.sh.
+# gated by nothing at all. No inventory of the suites is kept here either —
+# a list in a comment drifts exactly as a list in a run step does, and
+# scripts/graph/ is the one place it cannot. See scripts/graph/run_tests.sh.
 
 # The two lists below are identical and must stay so. GitHub Actions does not
 # support YAML anchors in workflow files, so they are spelled out twice, as in

--- a/.github/workflows/graph-tests.yml
+++ b/.github/workflows/graph-tests.yml
@@ -2,17 +2,37 @@ name: Graph Tests
 
 # Offline tests for the graph tooling under scripts/graph/. These scripts live
 # outside backend/, so the backend-scoped lint/coverage gates don't cover them —
-# this workflow keeps the benchmark-trend ledger and the semantic staleness
-# probe honest.
+# this workflow keeps the benchmark-trend ledger, the semantic staleness probe,
+# the scan-prompt preamble guards, the hook guards, the memory loop, the
+# session-start restore and the wiki export honest.
+#
+# The run step globs the directory rather than naming suites, because naming
+# them drifted: this workflow once listed two of eight, so six suites were
+# gated by nothing at all. See scripts/graph/run_tests.sh.
 
+# The two lists below are identical and must stay so. GitHub Actions does not
+# support YAML anchors in workflow files, so they are spelled out twice, as in
+# every sibling workflow here; scripts/graph/test_run_tests.sh checks each
+# trigger's list separately, so editing one and forgetting the other fails.
 on:
   push:
     paths:
       - "scripts/graph/**"
+      # Files the suites assert over, all outside scripts/graph/. Without these
+      # a change to a scanned prompt or an agent instruction could not fire this
+      # workflow, so the guard covering it would never run.
+      - "prompts/scans/**"
+      - ".claude/**"
+      - "scripts/ralph/PROMPT.md"
+      - ".github/workflows/weekly-playbook.yml"
       - ".github/workflows/graph-tests.yml"
   pull_request:
     paths:
       - "scripts/graph/**"
+      - "prompts/scans/**"
+      - ".claude/**"
+      - "scripts/ralph/PROMPT.md"
+      - ".github/workflows/weekly-playbook.yml"
       - ".github/workflows/graph-tests.yml"
 
 permissions:
@@ -32,6 +52,4 @@ jobs:
           python-version: "3.12"
 
       - name: Run graph tool tests
-        run: |
-          bash scripts/graph/test_append_benchmark_trend.sh
-          bash scripts/graph/test_semantic_staleness.sh
+        run: bash scripts/graph/run_tests.sh

--- a/scripts/graph/README.md
+++ b/scripts/graph/README.md
@@ -171,9 +171,22 @@ the trend ledger gets at most one record per UTC day.
 
 `scripts/graph/test_append_benchmark_trend.sh` and
 `scripts/graph/test_semantic_staleness.sh` are offline shell tests for the
-two scripts above, run by `.github/workflows/graph-tests.yml` on any change
-under `scripts/graph/**` (this tooling lives outside `backend/`, so the
-backend-scoped lint/coverage gates don't otherwise cover it).
+two scripts above. They are two of the suites `.github/workflows/graph-tests.yml`
+runs — this tooling lives outside `backend/`, so the backend-scoped
+lint/coverage gates don't otherwise cover it.
+
+The workflow does not name suites. It runs `bash scripts/graph/run_tests.sh`,
+which globs every `scripts/graph/test_*.sh`, so a new suite is gated the moment
+it lands. (Naming them is what drifted: the workflow once listed two of eight,
+leaving six invoked by nothing.) The runner invokes each through `bash` — their
+recorded git modes are mixed — and fails if a suite fails, or if the glob
+matches nothing at all.
+
+Its `paths:` filter covers more than `scripts/graph/**`, because several suites
+assert over files elsewhere: `prompts/scans/**` (the scan-prompt preambles),
+`.claude/**` (the graph skill, agent instructions, hooks, settings),
+`scripts/ralph/PROMPT.md` and `.github/workflows/weekly-playbook.yml`. Editing
+a file a suite reads must be able to fire the suite that reads it.
 
 The ledger also feeds the Discord Ralph recap's knowledge-graph line — see
 [`scripts/ralph/RECAP.md`](../ralph/RECAP.md).

--- a/scripts/graph/run_tests.sh
+++ b/scripts/graph/run_tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/graph/run_tests.sh
+#
+# Runs every scripts/graph/test_*.sh suite and fails if any of them fail.
+#
+# This exists so the gate cannot drift from the suites it gates. graph-tests.yml
+# used to name suites by hand and had fallen six behind: six suites were
+# invoked by nothing, so they passed locally and no one would have found out
+# when they stopped. Globbing the directory means a suite is gated the moment
+# it lands.
+#
+# Every suite is invoked through `bash`, matching the `Run:` header each of
+# them documents. Their recorded git modes are mixed (0644 and 0755), so
+# executing them directly would exit 126 on some -- unlike scripts/ralph/,
+# where direct invocation is documented and the mode is itself guarded.
+#
+# Usage:  bash scripts/graph/run_tests.sh [directory]
+#
+# `directory` defaults to this script's own; it exists so the suite guarding
+# this runner can point it at fixtures.
+#
+# Note: deliberately no `set -e`. A failing suite must not stop the run, or one
+# broken suite would mask every suite after it and the next push would surface
+# a failure that was present all along.
+set -uo pipefail
+
+DIR="${1:-$(cd "$(dirname "$0")" && pwd)}"
+
+if [[ ! -d "$DIR" ]]; then
+  printf 'run_tests: no such directory: %s\n' "$DIR" >&2
+  exit 1
+fi
+
+# while-read instead of mapfile so macOS system bash 3.2 can run this too.
+suites=()
+while IFS= read -r suite; do suites+=("$suite"); done \
+  < <(find "$DIR" -maxdepth 1 -name 'test_*.sh' | sort)
+
+# A run that executed nothing is not a pass. If the glob ever breaks, this is
+# what turns a silent green into a visible failure.
+if [[ "${#suites[@]}" -eq 0 ]]; then
+  printf 'run_tests: no test_*.sh suites found in %s\n' "$DIR" >&2
+  exit 1
+fi
+
+failed=()
+for suite in "${suites[@]}"; do
+  name="$(basename "$suite")"
+  printf '\n=== %s ===\n' "$name"
+  if bash "$suite"; then
+    printf -- '--- %s: PASS\n' "$name"
+  else
+    printf -- '--- %s: FAIL (exit %s)\n' "$name" "$?"
+    failed+=("$name")
+  fi
+done
+
+printf '\n=== summary: %s suite(s), %s failed ===\n' "${#suites[@]}" "${#failed[@]}"
+if [[ "${#failed[@]}" -gt 0 ]]; then
+  for name in "${failed[@]}"; do printf 'FAILED: %s\n' "$name"; done
+  exit 1
+fi

--- a/scripts/graph/test_run_tests.sh
+++ b/scripts/graph/test_run_tests.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# scripts/graph/test_run_tests.sh
+#
+# Guard for the gate that runs every other guard.
+#
+# Six of the eight scripts/graph/test_*.sh suites were invoked by nothing:
+# graph-tests.yml named two of them by hand, so the other six existed, passed
+# locally, and nothing ever found out when they stopped. The fix is a runner
+# that globs the directory, so a suite is gated the moment it lands rather than
+# when someone remembers to edit a workflow.
+#
+# The assertions below are behavioural on purpose. Grepping the workflow for a
+# glob would prove the text says "*.sh" and nothing about whether a new suite
+# actually runs, whether a failure is reported, or whether an empty directory
+# reads as success -- and a guard that matches prose instead of behaviour is
+# the exact defect this repo keeps re-finding. So the runner is pointed at
+# fixture directories and its real exit code and output are checked.
+#
+# Run:  bash scripts/graph/test_run_tests.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNNER="$ROOT/scripts/graph/run_tests.sh"
+WORKFLOW="$ROOT/.github/workflows/graph-tests.yml"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# make_suite <dir> <name> <exit-code> [mode]
+# Writes a fake suite that announces itself, so output assertions can prove it
+# was actually executed rather than merely listed.
+make_suite() {
+  local dir="$1" name="$2" code="$3" mode="${4:-0755}"
+  mkdir -p "$dir"
+  printf '#!/usr/bin/env bash\necho "ran %s"\nexit %s\n' "$name" "$code" >"$dir/$name"
+  chmod "$mode" "$dir/$name"
+}
+
+if [[ ! -f "$RUNNER" ]]; then
+  bad "scripts/graph/run_tests.sh exists"
+  printf '\nrun_tests tests: %s passed, %s failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+ok "scripts/graph/run_tests.sh exists"
+
+# --- a directory of passing suites succeeds, and runs all of them -------------
+green="$TMP/green"
+make_suite "$green" "test_alpha.sh" 0
+make_suite "$green" "test_beta.sh" 0
+if out="$(bash "$RUNNER" "$green" 2>&1)"; then
+  ok "a directory of passing suites exits 0"
+else
+  bad "a directory of passing suites exits 0 (got rc=$?)"
+fi
+grep -q "ran test_alpha.sh" <<<"$out" && ok "runs the first suite" \
+  || bad "runs the first suite (output: $out)"
+grep -q "ran test_beta.sh" <<<"$out" && ok "runs the second suite" \
+  || bad "runs the second suite (output: $out)"
+
+# --- a new suite is picked up with no edit anywhere ---------------------------
+# The acceptance criterion "adding a new test_*.sh requires no workflow edit"
+# is exactly this: drop one in and it runs.
+make_suite "$green" "test_newly_added.sh" 0
+out="$(bash "$RUNNER" "$green" 2>&1 || true)"
+grep -q "ran test_newly_added.sh" <<<"$out" \
+  && ok "a newly added suite is gated without editing anything" \
+  || bad "a newly added suite is gated without editing anything (output: $out)"
+
+# --- a failure fails the run, but does not hide its siblings ------------------
+# Fail-fast here would report one broken suite and leave the rest unknown, so
+# the next push would surface a second failure that was present all along.
+mixed="$TMP/mixed"
+make_suite "$mixed" "test_first_ok.sh" 0
+make_suite "$mixed" "test_broken.sh" 1
+make_suite "$mixed" "test_last_ok.sh" 0
+set +e
+out="$(bash "$RUNNER" "$mixed" 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] && ok "a failing suite fails the run" \
+  || bad "a failing suite fails the run (got rc=0)"
+grep -q "ran test_last_ok.sh" <<<"$out" \
+  && ok "suites after a failure still run (no fail-fast)" \
+  || bad "suites after a failure still run (output: $out)"
+grep -q "test_broken.sh" <<<"$out" \
+  && ok "the failing suite is named in the output" \
+  || bad "the failing suite is named in the output (output: $out)"
+
+# --- exec bits are irrelevant -------------------------------------------------
+# These suites are recorded in git with mixed modes (0644 and 0755) and every
+# one documents `bash scripts/graph/<name>.sh` in its header, so the runner
+# must invoke through bash. Executing directly would exit 126 on the 0644 ones
+# -- which is two of the eight today.
+nonexec="$TMP/nonexec"
+make_suite "$nonexec" "test_not_executable.sh" 0 0644
+if out="$(bash "$RUNNER" "$nonexec" 2>&1)"; then
+  ok "a non-executable suite still runs (invoked via bash, not directly)"
+else
+  bad "a non-executable suite still runs (got rc=$?, output: $out)"
+fi
+
+# --- an empty directory must not read as success ------------------------------
+# A gate that passes when it ran nothing is worse than no gate: it reports
+# green while covering zero suites. If the glob ever breaks, this is the only
+# assertion that notices.
+empty="$TMP/empty"
+mkdir -p "$empty"
+set +e
+bash "$RUNNER" "$empty" >/dev/null 2>&1
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] && ok "an empty directory fails rather than passing vacuously" \
+  || bad "an empty directory fails rather than passing vacuously (got rc=0)"
+
+# --- the workflow delegates to the runner ------------------------------------
+if [[ ! -f "$WORKFLOW" ]]; then
+  bad "graph-tests.yml exists"
+else
+  grep -q "scripts/graph/run_tests.sh" "$WORKFLOW" \
+    && ok "graph-tests.yml invokes the runner" \
+    || bad "graph-tests.yml invokes the runner"
+  # Hand-enumerated suites are what drifted in the first place.
+  if grep -qE '^[[:space:]]+bash scripts/graph/test_[a-z_]+\.sh' "$WORKFLOW"; then
+    bad "graph-tests.yml still names individual suites by hand"
+  else
+    ok "graph-tests.yml names no individual suite by hand"
+  fi
+fi
+
+# --- the workflow triggers on what the suites actually read -------------------
+# A gate only fires on paths its filter names. These suites assert over files
+# well outside scripts/graph/, and none of them was in the filter -- so editing
+# a scanned prompt or an agent instruction could not trigger this workflow at
+# all. The gate existed; the event never reached it.
+#
+# Each entry below is a file some suite reads:
+#   prompts/scans/**       test_scan_graph_preamble.sh (every scan prompt)
+#   .claude/**             the graph SKILL, agent instructions, hooks, settings
+#   scripts/ralph/PROMPT.md, .github/workflows/weekly-playbook.yml
+#                          test_memory_loop.sh groups 5 and 6
+REQUIRED_PATHS=(
+  "prompts/scans/**"
+  ".claude/**"
+  "scripts/ralph/PROMPT.md"
+  ".github/workflows/weekly-playbook.yml"
+)
+paths_under() { # paths_under <push|pull_request>
+  awk -v key="  $1:" '
+    $0 == key { found = 1; next }
+    found && /^  [a-z_]+:/ { exit }
+    found { print }
+  ' "$WORKFLOW"
+}
+for trigger in push pull_request; do
+  block="$(paths_under "$trigger")"
+  for needed in "${REQUIRED_PATHS[@]}"; do
+    grep -qF -- "$needed" <<<"$block" \
+      && ok "$trigger triggers on $needed" \
+      || bad "$trigger triggers on $needed (absent from the $trigger paths filter)"
+  done
+done
+
+printf '\nrun_tests tests: %s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`graph-tests.yml` named its suites by hand and had fallen six behind. Of the eight `scripts/graph/test_*.sh` suites, only `test_append_benchmark_trend` and `test_semantic_staleness` ran in CI. The other six existed, passed locally, and nothing would have found out when they stopped.

Replaces the hand-written list with `scripts/graph/run_tests.sh`, which globs the directory — so a suite is gated the moment it lands, not when someone remembers to edit a workflow.

Closes #2137.

## Two things the enumeration was also hiding

**The paths filter was scoped to the wrong directory.** It named only `scripts/graph/**`, but these suites assert over files well outside it:

| Path | Asserted by |
|---|---|
| `prompts/scans/**` | `test_scan_graph_preamble.sh` — every scan prompt's preamble |
| `.claude/**` | the graph SKILL, agent instructions, hooks, `settings.json` |
| `scripts/ralph/PROMPT.md` | `test_memory_loop.sh` group 6 |
| `.github/workflows/weekly-playbook.yml` | `test_memory_loop.sh` group 5 |

Editing any of those could not fire this workflow *at all*. The guard existed; the event never reached it. That is a strictly worse failure than a missing guard, because the workflow list looks complete.

**Suites must be invoked through `bash`.** Their recorded git modes are mixed — `test_append_benchmark_trend.sh` and `test_semantic_staleness.sh` are `100644`, the other six `100755` — and every one documents `Run: bash scripts/graph/<name>.sh` in its header. Executing them directly would exit 126 on two of the eight. (This is the opposite of `scripts/ralph/`, where direct invocation *is* documented and `test_exec_bits.sh` guards the mode; that guard deliberately isn't copied here.)

## On the guard for the runner

`test_run_tests.sh` is behavioural rather than a grep for a glob. Asserting the workflow text contains `test_*.sh` would prove the file says the right words and nothing about whether a new suite actually runs — and a guard that matches prose instead of behaviour is a defect this repo has re-found four times in the last day, once in the PR immediately before this one.

So it points `run_tests.sh` at fixture directories and checks real exit codes and output:

- a new suite dropped in is picked up **with no edit anywhere** (the literal acceptance criterion)
- a failing suite fails the run, but suites *after* it still run — fail-fast would report one break and leave the rest unknown, so the next push surfaces a failure that was present all along
- a `0644` suite still runs, proving `bash "$f"` and not `"$f"`
- **an empty directory fails rather than passing vacuously** — a gate that reports green over zero suites is worse than no gate, and if the glob ever breaks this is the only assertion that notices

It also checks each trigger's `paths:` list separately, so editing one and forgetting the other fails. GitHub Actions doesn't support YAML anchors in workflow files, so the two lists are spelled out twice as in every sibling workflow.

## Verification

All nine suites (the eight, plus the new guard) pass against committed content:

```
=== summary: 9 suite(s), 0 failed ===
```

Red-then-green was observed at each step: the guard failed with `run_tests.sh exists` before the runner existed, then with the six workflow assertions before the workflow was rewritten, then 20/20.

`pre-commit run --files` on the three changed files: shellcheck **Passed**, check-yaml **Passed**, detect-secrets **Passed**.

## One thing found, deliberately not fixed here

Running the newly-gated set surfaced a real red: `prompts/scans/contract-drift-audit.md` fails `test_scan_graph_preamble.sh` on four assertions (no `Graph-first orientation` marker, no `absent or stale` fallback, no `## Context` body to sit in).

That file is **untracked** — a one-off audit prompt left in the working tree, not repo content. Every one of the 13 committed scans has a `scan-<name>.yml` wrapper calling `_claude-scan.yml`; this one has none, so it is not a registered scan and committing it here would be scope creep on a tooling PR.

Removing it and re-running gives `9 suite(s), 0 failed` — which is how the acceptance criterion "all eight suites pass" was verified. The gate added here is precisely what will block that file from landing unconformed. Follow-up to either register it as a real scan or relocate it: filed separately.

## Acceptance criteria

- [x] Every `scripts/graph/test_*.sh` runs in CI
- [x] Adding a new `test_*.sh` there requires no workflow edit to be gated — asserted behaviourally, not by inspection
- [x] All eight suites pass (verified against committed content)