### PR TITLE
fix(ci): stop the review job attaching a verdict for a PR it never read

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,11 +51,30 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"
           prompt:  |
-            Review this pull request against the repository's CLAUDE.md. Read the
-            change with `gh pr diff` and `gh pr view` (and any files you need).
+            Review pull request #${{ github.event.pull_request.number }} in the
+            repository ${{ github.repository }}, against that repository's
+            CLAUDE.md. Read the change with
+
+                gh pr diff ${{ github.event.pull_request.number }}
+                gh pr view ${{ github.event.pull_request.number }}
+
+            and any files you need.
+
+            Always pass that number explicitly. A bare `gh pr diff` resolves only
+            when the checkout is on a recognizable PR branch; here it is a merge
+            ref, so the bare form fails and any recovery that guesses -- listing
+            open PRs and taking the newest, say -- silently reviews somebody
+            else's change. The "Post review" step below attaches whatever you
+            return to #${{ github.event.pull_request.number }} regardless, so a
+            guess becomes a verdict on a PR you never read.
 
             Do NOT post a comment yourself. Return ONLY the structured result with
-            three fields:
+            four fields:
+
+            - "reviewed_pr_number": the number of the PR you actually read, as an
+              integer. This is checked against the PR being posted to and a
+              mismatch fails the run, so report what you read rather than what
+              you were asked to read.
 
             - "review_markdown": the full review as GitHub markdown, using this
               template (omit the verdict here — it is a separate field below):
@@ -105,8 +124,8 @@ jobs:
           # (fixes the flaky success-with-no-comment runs, #810). gh pr comment is
           # intentionally NOT in allowed-tools so the agent cannot post on its own.
           claude_args: >-
-            --json-schema '{"type":"object","additionalProperties":false,"required":["verdict","verdict_rationale","review_markdown"],"properties":{"verdict":{"type":"string","enum":["CHANGES_REQUESTED","COMMENTS","LGTM"]},"verdict_rationale":{"type":"string"},"review_markdown":{"type":"string"}}}'
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"required":["verdict","verdict_rationale","review_markdown","reviewed_pr_number"],"properties":{"verdict":{"type":"string","enum":["CHANGES_REQUESTED","COMMENTS","LGTM"]},"verdict_rationale":{"type":"string"},"review_markdown":{"type":"string"},"reviewed_pr_number":{"type":"integer"}}}'
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Post review
         # Deterministic: this step always runs after a successful review and posts
@@ -135,6 +154,18 @@ jobs:
               exit 0
             fi
             echo "::error::Claude review produced no structured output — failing so it is re-run, never a silent no-review."
+            exit 1
+          fi
+          # Refuse to post a review of a different PR. The agent resolves the PR
+          # itself, so a failed `gh pr diff` plus a guessing recovery can produce
+          # a complete, plausible review of somebody else's change -- which this
+          # step would otherwise attach here with full confidence. That happened:
+          # #2211's review landed on #2210. The dangerous direction is a
+          # misrouted LGTM, since pr-ready.sh treats it as the merge criterion
+          # and nothing downstream re-reads the body. Fail loudly instead.
+          reviewed=$(jq -r '.reviewed_pr_number // empty' <<<"$STRUCTURED")
+          if [ "$reviewed" != "$PR_NUMBER" ]; then
+            echo "::error::Review reports PR #${reviewed:-<missing>} but this run is for PR #$PR_NUMBER — refusing to post a review of a different change."
             exit 1
           fi
           verdict=$(jq -r '.verdict' <<<"$STRUCTURED")


### PR DESCRIPTION
> **⚠️ This PR cannot be reviewed by the automated reviewer and must not be auto-merged.**
> `claude-code-action` self-skips on any PR that edits `claude-code-review.yml` (anti-tamper), so the post step warns and exits 0 — `pr-ready.sh` will return `review-self-skipped`. **This needs a human read before merge.** I'm not merging it myself.

## What happened

**#2211's review was posted verbatim to #2210.** #2210 is a two-file `.github/dependabot.yml` change; the review it received discusses admin entitlement routes, `_AdminContext`, and "15 new tests" — none of which exist in it. `pr-ready.sh 2210` then reported `changes-requested`. #2210's own verdict was **LGTM**.

Closes #2212.

## Why

Posting was never the problem — that step takes `PR_NUMBER` from the event and is correct.

**Reviewing was.** The prompt said:

> Review this pull request against the repository's CLAUDE.md. Read the change with `gh pr diff` and `gh pr view`.

No number, anywhere. The agent had to work out which PR it was from ambient context, holding `gh pr diff`, `gh pr view` **and `gh pr list`**. A bare `gh pr diff` resolves only when the checkout is on a recognizable PR branch; this checkout is a merge ref, so the bare form fails — and the obvious recovery, listing open PRs and taking the newest, returns somebody else's change. At 01:13 the newest was #2211.

The post step then attached that review here with full confidence. Every part behaved reasonably in isolation.

## The fix

Three changes, because the first alone only makes the guess *less likely*:

1. **The prompt names the PR.** Number and repository interpolated, both commands spelled out with the number, plus a sentence on why guessing isn't recoverable.
2. **`gh pr list` leaves `allowed-tools`.** With the number pinned it has no legitimate use here, and it's the exact tool that supplies a plausible wrong answer.
3. **The agent reports `reviewed_pr_number`, and the post step refuses on a mismatch.** New required field in the `--json-schema` contract.

**The third is the one that matters**, and it's why I didn't stop at the prompt. A prompt fix makes the misroute rarer; only the check makes it *visible*. The failure that actually got caught here was a misrouted `CHANGES REQUESTED` on a clean PR — annoying, self-announcing. The dangerous one is the mirror image:

> A misrouted **LGTM**. `pr-ready.sh` treats LGTM as the merge criterion, both the Ralph fleet and interactive sessions merge on it, and nothing downstream re-reads the review body. An unreviewed change merges on an approval belonging to something else, and the only trace is a review describing code that isn't there.

That now fails the run instead.

## Audit

Checked the seven most recently merged PRs — #2207, #2206, #2202, #2196, #2198, #2197, #2193 — comparing each review's opening summary against its title and diff. All seven match. #2202 looked like a mismatch at first (title is the Dockerfile fix, review leads with `SKILL.md`) but its diff genuinely contains all three files, so the review is correct.

**No bad verdict has been acted on.** The misroute appears isolated to the #2210/#2211 incident.

## Testing

No test suite covers `.github/workflows/`, and I'd rather say that plainly than imply coverage I don't have. What I did verify:

```
$ python3 - <<'EOF'   # parse the workflow and the embedded schema
schema required: ['verdict', 'verdict_rationale', 'review_markdown', 'reviewed_pr_number']
gh pr list still allowed: False
guard present: True
prompt pins number: True
EOF
YAML OK
```

The embedded `--json-schema` is a single-quoted JSON blob inside YAML, so it round-trips through `yaml.safe_load` → `json.loads` — that's what "YAML OK" plus the parsed `required` list above confirms, and it's the failure mode most likely to bite (an unbalanced quote would break every review run).

The real proof is the next PR after this merges: it should carry a review whose summary matches its own diff, and a `reviewed_pr_number` equal to its own number.

## Acceptance criteria (from #2212)

- [x] The review prompt names the PR number and repository explicitly
- [x] `gh pr list` removed from `allowed-tools`
- [x] A misroute fails the check rather than posting
- [x] Audit of recent PRs for other misrouted verdicts — seven checked, all clean