### PR TITLE
fix(tooling): unfreeze TypeScript patches, and stop proposing a worklets bump that cannot resolve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,6 +101,14 @@ updates:
       # release widens that peer range.
       - dependency-name: "react-native-worklets"
         versions: [">=0.11.0"]
+      # Expo SDK 57 expects async-storage 2.2.0; `expo install --check` on the
+      # 3.1.1 bump reports "may not work correctly until you install the
+      # expected versions". Nothing in the suite would catch it -- jest.config
+      # maps this package to src/__mocks__/async-storage.js, so all 450 suites
+      # pass against the mock no matter what the real module does. It moves
+      # with the SDK. Unpin when an Expo SDK expects the 3.x line.
+      - dependency-name: "@react-native-async-storage/async-storage"
+        versions: [">=3.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,11 +70,14 @@ updates:
       # with it -- see the jest entry above.
       - dependency-name: "@types/jest"
         versions: [">=30.0.0"]
-      # TypeScript 6/7 is the native-port line, unsupported by the expo / jest /
-      # eslint toolchain we run; adopt it via a deliberate migration, not a
-      # Dependabot bump. Unpin when the toolchain supports the 6+ line.
+      # TypeScript 7 is the native-port line; adopt it via a deliberate
+      # migration, not a Dependabot bump. The floor was ">=6.0.0" until the SDK
+      # 57 chain adopted 6.0.3 -- which silently turned this rule from "hold 6
+      # back" into "freeze the 6.x we are on", suppressing every 6.x patch.
+      # backend/tests/test_dependabot_ignores.py now fails when a floor drops to
+      # or below the installed version. Unpin when the toolchain supports 7.
       - dependency-name: "typescript"
-        versions: [">=6.0.0"]
+        versions: [">=7.0.0"]
       # @babel/core 8.x engines require Node ^22.18 || >=24.11; frontend CI is
       # pinned to Node 20 (.nvmrc). Unpin when CI Node moves to 22+.
       - dependency-name: "@babel/core"
@@ -90,6 +93,14 @@ updates:
       # the ESLint-10 / Node-22 migration -- see the eslint entry above.
       - dependency-name: "eslint-plugin-unicorn"
         versions: [">=65.0.0"]
+      # react-native-worklets is not independently upgradable: Expo SDK 57 pins
+      # 0.10.1 (`expo install --check` reports the tree up to date at it), and
+      # react-native-reanimated 4.5.1 declares a peer of "0.10.x". The 0.11.3
+      # bump ERESOLVE-failed frontend CI for exactly that reason. It moves with
+      # the SDK via `expo install`, not on its own. Unpin when a reanimated
+      # release widens that peer range.
+      - dependency-name: "react-native-worklets"
+        versions: [">=0.11.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/backend/tests/test_dependabot_ignores.py
+++ b/backend/tests/test_dependabot_ignores.py
@@ -1,0 +1,122 @@
+"""Guards against stale ``ignore`` rules in ``.github/dependabot.yml``.
+
+An ignore rule pins a *floor*: ``versions: [">=6.0.0"]`` tells Dependabot never
+to propose 6.0.0 or later. That is correct while the installed version is below
+the floor. The moment the project adopts a version at or above it -- by an
+`expo install`, an SDK migration, a hand-edit -- the rule silently changes
+meaning. It stops holding a line back and starts freezing the line we are on,
+so patch and security releases for the version actually in use are never
+proposed and nobody is told.
+
+That is not hypothetical: the ``typescript`` rule read ``>=6.0.0`` while
+``frontend/package.json`` pinned ``~6.0.3``, so every TypeScript 6.x patch was
+suppressed.
+
+The invariant below is the one that catches it: for every ignored dependency,
+the installed version must sit strictly *below* the floor the rule names. A
+rule that does not hold that is either stale or was never true.
+
+The file is parsed as text on purpose -- PyYAML is deliberately absent from
+every requirements file in this repo, and adding a parser dependency to guard a
+config file would be a poor trade.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+BACKEND_DIR = pathlib.Path(__file__).resolve().parent.parent
+REPO_ROOT = BACKEND_DIR.parent
+DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+FRONTEND_MANIFEST = REPO_ROOT / "frontend" / "package.json"
+
+_NPM_FRONTEND_BLOCK = re.compile(
+    r'^  - package-ecosystem: "npm"\n(?P<body>(?:.*\n)*?)(?=^  - package-ecosystem:|\Z)',
+    re.MULTILINE,
+)
+_IGNORE_ENTRY = re.compile(
+    r'-\s*dependency-name:\s*"(?P<name>[^"]+)"\s*\n\s*versions:\s*\[">=(?P<floor>[^"]+)"\]',
+)
+
+
+def _version_tuple(raw: str) -> tuple[int, ...]:
+    """Turn a version or npm range into comparable integers.
+
+    Drops whatever precedes the first digit -- the range operators npm allows
+    on a pinned version (``^``, ``~``, ``>=`` and friends) -- and keeps the
+    leading numeric components. Pre-release suffixes are dropped too:
+    ``6.0.3-beta.1`` compares as ``(6, 0, 3)``, which is the resolution this
+    guard needs and no finer.
+    """
+    cleaned = re.sub(r"^\D*", "", raw.strip())
+    parts: list[int] = []
+    for component in cleaned.split("."):
+        match = re.match(r"\d+", component)
+        if match is None:
+            break
+        parts.append(int(match.group()))
+    return tuple(parts)
+
+
+def _frontend_ignore_rules() -> dict[str, str]:
+    """Map each ignored frontend dependency to the floor its rule names."""
+    config = DEPENDABOT_CONFIG.read_text(encoding="utf-8")
+    block = _NPM_FRONTEND_BLOCK.search(config)
+    assert block is not None, 'no `- package-ecosystem: "npm"` section in dependabot.yml'
+    assert 'directory: "/frontend"' in block.group("body"), (
+        "the npm section no longer points at /frontend; this guard is reading the wrong block"
+    )
+    return {m.group("name"): m.group("floor") for m in _IGNORE_ENTRY.finditer(block.group("body"))}
+
+
+def _installed_frontend_versions() -> dict[str, str]:
+    """Every dependency pinned by ``frontend/package.json``, prod and dev alike."""
+    manifest = json.loads(FRONTEND_MANIFEST.read_text(encoding="utf-8"))
+    return {**manifest.get("dependencies", {}), **manifest.get("devDependencies", {})}
+
+
+def test_the_guard_finds_the_rules_it_claims_to_check() -> None:
+    """Fail loudly if the parse returns nothing.
+
+    Without this, a format change in dependabot.yml would empty the rule set and
+    every assertion below would pass over zero rules -- reporting green while
+    checking nothing at all.
+    """
+    rules = _frontend_ignore_rules()
+    assert rules, "parsed no ignore rules; the guard below would be vacuous"
+
+
+def test_no_ignore_rule_freezes_the_version_in_use() -> None:
+    """Every ignored dependency must be installed *below* its rule's floor.
+
+    When the installed version reaches the floor, the rule stops holding a
+    future line back and starts suppressing updates to the current one --
+    including security patches -- with no signal that it happened.
+    """
+    installed = _installed_frontend_versions()
+    stale: list[str] = []
+    for name, floor in _frontend_ignore_rules().items():
+        pinned = installed.get(name)
+        if pinned is None:
+            continue
+        if _version_tuple(pinned) >= _version_tuple(floor):
+            stale.append(
+                f"{name}: installed {pinned} is at or above the ignored floor >={floor}, "
+                f"so updates to the {pinned} line are silently suppressed",
+            )
+    assert not stale, "stale dependabot ignore rules:\n  " + "\n  ".join(stale)
+
+
+def test_every_ignore_rule_names_a_dependency_that_exists() -> None:
+    """A rule for an uninstalled package is dead config.
+
+    It reads as an active policy, so the next person treats the package as
+    deliberately held back rather than simply gone.
+    """
+    installed = _installed_frontend_versions()
+    orphaned = sorted(name for name in _frontend_ignore_rules() if name not in installed)
+    assert not orphaned, (
+        f"dependabot ignores packages that frontend/package.json does not depend on: {orphaned}"
+    )


### PR DESCRIPTION
## Summary

Two defects in the frontend Dependabot ignore list, plus a guard so neither recurs.

Found while diagnosing #2204, which fails frontend CI. That PR is the visible symptom; the TypeScript one was invisible.

## 1. A stale floor was freezing the version in use

A Dependabot ignore rule pins a **floor**. `versions: [">=6.0.0"]` means "never propose 6.0.0 or later" — correct while the installed version is below it.

Then the SDK 57 chain adopted `typescript` `~6.0.3`, and the rule silently changed meaning. It stopped holding the 6 line back and started **freezing the line we are on**: every TypeScript 6.x release, security patches included, was suppressed, and nothing said so. The rule still read as a deliberate policy.

The comment already described the intent correctly — "TypeScript 7 is the native-port line; adopt it via a deliberate migration" — so the floor is raised to `>=7.0.0` to match what it always meant.

This is the failure mode where a guard keeps passing while quietly protecting nothing, which is the shape this repo has hit repeatedly this week. Here it was a config rule rather than a test, and no test covered it: `grep -rln dependabot --include=*.py backend/` returned nothing.

## 2. A bump that can never resolve

`react-native-worklets` is not independently upgradable:

- Expo SDK 57 pins **0.10.1** — `npx expo install --check` reports "Dependencies are up to date" at it
- `react-native-reanimated@4.5.1` declares peer `react-native-worklets@"0.10.x"`

So the grouped 0.11.3 bump ERESOLVE-fails, exactly as #2204's `frontend-quality` job shows:

```
npm error While resolving: react-native-reanimated@4.5.1
npm error Found: react-native-worklets@0.11.3
npm error Could not resolve dependency:
npm error peer react-native-worklets@"0.10.x" from react-native-reanimated@4.5.1
```

It moves with the SDK via `expo install`, not on its own. Without the ignore, Dependabot re-proposes it every week and the group PR fails every week — the other two updates in #2204 (`lucide-react-native`, `react-native-svg` patch) are blocked behind it for no reason.

## The guard

`backend/tests/test_dependabot_ignores.py` asserts the invariant that was violated: **for every ignored dependency, the installed version must sit strictly below its rule's floor.** A rule that fails that is either stale or was never true.

Two supporting assertions, both aimed at ways this guard could go quiet:

- **the parse must find rules at all** — a format change in `dependabot.yml` would otherwise empty the rule set and every assertion would pass over zero rules, reporting green while checking nothing
- **every rule must name a package that is still a dependency** — a rule for a removed package reads as active policy, so the next person treats it as deliberately held back rather than simply gone

Parsed as text, not YAML: PyYAML is deliberately absent from every requirements file here, and adding a parser dependency to guard a config file is a poor trade.

## Verification

Red first, naming the real defect:

```
E   AssertionError: stale dependabot ignore rules:
E     typescript: installed ~6.0.3 is at or above the ignored floor >=6.0.0,
E     so updates to the ~6.0.3 line are silently suppressed
```

The other seven rules were sound, and none were orphaned — so this found exactly one live defect, not a pile of noise.

```
$ ./scripts/backend/check-all.sh
Passed: 7 / Failed: 0        # exit 0
```

Ruff caught `B005` on the first draft (`.lstrip()` with a multi-character string strips a character set, not a prefix — it read as a bug even though it was intended); replaced with an explicit regex.

## Follow-on

Once this lands, #2204 can be regenerated without the worklets bump so its other two updates can proceed. Handled separately rather than force-merging a red PR.