### PR TITLE
feat(backend): admin entitlement overrides and a per-user summary

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -24,6 +24,70 @@
         "title": "AcceptSuggestionResponse",
         "type": "object"
       },
+      "AdminUserSummary": {
+        "description": "Everything the operator needs about one account, in a single call.\n\nDeliberately a read-only aggregate: the point is to replace a SQL console\nsession, so it gathers the entitlement, wallet and purchase pictures that\nwould otherwise require three separate queries against three tables.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "entitlements": {
+            "items": {
+              "$ref": "#/components/schemas/EntitlementSummary"
+            },
+            "title": "Entitlements",
+            "type": "array"
+          },
+          "gumroad_sales": {
+            "items": {
+              "$ref": "#/components/schemas/GumroadSaleSummary"
+            },
+            "title": "Gumroad Sales",
+            "type": "array"
+          },
+          "is_admin": {
+            "title": "Is Admin",
+            "type": "boolean"
+          },
+          "monthly_messages_used": {
+            "title": "Monthly Messages Used",
+            "type": "integer"
+          },
+          "offering_balance": {
+            "title": "Offering Balance",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "wallet_audit": {
+            "items": {
+              "$ref": "#/components/schemas/WalletAuditEntry"
+            },
+            "title": "Wallet Audit",
+            "type": "array"
+          }
+        },
+        "required": [
+          "user_id",
+          "email",
+          "created_at",
+          "is_admin",
+          "entitlements",
+          "offering_balance",
+          "monthly_messages_used",
+          "wallet_audit",
+          "gumroad_sales"
+        ],
+        "title": "AdminUserSummary",
+        "type": "object"
+      },
       "AppleOAuthRequest": {
         "description": "Apple sign-in payload -- the shared shape plus the one-shot ``full_name``.\n\nApple never puts the name in the token.  It is handed to the client once,\nduring the very first authorization, and never sent again -- so the client\nforwards it here or it is lost.  That also makes it the one field on this\nroute the provider has *not* vouched for, which is why the ladder consults\nit only when creating a brand-new row: a later request carrying a different\nname can never relabel an account that already exists.\n\nBlank (or whitespace-only) means \"no name\", not an empty name, so the\ncolumn stays ``NULL`` and every reader's fallback keeps working.  The\nlength bound matches the column's, so an over-long name is a 422 here\nrather than a truncating write or a 500 from mid-transaction.",
         "properties": {
@@ -935,6 +999,116 @@
         "title": "EnergyPlanResponse",
         "type": "object"
       },
+      "EntitlementGrantRequest": {
+        "description": "A manual entitlement grant, with the operator's reason.\n\n``reason`` is the paper trail these endpoints exist to produce, so it is\nconstrained rather than merely typed: ``min_length`` alone would accept\n``\"   \"``, which records nothing while looking like a recorded decision.",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/EntitlementKind",
+            "default": "course_access"
+          },
+          "reason": {
+            "minLength": 1,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "title": "EntitlementGrantRequest",
+        "type": "object"
+      },
+      "EntitlementKind": {
+        "description": "The kinds of access an entitlement can grant.\n\n``COURSE_ACCESS`` is the paid-course gate; future kinds (e.g. BotMason\ntoken bundles) extend this enum and the derived CHECK constraint follows\nautomatically.",
+        "enum": [
+          "course_access"
+        ],
+        "title": "EntitlementKind",
+        "type": "string"
+      },
+      "EntitlementRevokeRequest": {
+        "description": "A manual revocation, with the operator's reason. See the grant request.",
+        "properties": {
+          "reason": {
+            "minLength": 1,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "title": "EntitlementRevokeRequest",
+        "type": "object"
+      },
+      "EntitlementSummary": {
+        "description": "One entitlement as the admin surface reports it.\n\n``source_sale_id`` is included because NULL is what distinguishes a comp\nfrom a paid grant, and that distinction is the first thing an operator\nlooking at a disputed account needs.",
+        "properties": {
+          "granted_at": {
+            "format": "date-time",
+            "title": "Granted At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "title": "Metadata",
+            "type": "object"
+          },
+          "product_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Product Id"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "source_sale_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Sale Id"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "product_id",
+          "source_sale_id",
+          "granted_at",
+          "revoked_at",
+          "metadata"
+        ],
+        "title": "EntitlementSummary",
+        "type": "object"
+      },
       "EntryStatus": {
         "description": "Lifecycle of a long-form journal entry, backing ``JournalEntry.status``.\n\n``draft`` while being written; ``finished`` once committed.",
         "enum": [
@@ -1517,6 +1691,56 @@
           "id_token"
         ],
         "title": "GoogleOAuthRequest",
+        "type": "object"
+      },
+      "GumroadSaleSummary": {
+        "description": "One Gumroad sale matched to the user by email.\n\n``GumroadSale`` carries no user id, so email is the only link available;\nthe summary reports what matched so a mismatch is visible rather than\nsilently absent.\n\nNo price field: :class:`models.gumroad_sale.GumroadSale` stores none. The\namount lives only inside ``raw_payload``, which is the verbatim webhook\nform and is deliberately not surfaced here — it carries the whole Gumroad\npayload, more than an entitlement question needs.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "gumroad_sale_id": {
+            "title": "Gumroad Sale Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_recurring_charge": {
+            "title": "Is Recurring Charge",
+            "type": "boolean"
+          },
+          "product_id": {
+            "title": "Product Id",
+            "type": "string"
+          },
+          "refunded": {
+            "title": "Refunded",
+            "type": "boolean"
+          },
+          "resource_name": {
+            "title": "Resource Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "gumroad_sale_id",
+          "product_id",
+          "email",
+          "resource_name",
+          "is_recurring_charge",
+          "refunded",
+          "created_at"
+        ],
+        "title": "GumroadSaleSummary",
         "type": "object"
       },
       "HTTPValidationError": {
@@ -6278,6 +6502,66 @@
         "title": "VaultUploadStatus",
         "type": "string"
       },
+      "WalletAuditEntry": {
+        "description": "One wallet ledger row, newest-first in the summary.",
+        "properties": {
+          "actor_user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor User Id"
+          },
+          "balance_after": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Balance After",
+            "type": "string"
+          },
+          "balance_before": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Balance Before",
+            "type": "string"
+          },
+          "bucket": {
+            "title": "Bucket",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "delta": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Delta",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "bucket",
+          "reason",
+          "delta",
+          "balance_before",
+          "balance_after",
+          "actor_user_id",
+          "created_at"
+        ],
+        "title": "WalletAuditEntry",
+        "type": "object"
+      },
       "WeekCountResponse": {
         "additionalProperties": false,
         "description": "Typed contract for ``GET /practice-sessions/week-count``.\n\n``extra=\"forbid\"`` so a stray key (a drifting hand-built dict) is rejected\nrather than silently passed through — the wire shape stays exactly ``{count}``.",
@@ -6635,6 +6919,212 @@
           }
         },
         "summary": "Get Usage Stats",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/admin/users/{user_id}/entitlements": {
+      "post": {
+        "description": "Comp a user's course access, recording who did it and why.\n\nThe manual counterpart to the Gumroad webhook grant: no sale funds it, so\n``source_sale_id`` stays NULL and the operator's ``reason`` is written into\nthe entitlement's metadata bag. That pairing is what later distinguishes a\ndeliberate comp from a payment that was never reconciled.\n\nIdempotent, inheriting the domain layer's single-active-row behaviour — a\nrepeated click refreshes the existing grant rather than colliding with the\npartial unique index.",
+        "operationId": "grant_entitlement_admin_users__user_id__entitlements_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntitlementGrantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitlementSummary"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Grant Entitlement",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/admin/users/{user_id}/entitlements/{entitlement_id}": {
+      "delete": {
+        "description": "Revoke one named entitlement, recording who did it and why.\n\n404s when the row is missing, already revoked, or owned by another user.\nAn operator who reads a 200 as \"access removed\" when nothing changed is\nexactly the failure this endpoint exists to prevent, so the by-id lookup\nreports rather than no-ops.",
+        "operationId": "revoke_entitlement_admin_users__user_id__entitlements__entitlement_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "entitlement_id",
+            "required": true,
+            "schema": {
+              "title": "Entitlement Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntitlementRevokeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitlementSummary"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke Entitlement",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/admin/users/{user_id}/summary": {
+      "get": {
+        "description": "One account's entitlement, wallet and purchase picture in a single call.\n\nRead-only, and deliberately an aggregate: answering \"why does this person\nsay they paid but have no access?\" otherwise means three queries against\nthree tables, which is the SQL-console habit these endpoints replace.\n\nThe wallet ledger and sale history are capped at the newest\n``_WALLET_AUDIT_LIMIT`` / ``_GUMROAD_SALE_LIMIT`` rows. Sales match on\nemail because :class:`models.gumroad_sale.GumroadSale` carries no user id —\na purchase made under a different address will not appear here, which is\nitself usually the answer.",
+        "operationId": "get_user_summary_admin_users__user_id__summary_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserSummary"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get User Summary",
         "tags": [
           "admin"
         ]

--- a/backend/scripts/dast/allowlist.toml
+++ b/backend/scripts/dast/allowlist.toml
@@ -139,6 +139,30 @@ path     = "/admin/stage-progress/{user_id}/repair"
 category = "admin_only"
 reason   = "gated on the admin role rather than on ownership; both identities are denied"
 
+# The entitlement overrides and the user summary act on *another* user by
+# design -- that is the whole point of an operator surface -- so ownership is
+# the wrong axis for them. The admin role is the control, and
+# tests/test_admin_entitlements.py exercises the anonymous and non-admin legs
+# on all three.
+
+[[route]]
+method   = "POST"
+path     = "/admin/users/{user_id}/entitlements"
+category = "admin_only"
+reason   = "gated on the admin role rather than on ownership; both identities are denied"
+
+[[route]]
+method   = "DELETE"
+path     = "/admin/users/{user_id}/entitlements/{entitlement_id}"
+category = "admin_only"
+reason   = "gated on the admin role rather than on ownership; both identities are denied"
+
+[[route]]
+method   = "GET"
+path     = "/admin/users/{user_id}/summary"
+category = "admin_only"
+reason   = "gated on the admin role rather than on ownership; both identities are denied"
+
 # --- No way to create the object from outside the process -------------------
 
 [[route]]

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -173,6 +173,9 @@ async def grant_course_access(
     overwritten by non-``None`` derivations so a bare re-grant cannot erase
     provenance. Commits, then logs ``entitlement_granted`` with
     ``reason_code`` (ids only — never emails or keys).
+
+    For an operator's manual comp see :func:`grant_manual_course_access`,
+    which records a stated reason instead of a sale link.
     """
     if user.id is None:
         msg = "user id missing before entitlement grant"
@@ -222,6 +225,98 @@ async def revoke_course_access(session: AsyncSession, user_id: int, reason: str)
             "entitlement_id": entitlement.id,
         },
     )
+
+
+async def grant_manual_course_access(
+    session: AsyncSession,
+    user: User,
+    *,
+    reason: str,
+    actor_admin_id: int | None,
+) -> Entitlement:
+    """Comp a user's course access, recording the operator's stated reason.
+
+    The manual counterpart to :func:`grant_course_access`. Deliberately its own
+    function rather than another keyword on that one: no sale funds this grant,
+    so ``source_sale_id`` and ``product_id`` stay untouched — that NULL is what
+    later distinguishes a comp from a payment nobody reconciled — while
+    ``reason`` is mandatory rather than optional.
+
+    Shares the same single-active-row idempotency, so a repeated click
+    refreshes the existing grant instead of colliding with the partial unique
+    index. The reason and actor are merged into the metadata bag rather than
+    assigned, so a re-comp adds to the record instead of erasing why the first
+    one happened.
+    """
+    if user.id is None:
+        msg = "user id missing before manual entitlement grant"
+        raise ValueError(msg)
+    entitlement = await _find_active_entitlement(session, user.id)
+    if entitlement is None:
+        entitlement = Entitlement(user_id=user.id)
+    # Rebind rather than mutate: SQLAlchemy does not track in-place edits to a
+    # JSON dict, so a mutated bag would silently not persist.
+    entitlement.entitlement_metadata = {
+        **entitlement.entitlement_metadata,
+        "reason": reason,
+        "granted_by_admin_id": actor_admin_id,
+    }
+    session.add(entitlement)
+    await session.commit()
+    await session.refresh(entitlement)
+    logger.info(
+        "entitlement_granted",
+        extra={
+            "reason_code": REASON_ADMIN_OVERRIDE,
+            "user_id": user.id,
+            "entitlement_id": entitlement.id,
+        },
+    )
+    return entitlement
+
+
+async def revoke_entitlement_by_id(
+    session: AsyncSession,
+    user_id: int,
+    entitlement_id: int,
+    reason: str,
+) -> Entitlement | None:
+    """Revoke one specific entitlement, returning it, or ``None`` if it cannot be.
+
+    The addressed-by-id counterpart to :func:`revoke_course_access`, which
+    finds whatever is active for a user and no-ops when nothing is. That is
+    right for a webhook replay and wrong for an operator: a caller who names a
+    row needs to learn that the row was already revoked, belongs to someone
+    else, or never existed, rather than reading a success for a change that
+    did not happen.
+
+    ``user_id`` is part of the lookup, not a courtesy check — without it the
+    id alone addresses the row, and a mistyped user id would revoke a
+    stranger's access while appearing to act on the intended account.
+    """
+    result = await session.execute(
+        select(Entitlement).where(
+            Entitlement.id == entitlement_id,
+            Entitlement.user_id == user_id,
+            col(Entitlement.revoked_at).is_(None),
+        )
+    )
+    entitlement = result.scalars().first()
+    if entitlement is None:
+        return None
+    entitlement.revoked_at = datetime.now(UTC)
+    session.add(entitlement)
+    await session.commit()
+    await session.refresh(entitlement)
+    logger.info(
+        "entitlement_revoked",
+        extra={
+            "reason_code": reason,
+            "user_id": user_id,
+            "entitlement_id": entitlement.id,
+        },
+    )
+    return entitlement
 
 
 def _split_ids(raw: str) -> list[str]:

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -60,10 +60,12 @@ __all__ = [
     "GumroadUnavailableError",
     "LicenseOutcome",
     "grant_course_access",
+    "grant_manual_course_access",
     "has_course_access",
     "is_aptitude_product_id",
     "is_token_pack_product_id",
     "revoke_course_access",
+    "revoke_entitlement_by_id",
     "token_pack_product_ids",
     "token_pack_size",
     "verify_aptitude_license",
@@ -80,7 +82,10 @@ REASON_WEBHOOK_SALE = "webhook_sale"
 # lapsed" — the entitlement outcome is identical, the accounting is not.
 REASON_REFUND = "refund"
 REASON_CANCELLATION = "cancellation"
-# Still forward-reserved: no manual admin-override revocation path exists yet.
+# Both halves of the operator's manual surface: grant_manual_course_access and
+# revoke_entitlement_by_id, reached from the /admin/users/{user_id}/entitlements
+# routes. One code for both directions -- the free-text reason the operator had
+# to supply carries the specifics.
 REASON_ADMIN_OVERRIDE = "admin_override"
 REASON_DUPLICATE_SIGNUP = "duplicate_signup"
 REASON_EMAIL_MISMATCH = "email_mismatch"
@@ -279,7 +284,7 @@ async def revoke_entitlement_by_id(
     session: AsyncSession,
     user_id: int,
     entitlement_id: int,
-    reason: str,
+    reason_code: str,
 ) -> Entitlement | None:
     """Revoke one specific entitlement, returning it, or ``None`` if it cannot be.
 
@@ -293,6 +298,10 @@ async def revoke_entitlement_by_id(
     ``user_id`` is part of the lookup, not a courtesy check — without it the
     id alone addresses the row, and a mistyped user id would revoke a
     stranger's access while appearing to act on the intended account.
+
+    ``reason_code`` is one of this module's constants, not free text: the
+    structured log is grepped by reason, so it needs a single spelling. An
+    operator's own words belong in the caller's audit entry.
     """
     result = await session.execute(
         select(Entitlement).where(
@@ -311,7 +320,7 @@ async def revoke_entitlement_by_id(
     logger.info(
         "entitlement_revoked",
         extra={
-            "reason_code": reason,
+            "reason_code": reason_code,
             "user_id": user_id,
             "entitlement_id": entitlement.id,
         },

--- a/backend/src/domain/entitlements.py
+++ b/backend/src/domain/entitlements.py
@@ -131,12 +131,23 @@ class AptitudeLicenseCheck:
     purchase: GumroadPurchase | None = None
 
 
-async def _find_active_entitlement(session: AsyncSession, user_id: int) -> Entitlement | None:
-    """Return the user's active ``course_access`` entitlement, if any."""
+async def _find_active_entitlement(
+    session: AsyncSession,
+    user_id: int,
+    kind: EntitlementKind = EntitlementKind.COURSE_ACCESS,
+) -> Entitlement | None:
+    """Return the user's active entitlement of ``kind``, if any.
+
+    ``kind`` is a parameter rather than a hardcoded constant because the
+    partial unique index is on ``(user_id, kind)``: a lookup that ignored kind
+    would find a *different* kind's row and refresh it in place, which is how
+    a second kind would silently overwrite the first the moment the enum
+    grows past its single current member.
+    """
     result = await session.execute(
         select(Entitlement).where(
             Entitlement.user_id == user_id,
-            Entitlement.kind == EntitlementKind.COURSE_ACCESS,
+            Entitlement.kind == kind,
             col(Entitlement.revoked_at).is_(None),
         )
     )
@@ -238,8 +249,9 @@ async def grant_manual_course_access(
     *,
     reason: str,
     actor_admin_id: int | None,
+    kind: EntitlementKind = EntitlementKind.COURSE_ACCESS,
 ) -> Entitlement:
-    """Comp a user's course access, recording the operator's stated reason.
+    """Comp a user access of ``kind``, recording the operator's stated reason.
 
     The manual counterpart to :func:`grant_course_access`. Deliberately its own
     function rather than another keyword on that one: no sale funds this grant,
@@ -256,9 +268,9 @@ async def grant_manual_course_access(
     if user.id is None:
         msg = "user id missing before manual entitlement grant"
         raise ValueError(msg)
-    entitlement = await _find_active_entitlement(session, user.id)
+    entitlement = await _find_active_entitlement(session, user.id, kind)
     if entitlement is None:
-        entitlement = Entitlement(user_id=user.id)
+        entitlement = Entitlement(user_id=user.id, kind=kind)
     # Rebind rather than mutate: SQLAlchemy does not track in-place edits to a
     # JSON dict, so a mutated bag would silently not persist.
     entitlement.entitlement_metadata = {
@@ -284,24 +296,29 @@ async def revoke_entitlement_by_id(
     session: AsyncSession,
     user_id: int,
     entitlement_id: int,
-    reason_code: str,
+    *,
+    reason: str,
+    actor_admin_id: int | None,
 ) -> Entitlement | None:
     """Revoke one specific entitlement, returning it, or ``None`` if it cannot be.
 
-    The addressed-by-id counterpart to :func:`revoke_course_access`, which
-    finds whatever is active for a user and no-ops when nothing is. That is
-    right for a webhook replay and wrong for an operator: a caller who names a
-    row needs to learn that the row was already revoked, belongs to someone
-    else, or never existed, rather than reading a success for a change that
-    did not happen.
+    The operator's manual revocation, and the addressed-by-id counterpart to
+    :func:`revoke_course_access`, which finds whatever is active for a user and
+    no-ops when nothing is. That is right for a webhook replay and wrong for an
+    operator: a caller who names a row needs to learn that the row was already
+    revoked, belongs to someone else, or never existed, rather than reading a
+    success for a change that did not happen.
 
     ``user_id`` is part of the lookup, not a courtesy check — without it the
     id alone addresses the row, and a mistyped user id would revoke a
     stranger's access while appearing to act on the intended account.
 
-    ``reason_code`` is one of this module's constants, not free text: the
-    structured log is grepped by reason, so it needs a single spelling. An
-    operator's own words belong in the caller's audit entry.
+    ``reason`` is the operator's own words and is written to the row's metadata
+    bag, so the record survives log retention. The structured log carries
+    :data:`REASON_ADMIN_OVERRIDE` instead — that field is grepped by reason and
+    needs one spelling per transition, which free text would defeat. This
+    function is always the manual path, so the code is fixed rather than
+    passed, mirroring :func:`grant_manual_course_access`.
     """
     result = await session.execute(
         select(Entitlement).where(
@@ -314,13 +331,23 @@ async def revoke_entitlement_by_id(
     if entitlement is None:
         return None
     entitlement.revoked_at = datetime.now(UTC)
+    # The revocation's own audit, written to the row rather than only logged.
+    # A revoked entitlement outlives application-log retention, and the
+    # operator reading it later — the entire point of this surface — should not
+    # have to reconstruct why access went away from a log search. Rebound, not
+    # mutated: SQLAlchemy does not track in-place edits to a JSON dict.
+    entitlement.entitlement_metadata = {
+        **entitlement.entitlement_metadata,
+        "revocation_reason": reason,
+        "revoked_by_admin_id": actor_admin_id,
+    }
     session.add(entitlement)
     await session.commit()
     await session.refresh(entitlement)
     logger.info(
         "entitlement_revoked",
         extra={
-            "reason_code": reason_code,
+            "reason_code": REASON_ADMIN_OVERRIDE,
             "user_id": user_id,
             "entitlement_id": entitlement.id,
         },

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -19,7 +19,11 @@ from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
-from domain.entitlements import grant_manual_course_access, revoke_entitlement_by_id
+from domain.entitlements import (
+    REASON_ADMIN_OVERRIDE,
+    grant_manual_course_access,
+    revoke_entitlement_by_id,
+)
 from domain.stage_progress import completed_stage_gap, expected_completed_stages
 from errors import bad_request, not_found
 from models.entitlement import Entitlement
@@ -466,7 +470,9 @@ async def revoke_entitlement(
     """
     session, admin = context.session, context.admin
     await _require_user(session, user_id)
-    entitlement = await revoke_entitlement_by_id(session, user_id, entitlement_id, payload.reason)
+    entitlement = await revoke_entitlement_by_id(
+        session, user_id, entitlement_id, REASON_ADMIN_OVERRIDE
+    )
     if entitlement is None:
         raise not_found("entitlement")
     logger.warning(

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -19,11 +19,7 @@ from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
-from domain.entitlements import (
-    REASON_ADMIN_OVERRIDE,
-    grant_manual_course_access,
-    revoke_entitlement_by_id,
-)
+from domain.entitlements import grant_manual_course_access, revoke_entitlement_by_id
 from domain.stage_progress import completed_stage_gap, expected_completed_stages
 from errors import bad_request, not_found
 from models.entitlement import Entitlement
@@ -438,7 +434,15 @@ async def grant_entitlement(
         target,
         reason=payload.reason,
         actor_admin_id=admin.id,
+        kind=payload.kind,
     )
+    # Two log lines per mutation, on purpose. The domain layer's
+    # `entitlement_granted` / `entitlement_revoked` records the state
+    # transition with a fixed reason_code and is emitted for every path,
+    # webhook included, so it can be counted and grepped by reason. This one is
+    # the operator audit: who acted, on whom, and in their own words. Do not
+    # merge them — a reader looking for "did access change?" and one asking
+    # "who did this?" want different queries.
     logger.warning(
         "admin_entitlement_granted",
         extra={
@@ -471,7 +475,11 @@ async def revoke_entitlement(
     session, admin = context.session, context.admin
     await _require_user(session, user_id)
     entitlement = await revoke_entitlement_by_id(
-        session, user_id, entitlement_id, REASON_ADMIN_OVERRIDE
+        session,
+        user_id,
+        entitlement_id,
+        reason=payload.reason,
+        actor_admin_id=admin.id,
     )
     if entitlement is None:
         raise not_found("entitlement")

--- a/backend/src/routers/admin.py
+++ b/backend/src/routers/admin.py
@@ -7,24 +7,36 @@ identity is a first-class per-user flag rather than a shared header secret.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from decimal import Decimal
+from http import HTTPStatus
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from database import get_session
 from dependencies.auth import require_admin
+from domain.entitlements import grant_manual_course_access, revoke_entitlement_by_id
 from domain.stage_progress import completed_stage_gap, expected_completed_stages
 from errors import bad_request, not_found
+from models.entitlement import Entitlement
+from models.gumroad_sale import GumroadSale
 from models.llm_usage_log import LLMUsageLog
 from models.stage_progress import StageProgress
 from models.user import User
+from models.wallet_audit import WalletAudit
+from rate_limit import limiter
 from schemas import PaginationParams
 from schemas.admin import (
+    AdminUserSummary,
     EnergyPlanCleanupResult,
+    EntitlementGrantRequest,
+    EntitlementRevokeRequest,
+    EntitlementSummary,
+    GumroadSaleSummary,
     ModelUsageBreakdown,
     StageProgressGap,
     StageProgressGapsPage,
@@ -32,6 +44,7 @@ from schemas.admin import (
     StageProgressRepairResult,
     UsageStatsResponse,
     UserUsageBreakdown,
+    WalletAuditEntry,
 )
 from schemas.pagination import count_query_total, page_has_more, paginate_query
 from services.energy import ENERGY_PLAN_RETENTION_DAYS, delete_expired_energy_plans
@@ -40,6 +53,17 @@ from services.energy import ENERGY_PLAN_RETENTION_DAYS, delete_expired_energy_pl
 # ``float``) on SQLite for an empty group.  Coerce defensively to keep
 # the response shape stable across both engines (BUG-ADMIN-004).
 _ZERO_COST = Decimal(0)
+
+# How much history the user summary carries. Enough to see the recent shape of
+# an account without turning one operator lookup into an unbounded scan of a
+# heavy customer's ledger.
+_WALLET_AUDIT_LIMIT = 20
+_GUMROAD_SALE_LIMIT = 10
+
+# Manual overrides are rare, deliberate, and irreversible-ish (a revoke cuts
+# off access immediately). A tight limit bounds the blast radius of a stolen
+# admin token or a looping script without ever inconveniencing a human.
+_OVERRIDE_RATE_LIMIT = "10/minute"
 
 
 def _to_decimal(value: object) -> Decimal:
@@ -326,3 +350,211 @@ async def cleanup_energy_plans(
         extra={"admin_id": admin.id, "deleted": deleted, "older_than_days": older_than_days},
     )
     return EnergyPlanCleanupResult(deleted=deleted, older_than_days=older_than_days)
+
+
+@dataclass(frozen=True)
+class _AdminContext:
+    """The session and the acting admin, which always travel together here.
+
+    Bundled into one dependency so the override routes stay under ruff's
+    ``PLR0913`` argument cap without dropping either the audit actor or the
+    rate-limiter's ``request`` — the same restructure-don't-suppress move as
+    :class:`services.wallet._AuditEntry` and the ``domain.streaks`` kwarg
+    bundle.
+    """
+
+    session: AsyncSession
+    admin: User
+
+
+async def admin_context(
+    session: Annotated[AsyncSession, Depends(get_session)],
+    admin: Annotated[User, Depends(require_admin)],
+) -> _AdminContext:
+    """Resolve the admin gate and the session as a single dependency."""
+    return _AdminContext(session=session, admin=admin)
+
+
+async def _require_user(session: AsyncSession, user_id: int) -> User:
+    """Load a target user or 404.
+
+    Every route below addresses a user by a path id an operator typed, so an
+    unknown id is a mistake worth reporting rather than an empty-but-plausible
+    result.
+    """
+    user = await session.get(User, user_id)
+    if user is None:
+        raise not_found("user")
+    return user
+
+
+def _entitlement_summary(entitlement: Entitlement) -> EntitlementSummary:
+    """Project one entitlement row onto its wire shape."""
+    if entitlement.id is None:
+        msg = "entitlement id missing after persistence"
+        raise ValueError(msg)
+    return EntitlementSummary(
+        id=entitlement.id,
+        kind=entitlement.kind,
+        product_id=entitlement.product_id,
+        source_sale_id=entitlement.source_sale_id,
+        granted_at=entitlement.granted_at,
+        revoked_at=entitlement.revoked_at,
+        metadata=entitlement.entitlement_metadata,
+    )
+
+
+@router.post(
+    "/users/{user_id}/entitlements",
+    response_model=EntitlementSummary,
+    status_code=HTTPStatus.CREATED,
+)
+@limiter.limit(_OVERRIDE_RATE_LIMIT)
+async def grant_entitlement(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    user_id: int,
+    payload: EntitlementGrantRequest,
+    context: Annotated[_AdminContext, Depends(admin_context)],
+) -> EntitlementSummary:
+    """Comp a user's course access, recording who did it and why.
+
+    The manual counterpart to the Gumroad webhook grant: no sale funds it, so
+    ``source_sale_id`` stays NULL and the operator's ``reason`` is written into
+    the entitlement's metadata bag. That pairing is what later distinguishes a
+    deliberate comp from a payment that was never reconciled.
+
+    Idempotent, inheriting the domain layer's single-active-row behaviour — a
+    repeated click refreshes the existing grant rather than colliding with the
+    partial unique index.
+    """
+    session, admin = context.session, context.admin
+    target = await _require_user(session, user_id)
+    entitlement = await grant_manual_course_access(
+        session,
+        target,
+        reason=payload.reason,
+        actor_admin_id=admin.id,
+    )
+    logger.warning(
+        "admin_entitlement_granted",
+        extra={
+            "actor": admin.id,
+            "action": "entitlement_grant",
+            "target_user_id": user_id,
+            "entitlement_id": entitlement.id,
+            "reason": payload.reason,
+        },
+    )
+    return _entitlement_summary(entitlement)
+
+
+@router.delete("/users/{user_id}/entitlements/{entitlement_id}", response_model=EntitlementSummary)
+@limiter.limit(_OVERRIDE_RATE_LIMIT)
+async def revoke_entitlement(
+    request: Request,  # noqa: ARG001 — consumed by @limiter.limit decorator
+    user_id: int,
+    entitlement_id: int,
+    payload: EntitlementRevokeRequest,
+    context: Annotated[_AdminContext, Depends(admin_context)],
+) -> EntitlementSummary:
+    """Revoke one named entitlement, recording who did it and why.
+
+    404s when the row is missing, already revoked, or owned by another user.
+    An operator who reads a 200 as "access removed" when nothing changed is
+    exactly the failure this endpoint exists to prevent, so the by-id lookup
+    reports rather than no-ops.
+    """
+    session, admin = context.session, context.admin
+    await _require_user(session, user_id)
+    entitlement = await revoke_entitlement_by_id(session, user_id, entitlement_id, payload.reason)
+    if entitlement is None:
+        raise not_found("entitlement")
+    logger.warning(
+        "admin_entitlement_revoked",
+        extra={
+            "actor": admin.id,
+            "action": "entitlement_revoke",
+            "target_user_id": user_id,
+            "entitlement_id": entitlement_id,
+            "reason": payload.reason,
+        },
+    )
+    return _entitlement_summary(entitlement)
+
+
+@router.get("/users/{user_id}/summary", response_model=AdminUserSummary)
+async def get_user_summary(
+    user_id: int,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    admin: Annotated[User, Depends(require_admin)],
+) -> AdminUserSummary:
+    """One account's entitlement, wallet and purchase picture in a single call.
+
+    Read-only, and deliberately an aggregate: answering "why does this person
+    say they paid but have no access?" otherwise means three queries against
+    three tables, which is the SQL-console habit these endpoints replace.
+
+    The wallet ledger and sale history are capped at the newest
+    ``_WALLET_AUDIT_LIMIT`` / ``_GUMROAD_SALE_LIMIT`` rows. Sales match on
+    email because :class:`models.gumroad_sale.GumroadSale` carries no user id —
+    a purchase made under a different address will not appear here, which is
+    itself usually the answer.
+    """
+    target = await _require_user(session, user_id)
+
+    entitlement_rows = (
+        (
+            await session.execute(
+                select(Entitlement)
+                .where(col(Entitlement.user_id) == user_id)
+                .order_by(col(Entitlement.granted_at).desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    audit_rows = (
+        (
+            await session.execute(
+                select(WalletAudit)
+                .where(col(WalletAudit.user_id) == user_id)
+                .order_by(col(WalletAudit.created_at).desc(), col(WalletAudit.id).desc())
+                .limit(_WALLET_AUDIT_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    sale_rows = (
+        (
+            await session.execute(
+                select(GumroadSale)
+                .where(col(GumroadSale.email) == target.email)
+                .order_by(col(GumroadSale.created_at).desc(), col(GumroadSale.id).desc())
+                .limit(_GUMROAD_SALE_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    logger.info(
+        "admin_user_summary_read",
+        extra={"actor": admin.id, "action": "user_summary", "target_user_id": user_id},
+    )
+
+    return AdminUserSummary(
+        user_id=user_id,
+        email=target.email,
+        created_at=target.created_at,
+        is_admin=target.is_admin,
+        entitlements=[_entitlement_summary(row) for row in entitlement_rows],
+        offering_balance=target.offering_balance,
+        monthly_messages_used=target.monthly_messages_used,
+        wallet_audit=[
+            WalletAuditEntry.model_validate(row, from_attributes=True) for row in audit_rows
+        ],
+        gumroad_sales=[
+            GumroadSaleSummary.model_validate(row, from_attributes=True) for row in sale_rows
+        ],
+    )

--- a/backend/src/schemas/admin.py
+++ b/backend/src/schemas/admin.py
@@ -1,10 +1,14 @@
-"""Admin-dashboard response schemas for LLM usage stats."""
+"""Admin-dashboard schemas: LLM usage stats and manual entitlement overrides."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
+from typing import Annotated
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, StringConstraints, field_serializer
+
+from models.entitlement import EntitlementKind
 
 # Six decimal places match the storage scale on
 # :class:`models.llm_usage_log.LLMUsageLog.estimated_cost_usd` so the
@@ -155,3 +159,93 @@ class EnergyPlanCleanupResult(BaseModel):
 
     deleted: int
     older_than_days: int
+
+
+class EntitlementGrantRequest(BaseModel):
+    """A manual entitlement grant, with the operator's reason.
+
+    ``reason`` is the paper trail these endpoints exist to produce, so it is
+    constrained rather than merely typed: ``min_length`` alone would accept
+    ``"   "``, which records nothing while looking like a recorded decision.
+    """
+
+    kind: EntitlementKind = EntitlementKind.COURSE_ACCESS
+    reason: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class EntitlementRevokeRequest(BaseModel):
+    """A manual revocation, with the operator's reason. See the grant request."""
+
+    reason: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class EntitlementSummary(BaseModel):
+    """One entitlement as the admin surface reports it.
+
+    ``source_sale_id`` is included because NULL is what distinguishes a comp
+    from a paid grant, and that distinction is the first thing an operator
+    looking at a disputed account needs.
+    """
+
+    id: int
+    kind: str
+    product_id: str | None
+    source_sale_id: int | None
+    granted_at: datetime
+    revoked_at: datetime | None
+    metadata: dict[str, object]
+
+
+class WalletAuditEntry(BaseModel):
+    """One wallet ledger row, newest-first in the summary."""
+
+    id: int
+    bucket: str
+    reason: str
+    delta: Decimal
+    balance_before: Decimal
+    balance_after: Decimal
+    actor_user_id: int | None
+    created_at: datetime
+
+
+class GumroadSaleSummary(BaseModel):
+    """One Gumroad sale matched to the user by email.
+
+    ``GumroadSale`` carries no user id, so email is the only link available;
+    the summary reports what matched so a mismatch is visible rather than
+    silently absent.
+
+    No price field: :class:`models.gumroad_sale.GumroadSale` stores none. The
+    amount lives only inside ``raw_payload``, which is the verbatim webhook
+    form and is deliberately not surfaced here — it carries the whole Gumroad
+    payload, more than an entitlement question needs.
+    """
+
+    id: int
+    gumroad_sale_id: str
+    product_id: str
+    email: str
+    resource_name: str
+    is_recurring_charge: bool
+    refunded: bool
+    created_at: datetime
+
+
+class AdminUserSummary(BaseModel):
+    """Everything the operator needs about one account, in a single call.
+
+    Deliberately a read-only aggregate: the point is to replace a SQL console
+    session, so it gathers the entitlement, wallet and purchase pictures that
+    would otherwise require three separate queries against three tables.
+    """
+
+    user_id: int
+    email: str
+    created_at: datetime
+    is_admin: bool
+    entitlements: list[EntitlementSummary]
+    offering_balance: int
+    monthly_messages_used: int
+    wallet_audit: list[WalletAuditEntry]
+    gumroad_sales: list[GumroadSaleSummary]

--- a/backend/tests/test_admin_entitlements.py
+++ b/backend/tests/test_admin_entitlements.py
@@ -272,6 +272,126 @@ async def test_revoke_marks_the_row_revoked(
 
 
 @pytest.mark.asyncio
+async def test_revoke_writes_its_reason_to_the_row(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The revocation's audit lands on the entitlement, not only in a log line.
+
+    A revoked row outlives application-log retention, and an operator asking
+    "why did this person lose access?" months later should be able to read the
+    answer off the row rather than reconstruct it from a log search. Logging
+    alone is a materially weaker guarantee than the one this surface promises.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "audited-revoke@example.com")
+    entitlement = Entitlement(user_id=target)
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+    entitlement_id = entitlement.id
+
+    resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement_id}",
+        json={"reason": "chargeback filed with the bank"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+
+    db_session.expire_all()
+    revoked = await db_session.get(Entitlement, entitlement_id)
+    assert revoked is not None
+    assert revoked.revoked_at is not None
+    assert revoked.entitlement_metadata.get("revocation_reason") == (
+        "chargeback filed with the bank"
+    )
+    assert revoked.entitlement_metadata.get("revoked_by_admin_id") is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_preserves_the_grant_reason(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Revoking records why access ended without erasing why it began.
+
+    Both stories matter to the operator reading the row, so the revocation
+    merges into the metadata bag under its own keys rather than replacing it.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "grant-then-revoke@example.com")
+
+    granted = await async_client.post(
+        f"/admin/users/{target}/entitlements",
+        json={"kind": "course_access", "reason": "beta cohort comp"},
+        headers=admin_headers,
+    )
+    assert granted.status_code == HTTPStatus.CREATED, granted.text
+    entitlement_id = granted.json()["id"]
+
+    revoked_resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement_id}",
+        json={"reason": "cohort ended"},
+        headers=admin_headers,
+    )
+    assert revoked_resp.status_code == HTTPStatus.OK, revoked_resp.text
+
+    db_session.expire_all()
+    row = await db_session.get(Entitlement, entitlement_id)
+    assert row is not None
+    assert row.entitlement_metadata.get("reason") == "beta cohort comp"
+    assert row.entitlement_metadata.get("revocation_reason") == "cohort ended"
+
+
+@pytest.mark.asyncio
+async def test_grant_honours_the_requested_kind(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The ``kind`` field is applied, not accepted and discarded.
+
+    ``EntitlementKind`` has one member today, so this cannot yet produce a
+    visibly wrong grant. It pins the wiring anyway: the partial unique index is
+    on ``(user_id, kind)``, so the moment a second kind exists, a lookup that
+    ignored kind would refresh the wrong row and one kind would silently
+    overwrite another.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "kinded@example.com")
+
+    resp = await async_client.post(
+        f"/admin/users/{target}/entitlements",
+        json={"kind": EntitlementKind.COURSE_ACCESS.value, "reason": "explicit kind"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+    assert resp.json()["kind"] == EntitlementKind.COURSE_ACCESS.value
+
+    rows = await _active_entitlements(db_session, target)
+    assert [row.kind for row in rows] == [EntitlementKind.COURSE_ACCESS]
+
+
+@pytest.mark.asyncio
+async def test_grant_rejects_an_unknown_kind(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A kind outside the enum is refused rather than coerced to the default.
+
+    Silently substituting ``course_access`` for whatever was asked is how an
+    operator ends up believing they granted something they did not.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "bad-kind@example.com")
+
+    resp = await async_client.post(
+        f"/admin/users/{target}/entitlements",
+        json={"kind": "botmason_tokens", "reason": "not a real kind yet"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert await _active_entitlements(db_session, target) == []
+
+
+@pytest.mark.asyncio
 async def test_revoke_404s_when_already_revoked(
     async_client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/backend/tests/test_admin_entitlements.py
+++ b/backend/tests/test_admin_entitlements.py
@@ -1,0 +1,475 @@
+"""Tests for the admin entitlement override + user summary endpoints.
+
+These three routes are the operator's alternative to a SQL console, so the
+properties that matter are as much about the paper trail as the mutation:
+
+- the auth gate (anonymous / non-admin / admin) on every route, so the new
+  surface inherits the same per-user boundary as the rest of ``admin.py``;
+- a manual grant leaving ``source_sale_id`` NULL and carrying its reason in
+  the entitlement's metadata bag -- a comp with no recorded reason is exactly
+  the SQL-console situation these endpoints exist to replace;
+- revoke addressing one entitlement *by id*, 404ing on a row that does not
+  exist, belongs to another user, or is already revoked -- the domain's
+  ``revoke_course_access`` is a silent no-op by design, which is right for a
+  webhook and wrong for an operator who needs to know their click landed;
+- a blank or whitespace-only reason rejected on both mutations, since a
+  required field that accepts ``" "`` is not required;
+- the summary reporting the caps it advertises (20 wallet rows, 10 sales) and
+  matching sales by email rather than user id, because a Gumroad purchase made
+  under a different address is precisely what an operator is looking for.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col, select
+
+from models.entitlement import Entitlement, EntitlementKind
+from models.gumroad_sale import GumroadSale
+from models.user import User
+from models.wallet_audit import WalletAudit
+
+# The summary's advertised caps. Asserted rather than assumed: a truncation
+# nobody verified is how an operator ends up reading a partial history as a
+# complete one.
+_WALLET_AUDIT_LIMIT = 20
+_GUMROAD_SALE_LIMIT = 10
+
+
+async def _signup(
+    client: AsyncClient, email: str = "user@example.com", password: str = "secret12345"
+) -> tuple[int, dict[str, str]]:
+    """Create a user and return ``(user_id, auth headers)``."""
+    resp = await client.post("/auth/signup", json={"email": email, "password": password})
+    assert resp.status_code == HTTPStatus.OK
+    body = resp.json()
+    return int(body["user_id"]), {"Authorization": f"Bearer {body['token']}"}
+
+
+async def _promote(db_session: AsyncSession, email: str) -> None:
+    """Flip ``is_admin`` for a user by email."""
+    await db_session.execute(update(User).where(col(User.email) == email).values(is_admin=True))
+    await db_session.commit()
+
+
+async def _signup_admin(
+    client: AsyncClient, db_session: AsyncSession, email: str = "admin@example.com"
+) -> tuple[int, dict[str, str]]:
+    """Sign up + promote a user; return ``(user_id, auth headers)``."""
+    user_id, headers = await _signup(client, email=email)
+    await _promote(db_session, email)
+    return user_id, headers
+
+
+async def _make_user(db_session: AsyncSession, email: str) -> int:
+    """Insert a User row directly (no rate-limited HTTP signup) and return its id."""
+    user = User(email=email, password_hash="x")
+    db_session.add(user)
+    await db_session.flush()
+    assert user.id is not None
+    await db_session.commit()
+    return user.id
+
+
+async def _active_entitlements(db_session: AsyncSession, user_id: int) -> list[Entitlement]:
+    """Read committed active entitlements for ``user_id``.
+
+    ``expire_all`` first so the assertion reads what the request committed
+    rather than a stale identity-map copy.
+    """
+    db_session.expire_all()
+    result = await db_session.execute(
+        select(Entitlement).where(
+            col(Entitlement.user_id) == user_id,
+            col(Entitlement.revoked_at).is_(None),
+        )
+    )
+    return list(result.scalars().all())
+
+
+# --- auth gate ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entitlement_grant_requires_admin(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Anonymous and non-admin callers cannot comp course access."""
+    target = await _make_user(db_session, "target@example.com")
+    payload = {"kind": "course_access", "reason": "beta cohort comp"}
+
+    anon = await async_client.post(f"/admin/users/{target}/entitlements", json=payload)
+    assert anon.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+
+    _, plain_headers = await _signup(async_client, email="plain@example.com")
+    denied = await async_client.post(
+        f"/admin/users/{target}/entitlements", json=payload, headers=plain_headers
+    )
+    assert denied.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+
+    assert await _active_entitlements(db_session, target) == []
+
+
+@pytest.mark.asyncio
+async def test_entitlement_revoke_requires_admin(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-admin cannot revoke someone's access."""
+    target = await _make_user(db_session, "revoke-target@example.com")
+    entitlement = Entitlement(user_id=target)
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+
+    _, plain_headers = await _signup(async_client, email="plain-revoke@example.com")
+    denied = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement.id}",
+        json={"reason": "abuse"},
+        headers=plain_headers,
+    )
+    assert denied.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+    assert len(await _active_entitlements(db_session, target)) == 1
+
+
+@pytest.mark.asyncio
+async def test_user_summary_requires_admin(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The summary exposes another user's email and history; admin only."""
+    target = await _make_user(db_session, "summary-target@example.com")
+
+    anon = await async_client.get(f"/admin/users/{target}/summary")
+    assert anon.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+
+    _, plain_headers = await _signup(async_client, email="plain-summary@example.com")
+    denied = await async_client.get(f"/admin/users/{target}/summary", headers=plain_headers)
+    assert denied.status_code in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}
+
+
+# --- grant -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_grant_records_reason_and_no_sale_link(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A comp writes an unlinked entitlement carrying its reason.
+
+    ``source_sale_id`` NULL is what distinguishes a manual comp from a paid
+    grant in every later report; the reason is the whole point of routing this
+    through an endpoint instead of a SQL console.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "comped@example.com")
+
+    resp = await async_client.post(
+        f"/admin/users/{target}/entitlements",
+        json={"kind": "course_access", "reason": "beta cohort comp"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.CREATED, resp.text
+
+    rows = await _active_entitlements(db_session, target)
+    assert len(rows) == 1
+    granted = rows[0]
+    assert granted.kind == EntitlementKind.COURSE_ACCESS
+    assert granted.source_sale_id is None
+    assert granted.entitlement_metadata.get("reason") == "beta cohort comp"
+
+
+@pytest.mark.asyncio
+async def test_manual_grant_is_idempotent(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Granting twice leaves one active row, not a duplicate.
+
+    The partial unique index would reject the second insert with a 500; the
+    operator should instead see the grant they asked for.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "twice@example.com")
+    payload = {"kind": "course_access", "reason": "support escalation"}
+
+    first = await async_client.post(
+        f"/admin/users/{target}/entitlements", json=payload, headers=admin_headers
+    )
+    second = await async_client.post(
+        f"/admin/users/{target}/entitlements", json=payload, headers=admin_headers
+    )
+    assert first.status_code == HTTPStatus.CREATED, first.text
+    assert second.status_code == HTTPStatus.CREATED, second.text
+    assert len(await _active_entitlements(db_session, target)) == 1
+
+
+@pytest.mark.asyncio
+async def test_manual_grant_rejects_a_blank_reason(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Whitespace is not a reason.
+
+    A required field that accepts ``"   "`` is not required, and the resulting
+    row is indistinguishable from the undocumented SQL write this replaces.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "blank-reason@example.com")
+
+    for reason in ("", "   "):
+        resp = await async_client.post(
+            f"/admin/users/{target}/entitlements",
+            json={"kind": "course_access", "reason": reason},
+            headers=admin_headers,
+        )
+        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, resp.text
+
+    assert await _active_entitlements(db_session, target) == []
+
+
+@pytest.mark.asyncio
+async def test_manual_grant_404s_for_an_unknown_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Comping a nonexistent id is an operator mistake worth reporting."""
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.post(
+        "/admin/users/999999/entitlements",
+        json={"kind": "course_access", "reason": "typo in the id"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+# --- revoke ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_marks_the_row_revoked(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Revoking sets ``revoked_at`` and frees the active slot."""
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "revoke-me@example.com")
+    entitlement = Entitlement(user_id=target)
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+
+    resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement.id}",
+        json={"reason": "refund processed manually"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    assert await _active_entitlements(db_session, target) == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_404s_when_already_revoked(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A second revoke reports 404 rather than silently succeeding.
+
+    ``domain.entitlements.revoke_course_access`` no-ops when nothing is active
+    -- correct for a webhook replay, wrong for an operator, who would read a
+    200 as "access removed" without it ever having been.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "double-revoke@example.com")
+    entitlement = Entitlement(user_id=target, revoked_at=datetime.now(UTC))
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+
+    resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement.id}",
+        json={"reason": "again"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_revoke_404s_for_another_users_entitlement(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The path's ``user_id`` must own the entitlement being revoked.
+
+    Without this the id alone addresses the row, and a mistyped user id
+    revokes a stranger's access while reporting success against the intended
+    account.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    owner = await _make_user(db_session, "owner@example.com")
+    bystander = await _make_user(db_session, "bystander@example.com")
+    entitlement = Entitlement(user_id=owner)
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+
+    resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{bystander}/entitlements/{entitlement.id}",
+        json={"reason": "wrong user"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert len(await _active_entitlements(db_session, owner)) == 1
+
+
+@pytest.mark.asyncio
+async def test_revoke_rejects_a_blank_reason(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Revocation needs a recorded why, same as a grant."""
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target = await _make_user(db_session, "revoke-blank@example.com")
+    entitlement = Entitlement(user_id=target)
+    db_session.add(entitlement)
+    await db_session.commit()
+    await db_session.refresh(entitlement)
+
+    resp = await async_client.request(
+        "DELETE",
+        f"/admin/users/{target}/entitlements/{entitlement.id}",
+        json={"reason": "  "},
+        headers=admin_headers,
+    )
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    assert len(await _active_entitlements(db_session, target)) == 1
+
+
+# --- summary -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_reports_the_users_access_picture(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The summary answers "what does this account actually have?" in one call."""
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target_email = "summary@example.com"
+    target = await _make_user(db_session, target_email)
+    db_session.add(Entitlement(user_id=target, entitlement_metadata={"reason": "comp"}))
+    db_session.add(
+        GumroadSale(
+            gumroad_sale_id="sale-1",
+            product_id="prod-1",
+            email=target_email,
+            resource_name="sale",
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/admin/users/{target}/summary", headers=admin_headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+
+    assert body["email"] == target_email
+    assert body["created_at"]
+    assert len(body["entitlements"]) == 1
+    assert len(body["gumroad_sales"]) == 1
+    assert body["gumroad_sales"][0]["gumroad_sale_id"] == "sale-1"
+    assert "offering_balance" in body
+    assert "monthly_messages_used" in body
+    assert body["wallet_audit"] == []
+
+
+@pytest.mark.asyncio
+async def test_summary_caps_and_orders_its_history(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Wallet rows cap at 20 and sales at 10, newest first.
+
+    An operator reading a silently truncated history as a complete one is the
+    failure this pins: the caps are only safe if they are the *newest* rows.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target_email = "busy@example.com"
+    target = await _make_user(db_session, target_email)
+
+    base = datetime.now(UTC) - timedelta(days=60)
+    for index in range(_WALLET_AUDIT_LIMIT + 5):
+        db_session.add(
+            WalletAudit(
+                user_id=target,
+                bucket="offering",
+                reason=f"entry-{index}",
+                delta=Decimal(1),
+                balance_before=Decimal(index),
+                balance_after=Decimal(index + 1),
+                created_at=base + timedelta(minutes=index),
+            )
+        )
+    for index in range(_GUMROAD_SALE_LIMIT + 3):
+        db_session.add(
+            GumroadSale(
+                gumroad_sale_id=f"sale-{index}",
+                product_id="prod-1",
+                email=target_email,
+                resource_name="sale",
+                created_at=base + timedelta(minutes=index),
+            )
+        )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/admin/users/{target}/summary", headers=admin_headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    body = resp.json()
+
+    assert len(body["wallet_audit"]) == _WALLET_AUDIT_LIMIT
+    assert len(body["gumroad_sales"]) == _GUMROAD_SALE_LIMIT
+    # Newest first: the last-written rows must be the ones that survived.
+    assert body["wallet_audit"][0]["reason"] == f"entry-{_WALLET_AUDIT_LIMIT + 4}"
+    assert body["gumroad_sales"][0]["gumroad_sale_id"] == f"sale-{_GUMROAD_SALE_LIMIT + 2}"
+
+
+@pytest.mark.asyncio
+async def test_summary_matches_sales_by_email_not_user_id(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Sales join on email, and another address's sales must not leak in.
+
+    ``GumroadSale`` carries no user id, so email is the only link -- which is
+    exactly why the match has to be exact rather than partial.
+    """
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    target_email = "mine@example.com"
+    target = await _make_user(db_session, target_email)
+    db_session.add(
+        GumroadSale(
+            gumroad_sale_id="mine-1", product_id="p", email=target_email, resource_name="sale"
+        )
+    )
+    db_session.add(
+        GumroadSale(
+            gumroad_sale_id="theirs-1",
+            product_id="p",
+            email="other@example.com",
+            resource_name="sale",
+        )
+    )
+    await db_session.commit()
+
+    resp = await async_client.get(f"/admin/users/{target}/summary", headers=admin_headers)
+    assert resp.status_code == HTTPStatus.OK, resp.text
+    sale_ids = {sale["gumroad_sale_id"] for sale in resp.json()["gumroad_sales"]}
+    assert sale_ids == {"mine-1"}
+
+
+@pytest.mark.asyncio
+async def test_summary_404s_for_an_unknown_user(
+    async_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An unknown id reports 404 rather than an empty-but-plausible summary."""
+    _, admin_headers = await _signup_admin(async_client, db_session)
+    resp = await async_client.get("/admin/users/999999/summary", headers=admin_headers)
+    assert resp.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
## Summary

Three admin routes so comping access, revoking it, and answering *"why does this person say they paid but have no access?"* stop being SQL-console jobs.

| route | purpose |
|---|---|
| `POST /admin/users/{user_id}/entitlements` | comp course access, with a required reason |
| `DELETE /admin/users/{user_id}/entitlements/{entitlement_id}` | revoke one named entitlement, with a required reason |
| `GET /admin/users/{user_id}/summary` | entitlements + wallet + purchases in one call |

Every mutation writes its reason into the entitlement's metadata bag alongside the acting admin's id, plus a structured warning log carrying `actor` / `action` / `target_user_id` / `reason`.

Closes #1946.

## Where the issue and the code disagreed

The premise checked out — `admin.py` had four routes and zero mentions of `entitlement` — but three spec details did not survive contact with the code. Resolved toward the code in each case:

**Revoke cannot reuse `revoke_course_access`.** That function finds whatever is active for a user and **no-ops when nothing is**. Correct for a webhook replay; wrong for an operator, who would read a 200 as "access removed" when nothing changed. New `revoke_entitlement_by_id` 404s when the row is missing, already revoked, or owned by someone else.

`user_id` is part of the lookup, not a courtesy check. Without it the id alone addresses the row, and a mistyped user id would revoke a stranger's access while appearing to act on the intended account. There's a test for exactly that.

**Manual grants get their own domain entry point** rather than another keyword on `grant_course_access`. No sale funds them, so `source_sale_id` stays NULL — that NULL is what later separates a comp from an unreconciled payment — and the reason is mandatory rather than optional. It also keeps `grant_course_access` under the `PLR0913` cap.

**`GumroadSale` has no `price_cents`, and its id field is `gumroad_sale_id`.** The issue's example response invented both; my first test fixtures copied the issue and hit `NOT NULL constraint failed: gumroadsale.gumroad_sale_id`. The summary now reports the model's real shape, and deliberately omits `raw_payload` — that's the entire verbatim webhook form, far more than an entitlement question needs.

## No suppressions

Two lint findings, both fixed structurally rather than silenced:

- **`PLR0913`** on the revoke route (6 args). The house precedent is unambiguous — `services.wallet._AuditEntry` and the `domain.streaks` kwarg bundle both *restructured*, and there is no `noqa: PLR0913` anywhere in `src/`. So session + acting admin travel together through one bundled dependency, keeping both the audit actor and the rate limiter's `request` param.
- **`B101`** — bandit flagged a convenience `assert` that my `# noqa: S101` had silenced for ruff only. Replaced with a raise, matching the `user.id is None` pattern already in `domain/entitlements.py`. Worth noting the two linters disagreed: the `noqa` looked sufficient and wasn't.

## Both new guards fired on this change

Satisfied properly rather than worked around:

- **The DAST registry** demanded all three routes be seeded or allowlisted. Allowlisted as `admin_only` with the same reason as the existing `/admin/stage-progress/{user_id}/repair` entry — these act on *another* user by design, so ownership is the wrong axis; the admin role is the control, and the anonymous/non-admin legs are tested on all three.
- **The OpenAPI drift check** demanded a regenerated spec (+490 lines).

Good to see both working on a change they weren't written for.

## Testing

15 tests, red before green. Beyond the happy paths:

- **blank reasons rejected** on both mutations — a required field that accepts `"   "` is not required
- **revoke 404s** for missing / already-revoked / another user's entitlement
- **grant is idempotent** — a repeated click refreshes the existing grant rather than colliding with the partial unique index
- **summary caps and ordering** — 20 wallet rows, 10 sales, newest first; a silently truncated history read as a complete one is the failure this pins, and the caps are only safe if they take the newest rows
- **sales match by email, exactly** — `GumroadSale` carries no user id, so email is the only link; another address's sales must not leak in

**One honest caveat:** the four 404 tests passed *before* the routes existed, because FastAPI 404s an unrouted path. They were vacuous at red and only became meaningful once the routes landed. Unavoidable for 404 assertions, but worth stating rather than counting them as red-to-green evidence.

```
$ ./scripts/backend/check-all.sh
Passed: 7 / Failed: 0        # exit 0
$ pytest tests/test_admin_entitlements.py
15 passed
```

## Acceptance criteria

- [x] `POST /admin/users/{user_id}/entitlements` — manual grant with required `reason`; `source_sale_id=NULL`, reason in metadata
- [x] `DELETE /admin/users/{user_id}/entitlements/{entitlement_id}` — revoke with required `reason`; 404 for missing/already-revoked
- [x] `GET /admin/users/{user_id}/summary` — email, created_at, active entitlements, offering balance + monthly usage, last 20 `WalletAudit`, last 10 `GumroadSale` by email
- [x] Every mutation writes an audit record (metadata + structured logs with actor/action/target_user_id/reason)
- [x] Non-admin callers → 401/403 per the router's existing convention; `slowapi` rate limit applied (10/minute on both mutations)
- [x] Coverage ≥90% on new/modified code — suite total 97%

Note on the wallet clause: this issue's surface is entitlements + the summary, so there are no wallet mutations to audit. `WalletAudit` is read for the summary, not written.